### PR TITLE
Update Binder URL on the tutorials landing page

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -15,6 +15,6 @@
 
 This collection of Python tutorials are written for running on [Jupyter*](https://jupyter.org) notebooks. The tutorials provide an introduction to the OpenVINO™ toolkit and explain how to use the Python API and tools for optimized deep learning inference. You can run the code one section at a time to see how to integrate your application with OpenVINO™ libraries.
 
-![Binder logo](img/badge_logo.svg)
+[![Binder logo](img/badge_logo.svg)](https://mybinder.org/v2/gh/openvinotoolkit/openvino_notebooks/HEAD?filepath=notebooks%2F001-hello-world%2F001-hello-world.ipynb)
 
 Tutorials showing this logo may be run remotely using Binder with no setup, although running the notebooks on a local system is recommended for best performance. See the [OpenVINO™ Notebooks Installation Guide](https://github.com/openvinotoolkit/openvino_notebooks/blob/main/README.md#-installation-guide) to install and run locally.


### PR DESCRIPTION
Binder URL was linking to a file. It should go to an actual Binder tutorial.
