### PR TITLE
[ONNX] Fix reading allowzero attr of Reshape op

### DIFF
--- a/src/frontends/onnx/frontend/src/op/reshape.cpp
+++ b/src/frontends/onnx/frontend/src/op/reshape.cpp
@@ -23,26 +23,20 @@ OutputVector reshape(const Node& node) {
     const auto data = ng_inputs.at(0);
 
     Output<ngraph::Node> pattern;
-    bool special_zero = true;
     // Since opset 5 the target shape is provided as input
     if (ng_inputs.size() == 2) {
         pattern = ng_inputs.at(1);
     } else {
         const auto output_shape = node.get_attribute_value<std::vector<int64_t>>("shape", {});
-
-        // Added in onnx reshape version 14
-        special_zero = !node.get_attribute_value<int64_t>("allowzero", 0);
-
         pattern = default_opset::Constant::create(element::i64, Shape{output_shape.size()}, output_shape);
     }
 
+    // Added in onnx reshape version 14
+    const bool special_zero = !node.get_attribute_value<int64_t>("allowzero", 0);
+
     return {std::make_shared<default_opset::Reshape>(data, pattern, special_zero)};
 }
-
 }  // namespace set_1
-
 }  // namespace op
-
 }  // namespace onnx_import
-
 }  // namespace ngraph


### PR DESCRIPTION
### Details:
 `special_zero` was always `true` due to misplaced read of _allowzero_ attribute from _Reshape_ operator.

### Tickets:
 Found while debugging other issue (which isn't solved by this fix).
