### PR TITLE
Fix get_constant_from_source

### DIFF
--- a/src/core/src/validation_util.cpp
+++ b/src/core/src/validation_util.cpp
@@ -1271,7 +1271,7 @@ HostTensorPtr evaluate_bound(const Output<Node>& output, bool is_upper, bool inv
                         should_invalidate |= true;
                     if (tensor.get_upper_value() && shape_size(tensor.get_upper_value()->get_shape()) > 10)
                         should_invalidate |= true;
-                    if (should_invalidate)
+                    if (should_invalidate && input.get_target_inputs().size() == 1)
                         tensor.invalidate_values();
                 }
                 propagate_rt_info(node, output);

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -410,6 +410,7 @@ set(SRC
     visitors/op/unsqueeze.cpp
     visitors/op/variadic_split.cpp
     uint4.cpp
+    validation_utils.cpp
 )
 
 # For type relaxed types

--- a/src/core/tests/validation_utils.cpp
+++ b/src/core/tests/validation_utils.cpp
@@ -1,0 +1,36 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <openvino/core/type.hpp>
+#include <openvino/core/validation_util.hpp>
+#include <openvino/opsets/opset8.hpp>
+#include <openvino/util/common_util.hpp>
+
+TEST(get_constant_from_source, invalidation_check) {
+    auto a = ov::opset8::Constant::create(ov::element::i64, {100}, {123});
+    auto b = ov::opset8::Constant::create(ov::element::i64, {1}, {123});
+    auto div = std::make_shared<ov::opset8::Divide>(a, b);
+    auto s = std::make_shared<ov::opset8::ShapeOf>(a);
+    auto r = std::make_shared<ov::opset8::Reshape>(div, s, true);
+    auto tmp_consumer = std::make_shared<ov::opset8::ShapeOf>(s);
+
+    ASSERT_TRUE(ov::get_constant_from_source(r));
+
+    ASSERT_TRUE(r->get_output_tensor(0).get_lower_value());
+    ASSERT_TRUE(r->get_output_tensor(0).get_upper_value());
+
+    ASSERT_TRUE(s->get_output_tensor(0).get_lower_value());
+    ASSERT_TRUE(s->get_output_tensor(0).get_upper_value());
+
+    ASSERT_TRUE(b->get_output_tensor(0).get_lower_value());
+    ASSERT_TRUE(b->get_output_tensor(0).get_upper_value());
+
+    ASSERT_TRUE(a->get_output_tensor(0).get_lower_value());
+    ASSERT_TRUE(a->get_output_tensor(0).get_upper_value());
+
+    ASSERT_FALSE(div->get_output_tensor(0).get_lower_value());
+    ASSERT_FALSE(div->get_output_tensor(0).get_upper_value());
+}


### PR DESCRIPTION
### Description
Fixed `evaluate_bound` function to avoid bounds invalidation for cases when output has more than one consumer.

### Ticket
This problem was found in https://github.com/openvinotoolkit/openvino/pull/10310 
