### PR TITLE
[GPU] Adjust build batch size to 9 from 10 due to the compiler limitation

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
@@ -148,7 +148,7 @@ bool kernels_cache::is_cache_enabled() const {
 }
 
 size_t kernels_cache::get_max_kernels_per_batch() const {
-    return 10;
+    return 9;
 }
 
 


### PR DESCRIPTION
### Details:
- If the module size increased, some compiler optimizations are disabled. (limit: 500k llvm instructions)
- Due to the above restriction, some kernels get degradation when it is batched with other large kernels. 
- So reduced the bsize to reduce the chance of such cases. 

### Tickets:
 - 73245
