### PR TITLE
[CPU] [SANITIZER] Avoid possible stack-use-after-scope

### DIFF
--- a/src/plugins/intel_cpu/src/mkldnn_memory.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_memory.cpp
@@ -116,7 +116,7 @@ void MKLDNNMemory::FillZero() {
 
 void *MKLDNNMemory::GetPtr() const  {
     auto ptr = static_cast<uint8_t*>(GetData());
-    const auto& md = prim->get_desc().data;
+    const mkldnn_memory_desc_t md = prim->get_desc().data;
     mkldnn::impl::memory_desc_wrapper wrapper(md);
     ptr += wrapper.offset0() * wrapper.data_type_size();
     return ptr;

--- a/src/tests/unit/cpu/nodes/reorder_node_test.cpp
+++ b/src/tests/unit/cpu/nodes/reorder_node_test.cpp
@@ -28,12 +28,12 @@ public:
         bool inPlace;
         std::tie(srcDims, inPlace) = obj.param;
         std::ostringstream result;
-        result << "IS:(";
+        result << "IS=(";
         for (const auto s : srcDims)
             result << s << ".";
         result.seekp(-1, result.cur);
         result << ")";
-        result << "_InPlace:" << inPlace;
+        result << "_InPlace=" << inPlace;
         return result.str();
     }
 


### PR DESCRIPTION
Const & should extend the lifetime of the object.
But we still support old compilers (like for centos7)
which have issues with applying this rule.

Also taking by value is perfectly fine in this case
and generates basically the same assembly.

### Tickets:
    - 79079