### PR TITLE
[CPU] [TESTS] Avoid performing extra skip check

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/generate_proposals.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/generate_proposals.cpp
@@ -237,7 +237,6 @@ INSTANTIATE_TEST_SUITE_P(
 struct GenerateProposalsBenchmarkTest : ov::test::BenchmarkLayerTest<GenerateProposalsLayerTest> {};
 
 TEST_P(GenerateProposalsBenchmarkTest, DISABLED_GenerateProposals_Benchmark) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run_benchmark("GenerateProposals", std::chrono::milliseconds(2000), 10000);
 }
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/activation.cpp
@@ -123,8 +123,6 @@ protected:
 };
 
 TEST_P(ActivationLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "Eltwise");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/adaptive_pooling.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/adaptive_pooling.cpp
@@ -177,7 +177,6 @@ private:
 };
 
 TEST_P(AdaPoolLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "AdaptivePooling");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/augru_cell.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/augru_cell.cpp
@@ -106,8 +106,6 @@ protected:
 };
 
 TEST_P(AUGRUCellCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "RNNCell");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/augru_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/augru_sequence.cpp
@@ -166,8 +166,6 @@ protected:
 };
 
 TEST_P(AUGRUSequenceCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "RNNSeq");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/batch_to_space.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/batch_to_space.cpp
@@ -84,8 +84,6 @@ protected:
 };
 
 TEST_P(BatchToSpaceCPULayerTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "BatchToSpace");
 };

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/broadcast.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/broadcast.cpp
@@ -187,8 +187,6 @@ protected:
 };
 
 TEST_P(BroadcastLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "Broadcast");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/bucketize.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/bucketize.cpp
@@ -103,7 +103,6 @@ protected:
 };
 
 TEST_P(BucketizeLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/concat.cpp
@@ -88,8 +88,6 @@ protected:
 };
 
 TEST_P(ConcatLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "Concatenation");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/conversion.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/conversion.cpp
@@ -110,8 +110,6 @@ private:
 };
 
 TEST_P(ConvertCPULayerTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 
     CheckPluginRelatedResults(compiledModel, "Convert");

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/convert_to_plugin_specific_node.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/convert_to_plugin_specific_node.cpp
@@ -67,8 +67,6 @@ protected:
 };
 
 TEST_P(ConvertToPluginSpecificNode, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
     CheckNumberOfNodesWithType(executableNetwork, "Const", constNodeNum);
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/convolution.cpp
@@ -91,6 +91,8 @@ protected:
     InferenceEngine::SizeVector kernel, dilation;
 
     void checkBiasFusing(ov::CompiledModel &execNet) const {
+        if (!execNet) return;
+
         auto execGraph = execNet.get_runtime_model();
         ASSERT_NE(nullptr, execGraph);
 
@@ -202,8 +204,6 @@ protected:
 };
 
 TEST_P(ConvolutionLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     // Skip tests for sse41 convolution where ic or oc cannot be exactly divided by the block size,
     // since tails processing for sse41 nspc layout is not supported yet (see 52736).
     if (!inFmts.empty() && (inFmts.front() == nwc || inFmts.front() == nhwc || inFmts.front() == ndhwc) && selectedType.find("jit_sse") != std::string::npos) {

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/convolution_backprop_data.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/convolution_backprop_data.cpp
@@ -254,8 +254,6 @@ private:
 };
 
 TEST_P(DeconvolutionLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     if (!fusedOps.empty()) {
         bool isSupportedParams = stride[stride.size() - 1] <= kernel[kernel.size() - 1];
         if (stride.size() > 1)

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/ctc_greedy_decoder.cpp
@@ -130,7 +130,6 @@ protected:
 };
 
 TEST_P(CTCGreedyDecoderLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED();
     run();
     CheckPluginRelatedResults(compiledModel, "CTCGreedyDecoder");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/ctc_greedy_decoder_seq_len.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/ctc_greedy_decoder_seq_len.cpp
@@ -170,7 +170,6 @@ protected:
 };
 
 TEST_P(CTCGreedyDecoderSeqLenLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED();
     run();
     CheckPluginRelatedResults(compiledModel, "CTCGreedyDecoderSeqLen");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/ctc_loss.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/ctc_loss.cpp
@@ -186,8 +186,6 @@ private:
 };
 
 TEST_P(CTCLossLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED();
-
     run();
     CheckPluginRelatedResults(compiledModel, "CTCLoss");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/cum_sum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/cum_sum.cpp
@@ -67,8 +67,6 @@ protected:
 };
 
 TEST_P(CumSumLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "CumSum");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/deformable_convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/deformable_convolution.cpp
@@ -184,7 +184,6 @@ protected:
 };
 
 TEST_P(DefConvLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "DeformableConvolution");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/depth_to_space.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/depth_to_space.cpp
@@ -78,8 +78,6 @@ protected:
 };
 
 TEST_P(DepthToSpaceLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "DepthToSpace");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/detection_output.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/detection_output.cpp
@@ -243,7 +243,6 @@ private:
 };
 
 TEST_P(DetectionOutputLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/eltwise.cpp
@@ -168,8 +168,6 @@ private:
 };
 
 TEST_P(EltwiseLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "Eltwise");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/embedding_bag_offsets_sum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/embedding_bag_offsets_sum.cpp
