### PR TITLE
[LPT] Disable Move Fake Quantize on shuffle channels pattern

### DIFF
--- a/src/common/low_precision_transformations/include/low_precision/lstm_support.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/lstm_support.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <ngraph/ngraph.hpp>
+#include "low_precision/layer_transformation.hpp"
+
+namespace ngraph {
+namespace pass {
+namespace low_precision {
+
+class LP_TRANSFORMATIONS_API MoveFakeQuantize : public LayerTransformation {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    MoveFakeQuantize(const Params& params = Params());
+    bool transform(TransformationContext& context, ngraph::pattern::Matcher &m) override;
+    bool canBeTransformed(const TransformationContext& context, std::shared_ptr<Node> layer) const override;
+    bool isPrecisionPreserved(std::shared_ptr<Node> layer) const noexcept override;
+};
+
+} // namespace low_precision
+} // namespace pass
+} // namespace ngraph

--- a/src/common/low_precision_transformations/src/lstm_support.cpp
+++ b/src/common/low_precision_transformations/src/lstm_support.cpp
@@ -1,0 +1,190 @@
+﻿// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "low_precision/move_fake_quantize.hpp"
+
+#include <ngraph/pattern/op/wrap_type.hpp>
+#include <ngraph/opsets/opset1.hpp>
+
+#include <memory>
+#include <ngraph/node.hpp>
+#include <ngraph/opsets/opset1.hpp>
+#include <ngraph/pattern/op/or.hpp>
+
+#include "low_precision/concat.hpp"
+#include "low_precision/network_helper.hpp"
+/*
+namespace ngraph {
+namespace pass {
+namespace low_precision {
+
+NGRAPH_RTTI_DEFINITION(ngraph::pass::low_precision::MoveFakeQuantize, "MoveFakeQuantize", 0);
+
+MoveFakeQuantize::MoveFakeQuantize(const Params& params) : LayerTransformation(params) {
+    const auto concat = ngraph::pattern::wrap_type<opset1::Concat>(pattern::consumers_count(1));
+    const auto operation = ngraph::pattern::wrap_type<opset1::Relu>({ concat });
+    const auto input_low = ngraph::pattern::wrap_type<ngraph::opset1::Constant>();
+    const auto input_high = ngraph::pattern::wrap_type<ngraph::opset1::Constant>();
+    const auto output_low = ngraph::pattern::wrap_type<ngraph::opset1::Constant>();
+    const auto output_high = ngraph::pattern::wrap_type<ngraph::opset1::Constant>();
+    const auto fq_with_operation = ngraph::pattern::wrap_type<opset1::FakeQuantize>({ operation,
+        input_low,
+        input_high,
+        output_low,
+        output_high});
+    const auto fq = ngraph::pattern::wrap_type<opset1::FakeQuantize>({ concat,
+        input_low,
+        input_high,
+        output_low,
+        output_high });
+
+    ngraph::graph_rewrite_callback callback = [this](pattern::Matcher& m) {
+        auto op = m.get_match_root();
+        if (transformation_callback(op)) {
+            return false;
+        }
+
+        return transform(*context, m);
+    };
+
+    auto m = std::make_shared<ngraph::pattern::Matcher>(
+        std::make_shared<pattern::op::Or>(OutputVector{fq, fq_with_operation}),
+        "MoveFakeQuantize");
+    this->register_matcher(m, callback);
+}
+
+bool MoveFakeQuantize::transform(TransformationContext& context, ngraph::pattern::Matcher& m) {
+    const auto fq = m.get_match_root();
+    if (!canBeTransformed(context, fq)) {
+        return false;
+    }
+
+    const auto operation = fq->get_input_node_shared_ptr(0);
+    std::shared_ptr<ngraph::Node> concat;
+    bool without_operation = true;
+    const std::string fq_original_name = fq->get_friendly_name();
+    std::string operation_original_name;
+    if (is_type<opset1::Concat>(operation)) {
+        concat = operation;
+    } else {
+        operation_original_name = operation->get_friendly_name();
+        concat = operation->get_input_node_shared_ptr(0);
+        without_operation = false;
+    }
+
+    if (!ConcatTransformation::isQuantizedStatic(concat)) {
+        return false;
+    }
+
+    std::vector<std::shared_ptr<opset1::Constant>> curr_constants(4);
+    bool multi_chanels = false;
+    const auto concat_node = as_type_ptr<opset1::Concat>(concat);
+    if (concat_node == nullptr) {
+        return false;
+    }
+    const auto concat_axis = concat_node->get_concatenation_axis();
+    for (size_t i = 0; i < 4; i++) {
+        curr_constants[i] = as_type_ptr<opset1::Constant>(fq->get_input_node_shared_ptr(i + 1));
+        if (!multi_chanels && curr_constants[i]->get_shape().size() > concat_axis && curr_constants[i]->get_shape()[concat_axis] != 1) {
+            multi_chanels = true;
+        }
+    }
+
+    // it's impossible to split fq constants by channel if number of channels is dynamic
+    if (multi_chanels && fq->get_input_partial_shape(0)[concat_axis].is_dynamic()) {
+        return false;
+    }
+
+    std::vector<std::vector<std::shared_ptr<ngraph::opset1::Constant>>> new_constants;
+    if (multi_chanels) {
+        new_constants = NetworkHelper::splitConstantsBeforeConcat(concat, curr_constants);
+    }
+
+    const auto convert_q = fq->get_output_target_inputs(0).begin()->get_node()->shared_from_this();
+    if (convert_q == nullptr) {
+        return false;
+    }
+
+    const bool q_dq = is_type<opset1::Convert>(convert_q);
+    std::vector<std::shared_ptr<ngraph::Node>> newNodes;
+    for (size_t i = 0; i < concat->get_input_size(); ++i) {
+        ov::Output<ov::Node> parent_output;
+        if (without_operation) {
+            parent_output = concat->get_input_source_output(i);
+        } else {
+            auto fq_input = operation->clone_with_new_inputs({concat->get_input_source_output(i)});
+            fq_input->set_friendly_name(operation_original_name + "_" + std::to_string(i + 1));
+            parent_output = fq_input->output(0);
+        }
+
+        const std::shared_ptr<ngraph::Node> new_fq = multi_chanels ?
+            fq->clone_with_new_inputs({parent_output,
+                new_constants[0][new_constants[0].size() == 1 ? 0 : i],
+                new_constants[1][new_constants[1].size() == 1 ? 0 : i],
+                new_constants[2][new_constants[2].size() == 1 ? 0 : i],
+                new_constants[3][new_constants[3].size() == 1 ? 0 : i] }) :
+            fq->clone_with_new_inputs({parent_output,
+                fq->get_input_node_ptr(1)->clone_with_new_inputs({}),
+                fq->get_input_node_ptr(2)->clone_with_new_inputs({}),
+                fq->get_input_node_ptr(3)->clone_with_new_inputs({}),
+                fq->get_input_node_ptr(4)->clone_with_new_inputs({}) });
+
+        ngraph::copy_runtime_info(fq, new_fq);
+        new_fq->set_friendly_name(fq_original_name + "_" + std::to_string(i + 1));
+        if (q_dq) {
+            auto new_convert_q = convert_q->clone_with_new_inputs({new_fq});
+            ngraph::copy_runtime_info(convert_q, new_convert_q);
+            new_convert_q->set_friendly_name(convert_q->get_friendly_name() + "_" + std::to_string(i + 1));
+            newNodes.push_back(new_convert_q);
+        } else {
+            newNodes.push_back(new_fq);
+        }
+    }
+
+    auto newConcat = concat->clone_with_new_inputs(ngraph::OutputVector(newNodes.begin(), newNodes.end()));
+    newConcat->set_friendly_name(concat->get_friendly_name());
+    NetworkHelper::copyInfo(concat, newConcat);
+    if (q_dq) {
+        auto dq = NetworkHelper::getDequantizationBelow(convert_q);
+        moveDequantizationBefore(context, newConcat, dq, false);
+        return true;
+    }
+    replace_node(fq, newConcat);
+    updateOutput(context, newConcat, fq);
+
+    return true;
+}
+
+bool MoveFakeQuantize::canBeTransformed(const TransformationContext& context, std::shared_ptr<Node> layer) const {
+    auto operation = layer->get_input_node_shared_ptr(0);
+    std::shared_ptr<ngraph::Node> concat;
+    if (is_type<opset1::Concat>(operation)) {
+        concat = operation;
+    } else {
+        concat = operation->get_input_node_shared_ptr(0);
+    }
+    if (!ConcatTransformation::isQuantizedStatic(concat)) {
+        return false;
+    }
+    const auto convert_q_target_inputs = layer->output(0).get_target_inputs();
+    if (convert_q_target_inputs.empty()) {
+        return false;
+    }
+    const auto convert_q = convert_q_target_inputs.begin()->get_node()->shared_from_this();
+    bool q_dq = is_type<opset1::Convert>(convert_q);
+    if (q_dq && (convert_q->get_output_size() != 1 || layer->get_output_size() != 1)) {
+        return false;
+    }
+    return true;
+}
+
+bool MoveFakeQuantize::isPrecisionPreserved(std::shared_ptr<Node>) const noexcept {
+    return true;
+}
+
+} // namespace low_precision
+} // namespace pass
+} // namespace ngraph
+
+*/

