### PR TITLE
Checking compatibility between 'pyopenvino' and 'libopenvino'

### DIFF
--- a/src/bindings/python/src/pyopenvino/CMakeLists.txt
+++ b/src/bindings/python/src/pyopenvino/CMakeLists.txt
@@ -78,10 +78,7 @@ endif()
 target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..")
 target_link_libraries(${PROJECT_NAME} PRIVATE openvino::runtime ${OFFLINE_TRANSFORMATIONS_LIB})
 
-if(DEFINED CI_BUILD_NUMBER)
-    message(STATUS "Python CI Build Number: ${CI_BUILD_NUMBER}")
-    target_compile_definitions(${PROJECT_NAME} PRIVATE CI_BUILD_NUMBER=\"${CI_BUILD_NUMBER}\")
-endif()
+addVersionDefines(pyopenvino.cpp CI_BUILD_NUMBER)
 
 # perform copy
 if(OpenVINO_SOURCE_DIR)

--- a/src/bindings/python/src/pyopenvino/CMakeLists.txt
+++ b/src/bindings/python/src/pyopenvino/CMakeLists.txt
@@ -7,6 +7,13 @@ if(NOT DEFINED OpenVINO_SOURCE_DIR)
     find_package(OpenVINODeveloperPackage REQUIRED)
 endif()
 
+if (DEFINED ENV{CI_BUILD_NUMBER})
+    set(CI_BUILD_NUMBER $ENV{CI_BUILD_NUMBER})
+    message(STATUS "Python CI build number: ${CI_BUILD_NUMBER}")
+else()
+    set(CI_BUILD_NUMBER "")
+endif()
+
 # PYTHON_VERSION_MAJOR and PYTHON_VERSION_MINOR are defined inside pybind11
 set(PYTHON_VERSION python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
 message(STATUS "Python version=${PYTHON_VERSION}")
@@ -77,6 +84,7 @@ endif()
 
 target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..")
 target_link_libraries(${PROJECT_NAME} PRIVATE openvino::runtime ${OFFLINE_TRANSFORMATIONS_LIB})
+target_compile_definitions(${PROJECT_NAME} PRIVATE CI_BUILD_NUMBER=\"${CI_BUILD_NUMBER}\")
 
 # perform copy
 if(OpenVINO_SOURCE_DIR)

--- a/src/bindings/python/src/pyopenvino/CMakeLists.txt
+++ b/src/bindings/python/src/pyopenvino/CMakeLists.txt
@@ -7,13 +7,6 @@ if(NOT DEFINED OpenVINO_SOURCE_DIR)
     find_package(OpenVINODeveloperPackage REQUIRED)
 endif()
 
-if (DEFINED ENV{CI_BUILD_NUMBER})
-    set(CI_BUILD_NUMBER $ENV{CI_BUILD_NUMBER})
-    message(STATUS "Python CI build number: ${CI_BUILD_NUMBER}")
-else()
-    set(CI_BUILD_NUMBER "")
-endif()
-
 # PYTHON_VERSION_MAJOR and PYTHON_VERSION_MINOR are defined inside pybind11
 set(PYTHON_VERSION python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
 message(STATUS "Python version=${PYTHON_VERSION}")
@@ -84,7 +77,11 @@ endif()
 
 target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..")
 target_link_libraries(${PROJECT_NAME} PRIVATE openvino::runtime ${OFFLINE_TRANSFORMATIONS_LIB})
-target_compile_definitions(${PROJECT_NAME} PRIVATE CI_BUILD_NUMBER=\"${CI_BUILD_NUMBER}\")
+
+if(DEFINED CI_BUILD_NUMBER)
+    message(STATUS "Python CI Build Number: ${CI_BUILD_NUMBER}")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE CI_BUILD_NUMBER=\"${CI_BUILD_NUMBER}\")
+endif()
 
 # perform copy
 if(OpenVINO_SOURCE_DIR)

--- a/src/bindings/python/src/pyopenvino/pyopenvino.cpp
+++ b/src/bindings/python/src/pyopenvino/pyopenvino.cpp
@@ -69,24 +69,21 @@ std::string get_version() {
 
 PYBIND11_MODULE(pyopenvino, m) {
     m.doc() = "Package openvino.pyopenvino which wraps openvino C++ APIs";
-#ifdef CI_BUILD_NUMBER
     std::string pyopenvino_version = CI_BUILD_NUMBER;
     std::string runtime_version = get_version();
-    bool is_custom_pyopenvino_version = pyopenvino_version.find("custom_") == 0;
-    bool is_custom_runtime_version = runtime_version.find("custom_") == 0;
-    if (!is_custom_pyopenvino_version && !is_custom_runtime_version) {
-        auto versions_compatible =
-            pyopenvino_version.empty() || runtime_version.empty() || pyopenvino_version == runtime_version;
-        OPENVINO_ASSERT(versions_compatible,
-                        "OpenVINO Python version (",
-                        pyopenvino_version,
-                        ") mismatches with OpenVINO Runtime library version (",
-                        runtime_version,
-                        "). It can happen if you have 2 or more different versions of OpenVINO installed in system. "
-                        "Please ensure that environment variables (e.g. PATH, PYTHONPATH) are set correctly so that "
-                        "OpenVINO Runtime and Python libraries point to same release.");
-    }
-#endif
+    bool is_custom_pyopenvino_version = pyopenvino_version.empty() || pyopenvino_version.find("custom_") == 0;
+    bool is_custom_runtime_version = runtime_version.empty() || runtime_version.find("custom_") == 0;
+    auto versions_compatible =
+        is_custom_pyopenvino_version || is_custom_runtime_version || pyopenvino_version == runtime_version;
+    OPENVINO_ASSERT(versions_compatible,
+                    "OpenVINO Python version (",
+                    pyopenvino_version,
+                    ") mismatches with OpenVINO Runtime library version (",
+                    runtime_version,
+                    "). It can happen if you have 2 or more different versions of OpenVINO installed in system. "
+                    "Please ensure that environment variables (e.g. PATH, PYTHONPATH) are set correctly so that "
+                    "OpenVINO Runtime and Python libraries point to same release.");
+
     m.def("get_version", &get_version);
     m.def("get_batch", &ov::get_batch);
     m.def("set_batch", &ov::set_batch);

--- a/src/bindings/python/src/pyopenvino/pyopenvino.cpp
+++ b/src/bindings/python/src/pyopenvino/pyopenvino.cpp
@@ -69,6 +69,7 @@ std::string get_version() {
 
 PYBIND11_MODULE(pyopenvino, m) {
     m.doc() = "Package openvino.pyopenvino which wraps openvino C++ APIs";
+#ifdef CI_BUILD_NUMBER
     std::string pyopenvino_version = CI_BUILD_NUMBER;
     std::string runtime_version = get_version();
     bool is_custom_pyopenvino_version = pyopenvino_version.find("custom_") == 0;
@@ -85,6 +86,7 @@ PYBIND11_MODULE(pyopenvino, m) {
                         "Please ensure that environment variables (e.g. PATH, PYTHONPATH) are set correctly so that "
                         "OpenVINO Runtime and Python libraries point to same release.");
     }
+#endif
     m.def("get_version", &get_version);
     m.def("get_batch", &ov::get_batch);
     m.def("set_batch", &ov::set_batch);

--- a/src/bindings/python/src/pyopenvino/pyopenvino.cpp
+++ b/src/bindings/python/src/pyopenvino/pyopenvino.cpp
@@ -69,6 +69,22 @@ std::string get_version() {
 
 PYBIND11_MODULE(pyopenvino, m) {
     m.doc() = "Package openvino.pyopenvino which wraps openvino C++ APIs";
+    std::string pyopenvino_version = CI_BUILD_NUMBER;
+    std::string runtime_version = get_version();
+    bool is_custom_pyopenvino_version = pyopenvino_version.find("custom_") == 0;
+    bool is_custom_runtime_version = runtime_version.find("custom_") == 0;
+    if (!is_custom_pyopenvino_version && !is_custom_runtime_version) {
+        auto versions_compatible =
+            pyopenvino_version.empty() || runtime_version.empty() || pyopenvino_version == runtime_version;
+        OPENVINO_ASSERT(versions_compatible,
+                        "OpenVINO Python version (",
+                        pyopenvino_version,
+                        ") mismatches with OpenVINO Runtime library version (",
+                        runtime_version,
+                        "). It can happen if you have 2 or more different versions of OpenVINO installed in system. "
+                        "Please ensure that environment variables (e.g. PATH, PYTHONPATH) are set correctly so that "
+                        "OpenVINO Runtime and Python libraries point to same release.");
+    }
     m.def("get_version", &get_version);
     m.def("get_batch", &ov::get_batch);
     m.def("set_batch", &ov::set_batch);


### PR DESCRIPTION
### Details:
Checking compatibility between 'pyopenvino' and 'libopenvino' on 'import phase'

This fix is to prevent undefined behavior when user loads OpenVINO from python, but pyopenvino loads different version of 'libopenvino'
This may happen if user has several releases installed and played around PATH/PYTHONPATH environment variables.

In such case, user may have undefined behavior - application may crash in the middle of the usage or use incorrect release.

Fix checks build versions for pyopenvino and ov::get_openvino_version. If mismatch occurs, exception is thrown.

This logic is disabled if user has built OpenVINO locally, experienced developers probably know what they're doing, so if version has 'custom_'  prefix - this logic is disabled

### Tests:
 - Not covered by unit tests, only tested locally with 'CI_BUILD_NUMBER' environment variable

### Manual testing:
 - `export CI_BUILD_NUMBER=Release_1`, build sources from one location (/ov1)
 - `export CI_BUILD_NUMBER=Release_2`, build sources from another location (/ov2)
 - export PYTHONPATH=/ov1/bin/intel64/Release/lib/python/python3.6
 - export LD_PRELOAD=/ov2/bin/intel64/Release/lib/libopenvino.so
 - Try run some python tool, like 'accuracy_checker'
Verify error: OpenVINO Python version (Release_1) mismatches with OpenVINO Runtime library version (Release_2). It can happen if you have 2 or more different versions of OpenVINO installed in system. Please ensure that environment variables (e.g. PATH, PYTHONPATH) are set correctly so that OpenVINO Runtime and Python libraries point to same release.


### Tickets:
 - Related to 80212, where similar issue occurred due to incorrect CI setup. Need to prevent the same for end users
