### PR TITLE
fixed excessive outputs copying (in case when the fallback happened) and updated the test for that

### DIFF
--- a/src/plugins/auto_batch/auto_batch.cpp
+++ b/src/plugins/auto_batch/auto_batch.cpp
@@ -272,7 +272,8 @@ AutoBatchAsyncInferRequest::AutoBatchAsyncInferRequest(
                       if (batchReq._exceptionPtr)  // when the batchN execution failed
                           std::rethrow_exception(batchReq._exceptionPtr);
                       // in the case of non-batched execution the blobs were set explicitly
-                      if (this->_inferRequest->_wasBatchedRequestUsed)
+                      if (AutoBatchInferRequest::eExecutionFlavor::BATCH_EXECUTED ==
+                          this->_inferRequest->_wasBatchedRequestUsed)
                           this->_inferRequest->CopyOutputsIfNeeded();
                       if (needPerfCounters) {
                           try {
@@ -401,7 +402,8 @@ std::pair<AutoBatchExecutableNetwork::WorkerInferRequest&, int> AutoBatchExecuta
                             IE_ASSERT(workerRequestPtr->_tasks.try_pop(t));
                             workerRequestPtr->_completionTasks[n] = std::move(t.second);
                             t.first->_inferRequest->CopyInputsIfNeeded();
-                            t.first->_inferRequest->_wasBatchedRequestUsed = true;
+                            t.first->_inferRequest->_wasBatchedRequestUsed =
+                                AutoBatchInferRequest::eExecutionFlavor::BATCH_EXECUTED;
                         }
                         workerRequestPtr->_inferRequestBatched->StartAsync();
                     } else if ((status == std::cv_status::timeout) && sz) {
@@ -421,7 +423,8 @@ std::pair<AutoBatchExecutableNetwork::WorkerInferRequest&, int> AutoBatchExecuta
                                     if (sz == ++arrived)
                                         all_completed.set_value();
                                 });
-                            t.first->_inferRequest->_wasBatchedRequestUsed = false;
+                            t.first->_inferRequest->_wasBatchedRequestUsed =
+                                AutoBatchInferRequest::eExecutionFlavor::TIMEOUT_EXECUTED;
                             t.first->_inferRequest->SetBlobsToAnotherRequest(t.first->_inferRequestWithoutBatch);
                             t.first->_inferRequestWithoutBatch->StartAsync();
                         }

--- a/src/plugins/auto_batch/auto_batch.cpp
+++ b/src/plugins/auto_batch/auto_batch.cpp
@@ -271,7 +271,9 @@ AutoBatchAsyncInferRequest::AutoBatchAsyncInferRequest(
                       auto& batchReq = this->_inferRequest->_myBatchedRequestWrapper;
                       if (batchReq._exceptionPtr)  // when the batchN execution failed
                           std::rethrow_exception(batchReq._exceptionPtr);
-                      this->_inferRequest->CopyOutputsIfNeeded();
+                      // in the case of non-batched execution the blobs were set explicitly
+                      if (this->_inferRequest->_wasBatchedRequestUsed)
+                          this->_inferRequest->CopyOutputsIfNeeded();
                       if (needPerfCounters) {
                           try {
                               this->_inferRequest->_perfMap = batchReq._inferRequestBatched->GetPerformanceCounts();
@@ -399,6 +401,7 @@ std::pair<AutoBatchExecutableNetwork::WorkerInferRequest&, int> AutoBatchExecuta
                             IE_ASSERT(workerRequestPtr->_tasks.try_pop(t));
                             workerRequestPtr->_completionTasks[n] = std::move(t.second);
                             t.first->_inferRequest->CopyInputsIfNeeded();
+                            t.first->_inferRequest->_wasBatchedRequestUsed = true;
                         }
                         workerRequestPtr->_inferRequestBatched->StartAsync();
                     } else if ((status == std::cv_status::timeout) && sz) {
@@ -418,6 +421,7 @@ std::pair<AutoBatchExecutableNetwork::WorkerInferRequest&, int> AutoBatchExecuta
                                     if (sz == ++arrived)
                                         all_completed.set_value();
                                 });
+                            t.first->_inferRequest->_wasBatchedRequestUsed = false;
                             t.first->_inferRequest->SetBlobsToAnotherRequest(t.first->_inferRequestWithoutBatch);
                             t.first->_inferRequestWithoutBatch->StartAsync();
                         }

--- a/src/plugins/auto_batch/auto_batch.hpp
+++ b/src/plugins/auto_batch/auto_batch.hpp
@@ -106,6 +106,7 @@ public:
     void CopyOutputsIfNeeded();
     AutoBatchExecutableNetwork::WorkerInferRequest& _myBatchedRequestWrapper;
     std::exception_ptr _exceptionPtr;
+    bool _wasBatchedRequestUsed;
     std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> _perfMap;
 
 protected:

--- a/src/plugins/auto_batch/auto_batch.hpp
+++ b/src/plugins/auto_batch/auto_batch.hpp
@@ -106,7 +106,11 @@ public:
     void CopyOutputsIfNeeded();
     AutoBatchExecutableNetwork::WorkerInferRequest& _myBatchedRequestWrapper;
     std::exception_ptr _exceptionPtr;
-    bool _wasBatchedRequestUsed;
+    enum eExecutionFlavor : uint8_t {
+        NOT_EXECUTED,
+        BATCH_EXECUTED,
+        TIMEOUT_EXECUTED
+    } _wasBatchedRequestUsed = eExecutionFlavor::NOT_EXECUTED;
     std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> _perfMap;
 
 protected:


### PR DESCRIPTION


### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
