### PR TITLE
[MO] Add missed DeformableConvolution to back transformations

### DIFF
--- a/tools/mo/openvino/tools/mo/back/blob_normalizer.py
+++ b/tools/mo/openvino/tools/mo/back/blob_normalizer.py
@@ -33,7 +33,7 @@ class BlobNormalizer(BackReplacementPattern):
     @staticmethod
     def pattern():
         return dict(
-            nodes=[('conv', dict(type=lambda type: type in ['Convolution', 'Deconvolution', 'FullyConnected']))],
+            nodes=[('conv', dict(type=lambda type: type in ['Convolution', 'Deconvolution', 'FullyConnected', 'DeformableConvolution']))],
             edges=[]
         )
 

--- a/tools/mo/openvino/tools/mo/back/op_versioning.py
+++ b/tools/mo/openvino/tools/mo/back/op_versioning.py
@@ -33,6 +33,7 @@ class OpVersioning(BackReplacementPattern):
         "ConvolutionBackpropData",
         "Cos",
         "Cosh",
+        'DeformableConvolution',
         "DeformablePSROIPooling",
         "DepthToSpace",
         "DetectionOutput",


### PR DESCRIPTION
Root cause analysis: <analysis_of_the_issue_root_cause>

Solution: <description_of_the_solution>

Ticket: 78241

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names

Validation:
* [x]  Unit tests: N/A - No new implemented functions;
* [x]  Framework operation tests: N/A - No new enabled operations;
* [x]  Transformation tests: N/A - No new implemented transformations;
* [ ]  Model Optimizer IR Reader check: In progress.

Documentation:
* [x]  Supported frameworks operations list: N/A - No new supported operations;
* [x]  Supported **public** models list: N/A - Nothing to add;
* [x]  User guide update: N/A - Nothing to update.
