### PR TITLE
Fix warnings

### DIFF
--- a/docs/template_plugin/tests/functional/op_reference/reverse.cpp
+++ b/docs/template_plugin/tests/functional/op_reference/reverse.cpp
@@ -2,22 +2,29 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "openvino/op/reverse.hpp"
+
 #include <gtest/gtest.h>
 
-#include "openvino/op/reverse.hpp"
-#include "openvino/op/constant.hpp"
 #include "base_reference_test.hpp"
+#include "openvino/op/constant.hpp"
+
 
 using namespace reference_tests;
 using namespace ov;
 
 namespace {
 struct ReverseParams {
-    ReverseParams(const reference_tests::Tensor& constantTensor, const op::v1::Reverse::Mode reverseMode,
-                  const reference_tests::Tensor& dataTensor, const reference_tests::Tensor& expectedTensor, const std::string& testcaseName = "") :
-                  constantTensor(constantTensor), reverseMode(reverseMode),
-                  dataTensor(dataTensor), expectedTensor(expectedTensor),
-                  testcaseName(testcaseName) {}
+    ReverseParams(const reference_tests::Tensor& constantTensor,
+                  const op::v1::Reverse::Mode reverseMode,
+                  const reference_tests::Tensor& dataTensor,
+                  const reference_tests::Tensor& expectedTensor,
+                  const std::string& testcaseName = "")
+        : constantTensor(constantTensor),
+          reverseMode(reverseMode),
+          dataTensor(dataTensor),
+          expectedTensor(expectedTensor),
+          testcaseName(testcaseName) {}
 
     reference_tests::Tensor constantTensor;
     op::v1::Reverse::Mode reverseMode;
@@ -60,21 +67,17 @@ private:
                                                                  params.constantTensor.shape,
                                                                  params.constantTensor.data.data());
         const auto reverse = std::make_shared<op::v1::Reverse>(data, constant, params.reverseMode);
-        return std::make_shared<ov::Model>(NodeVector {reverse}, ParameterVector {data});
+        return std::make_shared<ov::Model>(NodeVector{reverse}, ParameterVector{data});
     }
 };
 
-class ReferenceReverseTestAxesRankIndexMode : public ReferenceReverseTest {
-};
+class ReferenceReverseTestAxesRankIndexMode : public ReferenceReverseTest {};
 
-class ReferenceReverseTestAxesElemsMaskMode : public ReferenceReverseTest {
-};
+class ReferenceReverseTestAxesElemsMaskMode : public ReferenceReverseTest {};
 
-class ReferenceReverseTestAxesOutOfBounds : public ReferenceReverseTest {
-};
+class ReferenceReverseTestAxesOutOfBounds : public ReferenceReverseTest {};
 
-class ReferenceReverseTestAxesOutOfBounds4 : public ReferenceReverseTest {
-};
+class ReferenceReverseTestAxesOutOfBounds4 : public ReferenceReverseTest {};
 
 TEST_P(ReferenceReverseTest, CompareWithRefs) {
     Exec();
@@ -82,37 +85,38 @@ TEST_P(ReferenceReverseTest, CompareWithRefs) {
 
 TEST_P(ReferenceReverseTestAxesRankIndexMode, CompareWithRefs) {
     const auto Data = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 2, 2});
-    const auto Rev_Axes = std::make_shared<op::v0::Parameter>(element::i64, Shape{1, 1});   // correct: 1D
-    EXPECT_THROW(std::make_shared<ov::Model>(std::make_shared<op::v1::Reverse>(Data, Rev_Axes, op::v1::Reverse::Mode::INDEX),
-                                                ParameterVector{Data, Rev_Axes}),
+    const auto Rev_Axes = std::make_shared<op::v0::Parameter>(element::i64, Shape{1, 1});  // correct: 1D
+    EXPECT_THROW(const auto unused = std::make_shared<ov::Model>(
+                     std::make_shared<op::v1::Reverse>(Data, Rev_Axes, op::v1::Reverse::Mode::INDEX),
+                     ParameterVector{Data, Rev_Axes}),
                  ngraph::NodeValidationFailure);
 }
 
 TEST_P(ReferenceReverseTestAxesElemsMaskMode, CompareWithRefs) {
     const auto Data = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 2, 2});
     const auto Rev_Axes = std::make_shared<op::v0::Parameter>(element::boolean, Shape{2});  // correct: 3
-    EXPECT_THROW(std::make_shared<op::v1::Reverse>(Data, Rev_Axes, op::v1::Reverse::Mode::MASK),
+    EXPECT_THROW(const auto unused = std::make_shared<op::v1::Reverse>(Data, Rev_Axes, op::v1::Reverse::Mode::MASK),
                  ngraph::NodeValidationFailure);
 }
 
 TEST_P(ReferenceReverseTestAxesOutOfBounds, CompareWithRefs) {
     const auto Data = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 2, 2});
     const auto Rev_Axes = op::v0::Constant::create(element::i64, Shape{2}, {1, 10});
-    EXPECT_THROW(std::make_shared<op::v1::Reverse>(Data, Rev_Axes, op::v1::Reverse::Mode::INDEX),
+    EXPECT_THROW(const auto unused = std::make_shared<op::v1::Reverse>(Data, Rev_Axes, op::v1::Reverse::Mode::INDEX),
                  ngraph::NodeValidationFailure);
 }
 
 TEST_P(ReferenceReverseTestAxesOutOfBounds4, CompareWithRefs) {
     const auto Data = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 2, 2});
     const auto Rev_Axes = op::v0::Constant::create(element::i64, Shape{4}, {0, 1, 2, 3});
-    EXPECT_THROW(std::make_shared<op::v1::Reverse>(Data, Rev_Axes, op::v1::Reverse::Mode::INDEX),
+    EXPECT_THROW(const auto unused = std::make_shared<op::v1::Reverse>(Data, Rev_Axes, op::v1::Reverse::Mode::INDEX),
                  ngraph::NodeValidationFailure);
 }
 
 template <element::Type_t IN_ET>
 std::vector<ReverseParams> generateParams() {
     using T = typename element_type_traits<IN_ET>::value_type;
-    std::vector<ReverseParams> params {
+    std::vector<ReverseParams> params{
         // nothing_to_reverse
         ReverseParams(reference_tests::Tensor({0}, element::i64, std::vector<int64_t>{}),
                       op::v1::Reverse::Mode::INDEX,
@@ -156,67 +160,74 @@ std::vector<ReverseParams> generateParams() {
                       reference_tests::Tensor({4, 3}, IN_ET, std::vector<T>{11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}),
                       "reverse_2d_01_mask"),
         // reverse_3d_0
-        ReverseParams(reference_tests::Tensor({1}, element::i64, std::vector<int64_t>{0}),
-                      op::v1::Reverse::Mode::INDEX,
-                      reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{
-                          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
-                      reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{
-                          12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}),
-                      "reverse_3d_0"),
+        ReverseParams(
+            reference_tests::Tensor({1}, element::i64, std::vector<int64_t>{0}),
+            op::v1::Reverse::Mode::INDEX,
+            reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                                                                     12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
+            reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                                                                     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11}),
+            "reverse_3d_0"),
         // reverse_3d_1
-        ReverseParams(reference_tests::Tensor({1}, element::i64, std::vector<int64_t>{1}),
-                      op::v1::Reverse::Mode::INDEX,
-                      reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{
-                          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
-                      reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{
-                          9, 10, 11, 6, 7, 8, 3, 4, 5, 0, 1, 2, 21, 22, 23, 18, 19, 20, 15, 16, 17, 12, 13, 14}),
-                      "reverse_3d_1"),
+        ReverseParams(
+            reference_tests::Tensor({1}, element::i64, std::vector<int64_t>{1}),
+            op::v1::Reverse::Mode::INDEX,
+            reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                                                                     12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
+            reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{9,  10, 11, 6,  7,  8,  3,  4,  5,  0,  1,  2,
+                                                                     21, 22, 23, 18, 19, 20, 15, 16, 17, 12, 13, 14}),
+            "reverse_3d_1"),
         // reverse_3d_2
-        ReverseParams(reference_tests::Tensor({1}, element::i64, std::vector<int64_t>{2}),
-                      op::v1::Reverse::Mode::INDEX,
-                      reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{
-                          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
-                      reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{
-                          2, 1, 0, 5, 4, 3, 8, 7, 6, 11, 10, 9, 14, 13, 12, 17, 16, 15, 20, 19, 18, 23, 22, 21}),
-                      "reverse_3d_2"),
+        ReverseParams(
+            reference_tests::Tensor({1}, element::i64, std::vector<int64_t>{2}),
+            op::v1::Reverse::Mode::INDEX,
+            reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                                                                     12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
+            reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{2,  1,  0,  5,  4,  3,  8,  7,  6,  11, 10, 9,
+                                                                     14, 13, 12, 17, 16, 15, 20, 19, 18, 23, 22, 21}),
+            "reverse_3d_2"),
         // reverse_3d_01
-        ReverseParams(reference_tests::Tensor({2}, element::i64, std::vector<int64_t>{0, 1}),
-                      op::v1::Reverse::Mode::INDEX,
-                      reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{
-                          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
-                      reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{
-                          21, 22, 23, 18, 19, 20, 15, 16, 17, 12, 13, 14, 9, 10, 11, 6, 7, 8, 3, 4, 5, 0, 1, 2}),
-                      "reverse_3d_01"),
+        ReverseParams(
+            reference_tests::Tensor({2}, element::i64, std::vector<int64_t>{0, 1}),
+            op::v1::Reverse::Mode::INDEX,
+            reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                                                                     12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
+            reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{21, 22, 23, 18, 19, 20, 15, 16, 17, 12, 13, 14,
+                                                                     9,  10, 11, 6,  7,  8,  3,  4,  5,  0,  1,  2}),
+            "reverse_3d_01"),
         // reverse_3d_02
-        ReverseParams(reference_tests::Tensor({2}, element::i64, std::vector<int64_t>{0, 2}),
-                      op::v1::Reverse::Mode::INDEX,
-                      reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{
-                          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
-                      reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{
-                          14, 13, 12, 17, 16, 15, 20, 19, 18, 23, 22, 21, 2, 1, 0, 5, 4, 3, 8, 7, 6, 11, 10, 9}),
-                      "reverse_3d_02"),
+        ReverseParams(
+            reference_tests::Tensor({2}, element::i64, std::vector<int64_t>{0, 2}),
+            op::v1::Reverse::Mode::INDEX,
+            reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                                                                     12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
+            reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{14, 13, 12, 17, 16, 15, 20, 19, 18, 23, 22, 21,
+                                                                     2,  1,  0,  5,  4,  3,  8,  7,  6,  11, 10, 9}),
+            "reverse_3d_02"),
         // reverse_3d_12
-        ReverseParams(reference_tests::Tensor({2}, element::i64, std::vector<int64_t>{1, 2}),
-                      op::v1::Reverse::Mode::INDEX,
-                      reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{
-                          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
-                      reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{
-                          11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12}),
-                      "reverse_3d_12"),
+        ReverseParams(
+            reference_tests::Tensor({2}, element::i64, std::vector<int64_t>{1, 2}),
+            op::v1::Reverse::Mode::INDEX,
+            reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                                                                     12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
+            reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{11, 10, 9,  8,  7,  6,  5,  4,  3,  2,  1,  0,
+                                                                     23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12}),
+            "reverse_3d_12"),
         // reverse_3d_012
