### PR TITLE
[Python API] Fix typo in method name

### DIFF
--- a/src/bindings/python/src/pyopenvino/graph/descriptors/tensor.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/descriptors/tensor.cpp
@@ -101,7 +101,7 @@ void regclass_graph_descriptor_Tensor(py::module m) {
                     Set of names
              )");
 
-    tensor.def("set_names",
+    tensor.def("add_names",
                &ov::descriptor::Tensor::add_names,
                py::arg("names"),
                R"(


### PR DESCRIPTION
### Details:
 - method named `set_names` while it should be `add_names`

### Tickets:
 - *ticket-id*
