### PR TITLE
[MO, TF frontend] Correct loaders for StridedSlice and Pack operations

### DIFF
--- a/src/frontends/tensorflow/src/op/pack.cpp
+++ b/src/frontends/tensorflow/src/op/pack.cpp
@@ -14,7 +14,7 @@ namespace tensorflow {
 namespace op {
 
 OutputVector translate_pack_op(const NodeContext& node) {
-    auto axis = node.get_attribute<int32_t>("axis");
+    auto axis = node.get_attribute<int64_t>("axis");
     auto axis_const = make_shared<Constant>(element::i64, Shape{}, axis);
 
     OutputVector concat_inputs;

--- a/src/frontends/tensorflow/src/op/strided_slice.cpp
+++ b/src/frontends/tensorflow/src/op/strided_slice.cpp
@@ -15,18 +15,22 @@ namespace op {
 
 OutputVector translate_strided_slice_op(const NodeContext& node) {
     auto input = node.get_input(0);
+    auto rank = input.get_partial_shape().rank();
     auto begin = node.get_input(1);
     auto end = node.get_input(2);
     auto strides = node.get_input(3);
 
-    auto begin_mask = node.get_attribute<int32_t>("begin_mask");
-    auto end_mask = node.get_attribute<int32_t>("end_mask");
-    auto new_axis_mask = node.get_attribute<int32_t>("new_axis_mask");
-    auto ellipsis_mask = node.get_attribute<int32_t>("ellipsis_mask");
-    auto shrink_axis_mask = node.get_attribute<int32_t>("shrink_axis_mask");
+    auto begin_mask = node.get_attribute<int64_t>("begin_mask");
+    auto end_mask = node.get_attribute<int64_t>("end_mask");
+    auto new_axis_mask = node.get_attribute<int64_t>("new_axis_mask");
+    auto ellipsis_mask = node.get_attribute<int64_t>("ellipsis_mask");
+    auto shrink_axis_mask = node.get_attribute<int64_t>("shrink_axis_mask");
 
-    auto mask_to_vec = [](int32_t mask) {
+    auto mask_to_vec = [](int64_t mask, const ov::Rank& rank) {
         auto length = sizeof(mask) * CHAR_BIT;
+        if (rank.is_static() && rank.get_length() < length) {
+            length = rank.get_length();
+        }
         vector<int64_t> vec(length, 0);
         if (mask == 0) {
             return vec;
@@ -43,11 +47,11 @@ OutputVector translate_strided_slice_op(const NodeContext& node) {
                                          begin,
                                          end,
                                          strides,
-                                         mask_to_vec(begin_mask),
-                                         mask_to_vec(end_mask),
-                                         mask_to_vec(new_axis_mask),
-                                         mask_to_vec(shrink_axis_mask),
-                                         mask_to_vec(ellipsis_mask));
+                                         mask_to_vec(begin_mask, rank),
+                                         mask_to_vec(end_mask, rank),
+                                         mask_to_vec(new_axis_mask, rank),
+                                         mask_to_vec(shrink_axis_mask, rank),
+                                         mask_to_vec(ellipsis_mask, rank));
     set_node_name(node.get_name(), res);
     return res->outputs();
 }

--- a/tools/mo/openvino/tools/mo/front/tf/loader.py
+++ b/tools/mo/openvino/tools/mo/front/tf/loader.py
@@ -11,6 +11,8 @@ from openvino.tools.mo.utils.error import Error, FrameworkError
 from openvino.tools.mo.utils.utils import refer_to_faq_msg
 from openvino.tools.mo.utils.versions_checker import get_environment_setup
 
+# do not print INFO and WARNING messages from TensorFlow
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 try:
     import tensorflow.compat.v1 as tf_v1
     # disable eager execution of TensorFlow 2 environment immediately
@@ -19,6 +21,9 @@ try:
     from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
 except ImportError:
     import tensorflow as tf_v1
+
+#in some environment suppressing through TF_CPP_MIN_LOG_LEVEL does not work
+tf_v1.get_logger().setLevel("ERROR")
 
 from google.protobuf import text_format
 from openvino.tools.mo.graph.graph import fill_graph_with_nodes, Graph

--- a/tools/mo/openvino/tools/mo/front/tf/partial_infer/tf.py
+++ b/tools/mo/openvino/tools/mo/front/tf/partial_infer/tf.py
@@ -2,16 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging as log
+import os
 from re import match
 
 import numpy as np
 
+# do not print INFO and WARNING messages from TensorFlow
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 try:
     import tensorflow.compat.v1 as tf_v1
     # disable eager execution of TensorFlow 2 environment immediately
     tf_v1.disable_eager_execution()
 except ImportError:
     import tensorflow as tf_v1
+
+#in some environment suppressing through TF_CPP_MIN_LOG_LEVEL does not work
+tf_v1.get_logger().setLevel("ERROR")
+
 from google.protobuf import text_format
 
 from openvino.tools.mo.front.extractor import node_defs_to_str

--- a/tools/mo/openvino/tools/mo/load/tf/loader.py
+++ b/tools/mo/openvino/tools/mo/load/tf/loader.py
@@ -1,13 +1,19 @@
 # Copyright (C) 2018-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
+# do not print INFO and WARNING messages from TensorFlow
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 try:
     import tensorflow.compat.v1 as tf_v1
-
     # disable eager execution of TensorFlow 2 environment immediately
     tf_v1.disable_eager_execution()
 except ImportError:
     import tensorflow as tf_v1
+
+#in some environment suppressing through TF_CPP_MIN_LOG_LEVEL does not work
+tf_v1.get_logger().setLevel("ERROR")
 
 try:
     import tensorflow.contrib  # pylint: disable=no-name-in-module,import-error

--- a/tools/mo/openvino/tools/mo/middle/CustomSubgraphCall.py
+++ b/tools/mo/openvino/tools/mo/middle/CustomSubgraphCall.py
@@ -5,6 +5,10 @@ import copy
 import logging as log
 
 import numpy as np
+import os
+
+# do not print INFO and WARNING messages from TensorFlow
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 
 from openvino.tools.mo.front.common.layout import nhwc_to_nchw_permute
 from openvino.tools.mo.front.common.partial_infer.utils import mo_array
@@ -55,6 +59,9 @@ class CustomSubgraphCall(MiddleReplacementPattern):
             tf_v1.disable_eager_execution()
         except ImportError:
             import tensorflow as tf_v1
+        # in some environment suppressing through TF_CPP_MIN_LOG_LEVEL does not work
+        tf_v1.get_logger().setLevel("ERROR")
+
         from openvino.tools.mo.front.common.layout import convert_shape, nhwc_to_nchw_permute, nchw_to_nhwc_permute
         from openvino.tools.mo.front.tf.extractors.utils import tf_tensor_shape
         from openvino.tools.mo.front.tf.partial_infer.tf import add_node_def_to_subgraph, update_input_in_pbs
@@ -275,6 +282,9 @@ class CustomSubgraphCall(MiddleReplacementPattern):
             tf_v1.disable_eager_execution()
         except ImportError:
             import tensorflow as tf_v1
+        # in some environment suppressing through TF_CPP_MIN_LOG_LEVEL does not work
+        tf_v1.get_logger().setLevel("ERROR")
+
         from openvino.tools.mo.front.tf.partial_infer.tf import get_subgraph_output_tensors, add_node_def_to_subgraph
         _, output_tensors = get_subgraph_output_tensors(node)
 

--- a/tools/mo/openvino/tools/mo/utils/convert.py
+++ b/tools/mo/openvino/tools/mo/utils/convert.py
@@ -5,12 +5,17 @@ import argparse
 import os
 import sys
 
+# do not print INFO and WARNING messages from TensorFlow
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 try:
     import tensorflow.compat.v1 as tf_v1
     # disable eager execution of TensorFlow 2 environment immediately
     tf_v1.disable_eager_execution()
 except ImportError:
     import tensorflow as tf_v1
+
+#in some environment suppressing through TF_CPP_MIN_LOG_LEVEL does not work
+tf_v1.get_logger().setLevel("ERROR")
 
 sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 from openvino.tools.mo.front.tf.loader import load_tf_graph_def

--- a/tools/mo/openvino/tools/mo/utils/summarize_graph.py
+++ b/tools/mo/openvino/tools/mo/utils/summarize_graph.py
@@ -7,6 +7,8 @@ import argparse
 import os
 import sys
 
+# do not print INFO and WARNING messages from TensorFlow
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 try:
     import tensorflow.compat.v1 as tf_v1
     # disable eager execution of TensorFlow 2 environment immediately
@@ -14,7 +16,9 @@ try:
 except ImportError:
     import tensorflow as tf_v1
 
-os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+#in some environment suppressing through TF_CPP_MIN_LOG_LEVEL does not work
+tf_v1.get_logger().setLevel("ERROR")
+
 unlikely_output_types = ['Const', 'Assign', 'NoOp', 'Parameter', 'Assert']
 
 

--- a/tools/mo/openvino/tools/mo/utils/tensorboard_util.py
+++ b/tools/mo/openvino/tools/mo/utils/tensorboard_util.py
@@ -1,12 +1,20 @@
 # Copyright (C) 2018-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
+# do not print INFO and WARNING messages from TensorFlow
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 try:
     import tensorflow.compat.v1 as tf_v1
     # disable eager execution of TensorFlow 2 environment immediately
     tf_v1.disable_eager_execution()
 except ImportError:
     import tensorflow as tf_v1
+
+#in some environment suppressing through TF_CPP_MIN_LOG_LEVEL does not work
+tf_v1.get_logger().setLevel("ERROR")
+
 try:
     import tensorflow.contrib  # pylint: disable=no-name-in-module,import-error
 except:

--- a/tools/mo/openvino/tools/mo/utils/versions_checker.py
+++ b/tools/mo/openvino/tools/mo/utils/versions_checker.py
@@ -8,6 +8,9 @@ import sys
 from distutils.version import LooseVersion
 from pathlib import Path
 
+# do not print INFO and WARNING messages from TensorFlow
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
+
 modules = {
     "protobuf": "google.protobuf",
     "test-generator": "generator",


### PR DESCRIPTION
**Root cause analysis:** TensorFlow operation attribute has of int64 type if, it is integer. Dynamic casting for ov::Any throws exception in case casting from int64 to int32 type.

**Solution:** Correct type of StridedSlice and Pack attributes

**Other:** Supress TensorFlow info and warning messages that significantly clutter logs during TensorFlow model conversion by legacy MO.

**Ticket:** 77357

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A
* [x]  Transformation preserves tensor names - N/A

Validation:
* [x]  Unit tests - N/A
* [x]  Framework operation tests - checked on layer tests
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A