@@ -97,7 +97,6 @@ public:
 };
 
 TEST_P(EmbeddingBagOffsetsSumLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "embeddingBagOffsetsSum");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/embedding_bag_packed_sum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/embedding_bag_packed_sum.cpp
@@ -87,7 +87,6 @@ protected:
 };
 
 TEST_P(EmbeddingBagPackedSumLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "embeddingBagPackedSum");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/embedding_segments_sum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/embedding_segments_sum.cpp
@@ -101,7 +101,6 @@ protected:
 };
 
 TEST_P(EmbeddingSegmentsSumLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "embeddingSegmentsSum");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/extract_image_patches.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/extract_image_patches.cpp
@@ -67,7 +67,6 @@ protected:
 };
 
 TEST_P(ExtractImagePatchesLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "ExtractImagePatches");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/eye.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/eye.cpp
@@ -129,7 +129,6 @@ protected:
 };
 
 TEST_P(EyeLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "Eye");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/fake_quantize.cpp
@@ -149,7 +149,6 @@ private:
 };
 
 TEST_P(FakeQuantizeLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
 
     CheckPluginRelatedResults(compiledModel, layerName);

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/gather.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/gather.cpp
@@ -147,8 +147,6 @@ protected:
 };
 
 TEST_P(GatherLayerTestCPU, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "Gather");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/gather_nd.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/gather_nd.cpp
@@ -90,14 +90,10 @@ protected:
 };
 
 TEST_P(GatherNDLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 }
 
 TEST_P(GatherND8LayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/grid_sample.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/grid_sample.cpp
@@ -129,8 +129,6 @@ protected:
 };
 
 TEST_P(GridSampleLayerTestCPU, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "GridSample");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/group_convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/group_convolution.cpp
@@ -200,8 +200,6 @@ protected:
 };
 
 TEST_P(GroupConvolutionLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     if (isBias) {
         checkBiasFusing(compiledModel);

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/group_convolution_backprop_data.cpp
@@ -256,8 +256,6 @@ private:
 };
 
 TEST_P(GroupDeconvolutionLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     if (!fusedOps.empty()) {
         bool isSupportedParams = stride[stride.size() - 1] <= kernel[kernel.size() - 1];
         if (stride.size() > 1)

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/gru_cell.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/gru_cell.cpp
@@ -103,8 +103,6 @@ protected:
 };
 
 TEST_P(GRUCellCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "RNNCell");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/gru_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/gru_sequence.cpp
@@ -167,8 +167,6 @@ protected:
 };
 
 TEST_P(GRUSequenceCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "RNNSeq");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/interpolate.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/interpolate.cpp
@@ -262,8 +262,6 @@ protected:
 };
 
 TEST_P(InterpolateLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "Interpolate");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/log_softmax.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/log_softmax.cpp
@@ -73,8 +73,6 @@ protected:
 };
 
 TEST_P(LogSoftmaxLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "logSoftmax");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/logical.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/logical.cpp
@@ -76,8 +76,6 @@ protected:
 };
 
 TEST_P(LogicalLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
     CheckPluginRelatedResults(executableNetwork, "Eltwise");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/loop.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/loop.cpp
@@ -362,26 +362,18 @@ protected:
 };
 
 TEST_P(LoopLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 }
 
 TEST_P(LoopWhileLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 }
 
 TEST_P(LoopForDiffShapesLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 }
 
 TEST_P(LoopForConcatLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/lrn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/lrn.cpp
@@ -63,8 +63,6 @@ protected:
 };
 
 TEST_P(LRNLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "LRN");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/lstm_cell.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/lstm_cell.cpp
