### PR TITLE
[GPU] Mixed precision fix for mask rcnn (#10467)

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -20,6 +20,7 @@
 #include <list>
 #include <map>
 #include <set>
+#include <tuple>
 
 using namespace cldnn;
 
@@ -562,7 +563,7 @@ void reorder_inputs::run(program& p, layout_optimizer& lo, reorder_factory& rf) 
         }
     };
 
-    const auto reorder_convolution = [&p, &lo, &rf](typed_program_node<convolution>& conv_node) {
+    const auto reorder_convolution = [&p, &lo, &rf, &debug_config](typed_program_node<convolution>& conv_node) {
         {
             // reorder weights convolution
             auto& weights = conv_node.weights();
@@ -602,35 +603,43 @@ void reorder_inputs::run(program& p, layout_optimizer& lo, reorder_factory& rf) 
             conv_node.get_dependencies().front()->set_output_layout(new_layout, false);
         }
 
-        std::vector<format> wrong_format = {format::b_fs_yx_fsv16, format::bs_fs_yx_bsv32_fsv16};
-        std::vector<format> correct_format = {format::b_fs_yx_fsv32, format::bs_fs_yx_bsv32_fsv32};
-        for (int i = 0; i < wrong_format.size(); i++) {
-            // reorder for onednn mixed-precision conv
-            // If the layouts are like below, change input layout to fsv32.
-            // From:
-            //   (bsv32_fsv16.u8) --> conv --> (bsv32_fsv16.fp16)
-            // To:
-            //   (bsv32_fsv16.u8) --> reorder --> (bsv32_fsv32.u8) --> conv --> (bsv32_fsv16.fp16)
-            //
-            // Do not apply such change for b=1 first conv
-
+        // reorder for onednn mixed-precision conv
+        // If the layouts are like below, change input layout to fsv32.
+        // From:
+        //   (bsv32_fsv16.u8) --> conv --> (bsv32_fsv16.fp16)
+        // To:
+        //   (bsv32_fsv16.u8) --> reorder --> (bsv32_fsv32.u8) --> conv --> (bsv32_fsv16.fp16)
+        //
+        // Do not apply such change for b=1 first conv
+        enum class __data_type {i8_u8, floating_point};
+        // Errata for mixed precision in onednn
+        // data_type, wrong_format, correct_format
+        std::vector<std::tuple<__data_type, format, format>> errata = {
+            {__data_type::i8_u8, format::b_fs_yx_fsv16, format::b_fs_yx_fsv32},
+            {__data_type::i8_u8, format::bs_fs_yx_bsv32_fsv16, format::bs_fs_yx_bsv32_fsv32},
+            {__data_type::floating_point, format::b_fs_yx_fsv32, format::b_fs_yx_fsv16},
+            {__data_type::floating_point, format::bs_fs_yx_bsv32_fsv32, format::bs_fs_yx_bsv32_fsv16}};
+        for (auto &e : errata) {
             auto prev_node = conv_node.get_dependencies().front();
-            auto old_layout = prev_node->get_output_layout();
+            auto prev_layout = prev_node->get_output_layout();
             auto conv_layout = conv_node.get_output_layout();
+            auto is_target_dt_in_errata = (std::get<0>(e) == __data_type::i8_u8 && data_type_traits::is_i8_u8(prev_layout.data_type)) ||
+                                          (std::get<0>(e) == __data_type::floating_point && data_type_traits::is_floating_point(prev_layout.data_type));
+            auto wrong_format = std::get<1>(e);
+            auto correct_format = std::get<2>(e);
             if (lo.get_optimization_attributes().use_onednn_impls
-                    && conv_layout.format == wrong_format[i]
-                    && data_type_traits::is_i8_u8(old_layout.data_type)
-                    && (old_layout.format == wrong_format[i])
-                    && !(old_layout.size.batch[0] == 1 && old_layout.size.feature[0] <= 4)) {
-                auto new_layout = old_layout;
-                new_layout.format = correct_format[i];
+                    && is_target_dt_in_errata
+                    && conv_layout.format == wrong_format
+                    && prev_layout.format == wrong_format
+                    && !(prev_layout.size.batch[0] == 1 && prev_layout.size.feature[0] <= 4)) {
+                auto new_layout = prev_layout;
+                new_layout.format = correct_format;
                 auto new_input = rf.get_reorder(prev_node->id(),
-                                                old_layout,
+                                                prev_layout,
                                                 new_layout);
 
-                if (new_input.first) {
+                if (new_input.first)
                     p.add_intermediate(new_input.first, conv_node, 0, !new_input.second);
-                }
 
                 // Prevent layout propagation as we are using mixed precision for conv
                 conv_node.get_dependencies().front()->set_output_layout(new_layout, false);

--- a/src/plugins/intel_gpu/tests/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/concatenation_gpu_test.cpp
@@ -1107,6 +1107,11 @@ public:
     }
 
     void test(format::type fmt) {
+        auto& engine = get_onednn_test_engine();
+        if (!engine.get_device_info().supports_immad) {
+            // This case is only for device that uses onednn.
+            return;
+        }
         auto input = generate_input();
 
         // implicit concat


### PR DESCRIPTION
* Select proper layout for fp16-int8 mixed precision network
* Set proper layout in layout propagation for mixed precision
* Disable onednn implicit concat test for HW that is not using onednn

Previous PR was reverted due to precommit failure: https://github.com/openvinotoolkit/openvino/pull/10467

### Tickets:
 - 79789
 - 74545
