### PR TITLE
Correction for install guides

### DIFF
--- a/docs/install_guides/installing-openvino-linux.md
+++ b/docs/install_guides/installing-openvino-linux.md
@@ -9,7 +9,6 @@
 
   * Ubuntu 18.04.x long-term support (LTS), 64-bit
   * Ubuntu 20.04.x long-term support (LTS), 64-bit
-  * Red Hat Enterprise Linux 8.x, 64-bit
 
   .. note::
      Since the OpenVINO™ 2022.1 release, CentOS 7.6, 64-bit is not longer supported.

--- a/docs/install_guides/installing-openvino-macos.md
+++ b/docs/install_guides/installing-openvino-macos.md
@@ -66,10 +66,9 @@ This guide provides step-by-step instructions on how to install the Intel® Dist
 
    By default, the Intel® Distribution of OpenVINO™ is installed in the following directory, referred to as `<INSTALL_DIR>` elsewhere in the documentation:
 
-   * For root or administrator: `/opt/intel/openvino_<version>/`
-   * For regular users: `~/intel/openvino_<version>/`
+   `/opt/intel/openvino_<version>/`
 
-   For simplicity, a symbolic link to the latest installation is also created: `/opt/intel/openvino_2022/` or `~/intel/openvino_2022/`.
+   For simplicity, a symbolic link to the latest installation is also created: `/opt/intel/openvino_2022/`.
 
 To check **Release Notes** please visit: [Release Notes](https://software.intel.com/en-us/articles/OpenVINO-RelNotes).
 

--- a/docs/install_guides/uninstalling-openvino.md
+++ b/docs/install_guides/uninstalling-openvino.md
@@ -66,13 +66,13 @@
    
   .. code-block:: sh
   
-    /home/<user>/intel/openvino/installer/installer
+    /home/<user>/intel/openvino_installer/installer
 
   or in a case of administrative installation:
 
   .. code-block:: sh
 
-    /opt/intel/openvino/installer/installer
+    /opt/intel/openvino_installer/installer
 
   2. Follow the uninstallation wizard instructions.
   
@@ -82,7 +82,7 @@
    
   .. code-block:: sh
   
-    open /opt/intel/openvino/installer/installer.app
+    open /opt/intel/openvino_installer/installer.app
 
   2. Follow the uninstallation wizard instructions.
 


### PR DESCRIPTION
### Details:
- OpenVINO installer path for macOS
- Default install path on macOS
- Red Hat Enterprise Linux 8.x, 64-bit is not part of IRC installer

### Tickets:
 - *79264*
