### PR TITLE
Corrected layout parsing error message.

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/cli_parser.py
+++ b/tools/mo/openvino/tools/mo/utils/cli_parser.py
@@ -996,8 +996,8 @@ def parse_layouts_by_destination(s: str, parsed: dict, dest: str = None) -> None
             elif m2:
                 found_g = m2.groups()
             else:
-                raise Error("More then one layout provided for --{}layout without providing name.".format(
-                    dest + '_' if dest else ''))
+                raise Error("Invalid usage of --layout parameter. Please use following syntax:\n name(nchw)\n "
+                            "name(nhwc->nchw)\n name[nchw]\n name[nhwc->nchw]\n")
             write_found_layout(found_g[0], found_g[1], parsed, dest)
 
 


### PR DESCRIPTION
Root cause analysis: 
Currently layout parsing error message is confusing.
Message  "More then one layout provided for --layout without providing name." can occur when tensor name without layout is specified or brackets are not closed.

Solution: 
Show more general error message, that syntax is incorrect.

Ticket: <CVS 77542>


Code:
* [ ]  Comments
* [ ]  Code style (PEP8)
* [ ]  Transformation generates reshape-able IR - N/A
* [ ]  Transformation preserves original framework node names - N/A
* [ ]  Transformation preserves tensor names - N/A


Validation:
* [ ]  Unit tests - N/A
* [ ]  Framework operation tests - N/A
* [ ]  Transformation tests - N/A
* [ ]  Model Optimizer IR Reader check - N/A

Documentation:
* [ ]  Supported frameworks operations list - N/A
* [ ]  Guide on how to convert the **public** model - N/A
* [ ]  User guide update - N/A
