### PR TITLE
Add note to YOLO-v3 conversion instructions

### DIFF
--- a/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_YOLO_From_Tensorflow.md
+++ b/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_YOLO_From_Tensorflow.md
@@ -72,7 +72,7 @@ git checkout ed60b90
 pip install pillow
 ```
 6. Run a converter:
-> **NOTE:** This converter works with TensorFlow 1.x and numpy 1.19 or lower.
+> **NOTE**: This converter works with TensorFlow 1.x and numpy 1.19 or lower.
 - For YOLO-v3:
 ```sh
 python3 convert_weights_pb.py --class_names coco.names --data_format NHWC --weights_file yolov3.weights

--- a/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_YOLO_From_Tensorflow.md
+++ b/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_YOLO_From_Tensorflow.md
@@ -72,7 +72,7 @@ git checkout ed60b90
 pip install pillow
 ```
 6. Run a converter:
-> **NOTE:** This converter works with TensorFlow 1 and numpy 1.19 or lower.
+> **NOTE:** This converter works with TensorFlow 1.x and numpy 1.19 or lower.
 - For YOLO-v3:
 ```sh
 python3 convert_weights_pb.py --class_names coco.names --data_format NHWC --weights_file yolov3.weights

--- a/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_YOLO_From_Tensorflow.md
+++ b/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_YOLO_From_Tensorflow.md
@@ -72,6 +72,7 @@ git checkout ed60b90
 pip install pillow
 ```
 6. Run a converter:
+> **NOTE:** This converter works with TensorFlow 1 and numpy 1.19 or lower.
 - For YOLO-v3:
 ```sh
 python3 convert_weights_pb.py --class_names coco.names --data_format NHWC --weights_file yolov3.weights


### PR DESCRIPTION
Description: The instructions for converting YOLO-v3 from DarkNet to TensorFlow only apply to TensorFlow 1.X. Also, if numpy version is 1.20 or higher, the conversion script will throw an error, which is presented in the ticket. Need to add a note about these restrictions.

Ticket: CVS-79042 