### PR TITLE
[GNA] Define static variable

### DIFF
--- a/src/plugins/intel_gna/gna_plugin_config.cpp
+++ b/src/plugins/intel_gna/gna_plugin_config.cpp
@@ -16,6 +16,8 @@ using namespace InferenceEngine;
 using namespace InferenceEngine::details;
 
 namespace GNAPluginNS {
+const uint8_t Config::max_num_requests;
+
 OPENVINO_SUPPRESS_DEPRECATED_START
 static const caseless_unordered_map<std::string, std::pair<Gna2AccelerationMode, bool>> supported_values = {
     {GNAConfigParams::GNA_AUTO,                 {Gna2AccelerationModeAuto,                          false}},


### PR DESCRIPTION
### Details:
To fix debug build.

according to [C++11: 9.4.2/3]:
 - If a non-volatile const static data member is of integral or enumeration type, its declaration in the class definition can specify a brace-or-equal-initializer in which every initializer-clause that is an assignment-expression is a constant expression (5.19). A static data member of literal type can be declared in the class definition with the constexpr specifier; if so, its declaration shall specify a brace-or-equal-initializer in which every initializer-clause that is an assignment-expression is a constant expression. [ Note: In both these cases, the member may appear in constant expressions. —end note ] **The member shall still be defined in a namespace scope if it is odr-used (3.2) in the program and the namespace scope definition shall not contain an initializer.**

### Tickets:
 - 77622
