### PR TITLE
[IE TESTS] Avoid extra checks for test skipping

### DIFF
--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -46,12 +46,16 @@ void SubgraphBaseTest::run() {
 #else
     if (sigsetjmp(CommonTestUtils::env, 1) == 0) {
 #endif
-        LayerTestsUtils::PassRate::Statuses status = FuncTestUtils::SkipTestsConfig::currentTestIsDisabled()
-                                                        ? LayerTestsUtils::PassRate::Statuses::SKIPPED
-                                                        : LayerTestsUtils::PassRate::Statuses::CRASHED;
+        bool isCurrentTestDisabled = FuncTestUtils::SkipTestsConfig::currentTestIsDisabled();
+
+        LayerTestsUtils::PassRate::Statuses status = isCurrentTestDisabled ?
+            LayerTestsUtils::PassRate::Statuses::SKIPPED :
+            LayerTestsUtils::PassRate::Statuses::CRASHED;
         summary.setDeviceName(targetDevice);
         summary.updateOPsStats(function, status);
-        SKIP_IF_CURRENT_TEST_IS_DISABLED();
+
+        if (isCurrentTestDisabled)
+            GTEST_SKIP() << "Disabled test due to configuration" << std::endl;
 
         ASSERT_FALSE(targetStaticShapes.empty()) << "Target Static Shape is empty!!!";
         std::string errorMessage;
@@ -68,7 +72,7 @@ void SubgraphBaseTest::run() {
                     generate_inputs(targetStaticShapeVec);
                 } catch (const std::exception& ex) {
                     throw std::runtime_error("Incorrect target static shape: " +
-                                            CommonTestUtils::vec2str(targetStaticShapeVec) + " " + ex.what());
+                                             CommonTestUtils::vec2str(targetStaticShapeVec) + " " + ex.what());
                 }
                 infer();
                 validate();

--- a/src/tests/ie_test_utils/functional_test_utils/src/skip_tests_config.cpp
+++ b/src/tests/ie_test_utils/functional_test_utils/src/skip_tests_config.cpp
@@ -14,15 +14,19 @@ namespace SkipTestsConfig {
 bool disable_tests_skipping = false;
 
 bool currentTestIsDisabled() {
-    bool skip_test = false;
+    if (disable_tests_skipping)
+        return false;
+
     const auto fullName = ::testing::UnitTest::GetInstance()->current_test_info()->test_case_name()
                           + std::string(".") + ::testing::UnitTest::GetInstance()->current_test_info()->name();
+
     for (const auto &pattern : disabledTestPatterns()) {
         std::regex re(pattern);
         if (std::regex_match(fullName, re))
-            skip_test = true;
+            return true;
     }
-    return skip_test && !disable_tests_skipping;
+
+    return false;
 }
 
 std::vector<std::string> readSkipTestConfigFiles(const std::vector<std::string>& filePaths) {


### PR DESCRIPTION
Avoid double iteration over skip patterns
Skip test after first pattern match

Main motivation: skip routine takes noticeable part of tests time (around 5-10%)