### PR TITLE
Added telemetry to modules names list.

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/versions_checker.py
+++ b/tools/mo/openvino/tools/mo/utils/versions_checker.py
@@ -14,6 +14,7 @@ os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 modules = {
     "protobuf": "google.protobuf",
     "test-generator": "generator",
+    "openvino-telemetry": "openvino_telemetry"
 }
 critical_modules = ["networkx", "defusedxml", "numpy"]
 


### PR DESCRIPTION
Root cause analysis: 
During checking of telemetry version wrong module name is used which results in "package error" warning.

Solution: 
Add telemetry to module names dictionary.

Ticket: 76840


Code:
* [x]  Comments - N/A
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A
* [x]  Transformation preserves tensor names - N/A


Validation:
* [x]  Unit tests - N/A
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A