### PR TITLE
Adding int64 and int32 as admissible element types for input port 0 data of Interpolate

### DIFF
--- a/src/core/src/op/interpolate.cpp
+++ b/src/core/src/op/interpolate.cpp
@@ -201,8 +201,9 @@ void op::v4::Interpolate::validate_and_infer_types() {
     element::Type input_et = get_input_element_type(0);
     NODE_VALIDATION_CHECK(this,
                           input_et == element::f32 || input_et == element::f16 || input_et == element::i8 ||
-                              input_et == element::bf16 || input_et == element::u8,
-                          "Input element type must be f32, f16, bf16, i8 or u8");
+                              input_et == element::bf16 || input_et == element::u8 || input_et == element::i64 ||
+                              input_et == element::i32,
+                          "Input element type must be f32, f16, bf16, i8, u8, i64, i32");
 
     element::Type sizes_et = get_input_element_type(1);
     NODE_VALIDATION_CHECK(


### PR DESCRIPTION
Root cause analysis:
There are TF models with the operation `ResizeNearestNeighbor` that has `int64` as the input port 0 element type. But there is no such element type as admissible in `op::v4::Interpolate::validate_and_infer_type()`.

Solution:
Add this type into `op::v4::Interpolate::validate_and_infer_type()`.

### Tickets:
 - *64906*
