### PR TITLE
[MO] Avoid maskedconstant to array conversion

### DIFF
--- a/tools/mo/openvino/tools/mo/ops/ReduceOps.py
+++ b/tools/mo/openvino/tools/mo/ops/ReduceOps.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2018-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-import numpy
+
 import numpy as np
 
 from openvino.tools.mo.front.common.partial_infer.utils import int64_array, is_fully_defined

--- a/tools/mo/openvino/tools/mo/ops/ReduceOps.py
+++ b/tools/mo/openvino/tools/mo/ops/ReduceOps.py
@@ -37,7 +37,7 @@ def reduce_helper(func: callable, x: np.array, axis: tuple, keepdims: bool):
     """
     result = func(x, axis=axis, keepdims=keepdims)
     # we need to handle this case specially to avoid problems with deepcopy method with MaskedConstant converted to
-    # masked_array
+    # masked_array - see issue https://github.com/numpy/numpy/issues/21022
     if isinstance(result, np.ma.core.MaskedConstant):
         return np.ma.masked_array(data=-1, mask=True, dtype=result.dtype)
     if is_fully_defined(x):

--- a/tools/mo/openvino/tools/mo/ops/ReduceOps.py
+++ b/tools/mo/openvino/tools/mo/ops/ReduceOps.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2018-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
+import numpy
 import numpy as np
 
 from openvino.tools.mo.front.common.partial_infer.utils import int64_array, is_fully_defined
@@ -36,6 +36,10 @@ def reduce_helper(func: callable, x: np.array, axis: tuple, keepdims: bool):
     :return: the result tensor
     """
     result = func(x, axis=axis, keepdims=keepdims)
+    # we need to handle this case specially to avoid problems with deepcopy method with MaskedConstant converted to
+    # masked_array
+    if isinstance(result, np.ma.core.MaskedConstant):
+        return np.ma.masked_array(data=-1, mask=True, dtype=result.dtype)
     if is_fully_defined(x):
         return result
     else:


### PR DESCRIPTION
Root cause analysis: We found an issue when trying to create a deepcopy of numpy masked_array which was created from masked constant - the result of numpy.prod operation.

Issue in NumPy repository: https://github.com/numpy/numpy/issues/21022

Solution: Create another masked array and return it as operation result.

Ticket: 77218

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names

Validation:
* [x]  Unit tests: N/A - No new implemented functions;
* [x]  Framework operation tests: N/A - No new enabled operations;
* [x]  Transformation tests: N/A - No new implemented transformations;
* [x]  Model Optimizer IR Reader check: Done manually.

Documentation:
* [x]  Supported frameworks operations list: N/A - No new supported operations;
* [x]  Supported **public** models list: N/A - Nothing to add;
* [x]  User guide update: N/A - Nothing to update.
