### PR TITLE
Correcting a regular expression for EXCLUDED_SOURCE_PATHS

### DIFF
--- a/cmake/developer_package/add_ie_target.cmake
+++ b/cmake/developer_package/add_ie_target.cmake
@@ -76,8 +76,8 @@ function(addIeTarget)
 
     # remove unnecessary directories
     foreach(excludedDir ${ARG_EXCLUDED_SOURCE_PATHS})
-        list(FILTER includes EXCLUDE REGEX "${excludedDir}*")
-        list(FILTER sources EXCLUDE REGEX "${excludedDir}*")
+        list(FILTER includes EXCLUDE REGEX "${excludedDir}.*")
+        list(FILTER sources EXCLUDE REGEX "${excludedDir}.*")
     endforeach()
 
     source_group("include" FILES ${includes})


### PR DESCRIPTION
### Details:
 - *Corrects regular expression for EXCLUDED_SOURCE_PATHS, star indicates 0 or more times repetition of the character in front of it*

### Tickets:
 - *79629*
