### PR TITLE
[GNA] Remove extra FQ layers from the final network

### DIFF
--- a/src/plugins/intel_gna/backend/make_pwl.cpp
+++ b/src/plugins/intel_gna/backend/make_pwl.cpp
@@ -229,7 +229,7 @@ void make_gna_pwl(const DnnActivation&  fun,
             int32_t x_upper = INT32_MAX;
             int16_t y_lower = y_min;
             int16_t y_upper = y_max;
-            if (fun == kActFakeQuantize && fun.fqParams.set) {
+            if ((fun == kActFakeQuantize || fun == kActIdentity) && fun.fqParams.set) {
                 x_lower = std::max(static_cast<int64_t>(*fun.fqParams.input_low * in_scale), static_cast<int64_t>(x_lower));
                 x_upper = std::min(static_cast<int64_t>(*fun.fqParams.input_high * in_scale), static_cast<int64_t>(x_upper));
                 y_lower = std::max(static_cast<int32_t>(*fun.fqParams.input_low * out_scale), static_cast<int32_t>(y_lower));
@@ -253,7 +253,7 @@ void make_gna_pwl(const DnnActivation&  fun,
                         x_upper = FLOAT_TO_INT32(y_upper  * in_scale / out_scale);
                     }
                 }
-            } else if (fun == kActIdentity) {
+            } else if (fun == kActIdentity && !fun.fqParams.set) {
                 if (x_lower < y_lower * in_scale / out_scale) x_lower = FLOAT_TO_INT32(y_lower * in_scale / out_scale);
                 if (x_upper > y_upper * in_scale / out_scale) x_upper = FLOAT_TO_INT32(y_upper * in_scale / out_scale);
                 if (y_lower < x_lower * out_scale / in_scale) y_lower = FLOAT_TO_INT16(x_lower * out_scale / in_scale);

--- a/src/plugins/intel_gna/frontend/scale_factor_calc.hpp
+++ b/src/plugins/intel_gna/frontend/scale_factor_calc.hpp
@@ -538,7 +538,8 @@ class ScaleFactorPerLayer<InferenceEngine::CNNLayer*, QUANT_DESC> {
             auto maxOutValue = quantizedParams->_dst_quant.GetMaxValues().front();
             auto absMax = std::max(std::abs(minOutValue), std::abs(maxOutValue));
 
-            result = CalculateScaleFactorFromStats(quantizedParams->_dst_quant.GetLevels(), minOutValue, maxOutValue);
+            auto levels = std::min(quantizedParams->_dst_quant.GetLevels(), static_cast<size_t>(std::numeric_limits<uint16_t>::max()) + 1);
+            result = CalculateScaleFactorFromStats(levels, minOutValue, maxOutValue);
             if (std::isinf(result) || fp32eq(absMax, 0.0f)) {
                 result = max_activation_scale_factor;
             }

--- a/src/tests/functional/plugin/gna/pass_tests/fq_fusion_with_multiple_weights.cpp
+++ b/src/tests/functional/plugin/gna/pass_tests/fq_fusion_with_multiple_weights.cpp
@@ -118,7 +118,7 @@ const std::vector<std::map<std::string, std::string>> configs = {
 };
 
 const std::vector<std::vector<size_t>> inputShape = {
-    {1, 1, 1, 128}
+    {1, 8, 1, 128}
 };
 
 const std::vector<std::pair<float, float>> weightsMinMax = {

--- a/src/tests/functional/plugin/gna/pass_tests/fq_fusion_with_multiple_weights.cpp
+++ b/src/tests/functional/plugin/gna/pass_tests/fq_fusion_with_multiple_weights.cpp
@@ -118,7 +118,7 @@ const std::vector<std::map<std::string, std::string>> configs = {
 };
 
 const std::vector<std::vector<size_t>> inputShape = {
-    {1, 8, 1, 128}
+    {1, 1, 1, 128}
 };
 
 const std::vector<std::pair<float, float>> weightsMinMax = {

--- a/src/tests/functional/plugin/gna/scale_factors_tests/eltwise_act_fq.cpp
+++ b/src/tests/functional/plugin/gna/scale_factors_tests/eltwise_act_fq.cpp
@@ -93,7 +93,7 @@ protected:
         const ngraph::Shape shape = {1, 128};
         auto params = ngraph::builder::makeParams(ngPrc, {shape});
 
-        auto lowNodeIn = ngraph::builder::makeConstant<float>(ngPrc, {1}, { 100 * inputDataMin });
+        auto lowNodeIn = ngraph::builder::makeConstant<float>(ngPrc, {1}, { 100 * -inputDataMax });
         auto highNodeIn = ngraph::builder::makeConstant<float>(ngPrc, {1}, { 100 * inputDataMax });
         auto fqIn = std::make_shared<ngraph::opset8::FakeQuantize>(params[0], lowNodeIn, highNodeIn,
             lowNodeIn, highNodeIn, levels16);

--- a/src/tests/functional/plugin/gna/scale_factors_tests/matmul_overload_correction.cpp
+++ b/src/tests/functional/plugin/gna/scale_factors_tests/matmul_overload_correction.cpp
@@ -67,6 +67,8 @@ protected:
         const ngraph::Shape shape2 = {1, inputShape[1] * inputShape[1]};
         const float maxInputValue = 10.0f;
         auto params = ngraph::builder::makeParams(ngPrc, {shape1});
+        auto relu = std::make_shared<ngraph::opset8::Relu>(params[0]);
+
         std::shared_ptr<ngraph::Node> input2;
         if (isSecondInputConst) {
             input2 = ngraph::builder::makeConstant<float>(ngPrc, ngraph::Shape{shape1[1], shape1[1]},
@@ -78,7 +80,7 @@ protected:
 
         auto lowNodeIn1 = ngraph::builder::makeConstant<float>(ngPrc, {1}, { -maxInputValue });
         auto highNodeIn1 = ngraph::builder::makeConstant<float>(ngPrc, {1}, { maxInputValue });
-        auto fqIn1 = std::make_shared<ngraph::opset8::FakeQuantize>(params[0], lowNodeIn1, highNodeIn1,
+        auto fqIn1 = std::make_shared<ngraph::opset8::FakeQuantize>(relu, lowNodeIn1, highNodeIn1,
             lowNodeIn1, highNodeIn1, levels16);
 
         auto lowNodeIn2 = ngraph::builder::makeConstant<float>(ngPrc, {1}, { -maxInputValue });

--- a/src/tests/functional/plugin/gna/scale_factors_tests/weighable_layer_without_fq.cpp
+++ b/src/tests/functional/plugin/gna/scale_factors_tests/weighable_layer_without_fq.cpp
@@ -56,8 +56,9 @@ protected:
 
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+        auto relu = std::make_shared<ngraph::opset8::Relu>(params[0]);
         auto fq1 = std::make_shared<ngraph::opset8::FakeQuantize>(
-            params[0],
+            relu,
             ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {-10.}),
             ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {10.}),
             ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {-10.}),
@@ -91,7 +92,7 @@ const std::vector<std::vector<size_t>> inputShapes = {
 };
 
 const std::vector<std::vector<size_t>> constantShapes = {
-    {{1, 5}}
+    {{1, 16}}
 };
 
 const std::vector<std::map<std::string, std::string>> configs = {

--- a/src/tests/functional/plugin/gna/scale_factors_tests/weighable_layer_without_fq.cpp
+++ b/src/tests/functional/plugin/gna/scale_factors_tests/weighable_layer_without_fq.cpp
@@ -58,20 +58,20 @@ protected:
         auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
         auto fq1 = std::make_shared<ngraph::opset8::FakeQuantize>(
             params[0],
-            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {1.}),
-            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {1.}),
-            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {1.}),
-            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {1.}),
-            255);
+            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {-10.}),
+            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {10.}),
+            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {-10.}),
+            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {10.}),
+            static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
         auto constant = ngraph::builder::makeConstant(ngPrc, constantShape, std::vector<float>{}, true);
         auto fq2 = std::make_shared<ngraph::opset8::FakeQuantize>(
             constant,
-            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {1}),
-            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {1.}),
-            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {1.}),
-            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {1.}),
-            255);
-        auto concat = ngraph::builder::makeConcat({fq1, fq2}, 0);
+            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {-10}),
+            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {10.}),
+            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {-10.}),
+            ngraph::opset8::Constant::create(ngraph::element::f32, {1}, {10.}),
+            static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()) + 1);
+        auto concat = ngraph::builder::makeConcat({fq1, fq2}, 1);
         function = std::make_shared<ngraph::Function>(concat, params, "WeighableLayerWithoutFq");
     }
 }; // class WeighableLayerWithoutFqTest
