### PR TITLE
[Transformaitons] BatchNormDecomposition fix

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -176,6 +176,7 @@ bool ngraph::pass::MOCTransformations::run_on_model(const std::shared_ptr<ngraph
     multiply_fusions->add_matcher<ngraph::pass::MultiplyGroupConvolutionBackpropDataFusion>();
     multiply_fusions->add_matcher<ngraph::pass::MatMulMultiplyFusion>();
     multiply_fusions->set_name("ngraph::pass::MultiplyFusions");
+    manager.register_pass<ngraph::pass::ConstantFolding>();
 
     manager.register_pass<ngraph::pass::ReverseInputChannelsFusion>();
 

--- a/src/common/transformations/src/transformations/op_conversions/batch_norm_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/batch_norm_decomposition.cpp
@@ -12,6 +12,7 @@
 #include <ngraph/opsets/opset5.hpp>
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
+#include <transformations/utils/utils.hpp>
 
 using namespace ngraph;
 
@@ -51,9 +52,9 @@ ngraph::pass::BatchNormDecomposition::BatchNormDecomposition() {
 
         const auto& input_type = m_input.get_element_type();
         // scale_add = variance + eps
-        auto scale_add = make_shared<opset5::Add>(m_var, opset5::Constant::create(input_type, Shape{}, {eps}));
+        auto scale_add = std::make_shared<opset5::Add>(m_var, opset5::Constant::create(input_type, Shape{}, {eps}));
         // scale = sqrt(variance + eps)
-        auto scale = make_shared<opset5::Sqrt>(scale_add);
+        auto scale = std::make_shared<opset5::Sqrt>(scale_add);
         // Divide `gamma` by `sqrt(variance + eps)`
         auto gamma_div_scale = std::make_shared<opset5::Divide>(m_gamma, scale);
 
@@ -61,21 +62,35 @@ ngraph::pass::BatchNormDecomposition::BatchNormDecomposition() {
         const auto one = op::Constant::create(element::i64, Shape{1}, {1});
         const auto tail_shape_rank = op::Constant::create(element::i64, Shape{1}, {dims_to_add});
         const auto tail_shape = std::make_shared<opset5::Broadcast>(one, tail_shape_rank);
-        const auto C_dim = std::make_shared<opset5::ShapeOf>(m_gamma);
+        // WA: it's necessary to fold m_gamma shape to the constant
+        // to avoid using m_gamma output twice as divide input and shapeOf input
+        // because this will make it impossible to get constant from source
+        // (lower/upper bounds will be invalidated after the first pass through the m_gamma input)
+        const auto C_dim = ngraph::op::util::make_try_fold<opset5::ShapeOf>(m_gamma);
         // create new shape [1, C, 1, 1, ...]
         const auto new_shape = std::make_shared<opset5::Concat>(
             OutputVector{one, C_dim, tail_shape}, 0);
 
-        auto gamma_div_scale_aligned = make_shared<opset5::Reshape>(gamma_div_scale, new_shape, true);
-        auto beta_aligned = make_shared<opset5::Reshape>(m_beta, new_shape, true);
-        auto mean_aligned = make_shared<opset5::Reshape>(m_mean, new_shape, true);
+        std::shared_ptr<Node> gamma_div_scale_aligned = std::make_shared<opset5::Reshape>(gamma_div_scale, new_shape, true);
+        std::shared_ptr<Node> beta_aligned = std::make_shared<opset5::Reshape>(m_beta, new_shape, true);
+        std::shared_ptr<Node> mean_aligned = std::make_shared<opset5::Reshape>(m_mean, new_shape, true);
+        std::shared_ptr<Node> mean_negative = std::make_shared<opset5::Multiply>(
+            mean_aligned,
+            opset5::Constant::create(mean_aligned->get_output_element_type(0), Shape{}, {-1}));
 
-        // input_sub_mean = input - mean
-        auto input_sub_mean = register_new_node<opset5::Subtract>(m_input, mean_aligned);
+         if (auto constant = ov::get_constant_from_source(beta_aligned))
+             beta_aligned = constant;
+         if (auto constant = ov::get_constant_from_source(mean_negative))
+             mean_negative = constant;
+         if (auto constant = ov::get_constant_from_source(gamma_div_scale_aligned))
+             gamma_div_scale_aligned = constant;
+
+        // input_sub_mean = input + mean * -1
+        auto input_sub_mean = register_new_node<opset5::Add>(m_input, mean_negative);
         // Multiply  `input - mean` and `gamma / sqrt(variance + eps)`
-        auto mul = std::make_shared<opset5::Multiply>(input_sub_mean, gamma_div_scale_aligned);
+        auto mul = register_new_node<opset5::Multiply>(input_sub_mean, gamma_div_scale_aligned);
         // Add `(input - mean) * gamma / sqrt(variance + eps)` and `beta`
-        auto add = std::make_shared<opset5::Add>(mul, beta_aligned);
+        auto add = register_new_node<opset5::Add>(mul, beta_aligned);
 
         add->set_friendly_name(m_bn->get_friendly_name());
 

--- a/src/tests/functional/inference_engine/transformations/op_conversions/batch_norm_decompositoin.cpp
+++ b/src/tests/functional/inference_engine/transformations/op_conversions/batch_norm_decompositoin.cpp
@@ -6,10 +6,9 @@
 
 #include <string>
 #include <memory>
-#include <queue>
-
 #include <ngraph/function.hpp>
 #include <ngraph/opsets/opset1.hpp>
+#include <ngraph/opsets/opset5.hpp>
 #include <transformations/op_conversions/batch_norm_decomposition.hpp>
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>
@@ -18,7 +17,63 @@
 
 using namespace testing;
 
-TEST_F(TransformationTestsF, BatchNormDecompositionDynamic) {
+TEST_F(TransformationTestsF, BatchNormDecompositionStaticRankOpset1) {
+    const ngraph::PartialShape input_shape{-1, -1, -1, -1};
+    const auto precision = ngraph::element::f32;
+    {
+        auto input = std::make_shared<ngraph::opset1::Parameter>(precision, input_shape);
+        auto gamma = ngraph::opset1::Constant::create(precision, ngraph::Shape{3}, {3});
+        auto beta = ngraph::opset1::Constant::create(precision, ngraph::Shape{3}, {3});
+        auto mean = ngraph::opset1::Constant::create(precision, ngraph::Shape{3}, {3});
+        auto var = ngraph::opset1::Constant::create(precision, ngraph::Shape{3}, {3});
+        auto batch_norm = std::make_shared<ngraph::opset1::BatchNormInference>(input, gamma, beta, mean, var, 0.001);
+
+        function = std::make_shared<ngraph::Function>(ngraph::NodeVector{batch_norm}, ngraph::ParameterVector{input});
+        manager.register_pass<ngraph::pass::BatchNormDecomposition>();
+        comparator.enable(FunctionsComparator::CONST_VALUES);
+    }
+    {
+        auto input = std::make_shared<ngraph::opset1::Parameter>(precision, input_shape);
+        auto add_const_1 = ngraph::opset1::Constant::create(precision, {1, 3, 1, 1}, {-3});
+        auto add_1 = std::make_shared<ngraph::opset1::Add>(input, add_const_1);
+        auto mul_const = ngraph::opset1::Constant::create(precision, {1, 3, 1, 1}, {1.7317622900009155});
+        auto mul = std::make_shared<ngraph::opset1::Multiply>(add_1, mul_const);
+        auto add_const_2 = ngraph::opset1::Constant::create(precision, {1, 3, 1, 1}, {3});
+        auto add_2 = std::make_shared<ngraph::opset1::Add>(mul, add_const_2);
+
+        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{add_2}, ngraph::ParameterVector{input});
+    }
+}
+
+TEST_F(TransformationTestsF, BatchNormDecompositionStaticRankOpset5) {
+    const ngraph::PartialShape input_shape{-1, -1, -1, -1};
+    const auto precision = ngraph::element::f32;
+    {
+        auto input = std::make_shared<ngraph::opset1::Parameter>(precision, input_shape);
+        auto gamma = ngraph::opset1::Constant::create(precision, ngraph::Shape{3}, {3});
+        auto beta = ngraph::opset1::Constant::create(precision, ngraph::Shape{3}, {3});
+        auto mean = ngraph::opset1::Constant::create(precision, ngraph::Shape{3}, {3});
+        auto var = ngraph::opset1::Constant::create(precision, ngraph::Shape{3}, {3});
+        auto batch_norm = std::make_shared<ngraph::opset5::BatchNormInference>(input, gamma, beta, mean, var, 0.001);
+
+        function = std::make_shared<ngraph::Function>(ngraph::NodeVector{batch_norm}, ngraph::ParameterVector{input});
+        manager.register_pass<ngraph::pass::BatchNormDecomposition>();
+        comparator.enable(FunctionsComparator::CONST_VALUES);
+    }
+    {
+        auto input = std::make_shared<ngraph::opset1::Parameter>(precision, input_shape);
+        auto add_const_1 = ngraph::opset1::Constant::create(precision, {1, 3, 1, 1}, {-3});
+        auto add_1 = std::make_shared<ngraph::opset1::Add>(input, add_const_1);
+        auto mul_const = ngraph::opset1::Constant::create(precision, {1, 3, 1, 1}, {1.7317622900009155});
+        auto mul = std::make_shared<ngraph::opset1::Multiply>(add_1, mul_const);
+        auto add_const_2 = ngraph::opset1::Constant::create(precision, {1, 3, 1, 1}, {3});
+        auto add_2 = std::make_shared<ngraph::opset1::Add>(mul, add_const_2);
+
+        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{add_2}, ngraph::ParameterVector{input});
+    }
+}
+
+TEST_F(TransformationTestsF, BatchNormDecompositionDynamicRank) {
     {
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic());
         auto gamma = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3}, {3});
@@ -29,7 +84,6 @@ TEST_F(TransformationTestsF, BatchNormDecompositionDynamic) {
         broadcast->set_friendly_name("broadcast");
 
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{broadcast}, ngraph::ParameterVector{input});
-        function_ref = ngraph::clone_function(*function);
         manager.register_pass<ngraph::pass::BatchNormDecomposition>();
     }
 }


### PR DESCRIPTION
BatchNormDecomposition correction to prepare decomposed parts for further fusions:
 - *input_sub_mean calculation changed from `input - mean` to `input + mean * -1`*
 - *Added calculation of constants from subgraphs (`get_constant_from_source` method)*

### Tickets:
 - *78122*
 - *77064*
