### PR TITLE
Remove deprecated classes from openvino headers

### DIFF
--- a/src/core/include/ngraph/pass/graph_rewrite.hpp
+++ b/src/core/include/ngraph/pass/graph_rewrite.hpp
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <memory>
+#include <ngraph/log.hpp>
 #include <set>
 
 #include "ngraph/pass/pass.hpp"
@@ -21,6 +22,69 @@ namespace pass {
 using ov::pass::BackwardGraphRewrite;
 using ov::pass::GraphRewrite;
 using ov::pass::MatcherPass;
-using ov::pass::RecurrentGraphRewrite;
+
+class NGRAPH_DEPRECATED("Use MatcherPass or FunctionPass instead.") NGRAPH_API RecurrentGraphRewrite
+    : public FunctionPass {
+public:
+    RecurrentGraphRewrite(size_t num_iters = 10) : ModelPass(), m_num_iters(num_iters) {}
+
+    void add_matcher(const std::shared_ptr<pattern::RecurrentMatcher>& m,
+                     const ov::recurrent_graph_rewrite_callback& callback,
+                     const PassPropertyMask& property) {
+        NGRAPH_SUPPRESS_DEPRECATED_START
+        m_matchers.push_back(std::make_shared<MatcherPass>(
+            "Recurrent matcher",
+            nullptr,
+            [m, callback](const std::shared_ptr<Node>& node) {
+                NGRAPH_DEBUG << "Running recurrent matcher on " << node;
+                if (m->match(node->output(0))) {
+                    NGRAPH_DEBUG << "Recurrent matcher matched " << m.get();
+                    return callback(*m.get());
+                }
+                return false;
+            },
+            property));
+        NGRAPH_SUPPRESS_DEPRECATED_END
+    }
+
+    // TODO: This interface may deprecate after all passes are refactored.
+    void add_matcher(const std::shared_ptr<pattern::RecurrentMatcher>& m,
+                     const ov::recurrent_graph_rewrite_callback& callback) {
+        NGRAPH_SUPPRESS_DEPRECATED_START
+        // TODO: before deprecate this function, by default expect the
+        // callback require static shape.
+        add_matcher(m, callback, {PassProperty::REQUIRE_STATIC_SHAPE});
+        NGRAPH_SUPPRESS_DEPRECATED_END
+    }
+
+    bool run_on_model(const std::shared_ptr<ov::Model>& m) override {
+        NGRAPH_SUPPRESS_DEPRECATED_START
+        bool changed = false;
+        size_t i = 0;
+
+        auto run_matchers = [&]() -> bool {
+            for (const auto& node : m->get_ops()) {
+                for (auto& m_pass : m_matchers) {
+                    if (m_pass->apply(node)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        };
+
+        do {
+            changed = run_matchers();
+            i++;
+        } while (changed && i < m_num_iters);
+        return changed;
+        NGRAPH_SUPPRESS_DEPRECATED_END
+    }
+
+private:
+    size_t m_num_iters;
+
+    std::vector<std::shared_ptr<ov::pass::MatcherPass>> m_matchers;
+};
 }  // namespace pass
 }  // namespace ngraph

--- a/src/core/include/ngraph/pass/pass.hpp
+++ b/src/core/include/ngraph/pass/pass.hpp
@@ -25,8 +25,6 @@ class Manager;
 namespace ngraph {
 namespace pass {
 using FunctionPass = ov::pass::ModelPass;
-using ov::pass::FusionType;
-using ov::pass::FusionTypeMask;
 using ov::pass::Manager;
 using ov::pass::PassBase;
 using ov::pass::PassProperty;
@@ -40,5 +38,20 @@ public:
     ~NodePass() override;
     virtual bool run_on_node(std::shared_ptr<ngraph::Node>) = 0;
 };
+
+enum class NGRAPH_DEPRECATED("FusionType is no longer used anywhere. Please do no use it.") FusionType : uint32_t {
+    //`DIFFERENTIABLE_FUSIONS` produce ops that support autodiff
+    // i.e. implement `generate_adjoints`
+    DIFFERENTIABLE_FUSIONS = 0x1,
+    REGULAR_FUSIONS = 0x2,
+    //`FOP_FUSIONS` produce ops in the FusedOps category that might
+    // not be supported by all backends
+    FOP_FUSIONS = 0x4,
+    ALL_FUSIONS = 0xFFFFFFFF
+};
+
+NGRAPH_SUPPRESS_DEPRECATED_START
+using FusionTypeMask = ov::EnumMask<FusionType>;
+NGRAPH_SUPPRESS_DEPRECATED_END
 }  // namespace pass
 }  // namespace ngraph

--- a/src/core/include/openvino/pass/graph_rewrite.hpp
+++ b/src/core/include/openvino/pass/graph_rewrite.hpp
@@ -225,25 +225,5 @@ public:
 
     bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 };
