### PR TITLE
Add multiple ouputs' precision support

### DIFF
--- a/src/tests/functional/plugin/cpu/bfloat16/memory_conv.cpp
+++ b/src/tests/functional/plugin/cpu/bfloat16/memory_conv.cpp
@@ -34,7 +34,7 @@ public:
 protected:
     void SetUp() override {
         SizeVector ie_shape;
-        std::tie(inPrc, ie_shape, targetDevice) = this->GetParam();
+        std::tie(inPrc.front(), ie_shape, targetDevice) = this->GetParam();
 
         using namespace ngraph;
         using std::make_shared;

--- a/src/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/topk.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/topk.cpp
@@ -15,6 +15,11 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP16
 };
 
+const std::vector<std::vector<InferenceEngine::Precision>> outPrecisions = {
+        {InferenceEngine::Precision::FP16, InferenceEngine::Precision::I32},
+        {InferenceEngine::Precision::FP32, InferenceEngine::Precision::I32}
+};
+
 const std::vector<int64_t> axes = {
         0,
         1,
@@ -49,7 +54,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_TopK, TopKLayerTest,
                 ::testing::ValuesIn(sortTypes),
                 ::testing::ValuesIn(netPrecisions),
                 ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                ::testing::ValuesIn(outPrecisions),
                 ::testing::Values(InferenceEngine::Layout::ANY),
                 ::testing::Values(std::vector<size_t>({21, 21, 21, 21})),
                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),

--- a/src/tests/functional/plugin/cpu/single_layer_tests/activation.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/activation.cpp
@@ -106,7 +106,7 @@ protected:
         activationType = activationTypeAndConstValue.first;
         auto constantsValue = activationTypeAndConstValue.second;
 
-        inType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrecision);
+        inType[0] = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrecision);
         outType[0] = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrecision);
         selectedType = getPrimitiveType() + "_" + netPrecision.name();
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/activation.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/activation.cpp
@@ -107,7 +107,7 @@ protected:
         auto constantsValue = activationTypeAndConstValue.second;
 
         inType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrecision);
-        outType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrecision);
+        outType[0] = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrecision);
         selectedType = getPrimitiveType() + "_" + netPrecision.name();
 
         init_input_shapes(inputShapes);

--- a/src/tests/functional/plugin/cpu/single_layer_tests/batch_to_space.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/batch_to_space.cpp
@@ -65,7 +65,7 @@ protected:
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         auto ngPrec = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        inType = outType[0] = ngPrec;
+        inType[0] = outType[0] = ngPrec;
 
         init_input_shapes(inputShapes);
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/batch_to_space.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/batch_to_space.cpp
@@ -65,7 +65,7 @@ protected:
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         auto ngPrec = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        inType = outType = ngPrec;
+        inType = outType[0] = ngPrec;
 
         init_input_shapes(inputShapes);
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
@@ -170,7 +170,7 @@ protected:
         convSpecificParams convParams;
         InputShape inputShape;
         auto netType = ElementType::undefined;
-        std::tie(convParams, netType, inType, outType[0], inputShape, targetDevice) = basicParamsSet;
+        std::tie(convParams, netType, inType[0], outType[0], inputShape, targetDevice) = basicParamsSet;
 
         init_input_shapes({inputShape});
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/convolution.cpp
@@ -170,7 +170,7 @@ protected:
         convSpecificParams convParams;
         InputShape inputShape;
         auto netType = ElementType::undefined;
-        std::tie(convParams, netType, inType, outType, inputShape, targetDevice) = basicParamsSet;
+        std::tie(convParams, netType, inType, outType[0], inputShape, targetDevice) = basicParamsSet;
 
         init_input_shapes({inputShape});
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
@@ -141,8 +141,8 @@ public:
                 if (i > 0) {
                     continue;
                 }
-                if (inType != ov::element::Type_t::undefined) {
-                    p.input(i).tensor().set_element_type(inType);
+                if (inType[0] != ov::element::Type_t::undefined) {
+                    p.input(i).tensor().set_element_type(inType[0]);
                 }
             }
         }
@@ -214,10 +214,10 @@ protected:
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outPadding) = basicParamsSet;
 
         if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
-            inType = outType[0] = prec = ElementType::bf16;
+            inType[0] = outType[0] = prec = ElementType::bf16;
             rel_threshold = 1e-2f;
         } else {
-            inType = outType[0] = prec;
+            inType[0] = outType[0] = prec;
         }
 
         selectedType = makeSelectedTypeStr(selectedType, prec);

--- a/src/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
@@ -148,9 +148,15 @@ public:
         }
         {
             auto results = function->get_results();
+            size_t gapSize = results.size() - outType.size();
+            if (gapSize) {
+                for (size_t i = 0; i < gapSize; i++) {
+                    outType.push_back(outType[0]);
+                }
+            }
             for (size_t i = 0; i < results.size(); i++) {
-                if (outType != ov::element::Type_t::undefined) {
-                    p.output(i).tensor().set_element_type(outType);
+                if (outType[i] != ov::element::Type_t::undefined) {
+                    p.output(i).tensor().set_element_type(outType[i]);
                 }
             }
         }
@@ -214,10 +220,10 @@ protected:
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outPadding) = basicParamsSet;
 
         if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
-            inType = outType = prec = ElementType::bf16;
+            inType = outType[0] = prec = ElementType::bf16;
             rel_threshold = 1e-2f;
         } else {
-            inType = outType = prec;
+            inType = outType[0] = prec;
         }
 
         selectedType = makeSelectedTypeStr(selectedType, prec);

--- a/src/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/convolution_backprop_data.cpp
@@ -148,15 +148,9 @@ public:
         }
         {
             auto results = function->get_results();
-            size_t gapSize = results.size() - outType.size();
-            if (gapSize) {
-                for (size_t i = 0; i < gapSize; i++) {
-                    outType.push_back(outType[0]);
-                }
-            }
             for (size_t i = 0; i < results.size(); i++) {
-                if (outType[i] != ov::element::Type_t::undefined) {
-                    p.output(i).tensor().set_element_type(outType[i]);
+                if (outType[0] != ov::element::Type_t::undefined) {
+                    p.output(i).tensor().set_element_type(outType[0]);
                 }
             }
         }

--- a/src/tests/functional/plugin/cpu/single_layer_tests/cum_sum.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/cum_sum.cpp
@@ -50,14 +50,14 @@ protected:
         std::int64_t axis;
         bool exclusive;
         bool reverse;
-        std::tie(inType, shapes, axis, exclusive, reverse) = this->GetParam();
-        if (inType == ElementType::bf16)
+        std::tie(inType[0], shapes, axis, exclusive, reverse) = this->GetParam();
+        if (inType[0] == ElementType::bf16)
             rel_threshold = 0.05f;
 
-        selectedType = makeSelectedTypeStr("ref_any", inType);
+        selectedType = makeSelectedTypeStr("ref_any", inType[0]);
         init_input_shapes({shapes});
 
-        auto params = ngraph::builder::makeDynamicParams(inType, inputDynamicShapes);
+        auto params = ngraph::builder::makeDynamicParams(inType[0], inputDynamicShapes);
         auto axisNode = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{}, std::vector<int64_t>{axis})->output(0);
         auto cumSum = ngraph::builder::makeCumSum(params[0], axisNode, exclusive, reverse);
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/depth_to_space.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/depth_to_space.cpp
@@ -61,19 +61,19 @@ protected:
         DepthToSpace::DepthToSpaceMode mode;
         std::size_t blockSize;
         CPUSpecificParams cpuParams;
-        std::tie(shapes, inType, mode, blockSize, cpuParams) = this->GetParam();
+        std::tie(shapes, inType[0], mode, blockSize, cpuParams) = this->GetParam();
 
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         if (selectedType.empty()) {
             selectedType = getPrimitiveType();
         }
-        selectedType = makeSelectedTypeStr(selectedType, inType);
+        selectedType = makeSelectedTypeStr(selectedType, inType[0]);
         targetDevice = CommonTestUtils::DEVICE_CPU;
         init_input_shapes({shapes});
 
-        auto params = ngraph::builder::makeDynamicParams(inType, inputDynamicShapes);
+        auto params = ngraph::builder::makeDynamicParams(inType[0], inputDynamicShapes);
         auto d2s = ngraph::builder::makeDepthToSpace(params[0], mode, blockSize);
-        function = makeNgraphFunction(inType, params, d2s, "DepthToSpace");
+        function = makeNgraphFunction(inType[0], params, d2s, "DepthToSpace");
     }
 };
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/eltwise.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/eltwise.cpp
@@ -84,7 +84,7 @@ protected:
         ngraph::helpers::InputLayerType secondaryInputType;
         CommonTestUtils::OpType opType;
         Config additional_config;
