### PR TITLE
Print capabilities from jit kernels

### DIFF
--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -12,10 +12,6 @@ if (WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOMINMAX")
 endif()
 
-if (ENABLE_CPU_DEBUG_CAPS)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCPU_DEBUG_CAPS")
-endif()
-
 file(GLOB_RECURSE SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 file(GLOB_RECURSE HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.h
                           ${CMAKE_CURRENT_SOURCE_DIR}/src/*.hpp)
@@ -45,6 +41,10 @@ endif()
 target_link_libraries(${TARGET_NAME} PRIVATE mkldnn
                                              ov_shape_inference
                                              inference_engine_snippets)
+
+if (ENABLE_CPU_DEBUG_CAPS)
+    target_compile_definitions(${TARGET_NAME} PRIVATE CPU_DEBUG_CAPS)
+endif()
 
 target_compile_definitions(${TARGET_NAME} PRIVATE IMPLEMENT_INFERENCE_EXTENSION_API)
 target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
@@ -87,6 +87,10 @@ if(BUILD_SHARED_LIBS)
         $<TARGET_PROPERTY:ngraph,INTERFACE_COMPILE_DEFINITIONS>
         $<TARGET_PROPERTY:inference_engine_plugin_api,INTERFACE_COMPILE_DEFINITIONS>
         )
+
+    if (ENABLE_CPU_DEBUG_CAPS)
+        target_compile_definitions(${TARGET_NAME}_obj PUBLIC CPU_DEBUG_CAPS)
+    endif()
 
     set_target_properties(${TARGET_NAME}_obj PROPERTIES EXCLUDE_FROM_ALL ON)
 

--- a/src/plugins/intel_cpu/src/nodes/color_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/color_convert.cpp
@@ -439,7 +439,7 @@ void JitConverter<T[N]>::generate() {
 
     width >>= reg_capacity_log;
 
-    foreach(0, width, [&](const Reg64 & idx) {
+    foreach(0, width, [&](const variable<size_t> & idx) {
         auto yuv = load_yuv(src_y, src_uv);
 
         // Aliases

--- a/src/tests/unit/cpu/CMakeLists.txt
+++ b/src/tests/unit/cpu/CMakeLists.txt
@@ -44,6 +44,10 @@ if (WIN32)
     target_compile_definitions(${TARGET_NAME} PRIVATE NOMINMAX)
 endif()
 
+if (ENABLE_CPU_DEBUG_CAPS)
+    target_compile_definitions(${TARGET_NAME} PRIVATE CPU_DEBUG_CAPS)
+endif()
+
 ie_faster_build(${TARGET_NAME}
     UNITY
 )

--- a/src/tests/unit/cpu/jit_kernel_test.cpp
+++ b/src/tests/unit/cpu/jit_kernel_test.cpp
@@ -273,14 +273,13 @@ struct jit_variable_load_store_test_kernel {
         kernel_impl<N> kernel;
         kernel.init();
 
-        const size_t size = 3;
+        const size_t size = N;
 
         std::array<SrcT, N> src {};
         std::array<DstT, N> result {};
 
         Params args = { src.data(), result.data(), size };
 
-        src.fill(static_cast<SrcT>(42));
         for (size_t i = 0; i < size; ++i) {
             src[i] = static_cast<SrcT>(i);
         }
@@ -303,13 +302,23 @@ private:
         void generate() override {
             jit_kernel::preamble();
 
+            jit_kernel::cout << "[ INFO     ] Hello from JIT kernel!\n";
+
             auto src_ptr = jit_kernel::arg(&Params::src);
             auto dst_ptr = jit_kernel::arg(&Params::dst);
             auto size = jit_kernel::arg(&Params::size);
 
+            jit_kernel::cout << "[ INFO     ] Size: " << size << "\n";
+
+            auto src = jit_kernel::var<SrcT[N]>();
             auto dst = jit_kernel::var<DstT[N]>();
 
+            jit_kernel::load(src, src_ptr, size);
             jit_kernel::load(dst, src_ptr, size);
+
+            jit_kernel::cout << "[ INFO     ] src: " << src << "\n";
+            jit_kernel::cout << "[ INFO     ] dst: " << dst << "\n";
+
             jit_kernel::store(dst_ptr, dst, size);
 
             jit_kernel::postamble();


### PR DESCRIPTION
### Details:
 - This fix allow to print several information from jit kernels: text and registers content in different types.

Possible output looks like this:
[ INFO     ] Hello from JIT kernel!
[ INFO     ] Size: r13:u64 { 16 }
[ INFO     ] src: xmm15:u8 { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }
[ INFO     ] dst: zmm14:f32 { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }

