### PR TITLE
[nGraph] TypeRelaxed: clone_with_new_inputs fix

### DIFF
--- a/src/common/low_precision_transformations/src/convolution_backprop_data.cpp
+++ b/src/common/low_precision_transformations/src/convolution_backprop_data.cpp
@@ -124,6 +124,8 @@ bool ConvolutionBackpropDataTransformation::transform(TransformationContext &con
             *ov::as_type_ptr<opset1::ConvolutionBackpropData>(copyNode),
             std::vector<element::Type>{deqPrecision, deqPrecision},
             std::vector<element::Type>{deqPrecision});
+        relaxedConvolutionBackpropData->set_friendly_name(convolutionBackpropData->get_friendly_name());
+        ngraph::copy_runtime_info(convolutionBackpropData, relaxedConvolutionBackpropData);
 
         newMultiplyAfter = std::make_shared<op::TypeRelaxed<opset1::Multiply>>(
             std::vector<element::Type>{ deqPrecision, deqPrecision },
@@ -136,6 +138,8 @@ bool ConvolutionBackpropDataTransformation::transform(TransformationContext &con
         inputs[0] = convolutionBackpropData->get_input_node_ptr(0)->input_value(0);
         if (ov::is_type<opset1::Convert>(convolutionBackpropData->get_input_node_ptr(0))) {
             auto newConvolution = convolutionBackpropData->clone_with_new_inputs(inputs);
+            newConvolution->set_friendly_name(convolutionBackpropData->get_friendly_name());
+            ngraph::copy_runtime_info(convolutionBackpropData, newConvolution);
             replace_node(convolutionBackpropData, newConvolution);
             convolutionBackpropData = newConvolution;
         }
@@ -164,7 +168,10 @@ bool ConvolutionBackpropDataTransformation::transform(TransformationContext &con
             auto inputs = convolutionBackpropData->input_values();
             inputs[1] = multiplyFromWeights->input_value(0);
 
-            const auto newconvolutionBackpropData = convolutionBackpropData->copy_with_new_inputs(inputs);
+            const auto newconvolutionBackpropData = convolutionBackpropData->clone_with_new_inputs(inputs);
+            newconvolutionBackpropData->set_friendly_name(convolutionBackpropData->get_friendly_name());
+            ngraph::copy_runtime_info(convolutionBackpropData, newconvolutionBackpropData);
+
             newMultiplyAfter = std::make_shared<opset1::Multiply>(
                 newconvolutionBackpropData,
                 foldConvert(
@@ -209,6 +216,8 @@ bool ConvolutionBackpropDataTransformation::transform(TransformationContext &con
             inputs[1] = convolutionBackpropData->get_input_node_ptr(1)->input_value(0);
             // remove Convert on weights
             auto newConvolution = convolutionBackpropData->clone_with_new_inputs(inputs);
+            newConvolution->set_friendly_name(convolutionBackpropData->get_friendly_name());
+            ngraph::copy_runtime_info(convolutionBackpropData, newConvolution);
             replace_node(convolutionBackpropData, newConvolution);
             convolutionBackpropData = newConvolution;
         }

--- a/src/common/low_precision_transformations/src/move_fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/move_fake_quantize.cpp
@@ -113,6 +113,7 @@ bool MoveFakeQuantize::transform(TransformationContext& context, ngraph::pattern
         } else {
             auto fq_input = operation->clone_with_new_inputs({concat->get_input_source_output(i)});
             fq_input->set_friendly_name(operation_original_name + "_" + std::to_string(i + 1));
+            ngraph::copy_runtime_info(operation, fq_input);
             parent_output = fq_input->output(0);
         }
 

--- a/src/common/transformations/include/ngraph_ops/type_relaxed.hpp
+++ b/src/common/transformations/include/ngraph_ops/type_relaxed.hpp
@@ -326,7 +326,7 @@ std::shared_ptr<Node> TypeRelaxed<BaseOp>::clone_with_new_inputs(const OutputVec
 
     // clean rt_info and friendly name (that mustn't be cloned due to semantic of this method)
     new_node->set_friendly_name("");
-    new_node->get_rt_info().clear();
+    new_node->get_rt_info() = {};
     return new_node;
 }
 

--- a/src/common/transformations/include/ngraph_ops/type_relaxed.hpp
+++ b/src/common/transformations/include/ngraph_ops/type_relaxed.hpp
@@ -323,6 +323,10 @@ std::shared_ptr<Node> TypeRelaxed<BaseOp>::clone_with_new_inputs(const OutputVec
     }
 
     new_node->validate_and_infer_types();
+
+    // clean rt_info and friendly name (that mustn't be cloned due to semantic of this method)
+    new_node->set_friendly_name("");
+    new_node->get_rt_info().clear();
     return new_node;
 }
 

--- a/src/common/transformations/include/ngraph_ops/type_relaxed.hpp
+++ b/src/common/transformations/include/ngraph_ops/type_relaxed.hpp
@@ -327,6 +327,7 @@ std::shared_ptr<Node> TypeRelaxed<BaseOp>::clone_with_new_inputs(const OutputVec
     // clean rt_info and friendly name (that mustn't be cloned due to semantic of this method)
     new_node->set_friendly_name("");
     new_node->get_rt_info() = {};
+    init_rt_info(*new_node);
     return new_node;
 }
 

--- a/src/plugins/intel_cpu/src/ngraph_transformations/move_eltwise_up_data_movement.cpp
+++ b/src/plugins/intel_cpu/src/ngraph_transformations/move_eltwise_up_data_movement.cpp
@@ -93,9 +93,6 @@ ov::intel_cpu::MoveEltwiseUpThroughDataMov::MoveEltwiseUpThroughDataMov() {
         ngraph::OutputVector eltwiseInputs = eltwise->input_values();
         eltwiseInputs[0] = child->input_value(0);
         auto newEltwise = eltwise->clone_with_new_inputs(eltwiseInputs);
-        // WA: it's necessary to set empty friendly name here
-        // to avoid name duplication in TypeRelaxed cases
-        newEltwise->set_friendly_name("");
         ngraph::copy_runtime_info(eltwise, newEltwise);
 
         ngraph::OutputVector childInputs = child->input_values();


### PR DESCRIPTION
### Details:
 - *TypeRelaxed::clone_with_new_inputs fix: removed rt_info and friendly_name copying to align a method behavior with other overrides*

### Tickets:
 - *80571*