@@ -102,8 +102,6 @@ protected:
 };
 
 TEST_P(LSTMCellLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "RNNCell");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/lstm_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/lstm_sequence.cpp
@@ -175,8 +175,6 @@ protected:
 };
 
 TEST_P(LSTMSequenceCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "RNNSeq");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/matmul.cpp
@@ -172,7 +172,6 @@ protected:
 };
 
 TEST_P(MatMulLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     // due to disabled BF16 fakequant fusing: src/plugins/intel_cpu/src/graph_optimizer.cpp#L755, skip this case
     if (inType == ElementType::bf16) {
         if (cpuNodeType == "FullyConnected") {

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/mvn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/mvn.cpp
@@ -108,8 +108,6 @@ protected:
 };
 
 TEST_P(MvnLayerCPUTest, CompareWithRefs) {
-   SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
    run();
    CheckPluginRelatedResults(compiledModel, "MVN");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/non_max_suppression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/non_max_suppression.cpp
@@ -396,7 +396,6 @@ private:
 };
 
 TEST_P(NmsLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     // CheckPluginRelatedResults(compiledModel, "NonMaxSuppression");
 };

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/nonzero.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/nonzero.cpp
@@ -94,7 +94,6 @@ protected:
 };
 
 TEST_P(NonZeroLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "NonZero");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/normalize.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/normalize.cpp
@@ -97,8 +97,6 @@ protected:
 };
 
 TEST_P(NormalizeL2LayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 
     CheckPluginRelatedResults(compiledModel, "NormalizeL2");

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/one_hot.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/one_hot.cpp
@@ -158,8 +158,6 @@ protected:
 };
 
 TEST_P(OneHotLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "OneHot");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/pad.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/pad.cpp
@@ -74,10 +74,7 @@ protected:
 };
 
 TEST_P(PadLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
-
     CheckPluginRelatedResults(compiledModel, "Pad");
 }
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/pooling.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/pooling.cpp
@@ -205,15 +205,11 @@ protected:
 };
 
 TEST_P(PoolingLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "Pooling");
 }
 
 TEST_P(MaxPoolingV8LayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "Pooling");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/prior_box.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/prior_box.cpp
@@ -152,7 +152,6 @@ protected:
 };
 
 TEST_P(PriorBoxLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "PriorBox");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/prior_box_clustered.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/prior_box_clustered.cpp
@@ -139,7 +139,6 @@ protected:
 };
 
 TEST_P(PriorBoxClusteredLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "PriorBoxClustered");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/proposal.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/proposal.cpp
@@ -191,8 +191,6 @@ protected:
 };
 
 TEST_P(ProposalLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "Proposal");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/psroi_pooling.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/psroi_pooling.cpp
@@ -101,7 +101,6 @@ protected:
 };
 
 TEST_P(PSROIPoolingLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     Run();
     CheckPluginRelatedResults(executableNetwork, "PSROIPooling");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/range.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/range.cpp
@@ -130,8 +130,7 @@
 //};
 //
 //TEST_P(RangeLayerCPUTest, CompareWithRefs) {
-//    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-//    Run();
+//    run();
 //    CheckPluginRelatedResults(executableNetwork, "Range");
 //}
 //

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/rdft.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/rdft.cpp
@@ -90,8 +90,6 @@ protected:
 };
 
 TEST_P(RDFTTestCPU, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "RDFT");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/reduce_ops.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/reduce_ops.cpp
@@ -179,8 +179,6 @@ private:
 };
 
 TEST_P(ReduceCPULayerTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 
     CheckPluginRelatedResults(compiledModel, "Reduce");

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/region_yolo.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/region_yolo.cpp
@@ -90,7 +90,6 @@ protected:
 };
 
 TEST_P(RegionYoloCPULayerTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "RegionYolo");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/rnn_cell.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/rnn_cell.cpp
@@ -98,8 +98,6 @@ protected:
 };
 
 TEST_P(RNNCellCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "RNNCell");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/rnn_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/rnn_sequence.cpp
@@ -161,8 +161,6 @@ protected:
 };
 
 TEST_P(RNNSequenceCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "RNNSeq");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/roi_pooling.cpp
