### PR TITLE
Fix loading time issues for POT models (with lots of results)

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/optimize_strided_slice.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/optimize_strided_slice.cpp
@@ -261,8 +261,9 @@ bool ngraph::pass::StridedSliceOptimization::run_on_model(const std::shared_ptr<
     bool rewritten = false;
     if (m_use_shapes) {
         rewritten = UselessStridedSliceEraser().run_on_model(f);
-        rewritten = rewritten || SharedStridedSliceEraser().run_on_model(f);
-        rewritten = rewritten || GroupedStridedSliceOptimizer().run_on_model(f);
+        // Execution of other passes is also needed even if 'rewritten' is already 'true'
+        rewritten = SharedStridedSliceEraser().run_on_model(f) || rewritten;
+        rewritten = GroupedStridedSliceOptimizer().run_on_model(f) || rewritten;
     }
     return rewritten;
 }

--- a/src/inference/dev_api/memory_solver.hpp
+++ b/src/inference/dev_api/memory_solver.hpp
@@ -147,7 +147,8 @@ public:
                     for (auto* box_in_slot : time_slots[i_slot]) {
                         // intersect with already stored boxes for all covered time slots
                         // and move up the new one if needed
-                        popped_up = popped_up || popupTogetherWith(box, *box_in_slot);
+                        // Execution of 'popupTogetherWith' is important even if 'popped_up' is already 'true'
+                        popped_up = popupTogetherWith(box, *box_in_slot) || popped_up;
                     }
                 }
             } while (popped_up);


### PR DESCRIPTION
### Details:
 - Fix of regression of PR #10278 
 - Root cause is that 'popupTogetherWith' shall be executed for boxes. With using logical or "||" - if popped_up is already  'true' - next calls will not execute 'popupTogetherWith'
 - Surprisingly, it significantly affects load time of some models, especially POT-ones during quantization
 - Same is also observed for optimize_strided_slice transformation, fixed this as well (but it didn't cause load time issues)

### Tickets:
 - 80808
