### PR TITLE
[GPU] Fix deconv b32 onednn regression in onednn

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -787,7 +787,17 @@ static bool is_node_for_onednn(deconvolution_node const& node) {
                                get_post_ops_count(node) <= 32 &&
                                input_layout.data_type == output_layout.data_type;
 
-    auto spatial_dims_num = input_layout.format.spatial_num();
+    auto spatial_dims_num = input_layout.get_spatial_rank();
+
+    // oneDNN doesn't support sum post ops for deconvolutions
+    for (auto& fused_op : node.get_fused_primitives()) {
+        if (fused_op.node->is_type<eltwise>() && fused_op.deps.size() == 1) {
+            auto eltw_in_layout = node.get_dependency(fused_op.dep_start_idx).get_output_layout();
+            if (program_helpers::needs_onednn_sum_post_op(fused_op.node->as<eltwise>(), eltw_in_layout)) {
+                return false;
+            }
+        }
+    }
 
     return onednn_valid_dt && onednn_valid_params && spatial_dims_num <= 3;
 }
@@ -1476,19 +1486,6 @@ impl_types layout_optimizer::get_preferred_impl_type(program_node& node, format 
         // oneDNN doesn't support asymmetric weights quantization
         if (node.is_type<convolution>() && node.as<convolution>().weights_zero_points_term())
             impl_candidate = impl_types::ocl;
-
-        // oneDNN doesn't support sum post ops for deconvolutions
-        if (node.is_type<deconvolution>() && impl_candidate == impl_types::onednn) {
-            for (auto& fused_op : node.get_fused_primitives()) {
-                if (fused_op.node->is_type<eltwise>() && fused_op.deps.size() == 1) {
-                    auto eltw_in_layout = node.get_dependency(fused_op.dep_start_idx).get_output_layout();
-                    if (program_helpers::needs_onednn_sum_post_op(fused_op.node->as<eltwise>(), eltw_in_layout)) {
-                        impl_candidate = impl_types::ocl;
-                        break;
-                    }
-                }
-            }
-        }
 
         preferred_impl = impl_candidate;
     } else if (node.is_type<concatenation>()) {


### PR DESCRIPTION
After enabling deconv b32 onednn, colorization-siggraph f16 b32 has regresison,
Fix it. Add to check sum post ops in case deconv onednn.

Signed-off-by: hyunback <hyunback.kim@intel.com>



### Tickets:
 - *75903*
