### PR TITLE
Transformations: eltwise and FQ fusings fixes

### DIFF
--- a/src/common/low_precision_transformations/src/fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/fake_quantize.cpp
@@ -104,11 +104,7 @@ bool FakeQuantizeTransformation::checkElementwise(const std::shared_ptr<Node>& e
             return false;
         }
 
-        if ((eltwiseOutputPShape.rank().get_length() - shape.size()) > 1) {
-            return false;
-        }
-
-        if ((eltwiseOutputPShape.rank().get_length() - shape.size()) == 1ul) {
+        while (eltwiseOutputPShape.size() > shape.size()) {
             shape.insert(shape.begin(), 1ul);
         }
 

--- a/src/tests/functional/inference_engine/lp_transformations/fuse_fake_quantize_transformation.cpp
+++ b/src/tests/functional/inference_engine/lp_transformations/fuse_fake_quantize_transformation.cpp
@@ -483,6 +483,36 @@ const std::vector<FuseFakeQuantizeTransformationTestValues> testValues = {
             { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } }
         }
     },
+    // non per-channel operation
+    {
+        {1, 3, 4},
+        LayerTransformation::createParamsU8I8(),
+        {
+            element::f32,
+            {},
+            element::u8,
+            {
+                {element::f32},
+                {{-128, -128, -128, -128}, ngraph::element::f32, {1, 1, 4}},
+                {{0.01f, 0.02f, 0.03f, 0.04f}, ngraph::element::f32, {1, 1, 4}}
+            },
+            element::f32,
+            { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } }
+        },
+        {
+            element::f32,
+            {},
+            element::u8,
+            {
+                {element::f32},
+                {{-128, -128, -128, -128}, ngraph::element::f32, {1, 1, 4}},
+                {{0.01f, 0.02f, 0.03f, 0.04f}, ngraph::element::f32, {1, 1, 4}}
+            },
+            element::f32,
+            element::f32,
+            { 256ul, {}, { 0.f }, { 2.55f }, { 0.f }, { 2.55f } }
+        }
+    },
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/src/tests/functional/inference_engine/transformations/common_optimizations/add_fake_quantize_fusion.cpp
+++ b/src/tests/functional/inference_engine/transformations/common_optimizations/add_fake_quantize_fusion.cpp
@@ -174,72 +174,64 @@ TEST_F(TransformationTestsF, AddFakeQuantizeFusionReshape) {
     }
 }
 
-TEST_F(TransformationTestsF, NegativeAddFakeQuantizeFusionNotAConstant) {
-    Shape data_shape{1, 3, 14, 14};
+TEST_F(TransformationTestsF, AddFakeQuantizeFusionWithPerChannelConstant) {
+    Shape data_shape{1, 3};
     {
         auto data = std::make_shared<opset5::Parameter>(element::f32, data_shape);
-        auto add_2nd_input = std::make_shared<opset5::Parameter>(element::f32, Shape{1});
-        auto add = std::make_shared<opset5::Add>(data, add_2nd_input);
+        auto add_const = opset5::Constant::create(element::f32, Shape{3}, {2, 3, 4});
+        auto add = std::make_shared<opset5::Add>(data, add_const);
         auto input_low = opset5::Constant::create(element::f32, Shape{1}, {0});
         auto input_high = opset5::Constant::create(element::f32, Shape{1}, {20});
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
-        auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low,
-                                                         input_high, output_low,
-                                                         output_high, 11);
-        function = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data, add_2nd_input});
+        auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low, input_high, output_low, output_high, 11);
+        function = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data});
         manager.register_pass<pass::AddFakeQuantizeFusion>();
     }
     {
         auto data = std::make_shared<opset5::Parameter>(element::f32, data_shape);
-        auto add_2nd_input = std::make_shared<opset5::Parameter>(element::f32, Shape{1});
-        auto add = std::make_shared<opset5::Add>(data, add_2nd_input);
-        auto input_low = opset5::Constant::create(element::f32, Shape{1}, {0});
-        auto input_high = opset5::Constant::create(element::f32, Shape{1}, {20});
+        auto input_low = opset5::Constant::create(element::f32, Shape{1, 3}, {-2, -3, -4});
+        auto input_high = opset5::Constant::create(element::f32, Shape{1, 3}, {18, 17, 16});
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
-        auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low,
-                                                         input_high, output_low,
-                                                         output_high, 11);
-        function_ref = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data, add_2nd_input});
+        auto fq = std::make_shared<opset5::FakeQuantize>(data, input_low, input_high, output_low, output_high, 11);
+        function_ref = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data});
     }
