### PR TITLE
Fix Conv3D translator in TF FE

### DIFF
--- a/src/frontends/tensorflow/src/op/conv_3d.cpp
+++ b/src/frontends/tensorflow/src/op/conv_3d.cpp
@@ -23,8 +23,8 @@ OutputVector translate_conv_3d_op(const NodeContext& node) {
     auto tf_data_format = node.get_attribute<std::string>("data_format");
 
     TENSORFLOW_OP_VALIDATION(node,
-                             tf_data_format == "NHWC" || tf_data_format == "NCHW",
-                             "Conv3D data format is neither NHWC nor NCHW");
+                             tf_data_format == "NDHWC" || tf_data_format == "NCDHW",
+                             "Conv3D data format is neither NDHWC nor NCDHW");
 
     bool is_ndhwc = (tf_data_format == "NDHWC");
 


### PR DESCRIPTION
### Details:
 - *3D convolution can have either NDHWC or NCDHW data format*

### Tickets:
 - *None*