--- a/src/common/low_precision_transformations/src/move_fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/move_fake_quantize.cpp
@@ -176,6 +176,19 @@ bool MoveFakeQuantize::canBeTransformed(const TransformationContext& context, st
     if (q_dq && (convert_q->get_output_size() != 1 || layer->get_output_size() != 1)) {
         return false;
     }
+    auto input = concat->get_input_node_ptr(0);
+    if (is_type<opset1::Split>(concat->get_input_node_ptr(0))) {
+        bool only_split = true;
+        const size_t id = concat->get_input_node_ptr(0)->get_instance_id();
+        for (size_t i = 1; i < concat->get_input_size(); ++i) {
+            if (concat->get_input_node_ptr(i)->get_instance_id() != id) {
+                only_split = false;
+            }
+        }
+        if (only_split) {
+            return false;
+        }
+    }
     return true;
 }
 

--- a/src/tests/functional/inference_engine/lp_transformations/lstm_support_transformation.cpp
+++ b/src/tests/functional/inference_engine/lp_transformations/lstm_support_transformation.cpp
@@ -1,0 +1,251 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <low_precision/common/operation_per_tensor_quantization_restriction.hpp>
+#include <low_precision/common/operation_precision_restriction.hpp>
+#include <low_precision/concat.hpp>
+#include <low_precision/fake_quantize_decomposition.hpp>
+#include <low_precision/fuse_multiply_to_fake_quantize.hpp>
+#include <low_precision/fuse_subtract_to_fake_quantize.hpp>
+#include <low_precision/rt_info/intervals_alignment_attribute.hpp>
+#include <low_precision/rt_info/precision_preserved_attribute.hpp>
+#include <low_precision/rt_info/quantization_alignment_attribute.hpp>
+#include <memory>
+#include <sstream>
+#include <vector>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include "layer_transformation.hpp"
+#include "lpt_ngraph_functions/common/builders.hpp"
+#include "lpt_ngraph_functions/common/fake_quantize_on_data.hpp"
+#include "lpt_ngraph_functions/lstm_function.hpp"
+#include "simple_low_precision_transformer.hpp"
+
+using namespace testing;
+using namespace ngraph;
+using namespace ngraph::pass;
+using namespace ngraph::builder::subgraph;
+
+namespace {
+
+class LSTMTransformationActualValues {
+public:
+    std::vector<ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant> fakeQuantizes;
+    std::vector<ngraph::builder::subgraph::DequantizationOperations::Convert> converts;
+    std::vector<ngraph::builder::subgraph::DequantizationOperations> dequantizations;
+};
+
+inline std::ostream& operator<<(std::ostream& out, const LSTMTransformationActualValues& values) {
+    return out << "_" << values.fakeQuantizes[0] << "_" << values.converts[0].outPrecision << "_"
+               << values.dequantizations[0];
+}
+
+class LSTMTransformationResultValues {
+public:
+    std::vector<ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant> fakeQuantizes;
+    std::vector<ngraph::builder::subgraph::DequantizationOperations::Convert> converts;
+    std::vector<ngraph::builder::subgraph::DequantizationOperations> dequantizations;
+    ngraph::element::Type precisionAfterOperation;
+    ngraph::builder::subgraph::DequantizationOperations dequantizationAfter;
+};
+
+inline std::ostream& operator<<(std::ostream& out, const LSTMTransformationResultValues& values) {
+    return out << "_" << values.fakeQuantizes[0] << "_" << values.converts[0].outPrecision << "_"
+               << values.dequantizations[0];
+}
+
+class LSTMTransformationTestValues {
+public:
+    LSTMTransformationTestValues() = default;
+    LSTMTransformationTestValues(const TestTransformationParams& params,
+                                 const bool multiChannels,
+                                 const std::int64_t axis,
+                                 const LSTMTransformationActualValues& actual,
+                                 const LSTMTransformationResultValues& result,
+                                 const bool addNotPrecisionPreservedOperation = false,
+                                 const bool checkIntervalsAlignmentAttributes = true)
+        : params(params),
+          multiChannels(multiChannels),
+          axis(axis),
+          actual(actual),
+          result(result),
+          addNotPrecisionPreservedOperation(addNotPrecisionPreservedOperation),
+          checkIntervalsAlignmentAttributes(checkIntervalsAlignmentAttributes) {}
+
+    TestTransformationParams params;
+    bool multiChannels;
+    std::int64_t axis;
+    LSTMTransformationActualValues actual;
+    LSTMTransformationResultValues result;
+    // add not precision preserved operation to set output precision for FakeQuantize
+    // don't set to 'true' by default to keep test cases with tested operation as output
+    bool addNotPrecisionPreservedOperation;
+    bool checkIntervalsAlignmentAttributes;
+};
+
+inline std::ostream& operator<<(std::ostream& out, const LSTMTransformationTestValues& values) {
+    return out << "_" << values.multiChannels << "_" << values.actual << "_" << values.result;
+}
+
+typedef std::tuple<ngraph::element::Type, std::vector<ngraph::PartialShape>, LSTMTransformationTestValues>
+    LSTMTransformationParams;
+
+class LSTMTransformation : public LayerTransformation, public testing::WithParamInterface<LSTMTransformationParams> {
+public:
+    void SetUp() override {
+        const ngraph::element::Type precision = std::get<0>(GetParam());
+        const std::vector<ngraph::PartialShape> shapes = std::get<1>(GetParam());
+        LSTMTransformationTestValues testValues = std::get<2>(GetParam());
+
+        // dequantization output precision depends on input precision
+        // to avoid huge amount of tests cases let's define dequantization output precision as input precision
+        /*if (!testValues.actual.dequantization1.multiply.empty()) {
+            testValues.actual.dequantization1.multiply.outPrecision = precision;
+        }
+        if (!testValues.actual.dequantization2.multiply.empty()) {
+            testValues.actual.dequantization2.multiply.outPrecision = precision;
+        }*/
+
+        actualFunction = ngraph::builder::subgraph::LSTMFunction::get(precision,
+                                                                      shapes,
+                                                                      testValues.actual.fakeQuantizes,
+                                                                      testValues.actual.converts,
+                                                                      testValues.actual.dequantizations,
+                                                                      {},
+                                                                      ngraph::element::undefined,
+                                                                      {});
+        ngraph::pass::VisualizeTree("C:\\Users\\ndemasho\\rep\\Visual\\test.actual.dot")
+            .run_on_function(actualFunction);
+        auto supportedPrecisionsOnActivation = std::vector<ngraph::pass::low_precision::OperationPrecisionRestriction>(
+            {ngraph::pass::low_precision::OperationPrecisionRestriction::create<ngraph::opset1::AvgPool>(
+                {{0, testValues.params.precisionsOnActivations}})});
+
+        auto quantizationRestrictions =
+            testValues.multiChannels
+                ? std::vector<ngraph::pass::low_precision::OperationPerTensorQuantizationRestriction>()
+                : std::vector<ngraph::pass::low_precision::OperationPerTensorQuantizationRestriction>(
+                      {ngraph::pass::low_precision::OperationPerTensorQuantizationRestriction::create<
+                          ngraph::opset1::AvgPool>()});
+
+        const auto params = TestTransformationParams::toParams(testValues.params);
+        SimpleLowPrecisionTransformer transformer(supportedPrecisionsOnActivation, quantizationRestrictions);
+        transformer.commonGraphRewrite
+            ->add_matcher<ngraph::pass::low_precision::FakeQuantizeDecompositionTransformation>(params);
+        transformer.commonGraphRewrite->add_matcher<ngraph::pass::low_precision::ConcatTransformation>(params);
+        transformer.transform(actualFunction);
+        ngraph::pass::VisualizeTree("C:\\Users\\ndemasho\\rep\\Visual\\test.transform.dot")
+            .run_on_function(actualFunction);
+        {
+            ngraph::pass::Manager standaloneCleanupManager;
+            standaloneCleanupManager
+                .register_pass<ngraph::pass::low_precision::FuseSubtractToFakeQuantizeTransformation>();
+            standaloneCleanupManager.run_passes(actualFunction);
+        }
+
+        {
+            ngraph::pass::Manager standaloneCleanupManager;
+            standaloneCleanupManager
+                .register_pass<ngraph::pass::low_precision::FuseMultiplyToFakeQuantizeTransformation>();
+            standaloneCleanupManager.run_passes(actualFunction);
+        }
+
+        // dequantization output precision depends on input precision
+        // to avoid huge amount of tests cases let's define dequantization output precision as input precision
+        if (!testValues.result.dequantizationAfter.multiply.empty()) {
+            testValues.result.dequantizationAfter.multiply.outPrecision = precision;
+        }
+
+        if (!testValues.params.updatePrecisions && (precision == ngraph::element::f32) &&
+            !testValues.result.dequantizationAfter.convert.empty()) {
+            testValues.result.dequantizationAfter.convert = {};
+        }
+
+        IntervalsAlignmentSharedValue::Interval interval{-1.28f, 2.55f};
+
+        referenceFunction = ngraph::builder::subgraph::LSTMFunction::get(precision,
+                                                                         shapes,
+                                                                         testValues.result.fakeQuantizes,
+                                                                         testValues.result.converts,
+                                                                         testValues.result.dequantizations,
+                                                                         {PrecisionPreservedAttribute(true),
+                                                                          IntervalsAlignmentAttribute(interval, 256),
+                                                                          QuantizationAlignmentAttribute(false)},
+                                                                         testValues.result.precisionAfterOperation,
+                                                                         testValues.result.dequantizationAfter);
+        ngraph::pass::VisualizeTree("C:\\Users\\ndemasho\\rep\\Visual\\test.reference.dot")
+            .run_on_function(referenceFunction);
+    }
+
+    static std::string getTestCaseName(testing::TestParamInfo<LSTMTransformationParams> obj) {
+        const ngraph::element::Type precision = std::get<0>(obj.param);
+        const std::vector<ngraph::PartialShape> shapes = std::get<1>(obj.param);
+        const LSTMTransformationTestValues testValues = std::get<2>(obj.param);
+
+        std::ostringstream result;
+        result << LayerTransformation::getTestCaseNameByParams(precision, shapes[0], testValues.params) << "_"
+               << (testValues.multiChannels ? "multiChannels_" : "notMultiChannels_") << "axis_" << testValues.axis
+               << "_" << testValues.actual << "_" << testValues.result << "_";
+        return result.str();
+    }
+};
+
+TEST_P(LSTMTransformation, CompareFunctions) {
+    actualFunction->validate_nodes_and_infer_types();
+    auto res = compare_functions(actualFunction, referenceFunction, true, true, false, true, false);
+    ASSERT_TRUE(res.first) << res.second;
+
+    ASSERT_TRUE(LayerTransformation::allNamesAreUnique(actualFunction)) << "Not all names are unique";
+
+    LSTMTransformationTestValues testValues = std::get<2>(GetParam());
+    const auto actualFakeQuantizes = LayerTransformation::get<opset1::FakeQuantize>(actualFunction);
+    if (testValues.axis == 1) {
+        ASSERT_TRUE(checkIfOutputAttributesSharedValuesAreTheSame<PrecisionsAttribute>(actualFakeQuantizes))
+            << "PrecisionsAttribute are not the same";
+
+        if (testValues.checkIntervalsAlignmentAttributes) {
+            auto operations = LayerTransformation::get<opset1::Concat>(actualFunction);
+            operations.insert(operations.end(), actualFakeQuantizes.begin(), actualFakeQuantizes.end());
+            ASSERT_TRUE(checkIfAttributesSharedValuesAreTheSame<IntervalsAlignmentAttribute>(operations))
+                << "IntervalsAlignmentAttribute are not the same";
+        }
+    }
+}
+
+const std::vector<ngraph::element::Type> precisions = {
+    ngraph::element::f32,
+    // ngraph::element::f16
+};
+
+namespace testValues1 {
+const std::vector<std::vector<ngraph::PartialShape>> shapes = {{{1, 16}, {1, 128}, {1, 128}}};
+
+const std::vector<LSTMTransformationTestValues> testValues = {
+    {LayerTransformation::createParamsU8I8(),
+     true,
+     1,
+     {{{256ul, {}, {0.f}, {2550.f}, {0.f}, {2550.f}}}, {{}}, {{}}},
+     {{{256ul,
+        {},
+        {0.f},
+        {2550.f},
+        {0.f},
+        {255.f},
+        ngraph::element::u8,
+        {IntervalsAlignmentAttribute(IntervalsAlignmentSharedValue::Interval{0.f, 2.55f}, 256ul)}}},
+      {{}},
+      {{}}},
+     true},
+};
+INSTANTIATE_TEST_SUITE_P(
+    smoke_LPT,
+    LSTMTransformation,
+    ::testing::Combine(
+        ::testing::ValuesIn(precisions),
+        ::testing::ValuesIn(shapes),
+        ::testing::ValuesIn(testValues)),
+    LSTMTransformation::getTestCaseName);
+}  // namespace testValues1
+}  // namespace

