### PR TITLE
Fix issue with default arguments in preprocessing python bindings

### DIFF
--- a/src/bindings/python/src/pyopenvino/graph/preprocess/pre_post_process.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/preprocess/pre_post_process.cpp
@@ -112,7 +112,7 @@ static void regclass_graph_PreProcessSteps(py::module m) {
         [](ov::preprocess::PreProcessSteps& self, ov::element::Type type = {}) {
             return &self.convert_element_type(type);
         },
-        py::arg("type") = ov::element::Type{},
+        py::arg_v("type", ov::element::undefined, "{}"),
         R"(
             Converts input tensor element type to specified type.
             Input tensor must have openvino.Type data type.
@@ -120,7 +120,7 @@ static void regclass_graph_PreProcessSteps(py::module m) {
             Parameters
             ----------
             type : openvino.runtime.Type
-                Destination type. By default type will be taken from model input's element type.
+                Destination type. If not specified, type will be taken from model input's element type.
 
             Returns
             ----------
@@ -203,7 +203,7 @@ static void regclass_graph_PostProcessSteps(py::module m) {
         [](ov::preprocess::PostProcessSteps& self, ov::element::Type type = {}) {
             return &self.convert_element_type(type);
         },
-        py::arg("type") = ov::element::Type{},
+        py::arg_v("type", ov::element::undefined, "{}"),
         R"(
             Converts tensor element type to specified type.
             Tensor must have openvino.Type data type.
@@ -211,7 +211,7 @@ static void regclass_graph_PostProcessSteps(py::module m) {
             Parameters
             ----------
             type : Type
-                Destination type. By default type will be taken from model output's element type.
+                Destination type. If not specified, type will be taken from model output's element type.
 
             Returns
             ----------

--- a/src/bindings/python/src/pyopenvino/graph/preprocess/pre_post_process.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/preprocess/pre_post_process.cpp
@@ -112,7 +112,7 @@ static void regclass_graph_PreProcessSteps(py::module m) {
         [](ov::preprocess::PreProcessSteps& self, ov::element::Type type = {}) {
             return &self.convert_element_type(type);
         },
-        py::arg_v("type", ov::element::undefined, "{}"),
+        py::arg_v("type", ov::element::undefined, "openvino.runtime.Type.undefined"),
         R"(
             Converts input tensor element type to specified type.
             Input tensor must have openvino.Type data type.
@@ -203,7 +203,7 @@ static void regclass_graph_PostProcessSteps(py::module m) {
         [](ov::preprocess::PostProcessSteps& self, ov::element::Type type = {}) {
             return &self.convert_element_type(type);
         },
-        py::arg_v("type", ov::element::undefined, "{}"),
+        py::arg_v("type", ov::element::undefined, "openvino.runtime.Type.undefined"),
         R"(
             Converts tensor element type to specified type.
             Tensor must have openvino.Type data type.

--- a/src/bindings/python/src/pyopenvino/graph/preprocess/pre_post_process.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/preprocess/pre_post_process.cpp
@@ -109,18 +109,18 @@ static void regclass_graph_PreProcessSteps(py::module m) {
 
     steps.def(
         "convert_element_type",
-        [](ov::preprocess::PreProcessSteps& self, ov::element::Type type) {
+        [](ov::preprocess::PreProcessSteps& self, ov::element::Type type = {}) {
             return &self.convert_element_type(type);
         },
-        py::arg("type"),
+        py::arg("type") = ov::element::Type{},
         R"(
             Converts input tensor element type to specified type.
-            Input tensor must have openvino.Type.f32 data type.
+            Input tensor must have openvino.Type data type.
 
             Parameters
             ----------
             type : openvino.runtime.Type
-                Destination type.
+                Destination type. By default type will be taken from model input's element type.
 
             Returns
             ----------
@@ -200,18 +200,18 @@ static void regclass_graph_PostProcessSteps(py::module m) {
 
     steps.def(
         "convert_element_type",
-        [](ov::preprocess::PostProcessSteps& self, ov::element::Type type) {
+        [](ov::preprocess::PostProcessSteps& self, ov::element::Type type = {}) {
             return &self.convert_element_type(type);
         },
-        py::arg("type"),
+        py::arg("type") = ov::element::Type{},
         R"(
             Converts tensor element type to specified type.
-            Tensor must have openvino.Type.f32 data type.
+            Tensor must have openvino.Type data type.
 
             Parameters
             ----------
             type : Type
-                Destination type.
+                Destination type. By default type will be taken from model output's element type.
 
             Returns
             ----------
@@ -322,7 +322,7 @@ static void regclass_graph_InputTensorInfo(py::module m) {
             return &self.set_color_format(format, sub_names);
         },
         py::arg("format"),
-        py::arg("sub_names"));
+        py::arg("sub_names") = std::vector<std::string>{});
 
     info.def(
         "set_memory_type",

--- a/src/bindings/python/src/pyopenvino/graph/types/element_type.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/types/element_type.cpp
@@ -29,10 +29,13 @@ void regclass_graph_Type(py::module m) {
     type.attr("u32") = ov::element::u32;
     type.attr("u64") = ov::element::u64;
     type.attr("bf16") = ov::element::bf16;
+    type.attr("undefined") = ov::element::undefined;
 
     type.def("__repr__", [](const ov::element::Type& self) {
         std::string bitwidth = std::to_string(self.bitwidth());
-        if (self.is_signed()) {
+        if (self == ov::element::undefined) {
+            return "<Type: '" + self.c_type_string() + "'>";
+        } else if (self.is_signed()) {
             return "<Type: '" + self.c_type_string() + bitwidth + "'>";
         }
         return "<Type: 'u" + self.c_type_string() + bitwidth + "'>";

--- a/src/bindings/python/tests/test_ngraph/test_preprocess.py
+++ b/src/bindings/python/tests/test_ngraph/test_preprocess.py
@@ -90,7 +90,7 @@ def test_ngraph_preprocess_mean_scale_convert():
     p = PrePostProcessor(function)
     inp2 = p.input(1)
     inp2.tensor().set_element_type(Type.i32)
-    inp2.preprocess().convert_element_type(Type.f32).mean(1.).scale(2.)
+    inp2.preprocess().convert_element_type(Type.f32).mean(1.).scale(2.).convert_element_type()
     inp1 = p.input(0)
     inp1.preprocess().convert_element_type(Type.f32).mean(1.).custom(custom_preprocess)
     function = p.build()
@@ -159,10 +159,14 @@ def test_ngraph_preprocess_output_postprocess():
     inp.tensor().set_layout(layout1)
     inp.preprocess().convert_element_type(Type.f32).mean([1., 2., 3.])
     out = p.output()
+    out.tensor().set_element_type(Type.f32)
     out.model().set_layout(layout1)
     out.postprocess().convert_element_type(Type.f32) \
                      .convert_layout(layout2) \
-                     .convert_layout(layout3).custom(custom_postprocess)
+                     .convert_layout(layout3) \
+                     .custom(custom_postprocess) \
+                     .convert_element_type(Type.f16) \
+                     .convert_element_type()
     function = p.build()
 
     input_data = np.array([[-1, -2, -3], [-4, -5, -6]]).astype(np.int32)
@@ -185,7 +189,7 @@ def test_ngraph_preprocess_spatial_static_shape():
 
     p = PrePostProcessor(function)
     inp = p.input()
-    inp.tensor().set_layout(layout).set_spatial_static_shape(2, 2).set_color_format(color_format, [])
+    inp.tensor().set_layout(layout).set_spatial_static_shape(2, 2).set_color_format(color_format)
     inp.preprocess().convert_element_type(Type.f32).mean([1., 2.])
     inp.model().set_layout(layout)
     out = p.output()

--- a/src/core/include/openvino/core/model.hpp
+++ b/src/core/include/openvino/core/model.hpp
@@ -398,8 +398,8 @@ OPENVINO_API ov::Dimension get_batch(const std::shared_ptr<const ov::Model>& f);
 /// applied. Possible reason could be that layout was not set for some parameters, or batch size can't be applied to
 /// model at all
 ///
-/// \param f model where to set batch_size value
+/// \param model model where to set batch_size value
 /// \param batch_size Batch size value. For dynamic batch size, Dimension::dynamic() can be passed.
-OPENVINO_API void set_batch(const std::shared_ptr<ov::Model>& f, ov::Dimension batch_size);
+OPENVINO_API void set_batch(const std::shared_ptr<ov::Model>& model, ov::Dimension batch_size);
 
 }  // namespace ov


### PR DESCRIPTION
### Details:

Fix in Preprocessing python bindings - add correct default arguments for:

    - PreProcessSteps::convert_element_type
    - PostProcessSteps::convert_element_type
    - InputTensorInfo::set_color_format

Otherwise, python users must always specify optional params

E.g. without fix, instead of writing `tensor().set_color_format(ColorFormat.RGB)` python users have to write `tensor().set_color_format(ColorFormat.RGB, [])`

Unit tests were also corrected to cover these cases

### Tickets:
 - 80563
