### PR TITLE
[CPU] Improve weights sharing sync on multiple outputs

### DIFF
--- a/src/plugins/intel_cpu/src/mkldnn_weights_cache.hpp
+++ b/src/plugins/intel_cpu/src/mkldnn_weights_cache.hpp
@@ -79,7 +79,6 @@ public:
 
         operator MKLDNNMemoryPtr() const;
         bool isValid() const;
-        bool tryLock();
         void valid(bool b);
 
     private:

--- a/src/plugins/intel_cpu/src/mkldnn_weights_cache.hpp
+++ b/src/plugins/intel_cpu/src/mkldnn_weights_cache.hpp
@@ -79,6 +79,7 @@ public:
 
         operator MKLDNNMemoryPtr() const;
         bool isValid() const;
+        bool tryLock();
         void valid(bool b);
 
     private:


### PR DESCRIPTION
### Details:
 - *Handle the case when one thread attempts to acquire all shared outputs of a const node, but gets blocked by another thread that also tries to lock one of the node outputs (that was already locked by the first thread)*

### Tickets:
 - *75058*
