### PR TITLE
Enable apivalidator check when BUILD_SHARED_LIBS=OFF

### DIFF
--- a/cmake/developer_package/api_validator/api_validator.cmake
+++ b/cmake/developer_package/api_validator/api_validator.cmake
@@ -51,12 +51,6 @@ endfunction()
 set(VALIDATED_LIBRARIES "" CACHE INTERNAL "")
 
 function(_ov_add_api_validator_post_build_step)
-    if(NOT BUILD_SHARED_LIBS)
-        # since _ov_add_api_validator_post_build_step
-        # is currently run only on shared libraries, we have nothing to test
-        return()
-    endif()
-
     set(UWP_API_VALIDATOR_APIS "${PROGRAMFILES}/Windows Kits/10/build/universalDDIs/x64/UniversalDDIs.xml")
     set(UWP_API_VALIDATOR_EXCLUSION "${UWP_SDK_PATH}/BinaryExclusionlist.xml")
 

--- a/cmake/developer_package/plugins/plugins.cmake
+++ b/cmake/developer_package/plugins/plugins.cmake
@@ -347,7 +347,7 @@ function(ie_generate_plugins_hpp)
     # for some reason dependency on source files does not work
     # so, we have to use explicit target and make it dependency for inference_engine
     add_custom_target(_ie_plugins_hpp DEPENDS ${ie_plugins_hpp})
-    add_dependencies(inference_engine _ie_plugins_hpp)
+    add_dependencies(inference_engine_obj _ie_plugins_hpp)
 
     # add dependency for object files
     get_target_property(sources inference_engine_obj SOURCES)


### PR DESCRIPTION
### Details:
 - Enable apivalidator check for windows build when `BUILD_SHARED_LIBS=OFF`
 - Change dependency `_ie_plugins_hpp` to `inference_engine_obj`
### Results:
 1. Build OpenVINO and extra module KMB plugin with the following command on Windows: 
 `cmake -D CMAKE_BUILD_TYPE=Release -D BUILD_SHARED_LIBS=OFF -D IE_EXTRA_MODULES=$KMB_PLUGIN_HOME -D ENABLE_INTEL_MYRIAD_COMMON=ON ..`
`cmake --build . --config Release -- -m:16`
     - Target `_ie_plugins_hpp` needs to be built manually, otherwise the build would fail. Thus this PR changes this dependency to `inference_engine_obj`
     - We get following error from intel gpu plugin, and this error still occurs when we disable apivalidator check and build with the same command `LINK : fatal error LNK1181: cannot open input file 'onednn_gpu.lib' [.....\ov\ov\build\samples\c\hello_classification\hello_classification_c.vcxproj]`
     - Result txt files of apivalidator check can be generated correctly except intel_gpu_plugin.
2. Build OpenVINO and extra module KMB plugin, enable tests and functional tests, turn off intel gpu plugin: 
`cmake -D CMAKE_BUILD_TYPE=Release -D BUILD_SHARED_LIBS=OFF -D ENABLE_INTEL_MYRIAD_COMMON=ON -D IE_EXTRA_MODULES=$KMB_PLUGIN_HOME -D ENABLE_INTEL_GPU=OFF -D ENABLE_TESTS=ON -D ENABLE_FUNCTIONAL_TESTS=ON ..`
`cmake --build . --config Release -- -m:16`
      - Get cmake error `CMake Error: install(EXPORT "OpenVINOTargets" ...) includes target "throw_test_backend" more than once in the export set`
      - Get build error `C:\umd\applications.ai.vpu-accelerators.vpux-plugin\tests\unit\mtl\test_case_json_parser_unit_test.cpp(14,10): fatal error C1083: Cannot open include file: 'vpux/hwtest/test_case_json_parser.hpp': No such file or directory [C:\umd\openvino\build_gpu_off_test\build-modules\applications.ai.vpu-accelerators.vpux-plugin\tests\unit\vpuxUnitTests.vcxproj]`
      - The above errors still occur when we disable apivalidator check and build with the same command.
      - Result txt files of apivalidator check can be generated correctly.

From current tests, enable apivalidator for static build does not bring regression. More details are displayed in the following jira ticket

### Tickets:
 - [CVS-76236](https://jira.devtools.intel.com/browse/CVS-76236)
