### PR TITLE
Fix Unpack translator in TF FE

### DIFF
--- a/src/frontends/tensorflow/src/op/unpack.cpp
+++ b/src/frontends/tensorflow/src/op/unpack.cpp
@@ -19,9 +19,16 @@ OutputVector translate_unpack_op(const NodeContext& node) {
     auto num = node.get_attribute<int64_t>("num");
 
     auto axis_const = make_shared<Constant>(element::i64, Shape{}, axis);
-    auto res = make_shared<Split>(input, axis_const, num);
-    set_node_name(node.get_name(), res);
-    return res->outputs();
+    auto split = make_shared<Split>(input, axis_const, num);
+    set_node_name(node.get_name(), split);
+    OutputVector res;
+    int i = 0;
+    for (auto out : split->outputs()) {
+        auto squeezed_res = make_shared<Squeeze>(out, axis_const);
+        set_node_name(node.get_name() + "/squeeze_" + to_string(i++), squeezed_res);
+        res.push_back(squeezed_res);
+    }
+    return res;
 }
 }  // namespace op
 }  // namespace tensorflow


### PR DESCRIPTION
### Details:
 - *Fix Unpack translator. Split doesn't squeeze the axis dimension while tf Unpack does.*

### Tickets:
 - *None*
