### PR TITLE
Fixed tensor names set in InputCut and AutomlEfficientDet transformation.

### DIFF
--- a/tools/mo/openvino/tools/mo/front/extractor.py
+++ b/tools/mo/openvino/tools/mo/front/extractor.py
@@ -936,7 +936,7 @@ def add_input_op(graph: Graph, node_id: str, port: int = 0, data: bool = False,
         tensor_name = str(port) + ":" + Node(graph, node_id).soft_get('name')
     fw_info = [(Node(graph, node_id).soft_get('name'), tensor_name)]
 
-    if port == 0:
+    if is_out_port and port == 0:
         tensor_name_no_port = Node(graph, node_id).soft_get('name')
         # TODO: This can be optimized. Tensor names can be stored as set, which is initialized after model loading.
         graph_tensor_names = graph.get_tensor_names_set()

--- a/tools/mo/openvino/tools/mo/front/extractor.py
+++ b/tools/mo/openvino/tools/mo/front/extractor.py
@@ -930,9 +930,13 @@ def add_input_op(graph: Graph, node_id: str, port: int = 0, data: bool = False,
     input_op = Parameter(graph, dict(shape=shape, user_shape=user_shape, data_type=data_type, initial_node_name=node_id,
                                      name=get_new_placeholder_name(node_id, is_out_port, port)))
 
-    tensor_name = Node(graph, node_id).soft_get('name') + ":" + str(port)
+    if is_out_port:
+        tensor_name = Node(graph, node_id).soft_get('name') + ":" + str(port)
+    else:
+        tensor_name = str(port) + ":" + Node(graph, node_id).soft_get('name')
     fw_info = [(Node(graph, node_id).soft_get('name'), tensor_name)]
-    if is_out_port and port == 0:
+
+    if port == 0:
         tensor_name_no_port = Node(graph, node_id).soft_get('name')
         # TODO: This can be optimized. Tensor names can be stored as set, which is initialized after model loading.
         graph_tensor_names = graph.get_tensor_names_set()

--- a/tools/mo/openvino/tools/mo/front/tf/AutomlEfficientDet.py
+++ b/tools/mo/openvino/tools/mo/front/tf/AutomlEfficientDet.py
@@ -48,7 +48,6 @@ class EfficientDet(FrontReplacementFromConfigFileGeneral):
     def transform_graph(self, graph: Graph, replacement_descriptions: dict):
         parameter_node = graph.get_op_nodes(op='Parameter')[0]
         parameter_node['data_type'] = data_type_str_to_np(parameter_node.graph.graph['cmd_params'].data_type)
-        parameter_node.out_port(0).disconnect()
 
         # remove existing Result operations to remove unsupported sub-graph
         graph.remove_nodes_from([node.id for node in graph.get_op_nodes(op='Result')] + ['detections'])


### PR DESCRIPTION
Root cause analysis: 
InputCut sets tensor name incorrectly for input port. It sets `<op name>:<port>`, but should be `<port>:<op name>`. Op name alias should also be added in tensor names for input cut by input port.
AutomlEfficientDet transformation loses tensor names by unnecessary disconnecting of Parameter node.

Solution: 
Set `<port>:<op name>` naming of tensor for input port cut.
Add op name alias for input port cut.
Remove disconnect of Parameter from AutomlEfficientDet.

Ticket: 77357


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update