### PR TITLE
Specify NonMaxSuppression-9

### DIFF
--- a/docs/OV_Runtime_UG/Operations_specifications.md
+++ b/docs/OV_Runtime_UG/Operations_specifications.md
@@ -119,6 +119,7 @@
    NonMaxSuppression-3 <openvino_docs_ops_sort_NonMaxSuppression_3>
    NonMaxSuppression-4 <openvino_docs_ops_sort_NonMaxSuppression_4>
    NonMaxSuppression-5 <openvino_docs_ops_sort_NonMaxSuppression_5>
+   NonMaxSuppression-9 <openvino_docs_ops_sort_NonMaxSuppression_9>
    NonZero-3 <openvino_docs_ops_condition_NonZero_3>
    NormalizeL2-1 <openvino_docs_ops_normalization_NormalizeL2_1>
    NotEqual-1 <openvino_docs_ops_comparison_NotEqual_1>

--- a/docs/ops/sort/NonMaxSuppression_9.md
+++ b/docs/ops/sort/NonMaxSuppression_9.md
@@ -17,7 +17,7 @@
 7.  For each input box `b_i` from `B` and the corresponding score `s_i`, set `s_i = s_i * func(IOU(b_i, b))` and go to step 3.
 8.  Return `D`, a collection of the corresponding scores `S`, and the number of elements in `D`.
 
-when `soft_nms_sigma == 0`, `func(iou) = 1 if iou <= iou_threshold else 0`, else `func(iou) = exp(-0.5 * iou * iou / soft_nms_sigma)`.
+Here `func(iou) = 1 if iou <= iou_threshold else 0` when `soft_nms_sigma == 0`, else `func(iou) = exp(-0.5 * iou * iou / soft_nms_sigma)`.
 
 This algorithm is applied independently to each class of each batch element. The total number of output boxes for each
 class must not exceed `max_output_boxes_per_class`.
@@ -68,11 +68,11 @@ class must not exceed `max_output_boxes_per_class`.
 
 **Outputs**:
 
-*   **1**: `selected_indices` - tensor of type *T_IND* and shape `[number of selected boxes, 3]` containing information about selected boxes as triplets `[batch_index, class_index, box_index]`.
+*   **1**: `selected_indices` - tensor of type *output_type* and shape `[number of selected boxes, 3]` containing information about selected boxes as triplets `[batch_index, class_index, box_index]`.
 
 *   **2**: `selected_scores` - tensor of type *T_THRESHOLDS* and shape `[number of selected boxes, 3]` containing information about scores for each selected box as triplets `[batch_index, class_index, box_score]`.
 
-*   **3**: `valid_outputs` - 1D tensor with 1 element of type *T_IND* representing the total number of selected boxes.
+*   **3**: `valid_outputs` - 1D tensor with 1 element of type *output_type* representing the total number of selected boxes.
 
 Plugins which do not support dynamic output tensors produce `selected_indices` and `selected_scores` tensors of shape `[min(num_boxes, max_output_boxes_per_class) * num_batches * num_classes, 3]` which is an upper bound for the number of possible selected boxes. Output tensor elements following the really selected boxes are filled with value -1.
 
@@ -84,7 +84,6 @@ Plugins which do not support dynamic output tensors produce `selected_indices` a
 
 * *T_THRESHOLDS*: floating-point type.
 
-* *T_IND*: `int64` or `int32`.
 
 **Example**
 

--- a/docs/ops/sort/NonMaxSuppression_9.md
+++ b/docs/ops/sort/NonMaxSuppression_9.md
@@ -59,7 +59,7 @@ class must not exceed `max_output_boxes_per_class`.
     * *true* - soft NMS is suppressed by IOU.
     * *false* - soft NMS is not suppressed by IOU.
   * **Type**: boolean
-  * **Default value**: false
+  * **Default value**: true
   * **Required**: *no*
 
 **Inputs**:

