### PR TITLE
Fix Deployment Manager configs for MacOS and Win-HDDL target

### DIFF
--- a/tools/deployment_manager/configs/darwin.json
+++ b/tools/deployment_manager/configs/darwin.json
@@ -16,16 +16,16 @@
     "ie_core": {
       "group": ["ie"],
       "files": [
-        "runtime/lib/intel64/libov_runtime.dylib",
-        "runtime/lib/intel64/libopenvino_gapi_preproc.so",
-        "runtime/lib/intel64/libopenvino_c.dylib",
-        "runtime/lib/intel64/libopenvino_hetero_plugin.so",
-        "runtime/lib/intel64/libopenvino_auto_plugin.so",
-        "runtime/lib/intel64/libopenvino_auto_batch_plugin.so",
-        "runtime/lib/intel64/libopenvino_ir_frontend.dylib",
-        "runtime/lib/intel64/libopenvino_onnx_frontend.dylib",
-        "runtime/lib/intel64/libopenvino_paddle_frontend.dylib",
-        "runtime/lib/intel64/plugins.xml",
+        "runtime/lib/intel64/Release/libov_runtime.dylib",
+        "runtime/lib/intel64/Release/libopenvino_gapi_preproc.so",
+        "runtime/lib/intel64/Release/libopenvino_c.dylib",
+        "runtime/lib/intel64/Release/libopenvino_hetero_plugin.so",
+        "runtime/lib/intel64/Release/libopenvino_auto_plugin.so",
+        "runtime/lib/intel64/Release/libopenvino_auto_batch_plugin.so",
+        "runtime/lib/intel64/Release/libopenvino_ir_frontend.dylib",
+        "runtime/lib/intel64/Release/libopenvino_onnx_frontend.dylib",
+        "runtime/lib/intel64/Release/libopenvino_paddle_frontend.dylib",
+        "runtime/lib/intel64/Release/plugins.xml",
         "runtime/3rdparty/tbb"
       ]
     },
@@ -34,7 +34,7 @@
       "group": ["ie"],
       "dependencies" : ["ie_core"],
       "files": [
-        "runtime/lib/intel64/libopenvino_intel_cpu_plugin.so"
+        "runtime/lib/intel64/Release/libopenvino_intel_cpu_plugin.so"
       ]
     },
     "vpu": {
@@ -42,9 +42,9 @@
       "group": ["ie"],
       "dependencies" : ["ie_core"],
       "files": [
-        "runtime/lib/intel64/libopenvino_intel_myriad_plugin.so",
-        "runtime/lib/intel64/usb-ma2x8x.mvcmd",
-        "runtime/lib/intel64/pcie-ma2x8x.mvcmd"
+        "runtime/lib/intel64/Release/libopenvino_intel_myriad_plugin.so",
+        "runtime/lib/intel64/Release/usb-ma2x8x.mvcmd",
+        "runtime/lib/intel64/Release/pcie-ma2x8x.mvcmd"
       ]
     },
     "python3.6": {

--- a/tools/deployment_manager/configs/darwin.json
+++ b/tools/deployment_manager/configs/darwin.json
@@ -16,7 +16,7 @@
     "ie_core": {
       "group": ["ie"],
       "files": [
-        "runtime/lib/intel64/Release/libov_runtime.dylib",
+        "runtime/lib/intel64/Release/libopenvino.dylib",
         "runtime/lib/intel64/Release/libopenvino_gapi_preproc.so",
         "runtime/lib/intel64/Release/libopenvino_c.dylib",
         "runtime/lib/intel64/Release/libopenvino_hetero_plugin.so",

--- a/tools/deployment_manager/configs/windows.json
+++ b/tools/deployment_manager/configs/windows.json
@@ -71,7 +71,6 @@
       "dependencies" : ["ie_core"],
       "files": [
         "runtime/bin/intel64/Release/openvino_intel_hddl_plugin.dll",
-        "runtime/3rdparty/MovidiusDriver",
         "runtime/3rdparty/hddl"
       ]
     },


### PR DESCRIPTION
### Details:
 - DM configs: Updated path for MacOS. Removed MovidiusDriver for HDDL target
 - Master PR https://github.com/openvinotoolkit/openvino/pull/11000