### PR TITLE
[CPU] Disabled sequences decomposition for dynamic case

### DIFF
--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -285,6 +285,10 @@ static void TransformationUpToCPUSpecificOpSet(std::shared_ptr<ngraph::Function>
     auto isSequencePrimitiveSupported = [](const_node_ptr &node) -> bool {
         const auto& data = node->input(0);
         const auto& data_pshape = data.get_partial_shape();
+        // WA: dynamic shapes make impossible to check seq_len due to shapeOf subgraphs
+        // but the sequence is still supported in CPU and doesn't need to be decomposed
+        if (data_pshape.is_dynamic())
+            return true;
         if (data_pshape.rank().is_static() && data_pshape.rank().get_length() > 1 && !data_pshape[1].is_static())
             return false;
         auto max_seq_len = data.get_shape().at(1);


### PR DESCRIPTION
### Details:
 - *RNN/GRU/LSTM decomposition: dynamic shapes make impossible to check seq_len in CPU callback due to shapeOf subgraphs but the sequence is still supported in CPU and doesn't need to be decomposed (to save a performance). For this reason, decomposition has been disabled for the dynamic case*

### Tickets:
 - *80363*
