### PR TITLE
[CPU] Fixed default ellipsis mask in StridedSlice

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
@@ -119,10 +119,12 @@ MKLDNNStridedSliceNode::MKLDNNStridedSliceNode(const std::shared_ptr<ov::Node>& 
         attrs.shrinkAxisMask = createMask(ss->get_shrink_axis_mask());
 
         auto origEllipsisMask = ss->get_ellipsis_mask();
+        bool isEllipsis = false;
         for (const auto &o : origEllipsisMask) {
+            isEllipsis = isEllipsis || o != 0;
             attrs.ellipsisMask.push_back(o);
         }
-        if (attrs.ellipsisMask.size() == 0) {
+        if (attrs.ellipsisMask.size() == 0 || !isEllipsis) {
             for (size_t i = attrs.ellipsisMask.size(); i < nDims; ++i) attrs.ellipsisMask.push_back(0);
         }
     } else {

--- a/src/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/strided_slice.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/strided_slice.cpp
@@ -66,6 +66,8 @@ std::vector<StridedSliceSpecificParams> ss_only_test_cases = {
                             { 1, 0 }, { 1, 0 },  {  },  {  },  { 1, 0 } },
         StridedSliceSpecificParams{ { 20, 10, 5 }, { 0, 0 }, { 0, -1 }, { 1, 1 },
                             { 1, 0 }, { 1, 0 },  {  },  {  },  { 1, 0 } },
+        StridedSliceSpecificParams{ { 20, 10, 5 }, { 0, 0 }, { 0, -1 }, { 1, 1 },
+                                    { 1, 0 }, { 1, 0 },  { 0, 0 },  { 0, 0 },  { 0, 0 } },
         StridedSliceSpecificParams{ { 1, 12, 100, 1, 1 }, { 0, -1, 0, 0 }, { 0, 0, 0, 0 }, { 1, 1, 1, 1 },
                             { 1, 0, 1, 0 }, { 1, 0, 1, 0 },  { },  { 0, 1, 0, 1 },  {} },
         StridedSliceSpecificParams{ { 2, 2, 2, 2 }, { 0, 0, 0, 0 }, { 2, 2, 2, 2 }, { 1, 1, 1, 1 },


### PR DESCRIPTION
### Details:
 - *There are cases when default ellipsis mask (has only 0) size is less than input/output rank but isn't equal to zero. So we should to fill mask by zero to full size as begin, end masks and other masks*
 - *DLB is successfully passed*

### Tickets:
 - *80532*
