### PR TITLE
[MO] fix ConvertGroupedStridedSlice.py for XLNet

### DIFF
--- a/tools/mo/openvino/tools/mo/middle/ConvertGroupedStridedSlice.py
+++ b/tools/mo/openvino/tools/mo/middle/ConvertGroupedStridedSlice.py
@@ -91,6 +91,10 @@ class ConvertGroupedStridedSlice(MiddleReplacementPattern):
 
             sorted_out_nodes = sorted(out_nodes, key=lambda n: list(n.slices))
             out_nodes = unique_by(sorted_out_nodes, strided_slices_equality)
+            # if there is only one StridedSlice out_node with unique 'slices',
+            # there is nothing to optimize, continue to the next data node
+            if len(out_nodes) <= 1:
+                continue
 
             for node in out_nodes:
                 if len(node.slices) != len(out_nodes[0].slices):

--- a/tools/mo/unit_tests/mo/middle/ConvertGroupedStridedSlice_test.py
+++ b/tools/mo/unit_tests/mo/middle/ConvertGroupedStridedSlice_test.py
@@ -806,6 +806,45 @@ class ConvertGroupedStridedSliceTests(unittest.TestCase):
         (flag, resp) = compare_graphs(graph, graph_ref, 'concat_1_data', check_op_attrs=True)
         self.assertTrue(flag, resp)
 
+    # one unuque StridedSlice
+    def test_12(self):
+        graph = build_graph(nodes_attributes,
+                            [('placeholder_1', 'placeholder_1_data'),
+                             ('placeholder_1_data', 'sslice_1'),
+                             ('sslice_1', 'sslice_1_data'),
+                             ('placeholder_1_data', 'sslice_2'),
+                             ('sslice_2', 'sslice_2_data'),
+                             ],
+                            {'placeholder_1_data': {'shape': np.array([1, 511])},
+
+                             'sslice_1': {'slices': np.array([slice(0, 1, 1), slice(0, 1, 1)]),
+                                          'begin_mask': np.array([0, 1, 0]),
+                                          'end_mask': np.array([0, 1, 0]),
+                                          'new_axis_mask': np.array([0, 0, 0]),
+                                          'shrink_axis_mask': np.array([0, 0, 0]),
+                                          'ellipsis_mask': np.array([0, 0, 0])},
+                             'sslice_1_data': {'shape': np.array([1, 1, 511])},
+
+                             'sslice_2': {'slices': np.array([slice(0, 1, 1), slice(0, 1, 1)]),
+                                          'begin_mask': np.array([0, 1, 0]),
+                                          'end_mask': np.array([0, 1, 0]),
+                                          'new_axis_mask': np.array([0, 0, 0]),
+                                          'shrink_axis_mask': np.array([0, 0, 0]),
+                                          'ellipsis_mask': np.array([0, 0, 0])},
+                             'sslice_2_data': {'shape': np.array([1, 1, 511])},
+                             })
+        graph.graph['layout'] = 'NHWC'
+
+        graph_ref = graph.copy()
+
+        pattern = ConvertGroupedStridedSlice()
+        pattern.find_and_replace_pattern(graph)
+
+        (flag, resp) = compare_graphs(graph, graph_ref, 'sslice_1_data', check_op_attrs=True)
+        self.assertTrue(flag, resp)
+        (flag, resp) = compare_graphs(graph, graph_ref, 'sslice_2_data', check_op_attrs=True)
+        self.assertTrue(flag, resp)
+
 
 class AddReshapeAfterStridedSliceTests(unittest.TestCase):
     def test_ss_1_shrink_last(self):


### PR DESCRIPTION
**Root cause analysis**: 
Error happens with model `TF_XLNET_LARGE_SQUAD` in `ConvertGroupedStridedSlice` StridedSlices is replaced with VariadicSplit and after re-inference new shapes are inconsistent with old ones.

This degradation was introduces in #5918. When dynamic shapes were added `out_nodes = unique_by(sorted_out_nodes, strided_slices_equality)` was moved below while continuation condition `if len(out_nodes) <= 1` has remained in the same place => therefore even if `out_nodes` had 2 `StridedSlices` with identical `slices` `ConvertGroupedStridedSlice` interpreted them as different and tried to replace them with `VariadicSplit`.

**Solution**:
Add continuation `if len(out_nodes) <= 1` condition right after sorting by unique slices to prevent trying to group 

Ticket: CVS-77777

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR: but the original model for which model was intended 
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names

Validation:
* [x]  Unit tests
* n/a  Framework operation tests: no new operations were added
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check: restoring and comparison was successful
* [x]  Local Offline e2e validation: green for batch=1, network is not reshape-able to batch=2 because of the hardcoded original shapes
![image](https://user-images.githubusercontent.com/5703039/154552730-e584dc23-7544-417f-afa8-5663c9c019df.png)


Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update