### PR TITLE
[Sinppets] Add virt destructors to Emitter and TargetMachine

### DIFF
--- a/src/common/snippets/include/snippets/emitter.hpp
+++ b/src/common/snippets/include/snippets/emitter.hpp
@@ -48,6 +48,7 @@ public:
      */
     virtual void emit_data() const {
     }
+    virtual ~Emitter() = default;
 };
 
 } // namespace snippets

--- a/src/common/snippets/include/snippets/generator.hpp
+++ b/src/common/snippets/include/snippets/generator.hpp
@@ -60,6 +60,7 @@ public:
     bool has(const ngraph::DiscreteTypeInfo type) const {
         return jitters.find(type) != jitters.end();
     }
+    virtual ~TargetMachine() = default;
 
 protected:
     std::map<const ngraph::DiscreteTypeInfo, std::function<std::shared_ptr<Emitter>(std::shared_ptr<ngraph::Node>)>> jitters;

--- a/src/plugins/intel_cpu/src/emitters/cpu_generator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/cpu_generator.hpp
@@ -28,7 +28,6 @@ private:
 class CPUGenerator : public ngraph::snippets::Generator {
 public:
     CPUGenerator(dnnl::impl::cpu::x64::cpu_isa_t isa);
-    ~CPUGenerator() = default;
 };
 
 }   // namespace intel_cpu


### PR DESCRIPTION
### Details:
Add virtual destructors to Emmiter and TargetMachine, since they are interface classes.