--- a/src/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/lstm_function.hpp
+++ b/src/tests/ngraph_helpers/lpt_ngraph_functions/include/lpt_ngraph_functions/lstm_function.hpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <ngraph/ngraph.hpp>
+#include "low_precision/layer_transformation.hpp"
+#include "common/fake_quantize_on_data.hpp"
+#include "common/dequantization_operations.hpp"
+
+namespace ngraph {
+namespace builder {
+namespace subgraph {
+
+class LSTMFunction {
+public:
+
+    static std::shared_ptr<ngraph::Function> get(
+        const ngraph::element::Type inputPrecision,
+        const std::vector<ngraph::PartialShape>& inputShapes,
+        const std::vector<FakeQuantizeOnDataWithConstant>& fqOnDatas,
+        const std::vector<DequantizationOperations::Convert>& converts,
+        const std::vector<DequantizationOperations>& dequantizations,
+        const std::vector<ov::Any>& concatAttributes,
+        const ngraph::element::Type precisionAfterOperation,
+        const DequantizationOperations& dequantizationAfter);
+};
+
+template <typename T>
+std::shared_ptr<Node> makeQuantizationAndDequantization(const std::shared_ptr<T>& input,
+                                                        const ngraph::element::Type inputPrecision,
+                                                        const std::string friendly_name,
+                                                        const FakeQuantizeOnDataWithConstant& fqOnData,
+                                                        const DequantizationOperations::Convert& convert,
+                                                        const DequantizationOperations& dequantization) {
+    std::shared_ptr<Node> parent;
+    if (fqOnData.empty()) {
+        parent = input;
+    } else {
+        std::shared_ptr<Node> fakeQuantize1 = makeFakeQuantizeTypeRelaxed(input, inputPrecision, fqOnData);
+        fakeQuantize1->set_friendly_name("fakeQuantize_" + friendly_name);
+        parent = fakeQuantize1;
+    }
+    if (!convert.empty()) {
+        parent = std::make_shared<opset1::Convert>(parent, convert.outPrecision);
+    }
+    if (!dequantization.empty()) {
+        parent = makeDequantization(parent, dequantization);
+    }
+    return parent;
+}
+
+}  // namespace subgraph
+}  // namespace builder
+}  // namespace ngraph

