### PR TITLE
Modify for CVS-69023: hint configuration

### DIFF
--- a/samples/cpp/benchmark_app/README.md
+++ b/samples/cpp/benchmark_app/README.md
@@ -85,11 +85,11 @@ Options:
     -l "<absolute_path>"        Required for CPU custom layers. Absolute path to a shared library with the kernels implementations.
           Or
     -c "<absolute_path>"        Required for GPU custom kernels. Absolute path to an .xml file with the kernels description.
-    -hint "<throughput(or just 'tput')/latency">
-                                Optional. Performance hint (optimize for latency or throughput).
-                                The hint allows the OpenVINO device to select the right network-specific settings,
-                                as opposite to just accepting specific values from the sample command line.
-                                So you can specify only the hint without setting explicit 'nstreams' or other device-specific options.
+    -hint "performance hint (latency or throughput or none)"   Optional. Performance hint allows the OpenVINO device to select the right network-specific settings.
+                                 'throughput' or 'tput': device performance mode will be set to THROUGHPUT.
+                                 'latency': device performance mode will be set to LATENCY.
+                                 'none': no device performance mode will be set.
+                                Using explicit 'nstreams' or other device-specific options, please set hint to 'none'
     -api "<sync/async>"         Optional (deprecated). Enable Sync/Async API. Default value is "async".
     -niter "<integer>"          Optional. Number of iterations. If not specified, the number of iterations is calculated depending on a device.
     -nireq "<integer>"          Optional. Number of infer requests. Default value is determined automatically for a device.

--- a/samples/cpp/benchmark_app/benchmark_app.hpp
+++ b/samples/cpp/benchmark_app/benchmark_app.hpp
@@ -33,10 +33,12 @@ static const char model_message[] =
 
 /// @brief message for performance hint
 static const char hint_message[] =
-    "Optional. Performance hint (optimize for latency or throughput)."
-    " The hint allows the OpenVINO device to select the right network-specific settings,"
-    " as opposite to just accepting specific values from the sample command line."
-    " So you can specify only the hint without setting  explicit 'nstreams' or other device-specific options";
+    "Optional. Performance hint allows the OpenVINO device to select the right network-specific settings.\n"
+    "                               'throughput' or 'tput': device performance mode will be set to THROUGHPUT.\n"
+    "                               'latency': device performance mode will be set to LATENCY.\n"
+    "                               'none': no device performance mode will be set.\n"
+    "                              Using explicit 'nstreams' or other device-specific options, please set hint to "
+    "'none'";
 
 /// @brief message for execution mode
 static const char api_message[] = "Optional (deprecated). Enable Sync/Async API. Default value is \"async\".";