-        ReverseParams(reference_tests::Tensor({3}, element::i64, std::vector<int64_t>{0, 1, 2}),
-                      op::v1::Reverse::Mode::INDEX,
-                      reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{
-                          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
-                      reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{
-                          23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}),
-                      "reverse_3d_012"),
+        ReverseParams(
+            reference_tests::Tensor({3}, element::i64, std::vector<int64_t>{0, 1, 2}),
+            op::v1::Reverse::Mode::INDEX,
+            reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                                                                     12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
+            reference_tests::Tensor({2, 4, 3}, IN_ET, std::vector<T>{23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12,
+                                                                     11, 10, 9,  8,  7,  6,  5,  4,  3,  2,  1,  0}),
+            "reverse_3d_012"),
     };
     return params;
 }
 
 std::vector<ReverseParams> generateCombinedParams() {
-    const std::vector<std::vector<ReverseParams>> reverseTypeParams {
+    const std::vector<std::vector<ReverseParams>> reverseTypeParams{
         generateParams<element::Type_t::i8>(),
         generateParams<element::Type_t::i16>(),
         generateParams<element::Type_t::i32>(),
@@ -237,7 +248,7 @@ std::vector<ReverseParams> generateCombinedParams() {
 }
 
 std::vector<ReverseParams> generateParamsAxesRankIndexMode() {
-    std::vector<ReverseParams> params {
+    std::vector<ReverseParams> params{
         // reverse_v1_incorrect_rev_axes_rank_index_mode
         ReverseParams(reference_tests::Tensor({1}, element::i64, std::vector<int64_t>{0}),
                       op::v1::Reverse::Mode::INDEX,
@@ -249,7 +260,7 @@ std::vector<ReverseParams> generateParamsAxesRankIndexMode() {
 }
 
 std::vector<ReverseParams> generateParamsAxesElemsMaskMode() {
-    std::vector<ReverseParams> params {
+    std::vector<ReverseParams> params{
         // reverse_v1_incorrect_rev_axes_elems_mask_mode
         ReverseParams(reference_tests::Tensor({1}, element::i64, std::vector<int64_t>{0}),
                       op::v1::Reverse::Mode::INDEX,
@@ -261,7 +272,7 @@ std::vector<ReverseParams> generateParamsAxesElemsMaskMode() {
 }
 
 std::vector<ReverseParams> generateParamsAxesOutOfBounds() {
-    std::vector<ReverseParams> params {
+    std::vector<ReverseParams> params{
         // reverse_v1_axes_out_of_bounds
         ReverseParams(reference_tests::Tensor({1}, element::i64, std::vector<int64_t>{0}),
                       op::v1::Reverse::Mode::INDEX,
@@ -273,7 +284,7 @@ std::vector<ReverseParams> generateParamsAxesOutOfBounds() {
 }
 
 std::vector<ReverseParams> generateParamsAxesOutOfBounds4() {
-    std::vector<ReverseParams> params {
+    std::vector<ReverseParams> params{
         // reverse_v1_axes_out_of_bounds_4
         ReverseParams(reference_tests::Tensor({1}, element::i64, std::vector<int64_t>{0}),
                       op::v1::Reverse::Mode::INDEX,
@@ -284,18 +295,28 @@ std::vector<ReverseParams> generateParamsAxesOutOfBounds4() {
     return params;
 }
 
-INSTANTIATE_TEST_SUITE_P(smoke_Reverse_With_Hardcoded_Refs, ReferenceReverseTest,
-    testing::ValuesIn(generateCombinedParams()), ReferenceReverseTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Reverse_With_Hardcoded_Refs,
+                         ReferenceReverseTest,
+                         testing::ValuesIn(generateCombinedParams()),
+                         ReferenceReverseTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Reverse_With_Hardcoded_Refs, ReferenceReverseTestAxesRankIndexMode,
-    testing::ValuesIn(generateParamsAxesRankIndexMode()), ReferenceReverseTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Reverse_With_Hardcoded_Refs,
+                         ReferenceReverseTestAxesRankIndexMode,
+                         testing::ValuesIn(generateParamsAxesRankIndexMode()),
+                         ReferenceReverseTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Reverse_With_Hardcoded_Refs, ReferenceReverseTestAxesElemsMaskMode,
-    testing::ValuesIn(generateParamsAxesElemsMaskMode()), ReferenceReverseTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Reverse_With_Hardcoded_Refs,
+                         ReferenceReverseTestAxesElemsMaskMode,
+                         testing::ValuesIn(generateParamsAxesElemsMaskMode()),
+                         ReferenceReverseTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Reverse_With_Hardcoded_Refs, ReferenceReverseTestAxesOutOfBounds,
-    testing::ValuesIn(generateParamsAxesOutOfBounds()), ReferenceReverseTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Reverse_With_Hardcoded_Refs,
+                         ReferenceReverseTestAxesOutOfBounds,
+                         testing::ValuesIn(generateParamsAxesOutOfBounds()),
+                         ReferenceReverseTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Reverse_With_Hardcoded_Refs, ReferenceReverseTestAxesOutOfBounds4,
-    testing::ValuesIn(generateParamsAxesOutOfBounds4()), ReferenceReverseTest::getTestCaseName);
-} // namespace
+INSTANTIATE_TEST_SUITE_P(smoke_Reverse_With_Hardcoded_Refs,
+                         ReferenceReverseTestAxesOutOfBounds4,
+                         testing::ValuesIn(generateParamsAxesOutOfBounds4()),
+                         ReferenceReverseTest::getTestCaseName);
+}  // namespace

--- a/src/common/low_precision_transformations/src/fake_quantize_decomposition.cpp
+++ b/src/common/low_precision_transformations/src/fake_quantize_decomposition.cpp
@@ -204,12 +204,12 @@ std::tuple<std::shared_ptr<Node>, std::shared_ptr<Node>> decomposeFakeQuantize(
             updatedOutputHighValue);
 
         if ((updatePrecisions == false) && (dequantizationMul == 1.f) && (dequantizationSub == 0.f)) {
-            std::make_tuple(nullptr, nullptr);
+            return std::make_tuple(nullptr, nullptr);
         }
 
         //TODO: pass min levels as a parameter?
         if (levels < 2ul) {
-            std::make_tuple(nullptr, nullptr);
+            return std::make_tuple(nullptr, nullptr);
         }
 
         // 2. update FakeQuantize - one time action
@@ -258,7 +258,7 @@ std::tuple<std::shared_ptr<Node>, std::shared_ptr<Node>> decomposeFakeQuantize(
 
         const auto newFakeQuantize = std::get<0>(QDQ);
         if (newFakeQuantize == nullptr) {
-            std::make_tuple(nullptr, nullptr);
+            return std::make_tuple(nullptr, nullptr);
         }
         matcherPass->register_new_node(newFakeQuantize);
         dequantize = std::get<1>(QDQ);

--- a/src/common/transformations/src/transformations/common_optimizations/dimension_tracking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/dimension_tracking.cpp
@@ -187,7 +187,7 @@ bool ov::batch_util::check_batch_tracks_through_all_the_nodes(const std::shared_
             bool others_are_static = true;
             for (const auto& dim : input_shape)
                 if (ov::DimensionTracker::get_label(dim) == 0)
-                    others_are_static &= dim.is_static();
+                    others_are_static = others_are_static && dim.is_static();
                 else
                     name_stays = true;
             any_input_has_batch |= name_stays && others_are_static;
@@ -199,7 +199,7 @@ bool ov::batch_util::check_batch_tracks_through_all_the_nodes(const std::shared_
             bool others_are_static = true;
             for (const auto& dim : output_shape)
                 if (ov::DimensionTracker::get_label(dim) == 0)
-                    others_are_static &= dim.is_static();
+                    others_are_static = others_are_static && dim.is_static();
                 else
                     name_stays = true;
             all_outputs_has_batch &= name_stays;  // && others_are_static;

--- a/src/common/transformations/src/transformations/common_optimizations/optimize_strided_slice.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/optimize_strided_slice.cpp
@@ -261,8 +261,8 @@ bool ngraph::pass::StridedSliceOptimization::run_on_model(const std::shared_ptr<
     bool rewritten = false;
     if (m_use_shapes) {
         rewritten = UselessStridedSliceEraser().run_on_model(f);
-        rewritten |= SharedStridedSliceEraser().run_on_model(f);
-        rewritten |= GroupedStridedSliceOptimizer().run_on_model(f);
+        rewritten = rewritten || SharedStridedSliceEraser().run_on_model(f);
+        rewritten = rewritten || GroupedStridedSliceOptimizer().run_on_model(f);
     }
     return rewritten;
 }

--- a/src/core/shape_inference/include/convolution_shape_inference.hpp
+++ b/src/core/shape_inference/include/convolution_shape_inference.hpp
@@ -509,14 +509,14 @@ void shape_infer(const ConvolutionBackpropData* op,
         if (output_shape_from_input.rank().is_static()) {
             NODE_VALIDATION_CHECK(op, output_shape_from_input.size() == num_spatial,
                                   "Output shape should be specified only and for all spatial dimensions.");
-            for (size_t i = 0; i < num_spatial; ++i)
+            for (int64_t i = 0; i < num_spatial; ++i)
                 output_shape[i + 2] = output_shape_from_input[i];
         }
     } else {
         const auto& strides = op->m_strides;
         const auto& dilations = op->m_dilations;
         const auto& output_padding = op->m_output_padding;
-        for (size_t i = 0; i < num_spatial; ++i) {
+        for (int64_t i = 0; i < num_spatial; ++i) {
             if (filters_shape[i + 2].is_static() && input_shape[i + 2].is_static())
                 output_shape[i + 2] = strides[i] * (input_shape[i + 2].get_length() - 1) +
                   dilations[i] * (filters_shape[i + 2].get_length() - 1) + 1 - pads_begin[i] - pads_end[i] +
@@ -595,14 +595,14 @@ void shape_infer(const GroupConvolutionBackpropData* op,
         if (output_shape_from_input.rank().is_static()) {
             NODE_VALIDATION_CHECK(op, output_shape_from_input.size() == num_spatial,
                                   "Output shape should be specified only and for all spatial dimensions.");
-            for (size_t i = 0; i < num_spatial; ++i)
+            for (int64_t i = 0; i < num_spatial; ++i)
                 output_shape[i + 2] = output_shape_from_input[i];
         }
     } else {
         const auto& strides = op->m_strides;
         const auto& dilations = op->m_dilations;
         const auto& output_padding = op->m_output_padding;
-        for (size_t i = 0; i < num_spatial; ++i) {
+        for (int64_t i = 0; i < num_spatial; ++i) {
             if (filters_shape[i + 3].is_static() && input_shape[i + 2].is_static())
                 output_shape[i + 2] = strides[i] * (input_shape[i + 2].get_length() - 1) +
                   dilations[i] * (filters_shape[i + 3].get_length() - 1) + 1 - pads_begin[i] - pads_end[i] +

--- a/src/core/shape_inference/include/fft_base_shape_inference.hpp
+++ b/src/core/shape_inference/include/fft_base_shape_inference.hpp
@@ -110,7 +110,7 @@ void shape_infer(const ov::op::util::FFTBase* op,
         }
     } else if (input_shape.rank().is_static() && (axes_shape.rank().is_dynamic() || !axes_are_known)) {
         const auto input_rank = input_shape.size();
-        for (int64_t i = 0; i < input_rank - 1; ++i) {
+        for (size_t i = 0; i < input_rank - 1; ++i) {
             output_shape[i] = ov::Dimension::dynamic();
         }
     }

--- a/src/core/shape_inference/include/interpolate_shape_inference.hpp
+++ b/src/core/shape_inference/include/interpolate_shape_inference.hpp
@@ -141,7 +141,7 @@ void shape_infer(const Interpolate* op,
                               "Axis value should less than input rank.");
 
         // Get padded input shape
-        for (int64_t i = 0; i < input_rank; ++i) {
+        for (size_t i = 0; i < input_rank; ++i) {
             output_shape[i] = DimType(pads_begin[i]) + DimType(pads_end[i]) + input_shape[i];
         }
 

--- a/src/core/tests/build_graph.cpp
+++ b/src/core/tests/build_graph.cpp
@@ -527,10 +527,10 @@ TEST(build_graph, build_graph_unregistred_variables) {
     auto crop = make_shared<Split>(pattern, axis, 3);
     auto res2 = make_shared<Result>(crop);
 
-    EXPECT_ANY_THROW(make_shared<Function>(OutputVector{res, res2},
-                                           SinkVector{assign, assign_2},
-                                           ParameterVector{arg, arg2},
-                                           VariableVector{variable}));
+    EXPECT_ANY_THROW(const auto unused = make_shared<Function>(OutputVector{res, res2},
+                                                               SinkVector{assign, assign_2},
+                                                               ParameterVector{arg, arg2},
+                                                               VariableVector{variable}));
 }
 
 TEST(build_graph, build_graph_with_sinks_compare) {

--- a/src/core/tests/type_prop/adaptive_avg_pool.cpp
+++ b/src/core/tests/type_prop/adaptive_avg_pool.cpp
@@ -81,7 +81,7 @@ TEST(type_prop, adaptive_avg_pool_unsupported_input_shape) {
     auto data = make_shared<op::Parameter>(element::f32, arg_shape);
     auto out_shape = op::Constant::create<int64_t>(element::i64, Shape{}, output_shape);
 
-    EXPECT_THROW(make_shared<op::v8::AdaptiveAvgPool>(data, out_shape), NodeValidationFailure);
+    EXPECT_THROW(const auto unused = make_shared<op::v8::AdaptiveAvgPool>(data, out_shape), NodeValidationFailure);
 }
 
 TEST(type_prop, adaptive_avg_pool_wrong_out_shape) {
@@ -91,5 +91,5 @@ TEST(type_prop, adaptive_avg_pool_wrong_out_shape) {
     auto data = make_shared<op::Parameter>(element::f32, arg_shape);
     auto out_shape = op::Constant::create<int64_t>(element::i64, Shape{3}, output_shape);
 
-    EXPECT_THROW(make_shared<op::v8::AdaptiveAvgPool>(data, out_shape), NodeValidationFailure);
+    EXPECT_THROW(const auto unused = make_shared<op::v8::AdaptiveAvgPool>(data, out_shape), NodeValidationFailure);
 }

--- a/src/core/tests/type_prop/adaptive_max_pool.cpp
+++ b/src/core/tests/type_prop/adaptive_max_pool.cpp
@@ -101,7 +101,7 @@ TEST(type_prop, adaptive_max_pool_unsupported_input_shape) {
     auto data = make_shared<op::Parameter>(element::f32, arg_shape);
     auto out_shape = op::Constant::create<int64_t>(element::i64, Shape{}, output_shape);
 
-    EXPECT_THROW(make_shared<op::v8::AdaptiveMaxPool>(data, out_shape), NodeValidationFailure);
+    EXPECT_THROW(const auto unused = make_shared<op::v8::AdaptiveMaxPool>(data, out_shape), NodeValidationFailure);
 }
 
 TEST(type_prop, adaptive_max_pool_wrong_out_shape) {
@@ -111,5 +111,5 @@ TEST(type_prop, adaptive_max_pool_wrong_out_shape) {
     auto data = make_shared<op::Parameter>(element::f32, arg_shape);
     auto out_shape = op::Constant::create<int64_t>(element::i64, Shape{3}, output_shape);
 
-    EXPECT_THROW(make_shared<op::v8::AdaptiveMaxPool>(data, out_shape), NodeValidationFailure);
+    EXPECT_THROW(const auto unused = make_shared<op::v8::AdaptiveMaxPool>(data, out_shape), NodeValidationFailure);
 }

--- a/src/core/tests/type_prop/arithmetic_ops.hpp
+++ b/src/core/tests/type_prop/arithmetic_ops.hpp
@@ -18,17 +18,15 @@
 #include "gtest/gtest.h"
 #include "ngraph/ngraph.hpp"
 
+
 using namespace ngraph;
 
 template <class T>
-class ArithmeticOperator : public testing::Test
-{
-};
+class ArithmeticOperator : public testing::Test {};
 
 TYPED_TEST_SUITE_P(ArithmeticOperator);
 
-TYPED_TEST_P(ArithmeticOperator, shape_inference_2D)
-{
+TYPED_TEST_P(ArithmeticOperator, shape_inference_2D) {
     auto A = std::make_shared<op::Parameter>(element::f32, Shape{2, 2});
     auto B = std::make_shared<op::Parameter>(element::f32, Shape{2, 2});
 
@@ -38,8 +36,7 @@ TYPED_TEST_P(ArithmeticOperator, shape_inference_2D)
     ASSERT_EQ(op->get_shape(), (Shape{2, 2}));
 }
 
-TYPED_TEST_P(ArithmeticOperator, shape_inference_4D)
-{
+TYPED_TEST_P(ArithmeticOperator, shape_inference_4D) {
     auto A = std::make_shared<op::Parameter>(element::f32, Shape{2, 2, 3, 3});
     auto B = std::make_shared<op::Parameter>(element::f32, Shape{2, 2, 3, 3});
 
@@ -49,8 +46,7 @@ TYPED_TEST_P(ArithmeticOperator, shape_inference_4D)
     ASSERT_EQ(op->get_shape(), (Shape{2, 2, 3, 3}));
 }
 
-TYPED_TEST_P(ArithmeticOperator, default_autobroadcast)
-{
+TYPED_TEST_P(ArithmeticOperator, default_autobroadcast) {
     auto A = std::make_shared<op::Parameter>(element::f32, Shape{2, 2});
     auto B = std::make_shared<op::Parameter>(element::f32, Shape{2, 2});
 
@@ -61,8 +57,7 @@ TYPED_TEST_P(ArithmeticOperator, default_autobroadcast)
     ASSERT_EQ(op->get_autob(), op::AutoBroadcastType::NUMPY);
 }
 
-TYPED_TEST_P(ArithmeticOperator, no_autobroadcast)
-{
+TYPED_TEST_P(ArithmeticOperator, no_autobroadcast) {
     auto A = std::make_shared<op::Parameter>(element::f32, Shape{2, 2});
     auto B = std::make_shared<op::Parameter>(element::f32, Shape{2, 2});
 
@@ -73,8 +68,7 @@ TYPED_TEST_P(ArithmeticOperator, no_autobroadcast)
     ASSERT_EQ(op->get_autob(), op::AutoBroadcastType::NONE);
 }
 
-TYPED_TEST_P(ArithmeticOperator, shape_inference_4D_x_scalar_numpy_broadcast)
-{
+TYPED_TEST_P(ArithmeticOperator, shape_inference_4D_x_scalar_numpy_broadcast) {
     auto A = std::make_shared<op::Parameter>(element::f32, Shape{2, 3, 4, 5});
     auto B = std::make_shared<op::Parameter>(element::f32, Shape{1});
 
@@ -84,8 +78,7 @@ TYPED_TEST_P(ArithmeticOperator, shape_inference_4D_x_scalar_numpy_broadcast)
     ASSERT_EQ(op->get_shape(), (Shape{2, 3, 4, 5}));
 }
 
-TYPED_TEST_P(ArithmeticOperator, shape_inference_4D_x_1D_numpy_broadcast)
-{
+TYPED_TEST_P(ArithmeticOperator, shape_inference_4D_x_1D_numpy_broadcast) {
     auto A = std::make_shared<op::Parameter>(element::f32, Shape{2, 3, 4, 5});
     auto B = std::make_shared<op::Parameter>(element::f32, Shape{5});
 
@@ -95,8 +88,7 @@ TYPED_TEST_P(ArithmeticOperator, shape_inference_4D_x_1D_numpy_broadcast)
     ASSERT_EQ(op->get_shape(), (Shape{2, 3, 4, 5}));
 }
 
-TYPED_TEST_P(ArithmeticOperator, shape_inference_2D_x_4D_numpy_broadcast)
-{
+TYPED_TEST_P(ArithmeticOperator, shape_inference_2D_x_4D_numpy_broadcast) {
     auto A = std::make_shared<op::Parameter>(element::f32, Shape{4, 5});
     auto B = std::make_shared<op::Parameter>(element::f32, Shape{2, 3, 4, 5});
 
@@ -106,8 +98,7 @@ TYPED_TEST_P(ArithmeticOperator, shape_inference_2D_x_4D_numpy_broadcast)
     ASSERT_EQ(op->get_shape(), (Shape{2, 3, 4, 5}));
 }
 
-TYPED_TEST_P(ArithmeticOperator, shape_inference_3D_x_4D_numpy_broadcast)
-{
+TYPED_TEST_P(ArithmeticOperator, shape_inference_3D_x_4D_numpy_broadcast) {
     auto A = std::make_shared<op::Parameter>(element::f32, Shape{1, 4, 5});
     auto B = std::make_shared<op::Parameter>(element::f32, Shape{2, 3, 1, 1});
 
@@ -117,8 +108,7 @@ TYPED_TEST_P(ArithmeticOperator, shape_inference_3D_x_4D_numpy_broadcast)
     ASSERT_EQ(op->get_shape(), (Shape{2, 3, 4, 5}));
 }
 
-TYPED_TEST_P(ArithmeticOperator, shape_inference_4D_x_3D_numpy_broadcast)
-{
+TYPED_TEST_P(ArithmeticOperator, shape_inference_4D_x_3D_numpy_broadcast) {
     auto A = std::make_shared<op::Parameter>(element::f32, Shape{8, 1, 6, 1});
     auto B = std::make_shared<op::Parameter>(element::f32, Shape{7, 1, 5});
 
@@ -129,48 +119,42 @@ TYPED_TEST_P(ArithmeticOperator, shape_inference_4D_x_3D_numpy_broadcast)
     ASSERT_EQ(op->get_autob(), op::AutoBroadcastType::NUMPY);
 }
 
-TYPED_TEST_P(ArithmeticOperator, incompatible_element_types)
-{
+TYPED_TEST_P(ArithmeticOperator, incompatible_element_types) {
     auto A = std::make_shared<op::Parameter>(element::f32, Shape{2, 2, 3, 3});
     auto B = std::make_shared<op::Parameter>(element::i32, Shape{2, 2, 3, 3});
 
-    ASSERT_THROW(std::make_shared<TypeParam>(A, B), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = std::make_shared<TypeParam>(A, B), ngraph::NodeValidationFailure);
 }
 
-TYPED_TEST_P(ArithmeticOperator, incompatible_boolean_type)
-{
+TYPED_TEST_P(ArithmeticOperator, incompatible_boolean_type) {
     auto A = std::make_shared<op::Parameter>(element::boolean, Shape{2, 2, 3, 3});
     auto B = std::make_shared<op::Parameter>(element::boolean, Shape{2, 2, 3, 3});
 
-    ASSERT_THROW(std::make_shared<TypeParam>(A, B), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = std::make_shared<TypeParam>(A, B), ngraph::NodeValidationFailure);
 }
 
-TYPED_TEST_P(ArithmeticOperator, shape_inference_1D_x_1D_incompatible)
-{
+TYPED_TEST_P(ArithmeticOperator, shape_inference_1D_x_1D_incompatible) {
     auto A = std::make_shared<op::Parameter>(element::f32, Shape{3});
     auto B = std::make_shared<op::Parameter>(element::f32, Shape{4});
 
-    ASSERT_THROW(std::make_shared<TypeParam>(A, B), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = std::make_shared<TypeParam>(A, B), ngraph::NodeValidationFailure);
 }
 
-TYPED_TEST_P(ArithmeticOperator, shape_inference_3D_x_3D_incompatible)
-{
+TYPED_TEST_P(ArithmeticOperator, shape_inference_3D_x_3D_incompatible) {
     auto A = std::make_shared<op::Parameter>(element::f32, Shape{3, 5, 6});
     auto B = std::make_shared<op::Parameter>(element::f32, Shape{4, 10, 12});
 
-    ASSERT_THROW(std::make_shared<TypeParam>(A, B), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = std::make_shared<TypeParam>(A, B), ngraph::NodeValidationFailure);
 }
 
-TYPED_TEST_P(ArithmeticOperator, shape_inference_5D_x_5D_incompatible)
-{
+TYPED_TEST_P(ArithmeticOperator, shape_inference_5D_x_5D_incompatible) {
     auto A = std::make_shared<op::Parameter>(element::f32, Shape{389, 112, 12});
     auto B = std::make_shared<op::Parameter>(element::f32, Shape{389, 112, 19});
 
-    ASSERT_THROW(std::make_shared<TypeParam>(A, B), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = std::make_shared<TypeParam>(A, B), ngraph::NodeValidationFailure);
 }
 
-TYPED_TEST_P(ArithmeticOperator, dynamic_shape_3D)
-{
+TYPED_TEST_P(ArithmeticOperator, dynamic_shape_3D) {
     Dimension dynamic = Dimension::dynamic();
     auto A = std::make_shared<op::Parameter>(element::f32, PartialShape{dynamic, dynamic, 6});
     auto B = std::make_shared<op::Parameter>(element::f32, PartialShape{dynamic, dynamic, 6});
@@ -181,13 +165,10 @@ TYPED_TEST_P(ArithmeticOperator, dynamic_shape_3D)
     ASSERT_EQ(op->get_output_partial_shape(0), (PartialShape{dynamic, dynamic, 6}));
 }
 
-TYPED_TEST_P(ArithmeticOperator, dynamic_shape_5D)
-{
+TYPED_TEST_P(ArithmeticOperator, dynamic_shape_5D) {
     Dimension dynamic = Dimension::dynamic();
-    auto A = std::make_shared<op::Parameter>(element::f32,
-                                             PartialShape{dynamic, 4, dynamic, dynamic, 6});
-    auto B = std::make_shared<op::Parameter>(element::f32,
-                                             PartialShape{dynamic, 4, dynamic, dynamic, 6});
+    auto A = std::make_shared<op::Parameter>(element::f32, PartialShape{dynamic, 4, dynamic, dynamic, 6});
+    auto B = std::make_shared<op::Parameter>(element::f32, PartialShape{dynamic, 4, dynamic, dynamic, 6});
 
     const auto op = std::make_shared<TypeParam>(A, B);
 
@@ -195,8 +176,7 @@ TYPED_TEST_P(ArithmeticOperator, dynamic_shape_5D)
     ASSERT_EQ(op->get_output_partial_shape(0), (PartialShape{dynamic, 4, dynamic, dynamic, 6}));
 }
 
-TYPED_TEST_P(ArithmeticOperator, full_dynamic_shape)
-{
+TYPED_TEST_P(ArithmeticOperator, full_dynamic_shape) {
     auto param = std::make_shared<op::Parameter>(element::f64, PartialShape::dynamic());
     const auto op = std::make_shared<TypeParam>(param, param);
     ASSERT_EQ(op->get_element_type(), element::f64);

--- a/src/core/tests/type_prop/avg_pool.cpp
+++ b/src/core/tests/type_prop/avg_pool.cpp
@@ -138,7 +138,8 @@ TEST(type_prop, avg_pool_1d_deduce) {
     const auto param = make_shared<op::Parameter>(element::f32, Shape{64, 3});
     const Shape kernel{10};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -147,7 +148,8 @@ TEST(type_prop, avg_pool_1d_deduce_strided) {
     const Shape kernel{10};
     const auto move_strides = Strides{2};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, move_strides, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, move_strides, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -156,7 +158,8 @@ TEST(type_prop, avg_pool_1d_deduce_strided_small_uneven) {
     const Shape kernel{2};
     const auto move_strides = Strides{2};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, move_strides, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, move_strides, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -165,7 +168,8 @@ TEST(type_prop, avg_pool_1d_deduce_strided_small_even) {
     const Shape kernel{2};
     const auto move_strides = Strides{2};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, move_strides, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, move_strides, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -253,7 +257,8 @@ TEST(type_prop, avg_pool_invalid_0d_input) {
     const auto param = make_shared<op::Parameter>(element::f32, Shape{});
     const Shape kernel{};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -261,7 +266,8 @@ TEST(type_prop, avg_pool_invalid_1d_input) {
     const auto param = make_shared<op::Parameter>(element::f32, Shape{2});
     const Shape kernel{};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -269,7 +275,8 @@ TEST(type_prop, avg_pool_invalid_2d_input) {
     const auto param = make_shared<op::Parameter>(element::f32, Shape{2, 6});
     const Shape kernel{};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -277,7 +284,8 @@ TEST(type_prop, avg_pool_invalid_0_batch_size) {
     const auto param = make_shared<op::Parameter>(element::f32, Shape{0, 6});
     const Shape kernel{1};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -285,7 +293,8 @@ TEST(type_prop, avg_pool_invalid_0_channels) {
     const auto param = make_shared<op::Parameter>(element::f32, Shape{6, 0});
     const Shape kernel{1};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -293,7 +302,8 @@ TEST(type_prop, avg_pool_invalid_wrong_number_of_window_dimensions_too_many) {
     const auto param = make_shared<op::Parameter>(element::f32, Shape{6, 2, 10, 10});
     const Shape kernel{3, 3, 3};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -301,7 +311,8 @@ TEST(type_prop, avg_pool_invalid_wrong_number_of_window_dimensions_too_few) {
     const auto param = make_shared<op::Parameter>(element::f32, Shape{6, 2, 10, 10});
     const Shape kernel{3};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -310,7 +321,8 @@ TEST(type_prop, avg_pool_invalid_movement_stride_rank) {
     const Shape kernel{3, 3};
     const auto move_strides = Strides{2, 3, 8};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, move_strides, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, move_strides, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -320,9 +332,14 @@ TEST(type_prop, avg_pool_invalid_padding_below_rank) {
     const auto move_strides = Strides{2, 3};
     const Shape pads_begin{1, 2, 3};
     const Shape pads_end{1, 2};
-    EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, move_strides, pads_begin, pads_end, kernel, true, op::RoundingType::FLOOR),
-        NodeValidationFailure);
+    EXPECT_THROW(const auto unused = make_shared<op::v1::AvgPool>(param,
+                                                                  move_strides,
+                                                                  pads_begin,
+                                                                  pads_end,
+                                                                  kernel,
+                                                                  true,
+                                                                  op::RoundingType::FLOOR),
+                 NodeValidationFailure);
 }
 
 TEST(type_prop, avg_pool_invalid_padding_above_rank) {
@@ -331,16 +348,22 @@ TEST(type_prop, avg_pool_invalid_padding_above_rank) {
     const auto move_strides = Strides{2, 3};
     const Shape pads_begin{1, 2};
     const Shape pads_end{1, 2, 3};
-    EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, move_strides, pads_begin, pads_end, kernel, true, op::RoundingType::FLOOR),
-        NodeValidationFailure);
+    EXPECT_THROW(const auto unused = make_shared<op::v1::AvgPool>(param,
+                                                                  move_strides,
+                                                                  pads_begin,
+                                                                  pads_end,
+                                                                  kernel,
+                                                                  true,
+                                                                  op::RoundingType::FLOOR),
+                 NodeValidationFailure);
 }
 
 TEST(type_prop, avg_pool_invalid_input_item_size_0) {
     const auto param = make_shared<op::Parameter>(element::f32, Shape{6, 2, 0, 10});
     const Shape kernel{3, 3};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -348,7 +371,8 @@ TEST(type_prop, avg_pool_invalid_window_size_0) {
     const auto param = make_shared<op::Parameter>(element::f32, Shape{6, 2, 10, 10});
     const Shape kernel{3, 0};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -356,7 +380,8 @@ TEST(type_prop, avg_pool_invalid_dilated_too_large) {
     const auto param = make_shared<op::Parameter>(element::f32, Shape{6, 2, 8, 8});
     const Shape kernel{9, 9};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, Strides{1}, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -383,7 +408,8 @@ TEST(type_prop, avg_pool_invalid_movement_stride_0) {
     const Shape kernel{3, 3};
     const auto move_strides = Strides{0, 1};
     EXPECT_THROW(
-        make_shared<op::v1::AvgPool>(param, move_strides, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
+        const auto unused =
+            make_shared<op::v1::AvgPool>(param, move_strides, Shape{}, Shape{}, kernel, true, op::RoundingType::FLOOR),
         NodeValidationFailure);
 }
 
@@ -416,13 +442,13 @@ TEST(type_prop, avg_pool_partial_rank_dynamic_attrib_rank_mismatch) {
 
     const auto param = make_shared<op::Parameter>(element::f32, arg_shape);
 
-    EXPECT_THROW(make_shared<op::v1::AvgPool>(param,
-                                              window_movement_strides,
-                                              pads_begin,
-                                              pads_end,
-                                              kernel,
-                                              false,
-                                              op::RoundingType::FLOOR),
+    EXPECT_THROW(const auto unused = make_shared<op::v1::AvgPool>(param,
+                                                                  window_movement_strides,
+                                                                  pads_begin,
+                                                                  pads_end,
+                                                                  kernel,
+                                                                  false,
+                                                                  op::RoundingType::FLOOR),
                  NodeValidationFailure);
 }
 
@@ -476,13 +502,13 @@ TEST(type_prop, avg_pool_partial_rank_static_dynamic_attrib_rank_mismatch) {
 
     const auto param = make_shared<op::Parameter>(element::f32, arg_shape);
 
-    EXPECT_THROW(make_shared<op::v1::AvgPool>(param,
-                                              window_movement_strides,
-                                              pads_begin,
-                                              pads_end,
-                                              kernel,
-                                              true,
-                                              op::RoundingType::FLOOR),
+    EXPECT_THROW(const auto unused = make_shared<op::v1::AvgPool>(param,
+                                                                  window_movement_strides,
+                                                                  pads_begin,
+                                                                  pads_end,
+                                                                  kernel,
+                                                                  true,
+                                                                  op::RoundingType::FLOOR),
                  NodeValidationFailure);
 }
 
@@ -495,13 +521,13 @@ TEST(type_prop, avg_pool_partial_rank_static_dynamic_window_not_too_big) {
 
     const auto param = make_shared<op::Parameter>(element::f32, arg_shape);
 
-    EXPECT_THROW(make_shared<op::v1::AvgPool>(param,
-                                              window_movement_strides,
-                                              pads_begin,
-                                              pads_end,
-                                              kernel,
-                                              true,
-                                              op::RoundingType::FLOOR),
+    EXPECT_THROW(const auto unused = make_shared<op::v1::AvgPool>(param,
+                                                                  window_movement_strides,
+                                                                  pads_begin,
+                                                                  pads_end,
+                                                                  kernel,
+                                                                  true,
+                                                                  op::RoundingType::FLOOR),
                  NodeValidationFailure);
 }
 
@@ -535,12 +561,12 @@ TEST(type_prop, avg_pool_partial_rank_static_dynamic_window_in_padding) {
 
     const auto param = make_shared<op::Parameter>(element::f32, arg_shape);
 
-    EXPECT_THROW(make_shared<op::v1::AvgPool>(param,
-                                              window_movement_strides,
-                                              pads_begin,
-                                              pads_end,
-                                              kernel,
-                                              true,
-                                              op::RoundingType::FLOOR),
+    EXPECT_THROW(const auto unused = make_shared<op::v1::AvgPool>(param,
+                                                                  window_movement_strides,
+                                                                  pads_begin,
+                                                                  pads_end,
+                                                                  kernel,
+                                                                  true,
+                                                                  op::RoundingType::FLOOR),
                  NodeValidationFailure);
 }

--- a/src/core/tests/type_prop/convert_color_i420_base.hpp
+++ b/src/core/tests/type_prop/convert_color_i420_base.hpp
@@ -3,21 +3,20 @@
 //
 
 #include <vector>
+
 #include "gtest/gtest.h"
 #include "openvino/op/op.hpp"
 #include "openvino/opsets/opset8.hpp"
 
+
 using namespace ov;
 
 template <class T>
-class ConvertI420BaseTest : public testing::Test
-{
-};
+class ConvertI420BaseTest : public testing::Test {};
 
 TYPED_TEST_SUITE_P(ConvertI420BaseTest);
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor) {
     auto param_shape = PartialShape{5, 3, 2, 1};
     auto out_shape = PartialShape{5, 2, 2, 3};
     auto param = std::make_shared<op::v0::Parameter>(element::f32, param_shape);
@@ -26,8 +25,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor)
     ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic) {
     auto param_shape = PartialShape::dynamic();
     auto out_shape = PartialShape{Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic(), 3};
     auto param = std::make_shared<op::v0::Parameter>(element::f32, param_shape);
@@ -36,8 +34,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic)
     ASSERT_EQ(op->output(0).get_element_type(), element::f32);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_dims)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_dims) {
     auto param_shape = PartialShape{Dimension::dynamic(), 3, Dimension::dynamic(), Dimension::dynamic()};
     auto out_shape = PartialShape{Dimension::dynamic(), 2, Dimension::dynamic(), 3};
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
@@ -46,8 +43,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_dims)
     ASSERT_EQ(op->output(0).get_element_type(), element::u8);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_height)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_height) {
     auto param_shape = PartialShape{Dimension::dynamic(), Dimension::dynamic(), 8, Dimension::dynamic()};
     auto out_shape = PartialShape{Dimension::dynamic(), Dimension::dynamic(), 8, 3};
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
@@ -56,8 +52,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_height)
     ASSERT_EQ(op->output(0).get_element_type(), element::u8);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_type)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_type) {
     auto param_shape = PartialShape{1, 6, 8, 1};
     auto out_shape = PartialShape{1, 4, 8, 3};
     auto param = std::make_shared<op::v0::Parameter>(element::dynamic, param_shape);
@@ -66,50 +61,43 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_dynamic_type)
     ASSERT_EQ(op->output(0).get_element_type(), element::dynamic);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_channels)
-{
-    auto param_shape = PartialShape{1, 3, 4, 2}; // shall be 1 channel, not 2
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_channels) {
+    auto param_shape = PartialShape{1, 3, 4, 2};  // shall be 1 channel, not 2
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_dims_5)
-{
-    auto param_shape = PartialShape{1, 3, 3, 1, 1}; // must be 4 dimensions
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_dims_5) {
+    auto param_shape = PartialShape{1, 3, 3, 1, 1};  // must be 4 dimensions
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_dims_3)
-{
-    auto param_shape = PartialShape{640, 480, 1}; // must be 4 dimensions
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_dims_3) {
+    auto param_shape = PartialShape{640, 480, 1};  // must be 4 dimensions
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_height)
-{
-    auto param_shape = PartialShape{1, 4, 6, 1}; // height = 4, can't split to Y and UV
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_height) {
+    auto param_shape = PartialShape{1, 4, 6, 1};  // height = 4, can't split to Y and UV
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_width_odd)
-{
-    auto param_shape = PartialShape{1, 6, 5, 1}; // width is odd, can't split to U and V
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_width_odd) {
+    auto param_shape = PartialShape{1, 6, 5, 1};  // width is odd, can't split to U and V
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_i8)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_single_tensor_error_i8) {
     auto param_shape = PartialShape{1, 640, 480, 1};
     auto param = std::make_shared<op::v0::Parameter>(element::i8, param_shape);
-    EXPECT_THROW(std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_simple)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_simple) {
     auto param_shape_y = PartialShape{10, 480, 640, 1};
     auto param_shape_uv = PartialShape{10, 240, 320, 1};
     auto out_shape = PartialShape{10, 480, 640, 3};
@@ -121,8 +109,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_simple)
     ASSERT_EQ(op->output(0).get_element_type(), element::u8);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_dynamic)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_dynamic) {
     auto param_shape_y = PartialShape::dynamic();
     auto param_shape_u = PartialShape::dynamic();
     auto param_shape_v = PartialShape::dynamic();
@@ -135,8 +122,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_dynamic)
     ASSERT_EQ(op->output(0).get_element_type(), element::f32);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_y_dynamic)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_y_dynamic) {
     auto param_shape_y = PartialShape::dynamic();
     auto param_shape_uv = PartialShape{1, 3, 2, 1};
     auto out_shape = PartialShape{1, 6, 4, 3};
@@ -148,8 +134,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_y_dynamic)
     ASSERT_EQ(op->output(0).get_element_type(), element::bf16);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_uv_dynamic)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_uv_dynamic) {
     auto param_shape_y = PartialShape{1, 4, 4, 1};
     auto param_shape_uv = PartialShape::dynamic();
     auto out_shape = PartialShape{1, 4, 4, 3};
@@ -161,8 +146,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_uv_dynamic)
     ASSERT_EQ(op->output(0).get_element_type(), element::f16);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_dynamic_types)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_dynamic_types) {
     auto param_shape_y = PartialShape{1, 4, 4, 1};
     auto param_shape_uv = PartialShape{1, 2, 2, 1};
     auto out_shape = PartialShape{1, 4, 4, 3};
@@ -177,8 +161,7 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_dynamic_types)
     ASSERT_EQ(op->output(0).get_element_type(), out_type);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_uv_type)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_uv_type) {
     auto param_shape_y = PartialShape{1, 4, 4, 1};
     auto param_shape_uv = PartialShape{1, 2, 2, 1};
     auto out_shape = PartialShape{1, 4, 4, 3};
@@ -193,139 +176,125 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_uv_type)
     ASSERT_EQ(op->output(0).get_element_type(), out_type);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_type_mismatch_y)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_type_mismatch_y) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, PartialShape::dynamic());
     auto param_u = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
     auto param_v = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_type_mismatch_u)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_type_mismatch_u) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, PartialShape::dynamic());
     auto param_v = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_type_mismatch_v)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_type_mismatch_v) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
     auto param_u = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, PartialShape::dynamic());
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_u_type)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_u_type) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
     auto param_u = std::make_shared<op::v0::Parameter>(element::i8, PartialShape::dynamic());
     auto param_v = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_v_type)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_v_type) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
     auto param_u = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
     auto param_v = std::make_shared<op::v0::Parameter>(element::i8, PartialShape::dynamic());
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_5dims)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_5dims) {
     auto param_shape_y = PartialShape::dynamic();
     auto param_shape_u = PartialShape{1, 1, 1, 1, 1};
     auto param_shape_v = PartialShape::dynamic();
     auto param_1 = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_2 = std::make_shared<op::v0::Parameter>(element::u8, param_shape_u);
     auto param_3 = std::make_shared<op::v0::Parameter>(element::u8, param_shape_v);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_1, param_2, param_3), ov::AssertFailure);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_1, param_3, param_2), ov::AssertFailure);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_2, param_1, param_3), ov::AssertFailure);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_2, param_3, param_1), ov::AssertFailure);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_3, param_1, param_2), ov::AssertFailure);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_3, param_2, param_1), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_1, param_2, param_3), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_1, param_3, param_2), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_2, param_1, param_3), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_2, param_3, param_1), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_3, param_1, param_2), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_3, param_2, param_1), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_3dims)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_3dims) {
     auto param_shape_good = PartialShape::dynamic();
     auto param_shape_bad = PartialShape{1, 1, 1};
     auto param_1 = std::make_shared<op::v0::Parameter>(element::u8, param_shape_good);
     auto param_2 = std::make_shared<op::v0::Parameter>(element::u8, param_shape_bad);
     auto param_3 = std::make_shared<op::v0::Parameter>(element::u8, param_shape_good);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_1, param_2, param_3), ov::AssertFailure);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_1, param_3, param_2), ov::AssertFailure);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_2, param_1, param_3), ov::AssertFailure);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_2, param_3, param_1), ov::AssertFailure);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_3, param_1, param_2), ov::AssertFailure);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_3, param_2, param_1), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_1, param_2, param_3), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_1, param_3, param_2), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_2, param_1, param_3), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_2, param_3, param_1), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_3, param_1, param_2), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_3, param_2, param_1), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_batch)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_batch) {
     auto param_shape_y = PartialShape{2, 480, 640, 1};
     auto param_shape_uv = PartialShape{1, 240, 320, 1};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_height)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_height) {
     auto param_shape_y = PartialShape{2, 480, 640, 1};
     auto param_shape_uv = PartialShape{2, 480, 320, 2};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_height_odd)
