### PR TITLE
[RT][VPU]: Fixes for dynamic models

### DIFF
--- a/src/plugins/intel_myriad/common/include/vpu/ngraph/operations/dynamic_shape_resolver.hpp
+++ b/src/plugins/intel_myriad/common/include/vpu/ngraph/operations/dynamic_shape_resolver.hpp
@@ -22,7 +22,8 @@ public:
 
     DynamicShapeResolver(const Output<Node>& tensorWithData,
                          const Output<Node>& tensorWithDims,
-                         const DynamicShapeResolverMode& mode = DynamicShapeResolverMode::INFER_UPPER_BOUND_SHAPE);
+                         const DynamicShapeResolverMode& mode = DynamicShapeResolverMode::INFER_UPPER_BOUND_SHAPE,
+                         const ngraph::PartialShape& output_partial_shape = ngraph::PartialShape{});
 
     void validate_and_infer_types() override;
 
@@ -34,11 +35,16 @@ public:
     bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
     OPENVINO_SUPPRESS_DEPRECATED_END
 
+    // Deprecated. Left for compatibility with tests
     void setMode(DynamicShapeResolverMode mode) { m_mode = mode; }
-    DynamicShapeResolverMode getMode() { return m_mode; }
+    DynamicShapeResolverMode getMode() const { return m_mode; }
+
+    void setOutputPartialShape(const ngraph::PartialShape& output_partial_shape) { m_output_partial_shape = output_partial_shape; }
+    const ngraph::PartialShape& getOutputPartialShape() const { return m_output_partial_shape; }
 
 private:
     DynamicShapeResolverMode m_mode;
+    ngraph::PartialShape m_output_partial_shape;
 };
 
 }  // namespace op

--- a/src/plugins/intel_myriad/common/src/ngraph/transformations/dynamic_to_static_shape_transpose.cpp
+++ b/src/plugins/intel_myriad/common/src/ngraph/transformations/dynamic_to_static_shape_transpose.cpp
@@ -37,9 +37,9 @@ void dynamicToStaticShapeTranspose(std::shared_ptr<ngraph::Node> target) {
         ngraph::element::i64,
         ngraph::Shape{std::initializer_list<std::size_t>{1}},
         std::vector<std::int64_t>{0});
-    const auto scatterElementsUpdate = std::make_shared<ngraph::opset3::ScatterElementsUpdate>(shape, transposition, shape, axis);
+    const auto gather = std::make_shared<ngraph::opset3::Gather>(shape, transposition, axis);
 
-    auto outDSR = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, scatterElementsUpdate);
+    auto outDSR = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(copied, gather);
     outDSR->set_friendly_name(transpose->get_friendly_name());
     ngraph::replace_node(std::move(target), std::move(outDSR));
 }

--- a/src/plugins/intel_myriad/common/src/ngraph/transformations/extract_dynamic_batch/extract_dynamic_batch.cpp
+++ b/src/plugins/intel_myriad/common/src/ngraph/transformations/extract_dynamic_batch/extract_dynamic_batch.cpp
@@ -49,6 +49,10 @@ private:
 
             {ngraph::opset5::Relu::get_type_info_static(),             sliceUnaryEltwise},
             {ngraph::opset5::Clamp::get_type_info_static(),            sliceUnaryEltwise},
+
+            // TODO: Need to make sure that all topologies/attributes scenarios can be covered by sliceUnaryEltwise
+            {ngraph::opset5::MaxPool::get_type_info_static(),          sliceUnaryEltwise},
+            {ngraph::opset5::AvgPool::get_type_info_static(),          sliceUnaryEltwise},
         };
         return slicers;
     }

