### PR TITLE
[GNA] Fix static analyzer issues

### DIFF
--- a/src/plugins/intel_gna/gna_graph_tools.hpp
+++ b/src/plugins/intel_gna/gna_graph_tools.hpp
@@ -725,8 +725,6 @@ inline void CNNNetworkRemoveLayer(CNNLayerPtr layer, bool checkDims = true) {
  *    - new & old prev layer must have exactly one outgoing port
  */
 inline void CNNNetworkReconnectLayer(CNNLayerPtr old_prev_layer, CNNLayerPtr new_prev_layer, CNNLayerPtr layer, bool checkDims = true) {
-    gnalog() << "Reconnecting " << old_prev_layer->name << " --> " << layer->name << " layer to "
-        << new_prev_layer->name << " -- > " << layer->name << "layer\n";
     if (!layer) {
         IE_THROW() << "Cannot reconnect layer pointed to NULL";
     }
@@ -736,6 +734,9 @@ inline void CNNNetworkReconnectLayer(CNNLayerPtr old_prev_layer, CNNLayerPtr new
     if (!new_prev_layer) {
         IE_THROW() << "Cannot reconnect layer new parent is NULL";
     }
+
+    gnalog() << "Reconnecting " << old_prev_layer->name << " --> " << layer->name << " layer to "
+        << new_prev_layer->name << " -- > " << layer->name << "layer\n";
 
     if (layer->insData.size() < 1) {
         IE_THROW() << "Cannot reconnect layer : " << layer->name

--- a/src/plugins/intel_gna/optimizer/gna_pass_manager.cpp
+++ b/src/plugins/intel_gna/optimizer/gna_pass_manager.cpp
@@ -1954,11 +1954,11 @@ void FuseFQIntoWeightsPass::run() {
             auto& relatedInputs = getInputTo(prevLayer->outData[0]);
             auto relatedInputsIter = relatedInputs.begin();
             while (relatedInputsIter != relatedInputs.end()) {
-                auto prevIter = relatedInputsIter;
-                if (LayerInfo(prevIter->second).isFakeQuantize()) {
-                    relatedInputs.erase(prevIter);
+                if (LayerInfo(relatedInputsIter->second).isFakeQuantize()) {
+                    relatedInputsIter = relatedInputs.erase(relatedInputsIter);
+                } else {
+                    ++relatedInputsIter;
                 }
-                ++relatedInputsIter;
             }
 
             weightableLayer->insData.resize(1);

--- a/src/plugins/intel_gna/transformations/decompose_2d_convolution.cpp
+++ b/src/plugins/intel_gna/transformations/decompose_2d_convolution.cpp
@@ -314,7 +314,7 @@ static std::shared_ptr<ngraph::Node> Create1DConv(const GraphData& graph_data, c
         }
 
         // Max pooling
-        if ((graph_data.max_pool && graph_data.pool_size_width > 1) || graph_data.pool_stride_width > 1) {
+        if (graph_data.max_pool && (graph_data.pool_size_width > 1 || graph_data.pool_stride_width > 1)) {
             last_conv_block_op = std::make_shared<ngraph::opset7::MaxPool>(last_conv_block_op,
                 ngraph::Strides{1, graph_data.pool_stride_width}, ngraph::Shape{0, 0}, ngraph::Shape{0, 0},
                 ngraph::Shape{1, graph_data.pool_size_width}, graph_data.max_pool->get_rounding_type(), ngraph::op::PadType::VALID);

--- a/src/plugins/intel_gna/transformations/handle_transposes_around_matmul.cpp
+++ b/src/plugins/intel_gna/transformations/handle_transposes_around_matmul.cpp
@@ -90,7 +90,7 @@ bool VerifyReshape(const ngraph::Output<ngraph::Node>& reshape_out) {
 
 bool VerifyConcat(const ngraph::Output<ngraph::Node>& node) {
     auto concat_node = std::dynamic_pointer_cast<ngraph::opset8::Concat>(node.get_node_shared_ptr());
-    return (concat_node->get_axis() == 0);
+    return concat_node && (concat_node->get_axis() == 0);
 }
 
 } // namespace


### PR DESCRIPTION
### Details:
 - Fixed invalid nullptr check - `graph_data.max_pool` have to be non-null in both cases in `Create1DConv`
 - Moved logging in `CNNNetworkReconnectLayer` to prevent nullptr dereference
 - Fixed erasing from the `relatedInputs` map, because iterators may be invalidated. `std::erase` in `C++11` returns `Iterator following the last removed element`.
 - Fixed check in `bool VerifyConcat(const ngraph::Output<ngraph::Node>& node)` to prevent nullptr dereference

### Tickets:
 - 78822
 - 79233