-{
-    auto param_shape_y = PartialShape{2, 3, 2, 1}; // 3 is invalid, as UV shall be 2 times smaller
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_height_odd) {
+    auto param_shape_y = PartialShape{2, 3, 2, 1};  // 3 is invalid, as UV shall be 2 times smaller
     auto param_shape_uv = PartialShape::dynamic();
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_width)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_width) {
     auto param_shape_y = PartialShape{2, 480, 640, 1};
     auto param_shape_uv = PartialShape{2, 240, 640, 2};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_width_odd)
-{
-    auto param_shape_y = PartialShape{2, 4, 3, 1}; // 3 is invalid, as UV width shall be 2 times smaller
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_width_odd) {
+    auto param_shape_y = PartialShape{2, 4, 3, 1};  // 3 is invalid, as UV width shall be 2 times smaller
     auto param_shape_uv = PartialShape::dynamic();
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_channels)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_3_plane_error_channels) {
     auto param_shape_y = PartialShape{2, 480, 640, 1};
     auto param_shape_uv = PartialShape{2, 240, 320, 2};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_u = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
     auto param_v = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_u, param_v), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertI420BaseTest, shape_inference_error_2_planes)
-{
+TYPED_TEST_P(ConvertI420BaseTest, shape_inference_error_2_planes) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
     auto param_u = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
     auto empty = std::make_shared<TypeParam>();
@@ -334,9 +303,8 @@ TYPED_TEST_P(ConvertI420BaseTest, shape_inference_error_2_planes)
     EXPECT_THROW(empty->constructor_validate_and_infer_types(), ov::AssertFailure);
 }
 
