### PR TITLE
Fix values reading from protobuf

### DIFF
--- a/src/frontends/tensorflow/src/utils.hpp
+++ b/src/frontends/tensorflow/src/utils.hpp
@@ -175,8 +175,9 @@ void values_from_const_node(const NodeContext& node, ov::Shape* const_tensor_sha
                 FRONT_END_THROW("Encountered unknown element type " + DataType_Name(dt) + " on an empty tensor_proto");
             }
             TENSORFLOW_OP_VALIDATION(node, val_size != 0, "Empty values vector");
-
-            if (i < val_size) {
+            if (val_size == 0) {
+                val_i = 0;
+            } else if (i < val_size) {
                 (*values)[i] = val_i;
                 val_lastsaved = val_i;
             } else {


### PR DESCRIPTION
### Details:
 - *pbtxt optimizing tensors with zeros so when reading const and shape is known and no tensor content is provided tensor will need to be filled with zeros*

### Tickets:
 - *None*