@@ -218,7 +218,6 @@ protected:
 };
 
 TEST_P(ROIPoolingCPULayerTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "ROIPooling");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/roialign.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/roialign.cpp
@@ -166,7 +166,6 @@ protected:
 };
 
 TEST_P(ROIAlignLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "ROIAlign");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/scatter_ND_update.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/scatter_ND_update.cpp
@@ -115,7 +115,6 @@ protected:
 };
 
 TEST_P(ScatterNDUpdateLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "ScatterUpdate");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/scatter_elements_update.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/scatter_elements_update.cpp
@@ -120,7 +120,6 @@ protected:
 };
 
 TEST_P(ScatterElementsUpdateLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "ScatterUpdate");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/scatter_update.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/scatter_update.cpp
@@ -80,7 +80,6 @@ protected:
 };
 
 TEST_P(ScatterUpdateLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "ScatterUpdate");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/select.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/select.cpp
@@ -72,9 +72,7 @@
 //};
 //
 //TEST_P(SelectLayerCPUTest, CompareWithRefs) {
-//    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-//
-//    Run();
+//    run();
 //    CheckPluginRelatedResults(executableNetwork, "Select");
 //}
 //

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/shape_ops.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/shape_ops.cpp
@@ -161,8 +161,6 @@ private:
 };
 
 TEST_P(ShapeOpsCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "Reshape");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/shapeof.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/shapeof.cpp
@@ -77,7 +77,6 @@ protected:
 };
 
 TEST_P(ShapeOfLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "ShapeOf");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/shuffle_channels.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/shuffle_channels.cpp
@@ -73,8 +73,6 @@ protected:
 };
 
 TEST_P(ShuffleChannelsLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "ShuffleChannels");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/slice.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/slice.cpp
@@ -79,8 +79,6 @@ protected:
 };
 
 TEST_P(Slice8LayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "Slice8");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/softmax.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/softmax.cpp
@@ -80,7 +80,6 @@ protected:
 };
 
 TEST_P(SoftMaxLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckPluginRelatedResults(compiledModel, "Softmax");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/space_to_batch.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/space_to_batch.cpp
@@ -78,8 +78,6 @@ protected:
 };
 
 TEST_P(SpaceToBatchCPULayerTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CPUTestsBase::CheckPluginRelatedResults(compiledModel, "SpaceToBatch");
 };

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/space_to_depth.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/space_to_depth.cpp
@@ -79,8 +79,6 @@ protected:
 };
 
 TEST_P(SpaceToDepthLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CPUTestsBase::CheckPluginRelatedResults(compiledModel, "SpaceToDepth");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/split.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/split.cpp
@@ -91,8 +91,6 @@ protected:
 };
 
 TEST_P(SplitLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 //     CheckPluginRelatedResults(executableNetwork, "Split");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/strided_slice.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/strided_slice.cpp
@@ -82,8 +82,6 @@ protected:
 };
 
 TEST_P(StridedSliceLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "StridedSlice");
 }
@@ -415,8 +413,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Dynamic_5D_Subset2, Stride
 class StridedSliceLayerDescriptorCPUTest : public StridedSliceLayerCPUTest {};
 
 TEST_P(StridedSliceLayerDescriptorCPUTest, DescriptorsCheck) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     ASSERT_THROW(compile_model(), ov::Exception);
 }
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/tensor_iterator.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/tensor_iterator.cpp
@@ -87,8 +87,6 @@ protected:
 };
 
 TEST_P(TensorIteratorCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/tile.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/tile.cpp
@@ -138,8 +138,6 @@ protected:
 };
 
 TEST_P(TileLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "Tile");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/topk.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/topk.cpp
@@ -218,8 +218,6 @@ private:
 };
 
 TEST_P(TopKLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "TopK");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/transpose.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/transpose.cpp
