### PR TITLE
Fix the unnecessary calculation of blk_stride for dynamic shape

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/mkldnn_topk_node.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mkldnn_topk_node.cpp
@@ -99,7 +99,7 @@ struct jit_uni_topk_kernel_f32 : public jit_uni_topk_kernel, public jit_generato
             mov(reg_table, l_table);
 
         data_type = MKLDNNExtensionUtils::IEPrecisionToDataType(jcp_.precision);
-        if (jcp_.layout == TopKLayoutType::topk_blocked && jcp_.topk_innermost)
+        if (!shape_agnostic_alg && jcp_.layout == TopKLayoutType::topk_blocked && jcp_.topk_innermost)
             blk_stride = jcp_.sort_stride * jcp_.blk_size;
 
         if (jcp_.mode_max) {
@@ -209,7 +209,7 @@ private:
     const int tail = jcp_.work_amount % step;
     const int topk_tail = jcp_.top_k % step;
 
-    int blk_stride;       // stride of channel blocks at the same space coordinate, only used in blocked layout with topk on channel
+    int blk_stride = 0;    // stride of channel blocks at the same space coordinate, only used in blocked layout with topk on channel
     unsigned char cmp_flg;
     unsigned char heap_cmp_flg;
 


### PR DESCRIPTION
### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
