### PR TITLE
Fix warnings from builders.hpp

### DIFF
--- a/src/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
+++ b/src/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
@@ -41,22 +41,16 @@ std::shared_ptr<Node> makeConstant(const element::Type &type, const std::vector<
         case TYPE: \
             weightsNode = std::make_shared<ngraph::opset1::Constant>( \
                     type, shape, \
-                    random ? NGraphFunctions::Utils::generateVector<TYPE>(ngraph::shape_size(shape), upTo, startFrom, seed) : \
-                             NGraphFunctions::Utils::castVector<T, ngraph::helpers::nGraphTypesTrait<TYPE>::value_type >(data)); \
+                    random ? NGraphFunctions::Utils::generateVector<TYPE>( \
+                                ngraph::shape_size(shape), \
+                                ngraph::helpers::nGraphTypesTrait<TYPE>::value_type(upTo), \
+                                ngraph::helpers::nGraphTypesTrait<TYPE>::value_type(startFrom), \
+                                seed) \
+                           : NGraphFunctions::Utils::castVector<T, ngraph::helpers::nGraphTypesTrait<TYPE>::value_type >(data)); \
             break;
     switch (type) {
-        case ngraph::element::Type_t::bf16:
-            weightsNode = std::make_shared<ngraph::opset1::Constant>(
-                    type, shape,
-                    random ? NGraphFunctions::Utils::generateBF16Vector(ngraph::shape_size(shape), upTo, startFrom) :
-                    NGraphFunctions::Utils::castVector<T, ngraph::bfloat16>(data));
-            break;
-        case ngraph::element::Type_t::f16:
-            weightsNode = std::make_shared<ngraph::opset1::Constant>(
-                    type, shape,
-                    random ? NGraphFunctions::Utils::generateF16Vector(ngraph::shape_size(shape), upTo, startFrom) :
-                    NGraphFunctions::Utils::castVector<T, ngraph::float16>(data));
-            break;
+        makeNode(ngraph::element::Type_t::bf16);
+        makeNode(ngraph::element::Type_t::f16);
         makeNode(ngraph::element::Type_t::f32);
         makeNode(ngraph::element::Type_t::f64);
         makeNode(ngraph::element::Type_t::i8);

--- a/src/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/utils/data_utils.hpp
+++ b/src/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/utils/data_utils.hpp
@@ -54,8 +54,12 @@ generateVector(size_t vec_len,
     }
 }
 
+template<>
 std::vector<ngraph::float16> inline
-generateF16Vector(size_t vec_len, ngraph::float16 upTo = 10, ngraph::float16 startFrom = 1, int32_t seed = 1) {
+generateVector<ngraph::element::Type_t::f16>(size_t vec_len,
+                                             ngraph::float16 upTo,
+                                             ngraph::float16 startFrom,
+                                             int32_t seed) {
     std::vector<ngraph::float16> res(vec_len);
     std::mt19937 gen(seed);
     // chose values between this range to avoid type overrun (e.g. in case of I8 precision)
@@ -69,8 +73,12 @@ generateF16Vector(size_t vec_len, ngraph::float16 upTo = 10, ngraph::float16 sta
     return res;
 }
 
+template<>
 std::vector<ngraph::bfloat16> inline
-generateBF16Vector(size_t vec_len, ngraph::bfloat16 upTo = 10, ngraph::bfloat16 startFrom = 1, int32_t seed = 1) {
+generateVector<ngraph::element::Type_t::bf16>(size_t vec_len,
+                                              ngraph::bfloat16 upTo,
+                                              ngraph::bfloat16 startFrom,
+                                              int32_t seed) {
     std::vector<ngraph::bfloat16> res(vec_len);
 
     std::mt19937 gen(seed);


### PR DESCRIPTION
### Details:
 - fixed several thousands of warnings from builders.hpp: warning C4244: 'argument': conversion from 'T' to 'ngraph::helpers::nGraphTypesTrait<....
 - Generalization for bf16 and f16

### Tickets:
 - *ticket-id*
