### PR TITLE
[CPU][INT8] Input->Transpose->FQ optimisation

### DIFF
--- a/src/plugins/intel_cpu/src/mkldnn_graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_graph_optimizer.cpp
@@ -66,6 +66,10 @@ void MKLDNNGraphOptimizer::ApplyCommonGraphOptimizations(MKLDNNGraph &graph) {
     FuseMultiplyAndAdd(graph);
     graph.RemoveDroppedNodes();
 
+    OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "MergeConvertAndScaleShift");
+    MergeConvertAndScaleShift(graph);
+    graph.RemoveDroppedNodes();
+
     OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, "FuseDeconvolutionAndSimpleOperation");
     FuseDeconvolutionAndSimpleOperation(graph);
     graph.RemoveDroppedNodes();
@@ -448,6 +452,73 @@ void MKLDNNGraphOptimizer::FuseMultiplyAndAdd(MKLDNNGraph &graph) {
         parentNode->setTypeStr("MulAdd");
         parentNode->addOriginalLayer(childNode->getOriginalLayers());
         graph.DropNode(childNode);
+    }
+}
+
+void MKLDNNGraphOptimizer::MergeConvertAndScaleShift(MKLDNNGraph& graph) {
+    auto& graphNodes = graph.GetNodes();
+
+    auto isSuitableParentNode = [](MKLDNNNodePtr node) {
+        return node->getType() == Convert && node->getChildEdges().size() == 1 &&
+               (node->getOriginalInputPrecisionAtPort(0) == Precision::U8 ||
+                node->getOriginalInputPrecisionAtPort(0) == Precision::I8) &&
+               node->getOriginalOutputPrecisionAtPort(0) == Precision::FP32;
+    };
+
+    auto isSuitableChildNode = [](MKLDNNNodePtr node) {
+        return node->getType() == Eltwise;
+    };
+
+    auto parent = graphNodes.begin();
+    while (parent != graphNodes.end()) {
+        auto parentNode = *parent;
+        if (!isSuitableParentNode(parentNode)) {
+            parent++;
+            continue;
+        }
+
+        auto childNode = parentNode->getChildEdgeAt(0)->getChild();
+        if (!isSuitableChildNode(childNode)) {
+            parent++;
+            continue;
+        }
+
+        auto parents = parentNode->parentEdges;
+        for (size_t i = 0; i < parents.size(); i++) {
+            auto p_edge = parents[i].lock();
+            if (!p_edge) continue;
+            auto parent = p_edge->getParent();
+            if (!parent) continue;
+
+            if (!parentNode->childEdges[0].lock())
+                continue;
+            auto child = parentNode->childEdges[0].lock()->getChild();
+            if (!child)
+                continue;
+
+            MKLDNNEdgePtr& remEdge = p_edge;
+            int inNum = 0;
+            if (remEdge) {
+                inNum = remEdge->getInputNum();
+                remEdge->drop();
+                graph.RemoveEdge(remEdge);
+            }
+            remEdge = parentNode->childEdges[0].lock();
+            int outNum = 0;
+            if (remEdge) {
+                outNum = remEdge->getOutputNum();
+                remEdge->drop();
+                graph.RemoveEdge(remEdge);
+            }
+            MKLDNNEdgePtr newEdge(new MKLDNNEdge(parent, child, inNum, outNum));
+            auto& graphEdges = graph.GetEdges();
+            graphEdges.push_back(newEdge);
+            parent->addEdge(newEdge);
+        }
+
+        childNode->setOriginalInputPrecisionAtPort(0, parentNode->getOriginalInputPrecisionAtPort(0));
+        childNode->addOriginalLayer(parentNode->getOriginalLayers());
+        graph.DropNode(parentNode);
     }
 }
 

--- a/src/plugins/intel_cpu/src/mkldnn_graph_optimizer.h
+++ b/src/plugins/intel_cpu/src/mkldnn_graph_optimizer.h
@@ -22,6 +22,7 @@ private:
     void FuseConvolutionMatMulAndBias(MKLDNNGraph &graph);
     void FuseDeconvolutionAndSimpleOperation(MKLDNNGraph &graph);
     void FuseMultiplyAndAdd(MKLDNNGraph &graph);
+    void MergeConvertAndScaleShift(MKLDNNGraph& graph);
     void FuseFullyConnectedAndSimpleOperation(MKLDNNGraph &graph);
     void FuseMatMulAndSimpleOperation(MKLDNNGraph &graph);
     void FuseConvolutionAndSimpleOperationThroughMaxPool(MKLDNNGraph &graph);

--- a/src/plugins/intel_cpu/src/mkldnn_plugin.cpp
+++ b/src/plugins/intel_cpu/src/mkldnn_plugin.cpp
@@ -116,6 +116,7 @@
 #include "ngraph_transformations/convert_to_cpu_specific_opset.hpp"
 #include "ngraph_transformations/move_eltwise_up_data_movement.hpp"
 #include "transformations/smart_reshape/smart_reshape.hpp"
+#include "ngraph_transformations/swap_convert_transpose.hpp"
 
 #if !defined(__arm__) && !defined(_M_ARM) && !defined(__aarch64__) && !defined(_M_ARM64)
 # ifdef _WIN32
