### PR TITLE
[PYTHON] Fix vector casting for Constants with float16 type

### DIFF
--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -57,6 +57,12 @@ py::array _cast_vector(const ov::op::v0::Constant& self) {
     return py::array(vec.size(), vec.data());
 }
 
+template <>
+py::array _cast_vector<ov::float16>(const ov::op::v0::Constant& self) {
+    auto vec = self.cast_vector<ov::float16>();
+    return py::array(py::dtype("float16"), vec.size(), vec.data());
+}
+
 void regclass_graph_op_Constant(py::module m) {
     py::class_<ov::op::v0::Constant, std::shared_ptr<ov::op::v0::Constant>, ov::Node> constant(m,
                                                                                                "Constant",


### PR DESCRIPTION
### Details:
Correct behavior for float16 type when using Constant class.
```python
c = ov.opset8.ops.Constant(ov.Type.f16, ov.Shape([2]), [1.0, 2.0])
c.get_vector()
>>> array([1., 2.], dtype=float16)
```

### Tickets:
 - *77797*