-        std::tie(shapes, eltwiseType, secondaryInputType, opType, netType, inType, outType[0], targetDevice, configuration) = basicParamsSet;
+        std::tie(shapes, eltwiseType, secondaryInputType, opType, netType, inType[0], outType[0], targetDevice, configuration) = basicParamsSet;
 
         if (ElementType::bf16 == netType) {
             rel_threshold = 2e-2f;

--- a/src/tests/functional/plugin/cpu/single_layer_tests/eltwise.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/eltwise.cpp
@@ -84,7 +84,7 @@ protected:
         ngraph::helpers::InputLayerType secondaryInputType;
         CommonTestUtils::OpType opType;
         Config additional_config;
-        std::tie(shapes, eltwiseType, secondaryInputType, opType, netType, inType, outType, targetDevice, configuration) = basicParamsSet;
+        std::tie(shapes, eltwiseType, secondaryInputType, opType, netType, inType, outType[0], targetDevice, configuration) = basicParamsSet;
 
         if (ElementType::bf16 == netType) {
             rel_threshold = 2e-2f;

--- a/src/tests/functional/plugin/cpu/single_layer_tests/embedding_bag_offsets_sum.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/embedding_bag_offsets_sum.cpp
@@ -66,7 +66,7 @@ public:
     void SetUp() override {
         embeddingBagOffsetsSumParams embParams;
         ElementType indPrecision;
-        std::tie(embParams, inType, indPrecision, targetDevice) = this->GetParam();
+        std::tie(embParams, inType[0], indPrecision, targetDevice) = this->GetParam();
 
         InputShape inputShapes;
         std::vector<size_t> indices, offsets;
@@ -74,16 +74,16 @@ public:
         size_t defaultIndex;
         std::tie(inputShapes, indices, offsets, defaultIndex, withWeights, withDefIndex) = embParams;
 
-        selectedType = makeSelectedTypeStr("ref", inType);
+        selectedType = makeSelectedTypeStr("ref", inType[0]);
         targetDevice = CommonTestUtils::DEVICE_CPU;
 
         init_input_shapes({ inputShapes });
 
-        auto emb_table_node = std::make_shared<ngraph::opset1::Parameter>(inType, inputShapes.first);
+        auto emb_table_node = std::make_shared<ngraph::opset1::Parameter>(inType[0], inputShapes.first);
         ngraph::ParameterVector params = {emb_table_node};
 
         auto embBag = std::dynamic_pointer_cast<ngraph::opset3::EmbeddingBagOffsetsSum>(ngraph::builder::makeEmbeddingBagOffsetsSum(
-            inType,
+            inType[0],
             indPrecision,
             emb_table_node,
             indices,

--- a/src/tests/functional/plugin/cpu/single_layer_tests/embedding_bag_packed_sum.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/embedding_bag_packed_sum.cpp
@@ -60,23 +60,23 @@ protected:
     void SetUp() override {
         embeddingBagPackedSumParams embParams;
         ElementType indPrecision;
-        std::tie(embParams, inType, indPrecision, targetDevice) = this->GetParam();
+        std::tie(embParams, inType[0], indPrecision, targetDevice) = this->GetParam();
 
         InputShape inputShapes;
         std::vector<std::vector<size_t>> indices;
         bool withWeights;
         std::tie(inputShapes, indices, withWeights) = embParams;
 
-        selectedType = makeSelectedTypeStr("ref", inType);
+        selectedType = makeSelectedTypeStr("ref", inType[0]);
         targetDevice = CommonTestUtils::DEVICE_CPU;
 
         init_input_shapes({ inputShapes });
 
-        auto emb_table_node = std::make_shared<ngraph::opset1::Parameter>(inType, inputShapes.first);
+        auto emb_table_node = std::make_shared<ngraph::opset1::Parameter>(inType[0], inputShapes.first);
         ngraph::ParameterVector params = {emb_table_node};
 
         auto embBag = std::dynamic_pointer_cast<ngraph::opset3::EmbeddingBagPackedSum>(ngraph::builder::makeEmbeddingBagPackedSum(
-            inType,
+            inType[0],
             indPrecision,
             emb_table_node,
             indices,

--- a/src/tests/functional/plugin/cpu/single_layer_tests/embedding_segments_sum.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/embedding_segments_sum.cpp
@@ -69,7 +69,7 @@ protected:
     void SetUp() override {
         embeddingSegmentsSumParams embParams;
         ElementType indPrecision;
-        std::tie(embParams, inType, indPrecision, targetDevice) = this->GetParam();
+        std::tie(embParams, inType[0], indPrecision, targetDevice) = this->GetParam();
 
         InputShape inputShapes;
         std::vector<size_t> indices, segmentIds;
@@ -77,16 +77,16 @@ protected:
         size_t numSegments, defaultIndex;
         std::tie(inputShapes, indices, segmentIds, numSegments, defaultIndex, withWeights, withDefIndex) = embParams;
 
-        selectedType = makeSelectedTypeStr("ref", inType);
+        selectedType = makeSelectedTypeStr("ref", inType[0]);
         targetDevice = CommonTestUtils::DEVICE_CPU;
 
         init_input_shapes({ inputShapes });
 
-        auto emb_table_node = std::make_shared<ngraph::opset1::Parameter>(inType, inputShapes.first);
+        auto emb_table_node = std::make_shared<ngraph::opset1::Parameter>(inType[0], inputShapes.first);
         ngraph::ParameterVector params = {emb_table_node};
 
         auto embBag = std::dynamic_pointer_cast<ngraph::opset3::EmbeddingSegmentsSum>(ngraph::builder::makeEmbeddingSegmentsSum(
-            inType,
+            inType[0],
             indPrecision,
             emb_table_node,
             indices,

--- a/src/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -171,7 +171,7 @@ protected:
         groupConvSpecificParams groupConvParams;
         InputShape inputShape;
         auto netType   = ElementType::undefined;
-        std::tie(groupConvParams, netType, inType, outType[0], inputShape, targetDevice) = basicParamsSet;
+        std::tie(groupConvParams, netType, inType[0], outType[0], inputShape, targetDevice) = basicParamsSet;
 
         init_input_shapes({inputShape});
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/group_convolution.cpp
@@ -171,7 +171,7 @@ protected:
         groupConvSpecificParams groupConvParams;
         InputShape inputShape;
         auto netType   = ElementType::undefined;
-        std::tie(groupConvParams, netType, inType, outType, inputShape, targetDevice) = basicParamsSet;
+        std::tie(groupConvParams, netType, inType, outType[0], inputShape, targetDevice) = basicParamsSet;
 
         init_input_shapes({inputShape});
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
@@ -149,15 +149,9 @@ public:
         }
         {
             auto results = function->get_results();
-            size_t gapSize = results.size() - outType.size();
-            if (gapSize) {
-                for (size_t i = 0; i < gapSize; i++) {
-                    outType.push_back(outType[0]);
-                }
-            }
             for (size_t i = 0; i < results.size(); i++) {
-                if (outType[i] != ov::element::Type_t::undefined) {
-                    p.output(i).tensor().set_element_type(outType[i]);
+                if (outType[0] != ov::element::Type_t::undefined) {
+                    p.output(i).tensor().set_element_type(outType[0]);
                 }
             }
         }

--- a/src/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
@@ -142,8 +142,8 @@ public:
                 if (i > 0) {
                     continue;
                 }
-                if (inType != ov::element::Type_t::undefined) {
-                    p.input(i).tensor().set_element_type(inType);
+                if (inType[0] != ov::element::Type_t::undefined) {
+                    p.input(i).tensor().set_element_type(inType[0]);
                 }
             }
         }
@@ -216,10 +216,10 @@ protected:
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
-            inType = outType[0] = prec = ElementType::bf16;
+            inType[0] = outType[0] = prec = ElementType::bf16;
             rel_threshold = 1e-2f;
         } else {
-            inType = outType[0] = prec;
+            inType[0] = outType[0] = prec;
         }
 
         selectedType = makeSelectedTypeStr(selectedType, prec);

--- a/src/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/group_convolution_backprop_data.cpp
@@ -149,9 +149,15 @@ public:
         }
         {
             auto results = function->get_results();
+            size_t gapSize = results.size() - outType.size();
+            if (gapSize) {
+                for (size_t i = 0; i < gapSize; i++) {
+                    outType.push_back(outType[0]);
+                }
+            }
             for (size_t i = 0; i < results.size(); i++) {
-                if (outType != ov::element::Type_t::undefined) {
-                    p.output(i).tensor().set_element_type(outType);
+                if (outType[i] != ov::element::Type_t::undefined) {
+                    p.output(i).tensor().set_element_type(outType[i]);
                 }
             }
         }
@@ -216,10 +222,10 @@ protected:
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
-            inType = outType = prec = ElementType::bf16;
+            inType = outType[0] = prec = ElementType::bf16;
             rel_threshold = 1e-2f;
         } else {
-            inType = outType = prec;
+            inType = outType[0] = prec;
         }
 
         selectedType = makeSelectedTypeStr(selectedType, prec);

--- a/src/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
@@ -131,12 +131,15 @@ public:
         ov::preprocess::PrePostProcessor p(function);
         {
             auto& params = function->get_parameters();
-            for (size_t i = 0; i < params.size(); i++) {
-                if (i > 0) {
-                    continue;
+            size_t gapSize = params.size() - inType.size();
+            if (gapSize) {
+                for (size_t i = 0; i < gapSize; i++) {
+                    inType.push_back(inType[0]);
                 }
-                if (inType != ov::element::Type_t::undefined) {
-                    p.input(i).tensor().set_element_type(inType);
+            }
+            for (size_t i = 0; i < params.size(); i++) {
+                if (inType[i] != ov::element::Type_t::undefined) {
+                    p.input(i).tensor().set_element_type(inType[i]);
                 }
             }
         }
@@ -213,10 +216,10 @@ protected:
         }
 
         if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
-            inType = outType[0] = ngPrc = ElementType::bf16;
+            inType[0] = outType[0] = ngPrc = ElementType::bf16;
             rel_threshold = 1e-2f;
         } else {
-            inType = outType[0] = ngPrc;
+            inType[0] = outType[0] = ngPrc;
         }
 
         init_input_shapes(inputShapes);

--- a/src/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
@@ -128,7 +128,7 @@ public:
     }
 
     void configure_model() override {
-        align_parameters();
+        init_inputs_and_outputs();
         ov::preprocess::PrePostProcessor p(function);
         {
             auto& params = function->get_parameters();

--- a/src/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
@@ -142,9 +142,15 @@ public:
         }
         {
             auto results = function->get_results();
+            size_t gapSize = results.size() - outType.size();
+            if (gapSize) {
+                for (size_t i = 0; i < gapSize; i++) {
+                    outType.push_back(outType[0]);
+                }
+            }
             for (size_t i = 0; i < results.size(); i++) {
-                if (outType != ov::element::Type_t::undefined) {
-                    p.output(i).tensor().set_element_type(outType);
+                if (outType[i] != ov::element::Type_t::undefined) {
+                    p.output(i).tensor().set_element_type(outType[i]);
                 }
             }
         }
@@ -207,10 +213,10 @@ protected:
         }
 
         if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
-            inType = outType = ngPrc = ElementType::bf16;
+            inType = outType[0] = ngPrc = ElementType::bf16;
             rel_threshold = 1e-2f;
         } else {
-            inType = outType = ngPrc;
+            inType = outType[0] = ngPrc;
         }
 
         init_input_shapes(inputShapes);

--- a/src/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
@@ -128,16 +128,10 @@ public:
     }
 
     void configure_model() override {
+        align_parameters();
         ov::preprocess::PrePostProcessor p(function);
         {
             auto& params = function->get_parameters();
-            size_t gapSize = params.size() - inType.size();
-            if (gapSize) {
-                auto inTypeDefaultValue = inType[0];
-                for (size_t i = 1; i <= gapSize; i++) {
-                    inType.push_back(inTypeDefaultValue);
-                }
-            }
             for (size_t i = 0; i < params.size(); i++) {
                 if (i > 0) {
                     continue;
@@ -149,13 +143,6 @@ public:
         }
         {
             auto results = function->get_results();
-            size_t gapSize = results.size() - outType.size();
-            if (gapSize) {
-                auto outTypeDefaultValue = outType[0];
-                for (size_t i = 1; i <= gapSize; i++) {
-                    outType.push_back(outTypeDefaultValue);
-                }
-            }
             for (size_t i = 0; i < results.size(); i++) {
                 if (outType[i] != ov::element::Type_t::undefined) {
                     p.output(i).tensor().set_element_type(outType[i]);

--- a/src/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/interpolate.cpp
@@ -133,11 +133,15 @@ public:
             auto& params = function->get_parameters();
             size_t gapSize = params.size() - inType.size();
             if (gapSize) {
-                for (size_t i = 0; i < gapSize; i++) {
-                    inType.push_back(inType[0]);
+                auto inTypeDefaultValue = inType[0];
+                for (size_t i = 1; i <= gapSize; i++) {
+                    inType.push_back(inTypeDefaultValue);
                 }
             }
             for (size_t i = 0; i < params.size(); i++) {
+                if (i > 0) {
+                    continue;
+                }
                 if (inType[i] != ov::element::Type_t::undefined) {
                     p.input(i).tensor().set_element_type(inType[i]);
                 }
@@ -147,8 +151,9 @@ public:
             auto results = function->get_results();
             size_t gapSize = results.size() - outType.size();
             if (gapSize) {
-                for (size_t i = 0; i < gapSize; i++) {
-                    outType.push_back(outType[0]);
+                auto outTypeDefaultValue = outType[0];
+                for (size_t i = 1; i <= gapSize; i++) {
+                    outType.push_back(outTypeDefaultValue);
                 }
             }
             for (size_t i = 0; i < results.size(); i++) {
@@ -216,10 +221,13 @@ protected:
         }
 
         if (additionalConfig[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] == InferenceEngine::PluginConfigParams::YES) {
-            inType[0] = outType[0] = ngPrc = ElementType::bf16;
+            ngPrc = ElementType::bf16;
+            inType.front() = ElementType::bf16;
+            outType.front() = ElementType::bf16;
             rel_threshold = 1e-2f;
         } else {
-            inType[0] = outType[0] = ngPrc;
+            inType.front() = ngPrc;
+            outType.front() = ngPrc;
         }
 
         init_input_shapes(inputShapes);

--- a/src/tests/functional/plugin/cpu/single_layer_tests/log_softmax.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/log_softmax.cpp
@@ -59,7 +59,7 @@ protected:
         std::tie(inputShapes, netPrecision, axis) = this->GetParam();
 
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        inType = outType = ngPrc;
+        inType = outType[0] = ngPrc;
 
         selectedType = std::string("unknown_") + netPrecision.name();
         init_input_shapes(inputShapes);

--- a/src/tests/functional/plugin/cpu/single_layer_tests/log_softmax.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/log_softmax.cpp
@@ -59,7 +59,7 @@ protected:
         std::tie(inputShapes, netPrecision, axis) = this->GetParam();
 
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        inType = outType[0] = ngPrc;
+        inType[0] = outType[0] = ngPrc;
 
         selectedType = std::string("unknown_") + netPrecision.name();
         init_input_shapes(inputShapes);

--- a/src/tests/functional/plugin/cpu/single_layer_tests/logical.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/logical.cpp
@@ -48,10 +48,10 @@ protected:
         InferenceEngine::Precision netPrecision;
         std::string targetName;
         std::map<std::string, std::string> additional_config;
-        std::tie(inputShapes, logicalOpType, secondInputType, netPrecision, inPrc, outPrc.front(),
+        std::tie(inputShapes, logicalOpType, secondInputType, netPrecision, inPrc.front(), outPrc.front(),
                  inLayout, outLayout, targetDevice, additional_config) = basicParamsSet;
 
-        selectedType = getPrimitiveType() + "_" + inPrc.name();
+        selectedType = getPrimitiveType() + "_" + inPrc[0].name();
 
         auto ngInputsPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(Precision::BOOL); // Because ngraph supports only boolean input for logical ops
         configuration.insert(additional_config.begin(), additional_config.end());

--- a/src/tests/functional/plugin/cpu/single_layer_tests/logical.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/logical.cpp
@@ -49,7 +49,7 @@ protected:
         std::string targetName;
         std::map<std::string, std::string> additional_config;
         std::tie(inputShapes, logicalOpType, secondInputType, netPrecision, inPrc.front(), outPrc.front(),
-                 inLayout, outLayout.front(), targetDevice, additional_config) = basicParamsSet;
+                 inLayout.front(), outLayout.front(), targetDevice, additional_config) = basicParamsSet;
 
         selectedType = getPrimitiveType() + "_" + inPrc[0].name();
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/logical.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/logical.cpp
@@ -48,7 +48,7 @@ protected:
         InferenceEngine::Precision netPrecision;
         std::string targetName;
         std::map<std::string, std::string> additional_config;
-        std::tie(inputShapes, logicalOpType, secondInputType, netPrecision, inPrc, outPrc,
+        std::tie(inputShapes, logicalOpType, secondInputType, netPrecision, inPrc, outPrc.front(),
                  inLayout, outLayout, targetDevice, additional_config) = basicParamsSet;
 
         selectedType = getPrimitiveType() + "_" + inPrc.name();

--- a/src/tests/functional/plugin/cpu/single_layer_tests/logical.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/logical.cpp
@@ -49,7 +49,7 @@ protected:
         std::string targetName;
         std::map<std::string, std::string> additional_config;
         std::tie(inputShapes, logicalOpType, secondInputType, netPrecision, inPrc.front(), outPrc.front(),
-                 inLayout, outLayout, targetDevice, additional_config) = basicParamsSet;
+                 inLayout, outLayout.front(), targetDevice, additional_config) = basicParamsSet;
 
         selectedType = getPrimitiveType() + "_" + inPrc[0].name();
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/loop.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/loop.cpp
@@ -170,20 +170,20 @@ protected:
         bool exec_cond;
         std::vector<InputShape> shapes;
         std::vector<LOOP_IN_TYPE> types;
-        std::tie(trip_count_type, trip_count, exec_cond, shapes, types, inType) = this->GetParam();
+        std::tie(trip_count_type, trip_count, exec_cond, shapes, types, inType[0]) = this->GetParam();
 
         targetDevice = CommonTestUtils::DEVICE_CPU;
         init_input_shapes(shapes);
         for (auto& target : targetStaticShapes)
             target.insert(target.begin(), ngraph::Shape{});
 
-        auto params = ngraph::builder::makeDynamicParams(inType, inputDynamicShapes);
+        auto params = ngraph::builder::makeDynamicParams(inType[0], inputDynamicShapes);
 
         // Body parameters
         const std::vector<ngraph::PartialShape> body_params_shapes(shapes.size(), ngraph::PartialShape::dynamic());
         ngraph::ParameterVector body_params = { std::make_shared<ngraph::opset1::Parameter>(ngraph::element::i64, ngraph::Shape{}) };
         for (const auto &pshape : body_params_shapes) {
-            body_params.emplace_back(std::make_shared<ngraph::opset1::Parameter>(inType, pshape));
+            body_params.emplace_back(std::make_shared<ngraph::opset1::Parameter>(inType[0], pshape));
         }
 
         auto exec_condition = std::make_shared<ngraph::opset5::Constant>(ngraph::element::boolean, ngraph::Shape{}, exec_cond);
@@ -197,7 +197,7 @@ protected:
         auto less = std::make_shared<ngraph::opset5::Less>(body_params[0], const_body_cond);
         auto exec_idx = std::make_shared<ngraph::opset5::Add>(body_params[0], const_body_step);
 
-        auto node_const = std::make_shared<ngraph::opset5::Constant>(inType, ngraph::Shape{}, 2);
+        auto node_const = std::make_shared<ngraph::opset5::Constant>(inType[0], ngraph::Shape{}, 2);
         auto node = std::make_shared<ngraph::opset5::Add>(body_params[1], node_const);
 
         // reference ngraph function is resized by input static shapes in tests but
@@ -241,19 +241,19 @@ protected:
         bool exec_cond;
         std::vector<InputShape> shapes;
         std::vector<LOOP_IN_TYPE> types;
-        std::tie(trip_count_type, trip_count, exec_cond, shapes, types, inType) = this->GetParam();
+        std::tie(trip_count_type, trip_count, exec_cond, shapes, types, inType[0]) = this->GetParam();
 
         targetDevice = CommonTestUtils::DEVICE_CPU;
         init_input_shapes(shapes);
 
-        auto params = ngraph::builder::makeDynamicParams(inType, inputDynamicShapes);
+        auto params = ngraph::builder::makeDynamicParams(inType[0], inputDynamicShapes);
 
         // Set up the cell body, a function from (Xi, Yi) -> (Zo)
         // Body parameters
         const std::vector<ngraph::PartialShape> body_params_shapes(shapes.size(), ngraph::PartialShape::dynamic());
         ngraph::ParameterVector body_params;
         for (const auto &pshape : body_params_shapes) {
-            body_params.emplace_back(std::make_shared<ngraph::opset1::Parameter>(inType, pshape));
+            body_params.emplace_back(std::make_shared<ngraph::opset1::Parameter>(inType[0], pshape));
         }
 
         auto body_condition_const = std::make_shared<ngraph::opset5::Constant>(ngraph::element::boolean, ngraph::Shape{1}, true);
@@ -273,8 +273,8 @@ protected:
 
         // Body
         const auto axis = 1;
-        auto s = ngraph::builder::makeSlice(body_params[0], {0}, {1}, {1}, {axis}, inType);
-        auto constant = ngraph::builder::makeConstant(inType, std::vector<size_t>{1}, std::vector<float>{0.5});
+        auto s = ngraph::builder::makeSlice(body_params[0], {0}, {1}, {1}, {axis}, inType[0]);
+        auto constant = ngraph::builder::makeConstant(inType[0], std::vector<size_t>{1}, std::vector<float>{0.5});
         auto eltwise = std::make_shared<ov::op::v1::Add>(body_params[0], constant);
 
         auto body = std::make_shared<ov::Model>(ngraph::OutputVector{body_condition_const, s, eltwise}, body_params);

--- a/src/tests/functional/plugin/cpu/single_layer_tests/matmul.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/matmul.cpp
@@ -119,7 +119,7 @@ protected:
         helpers::InputLayerType secondaryInputType;
         std::map<std::string, std::string> additionalConfig;
 
-        std::tie(shapeRelatedParams, netType, inType, outType[0], secondaryInputType, targetDevice, additionalConfig) = basicParamsSet;
+        std::tie(shapeRelatedParams, netType, inType[0], outType[0], secondaryInputType, targetDevice, additionalConfig) = basicParamsSet;
 
         init_input_shapes(shapeRelatedParams.inputShapes);
 
@@ -151,9 +151,9 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES)
-            inType = outType[0] = netType = ElementType::bf16;
+            inType[0] = outType[0] = netType = ElementType::bf16;
         else
-            inType = outType[0] = netType;
+            inType[0] = outType[0] = netType;
 
         cpuNodeType = nodeType == MatMulNodeType::MatMul ? "MatMul" : "FullyConnected";
         selectedType = makeSelectedTypeStr(selectedType, outType[0]);

--- a/src/tests/functional/plugin/cpu/single_layer_tests/matmul.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/matmul.cpp
@@ -119,7 +119,7 @@ protected:
         helpers::InputLayerType secondaryInputType;
         std::map<std::string, std::string> additionalConfig;
 
-        std::tie(shapeRelatedParams, netType, inType, outType, secondaryInputType, targetDevice, additionalConfig) = basicParamsSet;
+        std::tie(shapeRelatedParams, netType, inType, outType[0], secondaryInputType, targetDevice, additionalConfig) = basicParamsSet;
 
         init_input_shapes(shapeRelatedParams.inputShapes);
 
@@ -151,12 +151,12 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES)
-            inType = outType = netType = ElementType::bf16;
+            inType = outType[0] = netType = ElementType::bf16;
         else
-            inType = outType = netType;
+            inType = outType[0] = netType;
 
         cpuNodeType = nodeType == MatMulNodeType::MatMul ? "MatMul" : "FullyConnected";
-        selectedType = makeSelectedTypeStr(selectedType, outType);
+        selectedType = makeSelectedTypeStr(selectedType, outType[0]);
 
         auto params = builder::makeDynamicParams(netType, {inShapeA});
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/one_hot.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/one_hot.cpp
@@ -92,7 +92,7 @@ protected:
 
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         selectedType = std::string("ref_any_I32");
-        outType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
+        outType[0] = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
 
         init_input_shapes({inputShape});
         if (inputType.second) {
@@ -133,8 +133,8 @@ protected:
             depth = depthParam;
         }
         auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::opset3::Parameter>(params));
-        auto on_value_const = std::make_shared<ngraph::op::Constant>(outType, ngraph::Shape{ }, OnValue);
-        auto off_value_const = std::make_shared<ngraph::op::Constant>(outType, ngraph::Shape{ }, OffValue);
+        auto on_value_const = std::make_shared<ngraph::op::Constant>(outType[0], ngraph::Shape{ }, OnValue);
+        auto off_value_const = std::make_shared<ngraph::op::Constant>(outType[0], ngraph::Shape{ }, OffValue);
         auto oneHot = std::make_shared<ngraph::opset5::OneHot>(paramOuts[0], depth, on_value_const, off_value_const, Axis);
         return makeNgraphFunction(ngraph::element::i32, params, oneHot, "OneHot");
     }

--- a/src/tests/functional/plugin/cpu/single_layer_tests/one_hot.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/one_hot.cpp
@@ -32,10 +32,9 @@ public:
         std::pair<ngraph::helpers::InputLayerType, bool> inputType;
         size_t depth;
         float onValue, offValue;
-//        InferenceEngine::Precision outPrc;
-        std::vector<InferenceEngine::Precision> outPrc;
+        InferenceEngine::Precision outPrc;
         CPUSpecificParams cpuParams;
-        std::tie(inputShape, axis, inputType, depth, onValue, offValue, outPrc.front(), cpuParams) = obj.param;
+        std::tie(inputShape, axis, inputType, depth, onValue, offValue, outPrc, cpuParams) = obj.param;
 
         std::ostringstream result;
         if (inputShape.first.size() != 0) {
@@ -55,7 +54,7 @@ public:
         }
         result << "OnVal=" << onValue << "_";
         result << "OffVal=" << offValue << "_";
-        result << "outPRC=" << outPrc.front().name();
+        result << "outPRC=" << outPrc.name();
         result << CPUTestsBase::getTestCaseName(cpuParams);
         return result.str();
     }
@@ -83,9 +82,9 @@ protected:
 
         InputShape inputShape;
         std::pair<ngraph::helpers::InputLayerType, bool> inputType;
-        std::vector<InferenceEngine::Precision> outPrc;
+        InferenceEngine::Precision outPrc;
         CPUSpecificParams cpuParams;
-        std::tie(inputShape, Axis, inputType, Depth, OnValue, OffValue, outPrc.front(), cpuParams) = this->GetParam();
+        std::tie(inputShape, Axis, inputType, Depth, OnValue, OffValue, outPrc, cpuParams) = this->GetParam();
 
         if (inputType.second && inputType.first == ngraph::helpers::InputLayerType::CONSTANT) {
             generateDepth();
@@ -93,7 +92,7 @@ protected:
 
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         selectedType = std::string("ref_any_I32");
-        outType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc.front());
+        outType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
 
         init_input_shapes({inputShape});
         if (inputType.second) {

--- a/src/tests/functional/plugin/cpu/single_layer_tests/one_hot.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/one_hot.cpp
@@ -32,9 +32,10 @@ public:
         std::pair<ngraph::helpers::InputLayerType, bool> inputType;
         size_t depth;
         float onValue, offValue;
-        InferenceEngine::Precision outPrc;
+//        InferenceEngine::Precision outPrc;
+        std::vector<InferenceEngine::Precision> outPrc;
         CPUSpecificParams cpuParams;
-        std::tie(inputShape, axis, inputType, depth, onValue, offValue, outPrc, cpuParams) = obj.param;
+        std::tie(inputShape, axis, inputType, depth, onValue, offValue, outPrc.front(), cpuParams) = obj.param;
 
         std::ostringstream result;
         if (inputShape.first.size() != 0) {
@@ -54,7 +55,7 @@ public:
         }
         result << "OnVal=" << onValue << "_";
         result << "OffVal=" << offValue << "_";
-        result << "outPRC=" << outPrc.name();
+        result << "outPRC=" << outPrc.front().name();
         result << CPUTestsBase::getTestCaseName(cpuParams);
         return result.str();
     }
@@ -82,9 +83,9 @@ protected:
 
         InputShape inputShape;
         std::pair<ngraph::helpers::InputLayerType, bool> inputType;
-        InferenceEngine::Precision outPrc;
+        std::vector<InferenceEngine::Precision> outPrc;
         CPUSpecificParams cpuParams;
-        std::tie(inputShape, Axis, inputType, Depth, OnValue, OffValue, outPrc, cpuParams) = this->GetParam();
+        std::tie(inputShape, Axis, inputType, Depth, OnValue, OffValue, outPrc.front(), cpuParams) = this->GetParam();
 
         if (inputType.second && inputType.first == ngraph::helpers::InputLayerType::CONSTANT) {
             generateDepth();
@@ -92,7 +93,7 @@ protected:
 
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         selectedType = std::string("ref_any_I32");
-        outType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
+        outType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc.front());
 
         init_input_shapes({inputShape});
         if (inputType.second) {

--- a/src/tests/functional/plugin/cpu/single_layer_tests/pad.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/pad.cpp
@@ -60,16 +60,16 @@ protected:
         ngraph::helpers::PadMode padMode;
         float argPadValue;
         CPUSpecificParams cpuParams;
-        std::tie(shapes, inType, padsBegin, padsEnd, argPadValue, padMode, cpuParams) = this->GetParam();
+        std::tie(shapes, inType[0], padsBegin, padsEnd, argPadValue, padMode, cpuParams) = this->GetParam();
 
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-        selectedType = makeSelectedTypeStr("ref", inType);
+        selectedType = makeSelectedTypeStr("ref", inType[0]);
         targetDevice = CommonTestUtils::DEVICE_CPU;
         init_input_shapes({shapes});
 
-        auto params = ngraph::builder::makeDynamicParams(inType, inputDynamicShapes);
+        auto params = ngraph::builder::makeDynamicParams(inType[0], inputDynamicShapes);
         auto pad = ngraph::builder::makePad(params[0], padsBegin, padsEnd, argPadValue, padMode);
-        function = makeNgraphFunction(inType, params, pad, "Pad");
+        function = makeNgraphFunction(inType[0], params, pad, "Pad");
     }
 };
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/psroi_pooling.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/psroi_pooling.cpp
@@ -79,7 +79,8 @@ protected:
         CPULayerTestsDefinitions::PSROIPoolingSpecificParams psroiPoolingParams;
         auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
         std::tie(psroiPoolingParams, netPrecision, targetDevice) = basicParamsSet;
-        inPrc = outPrc = netPrecision;
+        inPrc = netPrecision;
+        outPrc = std::vector<InferenceEngine::Precision>(netPrecision);
         std::tie(featureMapShape, proposal, outputDim, groupSize,
                  spatialScale, spatialBinsX, spatialBinsY, mode) = psroiPoolingParams;
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/psroi_pooling.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/psroi_pooling.cpp
@@ -79,8 +79,8 @@ protected:
         CPULayerTestsDefinitions::PSROIPoolingSpecificParams psroiPoolingParams;
         auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
         std::tie(psroiPoolingParams, netPrecision, targetDevice) = basicParamsSet;
-        inPrc = netPrecision;
-        outPrc = std::vector<InferenceEngine::Precision>(netPrecision);
+        inPrc.front() = netPrecision;
+        outPrc.front() = netPrecision;
         std::tie(featureMapShape, proposal, outputDim, groupSize,
                  spatialScale, spatialBinsX, spatialBinsY, mode) = psroiPoolingParams;
 
@@ -93,7 +93,7 @@ protected:
         auto psroi = std::make_shared<ngraph::op::v0::PSROIPooling>(params[0], coords, outputDim, groupSize,
                                                        spatialScale, spatialBinsX, spatialBinsY, mode);
         psroi->get_rt_info() = getCPUInfo();
-        selectedType = getPrimitiveType() + "_" + inPrc.name();
+        selectedType = getPrimitiveType() + "_" + inPrc[0].name();
 
         threshold = 1e-2;
         const ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(psroi)};

--- a/src/tests/functional/plugin/cpu/single_layer_tests/space_to_batch.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/space_to_batch.cpp
@@ -61,7 +61,7 @@ protected:
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         auto ngPrec = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        inType = outType[0] = ngPrec;
+        inType[0] = outType[0] = ngPrec;
         const std::vector<InputShape> inputShapesVec{inputShapes};
         init_input_shapes(inputShapesVec);
 
@@ -73,7 +73,7 @@ protected:
         auto params = ngraph::builder::makeDynamicParams(ngPrec, {inputDynamicShapes.front()});
         auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
         auto s2b = ngraph::builder::makeSpaceToBatch(paramOuts[0], ngPrec, blockShape, padsBegin, padsEnd);
-        function = makeNgraphFunction(inType, params, s2b, "SpaceToBatchCPU");
+        function = makeNgraphFunction(inType[0], params, s2b, "SpaceToBatchCPU");
     }
 };
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/space_to_batch.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/space_to_batch.cpp
@@ -61,7 +61,7 @@ protected:
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         auto ngPrec = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        inType = outType = ngPrec;
+        inType = outType[0] = ngPrec;
         const std::vector<InputShape> inputShapesVec{inputShapes};
         init_input_shapes(inputShapesVec);
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/strided_slice.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/strided_slice.cpp
@@ -67,17 +67,17 @@ protected:
         InputShape shapes;
         StridedSliceParams ssParams;
         CPUSpecificParams cpuParams;
-        std::tie(shapes, ssParams, inType, cpuParams) = this->GetParam();
+        std::tie(shapes, ssParams, inType[0], cpuParams) = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
-        selectedType = makeSelectedTypeStr("ref", inType);
+        selectedType = makeSelectedTypeStr("ref", inType[0]);
         targetDevice = CommonTestUtils::DEVICE_CPU;
         init_input_shapes({shapes});
 
-        auto params = ngraph::builder::makeDynamicParams(inType, inputDynamicShapes);
-        auto ss = ngraph::builder::makeStridedSlice(params[0], ssParams.begin, ssParams.end, ssParams.strides, inType, ssParams.beginMask,
+        auto params = ngraph::builder::makeDynamicParams(inType[0], inputDynamicShapes);
+        auto ss = ngraph::builder::makeStridedSlice(params[0], ssParams.begin, ssParams.end, ssParams.strides, inType[0], ssParams.beginMask,
                                                     ssParams.endMask, ssParams.newAxisMask, ssParams.shrinkAxisMask, ssParams.ellipsisAxisMask);
-        function = makeNgraphFunction(inType, params, ss, "StridedSlice");
+        function = makeNgraphFunction(inType[0], params, ss, "StridedSlice");
     }
 };
 

--- a/src/tests/functional/plugin/cpu/single_layer_tests/topk.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/topk.cpp
@@ -90,18 +90,17 @@ protected:
         ngraph::opset4::TopK::SortType sort;
         ElementType inPrc;
         std::vector<ElementType> outPrc;
+        outPrc.reserve(2);
         InputShape inputShape;
         std::tie(keepK, axis, mode, sort, netPrecision, inPrc, outPrc, inputShape) = basicParamsSet;
 
-        if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES) {
+        if (additionalConfig[PluginConfigParams::KEY_ENFORCE_BF16] == PluginConfigParams::YES)
             inPrc = netPrecision = ElementType::bf16;
-            outType.front() = outPrc[0];
-            outType.push_back(outPrc[1]);
-        } else {
+        else
             inPrc = netPrecision;
-            outType.front() = outPrc[0];
-            outType.push_back(outPrc[1]);
-        }
+        outType.reserve(2);
+        outType[0] = outPrc[0];
+        outType.push_back(outPrc[1]);
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         selectedType = getPrimitiveType() + "_" + InferenceEngine::details::convertPrecision(netPrecision).name();

--- a/src/tests/functional/plugin/cpu/single_layer_tests/transpose.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/transpose.cpp
@@ -57,17 +57,17 @@ protected:
         std::tie(inputShapes, inputOrder, netPrecision, targetDevice, additionalConfig, cpuParams) = this->GetParam();
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
-        inType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        inType[0] = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         outType[0] = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
-        selectedType = makeSelectedTypeStr("unknown", inType);
+        selectedType = makeSelectedTypeStr("unknown", inType[0]);
 
         init_input_shapes({inputShapes});
 
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        auto params = ngraph::builder::makeDynamicParams(inType, { inputDynamicShapes[0] });
+        auto params = ngraph::builder::makeDynamicParams(inType[0], { inputDynamicShapes[0] });
 
         const auto inputOrderOp = std::make_shared<ov::op::v0::Constant>(ov::element::i64,
                                                                          ov::Shape({inputOrder.size()}),

--- a/src/tests/functional/plugin/cpu/single_layer_tests/transpose.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/transpose.cpp
@@ -58,7 +58,7 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         inType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        outType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        outType[0] = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/add_convert_to_reorder.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/add_convert_to_reorder.cpp
@@ -21,7 +21,8 @@ public:
         std::vector<size_t> indicesShape = {2, 2};
         std::vector<size_t> inputShape = {10, 20, 30, 40};
 
-        InferenceEngine::Precision netPrecision = inPrc = outPrc = Precision::FP32;
+        InferenceEngine::Precision netPrecision = inPrc = Precision::FP32;
+        outPrc = std::vector<Precision>(Precision::FP32);
         targetDevice = CommonTestUtils::DEVICE_CPU;
 
         ASSERT_EQ(ngraph::shape_size(indicesShape), indices.size())

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/add_convert_to_reorder.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/add_convert_to_reorder.cpp
@@ -21,8 +21,9 @@ public:
         std::vector<size_t> indicesShape = {2, 2};
         std::vector<size_t> inputShape = {10, 20, 30, 40};
 
-        InferenceEngine::Precision netPrecision = inPrc = Precision::FP32;
-        outPrc = std::vector<Precision>(Precision::FP32);
+        InferenceEngine::Precision netPrecision = Precision::FP32;
+        inPrc.front() =  Precision::FP32;
+        outPrc.front() = Precision::FP32;
         targetDevice = CommonTestUtils::DEVICE_CPU;
 
         ASSERT_EQ(ngraph::shape_size(indicesShape), indices.size())

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/concat_const_inplace.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/concat_const_inplace.cpp
@@ -37,7 +37,7 @@ public:
 
     void SetUp() override {
         targetDevice = CommonTestUtils::DEVICE_CPU;
-        if (Precision::BF16 == (inPrc = outPrc = this->GetParam()))
+        if (Precision::BF16 == (inPrc = outPrc.front() = this->GetParam()))
             configuration.insert({ PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES });
         else
             configuration.insert({ PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO });

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/concat_const_inplace.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/concat_const_inplace.cpp
@@ -37,7 +37,7 @@ public:
 
     void SetUp() override {
         targetDevice = CommonTestUtils::DEVICE_CPU;
-        if (Precision::BF16 == (inPrc = outPrc.front() = this->GetParam()))
+        if (Precision::BF16 == (inPrc.front() = outPrc.front() = this->GetParam()))
             configuration.insert({ PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES });
         else
             configuration.insert({ PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO });

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/conv3d_reshape.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/conv3d_reshape.cpp
@@ -69,6 +69,10 @@ protected:
         }
 
         ResultVector results;
+        outPrc.front() = InferenceEngine::Precision::FP32;
+        for (int i = 1; i < numOut; i++) {
+            outPrc.push_back(InferenceEngine::Precision::FP32);
+        }
         for (int i = 0; i < numOut; i++) {
             auto mockNode = std::make_shared<opset5::Multiply>(conv->output(0), opset5::Constant::create(element::f32, Shape{1}, {1}));
             results.push_back(std::make_shared<opset5::Result>(mockNode));

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/gather_add_avgpool.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/gather_add_avgpool.cpp
@@ -29,7 +29,7 @@ class GatherAddAvgpool : virtual public LayerTestsUtils::LayerTestsCommon {
 protected:
     void SetUp() override {
         targetDevice = CommonTestUtils::DEVICE_CPU;
-        inPrc = InferenceEngine::Precision::U8;
+        inPrc.front() = InferenceEngine::Precision::U8;
         outPrc.front() = InferenceEngine::Precision::FP32;
         auto type = element::f32;
         auto param = std::make_shared<opset8::Parameter>(type, Shape{1, 3, 64, 64});

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/gather_add_avgpool.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/gather_add_avgpool.cpp
@@ -30,7 +30,7 @@ protected:
     void SetUp() override {
         targetDevice = CommonTestUtils::DEVICE_CPU;
         inPrc = InferenceEngine::Precision::U8;
-        outPrc = InferenceEngine::Precision::FP32;
+        outPrc.front() = InferenceEngine::Precision::FP32;
         auto type = element::f32;
         auto param = std::make_shared<opset8::Parameter>(type, Shape{1, 3, 64, 64});
         auto gather = std::make_shared<opset8::Gather>(param,

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/input_noreorder_eltwise_bf16.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/input_noreorder_eltwise_bf16.cpp
@@ -17,7 +17,7 @@ class InputNoReorderEltwiseBF16 : virtual public LayerTestsUtils::LayerTestsComm
 protected:
     void SetUp() override {
         auto netPrecision = inPrc = Precision::FP32;
-        outPrc = Precision::BF16;
+        outPrc = std::vector<Precision>(Precision::BF16);
         targetDevice = CommonTestUtils::DEVICE_CPU;
         std::map<std::string, std::string> additional_config{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}};
         configuration.insert(additional_config.begin(), additional_config.end());

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/input_noreorder_eltwise_bf16.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/input_noreorder_eltwise_bf16.cpp
@@ -16,8 +16,9 @@ class InputNoReorderEltwiseBF16 : virtual public LayerTestsUtils::LayerTestsComm
                                   public CPUTestsBase {
 protected:
     void SetUp() override {
-        auto netPrecision = inPrc = Precision::FP32;
-        outPrc = std::vector<Precision>(Precision::BF16);
+        auto netPrecision = Precision::FP32;
+        inPrc.front() = Precision::FP32;
+        outPrc.front() = Precision::BF16;
         targetDevice = CommonTestUtils::DEVICE_CPU;
         std::map<std::string, std::string> additional_config{{PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO}};
         configuration.insert(additional_config.begin(), additional_config.end());

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/not_fused_conv_simple_op.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/not_fused_conv_simple_op.cpp
@@ -17,7 +17,8 @@ protected:
 
         auto inputParams = builder::makeParams(element::f32, {{1, 3, 12, 9}, {1, 16, 12, 9}});
         auto paramOuts = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(inputParams));
-
+        outPrc.front() = InferenceEngine::Precision::FP32;
+        outPrc.push_back(InferenceEngine::Precision::FP32);
         std::shared_ptr<Node> conv;
         {
             const std::vector<size_t> kernelSize = {3, 3};

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/param_result_custom_blob.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/param_result_custom_blob.cpp
@@ -47,7 +47,7 @@ TEST_P(ParameterResultCustomBlobTest, CompareWithRefs) {
 
     // Just to show that it is not possible to set different precisions for inputs and outputs with the same name.
     // If it was possible, the input would have I8 precision and couldn't store data from the custom blob.
-    inPrc = Precision::I8;
+    inPrc.front() = Precision::I8;
     outPrc.front() = Precision::FP32;
 
     Run();

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/param_result_custom_blob.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/param_result_custom_blob.cpp
@@ -48,7 +48,7 @@ TEST_P(ParameterResultCustomBlobTest, CompareWithRefs) {
     // Just to show that it is not possible to set different precisions for inputs and outputs with the same name.
     // If it was possible, the input would have I8 precision and couldn't store data from the custom blob.
     inPrc = Precision::I8;
-    outPrc = Precision::FP32;
+    outPrc.push_back(Precision::FP32);
 
     Run();
 }

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/param_result_custom_blob.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/param_result_custom_blob.cpp
@@ -48,7 +48,7 @@ TEST_P(ParameterResultCustomBlobTest, CompareWithRefs) {
     // Just to show that it is not possible to set different precisions for inputs and outputs with the same name.
     // If it was possible, the input would have I8 precision and couldn't store data from the custom blob.
     inPrc = Precision::I8;
-    outPrc.push_back(Precision::FP32);
+    outPrc.front() = Precision::FP32;
 
     Run();
 }

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/tile_with_two_output_edges.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/tile_with_two_output_edges.cpp
@@ -18,7 +18,8 @@ protected:
         auto ngPrc = element::f32;
         auto inputParams = builder::makeParams(ngPrc, {{1, 3, 12, 9}});
         auto paramOuts = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(inputParams));
-
+        outPrc.front() = InferenceEngine::Precision::FP32;
+        outPrc.push_back(InferenceEngine::Precision::FP32);
         auto tile = ngraph::builder::makeTile(paramOuts[0], std::vector<int64_t>{1, 2, 1, 1});
 
         const auto const1 = ngraph::builder::makeConstant(ngPrc, std::vector<size_t>{1, 6, 1, 1}, std::vector<float>{}, true);

--- a/src/tests/functional/plugin/gna/pass_tests/4d_eltwise.cpp
+++ b/src/tests/functional/plugin/gna/pass_tests/4d_eltwise.cpp
@@ -54,7 +54,7 @@ class Eltwise4dBroadcast : public testing::WithParamInterface<eltwiseParams>,
             ngraph::helpers::EltwiseTypes eltwiseType;
             std::tie(netPrecision, targetDevice, configuration, eltwiseType) = this->GetParam();
             auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-            outPrc.push_back(InferenceEngine::Precision::FP32);
+            outPrc.front() = InferenceEngine::Precision::FP32;
 
             auto params = ngraph::builder::makeParams(ngPrc, { {1, 72} });
 
@@ -101,7 +101,7 @@ protected:
         std::tie(netPrecision, targetDevice, configuration, eltwiseType) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
-        outPrc.push_back(InferenceEngine::Precision::FP32);
+        outPrc.front() = InferenceEngine::Precision::FP32;
 
         auto params = ngraph::builder::makeParams(ngPrc, { {1, 72}, {1, 72} });
 

--- a/src/tests/functional/plugin/gna/pass_tests/4d_eltwise.cpp
+++ b/src/tests/functional/plugin/gna/pass_tests/4d_eltwise.cpp
@@ -54,8 +54,7 @@ class Eltwise4dBroadcast : public testing::WithParamInterface<eltwiseParams>,
             ngraph::helpers::EltwiseTypes eltwiseType;
             std::tie(netPrecision, targetDevice, configuration, eltwiseType) = this->GetParam();
             auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-
-            outPrc = InferenceEngine::Precision::FP32;
+            outPrc.push_back(InferenceEngine::Precision::FP32);
 
             auto params = ngraph::builder::makeParams(ngPrc, { {1, 72} });
 
@@ -102,7 +101,7 @@ protected:
         std::tie(netPrecision, targetDevice, configuration, eltwiseType) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
-        outPrc = InferenceEngine::Precision::FP32;
+        outPrc.push_back(InferenceEngine::Precision::FP32);
 
         auto params = ngraph::builder::makeParams(ngPrc, { {1, 72}, {1, 72} });
 

--- a/src/tests/functional/plugin/gna/pass_tests/insert_copy_layer_before_self_concat.cpp
+++ b/src/tests/functional/plugin/gna/pass_tests/insert_copy_layer_before_self_concat.cpp
@@ -66,7 +66,7 @@ protected:
         std::vector<size_t> inputShape;
         size_t inputsNum, concatsNum;
         InferenceEngine::Precision netPrecision;
-        std::tie(axis, inputShape, inputsNum, concatsNum, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = this->GetParam();
+        std::tie(axis, inputShape, inputsNum, concatsNum, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
         ngraph::OutputVector concatInputs;

--- a/src/tests/functional/plugin/gna/pass_tests/insert_copy_layer_before_self_concat.cpp
+++ b/src/tests/functional/plugin/gna/pass_tests/insert_copy_layer_before_self_concat.cpp
@@ -67,7 +67,7 @@ protected:
         size_t inputsNum, concatsNum;
         InferenceEngine::Precision netPrecision;
         std::tie(axis, inputShape, inputsNum, concatsNum, netPrecision, inPrc.front(), outPrc.front(),
-                inLayout, outLayout.front(), targetDevice) = this->GetParam();
+                inLayout.front(), outLayout.front(), targetDevice) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
         ngraph::OutputVector concatInputs;

--- a/src/tests/functional/plugin/gna/pass_tests/insert_copy_layer_before_self_concat.cpp
+++ b/src/tests/functional/plugin/gna/pass_tests/insert_copy_layer_before_self_concat.cpp
@@ -66,7 +66,8 @@ protected:
         std::vector<size_t> inputShape;
         size_t inputsNum, concatsNum;
         InferenceEngine::Precision netPrecision;
-        std::tie(axis, inputShape, inputsNum, concatsNum, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
+        std::tie(axis, inputShape, inputsNum, concatsNum, netPrecision, inPrc.front(), outPrc.front(),
+                inLayout, outLayout.front(), targetDevice) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
         ngraph::OutputVector concatInputs;

--- a/src/tests/functional/plugin/gna/pass_tests/insert_copy_layer_before_self_concat.cpp
+++ b/src/tests/functional/plugin/gna/pass_tests/insert_copy_layer_before_self_concat.cpp
@@ -66,7 +66,7 @@ protected:
         std::vector<size_t> inputShape;
         size_t inputsNum, concatsNum;
         InferenceEngine::Precision netPrecision;
-        std::tie(axis, inputShape, inputsNum, concatsNum, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
+        std::tie(axis, inputShape, inputsNum, concatsNum, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
         ngraph::OutputVector concatInputs;

--- a/src/tests/functional/plugin/gna/preprocess_tests/precision_convert.cpp
+++ b/src/tests/functional/plugin/gna/preprocess_tests/precision_convert.cpp
@@ -48,7 +48,7 @@ protected:
         abs_threshold = std::numeric_limits<int32_t>::max();
         rel_threshold = std::numeric_limits<int32_t>::max();
 
-        std::tie(net_type, inType, outType[0], targetDevice, conf) = this->GetParam();
+        std::tie(net_type, inType[0], outType[0], targetDevice, conf) = this->GetParam();
 
         configuration.insert(conf.begin(), conf.end());
 

--- a/src/tests/functional/plugin/gna/preprocess_tests/precision_convert.cpp
+++ b/src/tests/functional/plugin/gna/preprocess_tests/precision_convert.cpp
@@ -48,7 +48,7 @@ protected:
         abs_threshold = std::numeric_limits<int32_t>::max();
         rel_threshold = std::numeric_limits<int32_t>::max();
 
-        std::tie(net_type, inType, outType, targetDevice, conf) = this->GetParam();
+        std::tie(net_type, inType, outType[0], targetDevice, conf) = this->GetParam();
 
         configuration.insert(conf.begin(), conf.end());
 

--- a/src/tests/functional/plugin/gpu/behavior/infer_request.cpp
+++ b/src/tests/functional/plugin/gpu/behavior/infer_request.cpp
@@ -71,7 +71,7 @@ void InferRequestIOPrecision::SetUp() {
     InferenceEngine::Precision netPrecision;
     std::vector<size_t> shape;
     std::tie(netPrecision, inLayout, outLayout, shape, targetDevice) = GetParam();
-    inPrc = netPrecision;
+    inPrc.front() = netPrecision;
     outPrc.front() = netPrecision;
 
     float clamp_min = netPrecision.isSigned() ? -5.f : 0.0f;

--- a/src/tests/functional/plugin/gpu/behavior/infer_request.cpp
+++ b/src/tests/functional/plugin/gpu/behavior/infer_request.cpp
@@ -70,7 +70,7 @@ std::string InferRequestIOPrecision::getTestCaseName(const testing::TestParamInf
 void InferRequestIOPrecision::SetUp() {
     InferenceEngine::Precision netPrecision;
     std::vector<size_t> shape;
-    std::tie(netPrecision, inLayout, outLayout.front(), shape, targetDevice) = GetParam();
+    std::tie(netPrecision, inLayout.front(), outLayout.front(), shape, targetDevice) = GetParam();
     inPrc.front() = netPrecision;
     outPrc.front() = netPrecision;
 

--- a/src/tests/functional/plugin/gpu/behavior/infer_request.cpp
+++ b/src/tests/functional/plugin/gpu/behavior/infer_request.cpp
@@ -72,7 +72,7 @@ void InferRequestIOPrecision::SetUp() {
     std::vector<size_t> shape;
     std::tie(netPrecision, inLayout, outLayout, shape, targetDevice) = GetParam();
     inPrc = netPrecision;
-    outPrc = netPrecision;
+    outPrc.front() = netPrecision;
 
     float clamp_min = netPrecision.isSigned() ? -5.f : 0.0f;
     float clamp_max = 5.0f;

--- a/src/tests/functional/plugin/gpu/behavior/infer_request.cpp
+++ b/src/tests/functional/plugin/gpu/behavior/infer_request.cpp
@@ -70,7 +70,7 @@ std::string InferRequestIOPrecision::getTestCaseName(const testing::TestParamInf
 void InferRequestIOPrecision::SetUp() {
     InferenceEngine::Precision netPrecision;
     std::vector<size_t> shape;
-    std::tie(netPrecision, inLayout, outLayout, shape, targetDevice) = GetParam();
+    std::tie(netPrecision, inLayout, outLayout.front(), shape, targetDevice) = GetParam();
     inPrc.front() = netPrecision;
     outPrc.front() = netPrecision;
 

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/topk.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/topk.cpp
@@ -15,6 +15,11 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP16
 };
 
+const std::vector<std::vector<InferenceEngine::Precision>> outPrecisions = {
+        {InferenceEngine::Precision::FP16, InferenceEngine::Precision::I32},
+        {InferenceEngine::Precision::FP32, InferenceEngine::Precision::I32}
+};
+
 const std::vector<int64_t> axes = {
         0,
         1,
@@ -46,7 +51,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_TopK, TopKLayerTest,
                 ::testing::ValuesIn(sortTypes),
                 ::testing::ValuesIn(netPrecisions),
                 ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                ::testing::ValuesIn(outPrecisions),
                 ::testing::Values(InferenceEngine::Layout::ANY),
                 ::testing::Values(std::vector<size_t>({10, 10, 10})),
                 ::testing::Values(CommonTestUtils::DEVICE_GPU)),

--- a/src/tests/functional/plugin/gpu/single_layer_tests/convolution.cpp
+++ b/src/tests/functional/plugin/gpu/single_layer_tests/convolution.cpp
@@ -74,7 +74,7 @@ protected:
         convSpecificParams convParams;
         InputShape inputShape;
         auto netType = ElementType::undefined;
-        std::tie(convParams, netType, inType, outType[0], inputShape, targetDevice) = this->GetParam();
+        std::tie(convParams, netType, inType[0], outType[0], inputShape, targetDevice) = this->GetParam();
 
         init_input_shapes({inputShape});
 
@@ -84,7 +84,7 @@ protected:
         size_t convOutChannels;
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convParams;
 
-        auto inputParams = ngraph::builder::makeDynamicParams(inType, inputDynamicShapes);
+        auto inputParams = ngraph::builder::makeDynamicParams(inType[0], inputDynamicShapes);
         auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParams));
 
         auto convolutionNode = ngraph::builder::makeConvolution(paramOuts.front(), netType, kernel, stride, padBegin,

--- a/src/tests/functional/plugin/gpu/single_layer_tests/convolution.cpp
+++ b/src/tests/functional/plugin/gpu/single_layer_tests/convolution.cpp
@@ -74,7 +74,7 @@ protected:
         convSpecificParams convParams;
         InputShape inputShape;
         auto netType = ElementType::undefined;
-        std::tie(convParams, netType, inType, outType, inputShape, targetDevice) = this->GetParam();
+        std::tie(convParams, netType, inType, outType[0], inputShape, targetDevice) = this->GetParam();
 
         init_input_shapes({inputShape});
 

--- a/src/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/logical.cpp
+++ b/src/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/logical.cpp
@@ -24,7 +24,7 @@ protected:
     void SetUp() override {
         SetupParams();
 
-        auto ngInputsPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+        auto ngInputsPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc[0]);
         auto inputs = ngraph::builder::makeParams(ngInputsPrc, {inputShapes.first, logicalOpType != ngraph::helpers::LogicalTypes::LOGICAL_NOT ?
                                                                                    inputShapes.second : ngraph::Shape()});
         ngraph::NodeVector convertedInputs;

--- a/src/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/topk.cpp
+++ b/src/tests/functional/plugin/myriad/shared_tests_instances/single_layer_tests/topk.cpp
@@ -15,6 +15,11 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
         InferenceEngine::Precision::FP16
 };
 
+const std::vector<std::vector<InferenceEngine::Precision>> outPrecisions = {
+        {InferenceEngine::Precision::FP16, InferenceEngine::Precision::I32},
+        {InferenceEngine::Precision::FP32, InferenceEngine::Precision::I32}
+};
+
 const std::vector<int64_t> axes = {
         0,
         1,
@@ -48,7 +53,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_TopK_IndicesValuesSort, TopKLayerTest,
             ::testing::ValuesIn(sortTypes),
             ::testing::ValuesIn(netPrecisions),
             ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+            ::testing::ValuesIn(outPrecisions),
             ::testing::Values(InferenceEngine::Layout::ANY),
             ::testing::Values(std::vector<size_t>({10, 10, 10})),
             ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),
@@ -62,7 +67,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_TopK_NoneSort, TopKLayerTest,
             ::testing::Values(ngraph::opset5::TopK::SortType::NONE),
             ::testing::ValuesIn(netPrecisions),
             ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+            ::testing::ValuesIn(outPrecisions),
             ::testing::Values(InferenceEngine::Layout::ANY),
             ::testing::Values(std::vector<size_t>({10, 10, 10})),
             ::testing::Values(CommonTestUtils::DEVICE_MYRIAD)),

--- a/src/tests/functional/plugin/myriad/single_layer_tests/out_shape_of_reshape.cpp
+++ b/src/tests/functional/plugin/myriad/single_layer_tests/out_shape_of_reshape.cpp
@@ -60,7 +60,7 @@ protected:
         OutShapeOfReshapeParam shapesParam;
         std::tie(shapesParam, targetDevice) = this->GetParam();
         inPrc = InferenceEngine::Precision::I32;
-        outPrc.push_back(InferenceEngine::Precision::I32);
+        outPrc.front() = InferenceEngine::Precision::I32;
 
         const auto& inputShape = std::get<0>(shapesParam);
         const auto& outShapeDescriptor = std::get<1>(shapesParam);

--- a/src/tests/functional/plugin/myriad/single_layer_tests/out_shape_of_reshape.cpp
+++ b/src/tests/functional/plugin/myriad/single_layer_tests/out_shape_of_reshape.cpp
@@ -60,7 +60,7 @@ protected:
         OutShapeOfReshapeParam shapesParam;
         std::tie(shapesParam, targetDevice) = this->GetParam();
         inPrc = InferenceEngine::Precision::I32;
-        outPrc = InferenceEngine::Precision::I32;
+        outPrc.push_back(InferenceEngine::Precision::I32);
 
         const auto& inputShape = std::get<0>(shapesParam);
         const auto& outShapeDescriptor = std::get<1>(shapesParam);

--- a/src/tests/functional/plugin/myriad/single_layer_tests/out_shape_of_reshape.cpp
+++ b/src/tests/functional/plugin/myriad/single_layer_tests/out_shape_of_reshape.cpp
@@ -59,14 +59,14 @@ protected:
 
         OutShapeOfReshapeParam shapesParam;
         std::tie(shapesParam, targetDevice) = this->GetParam();
-        inPrc = InferenceEngine::Precision::I32;
+        inPrc.front() = InferenceEngine::Precision::I32;
         outPrc.front() = InferenceEngine::Precision::I32;
 
         const auto& inputShape = std::get<0>(shapesParam);
         const auto& outShapeDescriptor = std::get<1>(shapesParam);
         const auto& specialZero = std::get<2>(shapesParam);
 
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc[0]);
 
         const auto inputShapeParam = std::make_shared<ngraph::opset3::Parameter>(
                 ngPrc, ngraph::Shape{inputShape.size()});

--- a/src/tests/functional/plugin/myriad/single_layer_tests/static_shape_broadcast.cpp
+++ b/src/tests/functional/plugin/myriad/single_layer_tests/static_shape_broadcast.cpp
@@ -63,7 +63,7 @@ protected:
 
         StaticShapeBroadcastParam shapes;
         std::tie(shapes, inPrc, targetDevice) = this->GetParam();
-        outPrc.push_back(inPrc);
+        outPrc.front() = inPrc;
 
         const auto inputShape = std::get<0>(shapes);
         const auto targetShape = std::get<1>(shapes);

--- a/src/tests/functional/plugin/myriad/single_layer_tests/static_shape_broadcast.cpp
+++ b/src/tests/functional/plugin/myriad/single_layer_tests/static_shape_broadcast.cpp
@@ -62,15 +62,15 @@ protected:
         configuration[InferenceEngine::MYRIAD_DETECT_NETWORK_BATCH] = CONFIG_VALUE(NO);
 
         StaticShapeBroadcastParam shapes;
-        std::tie(shapes, inPrc, targetDevice) = this->GetParam();
-        outPrc.front() = inPrc;
+        std::tie(shapes, inPrc.front(), targetDevice) = this->GetParam();
+        outPrc.front() = inPrc[0];
 
         const auto inputShape = std::get<0>(shapes);
         const auto targetShape = std::get<1>(shapes);
         const auto axesMapping = std::get<2>(shapes);
         const auto mode = std::get<3>(shapes);
 
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc[0]);
 
         const auto inputParam = std::make_shared<ngraph::opset3::Parameter>(
                 ngPrc, ngraph::Shape(inputShape));

--- a/src/tests/functional/plugin/myriad/single_layer_tests/static_shape_broadcast.cpp
+++ b/src/tests/functional/plugin/myriad/single_layer_tests/static_shape_broadcast.cpp
@@ -63,7 +63,7 @@ protected:
 
         StaticShapeBroadcastParam shapes;
         std::tie(shapes, inPrc, targetDevice) = this->GetParam();
-        outPrc = inPrc;
+        outPrc.push_back(inPrc);
 
         const auto inputShape = std::get<0>(shapes);
         const auto targetShape = std::get<1>(shapes);

--- a/src/tests/functional/plugin/myriad/single_layer_tests/static_shape_nms.cpp
+++ b/src/tests/functional/plugin/myriad/single_layer_tests/static_shape_nms.cpp
@@ -62,7 +62,7 @@ protected:
         SetRefMode(LayerTestsUtils::RefMode::INTERPRETER);
 
         StaticShapeNMSParam NMSParams;
-        std::tie(NMSParams, inPrc, targetDevice) = this->GetParam();
+        std::tie(NMSParams, inPrc.front(), targetDevice) = this->GetParam();
 
         const auto numBatches = std::get<0>(NMSParams);
         const auto numBoxes = std::get<1>(NMSParams);
@@ -72,7 +72,7 @@ protected:
         const auto scoreThreshold = std::get<5>(NMSParams);
         const auto softNMSSigma = std::get<6>(NMSParams);
 
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc[0]);
 
         const auto inputBoxes = std::make_shared<ngraph::opset3::Parameter>(
                 ngPrc, ngraph::Shape({static_cast<size_t>(numBatches), static_cast<size_t>(numBoxes), 4}));

--- a/src/tests/functional/plugin/myriad/single_layer_tests/static_shape_nonzero.cpp
+++ b/src/tests/functional/plugin/myriad/single_layer_tests/static_shape_nonzero.cpp
@@ -49,8 +49,8 @@ protected:
         configuration[InferenceEngine::MYRIAD_DISABLE_REORDER] = CONFIG_VALUE(YES);
 
         InferenceEngine::SizeVector inputShape;
-        std::tie(inputShape, inPrc, targetDevice) = this->GetParam();
-        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+        std::tie(inputShape, inPrc.front(), targetDevice) = this->GetParam();
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc[0]);
 
         const auto input = std::make_shared<ngraph::opset3::Parameter>(ngPrc, ngraph::Shape(inputShape));
         const auto staticShapeNonZero = std::make_shared<ngraph::vpu::op::StaticShapeNonZero>(input, ngraph::element::i32);

--- a/src/tests/functional/plugin/myriad/single_layer_tests/static_shape_nonzero.cpp
+++ b/src/tests/functional/plugin/myriad/single_layer_tests/static_shape_nonzero.cpp
@@ -57,7 +57,7 @@ protected:
         ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(staticShapeNonZero->output(0)),
                 std::make_shared<ngraph::opset3::Result>(staticShapeNonZero->output(1))};
         function = std::make_shared<ngraph::Function>(results, ngraph::ParameterVector{input});
-        outPrc = InferenceEngine::Precision::I32;
+        outPrc = std::vector<InferenceEngine::Precision>(InferenceEngine::Precision::I32);
     }
 
     InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo &info) const override {

--- a/src/tests/functional/plugin/myriad/subgraph_tests/dsr_gather.cpp
+++ b/src/tests/functional/plugin/myriad/subgraph_tests/dsr_gather.cpp
@@ -69,7 +69,7 @@ protected:
         const auto& idxType = std::get<1>(parameters);
         const auto& gatherSetup = std::get<2>(parameters);
         targetDevice = std::get<3>(parameters);
-        outPrc = InferenceEngine::details::convertPrecision(inDataType);;
+        outPrc.push_back(InferenceEngine::details::convertPrecision(inDataType));
 
         const auto dataParam = std::make_shared<ngraph::opset3::Parameter>(inDataType, gatherSetup.inputShapes.shape);
         m_parameterVector.push_back(dataParam);

--- a/src/tests/functional/plugin/myriad/subgraph_tests/dsr_gather.cpp
+++ b/src/tests/functional/plugin/myriad/subgraph_tests/dsr_gather.cpp
@@ -69,7 +69,7 @@ protected:
         const auto& idxType = std::get<1>(parameters);
         const auto& gatherSetup = std::get<2>(parameters);
         targetDevice = std::get<3>(parameters);
-        outPrc.push_back(InferenceEngine::details::convertPrecision(inDataType));
+        outPrc.front() = InferenceEngine::details::convertPrecision(inDataType);
 
         const auto dataParam = std::make_shared<ngraph::opset3::Parameter>(inDataType, gatherSetup.inputShapes.shape);
         m_parameterVector.push_back(dataParam);

--- a/src/tests/functional/plugin/myriad/subgraph_tests/dsr_reduce.cpp
+++ b/src/tests/functional/plugin/myriad/subgraph_tests/dsr_reduce.cpp
@@ -90,7 +90,7 @@ protected:
         // CNNNetworkNGraphImpl handles only I64, I32 and FP32 precisions and sets FP32 as default otherwise.
         // Set I32 explicitly.
         if (dataType == ngraph::element::boolean) {
-            outPrc = InferenceEngine::Precision::I32;
+            outPrc.push_back(InferenceEngine::Precision::I32);
         }
 
         return reduce;

--- a/src/tests/functional/plugin/myriad/subgraph_tests/dsr_reduce.cpp
+++ b/src/tests/functional/plugin/myriad/subgraph_tests/dsr_reduce.cpp
@@ -90,7 +90,7 @@ protected:
         // CNNNetworkNGraphImpl handles only I64, I32 and FP32 precisions and sets FP32 as default otherwise.
         // Set I32 explicitly.
         if (dataType == ngraph::element::boolean) {
-            outPrc.push_back(InferenceEngine::Precision::I32);
+            outPrc.front() = InferenceEngine::Precision::I32;
         }
 
         return reduce;

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/preprocessing.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/preprocessing.hpp
@@ -92,6 +92,7 @@ public:
         std::vector<size_t> inputShape(channels, 4);
 
         auto make_ngraph = [&](bool with_extra_conv) {
+            InferenceEngine::Precision nPrc = inPrc[0];
             auto in_prec =
                     FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(with_extra_conv ? nPrc : decltype(nPrc)(InferenceEngine::Precision::FP32));
             auto paramsIn = ngraph::builder::makeParams(in_prec, {inputShape});

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/preprocessing.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/preprocessing.hpp
@@ -83,7 +83,7 @@ public:
         SetRefMode(LayerTestsUtils::RefMode::INTERPRETER);
 
         std::tie(inPrc, channels, use_set_input, targetDevice, configuration) = this->GetParam();
-        outPrc = inPrc;
+        outPrc.front() = inPrc;
 
         bool specialZero = true;
 

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/preprocessing.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/preprocessing.hpp
@@ -82,9 +82,10 @@ public:
 
         SetRefMode(LayerTestsUtils::RefMode::INTERPRETER);
 
-        std::tie(inPrc.front(), channels, use_set_input, targetDevice, configuration) = this->GetParam();
-        outPrc.front() = inPrc.front();
-        auto nPrc = inPrc.front();
+        InferenceEngine::Precision nPrc;
+        std::tie(nPrc, channels, use_set_input, targetDevice, configuration) = this->GetParam();
+        inPrc.front() = nPrc;
+        outPrc.front() = nPrc;
 
         bool specialZero = true;
 

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/preprocessing.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/preprocessing.hpp
@@ -82,15 +82,17 @@ public:
 
         SetRefMode(LayerTestsUtils::RefMode::INTERPRETER);
 
-        std::tie(inPrc, channels, use_set_input, targetDevice, configuration) = this->GetParam();
-        outPrc.front() = inPrc;
+        std::tie(inPrc.front(), channels, use_set_input, targetDevice, configuration) = this->GetParam();
+        outPrc.front() = inPrc.front();
+        auto nPrc = inPrc.front();
 
         bool specialZero = true;
 
         std::vector<size_t> inputShape(channels, 4);
 
         auto make_ngraph = [&](bool with_extra_conv) {
-            auto in_prec = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(with_extra_conv ? inPrc : decltype(inPrc)(InferenceEngine::Precision::FP32));
+            auto in_prec =
+                    FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(with_extra_conv ? nPrc : decltype(nPrc)(InferenceEngine::Precision::FP32));
             auto paramsIn = ngraph::builder::makeParams(in_prec, {inputShape});
             auto paramIn = ngraph::helpers::convert2OutputVector(
                     ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));

--- a/src/tests/functional/plugin/shared/src/behavior/infer_request/set_io_blob_precision.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/infer_request/set_io_blob_precision.cpp
@@ -81,12 +81,14 @@ void SetBlobTest::Infer() {
     }
 
     if (type == setType::OUTPUT || type == setType::BOTH) {
+        int outputCnt = 0;
         for (const auto &output : executableNetwork.GetOutputsInfo()) {
             const auto &info = output.second;
-            Blob::Ptr outBlob = make_blob_with_precision(outPrc, info->getTensorDesc());
+            Blob::Ptr outBlob = make_blob_with_precision(outPrc[outputCnt], info->getTensorDesc());
             outBlob->allocate();
             fillBlob(outBlob);
             inferRequest.SetBlob(info->getName(), outBlob);
+            outputCnt++;
         }
     }
 
@@ -101,7 +103,7 @@ void SetBlobTest::SetUp() {
     if (type == setType::INPUT || type == setType::BOTH)
         inPrc = precNet;
     if (type == setType::OUTPUT || type == setType::BOTH)
-        outPrc = precNet;
+        outPrc.front() = precNet;
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(precNg);
     auto params = ngraph::builder::makeParams(ngPrc, {IS});

--- a/src/tests/functional/plugin/shared/src/behavior/infer_request/set_io_blob_precision.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/infer_request/set_io_blob_precision.cpp
@@ -70,7 +70,7 @@ void SetBlobTest::Infer() {
         const auto &info = input.second;
         Blob::Ptr inBlob;
         if (type == setType::INPUT || type == setType::BOTH) {
-            inBlob = make_blob_with_precision(inPrc, info->getTensorDesc());
+            inBlob = make_blob_with_precision(inPrc[0], info->getTensorDesc());
             inBlob->allocate();
             fillBlob(inBlob);
         } else {
@@ -81,14 +81,12 @@ void SetBlobTest::Infer() {
     }
 
     if (type == setType::OUTPUT || type == setType::BOTH) {
-        int outputCnt = 0;
         for (const auto &output : executableNetwork.GetOutputsInfo()) {
             const auto &info = output.second;
-            Blob::Ptr outBlob = make_blob_with_precision(outPrc[outputCnt], info->getTensorDesc());
+            Blob::Ptr outBlob = make_blob_with_precision(outPrc[0], info->getTensorDesc());
             outBlob->allocate();
             fillBlob(outBlob);
             inferRequest.SetBlob(info->getName(), outBlob);
-            outputCnt++;
         }
     }
 
@@ -101,7 +99,7 @@ void SetBlobTest::SetUp() {
     std::tie(precNet, precNg, type, targetDevice) = this->GetParam();
 
     if (type == setType::INPUT || type == setType::BOTH)
-        inPrc = precNet;
+        inPrc.front() = precNet;
     if (type == setType::OUTPUT || type == setType::BOTH)
         outPrc.front() = precNet;
 

--- a/src/tests/functional/plugin/shared/src/behavior/plugin/hetero_synthetic.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/plugin/hetero_synthetic.cpp
@@ -109,6 +109,9 @@ std::string HeteroSyntheticTest::getTestCaseName(const ::testing::TestParamInfo<
 
 void HeteroSyntheticTest::SetUp() {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    InferenceEngine::Precision netPrecision;
+    outPrc.front() = netPrecision;
+    outPrc.push_back(netPrecision);
     auto& param = GetParam();
     targetDevice = "HETERO:";
     int num = std::get<Plugin>(param).size() - 1;

--- a/src/tests/functional/plugin/shared/src/behavior/plugin/hetero_synthetic.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/plugin/hetero_synthetic.cpp
@@ -109,9 +109,6 @@ std::string HeteroSyntheticTest::getTestCaseName(const ::testing::TestParamInfo<
 
 void HeteroSyntheticTest::SetUp() {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
-    InferenceEngine::Precision netPrecision;
-    outPrc.front() = netPrecision;
-    outPrc.push_back(netPrecision);
     auto& param = GetParam();
     targetDevice = "HETERO:";
     int num = std::get<Plugin>(param).size() - 1;

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_child_and_output.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_child_and_output.cpp
@@ -51,7 +51,8 @@ void ConcatWithChildAndOutputTransformation::SetUp() {
     ConcatWithChildAndOutputTransformationParam param;
     ngraph::pass::low_precision::LayerTransformation::Params params;
     std::tie(netPrecision, inputShapes, targetDevice, param, params) = this->GetParam();
-
+    outPrc.front() = InferenceEngine::details::convertPrecision(netPrecision);
+    outPrc.push_back(InferenceEngine::details::convertPrecision(netPrecision));
     function = ngraph::builder::subgraph::ConcatFunction::getOriginalWithChildAndOutput(
         netPrecision, inputShapes, param.fqOnData1, param.fqOnData2);
 }

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_different_precision_on_children.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_different_precision_on_children.cpp
@@ -53,7 +53,8 @@ void ConcatWithDifferentChildrenTransformation::SetUp() {
     ConcatWithDifferentChildrenTransformationParam param;
     ngraph::pass::low_precision::LayerTransformation::Params params;
     std::tie(netPrecision, inputShapes, targetDevice, param, params) = this->GetParam();
-
+    outPrc.front() = InferenceEngine::details::convertPrecision(netPrecision);
+    outPrc.push_back(InferenceEngine::details::convertPrecision(netPrecision));
     function = ngraph::builder::subgraph::ConcatFunction::getOriginalWithDifferentPrecisionOnChildren(
         netPrecision, inputShapes, param.axis, param.fqOnData1, param.fqOnData2);
 }

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_intermediate_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_intermediate_transformation.cpp
@@ -65,7 +65,8 @@ void ConcatWithIntermediateTransformation::SetUp() {
     bool transparentIntermediate;
     bool multichannel;
     std::tie(ngPrecision, inputShape, targetDevice, trasformationParams, transparentIntermediate, multichannel) = this->GetParam();
-
+    outPrc.front() = InferenceEngine::details::convertPrecision(ngPrecision);
+    outPrc.push_back(InferenceEngine::details::convertPrecision(ngPrecision));
     function = ngraph::builder::subgraph::ConcatFunction::getOriginalWithIntermediate(
         ngPrecision,
         inputShape,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_neighbors_graph_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_neighbors_graph_transformation.cpp
@@ -46,7 +46,8 @@ void ConcatWithNeighborsGraphTransformation::SetUp() {
     ngraph::PartialShape inputShape;
     ngraph::pass::low_precision::LayerTransformation::Params params;
     std::tie(ngPrecision, inputShape, targetDevice, params) = this->GetParam();
-
+    outPrc.front() = InferenceEngine::details::convertPrecision(ngPrecision);
+    outPrc.push_back(InferenceEngine::details::convertPrecision(ngPrecision));
     function = ngraph::builder::subgraph::ConcatFunction::getOriginalWithNeighbors(
         ngPrecision,
         inputShape,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_split_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/concat_with_split_transformation.cpp
@@ -58,7 +58,8 @@ void ConcatWithSplitTransformation::SetUp() {
     ConcatWithSplitTransformationParam param;
     ngraph::pass::low_precision::LayerTransformation::Params params;
     std::tie(netPrecision, inputShapes, targetDevice, param, params) = this->GetParam();
-
+    outPrc.front() = InferenceEngine::details::convertPrecision(netPrecision);
+    outPrc.push_back(InferenceEngine::details::convertPrecision(netPrecision));
     function = ngraph::builder::subgraph::ConcatFunction::getOriginalWithSplitedIntermediate(
         netPrecision,
         inputShapes,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_to_group_convolution_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_to_group_convolution_transformation.cpp
@@ -44,7 +44,8 @@ void MultiplyToGroupConvolutionTransformation::SetUp() {
     ngraph::element::Type precision;
     MultiplyToGroupConvolutionTransformationParam param;
     std::tie(precision, shape, targetDevice, param) = this->GetParam();
-
+    outPrc.front() = InferenceEngine::details::convertPrecision(precision);
+    outPrc.push_back(InferenceEngine::details::convertPrecision(precision));
     function = ngraph::builder::subgraph::MultiplyToGroupConvolutionFunction::getOriginal(
         precision,
         shape,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/output_layers_handling_in_transformations.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/output_layers_handling_in_transformations.cpp
@@ -51,6 +51,8 @@ void OutputLayersHandlingInTransformations::SetUp() {
     InferenceEngine::Precision netPrecision;
     ngraph::pass::low_precision::LayerTransformation::Params params;
     std::tie(netPrecision, inputShape, targetDevice, params) = this->GetParam();
+    outPrc.front() = netPrecision;
+    outPrc.push_back(netPrecision);
     auto ngPrecision = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     const auto input = std::make_shared<ngraph::opset1::Parameter>(ngPrecision, ngraph::Shape(inputShape));

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/split_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/split_transformation.cpp
@@ -51,7 +51,10 @@ void SplitTransformation::SetUp() {
     ngraph::pass::low_precision::LayerTransformation::Params params;
     SplitTransformationParam param;
     std::tie(precision, inputShape, targetDevice, params, param) = this->GetParam();
-
+    outPrc.front() = InferenceEngine::details::convertPrecision(precision);
+    for (int i = 1; i < param.numSplit; i++) {
+        outPrc.push_back(InferenceEngine::details::convertPrecision(precision));
+    }
     function = ngraph::builder::subgraph::SplitFunction::getOriginal(
         precision,
         inputShape,

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/variadic_split_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/variadic_split_transformation.cpp
@@ -58,7 +58,10 @@ void VariadicSplitTransformation::SetUp() {
     ngraph::pass::low_precision::LayerTransformation::Params params;
     VariadicSplitTransformationParam param;
     std::tie(precision, inputShape, targetDevice, params, param) = this->GetParam();
-
+    outPrc.front() = InferenceEngine::details::convertPrecision(precision);
+    for (int i = 1; i < param.splitLengths.size(); i++) {
+        outPrc.push_back(InferenceEngine::details::convertPrecision(precision));
+    }
     function = ngraph::builder::subgraph::VariadicSplitFunction::getOriginal(
         precision,
         inputShape,

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -157,10 +157,10 @@ protected:
     std::shared_ptr<ngraph::Function> functionRefs;
     std::map<std::string, std::string> configuration;
     // Non default values of layouts/precisions will be set to CNNNetwork
-    std::vector<InferenceEngine::Layout> inLayout = { InferenceEngine::Layout::ANY };
-    std::vector<InferenceEngine::Layout> outLayout = { InferenceEngine::Layout::ANY };
-    std::vector<InferenceEngine::Precision> inPrc = { InferenceEngine::Precision::UNSPECIFIED };
-    std::vector<InferenceEngine::Precision> outPrc = { InferenceEngine::Precision::UNSPECIFIED };
+    std::vector<InferenceEngine::Layout> inLayout;
+    std::vector<InferenceEngine::Layout> outLayout;
+    std::vector<InferenceEngine::Precision> inPrc;
+    std::vector<InferenceEngine::Precision> outPrc;
     InferenceEngine::ExecutableNetwork executableNetwork;
     std::vector<InferenceEngine::Blob::Ptr> inputs;
     float threshold;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -160,7 +160,7 @@ protected:
     InferenceEngine::Layout inLayout = InferenceEngine::Layout::ANY;
     InferenceEngine::Layout outLayout = InferenceEngine::Layout::ANY;
     InferenceEngine::Precision inPrc = InferenceEngine::Precision::UNSPECIFIED;
-    InferenceEngine::Precision outPrc = InferenceEngine::Precision::UNSPECIFIED;
+    std::vector<InferenceEngine::Precision> outPrc;
     InferenceEngine::ExecutableNetwork executableNetwork;
     std::vector<InferenceEngine::Blob::Ptr> inputs;
     float threshold;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -142,6 +142,8 @@ protected:
         return core;
     }
 
+    virtual void AlignParameters();
+
     virtual void ConfigureNetwork();
 
     virtual void LoadNetwork();

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -158,7 +158,7 @@ protected:
     std::map<std::string, std::string> configuration;
     // Non default values of layouts/precisions will be set to CNNNetwork
     InferenceEngine::Layout inLayout = InferenceEngine::Layout::ANY;
-    InferenceEngine::Layout outLayout = InferenceEngine::Layout::ANY;
+    std::vector<InferenceEngine::Layout> outLayout = { InferenceEngine::Layout::ANY };
     std::vector<InferenceEngine::Precision> inPrc = { InferenceEngine::Precision::UNSPECIFIED };
     std::vector<InferenceEngine::Precision> outPrc = { InferenceEngine::Precision::UNSPECIFIED };
     InferenceEngine::ExecutableNetwork executableNetwork;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -142,7 +142,7 @@ protected:
         return core;
     }
 
-    virtual void AlignParameters();
+    virtual void InitInputsAndOutputs();
 
     virtual void ConfigureNetwork();
 

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -159,8 +159,8 @@ protected:
     // Non default values of layouts/precisions will be set to CNNNetwork
     InferenceEngine::Layout inLayout = InferenceEngine::Layout::ANY;
     InferenceEngine::Layout outLayout = InferenceEngine::Layout::ANY;
-    std::vector<InferenceEngine::Precision> inPrc = std::vector<InferenceEngine::Precision>(1, InferenceEngine::Precision::UNSPECIFIED);
-    std::vector<InferenceEngine::Precision> outPrc = std::vector<InferenceEngine::Precision>(1, InferenceEngine::Precision::UNSPECIFIED);
+    std::vector<InferenceEngine::Precision> inPrc = { InferenceEngine::Precision::UNSPECIFIED };
+    std::vector<InferenceEngine::Precision> outPrc = { InferenceEngine::Precision::UNSPECIFIED };
     InferenceEngine::ExecutableNetwork executableNetwork;
     std::vector<InferenceEngine::Blob::Ptr> inputs;
     float threshold;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -157,7 +157,7 @@ protected:
     std::shared_ptr<ngraph::Function> functionRefs;
     std::map<std::string, std::string> configuration;
     // Non default values of layouts/precisions will be set to CNNNetwork
-    InferenceEngine::Layout inLayout = InferenceEngine::Layout::ANY;
+    std::vector<InferenceEngine::Layout> inLayout = { InferenceEngine::Layout::ANY };
     std::vector<InferenceEngine::Layout> outLayout = { InferenceEngine::Layout::ANY };
     std::vector<InferenceEngine::Precision> inPrc = { InferenceEngine::Precision::UNSPECIFIED };
     std::vector<InferenceEngine::Precision> outPrc = { InferenceEngine::Precision::UNSPECIFIED };

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -159,10 +159,10 @@ protected:
     std::shared_ptr<ngraph::Function> functionRefs;
     std::map<std::string, std::string> configuration;
     // Non default values of layouts/precisions will be set to CNNNetwork
-    std::vector<InferenceEngine::Layout> inLayout;
-    std::vector<InferenceEngine::Layout> outLayout;
-    std::vector<InferenceEngine::Precision> inPrc;
-    std::vector<InferenceEngine::Precision> outPrc;
+    std::vector<InferenceEngine::Layout> inLayout = { InferenceEngine::Layout::ANY };
+    std::vector<InferenceEngine::Layout> outLayout = { InferenceEngine::Layout::ANY };
+    std::vector<InferenceEngine::Precision> inPrc = { InferenceEngine::Precision::UNSPECIFIED };
+    std::vector<InferenceEngine::Precision> outPrc = { InferenceEngine::Precision::UNSPECIFIED };
     InferenceEngine::ExecutableNetwork executableNetwork;
     std::vector<InferenceEngine::Blob::Ptr> inputs;
     float threshold;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -160,7 +160,7 @@ protected:
     InferenceEngine::Layout inLayout = InferenceEngine::Layout::ANY;
     InferenceEngine::Layout outLayout = InferenceEngine::Layout::ANY;
     InferenceEngine::Precision inPrc = InferenceEngine::Precision::UNSPECIFIED;
-    std::vector<InferenceEngine::Precision> outPrc;
+    std::vector<InferenceEngine::Precision> outPrc = std::vector<InferenceEngine::Precision>(1, InferenceEngine::Precision::UNSPECIFIED);
     InferenceEngine::ExecutableNetwork executableNetwork;
     std::vector<InferenceEngine::Blob::Ptr> inputs;
     float threshold;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/layer_test_utils.hpp
@@ -159,7 +159,7 @@ protected:
     // Non default values of layouts/precisions will be set to CNNNetwork
     InferenceEngine::Layout inLayout = InferenceEngine::Layout::ANY;
     InferenceEngine::Layout outLayout = InferenceEngine::Layout::ANY;
-    InferenceEngine::Precision inPrc = InferenceEngine::Precision::UNSPECIFIED;
+    std::vector<InferenceEngine::Precision> inPrc = std::vector<InferenceEngine::Precision>(1, InferenceEngine::Precision::UNSPECIFIED);
     std::vector<InferenceEngine::Precision> outPrc = std::vector<InferenceEngine::Precision>(1, InferenceEngine::Precision::UNSPECIFIED);
     InferenceEngine::ExecutableNetwork executableNetwork;
     std::vector<InferenceEngine::Blob::Ptr> inputs;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
@@ -47,7 +47,7 @@ protected:
     std::map<std::shared_ptr<ov::Node>, ov::Tensor> inputs;
     std::vector<ov::PartialShape> inputDynamicShapes;
     std::vector<std::vector<ov::Shape>> targetStaticShapes;
-    ElementType inType = ov::element::undefined;
+    std::vector<ElementType> inType = { ov::element::undefined };
     std::vector<ElementType> outType = {
             ov::element::undefined
     };

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
@@ -27,11 +27,8 @@ public:
     virtual void query_model();
 
 protected:
-    SubgraphBaseTest();
-
     virtual void compare(const std::vector<ov::Tensor> &expected,
                          const std::vector<ov::Tensor> &actual);
-
     virtual void init_inputs_and_outputs();
     virtual void configure_model();
     virtual void compile_model();
@@ -50,8 +47,8 @@ protected:
     std::map<std::shared_ptr<ov::Node>, ov::Tensor> inputs;
     std::vector<ov::PartialShape> inputDynamicShapes;
     std::vector<std::vector<ov::Shape>> targetStaticShapes;
-    std::vector<ElementType> inType;
-    std::vector<ElementType> outType;
+    std::vector<ElementType> inType = { ElementType::undefined };
+    std::vector<ElementType> outType = { ElementType::undefined };
 
     ov::CompiledModel compiledModel;
     ov::InferRequest inferRequest;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
@@ -32,7 +32,7 @@ protected:
     virtual void compare(const std::vector<ov::Tensor> &expected,
                          const std::vector<ov::Tensor> &actual);
 
-    virtual void align_parameters();
+    virtual void init_inputs_and_outputs();
     virtual void configure_model();
     virtual void compile_model();
     virtual void init_ref_function(std::shared_ptr<ov::Model> &funcRef, const std::vector<ov::Shape>& targetInputStaticShapes);

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
@@ -48,7 +48,9 @@ protected:
     std::vector<ov::PartialShape> inputDynamicShapes;
     std::vector<std::vector<ov::Shape>> targetStaticShapes;
     ElementType inType = ov::element::undefined;
-    std::vector<ElementType> outType = std::vector<ElementType>(1, ov::element::undefined);
+    std::vector<ElementType> outType = {
+            ov::element::undefined
+    };
 
     ov::CompiledModel compiledModel;
     ov::InferRequest inferRequest;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
@@ -47,7 +47,8 @@ protected:
     std::map<std::shared_ptr<ov::Node>, ov::Tensor> inputs;
     std::vector<ov::PartialShape> inputDynamicShapes;
     std::vector<std::vector<ov::Shape>> targetStaticShapes;
-    ElementType inType = ov::element::undefined, outType = ov::element::undefined;
+    ElementType inType = ov::element::undefined;
+    std::vector<ElementType> outType = std::vector<ElementType>(1, ov::element::undefined);
 
     ov::CompiledModel compiledModel;
     ov::InferRequest inferRequest;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
@@ -27,6 +27,8 @@ public:
     virtual void query_model();
 
 protected:
+    SubgraphBaseTest();
+
     virtual void compare(const std::vector<ov::Tensor> &expected,
                          const std::vector<ov::Tensor> &actual);
 
@@ -47,10 +49,8 @@ protected:
     std::map<std::shared_ptr<ov::Node>, ov::Tensor> inputs;
     std::vector<ov::PartialShape> inputDynamicShapes;
     std::vector<std::vector<ov::Shape>> targetStaticShapes;
-    std::vector<ElementType> inType = { ov::element::undefined };
-    std::vector<ElementType> outType = {
-            ov::element::undefined
-    };
+    std::vector<ElementType> inType;
+    std::vector<ElementType> outType;
 
     ov::CompiledModel compiledModel;
     ov::InferRequest inferRequest;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/ov_subgraph.hpp
@@ -32,6 +32,7 @@ protected:
     virtual void compare(const std::vector<ov::Tensor> &expected,
                          const std::vector<ov::Tensor> &actual);
 
+    virtual void align_parameters();
     virtual void configure_model();
     virtual void compile_model();
     virtual void init_ref_function(std::shared_ptr<ov::Model> &funcRef, const std::vector<ov::Shape>& targetInputStaticShapes);

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/topk.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/topk.hpp
@@ -19,7 +19,7 @@ typedef std::tuple<
         InferenceEngine::Precision,     // Net precision
         std::vector<InferenceEngine::Precision>, // Input precision
         std::vector<InferenceEngine::Precision>, // Output precision
-        InferenceEngine::Layout,        // Input layout
+        std::vector<InferenceEngine::Layout>,    // Input layout
         InferenceEngine::SizeVector,    // inputShape
         std::string                     // Target device name
 > TopKParams;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/topk.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/topk.hpp
@@ -18,7 +18,7 @@ typedef std::tuple<
         ngraph::opset4::TopK::SortType, // sort
         InferenceEngine::Precision,     // Net precision
         InferenceEngine::Precision,     // Input precision
-        InferenceEngine::Precision,     // Output precision
+        std::vector<InferenceEngine::Precision>, // Output precision
         InferenceEngine::Layout,        // Input layout
         InferenceEngine::SizeVector,    // inputShape
         std::string                     // Target device name

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/topk.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/topk.hpp
@@ -17,7 +17,7 @@ typedef std::tuple<
         ngraph::opset4::TopK::Mode,     // mode
         ngraph::opset4::TopK::SortType, // sort
         InferenceEngine::Precision,     // Net precision
-        InferenceEngine::Precision,     // Input precision
+        std::vector<InferenceEngine::Precision>, // Input precision
         std::vector<InferenceEngine::Precision>, // Output precision
         InferenceEngine::Layout,        // Input layout
         InferenceEngine::SizeVector,    // inputShape

--- a/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -342,13 +342,15 @@ void LayerTestsCommon::ConfigureNetwork() {
         }
     }
 
+    int outputCnt = 0;
     for (const auto &out : cnnNetwork.getOutputsInfo()) {
         if (outLayout != InferenceEngine::Layout::ANY) {
             out.second->setLayout(outLayout);
         }
-        if (outPrc != InferenceEngine::Precision::UNSPECIFIED) {
-            out.second->setPrecision(outPrc);
+        if (outPrc[outputCnt] != InferenceEngine::Precision::UNSPECIFIED) {
+            out.second->setPrecision(outPrc[outputCnt]);
         }
+        outputCnt++;
     }
 }
 

--- a/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -23,6 +23,7 @@ namespace LayerTestsUtils {
 
 LayerTestsCommon::LayerTestsCommon() : threshold(1e-2f), abs_threshold(-1.f) {
     core = PluginCache::get().ie(targetDevice);
+    inLayout.reserve(10);
     outLayout.reserve(10);
     inPrc.reserve(10);
     outPrc.reserve(10);
@@ -336,6 +337,13 @@ void LayerTestsCommon::Compare(const InferenceEngine::TensorDesc &actualDesc, co
 }
 
 void LayerTestsCommon::ConfigureNetwork() {
+    int gapInLayout = cnnNetwork.getInputsInfo().size() - inLayout.size();
+    if (gapInLayout) {
+        auto inLayoutDefaultValue = inLayout[0];
+        for (int i = 1; i <= gapInLayout; i++) {
+            inLayout.push_back(inLayoutDefaultValue);
+        }
+    }
     int gapInPrc = cnnNetwork.getInputsInfo().size() - inPrc.size();
     if (gapInPrc) {
         auto inPrcDefaultValue = inPrc[0];
@@ -345,8 +353,8 @@ void LayerTestsCommon::ConfigureNetwork() {
     }
     int inputCnt = 0;
     for (const auto &in : cnnNetwork.getInputsInfo()) {
-        if (inLayout != InferenceEngine::Layout::ANY) {
-            in.second->setLayout(inLayout);
+        if (inLayout[inputCnt] != InferenceEngine::Layout::ANY) {
+            in.second->setLayout(inLayout[inputCnt]);
         }
         if (inPrc[inputCnt] != InferenceEngine::Precision::UNSPECIFIED) {
             in.second->setPrecision(inPrc[inputCnt]);

--- a/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -23,14 +23,6 @@ namespace LayerTestsUtils {
 
 LayerTestsCommon::LayerTestsCommon() : threshold(1e-2f), abs_threshold(-1.f) {
     core = PluginCache::get().ie(targetDevice);
-    inLayout.reserve(10);
-    inLayout.push_back(InferenceEngine::Layout::ANY);
-    outLayout.reserve(10);
-    outLayout.push_back(InferenceEngine::Layout::ANY);
-    inPrc.reserve(10);
-    inPrc.push_back(InferenceEngine::Precision::UNSPECIFIED);
-    outPrc.reserve(10);
-    outPrc.push_back(InferenceEngine::Precision::UNSPECIFIED);
 }
 
 void LayerTestsCommon::Run() {

--- a/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -23,6 +23,7 @@ namespace LayerTestsUtils {
 
 LayerTestsCommon::LayerTestsCommon() : threshold(1e-2f), abs_threshold(-1.f) {
     core = PluginCache::get().ie(targetDevice);
+    outLayout.reserve(10);
     inPrc.reserve(10);
     outPrc.reserve(10);
 }
@@ -353,6 +354,13 @@ void LayerTestsCommon::ConfigureNetwork() {
         inputCnt++;
     }
 
+    int gapOutLayout = cnnNetwork.getOutputsInfo().size() - outLayout.size();
+    if (gapOutLayout) {
+        auto outLayoutDefaultValue = outLayout[0];
+        for (int i = 1; i <= gapOutLayout; i++) {
+            outLayout.push_back(outLayoutDefaultValue);
+        }
+    }
     int gapOutPrc = cnnNetwork.getOutputsInfo().size() - outPrc.size();
     if (gapOutPrc) {
         auto outPrcDefaultValue = outPrc[0];
@@ -362,8 +370,8 @@ void LayerTestsCommon::ConfigureNetwork() {
     }
     int outputCnt = 0;
     for (const auto &out : cnnNetwork.getOutputsInfo()) {
-        if (outLayout != InferenceEngine::Layout::ANY) {
-            out.second->setLayout(outLayout);
+        if (outLayout[outputCnt] != InferenceEngine::Layout::ANY) {
+            out.second->setLayout(outLayout[outputCnt]);
         }
         if (outPrc[outputCnt] != InferenceEngine::Precision::UNSPECIFIED) {
             out.second->setPrecision(outPrc[outputCnt]);

--- a/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -340,7 +340,7 @@ void LayerTestsCommon::Compare(const InferenceEngine::TensorDesc &actualDesc, co
     ASSERT_EQ(actualDesc.getPrecision(), expectedDesc.getPrecision());
 }
 
-void LayerTestsCommon::AlignParameters() {
+void LayerTestsCommon::InitInputsAndOutputs() {
     int gapInLayout = cnnNetwork.getInputsInfo().size() - inLayout.size();
     if (gapInLayout) {
         auto inLayoutDefaultValue = inLayout[0];
@@ -373,7 +373,7 @@ void LayerTestsCommon::AlignParameters() {
 }
 
 void LayerTestsCommon::ConfigureNetwork() {
-    AlignParameters();
+    InitInputsAndOutputs();
 
     int inputCnt = 0;
     for (const auto &in : cnnNetwork.getInputsInfo()) {

--- a/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -24,9 +24,13 @@ namespace LayerTestsUtils {
 LayerTestsCommon::LayerTestsCommon() : threshold(1e-2f), abs_threshold(-1.f) {
     core = PluginCache::get().ie(targetDevice);
     inLayout.reserve(10);
+    inLayout.push_back(InferenceEngine::Layout::ANY);
     outLayout.reserve(10);
+    outLayout.push_back(InferenceEngine::Layout::ANY);
     inPrc.reserve(10);
+    inPrc.push_back(InferenceEngine::Precision::UNSPECIFIED);
     outPrc.reserve(10);
+    outPrc.push_back(InferenceEngine::Precision::UNSPECIFIED);
 }
 
 void LayerTestsCommon::Run() {

--- a/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -333,33 +333,25 @@ void LayerTestsCommon::Compare(const InferenceEngine::TensorDesc &actualDesc, co
 }
 
 void LayerTestsCommon::InitInputsAndOutputs() {
-    int gapInLayout = cnnNetwork.getInputsInfo().size() - inLayout.size();
-    if (gapInLayout) {
-        auto inLayoutDefaultValue = inLayout[0];
-        for (int i = 1; i <= gapInLayout; i++) {
-            inLayout.push_back(inLayoutDefaultValue);
+    if (inLayout.size() == 1) {
+        for (size_t i = 1; i < cnnNetwork.getInputsInfo().size(); ++i) {
+            inLayout.push_back(inLayout.front());
         }
     }
-    int gapInPrc = cnnNetwork.getInputsInfo().size() - inPrc.size();
-    if (gapInPrc) {
-        auto inPrcDefaultValue = inPrc[0];
-        for (int i = 1; i <= gapInPrc; i++) {
-            inPrc.push_back(inPrcDefaultValue);
+    if (inPrc.size() == 1) {
+        for (size_t i = 1; i < cnnNetwork.getInputsInfo().size(); ++i) {
+            inPrc.push_back(inPrc.front());
         }
     }
 
-    int gapOutLayout = cnnNetwork.getOutputsInfo().size() - outLayout.size();
-    if (gapOutLayout) {
-        auto outLayoutDefaultValue = outLayout[0];
-        for (int i = 1; i <= gapOutLayout; i++) {
-            outLayout.push_back(outLayoutDefaultValue);
+    if (outLayout.size() == 1) {
+        for (size_t i = 1; i < cnnNetwork.getOutputsInfo().size(); ++i) {
+            outLayout.push_back(outLayout.front());
         }
     }
-    int gapOutPrc = cnnNetwork.getOutputsInfo().size() - outPrc.size();
-    if (gapOutPrc) {
-        auto outPrcDefaultValue = outPrc[0];
-        for (int i = 1; i <= gapOutPrc; i++) {
-            outPrc.push_back(outPrcDefaultValue);
+    if (outPrc.size() == 1) {
+        for (int i = 1; i < cnnNetwork.getOutputsInfo().size(); ++i) {
+            outPrc.push_back(outPrc.front());
         }
     }
 }

--- a/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -340,7 +340,7 @@ void LayerTestsCommon::Compare(const InferenceEngine::TensorDesc &actualDesc, co
     ASSERT_EQ(actualDesc.getPrecision(), expectedDesc.getPrecision());
 }
 
-void LayerTestsCommon::ConfigureNetwork() {
+void LayerTestsCommon::AlignParameters() {
     int gapInLayout = cnnNetwork.getInputsInfo().size() - inLayout.size();
     if (gapInLayout) {
         auto inLayoutDefaultValue = inLayout[0];
@@ -354,16 +354,6 @@ void LayerTestsCommon::ConfigureNetwork() {
         for (int i = 1; i <= gapInPrc; i++) {
             inPrc.push_back(inPrcDefaultValue);
         }
-    }
-    int inputCnt = 0;
-    for (const auto &in : cnnNetwork.getInputsInfo()) {
-        if (inLayout[inputCnt] != InferenceEngine::Layout::ANY) {
-            in.second->setLayout(inLayout[inputCnt]);
-        }
-        if (inPrc[inputCnt] != InferenceEngine::Precision::UNSPECIFIED) {
-            in.second->setPrecision(inPrc[inputCnt]);
-        }
-        inputCnt++;
     }
 
     int gapOutLayout = cnnNetwork.getOutputsInfo().size() - outLayout.size();
@@ -380,6 +370,22 @@ void LayerTestsCommon::ConfigureNetwork() {
             outPrc.push_back(outPrcDefaultValue);
         }
     }
+}
+
+void LayerTestsCommon::ConfigureNetwork() {
+    AlignParameters();
+
+    int inputCnt = 0;
+    for (const auto &in : cnnNetwork.getInputsInfo()) {
+        if (inLayout[inputCnt] != InferenceEngine::Layout::ANY) {
+            in.second->setLayout(inLayout[inputCnt]);
+        }
+        if (inPrc[inputCnt] != InferenceEngine::Precision::UNSPECIFIED) {
+            in.second->setPrecision(inPrc[inputCnt]);
+        }
+        inputCnt++;
+    }
+
     int outputCnt = 0;
     for (const auto &out : cnnNetwork.getOutputsInfo()) {
         if (outLayout[outputCnt] != InferenceEngine::Layout::ANY) {

--- a/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -23,6 +23,8 @@ namespace LayerTestsUtils {
 
 LayerTestsCommon::LayerTestsCommon() : threshold(1e-2f), abs_threshold(-1.f) {
     core = PluginCache::get().ie(targetDevice);
+    inPrc.reserve(10);
+    outPrc.reserve(10);
 }
 
 void LayerTestsCommon::Run() {
@@ -333,15 +335,31 @@ void LayerTestsCommon::Compare(const InferenceEngine::TensorDesc &actualDesc, co
 }
 
 void LayerTestsCommon::ConfigureNetwork() {
+    int gapInPrc = cnnNetwork.getInputsInfo().size() - inPrc.size();
+    if (gapInPrc) {
+        auto inPrcDefaultValue = inPrc[0];
+        for (int i = 1; i <= gapInPrc; i++) {
+            inPrc.push_back(inPrcDefaultValue);
+        }
+    }
+    int inputCnt = 0;
     for (const auto &in : cnnNetwork.getInputsInfo()) {
         if (inLayout != InferenceEngine::Layout::ANY) {
             in.second->setLayout(inLayout);
         }
-        if (inPrc != InferenceEngine::Precision::UNSPECIFIED) {
-            in.second->setPrecision(inPrc);
+        if (inPrc[inputCnt] != InferenceEngine::Precision::UNSPECIFIED) {
+            in.second->setPrecision(inPrc[inputCnt]);
         }
+        inputCnt++;
     }
 
+    int gapOutPrc = cnnNetwork.getOutputsInfo().size() - outPrc.size();
+    if (gapOutPrc) {
+        auto outPrcDefaultValue = outPrc[0];
+        for (int i = 1; i <= gapOutPrc; i++) {
+            outPrc.push_back(outPrcDefaultValue);
+        }
+    }
     int outputCnt = 0;
     for (const auto &out : cnnNetwork.getOutputsInfo()) {
         if (outLayout != InferenceEngine::Layout::ANY) {

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -313,11 +313,6 @@ std::vector<ov::Tensor> SubgraphBaseTest::calculate_refs() {
     }
 
     const auto& outputs = functionToProcess->outputs();
-    if (outType.size() == 1) {
-        for (size_t i = 1; i < outputs.size(); ++i) {
-            outType.push_back(outType.front());
-        }
-    }
     for (size_t i = 0; i < outputs.size(); ++i) {
         if (outType[i] != ElementType::undefined && outType[i] != outputs[i].get_element_type()) {
             p.output(i).tensor().set_element_type(outType[i]);

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -313,11 +313,9 @@ std::vector<ov::Tensor> SubgraphBaseTest::calculate_refs() {
     }
 
     const auto& outputs = functionToProcess->outputs();
-    size_t gapSize = outputs.size() - outType.size();
-    if (gapSize) {
-        auto outTypeDefaultValue = outType[0];
-        for (size_t i = 1; i <= gapSize; i++) {
-            outType.push_back(outTypeDefaultValue);
+    if (outType.size() == 1) {
+        for (size_t i = 1; i < outputs.size(); ++i) {
+            outType.push_back(outType.front());
         }
     }
     for (size_t i = 0; i < outputs.size(); ++i) {

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -184,9 +184,15 @@ void SubgraphBaseTest::configure_model() {
     // configure output precision
     {
         auto results = function->get_results();
+        size_t gapSize = results.size() - outType.size();
+        if (gapSize) {
+            for (size_t i = 0; i < gapSize; i++) {
+                outType.push_back(outType[0]);
+            }
+        }
         for (size_t i = 0; i < results.size(); i++) {
-            if (outType != ov::element::Type_t::undefined) {
-                p.output(i).tensor().set_element_type(outType);
+            if (outType[i] != ov::element::Type_t::undefined) {
+                p.output(i).tensor().set_element_type(outType[i]);
             }
         }
     }
@@ -291,8 +297,8 @@ std::vector<ov::Tensor> SubgraphBaseTest::calculate_refs() {
 
     const auto& outputs = functionToProcess->outputs();
     for (size_t i = 0; i < outputs.size(); ++i) {
-        if (outType != ElementType::undefined && outType != outputs[i].get_element_type()) {
-            p.output(i).tensor().set_element_type(outType);
+        if (outType[i] != ElementType::undefined && outType[i] != outputs[i].get_element_type()) {
+            p.output(i).tensor().set_element_type(outType[i]);
         }
     }
 

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -184,15 +184,15 @@ void SubgraphBaseTest::configure_model() {
     // configure output precision
     {
         auto results = function->get_results();
-        size_t gapSize = results.size() - outType.size();
-        if (gapSize) {
-            for (size_t i = 0; i < gapSize; i++) {
-                outType.push_back(outType[0]);
-            }
-        }
+//        size_t gapSize = results.size() - 1;
+//        if (gapSize) {
+//            for (size_t i = 1; i <= gapSize; i++) {
+//                outType[i] = outType[0];
+//            }
+//        }
         for (size_t i = 0; i < results.size(); i++) {
-            if (outType[i] != ov::element::Type_t::undefined) {
-                p.output(i).tensor().set_element_type(outType[i]);
+            if (outType[0] != ov::element::Type_t::undefined) {
+                p.output(i).tensor().set_element_type(outType[0]);
             }
         }
     }
@@ -297,8 +297,8 @@ std::vector<ov::Tensor> SubgraphBaseTest::calculate_refs() {
 
     const auto& outputs = functionToProcess->outputs();
     for (size_t i = 0; i < outputs.size(); ++i) {
-        if (outType[i] != ElementType::undefined && outType[i] != outputs[i].get_element_type()) {
-            p.output(i).tensor().set_element_type(outType[i]);
+        if (outType[0] != ElementType::undefined && outType[0] != outputs[i].get_element_type()) {
+            p.output(i).tensor().set_element_type(outType[0]);
         }
     }
 

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -174,9 +174,16 @@ void SubgraphBaseTest::configure_model() {
     ov::preprocess::PrePostProcessor p(function);
     {
         auto& params = function->get_parameters();
+        size_t gapSize = params.size() - inType.size();
+        if (gapSize) {
+            auto inTypeDefaultValue = inType[0];
+            for (size_t i = 1; i <= gapSize; i++) {
+                inType.push_back(inTypeDefaultValue);
+            }
+        }
         for (size_t i = 0; i < params.size(); i++) {
-            if (inType != ov::element::Type_t::undefined) {
-                p.input(i).tensor().set_element_type(inType);
+            if (inType[i] != ov::element::Type_t::undefined) {
+                p.input(i).tensor().set_element_type(inType[i]);
             }
         }
     }

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -176,7 +176,7 @@ void SubgraphBaseTest::compare(const std::vector<ov::Tensor>& expected,
     }
 }
 
-void SubgraphBaseTest::align_parameters() {
+void SubgraphBaseTest::init_inputs_and_outputs() {
     ov::preprocess::PrePostProcessor p(function);
     {
         auto& params = function->get_parameters();
@@ -202,7 +202,7 @@ void SubgraphBaseTest::align_parameters() {
 
 void SubgraphBaseTest::configure_model() {
     // align number of inputs outputs attributes to tensor inputs outputs
-    align_parameters();
+    init_inputs_and_outputs();
 
     // configure input precision
     ov::preprocess::PrePostProcessor p(function);

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -36,13 +36,6 @@ std::ostream& operator <<(std::ostream& os, const InputShape& inputShape) {
     return os;
 }
 
-SubgraphBaseTest::SubgraphBaseTest() {
-    inType.reserve(10);
-    inType.push_back(ov::element::Type_t::undefined);
-    outType.reserve(10);
-    outType.push_back(ov::element::Type_t::undefined);
-}
-
 void SubgraphBaseTest::run() {
     bool isCurrentTestDisabled = FuncTestUtils::SkipTestsConfig::currentTestIsDisabled();
 

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -184,15 +184,16 @@ void SubgraphBaseTest::configure_model() {
     // configure output precision
     {
         auto results = function->get_results();
-//        size_t gapSize = results.size() - 1;
-//        if (gapSize) {
-//            for (size_t i = 1; i <= gapSize; i++) {
-//                outType[i] = outType[0];
-//            }
-//        }
+        size_t gapSize = results.size() - outType.size();
+        if (gapSize) {
+            auto outTypeDefaultValue = outType[0];
+            for (size_t i = 1; i <= gapSize; i++) {
+                outType.push_back(outTypeDefaultValue);
+            }
+        }
         for (size_t i = 0; i < results.size(); i++) {
-            if (outType[0] != ov::element::Type_t::undefined) {
-                p.output(i).tensor().set_element_type(outType[0]);
+            if (outType[i] != ov::element::Type_t::undefined) {
+                p.output(i).tensor().set_element_type(outType[i]);
             }
         }
     }
@@ -296,9 +297,16 @@ std::vector<ov::Tensor> SubgraphBaseTest::calculate_refs() {
     }
 
     const auto& outputs = functionToProcess->outputs();
+    size_t gapSize = outputs.size() - outType.size();
+    if (gapSize) {
+        auto outTypeDefaultValue = outType[0];
+        for (size_t i = 1; i <= gapSize; i++) {
+            outType.push_back(outTypeDefaultValue);
+        }
+    }
     for (size_t i = 0; i < outputs.size(); ++i) {
-        if (outType[0] != ElementType::undefined && outType[0] != outputs[i].get_element_type()) {
-            p.output(i).tensor().set_element_type(outType[0]);
+        if (outType[i] != ElementType::undefined && outType[i] != outputs[i].get_element_type()) {
+            p.output(i).tensor().set_element_type(outType[i]);
         }
     }
 

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -173,21 +173,17 @@ void SubgraphBaseTest::init_inputs_and_outputs() {
     ov::preprocess::PrePostProcessor p(function);
     {
         auto& params = function->get_parameters();
-        size_t gapSize = params.size() - inType.size();
-        if (gapSize) {
-            auto inTypeDefaultValue = inType[0];
-            for (size_t i = 1; i <= gapSize; i++) {
-                inType.push_back(inTypeDefaultValue);
+        if (inType.size() == 1) {
+            for (size_t i = 1; i < params.size(); ++i) {
+                inType.push_back(inType.front());
             }
         }
     }
     {
         auto& results = function->get_results();
-        size_t gapSize = results.size() - outType.size();
-        if (gapSize) {
-            auto outTypeDefaultValue = outType[0];
-            for (size_t i = 1; i <= gapSize; i++) {
-                outType.push_back(outTypeDefaultValue);
+        if (outType.size() == 1) {
+            for (size_t i = 1; i < results.size(); ++i) {
+                outType.push_back(outType.front());
             }
         }
     }

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -36,6 +36,13 @@ std::ostream& operator <<(std::ostream& os, const InputShape& inputShape) {
     return os;
 }
 
+SubgraphBaseTest::SubgraphBaseTest() {
+    inType.reserve(10);
+    inType.push_back(ov::element::Type_t::undefined);
+    outType.reserve(10);
+    outType.push_back(ov::element::Type_t::undefined);
+}
+
 void SubgraphBaseTest::run() {
     bool isCurrentTestDisabled = FuncTestUtils::SkipTestsConfig::currentTestIsDisabled();
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/activation.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/activation.cpp
@@ -34,7 +34,7 @@ void ActivationLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     std::pair<std::vector<size_t>, std::vector<size_t>> shapes;
     std::pair<ngraph::helpers::ActivationTypes, std::vector<float>> activationDecl;
-    std::tie(activationDecl, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, shapes, targetDevice) = GetParam();
+    std::tie(activationDecl, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, shapes, targetDevice) = GetParam();
 
     activationType = activationDecl.first;
     auto constantsValue = activationDecl.second;
@@ -198,7 +198,8 @@ void ActivationParamLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     std::pair<std::vector<size_t>, std::vector<size_t>> shapes;
     std::pair<ngraph::helpers::ActivationTypes, std::vector<float>> activationDecl;
-    std::tie(activationDecl, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, shapes, targetDevice) = GetParam();
+    std::tie(activationDecl, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout, outLayout, shapes, targetDevice) = GetParam();
 
     activationType = activationDecl.first;
     constantsValue = activationDecl.second;

--- a/src/tests/functional/shared_test_classes/src/single_layer/activation.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/activation.cpp
@@ -34,7 +34,7 @@ void ActivationLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     std::pair<std::vector<size_t>, std::vector<size_t>> shapes;
     std::pair<ngraph::helpers::ActivationTypes, std::vector<float>> activationDecl;
-    std::tie(activationDecl, netPrecision, inPrc, outPrc, inLayout, outLayout, shapes, targetDevice) = GetParam();
+    std::tie(activationDecl, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, shapes, targetDevice) = GetParam();
 
     activationType = activationDecl.first;
     auto constantsValue = activationDecl.second;
@@ -198,7 +198,7 @@ void ActivationParamLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     std::pair<std::vector<size_t>, std::vector<size_t>> shapes;
     std::pair<ngraph::helpers::ActivationTypes, std::vector<float>> activationDecl;
-    std::tie(activationDecl, netPrecision, inPrc, outPrc, inLayout, outLayout, shapes, targetDevice) = GetParam();
+    std::tie(activationDecl, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, shapes, targetDevice) = GetParam();
 
     activationType = activationDecl.first;
     constantsValue = activationDecl.second;

--- a/src/tests/functional/shared_test_classes/src/single_layer/activation.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/activation.cpp
@@ -34,7 +34,8 @@ void ActivationLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     std::pair<std::vector<size_t>, std::vector<size_t>> shapes;
     std::pair<ngraph::helpers::ActivationTypes, std::vector<float>> activationDecl;
-    std::tie(activationDecl, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), shapes, targetDevice) = GetParam();
+    std::tie(activationDecl, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout.front(), outLayout.front(), shapes, targetDevice) = GetParam();
 
     activationType = activationDecl.first;
     auto constantsValue = activationDecl.second;
@@ -199,7 +200,7 @@ void ActivationParamLayerTest::SetUp() {
     std::pair<std::vector<size_t>, std::vector<size_t>> shapes;
     std::pair<ngraph::helpers::ActivationTypes, std::vector<float>> activationDecl;
     std::tie(activationDecl, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout.front(), shapes, targetDevice) = GetParam();
+            inLayout.front(), outLayout.front(), shapes, targetDevice) = GetParam();
 
     activationType = activationDecl.first;
     constantsValue = activationDecl.second;

--- a/src/tests/functional/shared_test_classes/src/single_layer/activation.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/activation.cpp
@@ -34,7 +34,7 @@ void ActivationLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     std::pair<std::vector<size_t>, std::vector<size_t>> shapes;
     std::pair<ngraph::helpers::ActivationTypes, std::vector<float>> activationDecl;
-    std::tie(activationDecl, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, shapes, targetDevice) = GetParam();
+    std::tie(activationDecl, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), shapes, targetDevice) = GetParam();
 
     activationType = activationDecl.first;
     auto constantsValue = activationDecl.second;
@@ -199,7 +199,7 @@ void ActivationParamLayerTest::SetUp() {
     std::pair<std::vector<size_t>, std::vector<size_t>> shapes;
     std::pair<ngraph::helpers::ActivationTypes, std::vector<float>> activationDecl;
     std::tie(activationDecl, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout, shapes, targetDevice) = GetParam();
+            inLayout, outLayout.front(), shapes, targetDevice) = GetParam();
 
     activationType = activationDecl.first;
     constantsValue = activationDecl.second;

--- a/src/tests/functional/shared_test_classes/src/single_layer/adaptive_pooling.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/adaptive_pooling.cpp
@@ -48,6 +48,10 @@ void AdaPoolLayerTest::SetUp() {
     auto adapoolMax = std::make_shared<ngraph::opset8::AdaptiveMaxPool>(params[0], pooledParam, ngraph::element::i32);
     auto adapoolAvg = std::make_shared<ngraph::opset8::AdaptiveAvgPool>(params[0], pooledParam);
 
+    outPrc.front() = netPrecision;
+    for (int i=1; i< adapoolMax->outputs().size(); i++) {
+        outPrc.push_back(netPrecision);
+    }
     function = (poolingMode == "max" ? std::make_shared<ngraph::Function>(adapoolMax->outputs(), params, "AdaPoolMax") :
                 std::make_shared<ngraph::Function>(adapoolAvg->outputs(), params, "AdaPoolAvg"));
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/batch_norm.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/batch_norm.cpp
@@ -34,7 +34,7 @@ void BatchNormLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     InferenceEngine::SizeVector inputShapes;
     double epsilon;
-    std::tie(epsilon, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShapes, targetDevice) = this->GetParam();
+    std::tie(epsilon, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShapes, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     auto params = ngraph::builder::makeParams(ngPrc, {inputShapes});

--- a/src/tests/functional/shared_test_classes/src/single_layer/batch_norm.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/batch_norm.cpp
@@ -34,7 +34,7 @@ void BatchNormLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     InferenceEngine::SizeVector inputShapes;
     double epsilon;
-    std::tie(epsilon, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShapes, targetDevice) = this->GetParam();
+    std::tie(epsilon, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShapes, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     auto params = ngraph::builder::makeParams(ngPrc, {inputShapes});

--- a/src/tests/functional/shared_test_classes/src/single_layer/batch_norm.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/batch_norm.cpp
@@ -34,7 +34,8 @@ void BatchNormLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     InferenceEngine::SizeVector inputShapes;
     double epsilon;
-    std::tie(epsilon, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShapes, targetDevice) = this->GetParam();
+    std::tie(epsilon, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout.front(), outLayout.front(), inputShapes, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     auto params = ngraph::builder::makeParams(ngPrc, {inputShapes});

--- a/src/tests/functional/shared_test_classes/src/single_layer/batch_norm.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/batch_norm.cpp
@@ -34,7 +34,7 @@ void BatchNormLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     InferenceEngine::SizeVector inputShapes;
     double epsilon;
-    std::tie(epsilon, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShapes, targetDevice) = this->GetParam();
+    std::tie(epsilon, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShapes, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     auto params = ngraph::builder::makeParams(ngPrc, {inputShapes});

--- a/src/tests/functional/shared_test_classes/src/single_layer/batch_to_space.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/batch_to_space.cpp
@@ -34,7 +34,7 @@ void BatchToSpaceLayerTest::SetUp() {
     std::vector<int64_t> blockShape, cropsBegin, cropsEnd;
     InferenceEngine::Precision netPrecision;
     std::tie(blockShape, cropsBegin, cropsEnd, inputShape, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout.front(), targetDevice) = this->GetParam();
+            inLayout.front(), outLayout.front(), targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/batch_to_space.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/batch_to_space.cpp
@@ -33,7 +33,8 @@ void BatchToSpaceLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::vector<int64_t> blockShape, cropsBegin, cropsEnd;
     InferenceEngine::Precision netPrecision;
-    std::tie(blockShape, cropsBegin, cropsEnd, inputShape, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
+    std::tie(blockShape, cropsBegin, cropsEnd, inputShape, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout, outLayout.front(), targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/batch_to_space.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/batch_to_space.cpp
@@ -33,7 +33,7 @@ void BatchToSpaceLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::vector<int64_t> blockShape, cropsBegin, cropsEnd;
     InferenceEngine::Precision netPrecision;
-    std::tie(blockShape, cropsBegin, cropsEnd, inputShape, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
+    std::tie(blockShape, cropsBegin, cropsEnd, inputShape, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/batch_to_space.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/batch_to_space.cpp
@@ -10,7 +10,7 @@ namespace LayerTestsDefinitions {
 std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<batchToSpaceParamsTuple> &obj) {
     std::vector<size_t> inShapes;
     std::vector<int64_t> blockShape, cropsBegin, cropsEnd;
-    InferenceEngine::Precision  netPrc;
+    InferenceEngine::Precision netPrc;
     InferenceEngine::Precision inPrc, outPrc;
     InferenceEngine::Layout inLayout, outLayout;
     std::string targetName;
@@ -33,7 +33,7 @@ void BatchToSpaceLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::vector<int64_t> blockShape, cropsBegin, cropsEnd;
     InferenceEngine::Precision netPrecision;
-    std::tie(blockShape, cropsBegin, cropsEnd, inputShape, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = this->GetParam();
+    std::tie(blockShape, cropsBegin, cropsEnd, inputShape, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/binary_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/binary_convolution.cpp
@@ -58,8 +58,8 @@ void BinaryConvolutionLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     InferenceEngine::SizeVector inputShape;
 
-    std::tie(binConvParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice) =
-        this->GetParam();
+    std::tie(binConvParams, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout.front(), outLayout.front(), inputShape, targetDevice) = this->GetParam();
 
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernelSize, strides, dilations;

--- a/src/tests/functional/shared_test_classes/src/single_layer/binary_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/binary_convolution.cpp
@@ -58,7 +58,7 @@ void BinaryConvolutionLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     InferenceEngine::SizeVector inputShape;
 
-    std::tie(binConvParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) =
+    std::tie(binConvParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice) =
         this->GetParam();
 
     ngraph::op::PadType padType;

--- a/src/tests/functional/shared_test_classes/src/single_layer/binary_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/binary_convolution.cpp
@@ -58,7 +58,7 @@ void BinaryConvolutionLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     InferenceEngine::SizeVector inputShape;
 
-    std::tie(binConvParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) =
+    std::tie(binConvParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) =
         this->GetParam();
 
     ngraph::op::PadType padType;

--- a/src/tests/functional/shared_test_classes/src/single_layer/binary_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/binary_convolution.cpp
@@ -58,7 +58,7 @@ void BinaryConvolutionLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     InferenceEngine::SizeVector inputShape;
 
-    std::tie(binConvParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) =
+    std::tie(binConvParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) =
         this->GetParam();
 
     ngraph::op::PadType padType;

--- a/src/tests/functional/shared_test_classes/src/single_layer/comparison.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/comparison.cpp
@@ -64,7 +64,7 @@ void ComparisonLayerTest::SetUp() {
     configuration.insert(additional_config.begin(), additional_config.end());
 
     inPrc = ieInPrecision;
-    outPrc = ieOutPrecision;
+    outPrc.front() = ieOutPrecision;
 
     auto inputs = ngraph::builder::makeParams(ngInputsPrc, {inputShapes.first});
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/comparison.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/comparison.cpp
@@ -63,7 +63,7 @@ void ComparisonLayerTest::SetUp() {
     auto ngInputsPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(ngInputsPrecision);
     configuration.insert(additional_config.begin(), additional_config.end());
 
-    inPrc = ieInPrecision;
+    inPrc.front() = ieInPrecision;
     outPrc.front() = ieOutPrecision;
 
     auto inputs = ngraph::builder::makeParams(ngInputsPrc, {inputShapes.first});

--- a/src/tests/functional/shared_test_classes/src/single_layer/concat.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/concat.cpp
@@ -30,7 +30,7 @@ void ConcatLayerTest::SetUp() {
     int axis;
     std::vector<std::vector<size_t>> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(axis, inputShape, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
+    std::tie(axis, inputShape, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, inputShape);
     auto paramOuts = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/concat.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/concat.cpp
@@ -30,7 +30,7 @@ void ConcatLayerTest::SetUp() {
     int axis;
     std::vector<std::vector<size_t>> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(axis, inputShape, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
+    std::tie(axis, inputShape, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, inputShape);
     auto paramOuts = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/concat.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/concat.cpp
@@ -30,7 +30,7 @@ void ConcatLayerTest::SetUp() {
     int axis;
     std::vector<std::vector<size_t>> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(axis, inputShape, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = this->GetParam();
+    std::tie(axis, inputShape, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, inputShape);
     auto paramOuts = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/concat.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/concat.cpp
@@ -30,7 +30,8 @@ void ConcatLayerTest::SetUp() {
     int axis;
     std::vector<std::vector<size_t>> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(axis, inputShape, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice) = this->GetParam();
+    std::tie(axis, inputShape, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout.front(), outLayout.front(), targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, inputShape);
     auto paramOuts = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/conversion.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/conversion.cpp
@@ -34,7 +34,7 @@ void ConversionLayerTest::SetUp() {
     ngraph::helpers::ConversionTypes conversionOpType;
     InferenceEngine::Precision inputPrecision, targetPrecision;
     std::vector<std::vector<size_t>> inputShape;
-    std::tie(conversionOpType, inputShape, inputPrecision, targetPrecision, inLayout, outLayout, targetDevice) =
+    std::tie(conversionOpType, inputShape, inputPrecision, targetPrecision, inLayout, outLayout.front(), targetDevice) =
         GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/conversion.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/conversion.cpp
@@ -34,8 +34,8 @@ void ConversionLayerTest::SetUp() {
     ngraph::helpers::ConversionTypes conversionOpType;
     InferenceEngine::Precision inputPrecision, targetPrecision;
     std::vector<std::vector<size_t>> inputShape;
-    std::tie(conversionOpType, inputShape, inputPrecision, targetPrecision, inLayout, outLayout.front(), targetDevice) =
-        GetParam();
+    std::tie(conversionOpType, inputShape, inputPrecision, targetPrecision,
+            inLayout.front(), outLayout.front(), targetDevice) = GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
     auto targetPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(targetPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution.cpp
@@ -43,7 +43,7 @@ void ConvolutionLayerTest::SetUp() {
     convSpecificParams convParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(convParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) =
+    std::tie(convParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) =
             this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution.cpp
@@ -43,8 +43,8 @@ void ConvolutionLayerTest::SetUp() {
     convSpecificParams convParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(convParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice) =
-            this->GetParam();
+    std::tie(convParams, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout.front(), outLayout.front(), inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution.cpp
@@ -43,7 +43,7 @@ void ConvolutionLayerTest::SetUp() {
     convSpecificParams convParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(convParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) =
+    std::tie(convParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice) =
             this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution.cpp
@@ -43,7 +43,7 @@ void ConvolutionLayerTest::SetUp() {
     convSpecificParams convParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(convParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) =
+    std::tie(convParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) =
             this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop.cpp
@@ -46,7 +46,8 @@ void ConvolutionBackpropLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::vector<size_t> outputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(convBackpropDataParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
+    std::tie(convBackpropDataParams, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop.cpp
@@ -47,7 +47,7 @@ void ConvolutionBackpropLayerTest::SetUp() {
     std::vector<size_t> outputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(convBackpropDataParams, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
+            inLayout, outLayout.front(), inputShape, outputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop.cpp
@@ -47,7 +47,7 @@ void ConvolutionBackpropLayerTest::SetUp() {
     std::vector<size_t> outputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(convBackpropDataParams, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout.front(), inputShape, outputShape, targetDevice) = this->GetParam();
+            inLayout.front(), outLayout.front(), inputShape, outputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop.cpp
@@ -46,7 +46,7 @@ void ConvolutionBackpropLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::vector<size_t> outputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(convBackpropDataParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
+    std::tie(convBackpropDataParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop_data.cpp
@@ -48,7 +48,8 @@ void ConvolutionBackpropDataLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::vector<size_t> outputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(convBackpropDataParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
+    std::tie(convBackpropDataParams, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop_data.cpp
@@ -48,7 +48,7 @@ void ConvolutionBackpropDataLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::vector<size_t> outputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(convBackpropDataParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
+    std::tie(convBackpropDataParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop_data.cpp
@@ -49,7 +49,7 @@ void ConvolutionBackpropDataLayerTest::SetUp() {
     std::vector<size_t> outputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(convBackpropDataParams, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
+            inLayout, outLayout.front(), inputShape, outputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;

--- a/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/convolution_backprop_data.cpp
@@ -49,7 +49,7 @@ void ConvolutionBackpropDataLayerTest::SetUp() {
     std::vector<size_t> outputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(convBackpropDataParams, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout.front(), inputShape, outputShape, targetDevice) = this->GetParam();
+            inLayout.front(), outLayout.front(), inputShape, outputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;

--- a/src/tests/functional/shared_test_classes/src/single_layer/ctc_greedy_decoder.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/ctc_greedy_decoder.cpp
@@ -38,7 +38,6 @@ std::string CTCGreedyDecoderLayerTest::getTestCaseName(
 void CTCGreedyDecoderLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     InferenceEngine::Precision inPrc;
-    std::vector<InferenceEngine::Precision> outPrc;
     InferenceEngine::Layout inLayout, outLayout;
     InferenceEngine::SizeVector inputShapes;
     bool mergeRepeated;

--- a/src/tests/functional/shared_test_classes/src/single_layer/ctc_greedy_decoder.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/ctc_greedy_decoder.cpp
@@ -37,11 +37,11 @@ std::string CTCGreedyDecoderLayerTest::getTestCaseName(
 
 void CTCGreedyDecoderLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
-    InferenceEngine::Precision inPrc;
+    InferenceEngine::Precision inPrc, outPrc;
     InferenceEngine::Layout inLayout, outLayout;
     InferenceEngine::SizeVector inputShapes;
     bool mergeRepeated;
-    std::tie(netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShapes, mergeRepeated, targetDevice) = GetParam();
+    std::tie(netPrecision, inPrc, outPrc, inLayout, outLayout, inputShapes, mergeRepeated, targetDevice) = GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, { inputShapes });

--- a/src/tests/functional/shared_test_classes/src/single_layer/ctc_greedy_decoder.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/ctc_greedy_decoder.cpp
@@ -37,11 +37,12 @@ std::string CTCGreedyDecoderLayerTest::getTestCaseName(
 
 void CTCGreedyDecoderLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
-    InferenceEngine::Precision inPrc, outPrc;
+    InferenceEngine::Precision inPrc;
+    std::vector<InferenceEngine::Precision> outPrc;
     InferenceEngine::Layout inLayout, outLayout;
     InferenceEngine::SizeVector inputShapes;
     bool mergeRepeated;
-    std::tie(netPrecision, inPrc, outPrc, inLayout, outLayout, inputShapes, mergeRepeated, targetDevice) = GetParam();
+    std::tie(netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShapes, mergeRepeated, targetDevice) = GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, { inputShapes });

--- a/src/tests/functional/shared_test_classes/src/single_layer/ctc_greedy_decoder_seq_len.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/ctc_greedy_decoder_seq_len.cpp
@@ -55,6 +55,8 @@ void CTCGreedyDecoderSeqLenLayerTest::SetUp() {
 
     auto ngDataPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(dataPrecision);
     auto ngIdxPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(indicesPrecision);
+    outPrc.front() = dataPrecision;
+    outPrc.push_back(indicesPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngDataPrc, { inputShape });
     auto paramOuts = ngraph::helpers::convert2OutputVector(
         ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));

--- a/src/tests/functional/shared_test_classes/src/single_layer/deformable_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/deformable_convolution.cpp
@@ -62,8 +62,8 @@ void DeformableConvolutionLayerTest::SetUp() {
     deformableConvSpecificParams convParams;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(convParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) =
-            this->GetParam();
+    std::tie(convParams, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector offsets, filter, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;

--- a/src/tests/functional/shared_test_classes/src/single_layer/deformable_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/deformable_convolution.cpp
@@ -63,7 +63,7 @@ void DeformableConvolutionLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
     std::tie(convParams, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
+            inLayout.front(), outLayout.front(), inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector offsets, filter, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;

--- a/src/tests/functional/shared_test_classes/src/single_layer/deformable_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/deformable_convolution.cpp
@@ -62,7 +62,7 @@ void DeformableConvolutionLayerTest::SetUp() {
     deformableConvSpecificParams convParams;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(convParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) =
+    std::tie(convParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) =
             this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector offsets, filter, stride, dilation;

--- a/src/tests/functional/shared_test_classes/src/single_layer/deformable_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/deformable_convolution.cpp
@@ -63,7 +63,7 @@ void DeformableConvolutionLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
     std::tie(convParams, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+            inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector offsets, filter, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;

--- a/src/tests/functional/shared_test_classes/src/single_layer/eltwise.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/eltwise.cpp
@@ -78,7 +78,7 @@ void EltwiseLayerTest::SetUp() {
     CommonTestUtils::OpType opType;
     ngraph::helpers::EltwiseTypes eltwiseType;
     Config additional_config;
-    std::tie(shapes, eltwiseType, secondaryInputType, opType, netType, inType, outType, targetDevice, configuration) =
+    std::tie(shapes, eltwiseType, secondaryInputType, opType, netType, inType, outType[0], targetDevice, configuration) =
             this->GetParam();
 
     init_input_shapes(shapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/eltwise.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/eltwise.cpp
@@ -78,7 +78,7 @@ void EltwiseLayerTest::SetUp() {
     CommonTestUtils::OpType opType;
     ngraph::helpers::EltwiseTypes eltwiseType;
     Config additional_config;
-    std::tie(shapes, eltwiseType, secondaryInputType, opType, netType, inType, outType[0], targetDevice, configuration) =
+    std::tie(shapes, eltwiseType, secondaryInputType, opType, netType, inType[0], outType[0], targetDevice, configuration) =
             this->GetParam();
 
     init_input_shapes(shapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_detection_output.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_detection_output.cpp
@@ -78,7 +78,7 @@ void ExperimentalDetectronDetectionOutputLayerTest::SetUp() {
         netPrecision,
         targetName) = this->GetParam();
 
-    inType = outType[0] = netPrecision;
+    inType[0] = outType[0] = netPrecision;
     targetDevice = targetName;
 
     init_input_shapes(inputShapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_detection_output.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_detection_output.cpp
@@ -78,7 +78,7 @@ void ExperimentalDetectronDetectionOutputLayerTest::SetUp() {
         netPrecision,
         targetName) = this->GetParam();
 
-    inType = outType = netPrecision;
+    inType = outType[0] = netPrecision;
     targetDevice = targetName;
 
     init_input_shapes(inputShapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_generate_proposals_single_image.cpp
@@ -70,7 +70,7 @@ void ExperimentalDetectronGenerateProposalsSingleImageLayerTest::SetUp() {
         netPrecision,
         targetName) = this->GetParam();
 
-    inType = outType[0] = netPrecision;
+    inType[0] = outType[0] = netPrecision;
     targetDevice = targetName;
 
     init_input_shapes(inputShapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_generate_proposals_single_image.cpp
@@ -70,7 +70,7 @@ void ExperimentalDetectronGenerateProposalsSingleImageLayerTest::SetUp() {
         netPrecision,
         targetName) = this->GetParam();
 
-    inType = outType = netPrecision;
+    inType = outType[0] = netPrecision;
     targetDevice = targetName;
 
     init_input_shapes(inputShapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_prior_grid_generator.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_prior_grid_generator.cpp
@@ -53,7 +53,7 @@ void ExperimentalDetectronPriorGridGeneratorLayerTest::SetUp() {
     std::string targetName;
     std::tie(param, inputTensors, netPrecision, targetName) = this->GetParam();
 
-    inType = outType[0] = netPrecision;
+    inType[0] = outType[0] = netPrecision;
     targetDevice = targetName;
 
     init_input_shapes(param.inputShapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_prior_grid_generator.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_prior_grid_generator.cpp
@@ -53,7 +53,7 @@ void ExperimentalDetectronPriorGridGeneratorLayerTest::SetUp() {
     std::string targetName;
     std::tie(param, inputTensors, netPrecision, targetName) = this->GetParam();
 
-    inType = outType = netPrecision;
+    inType = outType[0] = netPrecision;
     targetDevice = targetName;
 
     init_input_shapes(param.inputShapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_roifeatureextractor.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_roifeatureextractor.cpp
@@ -59,7 +59,7 @@ void ExperimentalDetectronROIFeatureExtractorLayerTest::SetUp() {
     std::string targetName;
     std::tie(inputShapes, outputSize, samplingRatio, pyramidScales, aligned, netPrecision, targetName) = this->GetParam();
 
-    inType = outType[0] = netPrecision;
+    inType[0] = outType[0] = netPrecision;
     targetDevice = targetName;
 
     init_input_shapes(inputShapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_roifeatureextractor.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_roifeatureextractor.cpp
@@ -59,7 +59,7 @@ void ExperimentalDetectronROIFeatureExtractorLayerTest::SetUp() {
     std::string targetName;
     std::tie(inputShapes, outputSize, samplingRatio, pyramidScales, aligned, netPrecision, targetName) = this->GetParam();
 
-    inType = outType = netPrecision;
+    inType = outType[0] = netPrecision;
     targetDevice = targetName;
 
     init_input_shapes(inputShapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_topkrois.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_topkrois.cpp
@@ -45,7 +45,7 @@ void ExperimentalDetectronTopKROIsLayerTest::SetUp() {
     std::string targetName;
     std::tie(inputShapes, maxRois, netPrecision, targetName) = this->GetParam();
 
-    inType = outType = netPrecision;
+    inType = outType[0] = netPrecision;
     targetDevice = targetName;
 
     init_input_shapes(inputShapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_topkrois.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/experimental_detectron_topkrois.cpp
@@ -45,7 +45,7 @@ void ExperimentalDetectronTopKROIsLayerTest::SetUp() {
     std::string targetName;
     std::tie(inputShapes, maxRois, netPrecision, targetName) = this->GetParam();
 
-    inType = outType[0] = netPrecision;
+    inType[0] = outType[0] = netPrecision;
     targetDevice = targetName;
 
     init_input_shapes(inputShapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/extract_image_patches.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/extract_image_patches.cpp
@@ -34,7 +34,7 @@ void ExtractImagePatchesTest::SetUp() {
     std::vector<size_t> inputShape, kernel, strides, rates;
     ngraph::op::PadType pad_type;
     InferenceEngine::Precision netPrecision;
-    std::tie(inputShape, kernel, strides, rates, pad_type, netPrecision, inPrc, outPrc.front(), inLayout, targetDevice) = this->GetParam();
+    std::tie(inputShape, kernel, strides, rates, pad_type, netPrecision, inPrc.front(), outPrc.front(), inLayout, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     auto inputNode = std::make_shared<ngraph::opset1::Parameter>(ngPrc, ngraph::Shape(inputShape));

--- a/src/tests/functional/shared_test_classes/src/single_layer/extract_image_patches.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/extract_image_patches.cpp
@@ -34,7 +34,7 @@ void ExtractImagePatchesTest::SetUp() {
     std::vector<size_t> inputShape, kernel, strides, rates;
     ngraph::op::PadType pad_type;
     InferenceEngine::Precision netPrecision;
-    std::tie(inputShape, kernel, strides, rates, pad_type, netPrecision, inPrc, outPrc, inLayout, targetDevice) = this->GetParam();
+    std::tie(inputShape, kernel, strides, rates, pad_type, netPrecision, inPrc, outPrc.front(), inLayout, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     auto inputNode = std::make_shared<ngraph::opset1::Parameter>(ngPrc, ngraph::Shape(inputShape));

--- a/src/tests/functional/shared_test_classes/src/single_layer/extract_image_patches.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/extract_image_patches.cpp
@@ -34,7 +34,8 @@ void ExtractImagePatchesTest::SetUp() {
     std::vector<size_t> inputShape, kernel, strides, rates;
     ngraph::op::PadType pad_type;
     InferenceEngine::Precision netPrecision;
-    std::tie(inputShape, kernel, strides, rates, pad_type, netPrecision, inPrc.front(), outPrc.front(), inLayout, targetDevice) = this->GetParam();
+    std::tie(inputShape, kernel, strides, rates, pad_type, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout.front(), targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     auto inputNode = std::make_shared<ngraph::opset1::Parameter>(ngPrc, ngraph::Shape(inputShape));

--- a/src/tests/functional/shared_test_classes/src/single_layer/fake_quantize.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/fake_quantize.cpp
@@ -51,7 +51,7 @@ void FakeQuantizeLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::pair<std::string, std::map<std::string, std::string>> config;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(fqParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
+    std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
     InferenceEngine::SizeVector kernel, stride, dilation;
     size_t levels;
     std::vector<size_t> constShape;

--- a/src/tests/functional/shared_test_classes/src/single_layer/fake_quantize.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/fake_quantize.cpp
@@ -51,7 +51,7 @@ void FakeQuantizeLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::pair<std::string, std::map<std::string, std::string>> config;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(fqParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
+    std::tie(fqParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
     InferenceEngine::SizeVector kernel, stride, dilation;
     size_t levels;
     std::vector<size_t> constShape;

--- a/src/tests/functional/shared_test_classes/src/single_layer/fake_quantize.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/fake_quantize.cpp
@@ -51,7 +51,7 @@ void FakeQuantizeLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::pair<std::string, std::map<std::string, std::string>> config;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice, config) = this->GetParam();
+    std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(), inLayout.front(), outLayout.front(), inputShape, targetDevice, config) = this->GetParam();
     InferenceEngine::SizeVector kernel, stride, dilation;
     size_t levels;
     std::vector<size_t> constShape;

--- a/src/tests/functional/shared_test_classes/src/single_layer/fake_quantize.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/fake_quantize.cpp
@@ -51,7 +51,7 @@ void FakeQuantizeLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::pair<std::string, std::map<std::string, std::string>> config;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
+    std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice, config) = this->GetParam();
     InferenceEngine::SizeVector kernel, stride, dilation;
     size_t levels;
     std::vector<size_t> constShape;

--- a/src/tests/functional/shared_test_classes/src/single_layer/gather.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gather.cpp
@@ -13,7 +13,8 @@ void GatherLayerTestBase::SetUp(const gatherParamsTuple& params) {
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
     InferenceEngine::Precision inPrc, outPrc;
-    std::tie(indices, indicesShape, axis, inputShape, netPrecision, inPrc, outPrc, inLayout, outLayout.front(), targetDevice) = params;
+    std::tie(indices, indicesShape, axis, inputShape, netPrecision, inPrc, outPrc,
+            inLayout.front(), outLayout.front(), targetDevice) = params;
     ASSERT_EQ(ngraph::shape_size(indicesShape), indices.size()) << "Indices vector size and provided indices shape doesn't fit each other";
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto functionParams = ngraph::builder::makeParams(ngPrc, {inputShape});
@@ -81,7 +82,7 @@ void Gather7LayerTest::SetUp() {
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
     std::tie(inputShape, indicesShape, axis_batchIdx, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout.front(), targetDevice) = GetParam();
+            inLayout.front(), outLayout.front(), targetDevice) = GetParam();
     int axis = std::get<0>(axis_batchIdx);
     int batchIdx = std::get<1>(axis_batchIdx);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
@@ -123,7 +124,8 @@ void Gather8LayerTest::SetUp() {
     std::vector<size_t> indicesShape;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(inputShape, indicesShape, axis_batchIdx, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice) = GetParam();
+    std::tie(inputShape, indicesShape, axis_batchIdx, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout.front(), outLayout.front(), targetDevice) = GetParam();
     int axis = std::get<0>(axis_batchIdx);
     int batchIdx = std::get<1>(axis_batchIdx);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/gather.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gather.cpp
@@ -12,7 +12,7 @@ void GatherLayerTestBase::SetUp(const gatherParamsTuple& params) {
     std::vector<size_t> indicesShape;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(indices, indicesShape, axis, inputShape, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = params;
+    std::tie(indices, indicesShape, axis, inputShape, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = params;
     ASSERT_EQ(ngraph::shape_size(indicesShape), indices.size()) << "Indices vector size and provided indices shape doesn't fit each other";
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto functionParams = ngraph::builder::makeParams(ngPrc, {inputShape});
@@ -79,7 +79,7 @@ void Gather7LayerTest::SetUp() {
     std::vector<size_t> indicesShape;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(inputShape, indicesShape, axis_batchIdx, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(inputShape, indicesShape, axis_batchIdx, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
     int axis = std::get<0>(axis_batchIdx);
     int batchIdx = std::get<1>(axis_batchIdx);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
@@ -121,7 +121,7 @@ void Gather8LayerTest::SetUp() {
     std::vector<size_t> indicesShape;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(inputShape, indicesShape, axis_batchIdx, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(inputShape, indicesShape, axis_batchIdx, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
     int axis = std::get<0>(axis_batchIdx);
     int batchIdx = std::get<1>(axis_batchIdx);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/gather.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gather.cpp
@@ -12,7 +12,8 @@ void GatherLayerTestBase::SetUp(const gatherParamsTuple& params) {
     std::vector<size_t> indicesShape;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(indices, indicesShape, axis, inputShape, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = params;
+    InferenceEngine::Precision inPrc, outPrc;
+    std::tie(indices, indicesShape, axis, inputShape, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = params;
     ASSERT_EQ(ngraph::shape_size(indicesShape), indices.size()) << "Indices vector size and provided indices shape doesn't fit each other";
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto functionParams = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/gather.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gather.cpp
@@ -13,7 +13,7 @@ void GatherLayerTestBase::SetUp(const gatherParamsTuple& params) {
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
     InferenceEngine::Precision inPrc, outPrc;
-    std::tie(indices, indicesShape, axis, inputShape, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = params;
+    std::tie(indices, indicesShape, axis, inputShape, netPrecision, inPrc, outPrc, inLayout, outLayout.front(), targetDevice) = params;
     ASSERT_EQ(ngraph::shape_size(indicesShape), indices.size()) << "Indices vector size and provided indices shape doesn't fit each other";
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto functionParams = ngraph::builder::makeParams(ngPrc, {inputShape});
@@ -81,7 +81,7 @@ void Gather7LayerTest::SetUp() {
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
     std::tie(inputShape, indicesShape, axis_batchIdx, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout, targetDevice) = GetParam();
+            inLayout, outLayout.front(), targetDevice) = GetParam();
     int axis = std::get<0>(axis_batchIdx);
     int batchIdx = std::get<1>(axis_batchIdx);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
@@ -123,7 +123,7 @@ void Gather8LayerTest::SetUp() {
     std::vector<size_t> indicesShape;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(inputShape, indicesShape, axis_batchIdx, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(inputShape, indicesShape, axis_batchIdx, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice) = GetParam();
     int axis = std::get<0>(axis_batchIdx);
     int batchIdx = std::get<1>(axis_batchIdx);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/gather.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gather.cpp
@@ -80,7 +80,8 @@ void Gather7LayerTest::SetUp() {
     std::vector<size_t> indicesShape;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(inputShape, indicesShape, axis_batchIdx, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(inputShape, indicesShape, axis_batchIdx, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout, outLayout, targetDevice) = GetParam();
     int axis = std::get<0>(axis_batchIdx);
     int batchIdx = std::get<1>(axis_batchIdx);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
@@ -122,7 +123,7 @@ void Gather8LayerTest::SetUp() {
     std::vector<size_t> indicesShape;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(inputShape, indicesShape, axis_batchIdx, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(inputShape, indicesShape, axis_batchIdx, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
     int axis = std::get<0>(axis_batchIdx);
     int batchIdx = std::get<1>(axis_batchIdx);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/gather_elements.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gather_elements.cpp
@@ -35,7 +35,7 @@ void GatherElementsLayerTest::SetUp() {
     InferenceEngine::Precision dPrecision, iPrecision;
     int axis;
     std::tie(dataShape, indicesShape, axis, dPrecision, iPrecision, targetDevice) = this->GetParam();
-    outPrc = dPrecision;
+    outPrc.push_back(dPrecision);
 
     auto ngDPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(dPrecision);
     auto ngIPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(iPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/gather_elements.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gather_elements.cpp
@@ -35,7 +35,7 @@ void GatherElementsLayerTest::SetUp() {
     InferenceEngine::Precision dPrecision, iPrecision;
     int axis;
     std::tie(dataShape, indicesShape, axis, dPrecision, iPrecision, targetDevice) = this->GetParam();
-    outPrc.push_back(dPrecision);
+    outPrc.front() = dPrecision;
 
     auto ngDPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(dPrecision);
     auto ngIPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(iPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/gather_tree.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gather_tree.cpp
@@ -32,7 +32,7 @@ void GatherTreeLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     ngraph::helpers::InputLayerType secondaryInputType;
 
-    std::tie(inputShape, secondaryInputType, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(inputShape, secondaryInputType, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice) = GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/gather_tree.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gather_tree.cpp
@@ -32,7 +32,7 @@ void GatherTreeLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     ngraph::helpers::InputLayerType secondaryInputType;
 
-    std::tie(inputShape, secondaryInputType, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(inputShape, secondaryInputType, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/gather_tree.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gather_tree.cpp
@@ -32,7 +32,8 @@ void GatherTreeLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     ngraph::helpers::InputLayerType secondaryInputType;
 
-    std::tie(inputShape, secondaryInputType, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice) = GetParam();
+    std::tie(inputShape, secondaryInputType, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout.front(), outLayout.front(), targetDevice) = GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/gather_tree.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gather_tree.cpp
@@ -32,7 +32,7 @@ void GatherTreeLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     ngraph::helpers::InputLayerType secondaryInputType;
 
-    std::tie(inputShape, secondaryInputType, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(inputShape, secondaryInputType, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/grn.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/grn.cpp
@@ -34,7 +34,7 @@ std::string GrnLayerTest::getTestCaseName(const testing::TestParamInfo<grnParams
 
 void GrnLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
-    std::tie(netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShapes, bias, targetDevice) = GetParam();
+    std::tie(netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShapes, bias, targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, { inputShapes });
     auto paramsOut = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/grn.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/grn.cpp
@@ -34,7 +34,7 @@ std::string GrnLayerTest::getTestCaseName(const testing::TestParamInfo<grnParams
 
 void GrnLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
-    std::tie(netPrecision, inPrc, outPrc, inLayout, outLayout, inputShapes, bias, targetDevice) = GetParam();
+    std::tie(netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShapes, bias, targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, { inputShapes });
     auto paramsOut = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/grn.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/grn.cpp
@@ -34,7 +34,7 @@ std::string GrnLayerTest::getTestCaseName(const testing::TestParamInfo<grnParams
 
 void GrnLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
-    std::tie(netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShapes, bias, targetDevice) = GetParam();
+    std::tie(netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShapes, bias, targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, { inputShapes });
     auto paramsOut = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/grn.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/grn.cpp
@@ -34,7 +34,7 @@ std::string GrnLayerTest::getTestCaseName(const testing::TestParamInfo<grnParams
 
 void GrnLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
-    std::tie(netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShapes, bias, targetDevice) = GetParam();
+    std::tie(netPrecision, inPrc.front(), outPrc.front(), inLayout.front(), outLayout.front(), inputShapes, bias, targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, { inputShapes });
     auto paramsOut = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/group_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/group_convolution.cpp
@@ -43,7 +43,7 @@ void GroupConvolutionLayerTest::SetUp() {
     groupConvSpecificParams groupConvParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(groupConvParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
+    std::tie(groupConvParams, netPrecision, inPrc.front(), outPrc.front(), inLayout.front(), outLayout.front(), inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;

--- a/src/tests/functional/shared_test_classes/src/single_layer/group_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/group_convolution.cpp
@@ -43,7 +43,7 @@ void GroupConvolutionLayerTest::SetUp() {
     groupConvSpecificParams groupConvParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(groupConvParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(groupConvParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;

--- a/src/tests/functional/shared_test_classes/src/single_layer/group_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/group_convolution.cpp
@@ -43,7 +43,7 @@ void GroupConvolutionLayerTest::SetUp() {
     groupConvSpecificParams groupConvParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(groupConvParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(groupConvParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;

--- a/src/tests/functional/shared_test_classes/src/single_layer/group_convolution.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/group_convolution.cpp
@@ -43,7 +43,7 @@ void GroupConvolutionLayerTest::SetUp() {
     groupConvSpecificParams groupConvParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(groupConvParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(groupConvParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;

--- a/src/tests/functional/shared_test_classes/src/single_layer/group_convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/group_convolution_backprop_data.cpp
@@ -45,7 +45,7 @@ void GroupConvBackpropDataLayerTest::SetUp() {
     groupConvBackpropDataSpecificParams groupConvBackpropDataParams;
     std::vector<size_t> inputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(groupConvBackpropDataParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(groupConvBackpropDataParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;
@@ -101,7 +101,8 @@ void GroupConvBackpropLayerTest::SetUp() {
     groupConvBackpropSpecificParams groupConvBackpropDataParams;
     std::vector<size_t> inputShape, outputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(groupConvBackpropDataParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
+    std::tie(groupConvBackpropDataParams, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;

--- a/src/tests/functional/shared_test_classes/src/single_layer/group_convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/group_convolution_backprop_data.cpp
@@ -45,7 +45,7 @@ void GroupConvBackpropDataLayerTest::SetUp() {
     groupConvBackpropDataSpecificParams groupConvBackpropDataParams;
     std::vector<size_t> inputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(groupConvBackpropDataParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(groupConvBackpropDataParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;
@@ -101,7 +101,7 @@ void GroupConvBackpropLayerTest::SetUp() {
     groupConvBackpropSpecificParams groupConvBackpropDataParams;
     std::vector<size_t> inputShape, outputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(groupConvBackpropDataParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
+    std::tie(groupConvBackpropDataParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;

--- a/src/tests/functional/shared_test_classes/src/single_layer/group_convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/group_convolution_backprop_data.cpp
@@ -46,7 +46,7 @@ void GroupConvBackpropDataLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(groupConvBackpropDataParams, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
+            inLayout.front(), outLayout.front(), inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;
@@ -103,7 +103,7 @@ void GroupConvBackpropLayerTest::SetUp() {
     std::vector<size_t> inputShape, outputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(groupConvBackpropDataParams, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout.front(), inputShape, outputShape, targetDevice) = this->GetParam();
+            inLayout.front(), outLayout.front(), inputShape, outputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;

--- a/src/tests/functional/shared_test_classes/src/single_layer/group_convolution_backprop_data.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/group_convolution_backprop_data.cpp
@@ -45,7 +45,8 @@ void GroupConvBackpropDataLayerTest::SetUp() {
     groupConvBackpropDataSpecificParams groupConvBackpropDataParams;
     std::vector<size_t> inputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(groupConvBackpropDataParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(groupConvBackpropDataParams, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;
@@ -102,7 +103,7 @@ void GroupConvBackpropLayerTest::SetUp() {
     std::vector<size_t> inputShape, outputShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(groupConvBackpropDataParams, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout, inputShape, outputShape, targetDevice) = this->GetParam();
+            inLayout, outLayout.front(), inputShape, outputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd, outPadding;

--- a/src/tests/functional/shared_test_classes/src/single_layer/gru_sequence.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/gru_sequence.cpp
@@ -65,6 +65,8 @@ namespace LayerTestsDefinitions {
                  {num_directions, (linear_before_reset ? 4 : 3) * hidden_size}},
         };
         m_max_seq_len = seq_lengths;
+        outPrc.front() = netPrecision;
+        outPrc.push_back(netPrecision);
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1]});
         if (m_mode == SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_PARAM ||

--- a/src/tests/functional/shared_test_classes/src/single_layer/interpolate.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/interpolate.cpp
@@ -59,7 +59,7 @@ void InterpolateLayerTest::SetUp() {
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::map<std::string, std::string> additional_config;
     std::tie(interpolateParams, netPrecision, inPrc.front(), outPrc.front(),
-             inLayout, outLayout.front(), inputShape, targetShape, targetDevice, additional_config) = this->GetParam();
+             inLayout.front(), outLayout.front(), inputShape, targetShape, targetDevice, additional_config) = this->GetParam();
     std::vector<size_t> padBegin, padEnd;
     std::vector<int64_t> axes;
     std::vector<float> scales;

--- a/src/tests/functional/shared_test_classes/src/single_layer/interpolate.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/interpolate.cpp
@@ -58,7 +58,7 @@ void InterpolateLayerTest::SetUp() {
     std::vector<size_t> inputShape, targetShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::map<std::string, std::string> additional_config;
-    std::tie(interpolateParams, netPrecision, inPrc, outPrc.front(),
+    std::tie(interpolateParams, netPrecision, inPrc.front(), outPrc.front(),
              inLayout, outLayout, inputShape, targetShape, targetDevice, additional_config) = this->GetParam();
     std::vector<size_t> padBegin, padEnd;
     std::vector<int64_t> axes;

--- a/src/tests/functional/shared_test_classes/src/single_layer/interpolate.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/interpolate.cpp
@@ -59,7 +59,7 @@ void InterpolateLayerTest::SetUp() {
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::map<std::string, std::string> additional_config;
     std::tie(interpolateParams, netPrecision, inPrc.front(), outPrc.front(),
-             inLayout, outLayout, inputShape, targetShape, targetDevice, additional_config) = this->GetParam();
+             inLayout, outLayout.front(), inputShape, targetShape, targetDevice, additional_config) = this->GetParam();
     std::vector<size_t> padBegin, padEnd;
     std::vector<int64_t> axes;
     std::vector<float> scales;

--- a/src/tests/functional/shared_test_classes/src/single_layer/interpolate.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/interpolate.cpp
@@ -19,7 +19,8 @@ std::string InterpolateLayerTest::getTestCaseName(const testing::TestParamInfo<I
     InferenceEngine::SizeVector inputShapes, targetShapes;
     std::string targetDevice;
     std::map<std::string, std::string> additional_config;
-    std::tie(interpolateParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShapes, targetShapes, targetDevice, additional_config) = obj.param;
+    std::tie(interpolateParams, netPrecision, inPrc, outPrc,
+             inLayout, outLayout, inputShapes, targetShapes, targetDevice, additional_config) = obj.param;
     std::vector<size_t> padBegin, padEnd;
     std::vector<int64_t> axes;
     std::vector<float> scales;
@@ -57,7 +58,8 @@ void InterpolateLayerTest::SetUp() {
     std::vector<size_t> inputShape, targetShape;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::map<std::string, std::string> additional_config;
-    std::tie(interpolateParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetShape, targetDevice, additional_config) = this->GetParam();
+    std::tie(interpolateParams, netPrecision, inPrc, outPrc.front(),
+             inLayout, outLayout, inputShape, targetShape, targetDevice, additional_config) = this->GetParam();
     std::vector<size_t> padBegin, padEnd;
     std::vector<int64_t> axes;
     std::vector<float> scales;

--- a/src/tests/functional/shared_test_classes/src/single_layer/log_softmax.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/log_softmax.cpp
@@ -34,8 +34,9 @@ void LogSoftmaxLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     int64_t axis;
 
-    std::tie(netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, axis, targetDevice, configuration) = GetParam();
-    outLayout.front() = inLayout;
+    std::tie(netPrecision, inPrc.front(), outPrc.front(),
+            inLayout.front(), outLayout.front(), inputShape, axis, targetDevice, configuration) = GetParam();
+    outLayout.front() = inLayout.front();
 
     const auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/log_softmax.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/log_softmax.cpp
@@ -34,7 +34,7 @@ void LogSoftmaxLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     int64_t axis;
 
-    std::tie(netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, axis, targetDevice, configuration) = GetParam();
+    std::tie(netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, axis, targetDevice, configuration) = GetParam();
     outLayout = inLayout;
 
     const auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/log_softmax.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/log_softmax.cpp
@@ -34,7 +34,7 @@ void LogSoftmaxLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     int64_t axis;
 
-    std::tie(netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, axis, targetDevice, configuration) = GetParam();
+    std::tie(netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, axis, targetDevice, configuration) = GetParam();
     outLayout = inLayout;
 
     const auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/log_softmax.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/log_softmax.cpp
@@ -34,8 +34,8 @@ void LogSoftmaxLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     int64_t axis;
 
-    std::tie(netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, axis, targetDevice, configuration) = GetParam();
-    outLayout = inLayout;
+    std::tie(netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, axis, targetDevice, configuration) = GetParam();
+    outLayout.front() = inLayout;
 
     const auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/logical.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/logical.cpp
@@ -54,7 +54,7 @@ InferenceEngine::Blob::Ptr LogicalLayerTest::GenerateInput(const InferenceEngine
 
 void LogicalLayerTest::SetupParams() {
     std::tie(inputShapes, logicalOpType, secondInputType, netPrecision,
-             inPrc, outPrc.front(), inLayout, outLayout, targetDevice, additional_config) =
+             inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice, additional_config) =
         this->GetParam();
 
     configuration.insert(additional_config.begin(), additional_config.end());
@@ -63,7 +63,7 @@ void LogicalLayerTest::SetupParams() {
 void LogicalLayerTest::SetUp() {
     SetupParams();
 
-    auto ngInputsPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+    auto ngInputsPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc[0]);
     auto inputs = ngraph::builder::makeParams(ngInputsPrc, {inputShapes.first});
 
     std::shared_ptr<ngraph::Node> logicalNode;

--- a/src/tests/functional/shared_test_classes/src/single_layer/logical.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/logical.cpp
@@ -54,7 +54,7 @@ InferenceEngine::Blob::Ptr LogicalLayerTest::GenerateInput(const InferenceEngine
 
 void LogicalLayerTest::SetupParams() {
     std::tie(inputShapes, logicalOpType, secondInputType, netPrecision,
-             inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice, additional_config) =
+             inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice, additional_config) =
         this->GetParam();
 
     configuration.insert(additional_config.begin(), additional_config.end());

--- a/src/tests/functional/shared_test_classes/src/single_layer/logical.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/logical.cpp
@@ -54,7 +54,7 @@ InferenceEngine::Blob::Ptr LogicalLayerTest::GenerateInput(const InferenceEngine
 
 void LogicalLayerTest::SetupParams() {
     std::tie(inputShapes, logicalOpType, secondInputType, netPrecision,
-             inPrc, outPrc, inLayout, outLayout, targetDevice, additional_config) =
+             inPrc, outPrc.front(), inLayout, outLayout, targetDevice, additional_config) =
         this->GetParam();
 
     configuration.insert(additional_config.begin(), additional_config.end());

--- a/src/tests/functional/shared_test_classes/src/single_layer/logical.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/logical.cpp
@@ -53,9 +53,8 @@ InferenceEngine::Blob::Ptr LogicalLayerTest::GenerateInput(const InferenceEngine
 }
 
 void LogicalLayerTest::SetupParams() {
-    std::tie(inputShapes, logicalOpType, secondInputType, netPrecision,
-             inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice, additional_config) =
-        this->GetParam();
+    std::tie(inputShapes, logicalOpType, secondInputType, netPrecision, inPrc.front(), outPrc.front(),
+             inLayout.front(), outLayout.front(), targetDevice, additional_config) = this->GetParam();
 
     configuration.insert(additional_config.begin(), additional_config.end());
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/loop.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/loop.cpp
@@ -46,6 +46,9 @@ namespace LayerTestsDefinitions {
         int64_t trip_count;
         std::vector<std::pair<std::vector<size_t>, LOOP_IN_TYPE>> inputs;
         InferenceEngine::Precision netPrecision;
+        outPrc.front() = netPrecision;
+        outPrc.push_back(netPrecision);
+        outPrc.push_back(netPrecision);
         std::tie(execute_first_iteration, is_body_condition_const, body_condition, trip_count, inputs, netPrecision,
                  targetDevice) = this->GetParam();
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/lrn.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/lrn.cpp
@@ -38,7 +38,7 @@ void LrnLayerTest::SetUp() {
     double alpha, beta, bias;
     size_t size;
     std::vector<int64_t> axes;
-    std::tie(alpha, beta, bias, size, axes, netPrecision, inPrc, outPrc.front(), inputShapes, targetDevice) = GetParam();
+    std::tie(alpha, beta, bias, size, axes, netPrecision, inPrc.front(), outPrc.front(), inputShapes, targetDevice) = GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShapes});

--- a/src/tests/functional/shared_test_classes/src/single_layer/lrn.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/lrn.cpp
@@ -10,7 +10,7 @@ std::string LrnLayerTest::getTestCaseName(const testing::TestParamInfo<lrnLayerT
     double alpha, beta, bias;
     size_t size;
     std::vector<int64_t> axes;
-    InferenceEngine::Precision  netPrecision;
+    InferenceEngine::Precision netPrecision;
     InferenceEngine::Precision inPrc, outPrc;
     std::vector<size_t> inputShapes;
     std::string targetDevice;
@@ -38,7 +38,7 @@ void LrnLayerTest::SetUp() {
     double alpha, beta, bias;
     size_t size;
     std::vector<int64_t> axes;
-    std::tie(alpha, beta, bias, size, axes, netPrecision, inPrc, outPrc, inputShapes, targetDevice) = GetParam();
+    std::tie(alpha, beta, bias, size, axes, netPrecision, inPrc, outPrc.front(), inputShapes, targetDevice) = GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShapes});

--- a/src/tests/functional/shared_test_classes/src/single_layer/lstm_cell.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/lstm_cell.cpp
@@ -52,6 +52,8 @@ void LSTMCellTest::SetUp() {
             {{batch, input_size}, {batch, hidden_size}, {batch, hidden_size}, {4 * hidden_size, input_size},
                     {4 * hidden_size, hidden_size}, {4 * hidden_size}},
     };
+    outPrc.front() = netPrecision;
+    outPrc.push_back(netPrecision);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1], inputShapes[2]});
     std::vector<ngraph::Shape> WRB = {inputShapes[3], inputShapes[4], inputShapes[5]};

--- a/src/tests/functional/shared_test_classes/src/single_layer/lstm_cell.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/lstm_cell.cpp
@@ -42,8 +42,7 @@ void LSTMCellTest::SetUp() {
     size_t batch;
     size_t hidden_size;
     size_t input_size;
-    std::vector<std::string> activations;
-    std::vector<float> activations_alpha;
+    std::vector<std::string> activations;  std::vector<float> activations_alpha;
     std::vector<float> activations_beta;
     float clip;
     InferenceEngine::Precision netPrecision;

--- a/src/tests/functional/shared_test_classes/src/single_layer/lstm_sequence.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/lstm_sequence.cpp
@@ -65,6 +65,9 @@ namespace LayerTestsDefinitions {
                 {{batch, seq_lengths, input_size}, {batch, num_directions, hidden_size}, {batch, num_directions, hidden_size},
                  {batch}, {num_directions, 4 * hidden_size, input_size}, {num_directions, 4 * hidden_size, hidden_size}, {num_directions, 4 * hidden_size}},
         };
+        outPrc.front() = netPrecision;
+        outPrc.push_back(netPrecision);
+        outPrc.push_back(netPrecision);
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto params = makeParams(ngPrc, {inputShapes[0], inputShapes[1], inputShapes[2]});
         if (m_mode == SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_PARAM ||

--- a/src/tests/functional/shared_test_classes/src/single_layer/mat_mul.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/mat_mul.cpp
@@ -55,7 +55,7 @@ void MatMulTest::SetUp() {
     ngraph::helpers::InputLayerType secondaryInputType;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::map<std::string, std::string> additionalConfig;
-    std::tie(shapeRelatedParams, netPrecision, inPrc, outPrc.front(), inLayout, secondaryInputType, targetDevice, additionalConfig) =
+    std::tie(shapeRelatedParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, secondaryInputType, targetDevice, additionalConfig) =
         this->GetParam();
 
     configuration.insert(additionalConfig.begin(), additionalConfig.end());

--- a/src/tests/functional/shared_test_classes/src/single_layer/mat_mul.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/mat_mul.cpp
@@ -55,8 +55,8 @@ void MatMulTest::SetUp() {
     ngraph::helpers::InputLayerType secondaryInputType;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::map<std::string, std::string> additionalConfig;
-    std::tie(shapeRelatedParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, secondaryInputType, targetDevice, additionalConfig) =
-        this->GetParam();
+    std::tie(shapeRelatedParams, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout.front(), secondaryInputType, targetDevice, additionalConfig) = this->GetParam();
 
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/mat_mul.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/mat_mul.cpp
@@ -55,7 +55,7 @@ void MatMulTest::SetUp() {
     ngraph::helpers::InputLayerType secondaryInputType;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::map<std::string, std::string> additionalConfig;
-    std::tie(shapeRelatedParams, netPrecision, inPrc, outPrc, inLayout, secondaryInputType, targetDevice, additionalConfig) =
+    std::tie(shapeRelatedParams, netPrecision, inPrc, outPrc.front(), inLayout, secondaryInputType, targetDevice, additionalConfig) =
         this->GetParam();
 
     configuration.insert(additionalConfig.begin(), additionalConfig.end());

--- a/src/tests/functional/shared_test_classes/src/single_layer/memory.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/memory.cpp
@@ -36,6 +36,8 @@ namespace LayerTestsDefinitions {
 
     void MemoryTest::SetUp() {
         std::tie(transformation, iteration_count, inputShape, netPrecision, targetDevice) = this->GetParam();
+        outPrc.front() = netPrecision;
+        outPrc.push_back(netPrecision);
         ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
         if (transformation == ngraph::helpers::MemoryTransformation::NONE) {

--- a/src/tests/functional/shared_test_classes/src/single_layer/minimum_maximum.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/minimum_maximum.cpp
@@ -33,7 +33,7 @@ namespace LayerTestsDefinitions {
         InferenceEngine::Precision netPrecision;
         ngraph::helpers::InputLayerType inputType;
         ngraph::helpers::MinMaxOpType opType;
-        std::tie(inputShapes, opType, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputType, targetDevice) = this->GetParam();
+        std::tie(inputShapes, opType, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputType, targetDevice) = this->GetParam();
         if (inputShapes.size() != 2) {
             IE_THROW() << "Unsupported inputs number for Minimum/Maximum operaton";
         }

--- a/src/tests/functional/shared_test_classes/src/single_layer/minimum_maximum.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/minimum_maximum.cpp
@@ -33,7 +33,7 @@ namespace LayerTestsDefinitions {
         InferenceEngine::Precision netPrecision;
         ngraph::helpers::InputLayerType inputType;
         ngraph::helpers::MinMaxOpType opType;
-        std::tie(inputShapes, opType, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputType, targetDevice) = this->GetParam();
+        std::tie(inputShapes, opType, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputType, targetDevice) = this->GetParam();
         if (inputShapes.size() != 2) {
             IE_THROW() << "Unsupported inputs number for Minimum/Maximum operaton";
         }

--- a/src/tests/functional/shared_test_classes/src/single_layer/minimum_maximum.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/minimum_maximum.cpp
@@ -33,7 +33,8 @@ namespace LayerTestsDefinitions {
         InferenceEngine::Precision netPrecision;
         ngraph::helpers::InputLayerType inputType;
         ngraph::helpers::MinMaxOpType opType;
-        std::tie(inputShapes, opType, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputType, targetDevice) = this->GetParam();
+        std::tie(inputShapes, opType, netPrecision, inPrc.front(), outPrc.front(),
+                inLayout.front(), outLayout.front(), inputType, targetDevice) = this->GetParam();
         if (inputShapes.size() != 2) {
             IE_THROW() << "Unsupported inputs number for Minimum/Maximum operaton";
         }

--- a/src/tests/functional/shared_test_classes/src/single_layer/minimum_maximum.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/minimum_maximum.cpp
@@ -33,7 +33,7 @@ namespace LayerTestsDefinitions {
         InferenceEngine::Precision netPrecision;
         ngraph::helpers::InputLayerType inputType;
         ngraph::helpers::MinMaxOpType opType;
-        std::tie(inputShapes, opType, netPrecision, inPrc, outPrc, inLayout, outLayout, inputType, targetDevice) = this->GetParam();
+        std::tie(inputShapes, opType, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputType, targetDevice) = this->GetParam();
         if (inputShapes.size() != 2) {
             IE_THROW() << "Unsupported inputs number for Minimum/Maximum operaton";
         }

--- a/src/tests/functional/shared_test_classes/src/single_layer/non_max_suppression.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/non_max_suppression.cpp
@@ -352,7 +352,7 @@ void NmsLayerTest::SetUp() {
     element::Type outType;
     std::tie(inShapeParams, inPrecisions, maxOutBoxesPerClass, iouThr, scoreThr, softNmsSigma, boxEncoding, sortResDescend, outType,
              targetDevice) = this->GetParam();
-
+    const auto outTypePrc = InferenceEngine::details::convertPrecision(outType);
     size_t numBatches, numBoxes, numClasses;
     std::tie(numBatches, numBoxes, numClasses) = inShapeParams;
 
@@ -366,6 +366,9 @@ void NmsLayerTest::SetUp() {
     auto params = builder::makeParams(ngPrc, {boxesShape, scoresShape});
     auto paramOuts = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(params));
 
+    outPrc.front() = outTypePrc;
+    outPrc.push_back(paramsPrec);
+    outPrc.push_back(outTypePrc);
     auto nms = builder::makeNms(paramOuts[0], paramOuts[1], convertIE2nGraphPrc(maxBoxPrec), convertIE2nGraphPrc(thrPrec), maxOutBoxesPerClass, iouThr,
                                 scoreThr, softNmsSigma, boxEncoding, sortResDescend, outType);
     if (targetDevice == CommonTestUtils::DEVICE_CPU) {

--- a/src/tests/functional/shared_test_classes/src/single_layer/pad.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/pad.cpp
@@ -40,7 +40,7 @@ void PadLayerTest::SetUp() {
     float argPadValue;
     ngraph::helpers::PadMode padMode;
     InferenceEngine::Precision netPrecision;
-    std::tie(padsBegin, padsEnd, argPadValue, padMode, netPrecision, inPrc, outPrc.front(), inLayout, inputShape, targetDevice) =
+    std::tie(padsBegin, padsEnd, argPadValue, padMode, netPrecision, inPrc.front(), outPrc.front(), inLayout, inputShape, targetDevice) =
     this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/pad.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/pad.cpp
@@ -40,7 +40,7 @@ void PadLayerTest::SetUp() {
     float argPadValue;
     ngraph::helpers::PadMode padMode;
     InferenceEngine::Precision netPrecision;
-    std::tie(padsBegin, padsEnd, argPadValue, padMode, netPrecision, inPrc, outPrc, inLayout, inputShape, targetDevice) =
+    std::tie(padsBegin, padsEnd, argPadValue, padMode, netPrecision, inPrc, outPrc.front(), inLayout, inputShape, targetDevice) =
     this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/pad.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/pad.cpp
@@ -40,8 +40,8 @@ void PadLayerTest::SetUp() {
     float argPadValue;
     ngraph::helpers::PadMode padMode;
     InferenceEngine::Precision netPrecision;
-    std::tie(padsBegin, padsEnd, argPadValue, padMode, netPrecision, inPrc.front(), outPrc.front(), inLayout, inputShape, targetDevice) =
-    this->GetParam();
+    std::tie(padsBegin, padsEnd, argPadValue, padMode, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout.front(), inputShape, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/pooling.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/pooling.cpp
@@ -134,7 +134,7 @@ void PoolingLayerTest::SetUp() {
     poolSpecificParams poolParams;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
     ngraph::helpers::PoolingTypes poolType;
     std::vector<size_t> kernel, stride;
     std::vector<size_t> padBegin, padEnd;
@@ -166,7 +166,7 @@ void GlobalPoolingLayerTest::SetUp() {
     poolSpecificParams poolParams;
     InferenceEngine::Precision netPrecision;
     size_t channels;
-    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, channels, targetDevice) = this->GetParam();
+    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), channels, targetDevice) = this->GetParam();
     ngraph::helpers::PoolingTypes poolType;
     std::vector<size_t> kernel, stride;
     std::vector<size_t> padBegin, padEnd;
@@ -200,7 +200,7 @@ void MaxPoolingV8LayerTest::SetUp() {
     maxPoolV8SpecificParams poolParams;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
     std::vector<size_t> kernel, stride, dilation;
     std::vector<size_t> padBegin, padEnd;
     ngraph::op::PadType padType;

--- a/src/tests/functional/shared_test_classes/src/single_layer/pooling.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/pooling.cpp
@@ -134,7 +134,8 @@ void PoolingLayerTest::SetUp() {
     poolSpecificParams poolParams;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
+    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout.front(), outLayout.front(), inputShape, targetDevice) = this->GetParam();
     ngraph::helpers::PoolingTypes poolType;
     std::vector<size_t> kernel, stride;
     std::vector<size_t> padBegin, padEnd;
@@ -166,7 +167,7 @@ void GlobalPoolingLayerTest::SetUp() {
     poolSpecificParams poolParams;
     InferenceEngine::Precision netPrecision;
     size_t channels;
-    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), channels, targetDevice) = this->GetParam();
+    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(), inLayout.front(), outLayout.front(), channels, targetDevice) = this->GetParam();
     ngraph::helpers::PoolingTypes poolType;
     std::vector<size_t> kernel, stride;
     std::vector<size_t> padBegin, padEnd;
@@ -200,7 +201,7 @@ void MaxPoolingV8LayerTest::SetUp() {
     maxPoolV8SpecificParams poolParams;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
+    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(), inLayout.front(), outLayout.front(), inputShape, targetDevice) = this->GetParam();
     std::vector<size_t> kernel, stride, dilation;
     std::vector<size_t> padBegin, padEnd;
     ngraph::op::PadType padType;

--- a/src/tests/functional/shared_test_classes/src/single_layer/pooling.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/pooling.cpp
@@ -134,7 +134,7 @@ void PoolingLayerTest::SetUp() {
     poolSpecificParams poolParams;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(poolParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
     ngraph::helpers::PoolingTypes poolType;
     std::vector<size_t> kernel, stride;
     std::vector<size_t> padBegin, padEnd;
@@ -166,7 +166,7 @@ void GlobalPoolingLayerTest::SetUp() {
     poolSpecificParams poolParams;
     InferenceEngine::Precision netPrecision;
     size_t channels;
-    std::tie(poolParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, channels, targetDevice) = this->GetParam();
+    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, channels, targetDevice) = this->GetParam();
     ngraph::helpers::PoolingTypes poolType;
     std::vector<size_t> kernel, stride;
     std::vector<size_t> padBegin, padEnd;
@@ -200,7 +200,7 @@ void MaxPoolingV8LayerTest::SetUp() {
     maxPoolV8SpecificParams poolParams;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(poolParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(poolParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
     std::vector<size_t> kernel, stride, dilation;
     std::vector<size_t> padBegin, padEnd;
     ngraph::op::PadType padType;

--- a/src/tests/functional/shared_test_classes/src/single_layer/pooling.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/pooling.cpp
@@ -134,7 +134,7 @@ void PoolingLayerTest::SetUp() {
     poolSpecificParams poolParams;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(poolParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(poolParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
     ngraph::helpers::PoolingTypes poolType;
     std::vector<size_t> kernel, stride;
     std::vector<size_t> padBegin, padEnd;
@@ -166,7 +166,7 @@ void GlobalPoolingLayerTest::SetUp() {
     poolSpecificParams poolParams;
     InferenceEngine::Precision netPrecision;
     size_t channels;
-    std::tie(poolParams, netPrecision, inPrc, outPrc, inLayout, outLayout, channels, targetDevice) = this->GetParam();
+    std::tie(poolParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, channels, targetDevice) = this->GetParam();
     ngraph::helpers::PoolingTypes poolType;
     std::vector<size_t> kernel, stride;
     std::vector<size_t> padBegin, padEnd;
@@ -200,7 +200,7 @@ void MaxPoolingV8LayerTest::SetUp() {
     maxPoolV8SpecificParams poolParams;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
-    std::tie(poolParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(poolParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
     std::vector<size_t> kernel, stride, dilation;
     std::vector<size_t> padBegin, padEnd;
     ngraph::op::PadType padType;

--- a/src/tests/functional/shared_test_classes/src/single_layer/power.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/power.cpp
@@ -32,7 +32,7 @@ namespace LayerTestsDefinitions {
         std::vector<std::vector<size_t>> inputShapes;
         InferenceEngine::Precision netPrecision;
         std::vector<float> power;
-        std::tie(inputShapes, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice, power) = this->GetParam();
+        std::tie(inputShapes, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice, power) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes[0]});
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/power.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/power.cpp
@@ -32,7 +32,7 @@ namespace LayerTestsDefinitions {
         std::vector<std::vector<size_t>> inputShapes;
         InferenceEngine::Precision netPrecision;
         std::vector<float> power;
-        std::tie(inputShapes, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice, power) = this->GetParam();
+        std::tie(inputShapes, netPrecision, inPrc.front(), outPrc.front(), inLayout.front(), outLayout.front(), targetDevice, power) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes[0]});
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/power.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/power.cpp
@@ -32,7 +32,7 @@ namespace LayerTestsDefinitions {
         std::vector<std::vector<size_t>> inputShapes;
         InferenceEngine::Precision netPrecision;
         std::vector<float> power;
-        std::tie(inputShapes, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice, power) = this->GetParam();
+        std::tie(inputShapes, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice, power) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes[0]});
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/power.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/power.cpp
@@ -32,7 +32,7 @@ namespace LayerTestsDefinitions {
         std::vector<std::vector<size_t>> inputShapes;
         InferenceEngine::Precision netPrecision;
         std::vector<float> power;
-        std::tie(inputShapes, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice, power) = this->GetParam();
+        std::tie(inputShapes, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice, power) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes[0]});
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/prior_box.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/prior_box.cpp
@@ -56,7 +56,7 @@ std::string PriorBoxLayerTest::getTestCaseName(const testing::TestParamInfo<prio
 void PriorBoxLayerTest::SetUp() {
     priorBoxSpecificParams specParams;
     std::tie(specParams, netPrecision,
-             inPrc.front(), outPrc.front(), inLayout, outLayout,
+             inPrc.front(), outPrc.front(), inLayout, outLayout.front(),
              inputShapes, imageShapes, targetDevice) = GetParam();
 
     std::tie(min_size, max_size, aspect_ratio,

--- a/src/tests/functional/shared_test_classes/src/single_layer/prior_box.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/prior_box.cpp
@@ -56,7 +56,7 @@ std::string PriorBoxLayerTest::getTestCaseName(const testing::TestParamInfo<prio
 void PriorBoxLayerTest::SetUp() {
     priorBoxSpecificParams specParams;
     std::tie(specParams, netPrecision,
-             inPrc, outPrc.front(), inLayout, outLayout,
+             inPrc.front(), outPrc.front(), inLayout, outLayout,
              inputShapes, imageShapes, targetDevice) = GetParam();
 
     std::tie(min_size, max_size, aspect_ratio,

--- a/src/tests/functional/shared_test_classes/src/single_layer/prior_box.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/prior_box.cpp
@@ -56,7 +56,7 @@ std::string PriorBoxLayerTest::getTestCaseName(const testing::TestParamInfo<prio
 void PriorBoxLayerTest::SetUp() {
     priorBoxSpecificParams specParams;
     std::tie(specParams, netPrecision,
-             inPrc.front(), outPrc.front(), inLayout, outLayout.front(),
+             inPrc.front(), outPrc.front(), inLayout.front(), outLayout.front(),
              inputShapes, imageShapes, targetDevice) = GetParam();
 
     std::tie(min_size, max_size, aspect_ratio,

--- a/src/tests/functional/shared_test_classes/src/single_layer/prior_box.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/prior_box.cpp
@@ -56,7 +56,7 @@ std::string PriorBoxLayerTest::getTestCaseName(const testing::TestParamInfo<prio
 void PriorBoxLayerTest::SetUp() {
     priorBoxSpecificParams specParams;
     std::tie(specParams, netPrecision,
-             inPrc, outPrc, inLayout, outLayout,
+             inPrc, outPrc.front(), inLayout, outLayout,
              inputShapes, imageShapes, targetDevice) = GetParam();
 
     std::tie(min_size, max_size, aspect_ratio,

--- a/src/tests/functional/shared_test_classes/src/single_layer/prior_box_clustered.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/prior_box_clustered.cpp
@@ -60,7 +60,7 @@ std::string PriorBoxClusteredLayerTest::getTestCaseName(const testing::TestParam
 void PriorBoxClusteredLayerTest::SetUp() {
     priorBoxClusteredSpecificParams specParams;
     std::tie(specParams, netPrecision,
-        inPrc.front(), outPrc.front(), inLayout, outLayout,
+        inPrc.front(), outPrc.front(), inLayout, outLayout.front(),
         inputShapes, imageShapes, targetDevice) = GetParam();
 
     std::tie(widths,

--- a/src/tests/functional/shared_test_classes/src/single_layer/prior_box_clustered.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/prior_box_clustered.cpp
@@ -60,7 +60,7 @@ std::string PriorBoxClusteredLayerTest::getTestCaseName(const testing::TestParam
 void PriorBoxClusteredLayerTest::SetUp() {
     priorBoxClusteredSpecificParams specParams;
     std::tie(specParams, netPrecision,
-        inPrc, outPrc.front(), inLayout, outLayout,
+        inPrc.front(), outPrc.front(), inLayout, outLayout,
         inputShapes, imageShapes, targetDevice) = GetParam();
 
     std::tie(widths,

--- a/src/tests/functional/shared_test_classes/src/single_layer/prior_box_clustered.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/prior_box_clustered.cpp
@@ -60,7 +60,7 @@ std::string PriorBoxClusteredLayerTest::getTestCaseName(const testing::TestParam
 void PriorBoxClusteredLayerTest::SetUp() {
     priorBoxClusteredSpecificParams specParams;
     std::tie(specParams, netPrecision,
-        inPrc, outPrc, inLayout, outLayout,
+        inPrc, outPrc.front(), inLayout, outLayout,
         inputShapes, imageShapes, targetDevice) = GetParam();
 
     std::tie(widths,

--- a/src/tests/functional/shared_test_classes/src/single_layer/prior_box_clustered.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/prior_box_clustered.cpp
@@ -60,7 +60,7 @@ std::string PriorBoxClusteredLayerTest::getTestCaseName(const testing::TestParam
 void PriorBoxClusteredLayerTest::SetUp() {
     priorBoxClusteredSpecificParams specParams;
     std::tie(specParams, netPrecision,
-        inPrc.front(), outPrc.front(), inLayout, outLayout.front(),
+        inPrc.front(), outPrc.front(), inLayout.front(), outLayout.front(),
         inputShapes, imageShapes, targetDevice) = GetParam();
 
     std::tie(widths,

--- a/src/tests/functional/shared_test_classes/src/single_layer/proposal.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/proposal.cpp
@@ -146,6 +146,8 @@ void ProposalLayerTest::SetUp() {
     std::vector<size_t> imageInfoShape = {3};
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(InferenceEngine::Precision::FP16);
+    outPrc.front() = InferenceEngine::Precision::FP16;
+    outPrc.push_back(InferenceEngine::Precision::FP16);
         // a_ and b_ are a workaround to solve alphabetic param sorting that destroys ordering
     auto params = ngraph::builder::makeParams(ngPrc, {{"a_scores", scoresShape}, {"b_boxes", boxesShape}});
     auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));

--- a/src/tests/functional/shared_test_classes/src/single_layer/range.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/range.cpp
@@ -48,7 +48,7 @@ void RangeLayerTest::Infer() {
 
 void RangeLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
-    tie(start, stop, step, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice) = GetParam();
+    tie(start, stop, step, netPrecision, inPrc.front(), outPrc.front(), inLayout.front(), outLayout.front(), targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     std::vector<std::pair<std::string, std::vector<size_t>>> inputs {{"start", {}}, {"stop", {}}, {"step", {}}};
     auto params = ngraph::builder::makeParams(ngPrc, inputs);
@@ -101,7 +101,7 @@ void RangeNumpyLayerTest::Infer() {
 void RangeNumpyLayerTest::SetUp() {
     InferenceEngine::Precision netPrc;
     InferenceEngine::Precision paramPrc;
-    std::tie(start, stop, step, paramPrc, netPrc, outPrc.front(), inLayout, outLayout.front(), targetDevice) = GetParam();
+    std::tie(start, stop, step, paramPrc, netPrc, outPrc.front(), inLayout.front(), outLayout.front(), targetDevice) = GetParam();
     auto ngNetPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrc);
     auto ngParamPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(paramPrc);
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/range.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/range.cpp
@@ -48,7 +48,7 @@ void RangeLayerTest::Infer() {
 
 void RangeLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
-    tie(start, stop, step, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = GetParam();
+    tie(start, stop, step, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     std::vector<std::pair<std::string, std::vector<size_t>>> inputs {{"start", {}}, {"stop", {}}, {"step", {}}};
     auto params = ngraph::builder::makeParams(ngPrc, inputs);
@@ -101,7 +101,7 @@ void RangeNumpyLayerTest::Infer() {
 void RangeNumpyLayerTest::SetUp() {
     InferenceEngine::Precision netPrc;
     InferenceEngine::Precision paramPrc;
-    std::tie(start, stop, step, paramPrc, netPrc, outPrc, inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(start, stop, step, paramPrc, netPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
     auto ngNetPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrc);
     auto ngParamPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(paramPrc);
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/range.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/range.cpp
@@ -48,7 +48,7 @@ void RangeLayerTest::Infer() {
 
 void RangeLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
-    tie(start, stop, step, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
+    tie(start, stop, step, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     std::vector<std::pair<std::string, std::vector<size_t>>> inputs {{"start", {}}, {"stop", {}}, {"step", {}}};
     auto params = ngraph::builder::makeParams(ngPrc, inputs);

--- a/src/tests/functional/shared_test_classes/src/single_layer/range.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/range.cpp
@@ -48,7 +48,7 @@ void RangeLayerTest::Infer() {
 
 void RangeLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
-    tie(start, stop, step, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
+    tie(start, stop, step, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     std::vector<std::pair<std::string, std::vector<size_t>>> inputs {{"start", {}}, {"stop", {}}, {"step", {}}};
     auto params = ngraph::builder::makeParams(ngPrc, inputs);
@@ -101,7 +101,7 @@ void RangeNumpyLayerTest::Infer() {
 void RangeNumpyLayerTest::SetUp() {
     InferenceEngine::Precision netPrc;
     InferenceEngine::Precision paramPrc;
-    std::tie(start, stop, step, paramPrc, netPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(start, stop, step, paramPrc, netPrc, outPrc.front(), inLayout, outLayout.front(), targetDevice) = GetParam();
     auto ngNetPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrc);
     auto ngParamPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(paramPrc);
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/reduce_ops.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/reduce_ops.cpp
@@ -38,7 +38,7 @@ void ReduceOpsLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::vector<int> axes;
     CommonTestUtils::OpType opType;
-    std::tie(axes, opType, keepDims, reductionType, netPrecision, inPrc.front(), outPrc.front(), inLayout, inputShape, targetDevice) = GetParam();
+    std::tie(axes, opType, keepDims, reductionType, netPrecision, inPrc.front(), outPrc.front(), inLayout.front(), inputShape, targetDevice) = GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/reduce_ops.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/reduce_ops.cpp
@@ -38,7 +38,7 @@ void ReduceOpsLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::vector<int> axes;
     CommonTestUtils::OpType opType;
-    std::tie(axes, opType, keepDims, reductionType, netPrecision, inPrc, outPrc, inLayout, inputShape, targetDevice) = GetParam();
+    std::tie(axes, opType, keepDims, reductionType, netPrecision, inPrc, outPrc.front(), inLayout, inputShape, targetDevice) = GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/reduce_ops.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/reduce_ops.cpp
@@ -38,7 +38,7 @@ void ReduceOpsLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::vector<int> axes;
     CommonTestUtils::OpType opType;
-    std::tie(axes, opType, keepDims, reductionType, netPrecision, inPrc, outPrc.front(), inLayout, inputShape, targetDevice) = GetParam();
+    std::tie(axes, opType, keepDims, reductionType, netPrecision, inPrc.front(), outPrc.front(), inLayout, inputShape, targetDevice) = GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/reshape.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/reshape.cpp
@@ -33,7 +33,7 @@ void ReshapeLayerTest::SetUp() {
     std::vector<int64_t> outFormShapes;
     bool specialZero;
     InferenceEngine::Precision netPrecision;
-    std::tie(specialZero, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShapes, outFormShapes, targetDevice, configuration) =
+    std::tie(specialZero, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShapes, outFormShapes, targetDevice, configuration) =
         this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes});

--- a/src/tests/functional/shared_test_classes/src/single_layer/reshape.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/reshape.cpp
@@ -33,7 +33,7 @@ void ReshapeLayerTest::SetUp() {
     std::vector<int64_t> outFormShapes;
     bool specialZero;
     InferenceEngine::Precision netPrecision;
-    std::tie(specialZero, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShapes, outFormShapes, targetDevice, configuration) =
+    std::tie(specialZero, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShapes, outFormShapes, targetDevice, configuration) =
         this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes});

--- a/src/tests/functional/shared_test_classes/src/single_layer/reshape.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/reshape.cpp
@@ -33,8 +33,8 @@ void ReshapeLayerTest::SetUp() {
     std::vector<int64_t> outFormShapes;
     bool specialZero;
     InferenceEngine::Precision netPrecision;
-    std::tie(specialZero, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShapes, outFormShapes, targetDevice, configuration) =
-        this->GetParam();
+    std::tie(specialZero, netPrecision, inPrc.front(), outPrc.front(), inLayout.front(), outLayout.front(),
+            inputShapes, outFormShapes, targetDevice, configuration) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes});
     auto paramIn = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/reshape.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/reshape.cpp
@@ -33,7 +33,7 @@ void ReshapeLayerTest::SetUp() {
     std::vector<int64_t> outFormShapes;
     bool specialZero;
     InferenceEngine::Precision netPrecision;
-    std::tie(specialZero, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShapes, outFormShapes, targetDevice, configuration) =
+    std::tie(specialZero, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShapes, outFormShapes, targetDevice, configuration) =
         this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes});

--- a/src/tests/functional/shared_test_classes/src/single_layer/rnn_sequence.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/rnn_sequence.cpp
@@ -63,6 +63,8 @@ namespace LayerTestsDefinitions {
                  {num_directions, hidden_size}},
         };
         m_max_seq_len = seq_lengths;
+        outPrc.front() = netPrecision;
+        outPrc.push_back(netPrecision);
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1]});
         if (m_mode == SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_PARAM ||

--- a/src/tests/functional/shared_test_classes/src/single_layer/shape_of.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/shape_of.cpp
@@ -23,9 +23,9 @@ namespace LayerTestsDefinitions {
     void ShapeOfLayerTest::SetUp() {
         InferenceEngine::SizeVector inputShapes;
         InferenceEngine::Precision inputPrecision;
-        std::tie(inputPrecision, outPrc, inputShapes, targetDevice) = this->GetParam();
+        std::tie(inputPrecision, outPrc.front(), inputShapes, targetDevice) = this->GetParam();
         auto inType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
-        auto outType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc);
+        auto outType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(outPrc.front());
         auto param = ngraph::builder::makeParams(inType, {inputShapes});
         auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::opset3::Parameter>(param));
         auto shapeOf = std::make_shared<ngraph::opset3::ShapeOf>(paramOuts[0], outType);

--- a/src/tests/functional/shared_test_classes/src/single_layer/shuffle_channels.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/shuffle_channels.cpp
@@ -35,7 +35,7 @@ void ShuffleChannelsLayerTest::SetUp() {
     shuffleChannelsSpecificParams shuffleChannelsParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(shuffleChannelsParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(shuffleChannelsParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
     int axis, group;
     std::tie(axis, group) = shuffleChannelsParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/shuffle_channels.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/shuffle_channels.cpp
@@ -35,7 +35,7 @@ void ShuffleChannelsLayerTest::SetUp() {
     shuffleChannelsSpecificParams shuffleChannelsParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(shuffleChannelsParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(shuffleChannelsParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
     int axis, group;
     std::tie(axis, group) = shuffleChannelsParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/shuffle_channels.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/shuffle_channels.cpp
@@ -35,7 +35,8 @@ void ShuffleChannelsLayerTest::SetUp() {
     shuffleChannelsSpecificParams shuffleChannelsParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(shuffleChannelsParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
+    std::tie(shuffleChannelsParams, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout.front(), outLayout.front(), inputShape, targetDevice) = this->GetParam();
     int axis, group;
     std::tie(axis, group) = shuffleChannelsParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/shuffle_channels.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/shuffle_channels.cpp
@@ -35,7 +35,7 @@ void ShuffleChannelsLayerTest::SetUp() {
     shuffleChannelsSpecificParams shuffleChannelsParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(shuffleChannelsParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(shuffleChannelsParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
     int axis, group;
     std::tie(axis, group) = shuffleChannelsParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/slice.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/slice.cpp
@@ -41,11 +41,10 @@ std::string Slice8LayerTest::getTestCaseName(const testing::TestParamInfo<Slice8
 
 void Slice8LayerTest::SetUp() {
     Slice8SpecificParams sliceParams;
-    ov::test::ElementType netPrecision, inPrecision;
-    std::vector<ov::element::Type_t> outPrecision;
+    ov::test::ElementType netPrecision, inPrecision, outPrecision;
     InferenceEngine::Layout inLayout, outLayout;
     std::map<std::string, std::string> additionalConfig;
-    std::tie(sliceParams, netPrecision, inPrecision, outPrecision.front(), inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
+    std::tie(sliceParams, netPrecision, inPrecision, outPrecision, inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
 
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
     init_input_shapes(sliceParams.shapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/slice.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/slice.cpp
@@ -41,10 +41,11 @@ std::string Slice8LayerTest::getTestCaseName(const testing::TestParamInfo<Slice8
 
 void Slice8LayerTest::SetUp() {
     Slice8SpecificParams sliceParams;
-    ov::test::ElementType netPrecision, inPrecision, outPrecision;
+    ov::test::ElementType netPrecision, inPrecision;
+    std::vector<ov::element::Type_t> outPrecision;
     InferenceEngine::Layout inLayout, outLayout;
     std::map<std::string, std::string> additionalConfig;
-    std::tie(sliceParams, netPrecision, inPrecision, outPrecision, inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
+    std::tie(sliceParams, netPrecision, inPrecision, outPrecision.front(), inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
 
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
     init_input_shapes(sliceParams.shapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/softmax.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/softmax.cpp
@@ -40,7 +40,7 @@ void SoftMaxLayerTest::SetUp() {
     ElementType ngPrc;
     size_t axis;
 
-    std::tie(ngPrc, inType, outType, shapes, axis, targetDevice, configuration) = GetParam();
+    std::tie(ngPrc, inType, outType[0], shapes, axis, targetDevice, configuration) = GetParam();
     init_input_shapes({shapes});
 
     const auto params = ngraph::builder::makeDynamicParams(ngPrc, inputDynamicShapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/softmax.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/softmax.cpp
@@ -40,7 +40,7 @@ void SoftMaxLayerTest::SetUp() {
     ElementType ngPrc;
     size_t axis;
 
-    std::tie(ngPrc, inType, outType[0], shapes, axis, targetDevice, configuration) = GetParam();
+    std::tie(ngPrc, inType[0], outType[0], shapes, axis, targetDevice, configuration) = GetParam();
     init_input_shapes({shapes});
 
     const auto params = ngraph::builder::makeDynamicParams(ngPrc, inputDynamicShapes);

--- a/src/tests/functional/shared_test_classes/src/single_layer/space_to_batch.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/space_to_batch.cpp
@@ -33,7 +33,8 @@ void SpaceToBatchLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::vector<int64_t> blockShape, padsBegin, padsEnd;
     InferenceEngine::Precision netPrecision;
-    std::tie(blockShape, padsBegin, padsEnd, inputShape, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
+    std::tie(blockShape, padsBegin, padsEnd, inputShape, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout, outLayout.front(), targetDevice) = this->GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/space_to_batch.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/space_to_batch.cpp
@@ -33,7 +33,7 @@ void SpaceToBatchLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::vector<int64_t> blockShape, padsBegin, padsEnd;
     InferenceEngine::Precision netPrecision;
-    std::tie(blockShape, padsBegin, padsEnd, inputShape, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = this->GetParam();
+    std::tie(blockShape, padsBegin, padsEnd, inputShape, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/space_to_batch.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/space_to_batch.cpp
@@ -33,7 +33,7 @@ void SpaceToBatchLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     std::vector<int64_t> blockShape, padsBegin, padsEnd;
     InferenceEngine::Precision netPrecision;
-    std::tie(blockShape, padsBegin, padsEnd, inputShape, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
+    std::tie(blockShape, padsBegin, padsEnd, inputShape, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = this->GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/space_to_batch.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/space_to_batch.cpp
@@ -34,7 +34,7 @@ void SpaceToBatchLayerTest::SetUp() {
     std::vector<int64_t> blockShape, padsBegin, padsEnd;
     InferenceEngine::Precision netPrecision;
     std::tie(blockShape, padsBegin, padsEnd, inputShape, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout.front(), targetDevice) = this->GetParam();
+            inLayout.front(), outLayout.front(), targetDevice) = this->GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/split.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/split.cpp
@@ -36,7 +36,8 @@ void SplitLayerTest::SetUp() {
     size_t axis, numSplits;
     std::vector<size_t> inputShape, outIndices;
     InferenceEngine::Precision netPrecision;
-    std::tie(numSplits, axis, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, outIndices, targetDevice) = this->GetParam();
+    std::tie(numSplits, axis, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout, outLayout.front(), inputShape, outIndices, targetDevice) = this->GetParam();
     if (outIndices.empty()) {
         for (int i = 0; i < numSplits; ++i) {
             outIndices.push_back(i);

--- a/src/tests/functional/shared_test_classes/src/single_layer/split.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/split.cpp
@@ -36,16 +36,13 @@ void SplitLayerTest::SetUp() {
     size_t axis, numSplits;
     std::vector<size_t> inputShape, outIndices;
     InferenceEngine::Precision netPrecision;
-    std::tie(numSplits, axis, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, outIndices, targetDevice) = this->GetParam();
+    std::tie(numSplits, axis, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, outIndices, targetDevice) = this->GetParam();
     if (outIndices.empty()) {
         for (int i = 0; i < numSplits; ++i) {
             outIndices.push_back(i);
         }
     }
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-    for (int k = 1; k < numSplits; k++) {
-        outPrc.push_back(outPrc.front());
-    }
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(
             ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));

--- a/src/tests/functional/shared_test_classes/src/single_layer/split.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/split.cpp
@@ -43,7 +43,7 @@ void SplitLayerTest::SetUp() {
         }
     }
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-    for (int k = 1; k < outIndices.size(); k++) {
+    for (int k = 1; k < numSplits; k++) {
         outPrc.push_back(outPrc.front());
     }
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/split.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/split.cpp
@@ -37,7 +37,7 @@ void SplitLayerTest::SetUp() {
     std::vector<size_t> inputShape, outIndices;
     InferenceEngine::Precision netPrecision;
     std::tie(numSplits, axis, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout.front(), inputShape, outIndices, targetDevice) = this->GetParam();
+            inLayout.front(), outLayout.front(), inputShape, outIndices, targetDevice) = this->GetParam();
     if (outIndices.empty()) {
         for (int i = 0; i < numSplits; ++i) {
             outIndices.push_back(i);

--- a/src/tests/functional/shared_test_classes/src/single_layer/split.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/split.cpp
@@ -43,6 +43,9 @@ void SplitLayerTest::SetUp() {
         }
     }
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    for (int k = 1; k < outIndices.size(); k++) {
+        outPrc.push_back(outPrc.front());
+    }
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(
             ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));

--- a/src/tests/functional/shared_test_classes/src/single_layer/split.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/split.cpp
@@ -36,7 +36,7 @@ void SplitLayerTest::SetUp() {
     size_t axis, numSplits;
     std::vector<size_t> inputShape, outIndices;
     InferenceEngine::Precision netPrecision;
-    std::tie(numSplits, axis, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, outIndices, targetDevice) = this->GetParam();
+    std::tie(numSplits, axis, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, outIndices, targetDevice) = this->GetParam();
     if (outIndices.empty()) {
         for (int i = 0; i < numSplits; ++i) {
             outIndices.push_back(i);

--- a/src/tests/functional/shared_test_classes/src/single_layer/squeeze_unsqueeze.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/squeeze_unsqueeze.cpp
@@ -35,7 +35,7 @@ void SqueezeUnsqueezeLayerTest::SetUp() {
     ShapeAxesTuple shapeItem;
     ngraph::helpers::SqueezeOpType opType;
     std::tie(shapeItem, opType, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout.front(), targetDevice) = GetParam();
+            inLayout.front(), outLayout.front(), targetDevice) = GetParam();
     std::tie(inputShapes, axesVector) = shapeItem;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/squeeze_unsqueeze.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/squeeze_unsqueeze.cpp
@@ -34,7 +34,7 @@ void SqueezeUnsqueezeLayerTest::SetUp() {
     std::vector<int> axesVector;
     ShapeAxesTuple shapeItem;
     ngraph::helpers::SqueezeOpType opType;
-    std::tie(shapeItem, opType, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(shapeItem, opType, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
     std::tie(inputShapes, axesVector) = shapeItem;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/squeeze_unsqueeze.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/squeeze_unsqueeze.cpp
@@ -34,7 +34,8 @@ void SqueezeUnsqueezeLayerTest::SetUp() {
     std::vector<int> axesVector;
     ShapeAxesTuple shapeItem;
     ngraph::helpers::SqueezeOpType opType;
-    std::tie(shapeItem, opType, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(shapeItem, opType, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout, outLayout.front(), targetDevice) = GetParam();
     std::tie(inputShapes, axesVector) = shapeItem;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/squeeze_unsqueeze.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/squeeze_unsqueeze.cpp
@@ -34,7 +34,7 @@ void SqueezeUnsqueezeLayerTest::SetUp() {
     std::vector<int> axesVector;
     ShapeAxesTuple shapeItem;
     ngraph::helpers::SqueezeOpType opType;
-    std::tie(shapeItem, opType, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(shapeItem, opType, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
     std::tie(inputShapes, axesVector) = shapeItem;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/strided_slice.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/strided_slice.cpp
@@ -39,7 +39,7 @@ void StridedSliceLayerTest::SetUp() {
     StridedSliceSpecificParams ssParams;
     InferenceEngine::Precision netPrecision;
     std::map<std::string, std::string> additionalConfig;
-    std::tie(ssParams, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
+    std::tie(ssParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/strided_slice.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/strided_slice.cpp
@@ -39,7 +39,7 @@ void StridedSliceLayerTest::SetUp() {
     StridedSliceSpecificParams ssParams;
     InferenceEngine::Precision netPrecision;
     std::map<std::string, std::string> additionalConfig;
-    std::tie(ssParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
+    std::tie(ssParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/strided_slice.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/strided_slice.cpp
@@ -39,7 +39,8 @@ void StridedSliceLayerTest::SetUp() {
     StridedSliceSpecificParams ssParams;
     InferenceEngine::Precision netPrecision;
     std::map<std::string, std::string> additionalConfig;
-    std::tie(ssParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
+    std::tie(ssParams, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout, outLayout.front(), targetDevice, additionalConfig) = this->GetParam();
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/strided_slice.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/strided_slice.cpp
@@ -40,7 +40,7 @@ void StridedSliceLayerTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     std::map<std::string, std::string> additionalConfig;
     std::tie(ssParams, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout.front(), targetDevice, additionalConfig) = this->GetParam();
+            inLayout.front(), outLayout.front(), targetDevice, additionalConfig) = this->GetParam();
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/single_layer/tensor_iterator.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/tensor_iterator.cpp
@@ -72,6 +72,9 @@ namespace LayerTestsDefinitions {
         std::tie(should_decompose, seq_lengths, batch, hidden_size, sequence_axis, clip, ti_body, direction, netPrecision,
                  targetDevice) = this->GetParam();
         std::vector<std::vector<size_t>> inputShapes;
+        outPrc.front() = netPrecision;
+        outPrc.push_back(netPrecision);
+        outPrc.push_back(netPrecision);
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto tensor_iterator = std::make_shared<ngraph::opset5::TensorIterator>();
 

--- a/src/tests/functional/shared_test_classes/src/single_layer/tile.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/tile.cpp
@@ -31,7 +31,8 @@ void TileLayerTest::SetUp() {
     TileSpecificParams tileParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(tileParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(tileParams, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/tile.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/tile.cpp
@@ -32,7 +32,7 @@ void TileLayerTest::SetUp() {
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(tileParams, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
+            inLayout.front(), outLayout.front(), inputShape, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/tile.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/tile.cpp
@@ -31,7 +31,7 @@ void TileLayerTest::SetUp() {
     TileSpecificParams tileParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(tileParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(tileParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/tile.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/tile.cpp
@@ -31,7 +31,7 @@ void TileLayerTest::SetUp() {
     TileSpecificParams tileParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(tileParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(tileParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/topk.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/topk.cpp
@@ -8,8 +8,11 @@ namespace LayerTestsDefinitions {
     std::string TopKLayerTest::getTestCaseName(const testing::TestParamInfo<TopKParams>& obj) {
     InferenceEngine::Precision netPrecision;
     std::vector<InferenceEngine::Precision> inPrc;
+    inPrc.reserve(2);
     std::vector<InferenceEngine::Precision> outPrc;
-    InferenceEngine::Layout inLayout;
+    outPrc.reserve(2);
+    std::vector<InferenceEngine::Layout> inLayout;
+    inLayout.reserve(2);
     InferenceEngine::SizeVector inputShape;
     std::string targetDevice;
     int64_t keepK, axis;
@@ -27,7 +30,8 @@ namespace LayerTestsDefinitions {
     result << "inPRC2=" << inPrc[1].name() << "_";
     result << "outPRC1=" << outPrc[0].name() << "_";
     result << "outPRC2=" << outPrc[1].name() << "_";
-    result << "inL=" << inLayout << "_";
+    result << "inL1=" << inLayout[0] << "_";
+    result << "inL2=" << inLayout[1] << "_";
     result << "trgDev=" << targetDevice;
     return result.str();
 }

--- a/src/tests/functional/shared_test_classes/src/single_layer/topk.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/topk.cpp
@@ -7,7 +7,7 @@
 namespace LayerTestsDefinitions {
     std::string TopKLayerTest::getTestCaseName(const testing::TestParamInfo<TopKParams>& obj) {
     InferenceEngine::Precision netPrecision;
-    InferenceEngine::Precision inPrc;
+    std::vector<InferenceEngine::Precision> inPrc;
     std::vector<InferenceEngine::Precision> outPrc;
     InferenceEngine::Layout inLayout;
     InferenceEngine::SizeVector inputShape;
@@ -23,7 +23,8 @@ namespace LayerTestsDefinitions {
     result << "mode=" << mode << "_";
     result << "sort=" << sort << "_";
     result << "netPRC=" << netPrecision.name() << "_";
-    result << "inPRC=" << inPrc.name() << "_";
+    result << "inPRC1=" << inPrc[0].name() << "_";
+    result << "inPRC2=" << inPrc[1].name() << "_";
     result << "outPRC1=" << outPrc[0].name() << "_";
     result << "outPRC2=" << outPrc[1].name() << "_";
     result << "inL=" << inLayout << "_";

--- a/src/tests/functional/shared_test_classes/src/single_layer/topk.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/topk.cpp
@@ -7,7 +7,8 @@
 namespace LayerTestsDefinitions {
     std::string TopKLayerTest::getTestCaseName(const testing::TestParamInfo<TopKParams>& obj) {
     InferenceEngine::Precision netPrecision;
-    InferenceEngine::Precision inPrc, outPrc;
+    InferenceEngine::Precision inPrc;
+    std::vector<InferenceEngine::Precision> outPrc;
     InferenceEngine::Layout inLayout;
     InferenceEngine::SizeVector inputShape;
     std::string targetDevice;
@@ -23,7 +24,8 @@ namespace LayerTestsDefinitions {
     result << "sort=" << sort << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "inPRC=" << inPrc.name() << "_";
-    result << "outPRC=" << outPrc.name() << "_";
+    result << "outPRC1=" << outPrc[0].name() << "_";
+    result << "outPRC2=" << outPrc[1].name() << "_";
     result << "inL=" << inLayout << "_";
     result << "trgDev=" << targetDevice;
     return result.str();

--- a/src/tests/functional/shared_test_classes/src/single_layer/transpose.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/transpose.cpp
@@ -28,7 +28,8 @@ std::string TransposeLayerTest::getTestCaseName(const testing::TestParamInfo<tra
 void TransposeLayerTest::SetUp() {
     std::vector<size_t> inputShape, inputOrder;
     InferenceEngine::Precision netPrecision;
-    std::tie(inputOrder, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(inputOrder, netPrecision, inPrc.front(), outPrc.front(),
+            inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/transpose.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/transpose.cpp
@@ -29,7 +29,7 @@ void TransposeLayerTest::SetUp() {
     std::vector<size_t> inputShape, inputOrder;
     InferenceEngine::Precision netPrecision;
     std::tie(inputOrder, netPrecision, inPrc.front(), outPrc.front(),
-            inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
+            inLayout.front(), outLayout.front(), inputShape, targetDevice) = this->GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/transpose.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/transpose.cpp
@@ -28,7 +28,7 @@ std::string TransposeLayerTest::getTestCaseName(const testing::TestParamInfo<tra
 void TransposeLayerTest::SetUp() {
     std::vector<size_t> inputShape, inputOrder;
     InferenceEngine::Precision netPrecision;
-    std::tie(inputOrder, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(inputOrder, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/transpose.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/transpose.cpp
@@ -28,7 +28,7 @@ std::string TransposeLayerTest::getTestCaseName(const testing::TestParamInfo<tra
 void TransposeLayerTest::SetUp() {
     std::vector<size_t> inputShape, inputOrder;
     InferenceEngine::Precision netPrecision;
-    std::tie(inputOrder, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+    std::tie(inputOrder, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/src/tests/functional/shared_test_classes/src/single_layer/variadic_split.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/variadic_split.cpp
@@ -33,7 +33,7 @@ namespace LayerTestsDefinitions {
         size_t axis;
         std::vector<size_t> inputShape, numSplits;
         InferenceEngine::Precision netPrecision;
-        std::tie(numSplits, axis, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+        std::tie(numSplits, axis, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
         auto paramOuts = ngraph::helpers::convert2OutputVector(

--- a/src/tests/functional/shared_test_classes/src/single_layer/variadic_split.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/variadic_split.cpp
@@ -33,7 +33,8 @@ namespace LayerTestsDefinitions {
         size_t axis;
         std::vector<size_t> inputShape, numSplits;
         InferenceEngine::Precision netPrecision;
-        std::tie(numSplits, axis, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+        std::tie(numSplits, axis, netPrecision, inPrc.front(), outPrc.front(),
+                inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         for (int k = 1; k < numSplits.size(); k++) {
             outPrc.push_back(outPrc.front());

--- a/src/tests/functional/shared_test_classes/src/single_layer/variadic_split.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/variadic_split.cpp
@@ -33,7 +33,7 @@ namespace LayerTestsDefinitions {
         size_t axis;
         std::vector<size_t> inputShape, numSplits;
         InferenceEngine::Precision netPrecision;
-        std::tie(numSplits, axis, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
+        std::tie(numSplits, axis, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         for (int k = 1; k < numSplits.size(); k++) {
             outPrc.push_back(outPrc.front());

--- a/src/tests/functional/shared_test_classes/src/single_layer/variadic_split.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/variadic_split.cpp
@@ -35,6 +35,9 @@ namespace LayerTestsDefinitions {
         InferenceEngine::Precision netPrecision;
         std::tie(numSplits, axis, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        for (int k = 1; k < numSplits.size(); k++) {
+            outPrc.push_back(outPrc.front());
+        }
         auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
         auto paramOuts = ngraph::helpers::convert2OutputVector(
                 ngraph::helpers::castOps2Nodes<ngraph::opset3::Parameter>(params));

--- a/src/tests/functional/shared_test_classes/src/single_layer/variadic_split.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/variadic_split.cpp
@@ -34,7 +34,7 @@ namespace LayerTestsDefinitions {
         std::vector<size_t> inputShape, numSplits;
         InferenceEngine::Precision netPrecision;
         std::tie(numSplits, axis, netPrecision, inPrc.front(), outPrc.front(),
-                inLayout, outLayout.front(), inputShape, targetDevice) = this->GetParam();
+                inLayout.front(), outLayout.front(), inputShape, targetDevice) = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         for (int k = 1; k < numSplits.size(); k++) {
             outPrc.push_back(outPrc.front());

--- a/src/tests/functional/shared_test_classes/src/subgraph/activation_concats_eltwise.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/activation_concats_eltwise.cpp
@@ -32,6 +32,8 @@ void ActivationConcatsEltwise::SetUp() {
     size_t concatSize;
     std::map<std::string, std::string> config;
     std::tie(inputSize, concatSize, netPrecision, targetDevice, config) = this->GetParam();
+    outPrc.front() = netPrecision;
+    outPrc.push_back(netPrecision);
     configuration.insert(config.begin(), config.end());
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 

--- a/src/tests/functional/shared_test_classes/src/subgraph/activation_fq.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/activation_fq.cpp
@@ -48,7 +48,7 @@ namespace SubgraphTestsDefinitions {
         std::vector<size_t> inputShape;
         std::pair<std::string, std::map<std::string, std::string>> config;
         InferenceEngine::Precision netPrecision;
-        std::tie(fqParams, activationType, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
+        std::tie(fqParams, activationType, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
         configuration.insert(config.second.begin(), config.second.end());
 
         std::vector<size_t> levels;

--- a/src/tests/functional/shared_test_classes/src/subgraph/activation_fq.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/activation_fq.cpp
@@ -49,7 +49,7 @@ namespace SubgraphTestsDefinitions {
         std::pair<std::string, std::map<std::string, std::string>> config;
         InferenceEngine::Precision netPrecision;
         std::tie(fqParams, activationType, netPrecision, inPrc.front(), outPrc.front(),
-                inLayout, outLayout.front(), inputShape, targetDevice, config) = this->GetParam();
+                inLayout.front(), outLayout.front(), inputShape, targetDevice, config) = this->GetParam();
         configuration.insert(config.second.begin(), config.second.end());
 
         std::vector<size_t> levels;

--- a/src/tests/functional/shared_test_classes/src/subgraph/activation_fq.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/activation_fq.cpp
@@ -49,7 +49,7 @@ namespace SubgraphTestsDefinitions {
         std::pair<std::string, std::map<std::string, std::string>> config;
         InferenceEngine::Precision netPrecision;
         std::tie(fqParams, activationType, netPrecision, inPrc.front(), outPrc.front(),
-                inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
+                inLayout, outLayout.front(), inputShape, targetDevice, config) = this->GetParam();
         configuration.insert(config.second.begin(), config.second.end());
 
         std::vector<size_t> levels;

--- a/src/tests/functional/shared_test_classes/src/subgraph/activation_fq.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/activation_fq.cpp
@@ -48,7 +48,8 @@ namespace SubgraphTestsDefinitions {
         std::vector<size_t> inputShape;
         std::pair<std::string, std::map<std::string, std::string>> config;
         InferenceEngine::Precision netPrecision;
-        std::tie(fqParams, activationType, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
+        std::tie(fqParams, activationType, netPrecision, inPrc.front(), outPrc.front(),
+                inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
         configuration.insert(config.second.begin(), config.second.end());
 
         std::vector<size_t> levels;

--- a/src/tests/functional/shared_test_classes/src/subgraph/basic_lstm.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/basic_lstm.cpp
@@ -43,7 +43,7 @@ void Basic_LSTM_S::SetUp() {
     std::tie(netPrecision, targetDevice, configuration, size_params, num_cells, decompose, weights_range) = this->GetParam();
     third_dim = size_params.first;
     hidden_size = size_params.second;
-    outPrc.push_back(InferenceEngine::Precision::FP32);
+    outPrc.front() = InferenceEngine::Precision::FP32;
 
     function = GetNetwork(size_params.first, size_params.second, num_cells, weights_range, netPrecision, &hidden_memory_init, &cell_memory_init);
     if (decompose) {

--- a/src/tests/functional/shared_test_classes/src/subgraph/basic_lstm.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/basic_lstm.cpp
@@ -43,7 +43,7 @@ void Basic_LSTM_S::SetUp() {
     std::tie(netPrecision, targetDevice, configuration, size_params, num_cells, decompose, weights_range) = this->GetParam();
     third_dim = size_params.first;
     hidden_size = size_params.second;
-    outPrc = InferenceEngine::Precision::FP32;
+    outPrc.push_back(InferenceEngine::Precision::FP32);
 
     function = GetNetwork(size_params.first, size_params.second, num_cells, weights_range, netPrecision, &hidden_memory_init, &cell_memory_init);
     if (decompose) {

--- a/src/tests/functional/shared_test_classes/src/subgraph/cascade_concat.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/cascade_concat.cpp
@@ -31,6 +31,10 @@ void CascadeConcat::SetUp() {
     bool multioutput;
     std::tie(input1, input2, input3, netPrecision, multioutput, targetDevice, additional_config) = this->GetParam();
     configuration.insert(additional_config.begin(), additional_config.end());
+    outPrc.front() = netPrecision;
+    if (multioutput) {
+        outPrc.push_back(netPrecision);
+    }
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto input = ngraph::builder::makeParams(ngPrc, {input1[0], input2[0], input3[0]});
     auto relu1 = std::make_shared<ngraph::opset1::Relu>(input[0]);

--- a/src/tests/functional/shared_test_classes/src/subgraph/clamp_fq.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/clamp_fq.cpp
@@ -48,7 +48,7 @@ namespace SubgraphTestsDefinitions {
         std::vector<size_t> inputShape;
         std::pair<std::string, std::map<std::string, std::string>> config;
         auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-        std::tie(fqParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
+        std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
         InferenceEngine::SizeVector kernel, stride, dilation;
         std::vector<size_t> levels;
         std::vector<std::vector<size_t>> constShape;

--- a/src/tests/functional/shared_test_classes/src/subgraph/clamp_fq.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/clamp_fq.cpp
@@ -48,7 +48,7 @@ namespace SubgraphTestsDefinitions {
         std::vector<size_t> inputShape;
         std::pair<std::string, std::map<std::string, std::string>> config;
         auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-        std::tie(fqParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
+        std::tie(fqParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
         InferenceEngine::SizeVector kernel, stride, dilation;
         std::vector<size_t> levels;
         std::vector<std::vector<size_t>> constShape;

--- a/src/tests/functional/shared_test_classes/src/subgraph/clamp_fq.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/clamp_fq.cpp
@@ -48,7 +48,7 @@ namespace SubgraphTestsDefinitions {
         std::vector<size_t> inputShape;
         std::pair<std::string, std::map<std::string, std::string>> config;
         auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-        std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice, config) = this->GetParam();
+        std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice, config) = this->GetParam();
         InferenceEngine::SizeVector kernel, stride, dilation;
         std::vector<size_t> levels;
         std::vector<std::vector<size_t>> constShape;

--- a/src/tests/functional/shared_test_classes/src/subgraph/clamp_fq.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/clamp_fq.cpp
@@ -48,7 +48,8 @@ namespace SubgraphTestsDefinitions {
         std::vector<size_t> inputShape;
         std::pair<std::string, std::map<std::string, std::string>> config;
         auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
-        std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice, config) = this->GetParam();
+        std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(),
+                inLayout.front(), outLayout.front(), inputShape, targetDevice, config) = this->GetParam();
         InferenceEngine::SizeVector kernel, stride, dilation;
         std::vector<size_t> levels;
         std::vector<std::vector<size_t>> constShape;

--- a/src/tests/functional/shared_test_classes/src/subgraph/concat_quantization_during_memory_requantization.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/concat_quantization_during_memory_requantization.cpp
@@ -31,6 +31,8 @@ namespace SubgraphTestsDefinitions {
         std::map<std::string, std::string> config;
         std::tie(netPrecision, targetDevice, inputSize, hiddenSize, config) = this->GetParam();
         configuration.insert(config.begin(), config.end());
+        outPrc.front() = netPrecision;
+        outPrc.push_back(netPrecision);
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
         memory_1_init = CommonTestUtils::generate_float_numbers(hiddenSize, -0.2f, 0.0f);

--- a/src/tests/functional/shared_test_classes/src/subgraph/constant_result.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/constant_result.cpp
@@ -46,13 +46,16 @@ void ConstantResultSubgraphTest::createGraph(const ConstantSubgraphType& type, c
     switch (type) {
         case ConstantSubgraphType::SINGLE_COMPONENT: {
             auto input = builder::makeConstant<float>(ngPrc, inputShape, {}, true);
+            outPrc.front() = inputPrecision;
             results.push_back(std::make_shared<opset3::Result>(input));
             break;
         }
         case ConstantSubgraphType::SEVERAL_COMPONENT: {
             auto input1 = builder::makeConstant<float>(ngPrc, inputShape, {}, true);
+            outPrc.front() = inputPrecision;
             results.push_back(std::make_shared<opset3::Result>(input1));
             auto input2 = builder::makeConstant<float>(ngPrc, inputShape, {}, true);
+            outPrc.push_back(inputPrecision);
             results.push_back(std::make_shared<opset3::Result>(input2));
             break;
         }

--- a/src/tests/functional/shared_test_classes/src/subgraph/convolution_relu_sequence.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/convolution_relu_sequence.cpp
@@ -44,7 +44,7 @@ void ConvolutionReluSequenceTest::SetUp() {
     convReluSpecificParamsAll convParamsAll;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
     std::map<std::string, std::string> config;
-    std::tie(convParamsAll, netPrecision, inPrc, outPrc, targetDevice, config) =
+    std::tie(convParamsAll, netPrecision, inPrc, outPrc.front(), targetDevice, config) =
         this->GetParam();
     configuration.insert(config.begin(), config.end());
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/subgraph/convolution_relu_sequence.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/convolution_relu_sequence.cpp
@@ -44,7 +44,7 @@ void ConvolutionReluSequenceTest::SetUp() {
     convReluSpecificParamsAll convParamsAll;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
     std::map<std::string, std::string> config;
-    std::tie(convParamsAll, netPrecision, inPrc, outPrc.front(), targetDevice, config) =
+    std::tie(convParamsAll, netPrecision, inPrc.front(), outPrc.front(), targetDevice, config) =
         this->GetParam();
     configuration.insert(config.begin(), config.end());
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/subgraph/delayed_copy_layer.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/delayed_copy_layer.cpp
@@ -63,6 +63,7 @@ namespace SubgraphTestsDefinitions {
         std::map<std::string, std::string> additional_config;
         size_t memory_size;
         std::tie(netPrecision, targetDevice, additional_config, memory_size) = this->GetParam();
+        outPrc.front() = netPrecision;
         configuration.insert(additional_config.begin(), additional_config.end());
 
         ASSERT_EQ(memory_size % 2, 0);

--- a/src/tests/functional/shared_test_classes/src/subgraph/get_output_before_activation.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/get_output_before_activation.cpp
@@ -42,6 +42,8 @@ void OutputBeforeActivation::SetUp() {
     midOutputType outputType;
     std::tie(targetDevice, netPrecision, inputSize, outputType, config) = this->GetParam();
     configuration.insert(config.begin(), config.end());
+    outPrc.front() = netPrecision;
+    outPrc.push_back(netPrecision);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     std::vector<size_t> input_dims { 1, inputSize };

--- a/src/tests/functional/shared_test_classes/src/subgraph/handling_orientation_conv.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/handling_orientation_conv.cpp
@@ -20,6 +20,8 @@ namespace SubgraphTestsDefinitions {
     void HandlingOrientationClass::SetUp() {
         InferenceEngine::Precision netPrecision;
         std::tie(netPrecision, targetDevice, configuration) = this->GetParam();
+        outPrc.front() = netPrecision;
+        outPrc.push_back(netPrecision);
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
         auto params = ngraph::builder::makeParams(ngPrc, { {1, 336} , {1, 336}});

--- a/src/tests/functional/shared_test_classes/src/subgraph/input_split_concat.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/input_split_concat.cpp
@@ -30,6 +30,8 @@ void InputSplitConcatTest::SetUp() {
     std::vector<size_t> inputShape;
     std::tie(netPrecision, targetDevice, tempConfig, inputShape) = this->GetParam();
     configuration.insert(tempConfig.begin(), tempConfig.end());
+    outPrc.front() = netPrecision;
+    outPrc.push_back(netPrecision);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, { inputShape });
 

--- a/src/tests/functional/shared_test_classes/src/subgraph/memory_LSTMCell.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/memory_LSTMCell.cpp
@@ -40,6 +40,9 @@ namespace SubgraphTestsDefinitions {
         std::map<std::string, std::string> config;
         size_t inputSize;
         std::tie(transformation, targetDevice, netPrecision, inputSize, hiddenSize, config) = this->GetParam();
+        outPrc.front() = netPrecision;
+        outPrc.push_back(netPrecision);
+        outPrc.push_back(netPrecision);
         configuration.insert(config.begin(), config.end());
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 

--- a/src/tests/functional/shared_test_classes/src/subgraph/multioutput_eltwise_squeeze_eltwise.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/multioutput_eltwise_squeeze_eltwise.cpp
@@ -25,6 +25,8 @@ namespace SubgraphTestsDefinitions {
         std::map<std::string, std::string> additional_config;
         std::tie(inputs, netPrecision, targetDevice, additional_config) = this->GetParam();
         configuration.insert(additional_config.begin(), additional_config.end());
+        outPrc.front() = netPrecision;
+        outPrc.push_back(netPrecision);
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto input = ngraph::builder::makeParams(ngPrc, {inputs});
 

--- a/src/tests/functional/shared_test_classes/src/subgraph/multiple_LSTMCell.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/multiple_LSTMCell.cpp
@@ -40,6 +40,8 @@ void MultipleLSTMCellTest::SetUp() {
     size_t inputSize;
     std::tie(transformation, targetDevice, netPrecision, inputSize, hiddenSize, config) = this->GetParam();
     configuration.insert(config.begin(), config.end());
+    outPrc.front() = netPrecision;
+    outPrc.push_back(netPrecision);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     std::vector<size_t> input_dims { 1, inputSize };

--- a/src/tests/functional/shared_test_classes/src/subgraph/multiple_connect_split_concat.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/multiple_connect_split_concat.cpp
@@ -23,6 +23,8 @@ std::string MultipleConnectSplitConcatTest::getTestCaseName(const testing::TestP
 void MultipleConnectSplitConcatTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     std::tie(netPrecision, targetDevice, configuration) = this->GetParam();
+    outPrc.front() = netPrecision;
+    outPrc.push_back(netPrecision);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     auto params = ngraph::builder::makeParams(ngPrc, {{1, 256}});

--- a/src/tests/functional/shared_test_classes/src/subgraph/negative_memory_layer_offset.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/negative_memory_layer_offset.cpp
@@ -26,6 +26,8 @@ namespace SubgraphTestsDefinitions {
         size_t hiddenSize;
         std::map<std::string, std::string> config;
         std::tie(netPrecision, targetDevice, inputSize, hiddenSize, config) = this->GetParam();
+        outPrc.front() = netPrecision;
+        outPrc.push_back(netPrecision);
         configuration.insert(config.begin(), config.end());
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 

--- a/src/tests/functional/shared_test_classes/src/subgraph/parameter_shapeof_result.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/parameter_shapeof_result.cpp
@@ -22,7 +22,7 @@ std::string ParameterShapeOfResultSubgraphTest::getTestCaseName(const testing::T
 void ParameterShapeOfResultSubgraphTest::SetUp() {
     ngraph::element::Type inType;
     std::tie(inType, targetDevice) = this->GetParam();
-    inPrc = InferenceEngine::details::convertPrecision(inType);
+    inPrc.front() = InferenceEngine::details::convertPrecision(inType);
 
     const auto parameter = std::make_shared<ngraph::opset6::Parameter>(inType, ngraph::Shape{1, 3, 10, 10});
     const auto shapeOf = std::make_shared<ngraph::opset6::ShapeOf>(parameter);

--- a/src/tests/functional/shared_test_classes/src/subgraph/range_add.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/range_add.cpp
@@ -29,7 +29,7 @@ std::string RangeAddSubgraphTest::getTestCaseName(const testing::TestParamInfo<L
 void RangeAddSubgraphTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     float start, stop, step;
-    std::tie(start, stop, step, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(start, stop, step, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     auto startConstant = std::make_shared<ngraph::opset1::Constant>(ngPrc, ngraph::Shape{}, start);
@@ -47,8 +47,7 @@ void RangeAddSubgraphTest::SetUp() {
 
 std::string RangeNumpyAddSubgraphTest::getTestCaseName(const testing::TestParamInfo<LayerTestsDefinitions::RangeParams>& obj) {
     InferenceEngine::Precision netPrc;
-    InferenceEngine::Precision constPrc;
-    InferenceEngine::Precision outPrc;
+    InferenceEngine::Precision constPrc, outPrc;
     InferenceEngine::Layout inLayout, outLayout;
     float start, stop, step;
     std::string targetDevice;
@@ -69,7 +68,7 @@ void RangeNumpyAddSubgraphTest::SetUp() {
     InferenceEngine::Precision netPrc;
     InferenceEngine::Precision constPrc;
     float start, stop, step;
-    std::tie(start, stop, step, constPrc, netPrc, outPrc, inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(start, stop, step, constPrc, netPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
     auto ngConstPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(constPrc);
     auto ngNetPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrc);
 

--- a/src/tests/functional/shared_test_classes/src/subgraph/range_add.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/range_add.cpp
@@ -29,7 +29,7 @@ std::string RangeAddSubgraphTest::getTestCaseName(const testing::TestParamInfo<L
 void RangeAddSubgraphTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     float start, stop, step;
-    std::tie(start, stop, step, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(start, stop, step, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     auto startConstant = std::make_shared<ngraph::opset1::Constant>(ngPrc, ngraph::Shape{}, start);

--- a/src/tests/functional/shared_test_classes/src/subgraph/range_add.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/range_add.cpp
@@ -29,7 +29,7 @@ std::string RangeAddSubgraphTest::getTestCaseName(const testing::TestParamInfo<L
 void RangeAddSubgraphTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     float start, stop, step;
-    std::tie(start, stop, step, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice) = GetParam();
+    std::tie(start, stop, step, netPrecision, inPrc.front(), outPrc.front(), inLayout.front(), outLayout.front(), targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     auto startConstant = std::make_shared<ngraph::opset1::Constant>(ngPrc, ngraph::Shape{}, start);
@@ -68,7 +68,7 @@ void RangeNumpyAddSubgraphTest::SetUp() {
     InferenceEngine::Precision netPrc;
     InferenceEngine::Precision constPrc;
     float start, stop, step;
-    std::tie(start, stop, step, constPrc, netPrc, outPrc.front(), inLayout, outLayout.front(), targetDevice) = GetParam();
+    std::tie(start, stop, step, constPrc, netPrc, outPrc.front(), inLayout.front(), outLayout.front(), targetDevice) = GetParam();
     auto ngConstPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(constPrc);
     auto ngNetPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrc);
 

--- a/src/tests/functional/shared_test_classes/src/subgraph/range_add.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/range_add.cpp
@@ -29,7 +29,7 @@ std::string RangeAddSubgraphTest::getTestCaseName(const testing::TestParamInfo<L
 void RangeAddSubgraphTest::SetUp() {
     InferenceEngine::Precision netPrecision;
     float start, stop, step;
-    std::tie(start, stop, step, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(start, stop, step, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     auto startConstant = std::make_shared<ngraph::opset1::Constant>(ngPrc, ngraph::Shape{}, start);
@@ -68,7 +68,7 @@ void RangeNumpyAddSubgraphTest::SetUp() {
     InferenceEngine::Precision netPrc;
     InferenceEngine::Precision constPrc;
     float start, stop, step;
-    std::tie(start, stop, step, constPrc, netPrc, outPrc.front(), inLayout, outLayout, targetDevice) = GetParam();
+    std::tie(start, stop, step, constPrc, netPrc, outPrc.front(), inLayout, outLayout.front(), targetDevice) = GetParam();
     auto ngConstPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(constPrc);
     auto ngNetPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrc);
 

--- a/src/tests/functional/shared_test_classes/src/subgraph/split_concat_memory.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/split_concat_memory.cpp
@@ -27,7 +27,7 @@ std::string SplitConcatMemory::getTestCaseName(const testing::TestParamInfo<Para
 
 void SplitConcatMemory::SetUp() {
     SizeVector shape;
-    std::tie(shape, inPrc, axis, targetDevice) = this->GetParam();
+    std::tie(shape, inPrc.front(), axis, targetDevice) = this->GetParam();
 
     auto shape_14 = shape;
     shape_14[axis] /= 4;
@@ -47,7 +47,7 @@ void SplitConcatMemory::SetUp() {
      *      __|___         __|___
      *     [_out1_]       [_mem2_]
      */
-    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc[0]);
     ngraph::Shape ng_share_14(shape_14);
     ngraph::Shape ng_share_34(shape_34);
 

--- a/src/tests/functional/shared_test_classes/src/subgraph/split_concat_multi_inputs.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/split_concat_multi_inputs.cpp
@@ -41,6 +41,10 @@ void SplitConcatMultiInputsTest::SetUp() {
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
 
     auto split = ngraph::builder::makeSplit(params[0], ngPrc, splitsNum, 1);
+    outPrc.front() = netPrecision;
+    for (int i = 1; i< split->outputs().size(); i++) {
+        outPrc.push_back(netPrecision);
+    }
     ngraph::OutputVector concatInputs = split->outputs();
 
     auto concat = std::make_shared<ngraph::opset7::Concat>(concatInputs, 1);

--- a/src/tests/functional/shared_test_classes/src/subgraph/split_conv.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/split_conv.cpp
@@ -60,6 +60,8 @@ void SplitConvTest::SetUp() {
     size_t stride;
     std::tie(inputShape, kernelShape, stride) = convolutionParams;
 
+    outPrc.front() = netPrecision;
+    outPrc.push_back(netPrecision);
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, { inputShape });
     const auto splitsNum = 2;

--- a/src/tests/functional/shared_test_classes/src/subgraph/split_relu.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/split_relu.cpp
@@ -28,6 +28,10 @@ namespace SubgraphTestsDefinitions {
         std::map<std::string, std::string> additional_config;
         std::tie(inputs, connect_index, netPrecision, targetDevice, additional_config) = this->GetParam();
         configuration.insert(additional_config.begin(), additional_config.end());
+        outPrc.front() = netPrecision;
+        for (int i = 1; i< connect_index.size(); i++) {
+            outPrc.push_back(netPrecision);
+        }
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto input = ngraph::builder::makeParams(ngPrc, {inputs});
         auto split = ngraph::builder::makeSplit(input[0], ngPrc, 4, 1);

--- a/src/tests/functional/shared_test_classes/src/subgraph/split_trivial_permute_concat.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/split_trivial_permute_concat.cpp
@@ -32,6 +32,8 @@ namespace SubgraphTestsDefinitions {
         std::map<std::string, std::string> config;
         std::tie(netPrecision, targetDevice, inputShape, splitAxis, concatAxis, config) = this->GetParam();
         configuration.insert(config.begin(), config.end());
+        outPrc.front() = netPrecision;
+        outPrc.push_back(netPrecision);
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto input = ngraph::builder::makeParams(ngPrc, { inputShape });
         auto split = ngraph::builder::makeSplit(input[0], ngPrc, 2, splitAxis);

--- a/src/tests/functional/shared_test_classes/src/subgraph/strided_slice.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/strided_slice.cpp
@@ -39,7 +39,7 @@ void StridedSliceTest::SetUp() {
     StridedSliceSpecificParams ssParams;
     InferenceEngine::Precision netPrecision;
     std::map<std::string, std::string> additionalConfig;
-    std::tie(ssParams, netPrecision, inPrc, outPrc, inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
+    std::tie(ssParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/subgraph/strided_slice.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/strided_slice.cpp
@@ -39,7 +39,7 @@ void StridedSliceTest::SetUp() {
     StridedSliceSpecificParams ssParams;
     InferenceEngine::Precision netPrecision;
     std::map<std::string, std::string> additionalConfig;
-    std::tie(ssParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
+    std::tie(ssParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/subgraph/strided_slice.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/strided_slice.cpp
@@ -39,7 +39,7 @@ void StridedSliceTest::SetUp() {
     StridedSliceSpecificParams ssParams;
     InferenceEngine::Precision netPrecision;
     std::map<std::string, std::string> additionalConfig;
-    std::tie(ssParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, targetDevice, additionalConfig) = this->GetParam();
+    std::tie(ssParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice, additionalConfig) = this->GetParam();
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/subgraph/strided_slice.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/strided_slice.cpp
@@ -39,7 +39,7 @@ void StridedSliceTest::SetUp() {
     StridedSliceSpecificParams ssParams;
     InferenceEngine::Precision netPrecision;
     std::map<std::string, std::string> additionalConfig;
-    std::tie(ssParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), targetDevice, additionalConfig) = this->GetParam();
+    std::tie(ssParams, netPrecision, inPrc.front(), outPrc.front(), inLayout.front(), outLayout.front(), targetDevice, additionalConfig) = this->GetParam();
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/src/tests/functional/shared_test_classes/src/subgraph/two_fake_quantize_to_fullyconnected.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/two_fake_quantize_to_fullyconnected.cpp
@@ -51,7 +51,7 @@ void FakeQuantizeSubgraphTest::SetUp() {
     std::pair<std::string, std::map<std::string, std::string>> config;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     bool biases = false;
-    std::tie(fqParams, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice, config, biases) = this->GetParam();
+    std::tie(fqParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice, config, biases) = this->GetParam();
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<size_t> levels;
     std::vector<std::vector<size_t>> constShape;

--- a/src/tests/functional/shared_test_classes/src/subgraph/two_fake_quantize_to_fullyconnected.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/two_fake_quantize_to_fullyconnected.cpp
@@ -51,7 +51,8 @@ void FakeQuantizeSubgraphTest::SetUp() {
     std::pair<std::string, std::map<std::string, std::string>> config;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     bool biases = false;
-    std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice, config, biases) = this->GetParam();
+    std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(), inLayout.front(), outLayout.front(),
+            inputShape, targetDevice, config, biases) = this->GetParam();
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<size_t> levels;
     std::vector<std::vector<size_t>> constShape;

--- a/src/tests/functional/shared_test_classes/src/subgraph/two_fake_quantize_to_fullyconnected.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/two_fake_quantize_to_fullyconnected.cpp
@@ -51,7 +51,7 @@ void FakeQuantizeSubgraphTest::SetUp() {
     std::pair<std::string, std::map<std::string, std::string>> config;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     bool biases = false;
-    std::tie(fqParams, netPrecision, inPrc, outPrc.front(), inLayout, outLayout, inputShape, targetDevice, config, biases) = this->GetParam();
+    std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice, config, biases) = this->GetParam();
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<size_t> levels;
     std::vector<std::vector<size_t>> constShape;

--- a/src/tests/functional/shared_test_classes/src/subgraph/two_fake_quantize_to_fullyconnected.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/two_fake_quantize_to_fullyconnected.cpp
@@ -51,7 +51,7 @@ void FakeQuantizeSubgraphTest::SetUp() {
     std::pair<std::string, std::map<std::string, std::string>> config;
     auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     bool biases = false;
-    std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout, inputShape, targetDevice, config, biases) = this->GetParam();
+    std::tie(fqParams, netPrecision, inPrc.front(), outPrc.front(), inLayout, outLayout.front(), inputShape, targetDevice, config, biases) = this->GetParam();
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<size_t> levels;
     std::vector<std::vector<size_t>> constShape;

--- a/src/tests/functional/shared_test_classes/src/subgraph/variadic_split_pad.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/variadic_split_pad.cpp
@@ -37,6 +37,10 @@ void VariadicSplitPad::SetUp() {
     ngraph::helpers::PadMode padMode;
     InferenceEngine::Precision netPrecision;
     std::tie(inputs, axis, numSplits, connectIndexes, padBegin, padEnd, padMode, netPrecision, targetDevice) = this->GetParam();
+    outPrc.front() = netPrecision;
+    for (int i = 1; i< connectIndexes.size(); i++) {
+        outPrc.push_back(netPrecision);
+    }
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto input = ngraph::builder::makeParams(ngPrc, {inputs});
     auto split = ngraph::builder::makeVariadicSplit(input[0], numSplits, axis);


### PR DESCRIPTION
### Details:
 - Add multiple ouputs' precision support. By adding this support, multiple output precisions can be set separately. For example, TopK has two outputs with different precision: value(FP16/32) index(I32). 

### Tickets:
 - CVS-77267
