### PR TITLE
MO JSON model analysis - null nodes skip

### DIFF
--- a/tools/mo/openvino/tools/mo/moc_frontend/analysis.py
+++ b/tools/mo/openvino/tools/mo/moc_frontend/analysis.py
@@ -29,7 +29,7 @@ def json_model_analysis_dump(framework_model: Model):
 
     json_dump['intermediate'] = {}
     #TODO: extend model analysis dump for operations with body graphs (If, Loop, and TensorIterator)
-    for op in framework_model.get_ordered_ops():
+    for op in filter(lambda node: node.type_info.name != "NullNode", framework_model.get_ordered_ops()):
         for out_idx in range(op.get_output_size()):
             output = op.output(out_idx)
             tensor_name = output.get_any_name()


### PR DESCRIPTION
Null nodes represent optional outputs in ONNX models and should not be processed in the analysis.

### Tickets:
 - *78654*