### PR TITLE
[Snippets][CPU] Fix empty shapes handling in canonicalization

### DIFF
--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -184,7 +184,7 @@ Shape snippets::op::Subgraph::canonicalize(const BlockedShapeVector& outputShape
     auto skipStartEndOnes = [](const Shape& shape) {
         auto begin = shape.begin();
         auto end = shape.end();
-        while (*begin == 1 && begin != end)
+        while (begin != end && *begin == 1)
             begin++;
         while (begin != end && *(end-1) == 1)
             end--;


### PR DESCRIPTION
### Details:
 - *eliminate invalid read for empty shapes*