@@ -226,6 +227,7 @@ static void TransformationUpToCPUSpecificOpSet(const std::shared_ptr<ngraph::Fun
     manager.register_pass<ngraph::pass::Validate>();
     manager.register_pass<ngraph::pass::ConvertPrecision>(precisions);
     manager.register_pass<ngraph::pass::EliminateConvert>();
+    manager.register_pass<SwapConvertTranspose>();
 
     auto pass_config = manager.get_pass_config();
 

--- a/src/plugins/intel_cpu/src/ngraph_transformations/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/ngraph_transformations/snippets_mark_skipped.cpp
@@ -339,6 +339,9 @@ bool SnippetsMarkSkipped::run_on_model(const std::shared_ptr<ov::Model> &m) {
                     PropagateIfHasOnlyChild(node, updatedChainType);
             } else if (fusingChainType == NodeFusingType::IgnoredAfterInputs && snippets::pass::AppropriateForSubgraph(node)) {
                 SetNodeFusingType(node, NodeFusingType::IgnoredAfterInputs);
+            } else if (fusingChainType == NodeFusingType::IgnoredAfterInputs &&
+                       (ov::is_type<ngraph::opset1::Convert>(node) || ov::is_type<ngraph::opset1::Transpose>(node))) {
+                SetNodeFusingType(node, NodeFusingType::IgnoredAfterInputs);
             }
         }
         if (GetNodeFusingType(node) != NodeFusingType::NotSet) {

--- a/src/plugins/intel_cpu/src/ngraph_transformations/swap_convert_transpose.cpp
+++ b/src/plugins/intel_cpu/src/ngraph_transformations/swap_convert_transpose.cpp
@@ -1,0 +1,43 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "swap_convert_transpose.hpp"
+
+#include <ngraph/opsets/opset1.hpp>
+#include <ngraph/rt_info.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+
+NGRAPH_RTTI_DEFINITION(MKLDNNPlugin::SwapConvertTranspose, "SwapConvertTranspose", 0);
+
+MKLDNNPlugin::SwapConvertTranspose::SwapConvertTranspose() {
+    ngraph::element::TypeVector param_precisions{ ngraph::element::i8, ngraph::element::u8 };
+    auto input_m = ngraph::pattern::wrap_type<ngraph::opset1::Parameter>(ngraph::pattern::type_matches_any(param_precisions));
+    auto convert_m = ngraph::pattern::wrap_type<ngraph::opset1::Convert>({input_m}, ngraph::pattern::type_matches(ngraph::element::f32));
+    auto transpose_m = ngraph::pattern::wrap_type<ngraph::opset1::Transpose>({convert_m, ngraph::pattern::any_input()});
+
+    ngraph::matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
+        // Swap
+        // Input -> [i8/u8] -> Convert -> [f32] -> Transpose -> [f32]
+        // to
+        // Input -> [i8/u8] -> Transpose -> [i8/u8] -> Convert -> [f32]
+        const auto& pattern_map = m.get_pattern_value_map();
+        auto convert = pattern_map.at(convert_m).get_node_shared_ptr();
+        auto transpose = pattern_map.at(transpose_m).get_node_shared_ptr();
+
+        ngraph::OutputVector transposeInputs = transpose->input_values();
+        transposeInputs[0] = convert->input_value(0);
+        auto newTranspose = transpose->clone_with_new_inputs(transposeInputs);
+        ngraph::copy_runtime_info(transpose, newTranspose);
+        newTranspose->set_friendly_name(transpose->get_friendly_name());
+
+        ngraph::OutputVector convertInputs = convert->input_values();
+        convertInputs[0] = newTranspose;
+        auto newConvert = convert->clone_with_new_inputs(convertInputs);
+        ngraph::replace_node(transpose, newConvert);
+        return true;
+    };
+
+    auto m = std::make_shared<ngraph::pattern::Matcher>(transpose_m, "SwapConvertTranspose");
+    this->register_matcher(m, callback);
+}

--- a/src/plugins/intel_cpu/src/ngraph_transformations/swap_convert_transpose.hpp
+++ b/src/plugins/intel_cpu/src/ngraph_transformations/swap_convert_transpose.hpp
@@ -1,0 +1,17 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ngraph/pass/graph_rewrite.hpp>
+
+namespace MKLDNNPlugin {
+
+class SwapConvertTranspose : public ngraph::pass::MatcherPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    SwapConvertTranspose();
+};
+
+}  // namespace MKLDNNPlugin

--- a/src/plugins/intel_cpu/src/nodes/mkldnn_transpose_node.h
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_transpose_node.h
@@ -64,6 +64,7 @@ private:
     InferenceEngine::SizeVector order;
     InferenceEngine::Precision prec;
     bool isOptimized = false;
+    bool skipToExec = false;
 
     const std::vector<std::vector<size_t>> optimizedOrders = {
             std::vector<size_t>{0, 3, 1, 2},


### PR DESCRIPTION
### Details:
 1 *Swap Convert Transpose was made on a model input*
 2 *Ignoring Snippet after Input -> Transpose -> Convert*
 3 *Drop Convert I8->FP32 node before ScaleShift*
 4 *Remove waste Reorder in case 'Input -> Transpose -> FQ'*
