### PR TITLE
TestCase class fix

### DIFF
--- a/src/core/tests/engines_util/test_case.hpp
+++ b/src/core/tests/engines_util/test_case.hpp
@@ -149,6 +149,8 @@ public:
         ov::Tensor tensor(results[m_output_index]->get_output_element_type(0), expected_shape);
         std::copy(values.begin(), values.end(), tensor.data<T>());
 
+        m_expected_outputs.push_back(std::move(tensor));
+
         ++m_output_index;
     }
 

--- a/src/core/tests/runtime/ie/unit_test.manifest
+++ b/src/core/tests/runtime/ie/unit_test.manifest
@@ -29,12 +29,15 @@ IE_CPU.onnx_model_dequantize_linear_1d_zero_scale_int8_4d
 onnx_model_shape
 onnx_model_split_equal_parts_default
 onnx_model_argmin_no_keepdims
-onnx_model_softmax
 onnx_model_elu
 onnx_model_top_k
 onnx_model_erf
 onnx_model_addmul_abc
 IE_CPU.interpolate_down_scales_const_linear
+
+# Result mismatch - 77384
+onnx_model_softmax_axis_negative_1_opset11
+onnx_model_softmax_axis_negative_1_opset13
 
 # data [<name>] doesn't exist
 broadcast_trivial

--- a/src/core/tests/runtime/ie/unit_test.manifest
+++ b/src/core/tests/runtime/ie/unit_test.manifest
@@ -1433,6 +1433,11 @@ onnx_controlflow_loop_2d_both_cond_and_trip_count_as_inputs
 onnx_controlflow_loop_no_variadic_inputs_and_outputs
 onnx_controlflow_loop_power
 onnx_if_dynamic_inputs
+onnx_if_branches_with_same_inputs
+onnx_if_branches_with_different_inputs
+onnx_if_branches_without_inputs
+onnx_if_inside_if
+onnx_if_branches_with_multiple_outputs
 
 # Input body shape is changed during Loop iterations
 # Exception is throw during Loop shape inference

--- a/src/core/tests/runtime/interpreter/unit_test.manifest
+++ b/src/core/tests/runtime/interpreter/unit_test.manifest
@@ -69,9 +69,14 @@ INTERPRETER.onnx_model_dequantize_linear_1d_zero_scale_int8
 INTERPRETER.onnx_model_dequantize_linear_1d_zero_scale_int8_4d
 INTERPRETER.onnx_model_dequantize_linear_1d_zero_scale_uint8_negative_axis
 
-# If doesn't have evaluate method and we cannot infer it
+# ONNX If - result mismatch - 77383
 INTERPRETER.onnx_if_inside_if
 INTERPRETER.onnx_if_inside_loop
+INTERPRETER.onnx_if_branches_with_same_inputs
+INTERPRETER.onnx_if_branches_with_different_inputs
+INTERPRETER.onnx_if_branches_without_inputs
+INTERPRETER.onnx_if_branches_with_multiple_outputs
+INTERPRETER.onnx_if_dynamic_inputs
 
 # Activation function hardsigmoid unsupported
 onnx_model_gru_fwd_activations_relu_hardsigmoid

--- a/src/core/tests/runtime/interpreter/unit_test.manifest
+++ b/src/core/tests/runtime/interpreter/unit_test.manifest
@@ -96,6 +96,10 @@ INTERPRETER.ctc_greedy_decoder_f16
 onnx_model_softmax_axis_0
 onnx_model_reshape_negative_dim
 
+# Result mismatch - 77384
+onnx_model_softmax_axis_negative_1_opset11
+onnx_model_softmax_axis_negative_1_opset13
+
 # LogSoftmax's reference implementation doesn't handle scalar input properly
 onnx_model_logsoftmax_0D
 # Input body shape is changed during Loop iterations

--- a/src/core/tests/runtime/interpreter/unit_test.manifest
+++ b/src/core/tests/runtime/interpreter/unit_test.manifest
@@ -145,3 +145,12 @@ INTERPRETER.onnx_dyn_shapes_flatten_neg_axis
 INTERPRETER.onnx_dyn_shapes_slice_10_slice_2d_default_steps_dyn_begin_end
 INTERPRETER.onnx_model_instance_normalization_dyn_shape
 INTERPRETER.onnx_controlflow_loop_2d_no_identity_termination_cond_false
+
+# new failures after fixing the TestCase class - 77385
+onnx_bool_const_op
+onnx_bool_init_and
+onnx_bool_input_or
+onnx_bool_init_raw
+quant_dequant_pattern_axis
+onnx_clip_no_min_no_max_int64
+onnx_constant_sparse_tensor_boolean_3x4


### PR DESCRIPTION
The TestCase class does not store the expected output data and in the result, nothing gets compared after the inference. The missing line has been added and the failing tests have been temporarily skipped.