### PR TITLE
Write runtime version and how IR was genarated (legacy path or not)

### DIFF
--- a/tools/mo/openvino/tools/mo/main.py
+++ b/tools/mo/openvino/tools/mo/main.py
@@ -468,7 +468,8 @@ def emit_ir(graph: Graph, argv: argparse.Namespace):
         append_ir_info(file=orig_model_name,
                        meta_info=get_meta_info(argv),
                        mean_data=mean_data,
-                       input_names=input_names)
+                       input_names=input_names,
+                       legacy_path=True)
 
         print('[ SUCCESS ] Generated IR version {} model.'.format(get_ir_version(argv)))
         print('[ SUCCESS ] XML file: {}.xml'.format(orig_model_name))

--- a/tools/mo/openvino/tools/mo/moc_frontend/serialize.py
+++ b/tools/mo/openvino/tools/mo/moc_frontend/serialize.py
@@ -52,7 +52,8 @@ def moc_emit_ir(ngraph_function: Model, argv: argparse.Namespace):
     append_ir_info(file=orig_model_name,
                    meta_info=get_meta_info(argv),
                    mean_data=None,
-                   input_names=None)
+                   input_names=None,
+                   legacy_path=False)
 
     print('[ SUCCESS ] Generated IR version {} model.'.format(get_ir_version(argv)))
     print('[ SUCCESS ] XML file: {}.xml'.format(orig_model_name))


### PR DESCRIPTION
Root cause analysis: IR metadata contains only MO version, while it is equally important to know runtime version and if the IR was created using frontend or legacy MO.

Solution: 
 - *Add required data to meta info of IR*

```
<net>
        ...
        <meta_data>
                <MO_version value="2022.1.custom_mo/meta_improve_29fd24d7c2636efbfdb68932605a1b1db00802e2"/>
                <Runtime_version value="custom_mo/meta_improve_29fd24d7c2636efbfdb68932605a1b1db00802e2"/>
                <legacy_path value="False"/>
                <cli_parameters>...</cli_parameters>
        </meta_data>
</net>

```

Ticket: 77604


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update