### PR TITLE
[Python API] Remove get/set_config methods from the PyOV

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/compiled_model.cpp
+++ b/src/bindings/python/src/pyopenvino/core/compiled_model.cpp
@@ -149,15 +149,6 @@ void regclass_CompiledModel(py::module m) {
             :rtype: None
         )");
 
-    // todo: remove after Accuracy Checker migration to set/get_property API
-    cls.def(
-        "get_config",
-        [](ov::CompiledModel& self, const std::string& name) -> py::object {
-            PyErr_WarnEx(PyExc_DeprecationWarning, "get_config() is deprecated, use get_property() instead.", 1);
-            return Common::from_ov_any(self.get_property(name)).as<py::object>();
-        },
-        py::arg("name"));
-
     cls.def(
         "get_property",
         [](ov::CompiledModel& self, const std::string& name) -> py::object {
@@ -171,15 +162,6 @@ void regclass_CompiledModel(py::module m) {
             :type name: str
             :rtype: Any
         )");
-
-    // todo: remove after Accuracy Checker migration to set/get_property API
-    cls.def(
-        "get_metric",
-        [](ov::CompiledModel& self, const std::string& name) -> py::object {
-            PyErr_WarnEx(PyExc_DeprecationWarning, "get_metric() is deprecated, use get_property() instead.", 1);
-            return Common::from_ov_any(self.get_property(name)).as<py::object>();
-        },
-        py::arg("name"));
 
     cls.def("get_runtime_model",
             &ov::CompiledModel::get_runtime_model,

--- a/src/bindings/python/src/pyopenvino/core/core.cpp
+++ b/src/bindings/python/src/pyopenvino/core/core.cpp
@@ -32,19 +32,6 @@ void regclass_Core(py::module m) {
 
     cls.def(py::init<const std::string&>(), py::arg("xml_config_file") = "");
 
-    // todo: remove after Accuracy Checker migration to set/get_property API
-    cls.def(
-        "set_config",
-        [](ov::Core& self, const std::map<std::string, std::string>& config, const std::string& device_name) {
-            PyErr_WarnEx(PyExc_DeprecationWarning, "set_config() is deprecated, use set_property() instead.", 1);
-            self.set_property(device_name, {config.begin(), config.end()});
-        },
-        py::arg("device_name") = "",
-        py::arg("properties"),
-        R"(
-            Sets properties for the device.
-        )");
-
     cls.def(
         "set_property",
         [](ov::Core& self, const std::map<std::string, py::object>& properties) {
@@ -369,16 +356,6 @@ void regclass_Core(py::module m) {
                 new_compiled = core.import_model(user_stream, "CPU")
         )");
 
-    // todo: remove after Accuracy Checker migration to set/get_property API
-    cls.def(
-        "get_config",
-        [](ov::Core& self, const std::string& device_name, const std::string& name) -> py::object {
-            PyErr_WarnEx(PyExc_DeprecationWarning, "get_config() is deprecated, use get_property() instead.", 1);
-            return Common::from_ov_any(self.get_property(device_name, name)).as<py::object>();
-        },
-        py::arg("device_name"),
-        py::arg("name"));
-
     cls.def(
         "get_property",
         [](ov::Core& self, const std::string& device_name, const std::string& name) -> py::object {
@@ -396,16 +373,6 @@ void regclass_Core(py::module m) {
             :return: Extracted information from property.
             :rtype: object
         )");
-
-    // todo: remove after Accuracy Checker migration to set/get_property API
-    cls.def(
-        "get_metric",
-        [](ov::Core& self, const std::string device_name, const std::string name) -> py::object {
-            PyErr_WarnEx(PyExc_DeprecationWarning, "get_metric() is deprecated, use get_property() instead.", 1);
-            return Common::from_ov_any(self.get_property(device_name, name)).as<py::object>();
-        },
-        py::arg("device_name"),
-        py::arg("name"));
 
     cls.def("register_plugin",
             &ov::Core::register_plugin,


### PR DESCRIPTION
### Details:
 - Remove get/set_config, get_metric methods from the new Python API as OMZ was migrated to the new Configuration API.

### Tickets:
 - *ticket-id*
