### PR TITLE
[Coverity] Add nullptr check before dereferencing in InferRequest::GetBlob

### DIFF
--- a/src/inference/src/cpp/ie_infer_request.cpp
+++ b/src/inference/src/cpp/ie_infer_request.cpp
@@ -79,9 +79,9 @@ Blob::Ptr InferRequest::GetBlob(const std::string& name) {
     Blob::Ptr blobPtr;
     INFER_REQ_CALL_STATEMENT(blobPtr = _impl->GetBlob(name);)
     std::string error = "Internal error: blob with name `" + name + "` is not allocated!";
-    const bool remoteBlobPassed = blobPtr->is<RemoteBlob>();
     if (blobPtr == nullptr)
         IE_THROW() << error;
+    const bool remoteBlobPassed = blobPtr->is<RemoteBlob>();
     if (!remoteBlobPassed && blobPtr->buffer() == nullptr)
         IE_THROW() << error;
     return blobPtr;


### PR DESCRIPTION
### Details:
 - Fix coverity finding - move nullptr check before dereferencing
 - Even though it is not possible to hit into this situation using existing plugins - there is theoretical possibility that some plugin may return 'nullptr' as it is allowed.
- So this check shall remain in generic part which should not rely on plugin-specific behavior
- Test is not added as it is quite complicated to implement mock plugin which returns 'nullptr' on GetBlob just for such purposes

### Tickets:
 - 79239
