### PR TITLE
[snippets] Tokenization fix: fused names

### DIFF
--- a/src/common/snippets/src/pass/collapse_subgraph.cpp
+++ b/src/common/snippets/src/pass/collapse_subgraph.cpp
@@ -263,8 +263,8 @@ TokenizeSnippets::TokenizeSnippets() {
         OutputVector internal_inputs;
 
         auto input_values = node->input_values();
-        /* 
-        * Called with subgraph->input_value(i) arg and used to 
+        /*
+        * Called with subgraph->input_value(i) arg and used to
         * Check that the attached node input subgraph has the same input as the node itself.
         * If true, then ternary merge is initiated.
         *        input
@@ -511,7 +511,7 @@ TokenizeSnippets::TokenizeSnippets() {
         for (size_t i = 0; i < act_body1->get_parameters().size(); i++) {
             act_body1->get_parameters()[i]->set_friendly_name(body_parameters[i]->get_friendly_name());
         }
-        subgraph->get_rt_info()["originalLayersNames"] = node->get_friendly_name();
+        subgraph->get_rt_info()["originalLayersNames"] = fusedNames;
 
         remark(1) << "Replacement (merge) done for: "
                     << subgraph->get_friendly_name()


### PR DESCRIPTION
### Details:
 - `Subgraph` originalLayersNames property is not correct. PR fixes it.
