### PR TITLE
[CPU] INT8 tests for convolution sum fusing

### DIFF
--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -1238,7 +1238,8 @@ void MKLDNNGraphOptimizer::FuseConvolutionSumAndConvolutionSumActivation(MKLDNNG
             // Merged with DW_conv. Shape may change
             mergedConv->inputShapes.push_back(mergedConv->fusedWith[0]->getOutputShapeAtPort(0));
         } else {
-            mergedConv->inputShapes.push_back(sum->getInputShapeAtPort(1));
+            size_t secondTermPort = sum->getFusingPort() == 0 ? 1 : 0;
+            mergedConv->inputShapes.push_back(sum->getInputShapeAtPort(secondTermPort));
         }
 
         size_t childIdx = 0lu;

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/conv_sum_broadcast.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/conv_sum_broadcast.cpp
@@ -205,7 +205,7 @@ TEST_P(ConcatConvSumInPlaceTestInt8, CompareWithRefs) {
 
     run();
 
-    CheckPluginRelatedResults(executableNetwork, "Convolution");
+    CheckPluginRelatedResults(compiledModel, "Convolution");
 }
 
 namespace {

--- a/src/tests/functional/plugin/cpu/subgraph_tests/src/conv_sum_broadcast.cpp
+++ b/src/tests/functional/plugin/cpu/subgraph_tests/src/conv_sum_broadcast.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "test_utils/cpu_test_utils.hpp"
+#include <ngraph_ops/type_relaxed.hpp>
 #include "test_utils/fusing_test_utils.hpp"
 #include "test_utils/convolution_params.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
@@ -60,6 +60,28 @@ public:
         return result.str();
     }
 
+    virtual ngraph::ParameterVector makeParams() {
+        return ngraph::builder::makeDynamicParams(ngraph::element::f32, inputDynamicShapes);
+    }
+
+    virtual std::shared_ptr<ngraph::Node> makeConv(const ngraph::ParameterVector& inputParams) {
+        auto conv = ngraph::builder::makeConvolution(inputParams[0], ngraph::element::f32, _kernel, _stride, _padBegin,
+                                                     _padEnd, _dilation, ngraph::op::PadType::EXPLICIT, _convOutChannels);
+
+        return conv;
+    }
+
+    virtual std::shared_ptr<ngraph::Node> addSum(std::shared_ptr<ngraph::Node> lastNode, const ngraph::ParameterVector& inputParams) {
+        auto sum = std::make_shared<ngraph::opset3::Add>(lastNode, inputParams[1]);
+
+        fusedOps.insert(fusedOps.begin(), "Add"); // as we always fuse the sum first
+        return sum;
+    }
+
+    virtual ov::element::Type getNetType() const {
+        return ov::element::Type_t::f32;
+    }
+
     void SetUp() override {
         InputShape convShape;
         InputShape secondShape;
@@ -75,38 +97,41 @@ public:
 
         init_input_shapes({convShape, secondShape});
 
-        const InferenceEngine::SizeVector kernel = {3, 3};
-        const InferenceEngine::SizeVector stride = {1, 1};
-        const InferenceEngine::SizeVector dilation = {1, 1};
-        const std::vector<ptrdiff_t> padBegin = {0, 0};
-        const std::vector<ptrdiff_t> padEnd = {0, 0};
-        const size_t convOutChannels = 64;
+        auto inputParams = makeParams();
 
-        auto netType = ngraph::element::f32;
-        auto inputParams = ngraph::builder::makeDynamicParams(netType, inputDynamicShapes);
+        auto conv = makeConv(inputParams);
 
-        auto conv = ngraph::builder::makeConvolution(inputParams[0], ngraph::element::f32, kernel, stride, padBegin,
-                                                     padEnd, dilation, ngraph::op::PadType::EXPLICIT, convOutChannels);
         if (bias) {
-            auto biasNode = ngraph::builder::makeConstant<float>(ngraph::element::Type_t::f32, ngraph::Shape({1, convOutChannels, 1, 1}), {}, true);
+            auto biasNode = ngraph::builder::makeConstant<float>(ngraph::element::Type_t::f32, ngraph::Shape({1, _convOutChannels, 1, 1}), {}, true);
             conv = std::make_shared<ngraph::opset3::Add>(conv, biasNode);
         }
 
-        auto sum = std::make_shared<ngraph::opset3::Add>(conv, inputParams[1]);
+        auto sum = addSum(conv, inputParams);
 
-        fusedOps.insert(fusedOps.begin(), "Add"); // as we always fuse the sum first
-
-        auto runtimeType = netType;
+        auto runtimeType = getNetType();
         if (configuration.count(PluginConfigParams::KEY_ENFORCE_BF16) &&
             PluginConfigParams::YES == configuration[PluginConfigParams::KEY_ENFORCE_BF16].as<std::string>()) {
             runtimeType = ngraph::element::Type_t::bf16;
         }
 
+        if (inputParams.front()->get_element_type() == ngraph::element::i8 || inputParams.front()->get_element_type() == ngraph::element::u8) {
+            runtimeType = ngraph::element::i8;
+        }
+
         selectedType = makeSelectedTypeStr(getPrimitiveType(), runtimeType);
 
-        function = makeNgraphFunction(netType, inputParams, sum, "ConvolutionSumBroadcast");
+        function = makeNgraphFunction(getNetType(), inputParams, sum, "ConvolutionSumBroadcast");
+
         targetDevice = CommonTestUtils::DEVICE_CPU;
     }
