### PR TITLE
[CPU] Fixed legacy post ops behavior

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -1791,7 +1791,9 @@ void MKLDNNFakeQuantizeNode::initializePostOpDataLegacy(const VectorDims &dims, 
         quantizationData.insert(quantizationData.end(), outputScale.begin(), outputScale.end());
         quantizationData.insert(quantizationData.end(), outputShift.begin(), outputShift.end());
         quantizationDataSize = quantizationData.size();
-        quantizationData.resize(rnd_up(quantizationData.size(), bufferAlignment), 0);
+
+        int bufferPaddingSize = rnd_up(outputShift.size(), bufferAlignment) - outputShift.size();
+        quantizationData.resize(quantizationDataSize + bufferPaddingSize, 0);
     }
 
     isPostOpDataInitialized = true;


### PR DESCRIPTION
### Details:
 - The PR fixes regressions introduced in https://github.com/openvinotoolkit/openvino/pull/9938:
 -- Post ops data buffers padding was computed incorrectly which resulted in out-of-bounds read
 -- Composability of legacy and binary post ops was broken (required for int8 Deconvolution)

- PR in oneDNN fork: https://github.com/openvinotoolkit/oneDNN/pull/120/

### Tickets:
 - *CVS-79794*
