### PR TITLE
[GPU] Disable large TI unrolling by default

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -231,6 +231,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             } else if (const auto &lstm_seq = std::dynamic_pointer_cast<const ngraph::opset6::LSTMSequence>(node)) {
                 return lstm_seq->get_clip() == 0.0f &&
                        lstm_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"} &&
+                       max_seq_len < 16 &&
                        !ngraph::op::util::is_seq_len_provided(lstm_seq->get_input_node_shared_ptr(3),
                                                               max_seq_len);
             }
@@ -457,10 +458,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             [this](const std::shared_ptr<const ngraph::Node> &node) -> bool {
                 auto sub_graph_op = std::dynamic_pointer_cast<const ngraph::op::util::SubGraphOp>(node);
                 int64_t num_iter = sub_graph_op->get_num_iterations();
-                if (num_iter == 1) {
-                    return false;
-                }
-                return !config.enable_loop_unrolling;
+                if (!config.enable_loop_unrolling)
+                    return num_iter != 1;
+                return num_iter >= 16;
             });
         manager.register_pass<ov::pass::ResolveNameCollisions>();
 


### PR DESCRIPTION
Disable unrolling by default for LSTMsequence and TensorIterator having length>=16.
Unrolling of such large primitives takes enormous time and produces too large graphs, that exceed plugin limits.
Now, they will be executed using a loop primitive instead

### Tickets:
 - *77295*
 - *78808*