-
 REGISTER_TYPED_TEST_SUITE_P(ConvertI420BaseTest,
-        shape_inference_single_tensor,
+                            shape_inference_single_tensor,
                             shape_inference_single_tensor_dynamic,
                             shape_inference_single_tensor_dynamic_dims,
                             shape_inference_single_tensor_dynamic_height,
@@ -353,11 +321,11 @@ REGISTER_TYPED_TEST_SUITE_P(ConvertI420BaseTest,
                             shape_inference_3_plane_uv_dynamic,
                             shape_inference_3_plane_dynamic_types,
                             shape_inference_3_plane_uv_type,
-        shape_inference_3_plane_error_type_mismatch_y,
-        shape_inference_3_plane_error_type_mismatch_u,
-        shape_inference_3_plane_error_type_mismatch_v,
-        shape_inference_3_plane_error_u_type,
-        shape_inference_3_plane_error_v_type,
+                            shape_inference_3_plane_error_type_mismatch_y,
+                            shape_inference_3_plane_error_type_mismatch_u,
+                            shape_inference_3_plane_error_type_mismatch_v,
+                            shape_inference_3_plane_error_u_type,
+                            shape_inference_3_plane_error_v_type,
                             shape_inference_3_plane_error_5dims,
                             shape_inference_3_plane_error_3dims,
                             shape_inference_3_plane_error_batch,
@@ -366,5 +334,4 @@ REGISTER_TYPED_TEST_SUITE_P(ConvertI420BaseTest,
                             shape_inference_3_plane_error_width,
                             shape_inference_3_plane_error_width_odd,
                             shape_inference_3_plane_error_channels,
-                            shape_inference_error_2_planes
-);
+                            shape_inference_error_2_planes);

--- a/src/core/tests/type_prop/convert_color_nv12_base.hpp
+++ b/src/core/tests/type_prop/convert_color_nv12_base.hpp
@@ -3,21 +3,20 @@
 //
 
 #include <vector>
+
 #include "gtest/gtest.h"
 #include "openvino/op/op.hpp"
 #include "openvino/opsets/opset8.hpp"
 
+
 using namespace ov;
 
 template <class T>
-class ConvertNV12BaseTest : public testing::Test
-{
-};
+class ConvertNV12BaseTest : public testing::Test {};
 
 TYPED_TEST_SUITE_P(ConvertNV12BaseTest);
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor) {
     auto param_shape = PartialShape{5, 3, 2, 1};
     auto out_shape = PartialShape{5, 2, 2, 3};
     auto param = std::make_shared<op::v0::Parameter>(element::f32, param_shape);
@@ -26,8 +25,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor)
     ASSERT_EQ(op->output(0).get_partial_shape(), out_shape);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic) {
     auto param_shape = PartialShape::dynamic();
     auto out_shape = PartialShape{Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic(), 3};
     auto param = std::make_shared<op::v0::Parameter>(element::f32, param_shape);
@@ -36,8 +34,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic)
     ASSERT_EQ(op->output(0).get_element_type(), element::f32);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_dims)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_dims) {
     auto param_shape = PartialShape{Dimension::dynamic(), 3, Dimension::dynamic(), Dimension::dynamic()};
     auto out_shape = PartialShape{Dimension::dynamic(), 2, Dimension::dynamic(), 3};
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
@@ -46,8 +43,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_dims)
     ASSERT_EQ(op->output(0).get_element_type(), element::u8);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_height)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_height) {
     auto param_shape = PartialShape{Dimension::dynamic(), Dimension::dynamic(), 8, Dimension::dynamic()};
     auto out_shape = PartialShape{Dimension::dynamic(), Dimension::dynamic(), 8, 3};
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
@@ -56,8 +52,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_height)
     ASSERT_EQ(op->output(0).get_element_type(), element::u8);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_type)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_type) {
     auto param_shape = PartialShape{1, 6, 8, 1};
     auto out_shape = PartialShape{1, 4, 8, 3};
     auto param = std::make_shared<op::v0::Parameter>(element::dynamic, param_shape);
@@ -66,50 +61,43 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_dynamic_type)
     ASSERT_EQ(op->output(0).get_element_type(), element::dynamic);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_channels)
