### PR TITLE
Check the selected frontend to correspond use_new/legacy_frontend options

### DIFF
--- a/docs/MO_DG/prepare_model/convert_model/Converting_Model.md
+++ b/docs/MO_DG/prepare_model/convert_model/Converting_Model.md
@@ -194,8 +194,8 @@ Framework-agnostic parameters:
   --transformations_config TRANSFORMATIONS_CONFIG
                         Use the configuration file with transformations
                         description.
-  --use_new_frontend    Force to use new frontend API for model processing.
-  --use_legacy_frontend Force to use legacy API for model processing.
+  --use_new_frontend    Force the usage of new frontend API for model processing.
+  --use_legacy_frontend Force the usage of legacy API for model processing.
 ```
 
 The sections below provide details on using particular parameters and examples of CLI commands.

--- a/docs/MO_DG/prepare_model/convert_model/Converting_Model.md
+++ b/docs/MO_DG/prepare_model/convert_model/Converting_Model.md
@@ -194,6 +194,8 @@ Framework-agnostic parameters:
   --transformations_config TRANSFORMATIONS_CONFIG
                         Use the configuration file with transformations
                         description.
+  --use_new_frontend    Force to use new frontend API for model processing.
+  --use_legacy_frontend Force to use legacy API for model processing.
 ```
 
 The sections below provide details on using particular parameters and examples of CLI commands.

--- a/tools/mo/openvino/tools/mo/main.py
+++ b/tools/mo/openvino/tools/mo/main.py
@@ -35,7 +35,7 @@ from openvino.tools.mo.utils.cli_parser import check_available_transforms, get_c
 from openvino.tools.mo.utils.error import Error, FrameworkError
 from openvino.tools.mo.utils.find_ie_version import find_ie_version
 from openvino.tools.mo.utils.get_ov_update_message import get_ov_update_message
-from openvino.tools.mo.utils.guess_framework import deduce_framework_by_namespace
+from openvino.tools.mo.utils.guess_framework import deduce_legacy_frontend_by_namespace
 from openvino.tools.mo.utils.logger import init_logger, progress_printer
 from openvino.tools.mo.utils.model_analysis import AnalysisResults
 from openvino.tools.mo.utils.utils import refer_to_faq_msg
@@ -149,32 +149,34 @@ def arguments_post_parsing(argv: argparse.Namespace):
 
     if not moc_front_end and use_new_frontend:
         raise Error('Option --use_new_frontend is specified but the Model Optimizer is unable to find new frontend. '
-                    'Please ensure that your environment contains new frontend for the input model format.')
+                    'Please ensure that your environment contains new frontend for the input model format or '
+                    'try to convert the model without specifying --use_new_frontend option.')
 
     is_tf, is_caffe, is_mxnet, is_kaldi, is_onnx =\
-        deduce_framework_by_namespace(argv) if not moc_front_end else [False, False, False, False, False]
+        deduce_legacy_frontend_by_namespace(argv) if not moc_front_end else [False, False, False, False, False]
 
     is_legacy_frontend = any([is_tf, is_caffe, is_mxnet, is_kaldi, is_onnx])
     if not is_legacy_frontend and use_legacy_frontend:
-        raise Error('Option --use_legacy_frontend is specified but Model Optimizer does not have legacy frontend for the input model format. '
-                    'Please try to convert the model without specifying --use_legacy_frontend option.')
+        raise Error('Option --use_legacy_frontend is specified but Model Optimizer does not have legacy frontend '
+                    'for the input model format. Please try to convert the model without specifying --use_legacy_frontend option.')
 
-    if any([is_tf, is_caffe, is_mxnet, is_kaldi, is_onnx]):
+    # handle a default case, i.e. use_new_frontend and use_legacy_frontend are not specified, when no frontend is found
+    if not is_legacy_frontend and not moc_front_end:
+        legacy_frameworks = ['tf', 'caffe', 'mxnet', 'kaldi', 'onnx']
+        frameworks = list(set(legacy_frameworks + available_moc_front_ends))
+        if not argv.framework:
+            raise Error('Framework name can not be deduced from the given options: {}={}. '
+                        'Please use --framework with one from the list: {}.',
+                        '--input_model', argv.input_model, frameworks)
+        elif argv.framework not in frameworks:
+            raise Error('Framework {} is not a valid target. Please use --framework with one from the list: {}. ' +
+                        refer_to_faq_msg(15), argv.framework, frameworks)
+
+    if is_legacy_frontend:
         if new_extensions_used(argv):
             raise Error('New kind of extensions used on legacy path')
         if new_transformations_config_used(argv):
             raise Error('New kind of transformations configuration used on legacy path')
