### PR TITLE
Fix for broken model cache

### DIFF
--- a/src/common/transformations/include/ngraph_ops/nms_ie_internal.hpp
+++ b/src/common/transformations/include/ngraph_ops/nms_ie_internal.hpp
@@ -18,7 +18,7 @@ namespace internal {
 
 class TRANSFORMATIONS_API NonMaxSuppressionIEInternal : public Op {
 public:
-    OPENVINO_OP("NonMaxSuppressionIEInternal", "util");
+    OPENVINO_OP("NonMaxSuppressionIEInternal", "ie_internal_opset");
     BWDCMP_RTTI_DECLARATION;
 
     NonMaxSuppressionIEInternal() = default;

--- a/src/common/transformations/include/ngraph_ops/nms_static_shape_ie.hpp
+++ b/src/common/transformations/include/ngraph_ops/nms_static_shape_ie.hpp
@@ -109,7 +109,7 @@ const ::ngraph::Node::type_info_t& NmsStaticShapeIE<BaseNmsOp>::get_type_info_st
     static const std::string name = BaseNmsOpTypeInfoPtr->name;
 
     static const ::ngraph::Node::type_info_t type_info_static{
-        name.c_str(), BaseNmsOpTypeInfoPtr->version, BaseNmsOpTypeInfoPtr};
+        name.c_str(), BaseNmsOpTypeInfoPtr->version, "ie_internal_opset", BaseNmsOpTypeInfoPtr};
     return type_info_static;
 }
 

