### PR TITLE
[CPU] Prohibit int8 desc convolution creation in case s8 precision on…

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -289,7 +289,7 @@ bool Convolution::canBeExecutedInInt8() const {
     if (!weightsZeroPoints.empty())
         weightsDataType = memory::data_type::s8;
 
-    return one_of(inputDataType, memory::data_type::u8, memory::data_type::s8) && weightsDataType == memory::data_type::s8;
+    return inputDataType == memory::data_type::u8 && weightsDataType == memory::data_type::s8;
 }
 
 InferenceEngine::Precision Convolution::fusedEltwisePrecision(const NodePtr& fusingNode) const {
@@ -721,7 +721,7 @@ void Convolution::createDescriptor(const std::vector<MemoryDescPtr>& inputDesc,
 
     memory::data_type wdt = static_cast<memory::data_type>(inDnnlDesc.data.data_type);
 
-    if (inDnnlDesc.data.data_type == mkldnn_s8 || inDnnlDesc.data.data_type == mkldnn_u8) {
+    if (inDnnlDesc.data.data_type == mkldnn_u8) {
         wdt = memory::data_type::s8;
     }
 


### PR DESCRIPTION
… data input

### Details:
 - *Since we marked all primitives with s8 precision on data and weights inputs as unused (https://github.com/openvinotoolkit/oneDNN/blob/82ca2f931c1d588b67d154d873136d4af1ffb3a8/src/cpu/cpu_convolution_list.cpp), we mustn't create such desc.*

### Tickets:
 - *52942*
- *81019*