-{
-    auto param_shape = PartialShape{1, 3, 4, 2}; // shall be 1 channel, not 2
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_channels) {
+    auto param_shape = PartialShape{1, 3, 4, 2};  // shall be 1 channel, not 2
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_dims_5)
-{
-    auto param_shape = PartialShape{1, 3, 3, 1, 1}; // must be 4 dimensions
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_dims_5) {
+    auto param_shape = PartialShape{1, 3, 3, 1, 1};  // must be 4 dimensions
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_dims_3)
-{
-    auto param_shape = PartialShape{640, 480, 1}; // must be 4 dimensions
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_dims_3) {
+    auto param_shape = PartialShape{640, 480, 1};  // must be 4 dimensions
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_height)
-{
-    auto param_shape = PartialShape{1, 4, 6, 1}; // height = 4, can't split to Y and UV
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_height) {
+    auto param_shape = PartialShape{1, 4, 6, 1};  // height = 4, can't split to Y and UV
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_width_odd)
-{
-    auto param_shape = PartialShape{1, 6, 5, 1}; // width is odd, can't split to U and V
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_width_odd) {
+    auto param_shape = PartialShape{1, 6, 5, 1};  // width is odd, can't split to U and V
     auto param = std::make_shared<op::v0::Parameter>(element::u8, param_shape);
-    EXPECT_THROW(std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_i8)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_single_tensor_error_i8) {
     auto param_shape = PartialShape{1, 640, 480, 1};
     auto param = std::make_shared<op::v0::Parameter>(element::i8, param_shape);
-    EXPECT_THROW(std::make_shared<TypeParam>(param), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_simple)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_simple) {
     auto param_shape_y = PartialShape{10, 480, 640, 1};
     auto param_shape_uv = PartialShape{10, 240, 320, 2};
     auto out_shape = PartialShape{10, 480, 640, 3};
@@ -120,8 +108,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_simple)
     ASSERT_EQ(op->output(0).get_element_type(), element::u8);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_dynamic)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_dynamic) {
     auto param_shape_y = PartialShape::dynamic();
     auto param_shape_uv = PartialShape::dynamic();
     auto out_shape = PartialShape{Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic(), 3};
@@ -132,8 +119,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_dynamic)
     ASSERT_EQ(op->output(0).get_element_type(), element::f32);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_y_dynamic)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_y_dynamic) {
     auto param_shape_y = PartialShape::dynamic();
     auto param_shape_uv = PartialShape{1, 3, 2, 2};
     auto out_shape = PartialShape{1, 6, 4, 3};
@@ -144,8 +130,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_y_dynamic)
     ASSERT_EQ(op->output(0).get_element_type(), element::bf16);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_uv_dynamic)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_uv_dynamic) {
     auto param_shape_y = PartialShape{1, 4, 4, 1};
     auto param_shape_uv = PartialShape::dynamic();
     auto out_shape = PartialShape{1, 4, 4, 3};
@@ -156,8 +141,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_uv_dynamic)
     ASSERT_EQ(op->output(0).get_element_type(), element::f16);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_dynamic_types)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_dynamic_types) {
     auto param_shape_y = PartialShape{1, 4, 4, 1};
     auto param_shape_uv = PartialShape{1, 2, 2, 2};
     auto out_shape = PartialShape{1, 4, 4, 3};
@@ -171,8 +155,7 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_dynamic_types)
     ASSERT_EQ(op->output(0).get_element_type(), out_type);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_uv_type)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_uv_type) {
     auto param_shape_y = PartialShape{1, 4, 4, 1};
     auto param_shape_uv = PartialShape{1, 2, 2, 2};
     auto out_shape = PartialShape{1, 4, 4, 3};
@@ -186,94 +169,83 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_uv_type)
     ASSERT_EQ(op->output(0).get_element_type(), out_type);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_type_mismatch)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_type_mismatch) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, PartialShape::dynamic());
     auto param_uv = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic());
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_uv_type)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_uv_type) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
     auto param_uv = std::make_shared<op::v0::Parameter>(element::i8, PartialShape::dynamic());
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_5dims)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_5dims) {
     auto param_shape_y = PartialShape::dynamic();
     auto param_shape_uv = PartialShape{2, 2, 2, 2, 2};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_3dims)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_3dims) {
     auto param_shape_y = PartialShape::dynamic();
     auto param_shape_uv = PartialShape{2, 2, 2};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_batch)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_batch) {
     auto param_shape_y = PartialShape{2, 480, 640, 1};
     auto param_shape_uv = PartialShape{1, 240, 320, 2};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_height)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_height) {
     auto param_shape_y = PartialShape{2, 480, 640, 1};
     auto param_shape_uv = PartialShape{2, 480, 320, 2};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_height_odd)
-{
-    auto param_shape_y = PartialShape{2, 3, 2, 1}; // 3 is invalid, as UV shall be 2 times smaller
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_height_odd) {
+    auto param_shape_y = PartialShape{2, 3, 2, 1};  // 3 is invalid, as UV shall be 2 times smaller
     auto param_shape_uv = PartialShape::dynamic();
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_width)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_width) {
     auto param_shape_y = PartialShape{2, 480, 640, 1};
     auto param_shape_uv = PartialShape{2, 240, 640, 2};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_width_odd)
-{
-    auto param_shape_y = PartialShape{2, 4, 3, 1}; // 3 is invalid, as UV width shall be 2 times smaller
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_width_odd) {
+    auto param_shape_y = PartialShape{2, 4, 3, 1};  // 3 is invalid, as UV width shall be 2 times smaller
     auto param_shape_uv = PartialShape::dynamic();
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_channels)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_2_plane_error_channels) {
     auto param_shape_y = PartialShape{2, 480, 640, 1};
     auto param_shape_uv = PartialShape{2, 240, 320, 1};
     auto param_y = std::make_shared<op::v0::Parameter>(element::u8, param_shape_y);
     auto param_uv = std::make_shared<op::v0::Parameter>(element::u8, param_shape_uv);
-    EXPECT_THROW(std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
+    EXPECT_THROW(const auto unused = std::make_shared<TypeParam>(param_y, param_uv), ov::AssertFailure);
 }
 
-TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_error_many_types)
-{
+TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_error_many_types) {
     auto param_y = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
     auto param_u = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
     auto param_v = std::make_shared<op::v0::Parameter>(element::dynamic, PartialShape::dynamic());
@@ -283,9 +255,8 @@ TYPED_TEST_P(ConvertNV12BaseTest, shape_inference_error_many_types)
     EXPECT_THROW(empty->constructor_validate_and_infer_types(), ov::AssertFailure);
 }
 
-
 REGISTER_TYPED_TEST_SUITE_P(ConvertNV12BaseTest,
-        shape_inference_single_tensor,
+                            shape_inference_single_tensor,
                             shape_inference_single_tensor_dynamic,
                             shape_inference_single_tensor_dynamic_dims,
                             shape_inference_single_tensor_dynamic_height,
@@ -312,5 +283,4 @@ REGISTER_TYPED_TEST_SUITE_P(ConvertNV12BaseTest,
                             shape_inference_2_plane_error_width,
                             shape_inference_2_plane_error_width_odd,
                             shape_inference_2_plane_error_channels,
-                            shape_inference_error_many_types
-);
+                            shape_inference_error_many_types);

--- a/src/core/tests/type_prop/cum_sum.cpp
+++ b/src/core/tests/type_prop/cum_sum.cpp
@@ -118,7 +118,7 @@ TEST(type_prop, cum_sum_op_element_types) {
             auto axis = std::make_shared<op::Parameter>(element::i32, PartialShape{});
             auto A = std::make_shared<op::Parameter>(et, data_shape);
 
-            EXPECT_NO_THROW(std::make_shared<op::v0::CumSum>(A, axis));
+            EXPECT_NO_THROW(const auto unused = std::make_shared<op::v0::CumSum>(A, axis));
         } catch (...) {
             FAIL() << "Data input element type validation check failed for unexpected reason";
         }

--- a/src/core/tests/type_prop/gelu.cpp
+++ b/src/core/tests/type_prop/gelu.cpp
@@ -57,22 +57,22 @@ TEST(type_prop, gelu_tanh_mode_inference_f16) {
 
 TEST(type_prop, gelu_incompatible_input_type_boolean) {
     auto param = make_shared<op::Parameter>(element::boolean, Shape{1, 32, 32});
-    ASSERT_THROW(std::make_shared<op::v7::Gelu>(param), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = std::make_shared<op::v7::Gelu>(param), ngraph::NodeValidationFailure);
 }
 
 TEST(type_prop, gelu_incompatible_input_type_u16) {
     auto param = make_shared<op::Parameter>(element::u16, Shape{1, 32, 32});
-    ASSERT_THROW(std::make_shared<op::v7::Gelu>(param), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = std::make_shared<op::v7::Gelu>(param), ngraph::NodeValidationFailure);
 }
 
 TEST(type_prop, gelu_incompatible_input_type_i32) {
     auto param = make_shared<op::Parameter>(element::i32, Shape{1, 32, 32});
-    ASSERT_THROW(std::make_shared<op::v7::Gelu>(param), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = std::make_shared<op::v7::Gelu>(param), ngraph::NodeValidationFailure);
 }
 
 TEST(type_prop, gelu_incompatible_input_type_i16) {
     auto param = make_shared<op::Parameter>(element::i16, Shape{1, 32, 32});
-    ASSERT_THROW(std::make_shared<op::v7::Gelu>(param), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = std::make_shared<op::v7::Gelu>(param), ngraph::NodeValidationFailure);
 }
 
 TEST(type_prop, gelu_dynamic_rank_input_shape_2D) {

--- a/src/core/tests/type_prop/gru_cell.cpp
+++ b/src/core/tests/type_prop/gru_cell.cpp
@@ -138,31 +138,36 @@ TEST(type_prop, gru_cell_invalid_input_rank0) {
 
     // Invalid rank0 for W tensor.
     auto W = make_shared<op::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::GRUCell>(X, H_t, W, R, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::GRUCell>(X, H_t, W, R, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "GRUCell node was created with invalid data.";
 
     // Invalid rank0 for X tensor.
     W = make_shared<op::Parameter>(element::f32, PartialShape{gates_count * hidden_size, input_size});
     X = make_shared<op::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::GRUCell>(X, H_t, W, R, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::GRUCell>(X, H_t, W, R, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "GRUCell node was created with invalid data.";
 
     // Invalid rank0 for H_t tensor.
     X = make_shared<op::Parameter>(element::f32, PartialShape{batch_size, input_size});
     H_t = make_shared<op::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::GRUCell>(X, H_t, W, R, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::GRUCell>(X, H_t, W, R, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "GRUCell node was created with invalid data.";
 
     // Invalid rank0 for R tensor.
     H_t = make_shared<op::Parameter>(element::f32, PartialShape{batch_size, hidden_size});
     R = make_shared<op::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::GRUCell>(X, H_t, W, R, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::GRUCell>(X, H_t, W, R, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "GRUCell node was created with invalid data.";
 
     // Invalid rank0 for B tensor.
     R = make_shared<op::Parameter>(element::f32, PartialShape{gates_count * hidden_size, input_size});
     auto B = make_shared<op::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::GRUCell>(X, H_t, W, R, B, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::GRUCell>(X, H_t, W, R, B, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "GRUCell node was created with invalid data.";
 }
 

--- a/src/core/tests/type_prop/lstm_cell.cpp
+++ b/src/core/tests/type_prop/lstm_cell.cpp
@@ -180,37 +180,43 @@ TEST(type_prop, lstm_cell_invalid_input_rank0) {
 
     // Invalid rank0 for W tensor.
     W = make_shared<opset4::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::LSTMCell>(X, H_t, C_t, W, R, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::LSTMCell>(X, H_t, C_t, W, R, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "LSTMCell node was created with invalid data.";
 
     // Invalid rank0 for X tensor.
     W = make_shared<opset4::Parameter>(element::f32, PartialShape{gates_count * hidden_size, input_size});
     X = make_shared<opset4::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::LSTMCell>(X, H_t, C_t, W, R, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::LSTMCell>(X, H_t, C_t, W, R, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "LSTMCell node was created with invalid data.";
 
     // Invalid rank0 for H_t tensor.
     X = make_shared<opset4::Parameter>(element::f32, PartialShape{batch_size, input_size});
     H_t = make_shared<opset4::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::LSTMCell>(X, H_t, C_t, W, R, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::LSTMCell>(X, H_t, C_t, W, R, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "LSTMCell node was created with invalid data.";
 
     // Invalid rank0 for C_t tensor.
     H_t = make_shared<opset4::Parameter>(element::f32, PartialShape{batch_size, hidden_size});
     C_t = make_shared<opset4::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::LSTMCell>(X, H_t, C_t, W, R, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::LSTMCell>(X, H_t, C_t, W, R, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "LSTMCell node was created with invalid data.";
 
     // Invalid rank0 for R tensor.
     C_t = make_shared<opset4::Parameter>(element::f32, PartialShape{batch_size, hidden_size});
     R = make_shared<opset4::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::LSTMCell>(X, H_t, C_t, W, R, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::LSTMCell>(X, H_t, C_t, W, R, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "LSTMCell node was created with invalid data.";
 
     // Invalid rank0 for B tensor.
     R = make_shared<opset4::Parameter>(element::f32, PartialShape{gates_count * hidden_size, hidden_size});
     auto B = make_shared<opset4::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::LSTMCell>(X, H_t, C_t, W, R, B, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::LSTMCell>(X, H_t, C_t, W, R, B, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "LSTMCell node was created with invalid data.";
 }
 

--- a/src/core/tests/type_prop/matrix_nms.cpp
+++ b/src/core/tests/type_prop/matrix_nms.cpp
@@ -14,7 +14,7 @@ TEST(type_prop, matrix_nms_incorrect_boxes_rank) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3, 4});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
 
-        make_shared<op::v8::MatrixNms>(boxes, scores, op::v8::MatrixNms::Attributes());
+        const auto unused = make_shared<op::v8::MatrixNms>(boxes, scores, op::v8::MatrixNms::Attributes());
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a 3D tensor for the 'boxes' input");
     }
@@ -25,7 +25,7 @@ TEST(type_prop, matrix_nms_incorrect_scores_rank) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 4});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2});
 
-        make_shared<op::v8::MatrixNms>(boxes, scores, op::v8::MatrixNms::Attributes());
+        const auto unused = make_shared<op::v8::MatrixNms>(boxes, scores, op::v8::MatrixNms::Attributes());
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a 3D tensor for the 'scores' input");
     }
@@ -36,7 +36,7 @@ TEST(type_prop, matrix_nms_incorrect_scheme_num_batches) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 4});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{2, 2, 3});
 
-        make_shared<op::v8::MatrixNms>(boxes, scores, op::v8::MatrixNms::Attributes());
+        const auto unused = make_shared<op::v8::MatrixNms>(boxes, scores, op::v8::MatrixNms::Attributes());
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The first dimension of both 'boxes' and 'scores' must match");
     }
@@ -47,7 +47,7 @@ TEST(type_prop, matrix_nms_incorrect_scheme_num_boxes) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 4});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
 
-        make_shared<op::v8::MatrixNms>(boxes, scores, op::v8::MatrixNms::Attributes());
+        const auto unused = make_shared<op::v8::MatrixNms>(boxes, scores, op::v8::MatrixNms::Attributes());
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(),
                              "'boxes' and 'scores' input shapes must match at the second and third "
@@ -60,7 +60,7 @@ TEST(type_prop, matrix_nms_incorrect_boxes_rank2) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{2, 2, 2});
 
-        make_shared<op::v8::MatrixNms>(boxes, scores, op::v8::MatrixNms::Attributes());
+        const auto unused = make_shared<op::v8::MatrixNms>(boxes, scores, op::v8::MatrixNms::Attributes());
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The third dimension of the 'boxes' must be 4");
     }
@@ -73,7 +73,7 @@ TEST(type_prop, matrix_nms_incorrect_output_type) {
         op::v8::MatrixNms::Attributes attrs;
         attrs.output_type = ngraph::element::f32;
 
-        make_shared<op::v8::MatrixNms>(boxes, scores, attrs);
+        const auto unused = make_shared<op::v8::MatrixNms>(boxes, scores, attrs);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Output type must be i32 or i64");
     }
@@ -86,7 +86,7 @@ TEST(type_prop, matrix_nms_incorrect_nms_topk) {
         op::v8::MatrixNms::Attributes attrs;
         attrs.nms_top_k = -2;
 
-        make_shared<op::v8::MatrixNms>(boxes, scores, attrs);
+        const auto unused = make_shared<op::v8::MatrixNms>(boxes, scores, attrs);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The 'nms_top_k' must be great or equal -1");
     }
@@ -99,7 +99,7 @@ TEST(type_prop, matrix_nms_incorrect_keep_topk) {
         op::v8::MatrixNms::Attributes attrs;
         attrs.keep_top_k = -2;
 
-        make_shared<op::v8::MatrixNms>(boxes, scores, attrs);
+        const auto unused = make_shared<op::v8::MatrixNms>(boxes, scores, attrs);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The 'keep_top_k' must be great or equal -1");
     }
@@ -112,7 +112,7 @@ TEST(type_prop, matrix_nms_incorrect_background_class) {
         op::v8::MatrixNms::Attributes attrs;
         attrs.background_class = -2;
 
-        make_shared<op::v8::MatrixNms>(boxes, scores, attrs);
+        const auto unused = make_shared<op::v8::MatrixNms>(boxes, scores, attrs);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The 'background_class' must be great or equal -1");
     }
@@ -123,7 +123,7 @@ TEST(type_prop, matrix_nms_incorrect_input_type) {
         const auto boxes = make_shared<op::Parameter>(element::f16, Shape{1, 2, 4});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2, 2});
 
-        make_shared<op::v8::MatrixNms>(boxes, scores, op::v8::MatrixNms::Attributes());
+        const auto unused = make_shared<op::v8::MatrixNms>(boxes, scores, op::v8::MatrixNms::Attributes());
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected 'boxes', 'scores' type is same.");
     }

--- a/src/core/tests/type_prop/mish.cpp
+++ b/src/core/tests/type_prop/mish.cpp
@@ -37,15 +37,15 @@ TEST(type_prop, mish_partial_static_rank) {
 
 TEST(type_prop, mish_incompatible_dtype_i32) {
     auto data = make_shared<op::Parameter>(element::i32, Shape{1, 3, 6});
-    ASSERT_THROW(std::make_shared<op::v4::Mish>(data), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = std::make_shared<op::v4::Mish>(data), ngraph::NodeValidationFailure);
 }
 
 TEST(type_prop, mish_incompatible_dtype_u32) {
     auto data = make_shared<op::Parameter>(element::u32, Shape{1, 3, 6});
-    ASSERT_THROW(std::make_shared<op::v4::Mish>(data), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = std::make_shared<op::v4::Mish>(data), ngraph::NodeValidationFailure);
 }
 
 TEST(type_prop, mish_incompatible_dtype_boolean) {
     auto data = make_shared<op::Parameter>(element::boolean, Shape{1, 3, 6});
-    ASSERT_THROW(std::make_shared<op::v4::Mish>(data), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = std::make_shared<op::v4::Mish>(data), ngraph::NodeValidationFailure);
 }

--- a/src/core/tests/type_prop/multiclass_nms.cpp
+++ b/src/core/tests/type_prop/multiclass_nms.cpp
@@ -14,7 +14,7 @@ TEST(type_prop, multiclass_nms_incorrect_boxes_rank) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3, 4});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
 
-        make_shared<op::v8::MulticlassNms>(boxes, scores, op::v8::MulticlassNms::Attributes());
+        const auto unused = make_shared<op::v8::MulticlassNms>(boxes, scores, op::v8::MulticlassNms::Attributes());
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a 3D tensor for the 'boxes' input");
     }
@@ -25,7 +25,7 @@ TEST(type_prop, multiclass_nms_incorrect_scores_rank) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 4});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2});
 
