### PR TITLE
[MO] remove Pad fusing from model optimizer

### DIFF
--- a/tools/mo/openvino/tools/mo/middle/fusings.py
+++ b/tools/mo/openvino/tools/mo/middle/fusings.py
@@ -11,7 +11,6 @@ from openvino.tools.mo.middle.RemoveRedundantReshapes import RemoveRedundantResh
 from openvino.tools.mo.middle.pass_separator import PostMiddleStart
 from openvino.tools.mo.middle.quantize_fuses import MarkNodesToFuseUpToFakeQuantize, FakeQuantizeFuse
 from openvino.tools.mo.graph.graph import Graph
-from openvino.tools.mo.middle.passes.conv import fuse_pad
 from openvino.tools.mo.middle.passes.fusing.decomposition import convert_scale_shift_to_mul_add, convert_batch_norm
 from openvino.tools.mo.middle.passes.fusing.fuse_grouped_conv import grouped_convolutions_fusing
 from openvino.tools.mo.middle.passes.fusing.fuse_linear_ops import fuse_linear_ops
@@ -41,9 +40,6 @@ class Fusing(MiddleReplacementPattern):
         fw = graph.graph['fw']
         argv = graph.graph['cmd_params']
         layout = graph.graph['layout']
-
-        for_graph_and_each_sub_graph_recursively(graph, fuse_pad)
-        for_graph_and_each_sub_graph_recursively(graph, lambda G: G.clean_up())
 
         # Mark nodes with attr 'can_be_fused': False to disable fusing for specified nodes
         for_graph_and_each_sub_graph_recursively(graph, lambda graph: mark_unfused_nodes(graph, argv.finegrain_fusing))
@@ -93,9 +89,6 @@ class Fusing(MiddleReplacementPattern):
             AddFakeQuantizeFuse().find_and_replace_pattern(graph)
             MulFakeQuantizeFuse().find_and_replace_pattern(graph)
             for_graph_and_each_sub_graph_recursively(graph, lambda G: G.clean_up())
-
-        for_graph_and_each_sub_graph_recursively(graph, fuse_pad)
-        for_graph_and_each_sub_graph_recursively(graph, lambda G: G.clean_up())
 
         if layout != 'NHWC' and not argv.disable_resnet_optimization:
             stride_optimization(graph)


### PR DESCRIPTION
**Root cause analysis**: Pad fusion (fused pad+conv = conv{with_pads}) in MO with old port connection api cuted shapeof subgraph by mistake in lines [tools/mo/middle/passes/conv.py#L52-L53](https://github.com/openvinotoolkit/openvino/blob/master/tools/mo/openvino/tools/mo/middle/passes/conv.py#L52-L53).

**Solution**: It's possible to mark shape of subgraph as `can_be_fused=False` and use this attr in Pad fusing but such solution involves duplication. We already have the pass in offline transformation [common/transformations/src/transformations/common_optimizations/pad_fusion.cpp](https://github.com/openvinotoolkit/openvino/blob/master/src/common/transformations/src/transformations/common_optimizations/pad_fusion.cpp). 

We intend to keep optimization transformations instead of MO rather in ngraph, therefore I removed this transformation from MO. So for the network with padding values from shapeof subgraph remains correct, for other cases fusing will take place during offline transformations.

**Before Pad fusion**
![Screenshot 2022-02-15 121619](https://user-images.githubusercontent.com/5703039/154032134-944626c7-2bd7-4f04-9bb8-8ffc084a9d80.png)

**After Pad fusion**
![Screenshot 2022-02-15 121855](https://user-images.githubusercontent.com/5703039/154032140-904921b2-5b3a-4b66-a8d5-36f30cad8264.png)


Ticket: CVS-73874

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names

Validation:
* n/a  Unit tests: no new operations or transformation were added
* n/a  Framework operation tests: no new operations or transformation were added
* n/a  Transformation tests: no new operations or transformation were added
* [x]  Model Optimizer IR Reader check

Documentation:
* n/a  Supported frameworks operations list
* n/a Guide on how to convert the **public** model
* n/a  User guide update