### PR TITLE
[GPU] Support deconv double blocked format for b=32

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -772,6 +772,26 @@ bool layout_optimizer::deconvolution_b_fs_yx_fsv16_opt(layout const &input_layou
     return false;
 }
 
+static bool is_node_for_onednn(deconvolution_node const& node) {
+    auto prim = node.get_primitive();
+    auto input_layout = node.get_dependency(0).get_output_layout();
+    auto output_layout = node.get_output_layout();
+
+    // Onednn deconv does not support cross-precision
+    bool onednn_valid_dt = (data_type_traits::is_i8_u8(input_layout.data_type) && data_type_traits::is_i8_u8(output_layout.data_type)) ||
+                            (input_layout.data_type == data_types::f16 && output_layout.data_type == data_types::f16);
+
+    bool onednn_valid_params = onednn_valid_dt &&
+                               input_layout.size.feature[0] >= 16 &&
+                               prim->groups == 1 &&
+                               get_post_ops_count(node) <= 32 &&
+                               input_layout.data_type == output_layout.data_type;
+
+    auto spatial_dims_num = input_layout.format.spatial_num();
+
+    return onednn_valid_dt && onednn_valid_params && spatial_dims_num <= 3;
+}
+
 bool layout_optimizer::needs_all_usr_onednn_small_ic_to_blocked(const program_node& node) {
     bool all_users_match = true;
     for (auto usr : node.get_users()) {
@@ -1122,21 +1142,10 @@ layout layout_optimizer::get_expected_layout(layout const& current_layout,
     auto expected_data_type = current_layout.data_type;
     auto expected_format = current_layout.format;
     auto input_layout = node.get_dependency(0).get_output_layout();
-    auto spatial_dims_num = input_layout.format.spatial_num();
-    auto is_2d = spatial_dims_num == 2;
+    auto is_2d = input_layout.format.spatial_num() == 2;
     bool use_onednn_impls = _optimization_attributes.use_onednn_impls;
 
-    bool onednn_valid_dt = input_layout.data_type == data_types::i8 ||
-                           input_layout.data_type == data_types::u8 ||
-                           input_layout.data_type == data_types::f16;
-
-    bool onednn_valid_params = onednn_valid_dt &&
-                               input_layout.size.feature[0] >= 16 &&
-                               prim->groups == 1 &&
-                               get_post_ops_count(node) <= 32 &&
-                               input_layout.data_type == current_layout.data_type;
-
-    if (use_onednn_impls && onednn_valid_params && spatial_dims_num <= 3) {
+    if (use_onednn_impls && is_node_for_onednn(node)) {
         if (input_layout.data_type == data_types::f16) {
             if (input_layout.size.batch[0] < 16) {
                 expected_format = is_2d ? cldnn::format::b_fs_yx_fsv16 : cldnn::format::b_fs_zyx_fsv16;
@@ -1152,7 +1161,6 @@ layout layout_optimizer::get_expected_layout(layout const& current_layout,
         }
     } else if (_optimization_attributes.b_fs_zyx_fsv16_network &&
         deconvolution_b_fs_zyx_fsv16_opt(current_layout, output_or_weights_layout, prim)) {
-        expected_tensor = current_layout.size;
         if ((current_layout.data_type == data_types::f32 && expected_tensor.batch[0] % 16 == 0) ||
             (current_layout.data_type == data_types::f16 && expected_tensor.batch[0] % 32 == 0))
             expected_format = cldnn::format::bs_fs_zyx_bsv16_fsv16;
@@ -1160,7 +1168,6 @@ layout layout_optimizer::get_expected_layout(layout const& current_layout,
             expected_format = cldnn::format::b_fs_zyx_fsv16;
     } else if (_optimization_attributes.b_fs_yx_fsv16_network &&
                deconvolution_b_fs_yx_fsv16_opt(current_layout, output_or_weights_layout, prim)) {
-        expected_tensor = current_layout.size;
         auto input_tensor = node.get_dependency(0).get_output_layout().size;
         int input_features = input_tensor.feature[0];
         int output_features = expected_tensor.feature[0];

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1426,15 +1426,7 @@ impl_types layout_optimizer::get_preferred_impl_type(program_node& node, format 
         }
 
         if (node.is_type<deconvolution>()) {
-            auto& deconv = node.as<deconvolution>();
-            auto input_layout = deconv.input().get_output_layout();
-            bool valid_ic = input_layout.size.feature[0] >= 16;
-            bool valid_groups = deconv.get_primitive()->groups == 1;
-            bool onednn_valid_post_ops = get_post_ops_count(node) <= 32;
-            bool valid_params = valid_ic && valid_groups && onednn_valid_post_ops;
-            if (!valid_params)
-                impl_candidate = impl_types::ocl;
-            if (input_layout.data_type != deconv.get_output_layout().data_type)
+            if (!is_node_for_onednn(node.as<deconvolution>()))
                 impl_candidate = impl_types::ocl;
         }
 

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1134,7 +1134,7 @@ layout layout_optimizer::get_expected_layout(layout const& current_layout,
                                input_layout.size.feature[0] >= 16 &&
                                prim->groups == 1 &&
                                get_post_ops_count(node) <= 32 &&
-                               input_layout.size.batch[0] < 16;  // oneDNNs optimized kernel doesn't support big batches yet
+                               input_layout.data_type == current_layout.data_type;
 
     if (use_onednn_impls && onednn_valid_params && spatial_dims_num <= 3) {
         if (input_layout.data_type == data_types::f16) {
@@ -1424,8 +1424,7 @@ impl_types layout_optimizer::get_preferred_impl_type(program_node& node, format 
             bool valid_ic = input_layout.size.feature[0] >= 16;
             bool valid_groups = deconv.get_primitive()->groups == 1;
             bool onednn_valid_post_ops = get_post_ops_count(node) <= 32;
-            bool valid_batch = input_layout.size.batch[0] < 16;  // oneDNN's optimized kernel doesn't support big batches yet
-            bool valid_params = valid_ic && valid_groups && onednn_valid_post_ops && valid_batch;
+            bool valid_params = valid_ic && valid_groups && onednn_valid_post_ops;
             if (!valid_params)
                 impl_candidate = impl_types::ocl;
             if (input_layout.data_type != deconv.get_output_layout().data_type)


### PR DESCRIPTION
oneDNN rls-v2.6-pc2 supports double blocked format  batch32.
Remove the batch size limitation in oneDNN check logic.

Signed-off-by: hyunback <hyunback.kim@intel.com>


### Tickets:
 - *ticket-id* 75903
