### PR TITLE
[GPU] Removed unused variable "tuning_data" from the code

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/fully_connected/fully_connected_kernel_imad.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/fully_connected/fully_connected_kernel_imad.cpp
@@ -77,8 +77,6 @@ bool FullyConnectedKernelIMAD::Validate(const Params& params, const optional_par
     const auto& in = fc_params.inputs[0];
     const auto& wei = fc_params.weights;
 
-    auto tuning_data = GetTuningParams(fc_params);
-
     if ((in.X().pad.before != 0) || (in.X().pad.after != 0) ||
         (in.Y().pad.before != 0) || (in.Y().pad.after != 0)) {
         // Padding is not supported


### PR DESCRIPTION
### Details:
 - Fixed crash of Android build due to unused variable "tuning_data"

### Tickets:
 - *81796*
