### PR TITLE
[AUTOPLUGIN] don't check dynamic shape when there is only one device

### DIFF
--- a/src/plugins/auto/plugin.cpp
+++ b/src/plugins/auto/plugin.cpp
@@ -719,6 +719,14 @@ std::vector<DeviceInformation> MultiDeviceInferencePlugin::FilterDevice(const st
 }
 std::vector<DeviceInformation> MultiDeviceInferencePlugin::FilterDeviceByNetwork(const std::vector<DeviceInformation>& metaDevices,
                                                 InferenceEngine::CNNNetwork network) {
+    if (metaDevices.empty()) {
+        IE_THROW(NotFound) << "No available device to filter " << GetName() <<  " plugin";
+    }
+
+    if (metaDevices.size() == 1) {
+        return metaDevices;
+    }
+
     std::vector<DeviceInformation> filterDevice;
     auto model = network.getFunction();
     if (model->is_dynamic()) {

--- a/src/plugins/auto/plugin.cpp
+++ b/src/plugins/auto/plugin.cpp
@@ -721,9 +721,7 @@ std::vector<DeviceInformation> MultiDeviceInferencePlugin::FilterDeviceByNetwork
                                                 InferenceEngine::CNNNetwork network) {
     if (metaDevices.empty()) {
         IE_THROW(NotFound) << "No available device to filter " << GetName() <<  " plugin";
-    }
-
-    if (metaDevices.size() == 1) {
+    } else if (metaDevices.size() == 1) {
         return metaDevices;
     }
 


### PR DESCRIPTION
Signed-off-by: Hu, Yuan2 <yuan2.hu@intel.com>

### Details:
 - *when there is only one device, do not check the device if support dynamic shape*


### Tickets:
 - *81028*
