### PR TITLE
[GPU] Bugfix for onednn post op optimization

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -489,9 +489,9 @@ dnnl::post_ops program_node::try_optimize_post_ops(dnnl::post_ops& p_ops, const 
         auto prev_type = cur_post_ops[prev_post_op_idx].op_type;
 
         // Ignore optimized operations for "previous" operation in our operation pair
-        while (type_is_any_optimized(prev_type) && cur_post_op_idx < post_ops_size - 1) {
+        while (type_is_any_optimized(prev_type) && prev_post_op_idx < post_ops_size - 1) {
             prev_post_op_idx++;
-            if (prev_post_op_idx == cur_post_op_idx)
+            if (prev_post_op_idx == cur_post_op_idx && cur_post_op_idx < post_ops_size - 1)
                 cur_post_op_idx++;
             prev_type = cur_post_ops[prev_post_op_idx].op_type;
             cur_type = cur_post_ops[cur_post_op_idx].op_type;


### PR DESCRIPTION
When post-op has pattern like below, binary_mul was ignored previously.
1. binary_add
2. eltwise_linear
3. binary_mul
4. binary_add

It happens when prev_post_op_idx == 2, cur_post_op_idx == 4.
prev_post_op_idx was supposed to proceed to idx 3, but it did not.

### Tickets:
 - 71916
