### PR TITLE
[Benchmark] Fixed preprocessing inputs

### DIFF
--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -495,7 +495,7 @@ int main(int argc, char* argv[]) {
                     type_to_set = ov::element::u8;
                 }
 
-                auto& in = preproc.input(item.get_index());
+                auto& in = preproc.input(item.get_any_name());
                 if (type_to_set != ov::element::undefined) {
                     in.tensor().set_element_type(type_to_set);
 


### PR DESCRIPTION
### Details:
 - *If there are several inputs, `get_index()` can give  `0` for every input so we reuse always first preprocessing input. Thus I changed index to the tensor name to avoid conflicts*
 - *Fix is after changes from [PR#9703](https://github.com/openvinotoolkit/openvino/pull/9703)*

### Tickets:
 - *N/A*
