### PR TITLE
Fix for str_to_container if string value has whitespaces

### DIFF
--- a/src/frontends/ir/src/rt_info_deserializer.cpp
+++ b/src/frontends/ir/src/rt_info_deserializer.cpp
@@ -17,7 +17,7 @@ void RTInfoDeserializer::on_adapter(const std::string& name, ValueAccessor<void>
         return;
     if (auto a = as_type<AttributeAdapter<std::set<std::string>>>(&adapter)) {
         std::set<std::string> ss;
-        str_to_container(val, ss);
+        str_to_set_of_strings(val, ss);
         a->set(ss);
     } else {
         IE_THROW() << "Not implemented";

--- a/src/frontends/ir/src/utils.cpp
+++ b/src/frontends/ir/src/utils.cpp
@@ -98,4 +98,14 @@ bool get_dimension_from_attribute(const pugi::xml_node& node, const std::string&
     return true;
 }
 
+void str_to_set_of_strings(const std::string& value, std::set<std::string>& res) {
+    std::stringstream ss(value);
+    std::string field;
+    while (getline(ss, field, ',')) {
+        if (field.empty())
+            IE_THROW() << "Cannot get vector of parameters! \"" << value << "\" is incorrect";
+        res.insert(res.end(), field);
+    }
+}
+
 }  // namespace ov

--- a/src/frontends/ir/src/utils.cpp
+++ b/src/frontends/ir/src/utils.cpp
@@ -105,7 +105,8 @@ void str_to_set_of_strings(const std::string& value, std::set<std::string>& res)
         // trim leading and trailing whitespaces
         auto strBegin = field.find_first_not_of(" ");
         if (strBegin == std::string::npos)
-            IE_THROW() << "Cannot get set of strings from \"" << value << "\". Value \"" << field << "\" is incorrect";
+            IE_THROW() << "Cannot get a set of strings from \"" << value << "\". Value \"" << field
+                       << "\" is incorrect";
         auto strRange = field.find_last_not_of(" ") - strBegin + 1;
 
         res.insert(field.substr(strBegin, strRange));

--- a/src/frontends/ir/src/utils.cpp
+++ b/src/frontends/ir/src/utils.cpp
@@ -104,7 +104,14 @@ void str_to_set_of_strings(const std::string& value, std::set<std::string>& res)
     while (getline(ss, field, ',')) {
         if (field.empty())
             IE_THROW() << "Cannot get vector of parameters! \"" << value << "\" is incorrect";
-        res.insert(res.end(), field);
+
+        // trim leading and trailing whitespaces
+        auto strBegin = field.find_first_not_of(" ");
+        if (strBegin == std::string::npos)
+            IE_THROW() << "Cannot get vector of parameters! \"" << value << "\" is incorrect";
+        auto strRange = field.find_last_not_of(" ") - strBegin + 1;
+
+        res.insert(field.substr(strBegin, strRange));
     }
 }
 

--- a/src/frontends/ir/src/utils.cpp
+++ b/src/frontends/ir/src/utils.cpp
@@ -105,7 +105,7 @@ void str_to_set_of_strings(const std::string& value, std::set<std::string>& res)
         // trim leading and trailing whitespaces
         auto strBegin = field.find_first_not_of(" ");
         if (strBegin == std::string::npos)
-            IE_THROW() << "Cannot get vector of parameters! \"" << value << "\" is incorrect";
+            IE_THROW() << "Cannot get set of strings from \"" << value << "\". Value \"" << field << "\" is incorrect";
         auto strRange = field.find_last_not_of(" ") - strBegin + 1;
 
         res.insert(field.substr(strBegin, strRange));

--- a/src/frontends/ir/src/utils.cpp
+++ b/src/frontends/ir/src/utils.cpp
@@ -102,9 +102,6 @@ void str_to_set_of_strings(const std::string& value, std::set<std::string>& res)
     std::stringstream ss(value);
     std::string field;
     while (getline(ss, field, ',')) {
-        if (field.empty())
-            IE_THROW() << "Cannot get vector of parameters! \"" << value << "\" is incorrect";
-
         // trim leading and trailing whitespaces
         auto strBegin = field.find_first_not_of(" ");
         if (strBegin == std::string::npos)

--- a/src/frontends/ir/src/utils.hpp
+++ b/src/frontends/ir/src/utils.hpp
@@ -32,6 +32,9 @@ void str_to_container(const std::string& value, T& res) {
         res.insert(res.end(), val);
     }
 }
+// separated function for set<string> to keep whitespaces in values
+// because stringstream splits its values with whitespace delimiter
+void str_to_set_of_strings(const std::string& value, std::set<std::string>& res);
 
 template <class T>
 bool getParameters(const pugi::xml_node& node, const std::string& name, std::vector<T>& value) {

--- a/src/tests/functional/inference_engine/ir_serialization/rt_info_deserialization.cpp
+++ b/src/tests/functional/inference_engine/ir_serialization/rt_info_deserialization.cpp
@@ -472,7 +472,7 @@ TEST_F(RTInfoDeserialization, NodeV11) {
         <layer name="Round" id="1" type="Round" version="opset8">
             <data mode="half_to_even"/>
             <rt_info>
-                <attribute name="fused_names" version="0" value="Round 1,Round 2"/>
+                <attribute name="fused_names" version="0" value="Round 1  ,  Round 2  "/>
             </rt_info>
             <input>
                 <port id="1" precision="FP32">

--- a/src/tests/functional/inference_engine/ir_serialization/rt_info_deserialization.cpp
+++ b/src/tests/functional/inference_engine/ir_serialization/rt_info_deserialization.cpp
@@ -472,7 +472,7 @@ TEST_F(RTInfoDeserialization, NodeV11) {
         <layer name="Round" id="1" type="Round" version="opset8">
             <data mode="half_to_even"/>
             <rt_info>
-                <attribute name="fused_names" version="0" value="Round 1  ,  Round 2  "/>
+                <attribute name="fused_names" version="0" value="    Round 1  ,  Round 2  "/>
             </rt_info>
             <input>
                 <port id="1" precision="FP32">

--- a/src/tests/functional/inference_engine/ir_serialization/rt_info_deserialization.cpp
+++ b/src/tests/functional/inference_engine/ir_serialization/rt_info_deserialization.cpp
@@ -472,7 +472,7 @@ TEST_F(RTInfoDeserialization, NodeV11) {
         <layer name="Round" id="1" type="Round" version="opset8">
             <data mode="half_to_even"/>
             <rt_info>
-                <attribute name="fused_names" version="0" value="Round1,Round2"/>
+                <attribute name="fused_names" version="0" value="Round 1,Round 2"/>
             </rt_info>
             <input>
                 <port id="1" precision="FP32">
@@ -553,7 +553,7 @@ TEST_F(RTInfoDeserialization, NodeV11) {
     auto result = f->get_result();
     check_old_api_map_order(result->get_rt_info(), std::vector<uint64_t>({0, 3, 1, 2}));
     auto round = result->get_input_node_ptr(0);
-    check_fused_names(round->get_rt_info(), "Round1,Round2");
+    check_fused_names(round->get_rt_info(), "Round 1,Round 2");
 
     // read IR v11 with new API
     {


### PR DESCRIPTION
### Details:
 - Add new function to handle layer and fused names with whitespaces. Trim leading and trailing whitespaces
 - Modify tests

### Tickets:
 - CVS-71762
