### PR TITLE
[Python API] Improvement of dynamic reshape error message in compatibility ie

### DIFF
--- a/src/bindings/python/src/compatibility/openvino/inference_engine/ie_api.pyx
+++ b/src/bindings/python/src/compatibility/openvino/inference_engine/ie_api.pyx
@@ -1740,7 +1740,11 @@ cdef class IENetwork:
             if input not in net_inputs:
                 raise AttributeError(f"Specified '{input}' layer not in network inputs '{net_inputs}'! ")
             for v in shape:
-                c_shape.push_back(v)
+                try:
+                    c_shape.push_back(v)
+                except OverflowError:
+                    raise ValueError(f"Detected dynamic dimension in the shape {shape} of the `{input}` input. Dynamic shapes are supported since OpenVINO Runtime API 2022.1.")
+
             c_input_shapes[input.encode()] = c_shape
         self.impl.reshape(c_input_shapes)
 

--- a/src/bindings/python/tests_compatibility/test_inference_engine/test_IENetwork.py
+++ b/src/bindings/python/tests_compatibility/test_inference_engine/test_IENetwork.py
@@ -157,6 +157,14 @@ def test_reshape():
     assert net.input_info["data"].input_data.shape == [2, 3, 32, 32]
 
 
+def test_reshape_dynamic():
+    ie = IECore()
+    net = ie.read_network(model=test_net_xml, weights=test_net_bin)
+    with pytest.raises(ValueError) as e:
+        net.reshape({"data": (-1, 3, 32, 32)})
+    assert "Detected dynamic dimension in the shape (-1, 3, 32, 32) of the `data` input" in str(e.value)
+
+
 def test_net_from_buffer_valid():
     ie = IECore()
     with open(test_net_bin, 'rb') as f:


### PR DESCRIPTION
### Details:
Improvement of reshape error message with shape like dynamic in compatibility IE Python API bindings
Previous error: `OverflowError: can't convert negative value to size_t`

### Tickets:
 - related discussion in 76721