### PR TITLE
[MO] override_output_shape = True for Concat in StridedSliceNormalizer

### DIFF
--- a/tools/mo/openvino/tools/mo/middle/StridedSliceNormalizer.py
+++ b/tools/mo/openvino/tools/mo/middle/StridedSliceNormalizer.py
@@ -204,6 +204,10 @@ class StridedSliceNormalizer(MiddleReplacementPattern):
             if node.in_port(i).get_source().node.soft_get('type') == 'Concat':
                 # concat already exists
                 concat = node.in_port(i).get_source().node
+                # because output data node shape will be changed
+                # while shapes will be reinferred no need to check consistency
+                concat['override_output_shape'] = True
+
                 last_in_port = max(concat.in_ports().keys())
                 assert not concat.in_port(last_in_port).disconnected(), 'The last in_port of Concat node {} ' \
                                                                         'should be connected'. \


### PR DESCRIPTION
**Root cause analysis**: if there is already Concat for 1st input of StridedSlice during normalization extra inputs are added to this Concat and therefore output shape of Concat data node is changed. During reinferrence there is an assert that check that old and new shapes are equal [openvino/tools/mo/graph/port.py#L101-L102](https://github.com/openvinotoolkit/openvino/blob/master/tools/mo/openvino/tools/mo/graph/port.py#L101-L102), but these shapes should not be equal for cases when Concat is modified by StridedSliceNormalizer.

Picture below - after modifying Concat has 4 inputs but data node still stores out shape `[3]`, need to forcely rewrite it to `[4]`
![image](https://user-images.githubusercontent.com/5703039/151957913-c34b1ae7-43e3-4226-a2aa-8bcadc571cc7.png)

**Solution**: Mark Concat with `concat['override_output_shape'] = True` so that during reinference unnecessary [`strict_compare_tensors`](https://github.com/openvinotoolkit/openvino/blob/master/tools/mo/openvino/tools/mo/graph/port.py#L101-L102)  is not called.

Ticket: CVS-77187

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names

Validation:
* n/a  Unit tests
* n/a  Framework operation tests
* n/a  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* n/a  Supported frameworks operations list
* n/a  Guide on how to convert the **public** model
* n/a  User guide update