### PR TITLE
[LPT] Disable Move Fake Quantize on shuffle channels pattern

### DIFF
--- a/src/common/low_precision_transformations/src/move_fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/move_fake_quantize.cpp
@@ -176,17 +176,17 @@ bool MoveFakeQuantize::canBeTransformed(const TransformationContext& context, st
     if (q_dq && (convert_q->get_output_size() != 1 || layer->get_output_size() != 1)) {
         return false;
     }
-    if (is_type<opset1::Split>(concat->get_input_node_ptr(0))) {
-        bool only_split = true;
-        const size_t id = concat->get_input_node_ptr(0)->get_instance_id();
-        for (size_t i = 1; i < concat->get_input_size(); ++i) {
-            if (concat->get_input_node_ptr(i)->get_instance_id() != id) {
-                only_split = false;
-            }
+    bool only_split = true;
+    const size_t id = concat->get_input_node_ptr(0)->get_instance_id();
+    for (size_t i = 1; i < concat->get_input_size(); ++i) {
+        if (!is_type<opset1::Split>(concat->get_input_node_ptr(i)) ||
+            concat->get_input_node_ptr(i)->get_instance_id() != id) {
+            only_split = false;
+            break;
         }
-        if (only_split) {
-            return false;
-        }
+    }
+    if (only_split) {
+        return false;
     }
     return true;
 }

--- a/src/common/low_precision_transformations/src/move_fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/move_fake_quantize.cpp
@@ -176,6 +176,18 @@ bool MoveFakeQuantize::canBeTransformed(const TransformationContext& context, st
     if (q_dq && (convert_q->get_output_size() != 1 || layer->get_output_size() != 1)) {
         return false;
     }
+    if (is_type<opset1::Split>(concat->get_input_node_ptr(0))) {
+        bool only_split = true;
+        const size_t id = concat->get_input_node_ptr(0)->get_instance_id();
+        for (size_t i = 1; i < concat->get_input_size(); ++i) {
+            if (concat->get_input_node_ptr(i)->get_instance_id() != id) {
+                only_split = false;
+            }
+        }
+        if (only_split) {
+            return false;
+        }
+    }
     return true;
 }
 


### PR DESCRIPTION
### Details:
 - ReverseInputChannels pattern in Concat transformation

### Tickets:
 - 79074