### PR TITLE
[MO] fix setting 'out_ports_count' in ir_reader

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/ir_reader/layer_to_class.py
+++ b/tools/mo/openvino/tools/mo/utils/ir_reader/layer_to_class.py
@@ -372,9 +372,9 @@ def copy_graph_with_ops(graph: Graph) -> Graph:
             else:
                 node = Op.get_op_class_by_name(op_type)(new_graph, op.attrs()).create_node()
 
-            # Fill out_ports_count attribute
-            if 'out_ports_count' not in node and node.soft_get('type') != 'Result':
-                node['out_ports_count'] = len(op.out_edges())
+        # Fill out_ports_count attribute
+        if 'out_ports_count' not in node and node.soft_get('type') != 'Result':
+            node['out_ports_count'] = len(op.out_edges())
 
         # This attribute is no longer needed and we can delete it
         if 'ir_data_attrs' in node:


### PR DESCRIPTION
**Root cause analysis**: Because of the wrong indentation out port normalization didn't work for `Loop` this cause a lot of problems during shape and type inference while restoring saving IR for POT.

This problem revealed when Loop body contained body where not all ports were connected to the main graph and Loop had port with idx 0 which was disconnected.

Namely, `out_ports_count` remains uninitialized if `op_type in custom_ops`. `Loop` is in `custom_ops` and therefore `out_ports_count` is not initialized for it.

**Solution**: Fixed indentation and node `out_ports_count` is initialized correctly.

Ticket: CVS-77599

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names

Validation:
* n/a  Unit tests: no new unit-tests were added while existing ones are green
* [x]  Framework operation tests: checked inference manually and it matches to original
* n/a  Transformation tests
* [x]  Model Optimizer IR Reader check: checked, restoring, saving and comparison gives no error

Documentation:
* n/a  Supported frameworks operations list
* n/a  Guide on how to convert the **public** model
* n/a  User guide update