### PR TITLE
[TESTS][CPU] Convolution and GroupConvolution tests: multiple inference with one reference

### DIFF
--- a/src/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/skip_tests_config.cpp
@@ -48,7 +48,7 @@ std::vector<std::string> disabledTestPatterns() {
         // TODO: 56143. Enable nspc convolutions for bf16 precision
         R"(.*ConvolutionLayerCPUTest.*_inFmts=(ndhwc|nhwc).*ENFORCE_BF16=YES.*)",
         // TODO: 56827. Sporadic test failures
-        R"(.*smoke_Conv.+_FP32.ConvolutionLayerCPUTest\.CompareWithRefs.*TS=\(\(.\.67.+\).*inFmts=n.+c.*_primitive=jit_avx2.*)",
+        R"(.*smoke_Conv.+_FP32_avx2.ConvolutionLayerCPUTest\.CompareWithRefs.*TS=\(\(.\.67.+\).*inFmts=n.+c.*_primitive=jit_avx2.*)",
         // incorrect jit_uni_planar_convolution with dilation = {1, 2, 1} and output channel 1
         R"(.*smoke_Convolution3D.*D=\(1.2.1\)_O=1.*)",
 

--- a/src/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
+++ b/src/tests/functional/plugin/cpu/test_utils/cpu_test_utils.hpp
@@ -157,6 +157,8 @@ protected:
     std::vector<cpu_memory_format_t> inFmts, outFmts;
     std::vector<std::string> priority;
     std::string selectedType;
+    std::vector<CPUSpecificParams> cpuParamsVec;
+    ov::element::Type execElemType;
 };
 
 // common parameters


### PR DESCRIPTION
This PR reduces the execution time of functional tests by reducing calls to ngraph references for some CPU tests.
Local measurements show a decrease in the execution of smoke convolution and group convolution CPU tests by approximately 20% (275ms vs 340ms) on i9-11900K
At the moment there is some copy-paste, this will be fixed by separate PRs when we continue refactoring tests