-        make_shared<op::v8::MulticlassNms>(boxes, scores, op::v8::MulticlassNms::Attributes());
+        const auto unused = make_shared<op::v8::MulticlassNms>(boxes, scores, op::v8::MulticlassNms::Attributes());
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a 3D tensor for the 'scores' input");
     }
@@ -36,7 +36,7 @@ TEST(type_prop, multiclass_nms_incorrect_scheme_num_batches) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 4});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{2, 2, 3});
 
-        make_shared<op::v8::MulticlassNms>(boxes, scores, op::v8::MulticlassNms::Attributes());
+        const auto unused = make_shared<op::v8::MulticlassNms>(boxes, scores, op::v8::MulticlassNms::Attributes());
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The first dimension of both 'boxes' and 'scores' must match");
     }
@@ -47,7 +47,7 @@ TEST(type_prop, multiclass_nms_incorrect_scheme_num_boxes) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 4});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
 
-        make_shared<op::v8::MulticlassNms>(boxes, scores, op::v8::MulticlassNms::Attributes());
+        const auto unused = make_shared<op::v8::MulticlassNms>(boxes, scores, op::v8::MulticlassNms::Attributes());
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(),
                              "'boxes' and 'scores' input shapes must match at the second and third "
@@ -60,7 +60,7 @@ TEST(type_prop, multiclass_nms_incorrect_boxes_rank2) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{2, 2, 2});
 
-        make_shared<op::v8::MulticlassNms>(boxes, scores, op::v8::MulticlassNms::Attributes());
+        const auto unused = make_shared<op::v8::MulticlassNms>(boxes, scores, op::v8::MulticlassNms::Attributes());
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The third dimension of the 'boxes' must be 4");
     }
@@ -73,7 +73,7 @@ TEST(type_prop, multiclass_nms_incorrect_output_type) {
         op::v8::MulticlassNms::Attributes attrs;
         attrs.output_type = ngraph::element::f32;
 
-        make_shared<op::v8::MulticlassNms>(boxes, scores, attrs);
+        const auto unused = make_shared<op::v8::MulticlassNms>(boxes, scores, attrs);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Output type must be i32 or i64");
     }
@@ -86,7 +86,7 @@ TEST(type_prop, multiclass_nms_incorrect_nms_topk) {
         op::v8::MulticlassNms::Attributes attrs;
         attrs.nms_top_k = -2;
 
-        make_shared<op::v8::MulticlassNms>(boxes, scores, attrs);
+        const auto unused = make_shared<op::v8::MulticlassNms>(boxes, scores, attrs);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The 'nms_top_k' must be great or equal -1");
     }
@@ -99,7 +99,7 @@ TEST(type_prop, multiclass_nms_incorrect_keep_topk) {
         op::v8::MulticlassNms::Attributes attrs;
         attrs.keep_top_k = -2;
 
-        make_shared<op::v8::MulticlassNms>(boxes, scores, attrs);
+        const auto unused = make_shared<op::v8::MulticlassNms>(boxes, scores, attrs);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The 'keep_top_k' must be great or equal -1");
     }
@@ -112,7 +112,7 @@ TEST(type_prop, multiclass_nms_incorrect_background_class) {
         op::v8::MulticlassNms::Attributes attrs;
         attrs.background_class = -2;
 
-        make_shared<op::v8::MulticlassNms>(boxes, scores, attrs);
+        const auto unused = make_shared<op::v8::MulticlassNms>(boxes, scores, attrs);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The 'background_class' must be great or equal -1");
     }
@@ -125,7 +125,7 @@ TEST(type_prop, multiclass_nms_incorrect_eta) {
         op::v8::MulticlassNms::Attributes attrs;
         attrs.nms_eta = 2.0f;
 
-        make_shared<op::v8::MulticlassNms>(boxes, scores, attrs);
+        const auto unused = make_shared<op::v8::MulticlassNms>(boxes, scores, attrs);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The 'nms_eta' must be in close range [0, 1.0]");
     }
@@ -136,7 +136,7 @@ TEST(type_prop, multiclass_nms_incorrect_input_type) {
         const auto boxes = make_shared<op::Parameter>(element::f16, Shape{1, 2, 4});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2, 2});
 
-        make_shared<op::v8::MulticlassNms>(boxes, scores, op::v8::MulticlassNms::Attributes());
+        const auto unused = make_shared<op::v8::MulticlassNms>(boxes, scores, op::v8::MulticlassNms::Attributes());
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected 'boxes', 'scores' type is same.");
     }

--- a/src/core/tests/type_prop/non_max_suppression.cpp
+++ b/src/core/tests/type_prop/non_max_suppression.cpp
@@ -16,7 +16,7 @@ TEST(type_prop, nms_incorrect_boxes_rank) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3, 4});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
 
-        make_shared<op::v1::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v1::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a 3D tensor for the 'boxes' input");
     }
@@ -27,7 +27,7 @@ TEST(type_prop, nms_incorrect_scores_rank) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2});
 
-        make_shared<op::v1::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v1::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a 3D tensor for the 'scores' input");
     }
@@ -38,7 +38,7 @@ TEST(type_prop, nms_incorrect_scheme_num_batches) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{2, 2, 3});
 
-        make_shared<op::v1::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v1::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The first dimension of both 'boxes' and 'scores' must match");
     }
@@ -49,7 +49,7 @@ TEST(type_prop, nms_incorrect_scheme_num_boxes) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
 
-        make_shared<op::v1::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v1::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(),
                              "'boxes' and 'scores' input shapes must match at the second and third "
@@ -65,19 +65,19 @@ TEST(type_prop, nms_scalar_inputs_check) {
     const auto non_scalar = make_shared<op::Parameter>(element::f32, Shape{1});
 
     try {
-        make_shared<op::v1::NonMaxSuppression>(boxes, scores, non_scalar, scalar, scalar);
+        const auto unused = make_shared<op::v1::NonMaxSuppression>(boxes, scores, non_scalar, scalar, scalar);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a scalar for the 'max_output_boxes_per_class' input");
     }
 
     try {
-        make_shared<op::v1::NonMaxSuppression>(boxes, scores, scalar, non_scalar, scalar);
+        const auto unused = make_shared<op::v1::NonMaxSuppression>(boxes, scores, scalar, non_scalar, scalar);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a scalar for the 'iou_threshold' input");
     }
 
     try {
-        make_shared<op::v1::NonMaxSuppression>(boxes, scores, scalar, scalar, non_scalar);
+        const auto unused = make_shared<op::v1::NonMaxSuppression>(boxes, scores, scalar, scalar, non_scalar);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a scalar for the 'score_threshold' input");
     }
@@ -153,7 +153,7 @@ TEST(type_prop, nms_v3_incorrect_boxes_rank) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3, 4});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
 
-        make_shared<op::v3::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v3::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a 3D tensor for the 'boxes' input");
     }
@@ -164,7 +164,7 @@ TEST(type_prop, nms_v3_incorrect_scores_rank) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2});
 
-        make_shared<op::v3::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v3::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a 3D tensor for the 'scores' input");
     }
@@ -175,7 +175,7 @@ TEST(type_prop, nms_v3_incorrect_scheme_num_batches) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{2, 2, 3});
 
-        make_shared<op::v3::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v3::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The first dimension of both 'boxes' and 'scores' must match");
     }
@@ -186,7 +186,7 @@ TEST(type_prop, nms_v3_incorrect_scheme_num_boxes) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
 
-        make_shared<op::v3::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v3::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(),
                              "'boxes' and 'scores' input shapes must match at the second and third "
@@ -202,19 +202,19 @@ TEST(type_prop, nms_v3_scalar_inputs_check) {
     const auto non_scalar = make_shared<op::Parameter>(element::f32, Shape{1});
 
     try {
-        make_shared<op::v3::NonMaxSuppression>(boxes, scores, non_scalar, scalar, scalar);
+        const auto unused = make_shared<op::v3::NonMaxSuppression>(boxes, scores, non_scalar, scalar, scalar);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a scalar for the 'max_output_boxes_per_class' input");
     }
 
     try {
-        make_shared<op::v3::NonMaxSuppression>(boxes, scores, scalar, non_scalar, scalar);
+        const auto unused = make_shared<op::v3::NonMaxSuppression>(boxes, scores, scalar, non_scalar, scalar);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a scalar for the 'iou_threshold' input");
     }
 
     try {
-        make_shared<op::v3::NonMaxSuppression>(boxes, scores, scalar, scalar, non_scalar);
+        const auto unused = make_shared<op::v3::NonMaxSuppression>(boxes, scores, scalar, scalar, non_scalar);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a scalar for the 'score_threshold' input");
     }
@@ -310,7 +310,7 @@ TEST(type_prop, nms_v4_incorrect_boxes_rank) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3, 4});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
 
-        make_shared<op::v4::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v4::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a 3D tensor for the 'boxes' input");
     }
@@ -321,7 +321,7 @@ TEST(type_prop, nms_v4_incorrect_scores_rank) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2});
 
-        make_shared<op::v4::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v4::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a 3D tensor for the 'scores' input");
     }
@@ -332,7 +332,7 @@ TEST(type_prop, nms_v4_incorrect_scheme_num_batches) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{2, 2, 3});
 
-        make_shared<op::v4::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v4::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The first dimension of both 'boxes' and 'scores' must match");
     }
@@ -343,7 +343,7 @@ TEST(type_prop, nms_v4_incorrect_scheme_num_boxes) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
 
-        make_shared<op::v4::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v4::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(),
                              "'boxes' and 'scores' input shapes must match at the second and third "
