### PR TITLE
adding I64/U64 support to the auto-batching

### DIFF
--- a/src/plugins/auto_batch/auto_batch.cpp
+++ b/src/plugins/auto_batch/auto_batch.cpp
@@ -103,23 +103,55 @@ void AutoBatchInferRequest::ShareBlobsWithBatchRequest() {
                 _batchId,
                 _batchSize);
             break;
+        case InferenceEngine::Precision::I16:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::I16>(
+                _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
+                _batchId,
+                _batchSize);
+            break;
         case InferenceEngine::Precision::U16:
             res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::U16>(
                 _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
                 _batchId,
                 _batchSize);
             break;
-
-        case InferenceEngine::Precision::I16:
-            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::I16>(
+        case InferenceEngine::Precision::FP64:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::FP64>(
                 _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
                 _batchId,
                 _batchSize);
-
+            break;
+        case InferenceEngine::Precision::FP16:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::FP16>(
+                _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
+                _batchId,
+                _batchSize);
+            break;
+        case InferenceEngine::Precision::BF16:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::BF16>(
+                _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
+                _batchId,
+                _batchSize);
+            break;
+        case InferenceEngine::Precision::U64:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::U64>(
+                _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
+                _batchId,
+                _batchSize);
+        case InferenceEngine::Precision::I64:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::I64>(
+                _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
+                _batchId,
+                _batchSize);
             break;
         case InferenceEngine::Precision::U8:
-        case InferenceEngine::Precision::BOOL:
             res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::U8>(
+                _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
+                _batchId,
+                _batchSize);
+            break;
+        case InferenceEngine::Precision::BOOL:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::BOOL>(
                 _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
                 _batchId,
                 _batchSize);
@@ -152,23 +184,56 @@ void AutoBatchInferRequest::ShareBlobsWithBatchRequest() {
                 _batchId,
                 _batchSize);
             break;
+        case InferenceEngine::Precision::I16:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::I16>(
+                _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
+                _batchId,
+                _batchSize);
+            break;
         case InferenceEngine::Precision::U16:
             res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::U16>(
                 _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
                 _batchId,
                 _batchSize);
             break;
-
-        case InferenceEngine::Precision::I16:
-            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::I16>(
+        case InferenceEngine::Precision::FP64:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::FP64>(
                 _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
                 _batchId,
                 _batchSize);
-
+            break;
+        case InferenceEngine::Precision::FP16:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::FP16>(
+                _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
+                _batchId,
+                _batchSize);
+            break;
+        case InferenceEngine::Precision::BF16:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::BF16>(
+                _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
+                _batchId,
+                _batchSize);
+            break;
+        case InferenceEngine::Precision::U64:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::U64>(
+                _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
+                _batchId,
+                _batchSize);
+            break;
+        case InferenceEngine::Precision::I64:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::I64>(
+                _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
+                _batchId,
+                _batchSize);
             break;
         case InferenceEngine::Precision::U8:
-        case InferenceEngine::Precision::BOOL:
             res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::U8>(
+                _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
+                _batchId,
+                _batchSize);
+            break;
+        case InferenceEngine::Precision::BOOL:
+            res = create_shared_blob_on_top_of_batched_blob<InferenceEngine::Precision::BOOL>(
                 _myBatchedRequestWrapper._inferRequestBatched->GetBlob(it.first),
                 _batchId,
                 _batchSize);

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
@@ -69,6 +69,20 @@ std::vector<ov::element::Type> prcs = {
     ov::element::u64,
 };
 
+std::vector<ov::element::Type> supported_input_prcs = {
+        ov::element::boolean,
+        ov::element::f16,
+        ov::element::f32,
+        ov::element::i8,
+         // ov::element::i16,
+        ov::element::i32,
+        ov::element::i64,
+        ov::element::u8,
+        // ov::element::u16
+};
+
+    const std::vector<ov::AnyMap> emptyConfigs = {{}};
+
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferRequestIOTensorSetPrecisionTest,
                          ::testing::Combine(
                                  ::testing::ValuesIn(prcs),
@@ -96,4 +110,18 @@ INSTANTIATE_TEST_SUITE_P(smoke_AutoBatch_BehaviorTests, OVInferRequestIOTensorSe
                                  ::testing::Values(CommonTestUtils::DEVICE_BATCH),
                                  ::testing::ValuesIn(AutoBatchConfigs)),
                          OVInferRequestIOTensorSetPrecisionTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_GPU_BehaviorTests, OVInferRequestCheckTensorPrecision,
+                         ::testing::Combine(
+                                 ::testing::ValuesIn(supported_input_prcs),
+                                 ::testing::Values(CommonTestUtils::DEVICE_GPU),
+                                 ::testing::ValuesIn(emptyConfigs)),
+                         OVInferRequestCheckTensorPrecision::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_AutoBatch_BehaviorTests, OVInferRequestCheckTensorPrecision,
+                         ::testing::Combine(
+                                 ::testing::ValuesIn(supported_input_prcs),
+                                 ::testing::Values(CommonTestUtils::DEVICE_BATCH),
+                                 ::testing::ValuesIn(AutoBatchConfigs)),
+                         OVInferRequestCheckTensorPrecision::getTestCaseName);
 }  // namespace


### PR DESCRIPTION
NB: in the API 1.0 the I32 was automatically used (by the CNNetwork?), so i64 inputs it didn't fail...
 