### PR TITLE
[PYTHON API] NodeContext.get_attribute support float attribute

### DIFF
--- a/src/bindings/python/src/pyopenvino/frontend/node_context.cpp
+++ b/src/bindings/python/src/pyopenvino/frontend/node_context.cpp
@@ -72,6 +72,7 @@ void regclass_frontend_NodeContext(py::module m) {
             CAST_TO_PY(any, dtype, int64_t);
             CAST_TO_PY(any, dtype, bool);
             CAST_TO_PY(any, dtype, std::string);
+            CAST_TO_PY(any, dtype, float);
             CAST_TO_PY(any, dtype, double);
             CAST_TO_PY(any, dtype, ov::element::Type);
             CAST_TO_PY(any, dtype, ov::PartialShape);
@@ -83,6 +84,7 @@ void regclass_frontend_NodeContext(py::module m) {
             CAST_VEC_TO_PY(any, dtype, std::vector<bool>);
 #endif
             CAST_VEC_TO_PY(any, dtype, std::vector<std::string>);
+            CAST_VEC_TO_PY(any, dtype, std::vector<float>);
             CAST_VEC_TO_PY(any, dtype, std::vector<double>);
             CAST_VEC_TO_PY(any, dtype, std::vector<ov::element::Type>);
             CAST_VEC_TO_PY(any, dtype, std::vector<ov::PartialShape>);


### PR DESCRIPTION
### Details:
 - *NodeContext.get_attribute support float attribute to enable the following snippets*
```python
import numpy as np
import paddle
from paddle.static import InputSpec
import math
from openvino.runtime import Core, opset8 as opset
from openvino.frontend import NodeContext
from openvino.frontend.paddle import ConversionExtension

def gen_float_attr_model(name):
    @paddle.jit.to_static(input_spec=[InputSpec(shape=[1], name='x')])
    def test_model(x):
        return paddle.clip(x, min=0.1, max=0.2)
    paddle.jit.save(test_model, name)

def handle_model(model_path:str):
    def custom_converter(node: NodeContext):
        x = node.get_input('X')
        min = node.get_attribute("min")   # <---------- fail here, min/max is float32
        max = node.get_attribute("max", dtype=np.float32)    # <---------- fail here too
        assert(math.isclose(min, 0.1, abs_tol=0.001))
        assert(math.isclose(max, 0.2, abs_tol=0.001))
        return {'Out': [opset.clamp(x, min, max).output(0),]}
    core = Core()
    core.add_extension(ConversionExtension('clip', custom_converter))
    m = core.read_model(model_path)
    print(m)

gen_float_attr_model('x')
handle_model('x.pdmodel')
```