@@ -359,19 +359,19 @@ TEST(type_prop, nms_v4_scalar_inputs_check) {
     const auto non_scalar = make_shared<op::Parameter>(element::f32, Shape{1});
 
     try {
-        make_shared<op::v4::NonMaxSuppression>(boxes, scores, non_scalar, scalar, scalar);
+        const auto unused = make_shared<op::v4::NonMaxSuppression>(boxes, scores, non_scalar, scalar, scalar);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a scalar for the 'max_output_boxes_per_class' input");
     }
 
     try {
-        make_shared<op::v4::NonMaxSuppression>(boxes, scores, scalar, non_scalar, scalar);
+        const auto unused = make_shared<op::v4::NonMaxSuppression>(boxes, scores, scalar, non_scalar, scalar);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a scalar for the 'iou_threshold' input");
     }
 
     try {
-        make_shared<op::v4::NonMaxSuppression>(boxes, scores, scalar, scalar, non_scalar);
+        const auto unused = make_shared<op::v4::NonMaxSuppression>(boxes, scores, scalar, scalar, non_scalar);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a scalar for the 'score_threshold' input");
     }
@@ -467,7 +467,7 @@ TEST(type_prop, nms_v5_incorrect_boxes_rank) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3, 4});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
 
-        make_shared<op::v5::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v5::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a 3D tensor for the 'boxes' input");
     }
@@ -478,7 +478,7 @@ TEST(type_prop, nms_v5_incorrect_scores_rank) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2});
 
-        make_shared<op::v5::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v5::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected a 3D tensor for the 'scores' input");
     }
@@ -489,7 +489,7 @@ TEST(type_prop, nms_v5_incorrect_scheme_num_batches) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{2, 2, 3});
 
-        make_shared<op::v5::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v5::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "The first dimension of both 'boxes' and 'scores' must match");
     }