@@ -81,8 +81,6 @@ protected:
 };
 
 TEST_P(TransposeLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "Transpose");
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/variadic_split.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/variadic_split.cpp
@@ -75,8 +75,6 @@ protected:
 };
 
 TEST_P(VariadicSplitLayerCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckPluginRelatedResults(compiledModel, "Split");
 }

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/add_convert_to_reorder.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/add_convert_to_reorder.cpp
@@ -65,8 +65,6 @@ namespace  {
              Output[FP32]
 */
 TEST_F(AddConvertToReorderTest, smoke_TestAddReorder_CPU) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     BuildGraph(ngraph::element::i8);
     Run();
     CheckNumberOfNodesWithType(executableNetwork, "Convert", 0);

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/align_matmul_input_ranks.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/align_matmul_input_ranks.cpp
@@ -67,8 +67,6 @@ protected:
 };
 
 TEST_P(AlignMatMulInputRanksTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
     CheckNumberOfNodesWithType(executableNetwork, "Reshape", expectedNumOfReshapes); // Squeeze / Unsqueeze turns into Reshape
     CheckPluginRelatedResults(executableNetwork, "MatMul");

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/any_layout.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/any_layout.cpp
@@ -77,7 +77,6 @@ protected:
 };
 
 TEST_P(AnyLayoutOnInputsAndOutputs, CheckExpectedResult) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     Run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_const_inplace.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_const_inplace.cpp
