### PR TITLE
[CPU] Avoid using cache for constant inplace or multi-child edges

### DIFF
--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -292,7 +292,10 @@ void MKLDNNEdge::externalAllocate(MKLDNNWeightsSharing::Ptr weightsCache) {
     if (status != Status::NeedAllocation)
         return;
 
-    if (weightsCache) {
+    bool isTheOnlyChildEdge = getParent()->getChildEdges().size() == 1;
+    bool isConcurrentUpdatePossible = getParent()->isInPlace() || getChild()->isInPlace() || !isTheOnlyChildEdge;
+
+    if (weightsCache && !isConcurrentUpdatePossible) {
         auto alloc = [this] () {
             allocate();
             return memoryPtr;

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -288,12 +288,35 @@ std::string MKLDNNEdge::name() const {
     return  result.str();
 }
 
+
+
 void MKLDNNEdge::externalAllocate(MKLDNNWeightsSharing::Ptr weightsCache) {
+    auto isInPlace = [](const MKLDNNNodePtr node, int port) -> bool {
+        const auto& selected_pd = node->getSelectedPrimitiveDescriptor();
+        if (selected_pd == nullptr)
+            IE_THROW() << "Preferable primitive descriptor is not set.";
+
+        const auto& config = selected_pd->getConfig();
+
+        for (const auto& in : config.inConfs) {
+            if (in.inPlace() == port) {
+                return true;
+            }
+        }
+        for (const auto& out : config.outConfs) {
+            if (out.inPlace() == port) {
+                return true;
+            }
+        }
+
+        return false;
+    };
+
     if (status != Status::NeedAllocation)
         return;
 
     bool isTheOnlyChildEdgeAtPort = getParent()->getChildEdgesAtPort(getInputNum()).size() == 1;
-    bool isConcurrentUpdatePossible = getParent()->isInPlace() || getChild()->isInPlace() || !isTheOnlyChildEdgeAtPort;
+    bool isConcurrentUpdatePossible = isInPlace(getParent(), getInputNum()) || isInPlace(getChild(), getOutputNum()) || !isTheOnlyChildEdgeAtPort;
 
     if (weightsCache && !isConcurrentUpdatePossible) {
         auto alloc = [this] () {

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -292,8 +292,8 @@ void MKLDNNEdge::externalAllocate(MKLDNNWeightsSharing::Ptr weightsCache) {
     if (status != Status::NeedAllocation)
         return;
 
-    bool isTheOnlyChildEdge = getParent()->getChildEdges().size() == 1;
-    bool isConcurrentUpdatePossible = getParent()->isInPlace() || getChild()->isInPlace() || !isTheOnlyChildEdge;
+    bool isTheOnlyChildEdgeAtPort = getParent()->getChildEdgesAtPort(getInputNum()).size() == 1;
+    bool isConcurrentUpdatePossible = getParent()->isInPlace() || getChild()->isInPlace() || !isTheOnlyChildEdgeAtPort;
 
     if (weightsCache && !isConcurrentUpdatePossible) {
         auto alloc = [this] () {


### PR DESCRIPTION
To avoid concurrent allocation while resolving inplace conflicts
-------
### Tickets:
 - 79095