### PR TITLE
Fix BroadcastElementwiseFusion pass

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/broadcast_elementwise_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/broadcast_elementwise_fusion.cpp
@@ -72,7 +72,7 @@ bool can_eliminate_broadcast(const ngraph::Output<ngraph::Node>& eltwise,
 ngraph::pass::BroadcastElementwiseFusion::BroadcastElementwiseFusion() {
     MATCHER_SCOPE(BroadcastElementwiseFusion);
     auto broadcast_input = pattern::any_input();
-    auto broadcast = pattern::wrap_type<ngraph::opset5::Broadcast>({broadcast_input, pattern::any_input()});
+    auto broadcast = pattern::wrap_type<ngraph::opset5::Broadcast>({broadcast_input, pattern::any_input()}, pattern::consumers_count(1));
     auto eltwise_input = pattern::any_input();
     auto eltwise = pattern::wrap_type<op::util::BinaryElementwiseArithmetic>({eltwise_input, broadcast});
 

--- a/src/tests/functional/inference_engine/transformations/common_optimizations/broadcast_elementwise_fusion_test.cpp
+++ b/src/tests/functional/inference_engine/transformations/common_optimizations/broadcast_elementwise_fusion_test.cpp
@@ -286,3 +286,15 @@ TEST_F(TransformationTestsF, BroadcastElementwiseFusionWithShapeOf) {
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{elementwise}, ngraph::ParameterVector{input});
     }
 }
+
+TEST_F(TransformationTestsF, BroadcastElementwiseFusionWithShapeOfNeg) {
+    {
+        auto input =  std::make_shared<ngraph::opset5::Parameter>(ngraph::element::f32, Shape{1, 3});
+        auto shape_of = std::make_shared<ngraph::opset5::ShapeOf>(input);
+        auto broadcast = std::make_shared<ngraph::opset5::Broadcast>(input, shape_of);
+        auto elementwise = std::make_shared<ngraph::opset5::Multiply>(input, broadcast);
+        function = std::make_shared<ngraph::Function>(ngraph::NodeVector{elementwise, broadcast}, ngraph::ParameterVector{input});
+
+        manager.register_pass<pass::BroadcastElementwiseFusion>();
+    }
+}


### PR DESCRIPTION
### Details
Fix BroadcastElementwiseFusion pass for case when Broadcast has more that one consumer and can't be eliminated.

### Tickets
XXX-76838