--- a/src/tests/ngraph_helpers/lpt_ngraph_functions/src/lstm_function.cpp
+++ b/src/tests/ngraph_helpers/lpt_ngraph_functions/src/lstm_function.cpp
@@ -1,0 +1,109 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "lpt_ngraph_functions/lstm_function.hpp"
+
+#include <ngraph/opsets/opset1.hpp>
+#include "ngraph_ops/type_relaxed.hpp"
+#include "low_precision/network_helper.hpp"
+#include "low_precision/rt_info/precision_preserved_attribute.hpp"
+#include "low_precision/rt_info/intervals_alignment_attribute.hpp"
+#include "low_precision/rt_info/quantization_alignment_attribute.hpp"
+
+#include "ngraph_functions/builders.hpp"
+#include "lpt_ngraph_functions/common/builders.hpp"
+#include "lpt_ngraph_functions/common/fake_quantize_on_data.hpp"
+#include "lpt_ngraph_functions/common/dequantization_operations.hpp"
+#include "lpt_ngraph_functions/common/builders.hpp"
+
+namespace ngraph {
+namespace builder {
+namespace subgraph {
+
+using namespace ngraph::pass;
+
+std::shared_ptr<ngraph::Function> LSTMFunction::get(
+    const ngraph::element::Type inputPrecision,
+    const std::vector<ngraph::PartialShape>& inputShapes,
+    const std::vector<FakeQuantizeOnDataWithConstant>& fqOnDatas,
+    const std::vector<DequantizationOperations::Convert>& converts,
+    const std::vector<DequantizationOperations>& dequantizations,
+    const std::vector<ov::Any>& concatAttributes,
+    const ngraph::element::Type precisionAfterOperation,
+    const DequantizationOperations& dequantizationAfter) {
+    auto X = std::make_shared<opset1::Parameter>(inputPrecision, inputShapes[0]);
+    X->set_friendly_name("X");
+    std::shared_ptr<Node> parent_X = makeQuantizationAndDequantization(X,
+                                                                       inputPrecision,
+                                                                       X->get_friendly_name(),
+                                                                       fqOnDatas[0],
+                                                                       converts[0],
+                                                                       dequantizations[0]);
+    auto H = std::make_shared<opset1::Parameter>(inputPrecision, inputShapes[1]);
+    H->set_friendly_name("H");
+    std::shared_ptr<Node> parent_H = makeQuantizationAndDequantization(H,
+                                                                       inputPrecision,
+                                                                       H->get_friendly_name(),
+                                                                       fqOnDatas.size() > 1 ? fqOnDatas[1] : fqOnDatas[0],
+                                                                       converts.size() > 1 ? converts[1] : converts[0],
+                                                                       dequantizations.size() > 1 ? dequantizations[1] : dequantizations[0]);
+    auto C = std::make_shared<opset1::Parameter>(inputPrecision, inputShapes[2]);
+    C->set_friendly_name("C");
+    std::shared_ptr<Node> parent_C = makeQuantizationAndDequantization(C,
+                                          inputPrecision,
+                                          C->get_friendly_name(),
+                                          fqOnDatas.size() > 1 ? fqOnDatas[2] : fqOnDatas[0],
+                                          converts.size() > 1 ? converts[2] : converts[0],
+                                          dequantizations.size() > 1 ? dequantizations[2] : dequantizations[0]);
+    auto w_val = std::vector<float>(512 * 16, 0);
+    auto r_val = std::vector<float>(512 * 128, 0);
+    auto W = ngraph::opset1::Constant::create(inputPrecision, ngraph::Shape{512, 16}, w_val);
+    std::shared_ptr<Node> parent_W = makeQuantizationAndDequantization(W,
+                                                                       inputPrecision,
+                                                                       W->get_friendly_name(),
+                                          fqOnDatas.size() > 1 ? fqOnDatas[3] : fqOnDatas[0],
+                                          converts.size() > 1 ? converts[3] : converts[0],
+                                          dequantizations.size() > 1 ? dequantizations[3] : dequantizations[0]);
+    auto R = ngraph::opset1::Constant::create(inputPrecision, ngraph::Shape{512, 128}, r_val);
+    std::shared_ptr<Node> parent_R = makeQuantizationAndDequantization(R,
+                                                                       inputPrecision,
+                                                                       R->get_friendly_name(),
+                                          fqOnDatas.size() > 1 ? fqOnDatas[4] : fqOnDatas[0],
+                                          converts.size() > 1 ? converts[4] : converts[0],
+                                          dequantizations.size() > 1 ? dequantizations[4] : dequantizations[0]);
+
+    std::shared_ptr<opset1::LSTMCell> lstm;
+    if (fqOnDatas.size() > 5) {
+        auto b_val = std::vector<float>(512, 0);
+        auto B = ngraph::opset6::Constant::create(inputPrecision, ngraph::Shape{512}, b_val);
+        std::shared_ptr<Node> parent_B = makeQuantizationAndDequantization(B,
+                                                                           inputPrecision,
+                                                                           B->get_friendly_name(),
+                                              fqOnDatas.size() > 1 ? fqOnDatas[5] : fqOnDatas[0],
+                                              converts.size() > 1 ? converts[5] : converts[0],
+                                              dequantizations.size() > 1 ? dequantizations[5] : dequantizations[0]);
+        lstm = std::make_shared<opset1::LSTMCell>(parent_X, parent_H, parent_C, parent_W, parent_R, parent_B, 128);
+    }
+    lstm = std::make_shared<opset1::LSTMCell>(parent_X, parent_H, parent_C, parent_W, parent_R, 128);
+    lstm->set_friendly_name("lstm");
+
+    auto& rtInfo = lstm->get_rt_info();
+    rtInfo["Variant::std::string"] = "lstm";
+
+    const auto lastDequantization = makeDequantization(lstm, dequantizationAfter);
+    std::shared_ptr<ngraph::Node> parent = lastDequantization;
+    parent->set_friendly_name("output");
+
+    ngraph::ResultVector results{ std::make_shared<ngraph::opset1::Result>(parent) };
+    std::shared_ptr<ngraph::Function> function = std::make_shared<ngraph::Function>(
+        results,
+        ngraph::ParameterVector{X, H, C},
+        "LSTMTransformation");
+
+    return function;
+}
+
+}  // namespace subgraph
+}  // namespace builder
+}  // namespace ngraph


### PR DESCRIPTION
### Details:
 -ReverseInputChannels pattern in Concat transformation

### Tickets:
 - 79074