-
-class OPENVINO_API RecurrentGraphRewrite : public ModelPass {
-public:
-    RecurrentGraphRewrite(size_t num_iters = 10) : ModelPass(), m_num_iters(num_iters) {}
-
-    void add_matcher(const std::shared_ptr<pattern::RecurrentMatcher>& m,
-                     const ov::recurrent_graph_rewrite_callback& callback,
-                     const PassPropertyMask& property);
-
-    // TODO: This interface may deprecate after all passes are refactored.
-    void add_matcher(const std::shared_ptr<pattern::RecurrentMatcher>& m,
-                     const ov::recurrent_graph_rewrite_callback& callback);
-
-    bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
-
-private:
-    size_t m_num_iters;
-
-    std::vector<std::shared_ptr<ov::pass::MatcherPass>> m_matchers;
-};
 }  // namespace pass
 }  // namespace ov

--- a/src/core/include/openvino/pass/pass.hpp
+++ b/src/core/include/openvino/pass/pass.hpp
@@ -100,17 +100,5 @@ private:
     bool call_on_model{false};
 };
 
-class Manager;
-enum class FusionType : uint32_t {
-    //`DIFFERENTIABLE_FUSIONS` produce ops that support autodiff
-    // i.e. implement `generate_adjoints`
-    DIFFERENTIABLE_FUSIONS = 0x1,
-    REGULAR_FUSIONS = 0x2,
-    //`FOP_FUSIONS` produce ops in the FusedOps category that might
-    // not be supported by all backends
-    FOP_FUSIONS = 0x4,
-    ALL_FUSIONS = 0xFFFFFFFF
-};
-using FusionTypeMask = ov::EnumMask<FusionType>;
 }  // namespace pass
 }  // namespace ov

--- a/src/core/tests/models/ir/conv_with_rt_info.xml
+++ b/src/core/tests/models/ir/conv_with_rt_info.xml
@@ -3,8 +3,14 @@
 	<layers>
 		<layer id="0" name="Parameter_69" type="Parameter" version="opset1">
 			<data shape="490, 608, 1, 1" element_type="f32" />
+			<rt_info>
+				<attribute name="custom_attr" version="0"/>
+			</rt_info>
 			<output>
 				<port id="0" precision="FP32">
+					<rt_info>
+						<attribute name="another_custom_attr" version="0"/>
+					</rt_info>
 					<dim>490</dim>
 					<dim>608</dim>
 					<dim>1</dim>

--- a/src/frontends/ir/src/ir_deserializer.cpp
+++ b/src/frontends/ir/src/ir_deserializer.cpp
@@ -755,7 +755,8 @@ std::shared_ptr<ngraph::Node> XmlDeserializer::createNode(
                     IE_THROW() << "Attribute: " << item.name() << " is not recognized as runtime attribute";
                 }
             } else {
-                IE_THROW() << "Attribute: " << item.name() << " is not recognized";
+                // As runtime attributes are optional, so we skip attribute if it is unknown to avoid exception
+                // when loading new IR with new attribute in old IE version.
             }
         }
     };

--- a/src/tests/functional/inference_engine/ir_serialization/rt_info_deserialization.cpp
+++ b/src/tests/functional/inference_engine/ir_serialization/rt_info_deserialization.cpp
@@ -802,8 +802,8 @@ TEST_F(RTInfoDeserialization, NodeV11MultipleRTKeys) {
         <layer name="in1" type="Parameter" id="0" version="opset8">
             <data element_type="f32" shape="1,22,22,3"/>
             <rt_info>
-                <attribute name="old_api_map" version="0" order="0,2,3,1" element_type="f16"/>
-                <attribute name="old_api_map" version="0" order="0,1,2,3" element_type="f32"/>
+                <attribute name="old_api_map_order" version="0" value="0,2,3,1"/>
+                <attribute name="old_api_map_order" version="0" value="0,1,2,3"/>
                 <attribute name="fused_names" version="0" value="in1"/>
             </rt_info>
             <output>
@@ -843,7 +843,7 @@ TEST_F(RTInfoDeserialization, NodeV11MultipleRTKeys) {
         </layer>
         <layer name="output" type="Result" id="2" version="opset8">
             <rt_info>
-                <attribute name="old_api_map" version="0" order="0,3,1,2" element_type="f16"/>
+                <attribute name="old_api_map_order" version="0" value="0,3,1,2"/>
             </rt_info>
             <input>
                 <port id="0" precision="FP32">


### PR DESCRIPTION
### Description
* Remove some useless facilities to ngraph from new openvino headers
* Removed exception for case when reading IR with unknown attribute 