+}
+
+TEST_F(TransformationTestsF, NegativeAddFakeQuantizeFusionNotAConstant) {
+    Shape data_shape{1, 3, 14, 14};
+    auto data = std::make_shared<opset5::Parameter>(element::f32, data_shape);
+    auto add_2nd_input = std::make_shared<opset5::Parameter>(element::f32, Shape{1});
+    auto add = std::make_shared<opset5::Add>(data, add_2nd_input);
+    auto input_low = opset5::Constant::create(element::f32, Shape{1}, {0});
+    auto input_high = opset5::Constant::create(element::f32, Shape{1}, {20});
+    auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
+    auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
+    auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low,
+                                                        input_high, output_low,
+                                                        output_high, 11);
+    function = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data, add_2nd_input});
+    manager.register_pass<pass::AddFakeQuantizeFusion>();
 }
 
 TEST_F(TransformationTestsF, NegativeAddFakeQuantizeFusionWithConvolutionAndNonScalarConstant) {
     Shape data_shape{1, 3, 14, 14};
-    {
-        auto data = std::make_shared<opset5::Parameter>(element::f32, data_shape);
-        auto filter = std::make_shared<opset5::Parameter>(element::f32, Shape{4, 3, 2, 2});
-        auto conv = std::make_shared<opset5::Convolution>(data, filter, Strides{1, 1},
-                CoordinateDiff{0, 0}, CoordinateDiff{0, 0}, Strides{1, 1});
-        auto add_const = opset5::Constant::create(element::f32, Shape{1, 4, 1, 1}, {1, 2, 3, 4});
-        auto add = std::make_shared<opset5::Add>(conv, add_const);
-        auto input_low = opset5::Constant::create(element::f32, Shape{1}, {0});
-        auto input_high = opset5::Constant::create(element::f32, Shape{1}, {20});
-        auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
-        auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
-        auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low,
-                                                         input_high, output_low,
-                                                         output_high, 11);
-        function = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data, filter});
-        manager.register_pass<pass::AddFakeQuantizeFusion>();
-    }
-    {
-        auto data = std::make_shared<opset5::Parameter>(element::f32, data_shape);
-        auto filter = std::make_shared<opset5::Parameter>(element::f32, Shape{4, 3, 2, 2});
-        auto conv = std::make_shared<opset5::Convolution>(data, filter, Strides{1, 1},
-                CoordinateDiff{0, 0}, CoordinateDiff{0, 0}, Strides{1, 1});
-        auto add_const = opset5::Constant::create(element::f32, Shape{1, 4, 1, 1}, {1, 2, 3, 4});
-        auto add = std::make_shared<opset5::Add>(conv, add_const);
-        auto input_low = opset5::Constant::create(element::f32, Shape{1}, {0});
-        auto input_high = opset5::Constant::create(element::f32, Shape{1}, {20});
-        auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
-        auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
-        auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low,
-                                                         input_high, output_low,
-                                                         output_high, 11);
-        function_ref = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data, filter});
-    }
+    auto data = std::make_shared<opset5::Parameter>(element::f32, data_shape);
+    auto filter = std::make_shared<opset5::Parameter>(element::f32, Shape{4, 3, 2, 2});
+    auto conv = std::make_shared<opset5::Convolution>(data, filter, Strides{1, 1},
+            CoordinateDiff{0, 0}, CoordinateDiff{0, 0}, Strides{1, 1});
+    auto add_const = opset5::Constant::create(element::f32, Shape{1, 4, 1, 1}, {1, 2, 3, 4});
+    auto add = std::make_shared<opset5::Add>(conv, add_const);
+    auto input_low = opset5::Constant::create(element::f32, Shape{1}, {0});
+    auto input_high = opset5::Constant::create(element::f32, Shape{1}, {20});
+    auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
+    auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
+    auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low,
+                                                        input_high, output_low,
+                                                        output_high, 11);
+    function = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data, filter});
+    manager.register_pass<pass::AddFakeQuantizeFusion>();
 }
 
 TEST_F(TransformationTestsF, NegativeAddFakeQuantizeFusionLowPrecision) {
@@ -256,5 +248,19 @@ TEST_F(TransformationTestsF, NegativeAddFakeQuantizeFusionLowPrecision) {
                                                      output_high, 11);
     function = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data});
     function_ref = clone_function(*function);
+    manager.register_pass<pass::AddFakeQuantizeFusion>();
+}
+
+TEST_F(TransformationTestsF, NegativeAddFakeQuantizeFusionWithNonPerChannelConstant) {
+    Shape data_shape{1, 4, 3};
+    auto data = std::make_shared<opset5::Parameter>(element::f32, data_shape);
+    auto add_const = opset5::Constant::create(element::f32, Shape{3}, {2, 3, 4});
+    auto add = std::make_shared<opset5::Add>(data, add_const);
+    auto input_low = opset5::Constant::create(element::f32, Shape{1}, {0});
+    auto input_high = opset5::Constant::create(element::f32, Shape{1}, {20});
+    auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
+    auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
+    auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low, input_high, output_low, output_high, 11);
+    function = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data});
     manager.register_pass<pass::AddFakeQuantizeFusion>();
 }

--- a/src/tests/functional/inference_engine/transformations/common_optimizations/mul_fake_quantize_fusion.cpp
+++ b/src/tests/functional/inference_engine/transformations/common_optimizations/mul_fake_quantize_fusion.cpp
@@ -139,35 +139,45 @@ TEST_F(TransformationTestsF, MulFakeQuantizeFusionConstantNonScalarWithEqualValu
     }
 }
 