@@ -374,7 +376,7 @@ static void show_usage() {
     std::cout << "    -l \"<absolute_path>\"      " << custom_cpu_library_message << std::endl;
     std::cout << "          Or" << std::endl;
     std::cout << "    -c \"<absolute_path>\"      " << custom_cldnn_message << std::endl;
-    std::cout << "    -hint \"performance hint (latency or throughput)\"   " << hint_message << std::endl;
+    std::cout << "    -hint \"performance hint (latency or throughput or none)\"   " << hint_message << std::endl;
     std::cout << "    -api \"<sync/async>\"       " << api_message << std::endl;
     std::cout << "    -niter \"<integer>\"        " << iterations_count_message << std::endl;
     std::cout << "    -nireq \"<integer>\"        " << infer_requests_count_message << std::endl;

--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -55,9 +55,10 @@ bool ParseAndCheckCommandLine(int argc, char* argv[]) {
     if (FLAGS_api != "async" && FLAGS_api != "sync") {
         throw std::logic_error("Incorrect API. Please set -api option to `sync` or `async` value.");
     }
-    if (!FLAGS_hint.empty() && FLAGS_hint != "throughput" && FLAGS_hint != "tput" && FLAGS_hint != "latency") {
+    if (!FLAGS_hint.empty() && FLAGS_hint != "throughput" && FLAGS_hint != "tput" && FLAGS_hint != "latency" &&
+        FLAGS_hint != "none") {
         throw std::logic_error("Incorrect performance hint. Please set -hint option to"
-                               "either `throughput`(tput) or `latency' value.");
+                               "`throughput`(tput), `latency' value or 'none'.");
     }
     if (!FLAGS_report_type.empty() && FLAGS_report_type != noCntReport && FLAGS_report_type != averageCntReport &&
         FLAGS_report_type != detailedCntReport) {
@@ -104,6 +105,36 @@ static void next_step(const std::string additional_info = "") {
 
     std::cout << "[Step " << step_id << "/" << step_names.size() << "] " << step_names.at(step_id)
               << (additional_info.empty() ? "" : " (" + additional_info + ")") << std::endl;
+}
+
+ov::hint::PerformanceMode get_performance_hint(const std::string& device, const ov::Core& core) {
+    ov::hint::PerformanceMode ov_perf_hint = ov::hint::PerformanceMode::UNDEFINED;
+    auto supported_properties = core.get_property(device, ov::supported_properties);
+    if (std::find(supported_properties.begin(), supported_properties.end(), ov::hint::performance_mode) !=
+        supported_properties.end()) {
+        if (FLAGS_hint != "") {
+            if (FLAGS_hint == "throughput" || FLAGS_hint == "tput") {
+                slog::warn << "Device(" << device << ") performance hint is set to THROUGHPUT" << slog::endl;
+                ov_perf_hint = ov::hint::PerformanceMode::THROUGHPUT;
+            } else if (FLAGS_hint == "latency") {
+                slog::warn << "Device(" << device << ") performance hint is set to LATENCY" << slog::endl;
+                ov_perf_hint = ov::hint::PerformanceMode::LATENCY;
+            } else if (FLAGS_hint == "none") {
+                slog::warn << "No device(" << device << ") performance hint is set" << slog::endl;
+                ov_perf_hint = ov::hint::PerformanceMode::UNDEFINED;
+            }
+        } else {
+            slog::warn << "PerformanceMode was not explicitly specified in command line. "
+                          "Device("
+                       << device << ") performance hint will be set to THROUGHPUT." << slog::endl;
+            ov_perf_hint = ov::hint::PerformanceMode::THROUGHPUT;
+        }
+    } else {
+        if (FLAGS_hint != "") {
+            slog::warn << "Device(" << device << ") does not support performance hint property(-hint)." << slog::endl;
+        }
+    }
+    return ov_perf_hint;
 }
 
 /**
@@ -193,21 +224,6 @@ int main(int argc, char* argv[]) {
             slog::info << "GPU extensions is loaded " << ext << slog::endl;
         }
 
-        if (FLAGS_hint.empty()) {
-            for (auto& device : devices) {
-                auto supported_properties = core.get_property(device, ov::supported_properties);
-                if (std::find(supported_properties.begin(), supported_properties.end(), ov::hint::performance_mode) !=
-                    supported_properties.end()) {
-                    slog::warn << "-hint default value is determined as " << ov::hint::PerformanceMode::THROUGHPUT
-                               << " automatically for " << device
-                               << " device. For more detailed information look at README." << slog::endl;
-                    std::stringstream strm;
-                    strm << ov::hint::PerformanceMode::THROUGHPUT;
-                    FLAGS_hint = strm.str();
-                }
-            }
-        }
-
         slog::info << "OpenVINO: " << ov::get_openvino_version() << slog::endl;
         slog::info << "Device info: " << slog::endl;
         slog::info << core.get_versions(device_name) << slog::endl;
@@ -215,11 +231,6 @@ int main(int argc, char* argv[]) {
         // ----------------- 3. Setting device configuration
         // -----------------------------------------------------------
         next_step();
-        ov::hint::PerformanceMode ov_perf_hint = ov::hint::PerformanceMode::UNDEFINED;
-        if (FLAGS_hint == "throughput" || FLAGS_hint == "tput")
-            ov_perf_hint = ov::hint::PerformanceMode::THROUGHPUT;
-        else if (FLAGS_hint == "latency")
-            ov_perf_hint = ov::hint::PerformanceMode::LATENCY;
 
         auto getDeviceTypeFromName = [](std::string device) -> std::string {
             return device.substr(0, device.find_first_of(".("));
@@ -248,6 +259,7 @@ int main(int argc, char* argv[]) {
             auto& device_config = config.at(device);
 
             // high-level performance modes
+            auto ov_perf_hint = get_performance_hint(device, core);
             if (ov_perf_hint != ov::hint::PerformanceMode::UNDEFINED) {
                 device_config.emplace(ov::hint::performance_mode(ov_perf_hint));
                 if (FLAGS_nireq != 0)


### PR DESCRIPTION
Signed-off-by: xuejun <xuejun.zhai@intel.com>

### Details:
1. Check if the target device supports ov::hint::performance_mode
2. If step 1 is yes, check if user set hint as throughput or latency in command line
3. If step 2 is yes, set ov::hint::PerformanceMode to THROUGHPUT or LATENCY
4. if step 2 is no, check if user set nstreams or nthreads in command line as legacy
5. if step 4 is no,  set ov::hint::PerformanceMode to THROUGHPUT as default hint and output warn for "default hint value is determined"
6. if step 4 is yes, skip default hint for legacy

### Tickets:
https://jira.devtools.intel.com/browse/CVS-69023
