### PR TITLE
Fix template plugin tests

### DIFF
--- a/docs/template_plugin/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
+++ b/docs/template_plugin/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
@@ -18,7 +18,7 @@ namespace {
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_OVClassBasicTestP, OVClassBasicTestP,
-        ::testing::Values(std::make_pair("ov_template_plugin", CommonTestUtils::DEVICE_TEMPLATE)));
+        ::testing::Values(std::make_pair("openvino_template_plugin", CommonTestUtils::DEVICE_TEMPLATE)));
 
 INSTANTIATE_TEST_SUITE_P(
         smoke_OVClassNetworkTestP, OVClassNetworkTestP,


### PR DESCRIPTION
See https://openvino-ci.intel.com/job/private-ci/job/ie/job/ie-tests-linux-ubuntu20-cpu/55751/testReport/junit/(root)/smoke_OVClassBasicTestP_OVClassBasicTestP/registerNewPluginNoThrows_0/