-TEST_F(TransformationTestsF, NegativeMulFakeQuantizeFusionNotAConstant) {
-    Shape data_shape{1, 3, 14, 14};
+TEST_F(TransformationTestsF, MulFakeQuantizeFusionWithPerChannelConstant) {
+    Shape data_shape{1, 3};
     {
         auto data = std::make_shared<opset5::Parameter>(element::f32, data_shape);
-        auto mul_2nd_input = std::make_shared<opset5::Parameter>(element::f32, Shape{1});
-        auto mul = std::make_shared<opset5::Multiply>(data, mul_2nd_input);
-        auto input_low = opset5::Constant::create(element::f32, Shape{1}, {0});
+        auto mul_const = opset5::Constant::create(element::f32, Shape{3}, {2, 4, 5});
+        auto mul = std::make_shared<opset5::Multiply>(data, mul_const);
+        auto input_low = opset5::Constant::create(element::f32, Shape{1}, {1});
         auto input_high = opset5::Constant::create(element::f32, Shape{1}, {20});
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
-        auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low,
-                                                         input_high, output_low,
-                                                         output_high, 11);
-        function = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data, mul_2nd_input});
+        auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low, input_high, output_low, output_high, 11);
+        function = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data});
         manager.register_pass<pass::MulFakeQuantizeFusion>();
     }
     {
         auto data = std::make_shared<opset5::Parameter>(element::f32, data_shape);
-        auto mul_2nd_input = std::make_shared<opset5::Parameter>(element::f32, Shape{1});
-        auto mul = std::make_shared<opset5::Multiply>(data, mul_2nd_input);
-        auto input_low = opset5::Constant::create(element::f32, Shape{1}, {0});
-        auto input_high = opset5::Constant::create(element::f32, Shape{1}, {20});
+        auto input_low = opset5::Constant::create(element::f32, Shape{1, 3}, {0.5, 0.25, 0.2});
+        auto input_high = opset5::Constant::create(element::f32, Shape{1, 3}, {10, 5, 4});
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
-        auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low,
-                                                         input_high, output_low,
-                                                         output_high, 11);
-        function_ref = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data, mul_2nd_input});
+        auto fq = std::make_shared<opset5::FakeQuantize>(data, input_low, input_high, output_low, output_high, 11);
+        function_ref = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data});
     }
+}
+
+TEST_F(TransformationTestsF, NegativeMulFakeQuantizeFusionNotAConstant) {
+    Shape data_shape{1, 3, 14, 14};
+    auto data = std::make_shared<opset5::Parameter>(element::f32, data_shape);
+    auto mul_2nd_input = std::make_shared<opset5::Parameter>(element::f32, Shape{1});
+    auto mul = std::make_shared<opset5::Multiply>(data, mul_2nd_input);
+    auto input_low = opset5::Constant::create(element::f32, Shape{1}, {0});
+    auto input_high = opset5::Constant::create(element::f32, Shape{1}, {20});
+    auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
+    auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
+    auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low,
+                                                        input_high, output_low,
+                                                        output_high, 11);
+    function = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data, mul_2nd_input});
+    manager.register_pass<pass::MulFakeQuantizeFusion>();
 }
 
 TEST_F(TransformationTestsF, NegativeMulFakeQuantizeFusionLowPrecision) {
@@ -218,5 +228,19 @@ TEST_F(TransformationTestsF, NegativeMulFakeQuantizeFusionConstantSomeNegative) 
                                                      output_high, 20);
     function = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data});
     function_ref = clone_function(*function);
+    manager.register_pass<pass::MulFakeQuantizeFusion>();
+}
+
+TEST_F(TransformationTestsF, NegativeMulFakeQuantizeFusionWithNonPerChannelConstant) {
+    Shape data_shape{1, 4, 3};
+    auto data = std::make_shared<opset5::Parameter>(element::f32, data_shape);
+    auto mul_const = opset5::Constant::create(element::f32, Shape{3}, {2, 3, 4});
+    auto mul = std::make_shared<opset5::Multiply>(data, mul_const);
+    auto input_low = opset5::Constant::create(element::f32, Shape{1}, {0});
+    auto input_high = opset5::Constant::create(element::f32, Shape{1}, {20});
+    auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
+    auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
+    auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low, input_high, output_low, output_high, 11);
+    function = std::make_shared<Function>(NodeVector{fq}, ParameterVector{data});
     manager.register_pass<pass::MulFakeQuantizeFusion>();
 }


### PR DESCRIPTION
### Details:
This PR fixes cases with non-broadcasted eltwise constants (E.g. data_shape: {X, Y, C}, constant_shape: {C}). The following transformations were fixed:
 - *AddFakeQuantizeFusion*
 - *MulFakeQuantizeFusion*
- *FakeQuantizeTransformation*

### Tickets:
 - *CVS-77298*