@@ -91,7 +91,7 @@ const std::vector<std::vector<size_t>> inputShapes = {
 };
 
 const std::vector<std::vector<size_t>> constantShapes = {
-    {{16, 5}}
+    {{1, 5}}
 };
 
 const std::vector<std::map<std::string, std::string>> configs = {

--- a/src/tests/functional/shared_test_classes/src/subgraph/multiple_input_fq.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/multiple_input_fq.cpp
@@ -27,15 +27,33 @@ void MultipleInputTest::SetUp() {
     std::tie(targetDevice, netPrecision, inputSize, config) = this->GetParam();
     configuration.insert(config.begin(), config.end());
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+
+    const float minInput = -10.0;
+    const float maxInput = 10.0;
     auto input = ngraph::builder::makeParams(ngPrc, {{1, inputSize}, {1, inputSize}, {1, inputSize}});
-    auto fake1 = ngraph::builder::makeFakeQuantize(input[0], ngPrc, 255, { 1 }, { -0.5 }, { 0.5 }, { -0.5 }, { 0.5 });
-    auto mul1 = ngraph::builder::makeEltwise(input[0], fake1, ngraph::helpers::EltwiseTypes::ADD);
-    auto fake2 = ngraph::builder::makeFakeQuantize(input[1], ngPrc, 255, { 1 }, { -0.5 }, { 0.5 }, { -0.5 }, { 0.5 });
-    auto mul2 = ngraph::builder::makeEltwise(input[1], fake2, ngraph::helpers::EltwiseTypes::ADD);
-    auto mul3 = ngraph::builder::makeEltwise(mul1, mul2, ngraph::helpers::EltwiseTypes::ADD);
-    auto fake3 = ngraph::builder::makeFakeQuantize(input[2], ngPrc, 255, { 1 }, { -0.5 }, { 0.5 }, { -0.5 }, { 0.5 });
-    auto mul4 = ngraph::builder::makeEltwise(fake3, mul3, ngraph::helpers::EltwiseTypes::ADD);
-    auto result = std::make_shared<ngraph::opset7::Result>(mul4);
+    auto fake1 = ngraph::builder::makeFakeQuantize(input[0], ngPrc, std::numeric_limits<uint16_t>::max(), { 1 },
+        { minInput }, { maxInput }, { minInput }, { maxInput });
+    auto add1 = ngraph::builder::makeEltwise(input[0], fake1, ngraph::helpers::EltwiseTypes::ADD);
+    auto fake_add1 = ngraph::builder::makeFakeQuantize(add1, ngPrc, std::numeric_limits<uint16_t>::max(), { 1 },
+        { 2 * minInput }, { 2 * maxInput }, { 2 * minInput }, { 2 * maxInput });
+
+    auto fake2 = ngraph::builder::makeFakeQuantize(input[1], ngPrc, std::numeric_limits<uint16_t>::max(), { 1 },
+        { minInput }, { maxInput }, { minInput }, { maxInput });
+    auto add2 = ngraph::builder::makeEltwise(input[1], fake2, ngraph::helpers::EltwiseTypes::ADD);
+    auto fake_add2 = ngraph::builder::makeFakeQuantize(add2, ngPrc, std::numeric_limits<uint16_t>::max(), { 1 },
+        { 2 * minInput }, { 2 * maxInput }, { 2 * minInput }, { 2 * maxInput });
+
+    auto add3 = ngraph::builder::makeEltwise(fake_add1, fake_add2, ngraph::helpers::EltwiseTypes::ADD);
+    auto fake_add3 = ngraph::builder::makeFakeQuantize(add3, ngPrc, std::numeric_limits<uint16_t>::max(), { 1 },
+        { 4 * minInput }, { 4 * maxInput }, { 4 * minInput }, { 4 * maxInput });
+
+    auto fake3 = ngraph::builder::makeFakeQuantize(input[2], ngPrc, std::numeric_limits<uint16_t>::max(), { 1 },
+        { minInput }, { maxInput }, { minInput }, { maxInput });
+    auto add4 = ngraph::builder::makeEltwise(fake3, fake_add3, ngraph::helpers::EltwiseTypes::ADD);
+    auto fake_add4 = ngraph::builder::makeFakeQuantize(add4, ngPrc, std::numeric_limits<uint16_t>::max(), { 1 },
+        { 5 * minInput }, { 5 * maxInput }, { 5 * minInput }, { 5 * maxInput });
+
+    auto result = std::make_shared<ngraph::opset7::Result>(fake_add4);
     function = std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, input, "multiple_input");
 }
 


### PR DESCRIPTION
### Details:
 - FQ layers are fused with previous layers if they are not required for precision change
 - Calculation of PWL for Identity is made taking into account FQ statistics
 - Workaround is added for activation-activation patterns quantization until the final solution is not implemented in POT
 - Fixed Identity insertion before Eltwise which inputs are connected with the same layer
 - Fixed Identity insertion after layer with output connected to multiple layers
 - Added exception for the case when split alignment with ConvolutionFilter isn't supported
 - Some tests are fixed to allow their passing with the required accuracy

### Tickets:
58806
