### PR TITLE
Fixed input cut for case when port is not specified.

### DIFF
--- a/tools/mo/openvino/tools/mo/front/extractor.py
+++ b/tools/mo/openvino/tools/mo/front/extractor.py
@@ -936,7 +936,7 @@ def add_input_op(graph: Graph, node_id: str, port: int = 0, data: bool = False,
         tensor_name = str(port) + ":" + Node(graph, node_id).soft_get('name')
     fw_info = [(Node(graph, node_id).soft_get('name'), tensor_name)]
 
-    if is_out_port and port == 0:
+    if not is_out_port and port == 0:
         tensor_name_no_port = Node(graph, node_id).soft_get('name')
         if graph.has_tensor_name(tensor_name_no_port):
             log.warning('Could not add user defined input name {} to tensor names list of as '


### PR DESCRIPTION
Root cause analysis: 
If input is cut by operation name without port then 0 input port is used by default. So in this case op name should be added to tensor names. Currently op name is added for output port which is wrong.

Solution: 
Add op name to tensor names list in case if cut is performed by input 0-port instead of output 0-port.

Ticket: 78064


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update