-    else: # new frontend used
-        frameworks = ['tf', 'caffe', 'mxnet', 'kaldi', 'onnx']
-        frameworks = list(set(frameworks + available_moc_front_ends))
-        if argv.framework not in frameworks:
-            if argv.use_legacy_frontend:
-                raise Error('Framework {} is not a valid target when using the --use_legacy_frontend flag. '
-                            'The following legacy frameworks are available: {}' +
-                            refer_to_faq_msg(15), argv.framework, frameworks)
-            else:
-                raise Error('Framework {} is not a valid target. Please use --framework with one from the list: {}. ' +
-                            refer_to_faq_msg(15), argv.framework, frameworks)
 
     if is_tf and not argv.input_model and not argv.saved_model_dir and not argv.input_meta_graph:
         raise Error('Path to input model or saved model dir is required: use --input_model, --saved_model_dir or '
@@ -349,7 +351,7 @@ def check_fallback(argv : argparse.Namespace):
     fallback_reasons = {}
 
     # Some frontend such as PDPD does not have legacy path so it has no reasons to fallback
-    if not any(deduce_framework_by_namespace(argv)):
+    if not any(deduce_legacy_frontend_by_namespace(argv)):
         return fallback_reasons
 
     # There is no possibility for fallback if a user strictly wants to use new frontend
@@ -389,7 +391,7 @@ def prepare_ir(argv : argparse.Namespace):
             return graph, ngraph_function
         else: # apply fallback
             reasons_message = ", ".join(fallback_reasons)
-            load_extensions(argv, *list(deduce_framework_by_namespace(argv)))
+            load_extensions(argv, *list(deduce_legacy_frontend_by_namespace(argv)))
             t.send_event("mo", "fallback_reason", reasons_message)
             log.warning("The IR preparation was executed by the legacy MO path. "
                         "This is a fallback scenario applicable only for some specific cases. "

--- a/tools/mo/openvino/tools/mo/utils/cli_parser.py
+++ b/tools/mo/openvino/tools/mo/utils/cli_parser.py
@@ -443,10 +443,10 @@ def get_common_cli_parser(parser: argparse.ArgumentParser = None):
     common_group.add_argument('--legacy_ir_generation',
                               help=argparse.SUPPRESS, action=DeprecatedStoreTrue, default=False)
     common_group.add_argument("--use_new_frontend",
-                              help="Use new frontend API for model processing",
+                              help="Force to use new frontend API for model processing",
                               action='store_true', default=False)
     common_group.add_argument("--use_legacy_frontend",
-                              help="Use legacy API for model processing",
+                              help="Force to use legacy API for model processing",
                               action='store_true', default=False)
     return parser
 

--- a/tools/mo/openvino/tools/mo/utils/cli_parser.py
+++ b/tools/mo/openvino/tools/mo/utils/cli_parser.py
@@ -443,10 +443,10 @@ def get_common_cli_parser(parser: argparse.ArgumentParser = None):
     common_group.add_argument('--legacy_ir_generation',
                               help=argparse.SUPPRESS, action=DeprecatedStoreTrue, default=False)
     common_group.add_argument("--use_new_frontend",
-                              help="Force to use new frontend API for model processing",
+                              help="Force the usage of new frontend API for model processing",
                               action='store_true', default=False)
     common_group.add_argument("--use_legacy_frontend",
-                              help="Force to use legacy API for model processing",
+                              help="Force the usage of legacy API for model processing",
                               action='store_true', default=False)
     return parser
 

--- a/tools/mo/openvino/tools/mo/utils/guess_framework.py
+++ b/tools/mo/openvino/tools/mo/utils/guess_framework.py
@@ -8,7 +8,7 @@ from openvino.tools.mo.utils.error import Error
 from openvino.tools.mo.utils.utils import refer_to_faq_msg
 
 
-def deduce_framework_by_namespace(argv: Namespace):
+def deduce_legacy_frontend_by_namespace(argv: Namespace):
     if not argv.framework:
         if getattr(argv, 'saved_model_dir', None) or getattr(argv, 'input_meta_graph', None):
             argv.framework = 'tf'
@@ -20,9 +20,6 @@ def deduce_framework_by_namespace(argv: Namespace):
             raise Error('Path to input model is required: use --input_model.')
         else:
             argv.framework = guess_framework_by_ext(argv.input_model)
-        if not argv.framework:
-            raise Error('Framework name can not be deduced from the given options: {}={}. Use --framework to choose '
-                        'one of caffe, tf, mxnet, kaldi, onnx', '--input_model', argv.input_model, refer_to_faq_msg(15))
 
     return map(lambda x: argv.framework == x, ['tf', 'caffe', 'mxnet', 'kaldi', 'onnx'])
 


### PR DESCRIPTION
**Root cause analysis:** Despite of specified `--use_new_frontend` option, MO selects TensorFlow legacy frontend in case unsupported FW format or new frontend absence in a developer environment.

**Solution:** Strictly define what `--use_new_frontend` and `--use_legacy_frontend` options mean. Check consistency of MO command-line and ensure that the selected frontend does not contradict user defined options.

**Ticket:** 77399

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A
* [x]  Transformation preserves tensor names - N/A

Validation:
* [ ]  Unit tests
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A