### PR TITLE
[CPU] Use raw pointer to share peer data for constants

### DIFF
--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -404,7 +404,13 @@ MKLDNNMemoryPtr &MKLDNNEdge::getMemoryPtr() {
     if (status == Status::NotAllocated) {
         memoryPtr.reset(new MKLDNNMemory(getParent()->getEngine()));
         const auto &desc = getDesc();
-        memoryPtr->Create(desc, getSharedEdge()->getMemoryPtr()->getDnnlMemoryMngr());
+        auto sharedEdge = getSharedEdge();
+        auto sharedEdgeParent = sharedEdge->getParent();
+        if (sharedEdgeParent->isConstant()) {
+            memoryPtr->Create(desc, sharedEdge->getMemoryPtr()->GetData());
+        } else {
+            memoryPtr->Create(desc, sharedEdge->getMemoryPtr()->getDnnlMemoryMngr());
+        }
         memoryFromEdge.reset();
         changeStatus(Status::Allocated);
     }


### PR DESCRIPTION
### Details:
Due to the fact that the memory mngr is not thread safe, but constant layers are shared between threads we may have data race in case multiple edges shares the same constant node.

Release PR: https://github.com/openvinotoolkit/openvino/pull/10794

### Tickets:
 - 80654
- 80616