### PR TITLE
Add constant folding to hetero to avoid dynamism on GPU

### DIFF
--- a/src/plugins/hetero/executable_network.cpp
+++ b/src/plugins/hetero/executable_network.cpp
@@ -39,6 +39,7 @@
 #include "plugin.hpp"
 #include <ie_algorithm.hpp>
 
+#include <ngraph/pass/manager.hpp>
 #include <ngraph/function.hpp>
 #include <ngraph/variant.hpp>
 #include <ngraph/graph_util.hpp>
@@ -47,6 +48,7 @@
 #include <ngraph/op/util/op_types.hpp>
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pass/visualize_tree.hpp>
+#include <ngraph/pass/constant_folding.hpp>
 // clang-format on
 
 using namespace InferenceEngine;
@@ -68,6 +70,11 @@ HeteroExecutableNetwork::HeteroExecutableNetwork(const InferenceEngine::CNNNetwo
       _config{config} {
     auto function = network.getFunction();
     IE_ASSERT(function != nullptr);
+
+    ngraph::pass::Manager manager;
+    manager.register_pass<ngraph::pass::ConstantFolding>();
+    manager.run_passes(std::const_pointer_cast<ov::Model>(function));
+
     auto clonedFunction = ngraph::clone_function(*function);
     bool dumpDotFile = false;
     if (std::getenv("OPENVINO_HETERO_VISUALIZE")) {

--- a/src/plugins/hetero/executable_network.cpp
+++ b/src/plugins/hetero/executable_network.cpp
@@ -68,11 +68,9 @@ HeteroExecutableNetwork::HeteroExecutableNetwork(const InferenceEngine::CNNNetwo
       _heteroPlugin{plugin},
       _name{originalNetwork.getName()},
       _config{config} {
-    auto originalFunction = originalNetwork.getFunction();
-    IE_ASSERT(originalFunction != nullptr);
-
-    auto clonned_function = ngraph::clone_function(*originalFunction);
-    InferenceEngine::CNNNetwork clonned_network(clonned_function);
+    auto clonned_network = InferenceEngine::details::cloneNetwork(originalNetwork);
+    auto clonned_function = clonned_network.getFunction();
+    IE_ASSERT(clonned_function != nullptr);
 
     ngraph::pass::Manager manager;
     manager.register_pass<ngraph::pass::ConstantFolding>();


### PR DESCRIPTION
### Details:
 - Add constant folding to hetero plugin to avoid network splitting to dynamic parts and submit them to devices that do not support dynamism


### Tickets:
 - CVS-71762
