### PR TITLE
[GPU] Fix outputs blobs allocation for U16/I16 data types

### DIFF
--- a/src/plugins/auto_batch/auto_batch.cpp
+++ b/src/plugins/auto_batch/auto_batch.cpp
@@ -115,6 +115,12 @@ void AutoBatchInferRequest::ShareBlobsWithBatchRequest() {
                 _batchId,
                 _batchSize);
             break;
+        case InferenceEngine::Precision::U32:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::U32>(
+                _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
+                _batchId,
+                _batchSize);
+            break;
         case InferenceEngine::Precision::FP64:
             res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::FP64>(
                 _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
@@ -192,6 +198,12 @@ void AutoBatchInferRequest::ShareBlobsWithBatchRequest() {
             break;
         case InferenceEngine::Precision::U16:
             res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::U16>(
+                _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
+                _batchId,
+                _batchSize);
+            break;
+        case InferenceEngine::Precision::U32:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::U32>(
                 _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
                 _batchId,
                 _batchSize);

--- a/src/plugins/auto_batch/auto_batch.cpp
+++ b/src/plugins/auto_batch/auto_batch.cpp
@@ -144,6 +144,7 @@ void AutoBatchInferRequest::ShareBlobsWithBatchRequest() {
                 _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
                 _batchId,
                 _batchSize);
+            break;
         case InferenceEngine::Precision::I64:
             res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::I64>(
                 _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/common_utils.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/common_utils.hpp
@@ -34,6 +34,7 @@ inline cldnn::data_types DataTypeFromPrecision(InferenceEngine::Precision p) {
     case InferenceEngine::Precision::I16:
     case InferenceEngine::Precision::U16:
     case InferenceEngine::Precision::FP32:
+    case InferenceEngine::Precision::FP64:
         return cldnn::data_types::f32;
     case InferenceEngine::Precision::FP16:
         return cldnn::data_types::f16;
@@ -42,6 +43,8 @@ inline cldnn::data_types DataTypeFromPrecision(InferenceEngine::Precision p) {
     case InferenceEngine::Precision::I8:
         return cldnn::data_types::i8;
     case InferenceEngine::Precision::I32:
+    case InferenceEngine::Precision::U32:
+    case InferenceEngine::Precision::U64:
         return cldnn::data_types::i32;
     case InferenceEngine::Precision::I64:
         return cldnn::data_types::i64;
@@ -60,6 +63,7 @@ inline cldnn::data_types DataTypeFromPrecision(ngraph::element::Type t) {
     case ngraph::element::Type_t::i16:
     case ngraph::element::Type_t::u16:
     case ngraph::element::Type_t::f32:
+    case ngraph::element::Type_t::f64:
         return cldnn::data_types::f32;
     case ngraph::element::Type_t::f16:
         return cldnn::data_types::f16;
@@ -68,6 +72,8 @@ inline cldnn::data_types DataTypeFromPrecision(ngraph::element::Type t) {
     case ngraph::element::Type_t::i8:
         return cldnn::data_types::i8;
     case ngraph::element::Type_t::i32:
+    case ngraph::element::Type_t::u32:
+    case ngraph::element::Type_t::u64:
         return cldnn::data_types::i32;
     case ngraph::element::Type_t::i64:
         return cldnn::data_types::i64;

--- a/src/plugins/intel_gpu/src/graph/include/to_string_utils.h
+++ b/src/plugins/intel_gpu/src/graph/include/to_string_utils.h
@@ -8,6 +8,7 @@
 #include "intel_gpu/runtime/layout.hpp"
 #include "intel_gpu/runtime/device.hpp"
 #include "intel_gpu/primitives/primitive.hpp"
+#include "intel_gpu/primitives/activation.hpp"
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
 #include "program_node.h"
@@ -72,6 +73,58 @@ inline std::string allocation_type_to_str(allocation_type type) {
     case allocation_type::usm_shared: return "usm_shared";
     case allocation_type::usm_device: return "usm_device";
     default: return "unknown";
+    }
+}
+
+inline std::string activation_type_to_str(activation_func activation) {
+    switch (activation) {
+    case activation_func::none: return "none";
+    case activation_func::logistic: return "logistic";
+    case activation_func::hyperbolic_tan: return "hyperbolic_tan";
+    case activation_func::relu: return "relu";
+    case activation_func::relu_negative_slope: return "relu_negative_slope";
+    case activation_func::clamp: return "clamp";
+    case activation_func::softrelu: return "softrelu";
+    case activation_func::abs: return "abs";
+    case activation_func::linear: return "linear";
+    case activation_func::square: return "square";
+    case activation_func::sqrt: return "sqrt";
+    case activation_func::elu: return "elu";
+    case activation_func::sin: return "sin";
+    case activation_func::asin: return "asin";
+    case activation_func::sinh: return "sinh";
+    case activation_func::asinh: return "asinh";
+    case activation_func::cos: return "cos";
+    case activation_func::acos: return "acos";
+    case activation_func::cosh: return "cosh";
+    case activation_func::acosh: return "acosh";
+    case activation_func::log: return "log";
+    case activation_func::log2: return "log2";
+    case activation_func::exp: return "exp";
+    case activation_func::tan: return "tan";
+    case activation_func::atan: return "atan";
+    case activation_func::atanh: return "atanh";
+    case activation_func::floor: return "floor";
+    case activation_func::ceil: return "ceil";
+    case activation_func::negative: return "negative";
+    case activation_func::negation: return "negation";
+    case activation_func::pow: return "pow";
+    case activation_func::reciprocal: return "reciprocal";
+    case activation_func::erf: return "erf";
+    case activation_func::hard_sigmoid: return "hard_sigmoid";
+    case activation_func::hsigmoid: return "hsigmoid";
+    case activation_func::selu: return "selu";
+    case activation_func::sign: return "sign";
+    case activation_func::softplus: return "softplus";
+    case activation_func::softsign: return "softsign";
+    case activation_func::swish: return "swish";
+    case activation_func::hswish: return "hswish";
+    case activation_func::mish: return "mish";
+    case activation_func::gelu: return "gelu";
+    case activation_func::gelu_tanh: return "gelu_tanh";
+    case activation_func::round_half_to_even: return "round_half_to_even";
+    case activation_func::round_half_away_from_zero: return "round_half_away_from_zero";
+    default: return "unknown activation";
     }
 }
 

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -121,6 +121,20 @@ std::unique_ptr<json_composite> program_node::desc_to_json() const {
     }
     node_info->add("fused primitives", fused_nodes_info);
 
+    json_composite fused_activations;
+    auto fused_activations_funcs = get_fused_activations_funcs();
+    if (!fused_activations_funcs.empty()) {
+        for (size_t i = 0; i < fused_activations_funcs.size(); i++) {
+            json_composite fused_activation_info;
+            auto activation_type = activation_type_to_str(fused_activations_funcs[i]);
+            auto params = get_fused_activations_params()[i];
+            fused_activation_info.add("params", "a=" + std::to_string(params.a) + ", b=" + std::to_string(params.b));
+            fused_activation_info.add("activation", activation_type);
+            fused_activations.add("fused activation idx " + std::to_string(i), fused_activation_info);
+        }
+        node_info->add("fused activations (legacy)", fused_activations);
+    }
+
 #ifdef ENABLE_ONEDNN_FOR_GPU
     auto& onednn_post_ops = get_fused_primitives_onednn();
     if (onednn_post_ops.size()) {

--- a/src/plugins/intel_gpu/src/plugin/infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/infer_request.cpp
@@ -28,18 +28,18 @@ const char unsupported_batched_blob[] = "Batched input blob is expected to conta
 const char str_input_not_allocated[] = "Input data was not allocated.";
 const char str_output_not_allocated[] = "Output data was not allocated.";
 
-template <typename T>
-void copyToFloat(float* dst, const InferenceEngine::Blob* src) {
+template <typename src_t, typename dst_t>
+void convertAndCopy(const InferenceEngine::Blob* src, dst_t* dst) {
     if (!dst) {
         return;
     }
-    auto t_blob = dynamic_cast<const InferenceEngine::TBlob<T>*>(src);
+    auto t_blob = dynamic_cast<const InferenceEngine::TBlob<src_t>*>(src);
     if (!t_blob) {
         IE_THROW() << "input type is " << src->getTensorDesc().getPrecision() << " but input is not "
-                   << typeid(T).name();
+                   << typeid(src_t).name();
     }
 
-    const T* srcPtr = t_blob->readOnly();
+    const src_t* srcPtr = t_blob->readOnly();
     if (!srcPtr) {
         IE_THROW(NotAllocated) << str_input_not_allocated;
     }
@@ -47,7 +47,7 @@ void copyToFloat(float* dst, const InferenceEngine::Blob* src) {
         dst[i] = srcPtr[i];
 }
 
-template<typename T>
+template<typename src_dt, typename dst_dt>
 void copyResultToOutputBlob(cldnn::memory::ptr src, Blob::Ptr dst, ov::runtime::intel_gpu::buf_info* bi, cldnn::stream& stream) {
     size_t n = (bi == nullptr) ? dst->size() : bi->buf_size;
     size_t offset = (bi == nullptr) ? 0 : bi->buf_offset;
@@ -56,12 +56,12 @@ void copyResultToOutputBlob(cldnn::memory::ptr src, Blob::Ptr dst, ov::runtime::
     auto size = layout.size;
 
     auto locked_dst = dst->buffer();
-    auto dst_ptr = locked_dst.as<T*>();
+    auto dst_ptr = locked_dst.as<dst_dt*>();
     if (dst_ptr == nullptr) {
         IE_THROW() << "Invalid output blob";
     }
-    cldnn::mem_lock<T> src_lock{ src, stream };
-    T* src_ptr = src_lock.data();
+    cldnn::mem_lock<src_dt> src_lock{ src, stream };
+    src_dt* src_ptr = src_lock.data();
     dst_ptr += offset;
 
     if (layout.data_padding) {
@@ -898,12 +898,17 @@ void InferRequest::copy_output_data(cldnn::memory::ptr src, Blob::Ptr dst, buf_i
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "InferRequest::copy_output_data");
     auto& stream = m_graph->GetNetwork()->get_stream();
     switch (dst->getTensorDesc().getPrecision()) {
-    case Precision::FP32: copyResultToOutputBlob<float>(src, dst, bi, stream);    break;
-    case Precision::FP16: copyResultToOutputBlob<uint16_t>(src, dst, bi, stream); break;
-    case Precision::I32:  copyResultToOutputBlob<int32_t>(src, dst, bi, stream);  break;
-    case Precision::I64:  copyResultToOutputBlob<int64_t>(src, dst, bi, stream);  break;
-    case Precision::U8:  copyResultToOutputBlob<uint8_t>(src, dst, bi, stream);  break;
-    case Precision::I8:  copyResultToOutputBlob<int8_t>(src, dst, bi, stream);  break;
+    case Precision::FP64: copyResultToOutputBlob<float, double>(src, dst, bi, stream);    break;
+    case Precision::FP32: copyResultToOutputBlob<float, float>(src, dst, bi, stream);    break;
+    case Precision::FP16: copyResultToOutputBlob<uint16_t, uint16_t>(src, dst, bi, stream); break;
+    case Precision::I64:  copyResultToOutputBlob<int64_t, int64_t>(src, dst, bi, stream);  break;
+    case Precision::I32:  copyResultToOutputBlob<int32_t, int32_t>(src, dst, bi, stream);  break;
+    case Precision::I16:  copyResultToOutputBlob<float, int16_t>(src, dst, bi, stream);  break;
+    case Precision::I8:   copyResultToOutputBlob<int8_t, int8_t>(src, dst, bi, stream);  break;
+    case Precision::U16:  copyResultToOutputBlob<float, uint16_t>(src, dst, bi, stream);  break;
+    case Precision::U32:  copyResultToOutputBlob<int32_t, uint32_t>(src, dst, bi, stream);  break;
+    case Precision::U64:  copyResultToOutputBlob<int32_t, uint64_t>(src, dst, bi, stream);  break;
+    case Precision::U8:   copyResultToOutputBlob<uint8_t, uint8_t>(src, dst, bi, stream);  break;
     default: IE_THROW(NotImplemented) << "The plugin does not support output " << dst->getTensorDesc().getPrecision() << " precision";
     }
 }
@@ -1054,9 +1059,15 @@ void InferRequest::allocate_outputs() {
         }
 
         outputsMap[no.first] = outputID;
-        if (desc.getPrecision() == Precision::I16 || desc.getPrecision() == Precision::U16) {
+        if (desc.getPrecision() == Precision::I16 || desc.getPrecision() == Precision::U16 ||
+            desc.getPrecision() == Precision::U32 || desc.getPrecision() == Precision::U64 ||
+            desc.getPrecision() == Precision::FP64) {
             TensorDesc device_blob_desc = desc;
-            device_blob_desc.setPrecision(Precision::FP32);
+
+            if (desc.getPrecision() == Precision::U32 || desc.getPrecision() == Precision::U64)
+                device_blob_desc.setPrecision(Precision::I32);
+            else
+                device_blob_desc.setPrecision(Precision::FP32);
 
             auto host_blob = create_host_blob(desc);
             _outputs[no.first] = host_blob;
@@ -1125,6 +1136,7 @@ void InferRequest::prepare_input(const cldnn::primitive_id& inputName, Blob::Ptr
     bool is_dev_input = remote_ptr != nullptr;
 
     switch (prec) {
+        case Precision::FP64:
         case Precision::FP32:
         case Precision::FP16:
         case Precision::I8:
@@ -1133,6 +1145,8 @@ void InferRequest::prepare_input(const cldnn::primitive_id& inputName, Blob::Ptr
         case Precision::I16:
         case Precision::U16:
         case Precision::I32:
+        case Precision::U32:
+        case Precision::U64:
         case Precision::I64: {
             auto impl = getBlobImpl(is_dev_input ?
                                     remote_ptr :
@@ -1150,14 +1164,23 @@ void InferRequest::prepare_input(const cldnn::primitive_id& inputName, Blob::Ptr
             }
 
             if (!is_dev_input) {
-                if (prec == Precision::I16 || prec == Precision::U16) {
+                if (prec == Precision::I16 || prec == Precision::U16 || prec == Precision::FP64) {
                     // GPU plugin doesn't support I16 input precision,
                     // so have to convert input data to fp32 precision
                     cldnn::mem_lock<float> ptr{ inputMem, stream };
                     if (prec == Precision::I16) {
-                        copyToFloat<int16_t>(ptr.data(), inputBlob.get());
+                        convertAndCopy<int16_t, float>(inputBlob.get(), ptr.data());
+                    } else if (prec == Precision::U16) {
+                        convertAndCopy<uint16_t, float>(inputBlob.get(), ptr.data());
                     } else {
-                        copyToFloat<uint16_t>(ptr.data(), inputBlob.get());
+                        convertAndCopy<double, float>(inputBlob.get(), ptr.data());
+                    }
+                } else if (prec == Precision::U64 || prec == Precision::U32) {
+                    cldnn::mem_lock<int32_t> ptr{ inputMem, stream };
+                    if (prec == Precision::U64) {
+                        convertAndCopy<uint64_t, int32_t>(inputBlob.get(), ptr.data());
+                    } else {
+                        convertAndCopy<uint32_t, int32_t>(inputBlob.get(), ptr.data());
                     }
                 } else {
                     auto src_lock = inputBlob->cbuffer();

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -159,12 +159,15 @@ auto check_inputs = [](InferenceEngine::InputsDataMap _networkInputs) {
         auto input_precision = ii.second->getTensorDesc().getPrecision();
         if (input_precision != InferenceEngine::Precision::FP16 &&
             input_precision != InferenceEngine::Precision::FP32 &&
+            input_precision != InferenceEngine::Precision::FP64 &&
             input_precision != InferenceEngine::Precision::U8 &&
             input_precision != InferenceEngine::Precision::I8 &&
             input_precision != InferenceEngine::Precision::I16 &&
             input_precision != InferenceEngine::Precision::U16 &&
             input_precision != InferenceEngine::Precision::I32 &&
+            input_precision != InferenceEngine::Precision::U32 &&
             input_precision != InferenceEngine::Precision::I64 &&
+            input_precision != InferenceEngine::Precision::U64 &&
             input_precision != InferenceEngine::Precision::BOOL) {
             IE_THROW(NotImplemented)
                 << "Input image format " << input_precision << " is not supported yet...";

--- a/src/tests/functional/plugin/gpu/behavior/infer_request.cpp
+++ b/src/tests/functional/plugin/gpu/behavior/infer_request.cpp
@@ -14,8 +14,107 @@
 #include "functional_test_utils/blob_utils.hpp"
 #include "openvino/core/preprocess/pre_post_process.hpp"
 #include "transformations/utils/utils.hpp"
+#include "common_test_utils/common_utils.hpp"
+#include "shared_test_classes/base/layer_test_utils.hpp"
 
 using namespace ::testing;
+
+const std::vector<InferenceEngine::Precision> inputPrecisions = {
+        InferenceEngine::Precision::I16,
+        InferenceEngine::Precision::U16,
+        InferenceEngine::Precision::FP32,
+        InferenceEngine::Precision::FP16,
+        InferenceEngine::Precision::U8,
+        InferenceEngine::Precision::I8,
+        InferenceEngine::Precision::I32,
+        InferenceEngine::Precision::U32,
+        InferenceEngine::Precision::U64,
+        InferenceEngine::Precision::I64,
+        // Interpreter backend doesn't implement evaluate method for OP
+        // InferenceEngine::Precision::FP64,
+};
+
+typedef std::tuple<
+        InferenceEngine::Precision,    // Input/Output Precision
+        InferenceEngine::Layout,       // Input layout
+        InferenceEngine::Layout,       // Output layout
+        std::vector<size_t>,           // Input Shape
+        std::string> newtworkParams;
+
+class InferRequestIOPrecision : public testing::WithParamInterface<newtworkParams>,
+                             virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<newtworkParams> &obj);
+    InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo &info) const override;
+
+protected:
+    void SetUp() override;
+};
+
+std::string InferRequestIOPrecision::getTestCaseName(const testing::TestParamInfo<newtworkParams> &obj) {
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::Layout inLayout, outLayout;
+    std::vector<size_t> shape;
+    std::string targetDevice;
+    std::tie(netPrecision, inLayout, outLayout, shape, targetDevice) = obj.param;
+
+    std::ostringstream result;
+    const char separator = '_';
+    result << "netPRC=" << netPrecision.name() << separator;
+    result << "inL=" << inLayout << separator;
+    result << "outL=" << outLayout << separator;
+    result << "trgDev=" << targetDevice;
+    return result.str();
+}
+
+void InferRequestIOPrecision::SetUp() {
+    InferenceEngine::Precision netPrecision;
+    std::vector<size_t> shape;
+    std::tie(netPrecision, inLayout, outLayout, shape, targetDevice) = GetParam();
+    inPrc = netPrecision;
+    outPrc = netPrecision;
+
+    float clamp_min = netPrecision.isSigned() ? -5.f : 0.0f;
+    float clamp_max = 5.0f;
+
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {shape});
+    params[0]->set_friendly_name("Input");
+
+    auto activation = ngraph::builder::makeActivation(params[0],
+                                                      ngPrc,
+                                                      ngraph::helpers::ActivationTypes::Clamp,
+                                                      {},
+                                                      {clamp_min, clamp_max});
+
+    function = std::make_shared<ngraph::Function>(ngraph::NodeVector{activation}, params);
+}
+
+InferenceEngine::Blob::Ptr InferRequestIOPrecision::GenerateInput(const InferenceEngine::InputInfo &info) const {
+    bool inPrcSigned = function->get_parameters()[0]->get_element_type().is_signed();
+    bool inPrcReal = function->get_parameters()[0]->get_element_type().is_real();
+
+    int32_t data_start_from = inPrcSigned ? -10 : 0;
+    uint32_t data_range = 20;
+    int32_t resolution = inPrcReal ? 32768 : 1;
+
+    return FuncTestUtils::createAndFillBlob(info.getTensorDesc(), data_range,
+                                            data_start_from,
+                                            resolution);
+}
+
+TEST_P(InferRequestIOPrecision, CompareWithRefs) {
+    Run();
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_GPU_BehaviorTests, InferRequestIOPrecision,
+                         ::testing::Combine(
+                                 ::testing::ValuesIn(inputPrecisions),
+                                 ::testing::Values(InferenceEngine::Layout::ANY),
+                                 ::testing::Values(InferenceEngine::Layout::ANY),
+                                 ::testing::Values(std::vector<size_t>{1, 50}),
+                                 ::testing::Values(CommonTestUtils::DEVICE_GPU)),
+                         InferRequestIOPrecision::getTestCaseName);
 
 TEST(TensorTest, smoke_canSetShapeForPreallocatedTensor) {
     auto ie = ov::Core();

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
@@ -73,12 +73,15 @@ std::vector<ov::element::Type> supported_input_prcs = {
     ov::element::boolean,
     ov::element::f16,
     ov::element::f32,
+    ov::element::f64,
     ov::element::i8,
     ov::element::i16,
     ov::element::i32,
     ov::element::i64,
     ov::element::u8,
-    ov::element::u16
+    ov::element::u16,
+    ov::element::u32,
+    ov::element::u64
 };
 
 const std::vector<ov::AnyMap> emptyConfigs = {{}};

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
@@ -70,18 +70,18 @@ std::vector<ov::element::Type> prcs = {
 };
 
 std::vector<ov::element::Type> supported_input_prcs = {
-        ov::element::boolean,
-        ov::element::f16,
-        ov::element::f32,
-        ov::element::i8,
-         // ov::element::i16,
-        ov::element::i32,
-        ov::element::i64,
-        ov::element::u8,
-        // ov::element::u16
+    ov::element::boolean,
+    ov::element::f16,
+    ov::element::f32,
+    ov::element::i8,
+    ov::element::i16,
+    ov::element::i32,
+    ov::element::i64,
+    ov::element::u8,
+    ov::element::u16
 };
 
-    const std::vector<ov::AnyMap> emptyConfigs = {{}};
+const std::vector<ov::AnyMap> emptyConfigs = {{}};
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestIOTensorSetPrecisionTest,
                          ::testing::Combine(


### PR DESCRIPTION
### Details:
 - Fixed outputs blobs allocation for U16/I16 data types
 - Enabled OVInferRequestCheckTensorPrecision tests for supported precisions

### Tickets:
 - 75941
