### PR TITLE
[MO] update error message when reverse infer was not successful

### DIFF
--- a/tools/mo/openvino/tools/mo/middle/passes/infer.py
+++ b/tools/mo/openvino/tools/mo/middle/passes/infer.py
@@ -353,8 +353,20 @@ def reverse_infer(graph: Graph, nodes: list):
                 log.debug('Inputs:')
                 log_debug_dict(node.in_nodes(), 'inputs')
 
+    parameters_with_no_shape = []
     for node in graph.get_op_nodes(op='Parameter'):
-        name = node.soft_get('name', node.id)
         if not node.has_valid('shape'):
-            raise Error("Reverse infer couldn't calculate partial shape of Parameter node '{}'. "
-                        "Please use cli options --input or --input_shape to set model input shape.".format(name))
+            parameters_with_no_shape.append(node)
+
+    if len(parameters_with_no_shape) == 0:
+        return
+
+    parameters_names = ''
+    for idx, node in enumerate(parameters_with_no_shape):
+        parameters_names += "'{}'".format(node.soft_get('name', node.id))
+        if idx < len(parameters_with_no_shape) - 1:
+            parameters_names += ', '
+
+    if len(parameters_with_no_shape) > 0:
+        raise Error("Model Optimizer is unable to deduce input shapes for the following Parameter nodes: {}. "
+                    "Please use cli options --input or --input_shape to set model input shape.".format(parameters_names))

--- a/tools/mo/openvino/tools/mo/middle/passes/infer.py
+++ b/tools/mo/openvino/tools/mo/middle/passes/infer.py
@@ -353,3 +353,8 @@ def reverse_infer(graph: Graph, nodes: list):
                 log.debug('Inputs:')
                 log_debug_dict(node.in_nodes(), 'inputs')
 
+    for node in graph.get_op_nodes(op='Parameter'):
+        name = node.soft_get('name', node.id)
+        if not node.has_valid('shape'):
+            raise Error("Reverse infer couldn't calculate partial shape of Parameter node '{}'. "
+                        "Please use cli options --input or --input_shape to set model input shape.".format(name))

--- a/tools/mo/unit_tests/mo/front/common/partial_infer/eltwise_test.py
+++ b/tools/mo/unit_tests/mo/front/common/partial_infer/eltwise_test.py
@@ -180,7 +180,7 @@ class TestElementwiseReverseInfer(unittest.TestCase):
 
     def test_reverse_infer_6(self):
         # both output and input has the same rank, cannot deduce other inputs rank
-        with self.assertRaisesRegex(Error, "Reverse infer couldn't calculate"):
+        with self.assertRaisesRegex(Error, "Model Optimizer is unable to deduce input shapes"):
             self.build_and_test_reverse_inference(inp_shape_1=[dyn, dyn, dyn, dyn],
                                                   inp_shape_2=None,
                                                   out_shape=[dyn, dyn, 4, 1],

--- a/tools/mo/unit_tests/mo/front/common/partial_infer/eltwise_test.py
+++ b/tools/mo/unit_tests/mo/front/common/partial_infer/eltwise_test.py
@@ -180,7 +180,7 @@ class TestElementwiseReverseInfer(unittest.TestCase):
 
     def test_reverse_infer_6(self):
         # both output and input has the same rank, cannot deduce other inputs rank
-        with self.assertRaisesRegex(Error, 'Stopped shape/value propagation'):
+        with self.assertRaisesRegex(Error, "Reverse infer couldn't calculate"):
             self.build_and_test_reverse_inference(inp_shape_1=[dyn, dyn, dyn, dyn],
                                                   inp_shape_2=None,
                                                   out_shape=[dyn, dyn, 4, 1],


### PR DESCRIPTION
Root cause analysis: when reverse infer is not successful error message was unfriendly and didn't show user any hint how to convert model in that case.

Solution: catch if reverse infer was unsuccessfully from the very beginning and inform user to specify input shape directly with the use `--input` /`--input_shape`.

Ticket:  CVS-79979

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* n/a  Framework operation tests - no new operations were added
* n/a  Transformation tests - no new operations were added
* n/a  Model Optimizer IR Reader check - changes do not modify IR structure

Documentation:
* n/a  Supported frameworks operations list
* [ ]  Guide on how to convert the **public** model: need to review the current documentation
* [ ]  User guide update: need to review the current documentation