### PR TITLE
[GPU] Gemm tiled opt fix for minimal size of tile_n

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -60,17 +60,14 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
     auto total_batches = output.LogicalSize() / (output.X().v * output.Y().v);
     tuning_data.simd_size = 8;
 
-    if (n_size >= 8) {
-        tuning_data.tile_n_size = tuning_data.simd_size;
-
-        while (tuning_data.tile_n_size < 64 && n_size / (tuning_data.tile_n_size * 2) >= 1) {
-            tuning_data.tile_n_size *= 2;
-        }
+    tuning_data.tile_n_size = tuning_data.simd_size;
+    while (tuning_data.tile_n_size < 64 && n_size / (tuning_data.tile_n_size * 2) >= 1) {
+        tuning_data.tile_n_size *= 2;
     }
 
     // tuning_data.tile_k_size must be the same as simd_size when k % tile_k != 0
     tuning_data.tile_k_size = tuning_data.simd_size;
-    tuning_data.tile_m_size = 8;
+    tuning_data.tile_m_size = tuning_data.simd_size;
 
     bool leftovers = m_size % tuning_data.tile_m_size || k_size % tuning_data.tile_k_size || n_size % tuning_data.tile_n_size;
 
@@ -78,7 +75,7 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
         tuning_data.simd_size = 16;
         tuning_data.tile_n_size = tuning_data.simd_size;
         tuning_data.tile_k_size = tuning_data.simd_size;
-        tuning_data.tile_m_size = 16;
+        tuning_data.tile_m_size = tuning_data.simd_size;
     }
 
     return tuning_data;

--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/gemm/gemm_kernel_tiled_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/gemm/gemm_kernel_tiled_opt.h
@@ -16,7 +16,7 @@ public:
         size_t simd_size = 8;
         size_t tile_m_size = 1;
         size_t tile_k_size = 1;
-        size_t tile_n_size = 1;
+        size_t tile_n_size = 8;
     };
 
     GemmKernelTiledOpt() : GemmKernelBase("gemm_tiled_opt") {}


### PR DESCRIPTION
### Details:
 - _tile_n_ size inside _gemm_tiled_opt_ kernel should be >= than simd size, it significantly improves perf for small n sizes and prevents from division by zero in some cases

### Tickets:
 - *62373*