+
+protected:
+    const InferenceEngine::SizeVector _kernel = {3, 3};
+    const InferenceEngine::SizeVector _stride = {1, 1};
+    const InferenceEngine::SizeVector _dilation = {1, 1};
+    const std::vector<ptrdiff_t> _padBegin = {0, 0};
+    const std::vector<ptrdiff_t> _padEnd = {0, 0};
+    const size_t _convOutChannels = 64;
 };
 
 TEST_P(ConcatConvSumInPlaceTest, CompareWithRefs) {
@@ -115,6 +140,72 @@ TEST_P(ConcatConvSumInPlaceTest, CompareWithRefs) {
     run();
 
     CheckPluginRelatedResults(compiledModel, "Convolution");
+}
+
+class ConcatConvSumInPlaceTestInt8 : public ConcatConvSumInPlaceTest {
+public:
+    ngraph::ParameterVector makeParams() override {
+        ngraph::ParameterVector outs(2);
+        outs[0] = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::u8, inputDynamicShapes[0]);
+        outs[1] = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, inputDynamicShapes[1]);
+        return outs;
+    }
+
+    std::shared_ptr<ngraph::Node> makeConv(const ngraph::ParameterVector& inputParams) override {
+        using namespace ngraph;
+        auto inputParamsFP32 = builder::makeDynamicParams(element::f32, { inputParams.front()->get_partial_shape() });
+
+        auto convolutionNodeRelaxed = std::make_shared<op::TypeRelaxed<opset1::Convolution>>(
+                *as_type_ptr<opset1::Convolution>(builder::makeConvolution(inputParamsFP32.front(), element::f32, _kernel, _stride, _padBegin,
+                                                                          _padEnd, _dilation, ngraph::op::PadType::EXPLICIT, _convOutChannels)),
+                element::f32);
+
+        auto inpShape = inputParams.front()->get_partial_shape();
+        Shape filterShape = {_convOutChannels, static_cast<size_t>(inpShape[1].get_length())};
+        filterShape.insert(filterShape.end(), _kernel.begin(), _kernel.end());
+        auto filterWeightsNode = builder::makeConstant<int8_t>(element::i8, filterShape, {}, true);
+
+        auto conv = convolutionNodeRelaxed->copy_with_new_inputs({inputParams.front(), filterWeightsNode});
+
+        return conv;
+    }
+
+    std::shared_ptr<ngraph::Node> addSum(std::shared_ptr<ngraph::Node> lastNode, const ngraph::ParameterVector& inputParams) override {
+        std::vector<std::string> additionalFusedOps;
+
+        lastNode = ngraph::builder::makeActivation(lastNode, ngraph::element::f32, ngraph::helpers::Relu);
+        //additionalFusedOps.push_back("Relu");
+
+        auto fqShape = ngraph::Shape(lastNode->get_output_partial_shape(0).size(), 1);
+        lastNode = ngraph::builder::makeFakeQuantize(lastNode, ngraph::element::f32, 256, fqShape);
+        additionalFusedOps.push_back("FakeQuantize");
+
+        auto secondTerm = ngraph::builder::makeFakeQuantize(inputParams[1], ngraph::element::f32, 256, fqShape);
+
+        auto sum = std::make_shared<ngraph::opset3::Add>(lastNode, secondTerm);
+        additionalFusedOps.push_back("Add");
+
+        fusedOps.insert(fusedOps.begin(), additionalFusedOps.begin(), additionalFusedOps.end());
+        return sum;
+    }
+
+    void SetUp() override {
+        abs_threshold = 1.001f;
+        using ngraph::pass::ConvertPrecision;
+        ConcatConvSumInPlaceTest::SetUp();
+        functionRefs = ov::clone_model(*function);
+        ngraph::pass::ConvertPrecision<ngraph::element::Type_t::i8, ngraph::element::Type_t::f32>().run_on_function(functionRefs);
+        ngraph::pass::ConvertPrecision<ngraph::element::Type_t::u8, ngraph::element::Type_t::f32>().run_on_function(functionRefs);
+        functionRefs->validate_nodes_and_infer_types();
+    }
+};
+
+TEST_P(ConcatConvSumInPlaceTestInt8, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    run();
+
+    CheckPluginRelatedResults(executableNetwork, "Convolution");
 }
 
 namespace {
@@ -198,7 +289,6 @@ const std::vector<fusingSpecificParams> fusingParamsSet{
         fusingReluScaleShift,
         fusingMulAddFQMullAdd,
         fusingSigmoidFQFQ,
-//        fusingClampFQ // TODO: we need investigation, this particular pattern does not work even in static case
         fusingDivSubFQ
 };
 
@@ -248,6 +338,15 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_Sum_Broadcast_BF16, ConcatConvSumInPlaceTest
                                  ::testing::Values(true, false),
                                  ::testing::ValuesIn(fusingParamsSetBF16),
                                  ::testing::Values(cpuBF16PluginConfig)),
+                         ConcatConvSumInPlaceTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Conv_Sum_Broadcast_INT8, ConcatConvSumInPlaceTestInt8,
+                         ::testing::Combine(
+                                 ::testing::Values(convInpShape),
+                                 ::testing::Values(secondInp),
+                                 ::testing::Values(true, false),
+                                 ::testing::ValuesIn(fusingParamsSet),
+                                 ::testing::Values(cpuEmptyPluginConfig)),
                          ConcatConvSumInPlaceTest::getTestCaseName);
 
 } // namespace


### PR DESCRIPTION
### Details:
This is an addition to https://github.com/openvinotoolkit/openvino/pull/10235
Functional tests are extended with fusing sum into INT8 convolution, so that pattern with operations between the convolution and sum operations is tested.