--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -568,9 +568,7 @@ const std::vector<Edge> create_edge_mapping(const std::unordered_map<ngraph::Nod
 
 std::string get_opset_name(const ngraph::Node* n, const std::map<std::string, ngraph::OpSet>& custom_opsets) {
     OPENVINO_ASSERT(n != nullptr);
-    if (n->get_type_info().version_id != nullptr) {
-        return n->get_type_info().version_id;
-    }
+
     // Try to find opset name from RT info
     auto opset_it = n->get_rt_info().find("opset");
     if (opset_it != n->get_rt_info().end()) {
@@ -580,6 +578,10 @@ std::string get_opset_name(const ngraph::Node* n, const std::map<std::string, ng
                 return opset_name;
             }
         }
+    }
+
+    if (n->get_type_info().version_id != nullptr) {
+        return n->get_type_info().version_id;
     }
 
     for (const auto& custom_opset : custom_opsets) {

--- a/src/plugins/intel_cpu/src/ngraph_transformations/move_eltwise_up_data_movement.cpp
+++ b/src/plugins/intel_cpu/src/ngraph_transformations/move_eltwise_up_data_movement.cpp
@@ -96,7 +96,6 @@ ov::intel_cpu::MoveEltwiseUpThroughDataMov::MoveEltwiseUpThroughDataMov() {
         eltwiseInputs[0] = child->input_value(0);
         auto newEltwise = eltwise->clone_with_new_inputs(eltwiseInputs);
         ngraph::copy_runtime_info(eltwise, newEltwise);
-        newEltwise->set_friendly_name(eltwise->get_friendly_name());
 
         ngraph::OutputVector childInputs = child->input_values();
         childInputs[0] = newEltwise;

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -655,6 +655,7 @@ Engine::LoadExeNetworkImpl(const InferenceEngine::CNNNetwork &network, const std
     }
 
     auto config = orig_config;
+
     CNNNetwork clonedNetwork = InferenceEngine::details::cloneNetwork(network);
     const auto& lptProp = config.find(InferenceEngine::PluginConfigInternalParams::KEY_LP_TRANSFORMS_MODE);
     const bool enableLPT = (lptProp != config.end() && lptProp->second == PluginConfigParams::YES) /* enabled in the orig_config*/
@@ -822,7 +823,8 @@ Parameter Engine::GetMetric(const std::string& name, const std::map<std::string,
                                                     RO_property(ov::range_for_async_infer_requests.name()),
                                                     RO_property(ov::range_for_streams.name()),
                                                     RO_property(ov::device::full_name.name()),
-                                                    RO_property(ov::device::capabilities.name())
+                                                    RO_property(ov::device::capabilities.name()),
+                                                    RO_property(ov::cache_dir.name())   // WA Can be removed after implementing snippet serialization.
         };
         // the whole config is RW before network is loaded.
         std::vector<ov::PropertyName> rwProperties {RW_property(ov::num_streams.name()),

--- a/src/tests/unit/cpu/ngraph_transformations/move_eltwise_up_data_movement_test.cpp
+++ b/src/tests/unit/cpu/ngraph_transformations/move_eltwise_up_data_movement_test.cpp
@@ -14,11 +14,12 @@
 
 using namespace testing;
 
-TEST(MoveEltwiseUpThroughDataMov, SingleUnaryEltwise) {
+class MoveEltwiseUpThroughDataMovTest: public TransformationTestsF{};
+
+TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwise) {
     const ngraph::Shape shape{1, 3, 224, 224};
     const std::vector<int64_t> input_order = {3, 2, 1, 0};
     const int64_t unsqueeze_axis = 2;
-    std::shared_ptr<ngraph::Function> f(nullptr);
     {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
 
@@ -30,15 +31,9 @@ TEST(MoveEltwiseUpThroughDataMov, SingleUnaryEltwise) {
 
         auto sigmoid = std::make_shared<ngraph::opset8::Sigmoid>(unsqueeze);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{sigmoid}, ngraph::ParameterVector{input});
+        function = std::make_shared<ngraph::Function>(ngraph::NodeVector{sigmoid}, ngraph::ParameterVector{input});
+        manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
     }
-
-    ngraph::pass::Manager m;
-    m.register_pass<ngraph::pass::InitNodeInfo>();
-    m.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
-    m.run_passes(f);
-    ASSERT_NO_THROW(check_rt_info(f));
-    std::shared_ptr<ngraph::Function> f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
 
@@ -50,19 +45,14 @@ TEST(MoveEltwiseUpThroughDataMov, SingleUnaryEltwise) {
         auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(transpose, unsqueeze_const);
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
+        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
     }
-
-    auto res = compare_functions(f, f_ref);
-
-    ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(MoveEltwiseUpThroughDataMov, EltwiseSequence) {
+TEST_F(MoveEltwiseUpThroughDataMovTest, EltwiseSequence) {
     const ngraph::Shape shape{1, 3, 224, 224};
     const std::vector<int64_t> input_order = {1, 2, 0, 3};
     const int64_t unsqueeze_axis = 1;
-    std::shared_ptr<ngraph::Function> f(nullptr);
     {
         auto input_left = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
         auto input_right = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
@@ -79,16 +69,9 @@ TEST(MoveEltwiseUpThroughDataMov, EltwiseSequence) {
 
         auto sigmoid = std::make_shared<ngraph::opset8::Sigmoid>(unsqueeze);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{sigmoid}, ngraph::ParameterVector{input_left, input_right});
+        function = std::make_shared<ngraph::Function>(ngraph::NodeVector{sigmoid}, ngraph::ParameterVector{input_left, input_right});
+        manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
     }
-
-    ngraph::pass::Manager m;
-    m.register_pass<ngraph::pass::InitNodeInfo>();
-    m.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
-    m.run_passes(f);
-    ASSERT_NO_THROW(check_rt_info(f));
-
-    std::shared_ptr<ngraph::Function> f_ref(nullptr);
     {
         auto input_left = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
         auto input_right = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
@@ -105,60 +88,40 @@ TEST(MoveEltwiseUpThroughDataMov, EltwiseSequence) {
         auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(transpose, unsqueeze_const);
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input_left, input_right});
+        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input_left, input_right});
     }
-
-    auto res = compare_functions(f, f_ref);
-
-    ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(MoveEltwiseUpThroughDataMov, DataMovementTwoConsumers) {
+TEST_F(MoveEltwiseUpThroughDataMovTest, DataMovementTwoConsumers) {
     /* In this case transformation shouldn't apply */
-    auto create_graph = [] () -> std::shared_ptr<ngraph::Function> {
-        const ngraph::Shape shape{1, 3, 224, 224};
-        const std::vector<int64_t> input_order = {1, 2, 0, 3};
-        const int64_t unsqueeze_axis = 1;
+    const ngraph::Shape shape{1, 3, 224, 224};
+    const std::vector<int64_t> input_order = {1, 2, 0, 3};
+    const int64_t unsqueeze_axis = 1;
 
-        auto input_left = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
-        auto input_right = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
+    auto input_left = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
+    auto input_right = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
 
-        auto matmul = std::make_shared<ngraph::opset8::MatMul>(input_left, input_right);
+    auto matmul = std::make_shared<ngraph::opset8::MatMul>(input_left, input_right);
 
-        auto transpose_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
-        auto transpose = std::make_shared<ngraph::opset8::Transpose>(matmul, transpose_const);
+    auto transpose_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
+    auto transpose = std::make_shared<ngraph::opset8::Transpose>(matmul, transpose_const);
 
-        auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
-        auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(transpose, unsqueeze_const);
+    auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
+    auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(transpose, unsqueeze_const);
 
-        auto sigmoid = std::make_shared<ngraph::opset8::Sigmoid>(unsqueeze);
+    auto sigmoid = std::make_shared<ngraph::opset8::Sigmoid>(unsqueeze);
 
-        auto relu = std::make_shared<ngraph::opset8::Relu>(transpose);
+    auto relu = std::make_shared<ngraph::opset8::Relu>(transpose);
 
-        return std::make_shared<ngraph::Function>(ngraph::NodeVector{sigmoid, relu}, ngraph::ParameterVector{input_left, input_right});
-    };
-
-    std::shared_ptr<ngraph::Function> f = create_graph();
-
-    ngraph::pass::Manager m;
-    m.register_pass<ngraph::pass::InitNodeInfo>();
-    m.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
-    m.run_passes(f);
-    ASSERT_NO_THROW(check_rt_info(f));
-
-    std::shared_ptr<ngraph::Function> f_ref = create_graph();
-
-    auto res = compare_functions(f, f_ref);
-
-    ASSERT_TRUE(res.first) << res.second;
+    function = std::make_shared<ngraph::Function>(ngraph::NodeVector{sigmoid, relu}, ngraph::ParameterVector{input_left, input_right});
+    manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
 }
 
-TEST(MoveEltwiseUpThroughDataMov, SingleBinaryEltwiseWithScalarOnSecondBranch) {
+TEST_F(MoveEltwiseUpThroughDataMovTest, SingleBinaryEltwiseWithScalarOnSecondBranch) {
     const ngraph::Shape shape{1, 3, 224, 224};
     const std::vector<int64_t> input_order = {3, 2, 1, 0};
     const int64_t unsqueeze_axis = 2;
     const float scalar_value = 0.5f;
-    std::shared_ptr<ngraph::Function> f(nullptr);
     {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
 
@@ -170,14 +133,9 @@ TEST(MoveEltwiseUpThroughDataMov, SingleBinaryEltwiseWithScalarOnSecondBranch) {
 
         auto add = std::make_shared<ngraph::opset8::Add>(unsqueeze, ngraph::opset8::Constant::create(ngraph::element::f32, {}, {scalar_value}));
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input});
+        manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
+        function = std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input});
     }
-    ngraph::pass::Manager m;
-    m.register_pass<ngraph::pass::InitNodeInfo>();
-    m.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
-    m.run_passes(f);
-    ASSERT_NO_THROW(check_rt_info(f));
-    std::shared_ptr<ngraph::Function> f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
 
@@ -189,20 +147,15 @@ TEST(MoveEltwiseUpThroughDataMov, SingleBinaryEltwiseWithScalarOnSecondBranch) {
         auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(transpose, unsqueeze_const);
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
+        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
     }
-
-    auto res = compare_functions(f, f_ref);
-
-    ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(MoveEltwiseUpThroughDataMov, SingleEltwiseWith5ScalarOnSecondBranch) {
+TEST_F(MoveEltwiseUpThroughDataMovTest, SingleEltwiseWith5ScalarOnSecondBranch) {
     const ngraph::Shape shape{1, 3, 224, 224};
     const std::vector<int64_t> input_order = {3, 2, 1, 0};
     const int64_t unsqueeze_axis = 2;
     const float scalar_value = 0.5f;
-    std::shared_ptr<ngraph::Function> f(nullptr);
     {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
 
@@ -211,14 +164,9 @@ TEST(MoveEltwiseUpThroughDataMov, SingleEltwiseWith5ScalarOnSecondBranch) {
 
         auto add = std::make_shared<ngraph::opset8::Add>(unsqueeze, ngraph::opset8::Constant::create(ngraph::element::f32, {1, 1, 1, 1, 1}, {scalar_value}));
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input});
+        manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
+        function = std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input});
     }
-    ngraph::pass::Manager m;
-    m.register_pass<ngraph::pass::InitNodeInfo>();
-    m.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
-    m.run_passes(f);
-    ASSERT_NO_THROW(check_rt_info(f));
-    std::shared_ptr<ngraph::Function> f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
 
@@ -227,50 +175,33 @@ TEST(MoveEltwiseUpThroughDataMov, SingleEltwiseWith5ScalarOnSecondBranch) {
         auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(add, unsqueeze_const);
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
+        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
     }
-
-    auto res = compare_functions(f, f_ref);
-
-    ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(MoveEltwiseUpThroughDataMov, SingleBinaryEltwiseWithNotScalarOnSecondBranch) {
-    auto create_graph = [] () -> std::shared_ptr<ngraph::Function> {
-        const ngraph::Shape shape{1, 3, 224, 224};
-        const std::vector<int64_t> input_order = {3, 2, 1, 0};
-        const int64_t unsqueeze_axis = 2;
-        std::shared_ptr<ngraph::Function> f(nullptr);
-        auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
-
-        auto transpose_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
-        auto transpose = std::make_shared<ngraph::opset8::Transpose>(input, transpose_const);
-
-        auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
-        auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(transpose, unsqueeze_const);
-
-        auto add_scalar = ngraph::opset8::Constant::create(ngraph::element::f32, {1, 1, 1, 3}, {0.5, 0.2, 0.3});
-        auto add = std::make_shared<ngraph::opset8::Add>(unsqueeze, add_scalar);
-
-        return std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input});
-    };
-    std::shared_ptr<ngraph::Function> f = create_graph();
-    ngraph::pass::Manager m;
-    m.register_pass<ngraph::pass::InitNodeInfo>();
-    m.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
-    m.run_passes(f);
-    ASSERT_NO_THROW(check_rt_info(f));
-
-    std::shared_ptr<ngraph::Function> f_ref = create_graph();
-    auto res = compare_functions(f, f_ref);
-
-    ASSERT_TRUE(res.first) << res.second;
-}
-
-TEST(MoveEltwiseUpThroughDataMov, SingleUnaryEltwiseDynamicShape) {
+TEST_F(MoveEltwiseUpThroughDataMovTest, SingleBinaryEltwiseWithNotScalarOnSecondBranch) {
+    const ngraph::Shape shape{1, 3, 224, 224};
     const std::vector<int64_t> input_order = {3, 2, 1, 0};
     const int64_t unsqueeze_axis = 2;
-    std::shared_ptr<ngraph::Function> f(nullptr);
+
+    auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
+
+    auto transpose_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
+    auto transpose = std::make_shared<ngraph::opset8::Transpose>(input, transpose_const);
+
+    auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
+    auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(transpose, unsqueeze_const);
+
+    auto add_scalar = ngraph::opset8::Constant::create(ngraph::element::f32, {1, 1, 1, 3}, {0.5, 0.2, 0.3});
+    auto add = std::make_shared<ngraph::opset8::Add>(unsqueeze, add_scalar);
+
+    function = std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input});
+    manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
+}
+
+TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwiseDynamicShape) {
+    const std::vector<int64_t> input_order = {3, 2, 1, 0};
+    const int64_t unsqueeze_axis = 2;
     {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(3));
 
@@ -279,15 +210,10 @@ TEST(MoveEltwiseUpThroughDataMov, SingleUnaryEltwiseDynamicShape) {
 
         auto sigmoid = std::make_shared<ngraph::opset8::Sigmoid>(unsqueeze);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{sigmoid}, ngraph::ParameterVector{input});
+        function = std::make_shared<ngraph::Function>(ngraph::NodeVector{sigmoid}, ngraph::ParameterVector{input});
+        manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
     }
 
