### PR TITLE
Fix increased build time and memory consumption caused by multiple ov::Any instantiation

### DIFF
--- a/src/core/include/openvino/core/any.hpp
+++ b/src/core/include/openvino/core/any.hpp
@@ -960,9 +960,9 @@ public:
     }
 
     /**
-    * @brief Returns address to internal value if any is not empty and `nullptr` instead
-    * @return address to internal stored value
-    */
+     * @brief Returns address to internal value if any is not empty and `nullptr` instead
+     * @return address to internal stored value
+     */
     void* addressof();
 
     /**

--- a/src/core/include/openvino/core/any.hpp
+++ b/src/core/include/openvino/core/any.hpp
@@ -958,6 +958,18 @@ public:
         impl_check();
         return _impl.get();
     }
+
+    /**
+    * @brief Returns address to internal value if any is not empty and `nullptr` instead
+    * @return address to internal stored value
+    */
+    void* addressof();
+
+    /**
+     * @brief Returns address to internal value if any is not empty and `nullptr` instead
+     * @return address to internal stored value
+     */
+    const void* addressof() const;
 };
 
 /** @cond INTERNAL */

--- a/src/core/include/openvino/core/attribute_adapter.hpp
+++ b/src/core/include/openvino/core/attribute_adapter.hpp
@@ -63,7 +63,9 @@ public:
         return get();
     }
     void set_as_any(const ov::Any& x) override {
-        set(x.as<VAT>());
+        const auto* data = x.addressof();
+        OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty ov::Any is provided.");
+        set(*static_cast<const VAT*>(data));
     }
 };
 
@@ -108,13 +110,15 @@ public:
     }
 
     void set_as_any(const ov::Any& x) override {
+        const auto* data = x.addressof();
+        OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty ov::Any is provided.");
         // Try to represent x as VAT or AT
         if (x.is<VAT>()) {
-            set(x.as<VAT>());
+            set(*static_cast<const VAT *>(data));
         } else {
             // Don't call set here avoiding unnecessary casts AT -> VAT -> AT,
             // instead reimplement logic from set.
-            m_ref = x.as<AT>();
+            m_ref = *static_cast<const AT *>(data);
             m_buffer_valid = false;
         }
     }
@@ -153,15 +157,18 @@ public:
     }
 
     void set_as_any(const ov::Any& x) override {
+        const auto* data = x.addressof();
+        OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty ov::Any is provided.");
         // Try to represent x as VAT or AT
         if (x.is<VAT>()) {
-            set(x.as<VAT>());
+            set(*static_cast<const VAT *>(data));
         } else {
             // Don't call set here avoiding unnecessary casts AT -> VAT -> AT,
             // instead reimplement logic from set.
-            m_ref = x.as<AT>();
+            m_ref = *static_cast<const AT *>(data);
             m_buffer_valid = false;
         }
+
     }
     operator AT&() {
         return m_ref;
@@ -200,9 +207,11 @@ public:
         if (x.is<std::string>()) {
             set(x.as<std::string>());
         } else {
+            const auto* data = x.addressof();
+            OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty ov::Any is provided.");
             // Don't call set here avoiding unnecessary casts AT -> std::string -> AT,
             // instead reimplement logic from set.
-            m_ref = x.as<AT>();
+            m_ref = *static_cast<const AT *>(data);
         }
     }
 

--- a/src/core/include/openvino/core/attribute_adapter.hpp
+++ b/src/core/include/openvino/core/attribute_adapter.hpp
@@ -108,11 +108,11 @@ public:
         OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty data is provided.");
         // Try to represent x as VAT or AT
         if (x.is<VAT>()) {
-            set(*static_cast<const VAT *>(data));
+            set(*static_cast<const VAT*>(data));
         } else {
             // Don't call set here avoiding unnecessary casts AT -> VAT -> AT,
             // instead reimplement logic from set.
-            m_ref = *static_cast<const AT *>(data);
+            m_ref = *static_cast<const AT*>(data);
             m_buffer_valid = false;
         }
     }
