### PR TITLE
Update MO requirements to allow TF1.15 if already installed

### DIFF
--- a/tools/mo/requirements.txt
+++ b/tools/mo/requirements.txt
@@ -1,5 +1,4 @@
-tensorflow~=2.5.0; python_version <= "3.6"
-tensorflow~=2.5.3; python_version > "3.6"
+tensorflow>=1.15.5,<2.6
 mxnet~=1.2.0; sys_platform == 'win32'
 mxnet~=1.7.0.post2; sys_platform != 'win32'
 networkx~=2.5; python_version <= "3.6"

--- a/tools/mo/requirements_tf.txt
+++ b/tools/mo/requirements_tf.txt
@@ -1,5 +1,4 @@
-tensorflow>=1.15.5,<2.6; python_version <= "3.6"
-tensorflow>=1.15.5,<2.6; python_version > "3.6"
+tensorflow>=1.15.5,<2.6
 networkx~=2.5; python_version <= "3.6"
 networkx~=2.6; python_version > "3.6"
 numpy>=1.16.6,<1.20

--- a/tools/mo/requirements_tf.txt
+++ b/tools/mo/requirements_tf.txt
@@ -1,5 +1,5 @@
-tensorflow~=2.5.0; python_version <= "3.6"
-tensorflow~=2.5.3; python_version > "3.6"
+tensorflow>=1.15.5,<2.6; python_version <= "3.6"
+tensorflow>=1.15.5,<2.6; python_version > "3.6"
 networkx~=2.5; python_version <= "3.6"
 networkx~=2.6; python_version > "3.6"
 numpy>=1.16.6,<1.20


### PR DESCRIPTION
### Details:
 - As it was agreed we should not block the possibility to use TF1.x if user have already set up development environment based on TF1.x. By default latest TF version supported by OpenVINO should be installed.
 - Solution is to have range between latest supported TF1.x (1.15.5) and TF2.6


### Ticket-id:
 - CVS-80484