### PR TITLE
[CPU] Fixes for CpuBlockedMemoryDesc constructor and reorder availability checks 

### DIFF
--- a/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
@@ -8,25 +8,14 @@
 
 using namespace MKLDNNPlugin;
 
-CpuBlockedMemoryDesc::CpuBlockedMemoryDesc(InferenceEngine::Precision prc, const Shape& shape) : MemoryDesc(shape, Blocked), precision(prc) {
-    auto& dims = shape.getDims();
-    order.resize(dims.size());
-    std::iota(order.begin(), order.end(), 0);
-    blockedDims = dims;
-    offsetPadding = 0;
-    offsetPaddingToData.resize(dims.size(), 0);
-    if (shape.hasZeroDims()) {
-        strides.resize(order.size(), 0);
-    } else if (std::any_of(this->blockedDims.begin(), this->blockedDims.end(), [](size_t val) { return val == Shape::UNDEFINED_DIM; })) {
-        strides.resize(order.size(), Shape::UNDEFINED_DIM);
-    } else {
-        strides.resize(order.size());
-        strides.back() = 1;
-        for (size_t i = 2; i <= order.size(); i++) {
-            strides[order.size() - i] = strides[order.size() - (i - 1)] * blockedDims[blockedDims.size() - (i - 1)];
-        }
-    }
+static VectorDims makeRange(size_t size) {
+    VectorDims retVec(size, 0);
+    std::iota(retVec.begin(), retVec.end(), 0);
+    return retVec;
 }
+
+CpuBlockedMemoryDesc::CpuBlockedMemoryDesc(InferenceEngine::Precision prc, const Shape& shape) :
+    CpuBlockedMemoryDesc(prc, shape, shape.getDims(), makeRange(shape.getDims().size())) {}
 
 CpuBlockedMemoryDesc::CpuBlockedMemoryDesc(InferenceEngine::Precision prc, const Shape& shape, const VectorDims& blockedDims,
                   const VectorDims& order, size_t offsetPadding, const VectorDims& offsetPaddingToData,

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
@@ -15,11 +15,16 @@ CpuBlockedMemoryDesc::CpuBlockedMemoryDesc(InferenceEngine::Precision prc, const
     blockedDims = dims;
     offsetPadding = 0;
     offsetPaddingToData.resize(dims.size(), 0);
-    strides.resize(order.size());
-    // for empty tensor case we fill all strides with 0 values
-    strides[strides.size() - 1] = shape.hasZeroDims() ? 0 : 1;
-    for (size_t i = 2; i <= order.size(); i++) {
-        strides[strides.size() - i] = strides[strides.size() - (i - 1)] * blockedDims[blockedDims.size() - (i - 1)];
+    if (shape.hasZeroDims()) {
+        strides.resize(order.size(), 0);
+    } else if (std::any_of(this->blockedDims.begin(), this->blockedDims.end(), [](size_t val) { return val == Shape::UNDEFINED_DIM; })) {
+        strides.resize(order.size(), Shape::UNDEFINED_DIM);
+    } else {
+        strides.resize(order.size());
+        strides.back() = 1;
+        for (size_t i = 2; i <= order.size(); i++) {
+            strides[order.size() - i] = strides[order.size() - (i - 1)] * blockedDims[blockedDims.size() - (i - 1)];
+        }
     }
 }
 

--- a/src/plugins/intel_cpu/src/mkldnn_graph.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_graph.cpp
@@ -461,9 +461,11 @@ void MKLDNNGraph::ExecuteConstantNodesOnly() const {
 
 static bool isReorderAvailable(const MemoryDescPtr& parentDesc, const MemoryDescPtr& childDesc, const mkldnn::engine& eng) {
     auto definedParentDesc = parentDesc->isDefined() ? parentDesc : MemoryDescUtils::makeDummyDesc(*parentDesc);
+    memory::desc srcMemDesc = MemoryDescUtils::convertToDnnlMemoryDesc(definedParentDesc)->getDnnlDesc();
+
     auto definedChildDesc = childDesc->isDefined() ? childDesc : MemoryDescUtils::makeDummyDesc(*childDesc);
-    memory::desc dstMemDesc = MemoryDescUtils::convertToDnnlMemoryDesc(definedParentDesc)->getDnnlDesc();
-    memory::desc srcMemDesc = MemoryDescUtils::convertToDnnlMemoryDesc(definedChildDesc)->getDnnlDesc();
+    memory::desc dstMemDesc = MemoryDescUtils::convertToDnnlMemoryDesc(definedChildDesc)->getDnnlDesc();
+
     mkldnn::primitive_attr attr;
 
     dnnl_primitive_desc_t result = nullptr;


### PR DESCRIPTION
### Details:
This PR contains some fixes for CpuBlockedMemoryDesc constructor and isReorderAvailable routines induced by the introduction of dynamic shapes.