### PR TITLE
noise-suppression poconetlike0001 accuracy bug fix

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/mkldnn_interpolate_node.h
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_interpolate_node.h
@@ -243,6 +243,8 @@ private:
 
     bool isAxesSpecified = false;
     std::vector<int> axes;
+    std::vector<float> scales;
+    bool isScaleConstant = false;
 
     // 6 ptrs for each quantization, 2 ptrs for each depth_wise
     std::vector<const void*> postOpsDataPtrs;


### PR DESCRIPTION

### Details:
 - *If the input of interpolate scales is Constant, we only need to get its value during node init, no need to get it during every inference*

### Tickets:
   - *cvs-75660*
