### PR TITLE
Fix the issue in values_from_const method in OVTF integration with TF FE

### DIFF
--- a/src/frontends/tensorflow/src/utils.hpp
+++ b/src/frontends/tensorflow/src/utils.hpp
@@ -94,8 +94,8 @@ void values_from_const_node(const NodeContext& node, ov::Shape* const_tensor_sha
     const auto* decoder = node.get_decoder();
     auto dt = decoder->get_native_attribute("dtype").as<::tensorflow::DataType>();
 
-    // TODO: investigate why as<>() method using std::move leads to the issue (75371) in OVTF integration with
-    //  tensorflow frontend. The current fix: replace it with as<>() method using reference. But in fact, both
+    // TODO: investigate why as<>() && method using std::move leads to the issue (75371) in OVTF integration with
+    //  tensorflow frontend. The current fix: replace it with as<>() & method. But in fact, both
     //  approaches should work the same way.
     // auto tensor_proto = decoder->get_native_attribute("value").as<::tensorflow::TensorProto>();
     auto value = decoder->get_native_attribute("value");

--- a/src/frontends/tensorflow/src/utils.hpp
+++ b/src/frontends/tensorflow/src/utils.hpp
@@ -93,7 +93,14 @@ void values_from_const_node(const NodeContext& node, ov::Shape* const_tensor_sha
     TENSORFLOW_OP_VALIDATION(node, node.get_op_type() == "Const", "Node is expected to be Constant.");
     const auto* decoder = node.get_decoder();
     auto dt = decoder->get_native_attribute("dtype").as<::tensorflow::DataType>();
-    auto tensor_proto = decoder->get_native_attribute("value").as<::tensorflow::TensorProto>();
+
+    // TODO: investigate why as<>() method using std::move leads to the issue (75371) in OVTF integration with
+    //  tensorflow frontend. The current fix: replace it with as<>() method using reference. But in fact, both
+    //  approaches should work the same way.
+    // auto tensor_proto = decoder->get_native_attribute("value").as<::tensorflow::TensorProto>();
+    auto value = decoder->get_native_attribute("value");
+    auto tensor_proto = value.as<::tensorflow::TensorProto>();
+
     const ::tensorflow::TensorShapeProto& shape = tensor_proto.tensor_shape();
     ov::PartialShape pshape;
     tf_shape_to_ov_shape(shape, &pshape);


### PR DESCRIPTION
### Details:
 The difference between these two calls is which .as<>() method of ov::Any class is actually used.

    1. 
    // it calls as<>() method with rvalue qualifier ( std::move inside) : as() &&
    auto tensor_proto = decoder->get_native_attribute("value").as<::tensorflow::TensorProto>(); 
    
    2. 
    // it calls as<>() method with lvalue qualifier : as () &
    ov::Any any = decoder->get_native_attribute("value");
    auto tensor_proto = any.as<::tensorflow::TensorProto>();

For some reason the 1st variant causes the issue in OVTF integration with TF FE. 
It's not reproducible in TF FE separately.

### Tickets:
 - *75371*
