### PR TITLE
creating remote ocl buffer/tensor per request, to avoid simulteneous locking of the same ocl buffer when auto-batching is used

### DIFF
--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -789,8 +789,11 @@ int main(int argc, char* argv[]) {
         std::map<std::string, ov::TensorVector> inputsData;
         if (isFlagSetInCommandLine("use_device_mem")) {
             if (device_name.find("GPU") == 0) {
-                inputsData =
-                    ::gpu::get_remote_input_tensors(inputFiles, app_inputs_info, compiledModel, clInputsBuffer);
+                inputsData = ::gpu::get_remote_input_tensors(inputFiles,
+                                                             app_inputs_info,
+                                                             compiledModel,
+                                                             clInputsBuffer,
+                                                             inferRequestsQueue.requests.size());
                 useGpuMem = true;
             } else if (device_name.find("CPU") == 0) {
                 if (newInputType) {

--- a/samples/cpp/benchmark_app/remote_tensors_filling.hpp
+++ b/samples/cpp/benchmark_app/remote_tensors_filling.hpp
@@ -61,7 +61,8 @@ std::map<std::string, ov::TensorVector> get_remote_input_tensors(
     const std::map<std::string, std::vector<std::string>>& inputFiles,
     const std::vector<benchmark_app::InputsInfo>& app_inputs_info,
     const ov::CompiledModel& compiledModel,
-    std::vector<BufferType>& clBuffer);
+    std::vector<BufferType>& clBuffer,
+    size_t num_requests);
 
 std::map<std::string, ov::Tensor> get_remote_output_tensors(const ov::CompiledModel& compiledModel,
                                                             std::map<std::string, ::gpu::BufferType>& clBuffer);


### PR DESCRIPTION
when using auto-batching (e.g. take some simple classification network that is batched to the large batch size, like lenet or age-gender etc) the "--use-device-mem" crashes sporadically.

My impression is that the primary reason is that same (or limited set of the) OCL buffer(s) is set to the inference requests, eventually the may be locked (to [copy the input data to the input of the batched network's request](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/auto_batch/auto_batch.cpp#L539) ) **simultaneously** which leads to a crash due to [failure to lock](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_gpu/src/plugin/remote_context.cpp#L192).

A simple solution is always creating an OCL buffer/OV tensor per request's input.
BTW this gives more fair benchmarking.

still I'm a bit puzzled on the other possible reasons, since at the time when the auto-batching was merged, [the code logic seems to be pretty much the same](https://github.com/openvinotoolkit/openvino/blob/49b5e5728ba62a3e93ce63557accc85664abfc04/samples/cpp/benchmark_app/remote_blobs_filling.cpp#L91)  so potentially something has been changed on the GPU plugin side
so, CC-ing @vladimir-paramuzov 