@@ -500,7 +500,7 @@ TEST(type_prop, nms_v5_incorrect_scheme_num_boxes) {
         const auto boxes = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
         const auto scores = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
 
-        make_shared<op::v5::NonMaxSuppression>(boxes, scores);
+        const auto unused = make_shared<op::v5::NonMaxSuppression>(boxes, scores);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(),
                              "'boxes' and 'scores' input shapes must match at the second and third "
@@ -516,25 +516,25 @@ TEST(type_prop, nms_v5_scalar_inputs_check) {
     const auto non_0d_or_1d = make_shared<op::Parameter>(element::f32, Shape{2});
 
     try {
-        make_shared<op::v5::NonMaxSuppression>(boxes, scores, non_0d_or_1d, scalar, scalar);
+        const auto unused = make_shared<op::v5::NonMaxSuppression>(boxes, scores, non_0d_or_1d, scalar, scalar);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected 0D or 1D tensor for the 'max_output_boxes_per_class' input");
     }
 
     try {
-        make_shared<op::v5::NonMaxSuppression>(boxes, scores, scalar, non_0d_or_1d, scalar);
+        const auto unused = make_shared<op::v5::NonMaxSuppression>(boxes, scores, scalar, non_0d_or_1d, scalar);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected 0D or 1D tensor for the 'iou_threshold' input");
     }
 
     try {
-        make_shared<op::v5::NonMaxSuppression>(boxes, scores, scalar, scalar, non_0d_or_1d);
+        const auto unused = make_shared<op::v5::NonMaxSuppression>(boxes, scores, scalar, scalar, non_0d_or_1d);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected 0D or 1D tensor for the 'score_threshold' input");
     }
 
     try {
-        make_shared<op::v5::NonMaxSuppression>(boxes, scores, scalar, scalar, scalar, non_0d_or_1d);
+        const auto unused = make_shared<op::v5::NonMaxSuppression>(boxes, scores, scalar, scalar, scalar, non_0d_or_1d);
     } catch (const NodeValidationFailure& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Expected 0D or 1D tensor for the 'soft_nms_sigma' input");
     }

--- a/src/core/tests/type_prop/reshape.cpp
+++ b/src/core/tests/type_prop/reshape.cpp
@@ -559,9 +559,11 @@ TEST(type_prop, reshape_to_zero_shape_dynamic) {
 
 TEST(type_prop, reshape_to_zero_shape_incorrect) {
     auto param = make_shared<op::Parameter>(element::f32, Shape{2, 1});
-    ASSERT_THROW(
-        make_shared<op::v1::Reshape>(param, op::Constant::create(element::i64, {1}, std::vector<int64_t>{0}), false),
-        std::exception);
+    ASSERT_THROW(const auto unused =
+                     make_shared<op::v1::Reshape>(param,
+                                                  op::Constant::create(element::i64, {1}, std::vector<int64_t>{0}),
+                                                  false),
+                 std::exception);
 }
 
 TEST(type_prop, reshape_to_zero) {
@@ -590,9 +592,11 @@ TEST(type_prop, reshape_to_scalar_2) {
 
 TEST(type_prop, reshape_to_scalar_3) {
     auto param = make_shared<op::Parameter>(element::f32, Shape{1, 2, 3});
-    ASSERT_THROW(
-        make_shared<op::v1::Reshape>(param, op::Constant::create(element::i64, {}, std::vector<int64_t>{100}), false),
-        std::exception);
+    ASSERT_THROW(const auto unused =
+                     make_shared<op::v1::Reshape>(param,
+                                                  op::Constant::create(element::i64, {}, std::vector<int64_t>{100}),
+                                                  false),
+                 std::exception);
 }
 
 TEST(type_prop, dynamic_shape_propagation_with_i32_precision) {

--- a/src/core/tests/type_prop/reverse_sequence.cpp
+++ b/src/core/tests/type_prop/reverse_sequence.cpp
@@ -54,7 +54,7 @@ TEST(type_prop, reverse_sequence_data_et) {
             auto data = std::make_shared<op::Parameter>(et, PartialShape{4, 4});
             auto seq_lengths = std::make_shared<op::Parameter>(element::i32, PartialShape{4});
 
-            EXPECT_NO_THROW(std::make_shared<op::ReverseSequence>(data, seq_lengths));
+            EXPECT_NO_THROW(const auto unused = std::make_shared<op::ReverseSequence>(data, seq_lengths));
         } catch (...) {
             FAIL() << "Data input element type validation check failed for unexpected reason";
         }

--- a/src/core/tests/type_prop/rnn_cell.cpp
+++ b/src/core/tests/type_prop/rnn_cell.cpp
@@ -133,31 +133,36 @@ TEST(type_prop, rnn_cell_invalid_input_rank0) {
 
     // Invalid rank0 for W tensor.
     auto W = make_shared<opset4::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::RNNCell>(X, H_t, W, R, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::RNNCell>(X, H_t, W, R, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "RNNCell node was created with invalid data.";
 
     // Invalid rank0 for X tensor.
     W = make_shared<opset4::Parameter>(element::f32, PartialShape{hidden_size, input_size});
     X = make_shared<opset4::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::RNNCell>(X, H_t, W, R, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::RNNCell>(X, H_t, W, R, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "RNNCell node was created with invalid data.";
 
     // Invalid rank0 for H_t tensor.
     X = make_shared<opset4::Parameter>(element::f32, Shape{batch_size, input_size});
     H_t = make_shared<opset4::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::RNNCell>(X, H_t, W, R, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::RNNCell>(X, H_t, W, R, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "RNNCell node was created with invalid data.";
 
     // Invalid rank0 for R tensor.
     H_t = make_shared<opset4::Parameter>(element::f32, Shape{batch_size, hidden_size});
     R = make_shared<opset4::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::RNNCell>(X, H_t, W, R, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::RNNCell>(X, H_t, W, R, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "RNNCell node was created with invalid data.";
 
     // Invalid rank0 for B tensor.
     R = make_shared<opset4::Parameter>(element::f32, PartialShape{hidden_size, hidden_size});
     auto B = make_shared<opset4::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset4::RNNCell>(X, H_t, W, R, B, hidden_size), ngraph::NodeValidationFailure)
+    ASSERT_THROW(const auto unused = make_shared<opset4::RNNCell>(X, H_t, W, R, B, hidden_size),
+                 ngraph::NodeValidationFailure)
         << "RNNCell node was created with invalid data.";
 }
 

--- a/src/core/tests/type_prop/rnn_sequence.cpp
+++ b/src/core/tests/type_prop/rnn_sequence.cpp
@@ -257,36 +257,41 @@ TEST(type_prop, rnn_sequence_dynamic_invalid_input_rank0) {
 
     // Invalid rank0 for X tensor.
     X = make_shared<opset5::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset5::RNNSequence>(X, H_t, sequence_lengths, W, R, B, hidden_size, direction),
-                 ngraph::CheckFailure)
+    ASSERT_THROW(
+        const auto unused = make_shared<opset5::RNNSequence>(X, H_t, sequence_lengths, W, R, B, hidden_size, direction),
+        ngraph::CheckFailure)
         << "RNNSequence node was created with invalid data.";
 
     // Invalid rank0 for H_t tensor.
     X = make_shared<opset5::Parameter>(element::f32, Shape{batch_size, seq_length, input_size});
     H_t = make_shared<opset5::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset5::RNNSequence>(X, H_t, sequence_lengths, W, R, B, hidden_size, direction),
-                 ngraph::CheckFailure)
+    ASSERT_THROW(
+        const auto unused = make_shared<opset5::RNNSequence>(X, H_t, sequence_lengths, W, R, B, hidden_size, direction),
+        ngraph::CheckFailure)
         << "RNNSequence node was created with invalid data.";
 
     // Invalid rank0 for W tensor.
     H_t = make_shared<opset5::Parameter>(element::f32, Shape{batch_size, num_directions, hidden_size});
     W = make_shared<opset5::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset5::RNNSequence>(X, H_t, sequence_lengths, W, R, B, hidden_size, direction),
-                 ngraph::CheckFailure)
+    ASSERT_THROW(
+        const auto unused = make_shared<opset5::RNNSequence>(X, H_t, sequence_lengths, W, R, B, hidden_size, direction),
+        ngraph::CheckFailure)
         << "RNNSequence node was created with invalid data.";
 
     // Invalid rank0 for R tensor.
     W = make_shared<opset5::Parameter>(element::f32, Shape{num_directions, hidden_size, input_size});
     R = make_shared<opset5::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset5::RNNSequence>(X, H_t, sequence_lengths, W, R, B, hidden_size, direction),
-                 ngraph::CheckFailure)
+    ASSERT_THROW(
+        const auto unused = make_shared<opset5::RNNSequence>(X, H_t, sequence_lengths, W, R, B, hidden_size, direction),
+        ngraph::CheckFailure)
         << "RNNSequence node was created with invalid data.";
 
     // Invalid rank0 for B tensor.
     R = make_shared<opset5::Parameter>(element::f32, Shape{num_directions, hidden_size, hidden_size});
     B = make_shared<opset5::Parameter>(element::f32, PartialShape{});
-    ASSERT_THROW(make_shared<opset5::RNNSequence>(X, H_t, sequence_lengths, W, R, B, hidden_size, direction),
-                 ngraph::CheckFailure)
+    ASSERT_THROW(
+        const auto unused = make_shared<opset5::RNNSequence>(X, H_t, sequence_lengths, W, R, B, hidden_size, direction),
+        ngraph::CheckFailure)
         << "RNNSequence node was created with invalid data.";
 }
 

--- a/src/core/tests/type_prop/roi_align.cpp
+++ b/src/core/tests/type_prop/roi_align.cpp
@@ -37,7 +37,7 @@ TEST(type_prop_layers, roi_align_incompatible_num_rois) {
     const auto rois = make_shared<op::Parameter>(element::f32, PartialShape{1, Dimension{}});
     const auto batch_indices = make_shared<op::Parameter>(element::i32, Shape{2});
     // the first dimension of rois and batch_indices should be equal
-    ASSERT_THROW(make_shared<op::v3::ROIAlign>(data, rois, batch_indices, 3, 4, 1, 1.0f, "avg"),
+    ASSERT_THROW(const auto unused = make_shared<op::v3::ROIAlign>(data, rois, batch_indices, 3, 4, 1, 1.0f, "avg"),
                  ngraph::NodeValidationFailure);
 }
 
@@ -46,7 +46,7 @@ TEST(type_prop_layers, roi_align_incompatible_input_rank) {
     const auto rois = make_shared<op::Parameter>(element::f32, Shape{1, 4});
     const auto batch_indices = make_shared<op::Parameter>(element::i32, Shape{1});
     // data rank needs to be 4
-    ASSERT_THROW(make_shared<op::v3::ROIAlign>(data, rois, batch_indices, 3, 4, 1, 1.0f, "avg"),
+    ASSERT_THROW(const auto unused = make_shared<op::v3::ROIAlign>(data, rois, batch_indices, 3, 4, 1, 1.0f, "avg"),
                  ngraph::NodeValidationFailure);
 }
 
@@ -55,6 +55,6 @@ TEST(type_prop_layers, roi_align_incompatible_rois_second_dim) {
     const auto rois = make_shared<op::Parameter>(element::f32, Shape{1, 5});
     const auto batch_indices = make_shared<op::Parameter>(element::i32, Shape{1});
     // the second dim of rois needs to be 4
-    ASSERT_THROW(make_shared<op::v3::ROIAlign>(data, rois, batch_indices, 3, 4, 1, 1.0f, "avg"),
+    ASSERT_THROW(const auto unused = make_shared<op::v3::ROIAlign>(data, rois, batch_indices, 3, 4, 1, 1.0f, "avg"),
                  ngraph::NodeValidationFailure);
 }

--- a/src/core/tests/type_prop/roi_pooling.cpp
+++ b/src/core/tests/type_prop/roi_pooling.cpp
@@ -48,7 +48,7 @@ TEST(type_prop, roi_pooling_incompatible_input_rank) {
     const auto feat_maps = make_shared<op::Parameter>(element::f32, Shape{1, 3, 2, 6, 6});
     const auto rois = make_shared<op::Parameter>(element::f32, Shape{3, 5});
     // feat_maps must be of rank 4
-    ASSERT_THROW(make_shared<op::v0::ROIPooling>(feat_maps, rois, Shape{2, 2}, 0.625f, "max"),
+    ASSERT_THROW(const auto unused = make_shared<op::v0::ROIPooling>(feat_maps, rois, Shape{2, 2}, 0.625f, "max"),
                  ngraph::NodeValidationFailure);
 }
 
@@ -57,7 +57,7 @@ TEST(type_prop, roi_pooling_incompatible_pooling_shape) {
     const auto feat_maps = make_shared<op::Parameter>(element::f32, Shape{3, 2, 6, 6});
     const auto rois = make_shared<op::Parameter>(element::f32, Shape{3, 5});
     // pool_shape must be of rank 2 {pooled_h, pooled_w}
-    ASSERT_THROW(make_shared<op::v0::ROIPooling>(feat_maps, rois, pool_shape, 0.625f, "max"),
+    ASSERT_THROW(const auto unused = make_shared<op::v0::ROIPooling>(feat_maps, rois, pool_shape, 0.625f, "max"),
                  ngraph::NodeValidationFailure);
 }
 
@@ -65,7 +65,7 @@ TEST(type_prop, roi_pooling_incompatible_rois_second_dim) {
     const auto feat_maps = make_shared<op::Parameter>(element::f32, Shape{3, 2, 6, 6});
     const auto rois = make_shared<op::Parameter>(element::f32, Shape{3, 4});
     // the second dim of rois must be 5. [batch_id, x_1, y_1, x_2, y_2]
-    ASSERT_THROW(make_shared<op::v0::ROIPooling>(feat_maps, rois, Shape{2, 2}, 0.625f, "max"),
+    ASSERT_THROW(const auto unused = make_shared<op::v0::ROIPooling>(feat_maps, rois, Shape{2, 2}, 0.625f, "max"),
                  ngraph::NodeValidationFailure);
 }
 
@@ -73,7 +73,7 @@ TEST(type_prop, roi_pooling_incompatible_feature_maps_element_type) {
     const auto feat_maps = make_shared<op::Parameter>(element::i32, Shape{3, 2, 6, 6});
     const auto rois = make_shared<op::Parameter>(element::f32, Shape{3, 5});
     // feat_maps element type must be floating point type
-    ASSERT_THROW(make_shared<op::v0::ROIPooling>(feat_maps, rois, Shape{2, 2}, 0.625f, "max"),
+    ASSERT_THROW(const auto unused = make_shared<op::v0::ROIPooling>(feat_maps, rois, Shape{2, 2}, 0.625f, "max"),
                  ngraph::NodeValidationFailure);
 }
 
@@ -81,7 +81,7 @@ TEST(type_prop, roi_pooling_incompatible_rois_element_type) {
     const auto feat_maps = make_shared<op::Parameter>(element::f32, Shape{3, 2, 6, 6});
     const auto rois = make_shared<op::Parameter>(element::f16, Shape{3, 5});
     // rois element type must be equal to feat_maps element type (floating point type)
-    ASSERT_THROW(make_shared<op::v0::ROIPooling>(feat_maps, rois, Shape{2, 2}, 0.625f, "bilinear"),
+    ASSERT_THROW(const auto unused = make_shared<op::v0::ROIPooling>(feat_maps, rois, Shape{2, 2}, 0.625f, "bilinear"),
                  ngraph::NodeValidationFailure);
 }
 
@@ -89,7 +89,7 @@ TEST(type_prop, roi_pooling_invalid_pooling_method) {
     const auto feat_maps = make_shared<op::Parameter>(element::f32, Shape{3, 2, 6, 6});
     const auto rois = make_shared<op::Parameter>(element::f16, Shape{3, 5});
     // ROIPooling method is invalid: not max nor bilinear
-    ASSERT_THROW(make_shared<op::v0::ROIPooling>(feat_maps, rois, Shape{2, 2}, 0.625f, "invalid"),
+    ASSERT_THROW(const auto unused = make_shared<op::v0::ROIPooling>(feat_maps, rois, Shape{2, 2}, 0.625f, "invalid"),
                  ngraph::NodeValidationFailure);
 }
 
@@ -97,7 +97,7 @@ TEST(type_prop, roi_pooling_invalid_spatial_scale) {
     const auto feat_maps = make_shared<op::Parameter>(element::f32, Shape{3, 2, 6, 6});
     const auto rois = make_shared<op::Parameter>(element::f16, Shape{3, 5});
     // ROIPooling spatial scale attribute must be a positive floating point number
-    ASSERT_THROW(make_shared<op::v0::ROIPooling>(feat_maps, rois, Shape{2, 2}, -0.625f, "max"),
+    ASSERT_THROW(const auto unused = make_shared<op::v0::ROIPooling>(feat_maps, rois, Shape{2, 2}, -0.625f, "max"),
                  ngraph::NodeValidationFailure);
 }
 
@@ -105,6 +105,6 @@ TEST(type_prop, roi_pooling_invalid_pooled_size) {
     const auto feat_maps = make_shared<op::Parameter>(element::f32, Shape{3, 2, 6, 6});
     const auto rois = make_shared<op::Parameter>(element::f16, Shape{3, 5});
     // ROIPooling pooled_h and pooled_w must be non-negative integers
-    ASSERT_THROW(make_shared<op::v0::ROIPooling>(feat_maps, rois, Shape{1, 0}, 0.625f, "max"),
+    ASSERT_THROW(const auto unused = make_shared<op::v0::ROIPooling>(feat_maps, rois, Shape{1, 0}, 0.625f, "max"),
                  ngraph::NodeValidationFailure);
 }

--- a/src/core/tests/type_prop/softmax.cpp
+++ b/src/core/tests/type_prop/softmax.cpp
@@ -19,7 +19,7 @@ TEST(type_prop, softmax_out_of_bound_axis) {
     const Shape arg_shape{2, 3};
     auto arg = make_shared<op::Parameter>(element::f32, arg_shape);
     // axis cannot be a negative number
-    ASSERT_THROW(make_shared<op::v1::Softmax>(arg, -1), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = make_shared<op::v1::Softmax>(arg, -1), ngraph::NodeValidationFailure);
 }
 
 TEST(type_prop, softmax_8_default_axis) {
@@ -33,14 +33,14 @@ TEST(type_prop, softmax_8_out_of_bound_negative_axis) {
     const Shape arg_shape{2, 3};
     auto arg = make_shared<op::Parameter>(element::f32, arg_shape);
     // axis should be in range [-rank, rank - 1]
-    ASSERT_THROW(make_shared<op::v8::Softmax>(arg, -10), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = make_shared<op::v8::Softmax>(arg, -10), ngraph::NodeValidationFailure);
 }
 
 TEST(type_prop, softmax_8_out_of_bound_positive_axis) {
     const Shape arg_shape{2, 3};
     auto arg = make_shared<op::Parameter>(element::f32, arg_shape);
     // axis should be in range [-rank, rank - 1]
-    ASSERT_THROW(make_shared<op::v8::Softmax>(arg, 10), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = make_shared<op::v8::Softmax>(arg, 10), ngraph::NodeValidationFailure);
 }
 
 TEST(type_prop, softmax_8_positive_axis) {

--- a/src/core/tests/type_prop/swish.cpp
+++ b/src/core/tests/type_prop/swish.cpp
@@ -70,11 +70,11 @@ TEST(type_prop, swish_2_inputs) {
 TEST(type_prop, swish_incompatible_type_boolean) {
     auto data = make_shared<op::Parameter>(element::boolean, Shape{1, 3, 6});
     auto beta = make_shared<op::Parameter>(element::f32, Shape{});
-    ASSERT_THROW(make_shared<op::v4::Swish>(data, beta);, ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = make_shared<op::v4::Swish>(data, beta);, ngraph::NodeValidationFailure);
 }
 
 TEST(type_prop, swish_incompatible_types_u32) {
     auto data = make_shared<op::Parameter>(element::f32, Shape{1, 3, 6});
     auto beta = make_shared<op::Parameter>(element::u32, Shape{});
-    ASSERT_THROW(make_shared<op::v4::Swish>(data, beta);, ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = make_shared<op::v4::Swish>(data, beta);, ngraph::NodeValidationFailure);
 }

--- a/src/core/tests/type_prop/unary_ops.hpp
+++ b/src/core/tests/type_prop/unary_ops.hpp
@@ -3,82 +3,72 @@
 //
 
 #include <vector>
+
 #include "gtest/gtest.h"
 #include "ngraph/ngraph.hpp"
+
 
 using namespace ngraph;
 
 template <class T>
-class UnaryOperator : public testing::Test
-{
-};
+class UnaryOperator : public testing::Test {};
 
 TYPED_TEST_SUITE_P(UnaryOperator);
 
-TYPED_TEST_P(UnaryOperator, shape_inference_Shape1)
-{
+TYPED_TEST_P(UnaryOperator, shape_inference_Shape1) {
     auto param = std::make_shared<op::Parameter>(element::f32, Shape{2, 2});
     auto op = std::make_shared<TypeParam>(param);
     ASSERT_EQ(op->get_shape(), (Shape{2, 2}));
 }
-TYPED_TEST_P(UnaryOperator, shape_inference_Shape2)
-{
+TYPED_TEST_P(UnaryOperator, shape_inference_Shape2) {
     auto param = std::make_shared<op::Parameter>(element::i32, Shape{21, 15, 2});
     auto op = std::make_shared<TypeParam>(param);
     ASSERT_EQ(op->get_shape(), (Shape{21, 15, 2}));
 }
 
-TYPED_TEST_P(UnaryOperator, input_type_inference_F32)
-{
+TYPED_TEST_P(UnaryOperator, input_type_inference_F32) {
     auto param = std::make_shared<op::Parameter>(element::f32, Shape{10, 2, 2});
     auto op = std::make_shared<TypeParam>(param);
     ASSERT_EQ(op->get_element_type(), element::f32);
 }
 
-TYPED_TEST_P(UnaryOperator, input_type_inference_I64)
-{
+TYPED_TEST_P(UnaryOperator, input_type_inference_I64) {
     auto param = std::make_shared<op::Parameter>(element::i64, Shape{41, 28, 2});
     auto op = std::make_shared<TypeParam>(param);
     ASSERT_EQ(op->get_element_type(), element::i64);
 }
 
-TYPED_TEST_P(UnaryOperator, input_type_inference_U16)
-{
+TYPED_TEST_P(UnaryOperator, input_type_inference_U16) {
     auto param = std::make_shared<op::Parameter>(element::u16, Shape{100, 200, 7});
     auto op = std::make_shared<TypeParam>(param);
     ASSERT_EQ(op->get_element_type(), element::u16);
 }
 
-TYPED_TEST_P(UnaryOperator, incompatible_input_type_Shape1)
-{
+TYPED_TEST_P(UnaryOperator, incompatible_input_type_Shape1) {
     const auto param = std::make_shared<op::Parameter>(element::boolean, Shape{100, 2, 50});
-    ASSERT_THROW(std::make_shared<TypeParam>(param), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = std::make_shared<TypeParam>(param), ngraph::NodeValidationFailure);
 }
 
-TYPED_TEST_P(UnaryOperator, incompatible_input_type_Shape2)
-{
+TYPED_TEST_P(UnaryOperator, incompatible_input_type_Shape2) {
     const auto param = std::make_shared<op::Parameter>(element::boolean, Shape{40, 17, 50});
-    ASSERT_THROW(std::make_shared<TypeParam>(param), ngraph::NodeValidationFailure);
+    ASSERT_THROW(const auto unused = std::make_shared<TypeParam>(param), ngraph::NodeValidationFailure);
 }
 
-TYPED_TEST_P(UnaryOperator, dynamic_rank_input_shape_2D)
-{
+TYPED_TEST_P(UnaryOperator, dynamic_rank_input_shape_2D) {
     const PartialShape param_shape{Dimension::dynamic(), 10};
     const auto param = std::make_shared<op::Parameter>(element::f32, param_shape);
     const auto op = std::make_shared<TypeParam>(param);
     ASSERT_TRUE(op->get_output_partial_shape(0).same_scheme(PartialShape{Dimension(), 10}));
 }
 
-TYPED_TEST_P(UnaryOperator, dynamic_rank_input_shape_3D)
-{
+TYPED_TEST_P(UnaryOperator, dynamic_rank_input_shape_3D) {
     const PartialShape param_shape{100, Dimension::dynamic(), 58};
     const auto param = std::make_shared<op::Parameter>(element::f32, param_shape);
     const auto op = std::make_shared<TypeParam>(param);
     ASSERT_TRUE(op->get_output_partial_shape(0).same_scheme(PartialShape{100, Dimension(), 58}));
 }
 
-TYPED_TEST_P(UnaryOperator, dynamic_rank_input_shape_full)
-{
+TYPED_TEST_P(UnaryOperator, dynamic_rank_input_shape_full) {
     const auto param = std::make_shared<op::Parameter>(element::f64, PartialShape::dynamic());
     const auto op = std::make_shared<TypeParam>(param);
     ASSERT_TRUE(op->get_output_partial_shape(0).same_scheme(PartialShape::dynamic()));

--- a/src/inference/dev_api/memory_solver.hpp
+++ b/src/inference/dev_api/memory_solver.hpp
@@ -147,7 +147,7 @@ public:
                     for (auto* box_in_slot : time_slots[i_slot]) {
                         // intersect with already stored boxes for all covered time slots
                         // and move up the new one if needed
-                        popped_up |= popupTogetherWith(box, *box_in_slot);
+                        popped_up = popped_up || popupTogetherWith(box, *box_in_slot);
                     }
                 }
             } while (popped_up);

--- a/src/inference/include/ie/ie_allocator.hpp
+++ b/src/inference/include/ie/ie_allocator.hpp
@@ -61,7 +61,7 @@ public:
     virtual bool free(void* handle) noexcept = 0;
 
 protected:
-    ~IAllocator() = default;
+    virtual ~IAllocator() = default;
 };
 
 /**

--- a/src/plugins/intel_cpu/src/mkldnn_graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_graph_optimizer.cpp
@@ -1585,8 +1585,8 @@ void MKLDNNGraphOptimizer::FuseEltwiseAndSimple(MKLDNNGraph &graph) {
 
 void MKLDNNGraphOptimizer::DropDoubleReorders(MKLDNNGraph &graph) {
     std::set<MKLDNNNodePtr> processed;
-    int graphNodesSize = graph.GetNodes().size();
-    for (int i = 0; i < graphNodesSize; i++) {
+    std::size_t graphNodesSize = graph.GetNodes().size();
+    for (std::size_t i = 0; i < graphNodesSize; i++) {
         MKLDNNNodePtr& node = graph.GetNodes()[i];
         if (processed.find(node) == processed.end() && node->getType() == Reorder
             && node->getChildEdges().size() == 1

--- a/src/tests_deprecated/unit/engines/gna/matchers/weights_matcher.hpp
+++ b/src/tests_deprecated/unit/engines/gna/matchers/weights_matcher.hpp
@@ -97,7 +97,7 @@ class WeightsMatcher : public ::testing::MatcherInterface<const gna_nnet_type_t*
             return false;
         iterator.reset();
 
-        for(int i = 0; i < foo->nLayers; i++) {
+        for (uint32_t i = 0; i < foo->nLayers; i++) {
             if (foo->pLayers[i].nLayerKind != INTEL_AFFINE &&
                 foo->pLayers[i].nLayerKind != INTEL_AFFINE_DIAGONAL) continue;
 
@@ -156,7 +156,7 @@ class WeightsSizeMatcher : public ::testing::MatcherInterface<const gna_nnet_typ
 
         size_t sizeTotal = 0;
         std::stringstream ss;
-        for(int i = 0; i < foo->nLayers; i++) {
+        for(uint32_t i = 0; i < foo->nLayers; i++) {
             if (foo->pLayers[i].nLayerKind != INTEL_AFFINE && eMatchKind == eEqAffine) continue;
 
             auto affineWeightsSize = foo->pLayers[i].nOutputRows *
@@ -190,7 +190,7 @@ class WeightsSaver: public ::testing::MatcherInterface<const gna_nnet_type_t*> {
     bool MatchAndExplain(const gna_nnet_type_t *foo, ::testing::MatchResultListener *listener) const override {
         if (foo == nullptr)
             return false;
-        for(int i = 0; i < foo->nLayers; i++) {
+        for (uint32_t i = 0; i < foo->nLayers; i++) {
             if (foo->pLayers[i].nLayerKind != INTEL_AFFINE) continue;
 
             auto affine = (gna_affine_func_t*)foo->pLayers[i].pLayerStruct;


### PR DESCRIPTION
### Details:
 - ie_allocator.hpp: dtor was not virtual
 - fake_quantize_decomposition.cpp: lost return statements
 - std::make_shared: warning C4834: discarding return value of function with 'nodiscard' attribute
 - signed/unsigned mismatch
 - `|=` and `&=` is a bitwise operations, but operands `bool` (yeah, it will be conversion `bool` -> `int{1}` -> `bool`)
 - codestyle