### PR TITLE
[nG][IE] fix convert_nms_gather_path_to_unsigned: add Slice into pattern

### DIFF
--- a/src/bindings/python/tests/__init__.py
+++ b/src/bindings/python/tests/__init__.py
@@ -127,5 +127,4 @@ xfail_issue_63137 = xfail_test(reason="Unsupported operations: OptionalHasElemen
 xfail_issue_63138 = xfail_test(reason="Missing ONNX Shape-15 support")
 xfail_issue_68212 = xfail_test(reason="Unsupported reading model with bytes streams")
 
-xfail_issue_77668 = xfail_test(reason="Accuracy issue related to Gather-8.")
 xfail_issue_78843 = xfail_test(reason="Missing reference output files for ssd mobilenet models")

--- a/src/bindings/python/tests/test_onnx/test_zoo_models.py
+++ b/src/bindings/python/tests/test_onnx/test_zoo_models.py
@@ -22,8 +22,7 @@ from tests import (
     xfail_issue_48190,
     xfail_issue_58676,
     xfail_issue_78843,
-    xfail_issue_onnx_models_140,
-    xfail_issue_77668)
+    xfail_issue_onnx_models_140)
 
 MODELS_ROOT_DIR = tests.MODEL_ZOO_DIR
 
@@ -180,8 +179,6 @@ if len(zoo_models) > 0:
             (xfail_issue_48190, "test_onnx_model_zoo_text_machine_comprehension_roberta_model_roberta_base_11_roberta_base_11_roberta_base_11_cpu"),
             (xfail_issue_onnx_models_140, "test_onnx_model_zoo_vision_object_detection_segmentation_duc_model_ResNet101_DUC_7_ResNet101_DUC_HDC_ResNet101_DUC_HDC_cpu"),
             (xfail_issue_78843, "test_onnx_model_zoo_vision_object_detection_segmentation_ssd_mobilenetv1_model_ssd_mobilenet_v1_10_ssd_mobilenet_v1_ssd_mobilenet_v1_cpu"),
-            (xfail_issue_77668, "test_onnx_model_zoo_vision_object_detection_segmentation_faster_rcnn_model_FasterRCNN_10_faster_rcnn_R_50_FPN_1x_cpu"),
-            (xfail_issue_77668, "test_onnx_model_zoo_vision_object_detection_segmentation_mask_rcnn_model_MaskRCNN_10_mask_rcnn_R_50_FPN_1x_cpu"),
 
             # Model MSFT
             (xfail_issue_37973, "test_MSFT_opset7_tf_inception_v2_model_cpu"),
@@ -197,8 +194,6 @@ if len(zoo_models) > 0:
             (xfail_issue_47495, "test_MSFT_opset10_BERT_Squad_bertsquad10_cpu"),
             (xfail_issue_78843, "test_MSFT_opset10_mlperf_ssd_mobilenet_300_ssd_mobilenet_v1_coco_2018_01_28_cpu"),
 
-            (xfail_issue_77668, "test_MSFT_opset10_faster_rcnn_faster_rcnn_R_50_FPN_1x_cpu"),
-            (xfail_issue_77668, "test_MSFT_opset10_mask_rcnn_mask_rcnn_R_50_FPN_1x_cpu"),
         ]
         for test_case in import_xfail_list + execution_xfail_list:
             xfail, test_name = test_case

--- a/src/bindings/python/tests_compatibility/__init__.py
+++ b/src/bindings/python/tests_compatibility/__init__.py
@@ -136,6 +136,5 @@ xfail_issue_63136 = xfail_test(reason="Unsupported operation: CastLike")
 xfail_issue_63137 = xfail_test(reason="Unsupported operations: OptionalHasElement, OptionalGetElement")
 xfail_issue_63138 = xfail_test(reason="Missing ONNX Shape-15 support")
 
-xfail_issue_77668 = xfail_test(reason="Accuracy issue related to Gather-8.")
 xfail_issue_78843 = xfail_test(reason="Missing reference output files for ssd mobilenet models")
 xfail_issue_78741 = xfail_test(reason="Cannot get dims for non static shape")

--- a/src/bindings/python/tests_compatibility/test_onnx/test_zoo_models.py
+++ b/src/bindings/python/tests_compatibility/test_onnx/test_zoo_models.py
@@ -23,8 +23,7 @@ from tests_compatibility import (
     xfail_issue_48190,
     xfail_issue_58676,
     xfail_issue_78843,
-    xfail_issue_onnx_models_140,
-    xfail_issue_77668)
+    xfail_issue_onnx_models_140)
 
 MODELS_ROOT_DIR = tests_compatibility.MODEL_ZOO_DIR
 
@@ -168,7 +167,6 @@ if len(zoo_models) > 0:
             (xfail_issue_48190, "test_onnx_model_zoo_text_machine_comprehension_roberta_model_roberta_base_11_roberta_base_11_roberta_base_11_cpu"),
             (xfail_issue_onnx_models_140, "test_onnx_model_zoo_vision_object_detection_segmentation_duc_model_ResNet101_DUC_7_ResNet101_DUC_HDC_ResNet101_DUC_HDC_cpu"),
             (xfail_issue_78843, "test_onnx_model_zoo_vision_object_detection_segmentation_ssd_mobilenetv1_model_ssd_mobilenet_v1_10_ssd_mobilenet_v1_ssd_mobilenet_v1_cpu"),
-            (xfail_issue_77668, "test_onnx_model_zoo_vision_object_detection_segmentation_faster_rcnn_model_FasterRCNN_10_faster_rcnn_R_50_FPN_1x_cpu"),
 
             # Model MSFT
             (xfail_issue_37973, "test_MSFT_opset7_tf_inception_v2_model_cpu"),
@@ -185,8 +183,6 @@ if len(zoo_models) > 0:
             (xfail_issue_39669, "test_MSFT_opset9_cgan_cgan_cpu"),
             (xfail_issue_47495, "test_MSFT_opset10_BERT_Squad_bertsquad10_cpu"),
             (xfail_issue_78843, "test_MSFT_opset10_mlperf_ssd_mobilenet_300_ssd_mobilenet_v1_coco_2018_01_28_cpu"),
-
-            (xfail_issue_77668, "test_MSFT_opset10_faster_rcnn_faster_rcnn_R_50_FPN_1x_cpu"),
         ]
         for test_case in import_xfail_list + execution_xfail_list:
             xfail, test_name = test_case

--- a/src/common/transformations/src/transformations/common_optimizations/convert_nms_gather_path_to_unsigned.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convert_nms_gather_path_to_unsigned.cpp
@@ -49,6 +49,7 @@ class PropagateNMSPath: public pass::MatcherPass {
                     opset8::Reshape,
                     op::util::BroadcastBase,
                     opset8::StridedSlice,
+                    opset8::Slice,
                     opset8::VariadicSplit,
                     op::util::GatherBase,
                     opset8::Concat,


### PR DESCRIPTION
#### Details:
`Slice` from opset was missing in the list of operation to skip between `NMS -> Gather` path, therefore onnx models from `faster_rcnn_R_50_FPN` and `mask_rcnn_R_50_FPN` family where failing. Added `Slice` into patter in `convert_nms_gather_path_to_unsigned`.

Ticket: CVS-77668

#### Validation:
* [x]  Unit tests
* [x]  Model Optimizer IR Reader check
* [x] test_onnx/test_zoo_models : done, results are green

![image](https://user-images.githubusercontent.com/5703039/154264213-e2a45ab0-dc46-4b96-a1b1-e8326184dbb2.png)