--- a/src/plugins/intel_myriad/common/src/ngraph/transformations/extract_dynamic_batch/extract_dynamic_batch.cpp
+++ b/src/plugins/intel_myriad/common/src/ngraph/transformations/extract_dynamic_batch/extract_dynamic_batch.cpp
@@ -414,7 +414,7 @@ bool ExtractBatch::run_on_model(const std::shared_ptr<ngraph::Function>& functio
 
     Nodes sources;
     for (const auto& operation : function.get_ordered_ops()) {
-        if (targets.count(operation->get_type_info())) {
+        if (operation->is_dynamic() && targets.count(operation->get_type_info())) {
             sources.emplace(operation.get());
         }
     }

--- a/src/plugins/intel_myriad/graph_transformer/src/frontend/frontend.cpp
+++ b/src/plugins/intel_myriad/graph_transformer/src/frontend/frontend.cpp
@@ -195,7 +195,9 @@ ie::CNNNetwork FrontEnd::convertNetwork(ie::CNNNetwork& network) {
     manager.register_pass<vpu::ExtractBatch>(std::unordered_set<ngraph::Node::type_info_t> {
         ngraph::opset5::MatMul::get_type_info_static(),
         ngraph::opset5::Convolution::get_type_info_static(),
-        ngraph::opset5::GroupConvolution::get_type_info_static()
+        ngraph::opset5::GroupConvolution::get_type_info_static(),
+        ngraph::opset5::MaxPool::get_type_info_static(),
+        ngraph::opset5::AvgPool::get_type_info_static(),
     });
     manager.register_pass<vpu::DynamicToStaticShape>();
     manager.register_pass<vpu::EliminateShapeOfAfterDSR>();

--- a/src/plugins/intel_myriad/graph_transformer/src/frontend/in_out_convert.cpp
+++ b/src/plugins/intel_myriad/graph_transformer/src/frontend/in_out_convert.cpp
@@ -23,11 +23,6 @@ void FrontEnd::addDataTypeConvertStages(const Model& model) {
     VPU_LOGGER_SECTION(env.log);
 
     for (const auto& input : model->datas()) {
-        if (_core && _core->isNewAPI()) {
-            env.log->trace("OpenVINO API 2.0 has already inserted Convert operations. Skip this legacy pass for inputs.");
-            continue;
-        }
-
         if (input->usage() != DataUsage::Input) {
             continue;
         }
@@ -36,7 +31,12 @@ void FrontEnd::addDataTypeConvertStages(const Model& model) {
         VPU_LOGGER_SECTION(env.log);
 
         switch (input->desc().type()) {
-            case DataType::U8:
+            case DataType::U8: {
+                if (_core && _core->isNewAPI()) {
+                    env.log->trace("OpenVINO API 2.0 has already inserted Convert operations. Skip this legacy pass for inputs.");
+                    continue;
+                }
+            }
             case DataType::FP32: {
                 env.log->trace("Convert to FP16");
 

--- a/src/plugins/intel_myriad/graph_transformer/src/frontend/in_out_convert.cpp
+++ b/src/plugins/intel_myriad/graph_transformer/src/frontend/in_out_convert.cpp
@@ -23,6 +23,11 @@ void FrontEnd::addDataTypeConvertStages(const Model& model) {
     VPU_LOGGER_SECTION(env.log);
 
     for (const auto& input : model->datas()) {
+        if (_core && _core->isNewAPI()) {
+            env.log->trace("OpenVINO API 2.0 has already inserted Convert operations. Skip this legacy pass for inputs.");
+            continue;
+        }
+
         if (input->usage() != DataUsage::Input) {
             continue;
         }

--- a/src/plugins/intel_myriad/myriad_plugin/myriad_executable_network.cpp
+++ b/src/plugins/intel_myriad/myriad_plugin/myriad_executable_network.cpp
@@ -97,12 +97,13 @@ ExecutableNetwork::ExecutableNetwork(
                 const auto inDataParam = std::make_shared<ngraph::opset3::Parameter>(
                     input->get_output_element_type(0), inputShape.get_max_shape());
                 const auto inDataShapeParam = std::make_shared<ngraph::opset3::Parameter>(
-                    ngraph::element::i32, ov::Shape{inputShape.get_max_shape().size()});
+                    ngraph::element::i64, ov::Shape{inputShape.get_max_shape().size()});
                 inDataShapeParam->set_friendly_name(input->get_friendly_name()+"_real_shape");
                 inDataParam->set_friendly_name(input->get_friendly_name());
                 inDataParam->get_output_tensor(0).set_names(input->get_output_tensor(0).get_names());
                 const auto dsr = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(
-                    inDataParam, inDataShapeParam, ngraph::vpu::op::DynamicShapeResolverMode::INFER_DYNAMIC_SHAPE);
+                    inDataParam, inDataShapeParam,
+                    ngraph::vpu::op::DynamicShapeResolverMode::INFER_DYNAMIC_SHAPE, input->get_partial_shape());
                 function->replace_node(input, dsr);
                 function->remove_parameter(input);
                 function->add_parameters({inDataShapeParam, inDataParam});

--- a/src/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_transpose.cpp
+++ b/src/tests/functional/plugin/myriad/ngraph/transformations/dynamic_to_static_shape_transpose.cpp
@@ -92,8 +92,8 @@ protected:
             ngraph::element::u64,
             ngraph::Shape{std::initializer_list<std::size_t>{1}},
             std::vector<std::size_t>{0});
-        const auto scatterElementsUpdate = std::make_shared<ngraph::opset3::ScatterElementsUpdate>(dims, transposition, dims, axis);
-        const auto dsr1 = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(transpose, scatterElementsUpdate);
+        const auto gather = std::make_shared<ngraph::opset3::Gather>(dims, transposition, axis);
+        const auto dsr1 = std::make_shared<ngraph::vpu::op::DynamicShapeResolver>(transpose, gather);
         return std::make_shared<ngraph::Function>(
             ngraph::NodeVector{dsr1},
             ngraph::ParameterVector{data, dims},


### PR DESCRIPTION
### Details:
This PR contains several fixes for models with dynamic inputs
 - `DynamicShapeResolver` is able to save information about dynamic output in order to pass it in `INFER_DYNAMIC_SHAPE` mode. Previously, it propagated fully dynamic output shape (however ranks were equal) and dynamic Convolutions and Poolings were performed incorrectly. Now in the case of dynamic batch, DSR propagates only dynamic batch and Convolutions and Poolings are performed properly as a Loop of single-batch operations.
 - Fixed `dynamicToStaticShapeTranspose` transformation. There was a bug: transposition indices could not be applied with Scatter because the formula is not applicable for this. Replaced with Gather.
i.e. Shape of output tensor of Transpose with transition [0,3,1,2] indices (NHWC [1, 224, 224, 3]->NCHW [1, 3, 224, 224]) was calculated by ScatterElementsUpdate. So output_shape[transposition[i]] = input_shape[i] and the result was output_shape=[1, 224, 3, 224] which was wrong. Vise-versa Gather does output_shape[i] = input_shape[transposition[i]] and the result is [1, 3, 224, 224] which is right.
 - `MaxPool` and `AvgPool` can be sliced for loop in case of dynamic batch 
 - `Convert` stage for inputs is not inserted in the VPU model in the case of OV API 2.0. It did not cause a problem with non-dynamic functions because Graph Transformer has a pass to eliminate redundant converts (u8->f16, ~f16->f16~). In the case of dynamic inputs, yet another inserted Convert breaks data<->shape relations.
### Tickets:
 - 56665
 - 74905