--- a/docs/ops/sort/NonMaxSuppression_9.md
+++ b/docs/ops/sort/NonMaxSuppression_9.md
@@ -1,0 +1,134 @@
+# NonMaxSuppression {#openvino_docs_ops_sort_NonMaxSuppression_9}
+
+**Versioned name**: *NonMaxSuppression-9*
+
+**Category**: *Sorting and maximization*
+
+**Short description**: *NonMaxSuppression* performs non maximum suppression of the boxes with predicted scores.
+
+**Detailed description**: *NonMaxSuppression* performs non maximum suppression algorithm as described below:
+
+1.  Let `B = [b_0,...,b_n]` be the list of initial detection boxes, `S = [s_0,...,s_N]` be  the list of corresponding scores.
+2.  Let `D = []` be an initial collection of resulting boxes.
+3.  If `B` is empty then go to step 8.
+4.  Take the box with highest score. Suppose that it is the box `b` with the score `s`.
+5.  Delete `b` from `B`.
+6.  If the score `s` is greater or equal than `score_threshold`  then add `b` to `D` else go to step 8.
+7.  For each input box `b_i` from `B` and the corresponding score `s_i`, set `s_i = s_i * func(IOU(b_i, b))` and go to step 3.
+8.  Return `D`, a collection of the corresponding scores `S`, and the number of elements in `D`.
+
+when `soft_nms_sigma == 0`, `func(iou) = 1 if iou <= iou_threshold else 0`, else `func(iou) = exp(-0.5 * iou * iou / soft_nms_sigma) if soft_NMS_suppressed_by_IOU == false`, else `func(iou) = exp(-0.5 * iou * iou / soft_nms_sigma) if iou <= iou_threshold else 0`.
+
+This algorithm is applied independently to each class of each batch element. The total number of output boxes for each
+class must not exceed `max_output_boxes_per_class`.
+
+**Attributes**:
+
+* *box_encoding*
+
+  * **Description**: *box_encoding* specifies the format of boxes data encoding.
+  * **Range of values**: "corner" or "center"
+    * *corner* - the box data is supplied as `[y1, x1, y2, x2]` where `(y1, x1)` and `(y2, x2)` are the coordinates of any diagonal pair of box corners.
+    * *center* - the box data is supplied as `[x_center, y_center, width, height]`.
+  * **Type**: string
+  * **Default value**: "corner"
+  * **Required**: *no*
+
+* *sort_result_descending*
+
+  * **Description**: *sort_result_descending* is a flag that specifies whenever it is necessary to sort selected boxes across batches or not.
+  * **Range of values**: true of false
+    * *true* - sort selected boxes across batches.
+    * *false* - do not sort selected boxes across batches (boxes are sorted per class).
+  * **Type**: boolean
+  * **Default value**: true
+  * **Required**: *no*
+
+* *output_type*
+
+  * **Description**: the output tensor type
+  * **Range of values**: "i64" or "i32"
+  * **Type**: string
+  * **Default value**: "i64"
+  * **Required**: *no*
+  
+* *soft_NMS_suppressed_by_IOU*
+
+  * **Description**: *soft_NMS_suppressed_by_IOU* is a flag that specifies whenever soft NMS is suppressed by IOU. It is used only when `soft_nms_sigma != 0`.
+  * **Range of values**: true of false
+    * *true* - soft NMS is suppressed by IOU.
+    * *false* - soft NMS is not suppressed by IOU.
+  * **Type**: boolean
+  * **Default value**: false
+  * **Required**: *no*
+
+**Inputs**:
+
+*   **1**: `boxes` - tensor of type *T* and shape `[num_batches, num_boxes, 4]` with box coordinates. **Required.**
+
+*   **2**: `scores` - tensor of type *T* and shape `[num_batches, num_classes, num_boxes]` with box scores. **Required.**
+
+*   **3**: `max_output_boxes_per_class` - scalar or 1D tensor with 1 element of type *T_MAX_BOXES* specifying maximum number of boxes to be selected per class. Optional with default value 0 meaning select no boxes.
+
+*   **4**: `iou_threshold` - scalar or 1D tensor with 1 element of type *T_THRESHOLDS* specifying intersection over union threshold. Optional with default value 0 meaning keep all boxes.
+
+*   **5**: `score_threshold` - scalar or 1D tensor with 1 element of type *T_THRESHOLDS* specifying minimum score to consider box for the processing. Optional with default value 0.
+
+*   **6**:  `soft_nms_sigma` - scalar or 1D tensor with 1 element of type *T_THRESHOLDS* specifying the sigma parameter for Soft-NMS; see [Bodla et al](https://arxiv.org/abs/1704.04503.pdf). Optional with default value 0.
+
+**Outputs**:
+
+*   **1**: `selected_indices` - tensor of type *T_IND* and shape `[number of selected boxes, 3]` containing information about selected boxes as triplets `[batch_index, class_index, box_index]`.
+
+*   **2**: `selected_scores` - tensor of type *T_THRESHOLDS* and shape `[number of selected boxes, 3]` containing information about scores for each selected box as triplets `[batch_index, class_index, box_score]`.
+
+*   **3**: `valid_outputs` - 1D tensor with 1 element of type *T_IND* representing the total number of selected boxes.
+
+Plugins which do not support dynamic output tensors produce `selected_indices` and `selected_scores` tensors of shape `[min(num_boxes, max_output_boxes_per_class) * num_batches * num_classes, 3]` which is an upper bound for the number of possible selected boxes. Output tensor elements following the really selected boxes are filled with value -1.
+
+**Types**
+
+* *T*: floating-point type.
+
+* *T_MAX_BOXES*: integer type.
+
+* *T_THRESHOLDS*: floating-point type.
+
+* *T_IND*: `int64` or `int32`.
+
+**Example**
+
+```xml
+<layer ... type="NonMaxSuppression" ... >
+    <data box_encoding="corner" sort_result_descending="1" output_type="i64" soft_NMS_suppressed_by_IOU="0"/>
+    <input>
+        <port id="0">
+            <dim>3</dim>
+            <dim>100</dim>
+            <dim>4</dim>
+        </port>
+        <port id="1">
+            <dim>3</dim>
+            <dim>5</dim>
+            <dim>100</dim>
+        </port>
+        <port id="2"/> <!-- 10 -->
+        <port id="3"/>
+        <port id="4"/>
+        <port id="5"/>
+    </input>
+    <output>
+        <port id="6" precision="I64">
+            <dim>150</dim> <!-- min(100, 10) * 3 * 5 -->
+            <dim>3</dim>
+        </port>
+        <port id="7" precision="FP32">
+            <dim>150</dim> <!-- min(100, 10) * 3 * 5 -->
+            <dim>3</dim>
+        </port>
+        <port id="8" precision="I64">
+            <dim>1</dim>
+        </port>
+    </output>
+</layer>
+```

--- a/docs/ops/sort/NonMaxSuppression_9.md
+++ b/docs/ops/sort/NonMaxSuppression_9.md
@@ -17,7 +17,7 @@
 7.  For each input box `b_i` from `B` and the corresponding score `s_i`, set `s_i = s_i * func(IOU(b_i, b))` and go to step 3.
 8.  Return `D`, a collection of the corresponding scores `S`, and the number of elements in `D`.
 
-when `soft_nms_sigma == 0`, `func(iou) = 1 if iou <= iou_threshold else 0`, else `func(iou) = exp(-0.5 * iou * iou / soft_nms_sigma) if soft_NMS_suppressed_by_IOU == false`, else `func(iou) = exp(-0.5 * iou * iou / soft_nms_sigma) if iou <= iou_threshold else 0`.
+when `soft_nms_sigma == 0`, `func(iou) = 1 if iou <= iou_threshold else 0`, else `func(iou) = exp(-0.5 * iou * iou / soft_nms_sigma)`.
 
 This algorithm is applied independently to each class of each batch element. The total number of output boxes for each
 class must not exceed `max_output_boxes_per_class`.
@@ -50,16 +50,6 @@ class must not exceed `max_output_boxes_per_class`.
   * **Range of values**: "i64" or "i32"
   * **Type**: string
   * **Default value**: "i64"
-  * **Required**: *no*
-  
-* *soft_NMS_suppressed_by_IOU*
-
-  * **Description**: *soft_NMS_suppressed_by_IOU* is a flag that specifies whenever soft NMS is suppressed by IOU. It is used only when `soft_nms_sigma != 0`.
-  * **Range of values**: true of false
-    * *true* - soft NMS is suppressed by IOU.
-    * *false* - soft NMS is not suppressed by IOU.
-  * **Type**: boolean
-  * **Default value**: true
   * **Required**: *no*
 
 **Inputs**:
@@ -100,7 +90,7 @@ Plugins which do not support dynamic output tensors produce `selected_indices` a
 
 ```xml
 <layer ... type="NonMaxSuppression" ... >
-    <data box_encoding="corner" sort_result_descending="1" output_type="i64" soft_NMS_suppressed_by_IOU="0"/>
+    <data box_encoding="corner" sort_result_descending="1" output_type="i64"/>
     <input>
         <port id="0">
             <dim>3</dim>


### PR DESCRIPTION
### Details:
 - *NMS-9_specification*

New version of the operation NonMaxSuppression is created to support for soft NMS behavior, where the candidate box is only suppressed by degraded score instead of suppressed by IOU directly.

In the cases such as TF soft NMS5, candidate boxed never suppressed by IOU, only suppressed by score to avoid suppression to box, which have high IOU but also having very high score([code](https://github.com/tensorflow/tensorflow/blob/3a7362750d5c372420aa8f0caf7bf5b5c3d0f52d/tensorflow/core/kernels/image/non_max_suppression_op.cc#L236-L237), [spec](https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/non-max-suppression-v5)).


### Tickets:
 - *79200*
