### PR TITLE
[GPU] Fixed batch size again to 8 as a workaround of compiler restriction.

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
@@ -148,7 +148,7 @@ bool kernels_cache::is_cache_enabled() const {
 }
 
 size_t kernels_cache::get_max_kernels_per_batch() const {
-    return 9;
+    return 8;
 }
 
 


### PR DESCRIPTION
### Details:
 - Re-adjust the batch size to 8 to get more chance of compilation optimization 

### Tickets:
 -  73245