-    ngraph::pass::Manager m;
-    m.register_pass<ngraph::pass::InitNodeInfo>();
-    m.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
-    m.run_passes(f);
-    ASSERT_NO_THROW(check_rt_info(f));
-    std::shared_ptr<ngraph::Function> f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(3));
 
@@ -296,36 +222,19 @@ TEST(MoveEltwiseUpThroughDataMov, SingleUnaryEltwiseDynamicShape) {
         auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(sigmoid, unsqueeze_const);
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
+        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
     }
-
-    auto res = compare_functions(f, f_ref);
-
-    ASSERT_TRUE(res.first) << res.second;
 }
 
-TEST(MoveEltwiseUpThroughDataMov, SingleUnaryEltwiseDynamicRank) {
-    auto create_graph = [] () -> std::shared_ptr<ngraph::Function> {
-        const std::vector<int64_t> input_order = {3, 2, 1, 0};
-        const int64_t unsqueeze_axis = 2;
-        std::shared_ptr<ngraph::Function> f(nullptr);
-        auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(ngraph::Rank::dynamic()));
+TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwiseDynamicRank) {
+    const std::vector<int64_t> input_order = {3, 2, 1, 0};
+    const int64_t unsqueeze_axis = 2;
 
-        auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
-        auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(input, unsqueeze_const);
-        auto sigmoid = std::make_shared<ngraph::opset8::Sigmoid>(unsqueeze);
-        return std::make_shared<ngraph::Function>(ngraph::NodeVector{sigmoid}, ngraph::ParameterVector{input});
-    };
-    std::shared_ptr<ngraph::Function> f = create_graph();
-    ngraph::pass::Manager m;
-    m.register_pass<ngraph::pass::InitNodeInfo>();
-    m.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
+    auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(ngraph::Rank::dynamic()));
 
-    m.run_passes(f);
-    ASSERT_NO_THROW(check_rt_info(f));
-
-    std::shared_ptr<ngraph::Function> f_ref = create_graph();
-    auto res = compare_functions(f, f_ref);
-
-    ASSERT_TRUE(res.first) << res.second;
+    auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
+    auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(input, unsqueeze_const);
+    auto sigmoid = std::make_shared<ngraph::opset8::Sigmoid>(unsqueeze);
+    function = std::make_shared<ngraph::Function>(ngraph::NodeVector{sigmoid}, ngraph::ParameterVector{input});
+    manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
 }


### PR DESCRIPTION
### Details:
 - For type relaxed nodes opset name detected incorrectly at the serialization time.
 - "PRelu" renamed to "PReLU" during serialization, resulting in incorrect deserialization.
 - Snippets aren't disabled because the cache directory wasn't passed to the CPU plug-in. Snippets serialization isn't currently implemented.
 - ngraph::op::internal nodes exported with wrong opset.

### Tickets:
 - CVS-79088