@@ -155,14 +155,13 @@ public:
         OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty data is provided.");
         // Try to represent x as VAT or AT
         if (x.is<VAT>()) {
-            set(*static_cast<const VAT *>(data));
+            set(*static_cast<const VAT*>(data));
         } else {
             // Don't call set here avoiding unnecessary casts AT -> VAT -> AT,
             // instead reimplement logic from set.
-            m_ref = *static_cast<const AT *>(data);
+            m_ref = *static_cast<const AT*>(data);
             m_buffer_valid = false;
         }
-
     }
     operator AT&() {
         return m_ref;
@@ -205,7 +204,7 @@ public:
             OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty data is provided.");
             // Don't call set here avoiding unnecessary casts AT -> std::string -> AT,
             // instead reimplement logic from set.
-            m_ref = *static_cast<const AT *>(data);
+            m_ref = *static_cast<const AT*>(data);
         }
     }
 

--- a/src/core/include/openvino/core/attribute_adapter.hpp
+++ b/src/core/include/openvino/core/attribute_adapter.hpp
@@ -35,9 +35,6 @@ public:
     /// as_type.
     virtual const DiscreteTypeInfo& get_type_info() const = 0;
     virtual ~ValueAccessor() = default;
-    virtual ov::Any get_as_any() {
-        throw ov::Exception("get_as_any is not implemented");
-    }
     virtual void set_as_any(const ov::Any& x) {
         throw ov::Exception("set_as_any is not implemented");
     }
@@ -59,12 +56,9 @@ public:
     virtual const VAT& get() = 0;
     /// Sets the value
     virtual void set(const VAT& value) = 0;
-    ov::Any get_as_any() override {
-        return get();
-    }
     void set_as_any(const ov::Any& x) override {
         const auto* data = x.addressof();
-        OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty ov::Any is provided.");
+        OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty data is provided.");
         set(*static_cast<const VAT*>(data));
     }
 };
@@ -111,7 +105,7 @@ public:
 
     void set_as_any(const ov::Any& x) override {
         const auto* data = x.addressof();
-        OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty ov::Any is provided.");
+        OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty data is provided.");
         // Try to represent x as VAT or AT
         if (x.is<VAT>()) {
             set(*static_cast<const VAT *>(data));
@@ -158,7 +152,7 @@ public:
 
     void set_as_any(const ov::Any& x) override {
         const auto* data = x.addressof();
-        OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty ov::Any is provided.");
+        OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty data is provided.");
         // Try to represent x as VAT or AT
         if (x.is<VAT>()) {
             set(*static_cast<const VAT *>(data));
@@ -208,7 +202,7 @@ public:
             set(x.as<std::string>());
         } else {
             const auto* data = x.addressof();
-            OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty ov::Any is provided.");
+            OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty data is provided.");
             // Don't call set here avoiding unnecessary casts AT -> std::string -> AT,
             // instead reimplement logic from set.
             m_ref = *static_cast<const AT *>(data);

--- a/src/core/include/openvino/core/attribute_adapter.hpp
+++ b/src/core/include/openvino/core/attribute_adapter.hpp
@@ -61,8 +61,9 @@ public:
         OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty data is provided.");
         if (x.is<VAT>()) {
             set(*static_cast<const VAT*>(data));
+        } else {
+            OPENVINO_UNREACHABLE("Bad cast from: ", x.type_info().name(), " to: ", typeid(VAT).name());
         }
-        OPENVINO_UNREACHABLE("Bad cast from: ", x.type_info().name(), " to: ", typeid(VAT).name());
     }
 };
 
@@ -117,8 +118,9 @@ public:
             // instead reimplement logic from set.
             m_ref = *static_cast<const AT*>(data);
             m_buffer_valid = false;
+        } else {
+            OPENVINO_UNREACHABLE("Bad cast from: ", x.type_info().name(), " to: ", typeid(AT).name());
         }
-        OPENVINO_UNREACHABLE("Bad cast from: ", x.type_info().name(), " to: ", typeid(AT).name());
     }
 
 protected:
@@ -165,8 +167,9 @@ public:
             // instead reimplement logic from set.
             m_ref = *static_cast<const AT*>(data);
             m_buffer_valid = false;
+        } else {
+            OPENVINO_UNREACHABLE("Bad cast from: ", x.type_info().name(), " to: ", typeid(AT).name());
         }