@@ -69,8 +69,6 @@ public:
 
 namespace {
     TEST_P(ConcatConstantInPlaceTest, smoke_ConcatConstantInPlaceTest_CPU) {
-        SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
         Run();
         if (this->GetParam() == Precision::BF16)
             CheckNumberOfNodesWithType(executableNetwork, "Reorder", 4);

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_conv_sum_inplace.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_conv_sum_inplace.cpp
@@ -75,8 +75,6 @@ public:
 
 namespace {
     TEST_F(ReLuConcatConvSumInPlaceTest, smoke_ReLuConcatConvSumInPlace_CPU) {
-        SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
         Run();
     }
 } // namespace

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv3d_reshape.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv3d_reshape.cpp
@@ -79,8 +79,6 @@ protected:
 };
 
 TEST_P(Conv3dReshapeTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_concat.cpp
@@ -112,8 +112,6 @@ void ConvConcatSubgraphTest::SetUp() {
 }
 
 TEST_P(ConvConcatSubgraphTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 
     CheckPluginRelatedResults(executableNetwork, pluginTypeNode);

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_maxpool_activ.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_maxpool_activ.cpp
@@ -74,8 +74,6 @@ protected:
 };
 
 TEST_P(ConvPoolActivTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
     CheckPluginRelatedResults(executableNetwork, "Convolution");
 }

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_sum_broadcast.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_sum_broadcast.cpp
@@ -146,8 +146,6 @@ protected:
 };
 
 TEST_P(ConcatConvSumInPlaceTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 
     CheckPluginRelatedResults(compiledModel, "Convolution");
@@ -212,8 +210,6 @@ public:
 };
 
 TEST_P(ConcatConvSumInPlaceTestInt8, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 
     CheckPluginRelatedResults(compiledModel, "Convolution");

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/convs_and_sums.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/convs_and_sums.cpp
@@ -74,8 +74,6 @@ protected:
 };
 
 TEST_F(ConvsAndSums, smoke_CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/denormal_check.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/denormal_check.cpp
@@ -77,7 +77,6 @@ void SetUp() override {
 };
 
 TEST_F(DenormalNullifyCheck, smoke_CPU_Denormal_Check) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     using indexInterval = std::pair<size_t, size_t>;
     size_t elemsCount = pConstStorage->size();
     const indexInterval intervals[] = {

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/eltwise_chain.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/eltwise_chain.cpp
@@ -136,8 +136,6 @@ protected:
 };
 
 TEST_P(EltwiseChainTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fullyconnected_strided_inputs_outputs.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fullyconnected_strided_inputs_outputs.cpp
@@ -93,8 +93,6 @@ protected:
 */
 
 TEST_P(FullyConnectedStridedInputsOutputsTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_conv_fq_with_shared_constants.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_conv_fq_with_shared_constants.cpp
@@ -54,8 +54,6 @@ public:
 
 namespace {
     TEST_F(ConvAndFQWithSharedConstants, smoke_ConvAndFQWithSharedConstants_CPU) {
-        SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
         run();
         CheckPluginRelatedResults(compiledModel, "Convolution");
     }

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_muladd_ewsimple.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_muladd_ewsimple.cpp
@@ -54,8 +54,6 @@ void FuseMulAddAndEwSimpleTest1::CreateGraph() {
 }
 
 TEST_P(FuseMulAddAndEwSimpleTest1, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 }
 
@@ -79,8 +77,6 @@ void FuseMulAddAndEwSimpleTest2::CreateGraph() {
 }
 
 TEST_P(FuseMulAddAndEwSimpleTest2, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 }
 
@@ -103,8 +99,6 @@ void FuseMulAddAndEwSimpleTest3::CreateGraph() {
 }
 
 TEST_P(FuseMulAddAndEwSimpleTest3, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_non0_output_port.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_non0_output_port.cpp
@@ -58,8 +58,6 @@ class FuseNon0OuputPort : public SubgraphBaseTest {
 };
 
 TEST_F(FuseNon0OuputPort, smoke_FuseNon0OuputPort) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_scaleshift_and_fakequantize.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_scaleshift_and_fakequantize.cpp
@@ -80,8 +80,6 @@ protected:
 };
 
 TEST_P(FuseScaleShiftAndFakeQuantizeTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_split_concat_pair_to_interpolate.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_split_concat_pair_to_interpolate.cpp
@@ -71,8 +71,6 @@ protected:
 };
 
 TEST_P(FuseSplitConcatPairToInterpolateTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_transpose_reorder.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fuse_transpose_reorder.cpp
@@ -91,8 +91,6 @@ void FuseTransposeAndReorderTest::CreateGraph() {
 }
 
 TEST_P(FuseTransposeAndReorderTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
     CheckTransposeCount(0);
 }
@@ -168,8 +166,6 @@ void FuseTransposeAndReorderTest1::CreateGraph() {
 
 // Test disabled temporarily, it conflicts with TransposeFuse transformation in common optimizations step
 TEST_P(FuseTransposeAndReorderTest1, DISABLED_CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
     CheckTransposeCount(2);
 }
@@ -230,8 +226,6 @@ void FuseTransposeAndReorderTest2::CreateGraph() {
 }
 
 TEST_P(FuseTransposeAndReorderTest2, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
     CheckTransposeCount(1);
 }
@@ -285,8 +279,6 @@ void FuseTransposeAndReorderTest3::CreateGraph() {
 }
 
 TEST_P(FuseTransposeAndReorderTest3, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
     CheckTransposeCount(1);
 }
@@ -343,8 +335,6 @@ void FuseTransposeAndReorderTest4::CreateGraph() {
 }
 
 TEST_P(FuseTransposeAndReorderTest4, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
     CheckTransposeCount(0);
 }

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/gather_add_avgpool.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/gather_add_avgpool.cpp
@@ -63,8 +63,6 @@ protected:
 };
 
 TEST_F(GatherAddAvgpool, smoke_CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/input_noreorder_eltwise_bf16.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/input_noreorder_eltwise_bf16.cpp
@@ -51,8 +51,6 @@ protected:
              Output[BF16]
 */
 TEST_F(InputNoReorderEltwiseBF16, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 
     CheckNumberOfNodesWithType(executableNetwork, "Reorder", 0);

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/input_tensor_roi.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/input_tensor_roi.cpp
@@ -98,8 +98,6 @@ protected:
 };
 
 TEST_P(InputTensorROI, SetInputTensorROI) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     switch (GetParam().type) {
         case ov::element::Type_t::f32: {
             Run<float>();

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/interaction.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/interaction.cpp
@@ -175,7 +175,6 @@ protected:
 };
 
 TEST_P(IntertactionCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     CheckNumberOfNodesWithType(compiledModel, "Interaction", 1);
 }

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_strided_inputs_outputs.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/matmul_strided_inputs_outputs.cpp
@@ -84,8 +84,6 @@ protected:
 */
 
 TEST_P(MatmulStridedInputsOutputsTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/mha.cpp
@@ -219,8 +219,6 @@ protected:
 };
 
 TEST_P(MHATest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     std::vector<InputShape> inputShapes;
     std::vector<ElementType> inputPrecisions;
     std::vector<ElementType> matMulIn0Precisions;
@@ -491,8 +489,6 @@ protected:
 };
 
 TEST_P(MHAQuantTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     std::vector<InputShape> inputShapes;
     std::vector<ElementType> inputPrecisions;
     std::vector<ElementType> matMulIn0Precisions;

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/not_fused_conv_simple_op.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/not_fused_conv_simple_op.cpp
@@ -40,8 +40,6 @@ protected:
 };
 
 TEST_F(NotFusedConvSimpleOp, smoke_CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/param_result_custom_blob.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/param_result_custom_blob.cpp
@@ -43,8 +43,6 @@ class ParameterResultCustomBlobTest : public ParameterResultSubgraphTestLegacyAp
 };
 
 TEST_P(ParameterResultCustomBlobTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     // Just to show that it is not possible to set different precisions for inputs and outputs with the same name.
     // If it was possible, the input would have I8 precision and couldn't store data from the custom blob.
     inPrc = Precision::I8;
@@ -76,8 +74,6 @@ protected:
 };
 
 TEST_P(ParameterResultSameBlobTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 }
 namespace {

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/reshape_chain.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/reshape_chain.cpp
@@ -37,8 +37,6 @@ class ReshapeChain : public SubgraphBaseTest {
 };
 
 TEST_F(ReshapeChain, smoke_ReshapeChain) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/reshape_fc.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/reshape_fc.cpp
@@ -93,8 +93,6 @@ protected:
 };
 
 TEST_P(ReshapeFcCPUTest, CompareWithRefs) {
-   SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
    run();
    CheckPluginRelatedResults(compiledModel, "FullyConnected");
 }

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/reshape_inplace.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/reshape_inplace.cpp
@@ -83,8 +83,6 @@ protected:
 };
 
 TEST_F(InPlaceReshapeFromConstantCheck, smoke_CPU_InPlaceReshapeFromConstantCheck) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 }
 }  // namespace SubgraphTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/seq_native_order.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/seq_native_order.cpp
@@ -268,8 +268,6 @@ private:
 };
 
 TEST_P(SequenceCPUTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
     CheckNumberOfNodesWithType(compiledModel, "RNNSeq", 1);
     CheckNumberOfNodesWithType(compiledModel, "Transpose", 0);

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/static_zero_dims.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/static_zero_dims.cpp
@@ -54,8 +54,6 @@ protected:
 };
 
 TEST_F(StaticZeroDims, smoke_CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/subgraph_with_blocked_format.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/subgraph_with_blocked_format.cpp
@@ -49,7 +49,6 @@ protected:
 };
 
 TEST_F(SubgraphWithBlockedFormat, smoke_CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     Run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/tile_with_two_output_edges.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/tile_with_two_output_edges.cpp
@@ -33,8 +33,6 @@ protected:
 };
 
 TEST_F(TileWithTwoOutputEdges, smoke_CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
     Run();
 }
 

--- a/src/plugins/intel_cpu/tests/functional/test_utils/cpu_test_utils.cpp
+++ b/src/plugins/intel_cpu/tests/functional/test_utils/cpu_test_utils.cpp
@@ -116,6 +116,7 @@ std::string CPUTestsBase::impls2str(const std::vector<std::string> &priority) {
 }
 
 void CPUTestsBase::CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork &execNet, const std::string& nodeType) const {
+    if (!execNet) return;
     if (nodeType.empty()) return;
 
     ASSERT_TRUE(!selectedType.empty()) << "Node type is not defined.";
@@ -125,6 +126,7 @@ void CPUTestsBase::CheckPluginRelatedResults(InferenceEngine::ExecutableNetwork 
 }
 
 void CPUTestsBase::CheckPluginRelatedResults(const ov::CompiledModel &execNet, const std::string& nodeType) const {
+    if (!execNet) return;
     if (nodeType.empty()) return;
 
     ASSERT_TRUE(!selectedType.empty()) << "Node type is not defined.";
@@ -371,11 +373,15 @@ inline void CheckNumberOfNodesWithTypeImpl(std::shared_ptr<const ov::Model> func
 }
 
 void CheckNumberOfNodesWithType(ov::CompiledModel &compiledModel, std::string nodeType, size_t expectedCount) {
+    if (!compiledModel) return;
+
     std::shared_ptr<const ov::Model> function = compiledModel.get_runtime_model();
     CheckNumberOfNodesWithTypeImpl(function, nodeType, expectedCount);
 }
 
 void CheckNumberOfNodesWithType(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType, size_t expectedCount) {
+    if (!execNet) return;
+
     InferenceEngine::CNNNetwork execGraphInfo = execNet.GetExecGraphInfo();
     std::shared_ptr<const ov::Model> function = execGraphInfo.getFunction();
     CheckNumberOfNodesWithTypeImpl(function, nodeType, expectedCount);


### PR DESCRIPTION
The skip check is performed in scope of run() / Run() methods

Main motivation: the skip routine takes noticeable part of tests time (around 5-10 %)