### PR TITLE
set U8 precision for image-like inputs even in case of random filling

### DIFF
--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -500,8 +500,7 @@ int main(int argc, char* argv[]) {
                     type_to_set = iop_precision;
                 } else if (input_precision != ov::element::undefined) {
                     type_to_set = input_precision;
-                } else if (!name.empty() && app_inputs_info[0].at(name).is_image() &&
-                           (inputFiles.count("") || inputFiles.count(name))) {
+                } else if (!name.empty() && app_inputs_info[0].at(name).is_image()) {
                     // image input, set U8
                     type_to_set = ov::element::u8;
                 }


### PR DESCRIPTION
### Details:
set U8 precision for image-like inputs even in case of random filling (reverting earlier-changed logic)