### PR TITLE
[GPU] Fix issues with floating point fusings support for cldnn / onednn fully connected kernels

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -554,13 +554,9 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
         };
 
         auto fc_supports_fusings = [](fully_connected_node& node) -> bool {
-            auto out_fmt = node.get_output_layout().format;
-            auto in_l = node.get_dependency(0).get_output_layout();
-            auto in_dt = in_l.data_type;
-            auto in_b = in_l.size.batch[0];
+            auto in_dt = node.get_dependency(0).get_output_layout().data_type;
 
-            return (data_type_traits::is_i8_u8(in_dt) || (data_type_traits::is_floating_point(in_dt) && in_b > 1)) &&
-                   out_fmt != format::yxfb;
+            return data_type_traits::is_i8_u8(in_dt);
         };
 
         auto gemm_supports_fusings = [](gemm_node& node) -> bool {

--- a/src/plugins/intel_gpu/tests/fusions/fully_connected_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/fully_connected_fusion_test.cpp
@@ -359,9 +359,9 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, fc_int8_scale_activation_quantize_i8, ::te
     fully_connected_test_params{ CASE_FC_U8S8_3D_2, 2, 5 },
     fully_connected_test_params{ CASE_FC_U8S8_3D_3, 2, 5 },
 
-    fully_connected_test_params{ CASE_FC_FP32_3D_1, 2, 5 },
-    fully_connected_test_params{ CASE_FC_FP32_3D_2, 2, 5 },
-    fully_connected_test_params{ CASE_FC_FP32_3D_3, 2, 5 },
+    fully_connected_test_params{ CASE_FC_FP32_3D_1, 3, 5 },
+    fully_connected_test_params{ CASE_FC_FP32_3D_2, 3, 5 },
+    fully_connected_test_params{ CASE_FC_FP32_3D_3, 3, 5 },
 }));
 
 #ifdef ENABLE_ONEDNN_FOR_GPU


### PR DESCRIPTION
### Details:
 - Temporary removed support of fully connected fusings for fp inputs due to errors in bf_tiled (and potentially in bfyx_ref) fc kernels, the work will be finished after creating of release branch; currently it seems more safely for release stability to stay support of only i8/u8 fusings inside fc kernels as it was before my changes in PR #10035.
 - Onednn kernels also have some problems with support of fp fused ops for fully connected layers, needs extra investigations.

### Tickets:
 - 79558
 - 79568
 - 79596