-        OPENVINO_UNREACHABLE("Bad cast from: ", x.type_info().name(), " to: ", typeid(AT).name());
     }
     operator AT&() {
         return m_ref;
@@ -210,8 +213,9 @@ public:
             // Don't call set here avoiding unnecessary casts AT -> std::string -> AT,
             // instead reimplement logic from set.
             m_ref = *static_cast<const AT*>(data);
+        } else {
+            OPENVINO_UNREACHABLE("Bad cast from: ", x.type_info().name(), " to: ", typeid(AT).name());
         }
-        OPENVINO_UNREACHABLE("Bad cast from: ", x.type_info().name(), " to: ", typeid(AT).name());
     }
 
 protected:

--- a/src/core/include/openvino/core/attribute_adapter.hpp
+++ b/src/core/include/openvino/core/attribute_adapter.hpp
@@ -59,7 +59,10 @@ public:
     void set_as_any(const ov::Any& x) override {
         const auto* data = x.addressof();
         OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty data is provided.");
-        set(*static_cast<const VAT*>(data));
+        if (x.is<VAT>()) {
+            set(*static_cast<const VAT*>(data));
+        }
+        OPENVINO_UNREACHABLE("Bad cast from: ", x.type_info().name(), " to: ", typeid(VAT).name());
     }
 };
 
@@ -109,12 +112,13 @@ public:
         // Try to represent x as VAT or AT
         if (x.is<VAT>()) {
             set(*static_cast<const VAT*>(data));
-        } else {
+        } else if (x.is<AT>()) {
             // Don't call set here avoiding unnecessary casts AT -> VAT -> AT,
             // instead reimplement logic from set.
             m_ref = *static_cast<const AT*>(data);
             m_buffer_valid = false;
         }
+        OPENVINO_UNREACHABLE("Bad cast from: ", x.type_info().name(), " to: ", typeid(AT).name());
     }
 
 protected:
@@ -156,12 +160,13 @@ public:
         // Try to represent x as VAT or AT
         if (x.is<VAT>()) {
             set(*static_cast<const VAT*>(data));
-        } else {
+        } else if (x.is<AT>()) {
             // Don't call set here avoiding unnecessary casts AT -> VAT -> AT,
             // instead reimplement logic from set.
             m_ref = *static_cast<const AT*>(data);
             m_buffer_valid = false;
         }
+        OPENVINO_UNREACHABLE("Bad cast from: ", x.type_info().name(), " to: ", typeid(AT).name());
     }
     operator AT&() {
         return m_ref;
@@ -196,16 +201,17 @@ public:
     }
 
     void set_as_any(const ov::Any& x) override {
+        const auto* data = x.addressof();
+        OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty data is provided.");
         // Try to represent x as std::string or AT
         if (x.is<std::string>()) {
             set(x.as<std::string>());
-        } else {
-            const auto* data = x.addressof();
-            OPENVINO_ASSERT(data != nullptr, "Data conversion is not possible. Empty data is provided.");
+        } else if (x.is<AT>()) {
             // Don't call set here avoiding unnecessary casts AT -> std::string -> AT,
             // instead reimplement logic from set.
             m_ref = *static_cast<const AT*>(data);
         }
+        OPENVINO_UNREACHABLE("Bad cast from: ", x.type_info().name(), " to: ", typeid(AT).name());
     }
 
 protected:

--- a/src/core/src/any.cpp
+++ b/src/core/src/any.cpp
@@ -121,6 +121,13 @@ const Any::Base* Any::operator->() const {
     return _impl.get();
 }
 
+void* Any::addressof() {
+    return _impl != nullptr ? _impl->addressof() : nullptr;
+}
+
+const void* Any::addressof() const {
+    return _impl != nullptr ? _impl->addressof() : nullptr;
+}
 namespace util {
 
 void Read<bool>::operator()(std::istream& is, bool& value) const {


### PR DESCRIPTION
### Details:
 - *The increase in build time and memory consumption is caused by the multiple instantiation of  as<>() method from the ov::Any class, mostly with enums. For now, we're trying to avoid using the as<>() method, replacing it with the newly added public "addressof" method of the ov::Any class, which allows to operate with a pointer to raw data.*
 Tested with https://github.com/openvinotoolkit/openvino/pull/10445

### Tickets:
 - *78303*
 - *78773*
 - *79157*
