### PR TITLE
[POT] fix: diffrent batch shape in prediction and target in ac

### DIFF
--- a/tools/pot/openvino/tools/pot/algorithms/quantization/fast_bias_correction/algorithm.py
+++ b/tools/pot/openvino/tools/pot/algorithms/quantization/fast_bias_correction/algorithm.py
@@ -212,7 +212,10 @@ class FastBiasCorrection(Algorithm):
             if input_node.type == 'FakeQuantize':
                 input_node = nu.get_node_input(input_node, 0)
             calculate_input_shape[input_node.fullname] = {'shape_node': lambda x: x.shape}
+        calculate_metrics = self._engine.calculate_metrics
+        self._engine.calculate_metrics = False
         _, inputs_shape = self._engine.predict(calculate_input_shape, sampler)
+        self._engine.calculate_metrics = calculate_metrics
         for node_name, shape_node in inputs_shape.items():
             inputs_shape[node_name] = shape_node['shape_node'][0]
             if len(inputs_shape[node_name]) > 1:

--- a/tools/pot/openvino/tools/pot/engines/ie_engine.py
+++ b/tools/pot/openvino/tools/pot/engines/ie_engine.py
@@ -35,6 +35,7 @@ class IEEngine(Engine):
         self._per_sample_metrics = []
         self._tmp_dir = create_tmp_dir()
         self._device = self.config.device
+        self.calculate_metrics = False
 
     def set_model(self, model):
         """ Loads NetworkX model into InferenceEngine and stores it in Engine class


### PR DESCRIPTION
### Details:
If the model has a batch greater than 1, then the target and prediction dimensions do not match in the AC.
During the collection of shapes graph, pot doesn't need to collect metrics in the algorithm. 

### Tickets:
 - 77611
