### PR TITLE
[MO] Upgrade TensorFlow version dependency due to SNYK hits

### DIFF
--- a/tools/mo/requirements.txt
+++ b/tools/mo/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow~=2.5.0
+tensorflow~=2.5.3
 mxnet~=1.2.0; sys_platform == 'win32'
 mxnet~=1.7.0.post2; sys_platform != 'win32'
 networkx~=2.5; python_version <= "3.6"

--- a/tools/mo/requirements.txt
+++ b/tools/mo/requirements.txt
@@ -1,4 +1,5 @@
-tensorflow~=2.5.3
+tensorflow~=2.5.0; python_version <= "3.6"
+tensorflow~=2.5.3; python_version > "3.6"
 mxnet~=1.2.0; sys_platform == 'win32'
 mxnet~=1.7.0.post2; sys_platform != 'win32'
 networkx~=2.5; python_version <= "3.6"

--- a/tools/mo/requirements_tf.txt
+++ b/tools/mo/requirements_tf.txt
@@ -1,4 +1,4 @@
-tensorflow~=2.5.0
+tensorflow~=2.5.3
 networkx~=2.5; python_version <= "3.6"
 networkx~=2.6; python_version > "3.6"
 numpy>=1.16.6,<1.20

--- a/tools/mo/requirements_tf.txt
+++ b/tools/mo/requirements_tf.txt
@@ -1,4 +1,5 @@
-tensorflow~=2.5.3
+tensorflow~=2.5.0; python_version <= "3.6"
+tensorflow~=2.5.3; python_version > "3.6"
 networkx~=2.5; python_version <= "3.6"
 networkx~=2.6; python_version > "3.6"
 numpy>=1.16.6,<1.20

--- a/tools/mo/requirements_tf2.txt
+++ b/tools/mo/requirements_tf2.txt
@@ -1,4 +1,4 @@
-tensorflow~=2.5.0
+tensorflow~=2.5.3
 networkx~=2.5; python_version <= "3.6"
 networkx~=2.6; python_version > "3.6"
 numpy>=1.16.6,<1.20

--- a/tools/mo/requirements_tf2.txt
+++ b/tools/mo/requirements_tf2.txt
@@ -1,4 +1,5 @@
-tensorflow~=2.5.3
+tensorflow~=2.5.0; python_version <= "3.6"
+tensorflow~=2.5.3; python_version > "3.6"
 networkx~=2.5; python_version <= "3.6"
 networkx~=2.6; python_version > "3.6"
 numpy>=1.16.6,<1.20


### PR DESCRIPTION
**Details:** Due to SNYK hits we decided to upgrade TensorFlow version dependencies for MO.

**Ticket:** 70974
