### PR TITLE
[GPU] update to check quantize fusing condition in oneDNN

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -359,8 +359,7 @@ void minimize_local_reorders(program& p, std::map<program_node*, format::type>& 
             auto reorders_cnt = count_reorders(fmt_map, lo, node);
 
             if (reorders_cnt.number < best_reorder_cnt.number ||
-                (reorders_cnt.number == best_reorder_cnt.number && reorders_cnt.total_sizes < best_reorder_cnt.total_sizes) ||
-                (reorders_cnt.number == best_reorder_cnt.number && reorders_cnt.total_sizes == best_reorder_cnt.total_sizes)) {
+                (reorders_cnt.number == best_reorder_cnt.number && reorders_cnt.total_sizes <= best_reorder_cnt.total_sizes)) {
                 best_reorder_cnt = reorders_cnt;
                 best_format = new_fmt;
             }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -359,7 +359,7 @@ void minimize_local_reorders(program& p, std::map<program_node*, format::type>& 
             auto reorders_cnt = count_reorders(fmt_map, lo, node);
 
             if (reorders_cnt.number < best_reorder_cnt.number ||
-                (reorders_cnt.number == best_reorder_cnt.number && reorders_cnt.total_sizes <= best_reorder_cnt.total_sizes)) {
+                (reorders_cnt.number == best_reorder_cnt.number && reorders_cnt.total_sizes < best_reorder_cnt.total_sizes)) {
                 best_reorder_cnt = reorders_cnt;
                 best_format = new_fmt;
             }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -359,7 +359,8 @@ void minimize_local_reorders(program& p, std::map<program_node*, format::type>& 
             auto reorders_cnt = count_reorders(fmt_map, lo, node);
 
             if (reorders_cnt.number < best_reorder_cnt.number ||
-                (reorders_cnt.number == best_reorder_cnt.number && reorders_cnt.total_sizes < best_reorder_cnt.total_sizes) ) {
+                (reorders_cnt.number == best_reorder_cnt.number && reorders_cnt.total_sizes < best_reorder_cnt.total_sizes) ||
+                (reorders_cnt.number == best_reorder_cnt.number && reorders_cnt.total_sizes == best_reorder_cnt.total_sizes)) {
                 best_reorder_cnt = reorders_cnt;
                 best_format = new_fmt;
             }

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -371,7 +371,7 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
             }
         }
 
-        if (next.is_type<quantize>())
+        if (next.is_type<quantize>() && prev.get_users().size() == 1)
             return true;
 
         if (next.is_type<permute>()) {


### PR DESCRIPTION
local_formats from users/dependencies would be better
even though reorder_cnt.number and best_reorder_cnt.totla_size equal.

Signed-off-by: hyunback <hyunback.kim@intel.com>


### Tickets:
 - 74954
