### PR TITLE
[CPU] Fixed U8/I8 storing data in Eltwise node

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -737,7 +737,6 @@ private:
                 break;
             case Precision::I8:
                 if (isa == x64::avx512_common) {
-                    vmaxps(vmm_dst, vmm_zero, vmm_dst);
                     vpmovsdb(op, vmm_dst);
                 } else {
                     uni_vpackssdw(vmm_dst, vmm_dst, vmm_dst);
@@ -752,6 +751,7 @@ private:
                 break;
             case Precision::U8:
                 if (isa == x64::avx512_common) {
+                    vmaxps(vmm_dst, vmm_zero, vmm_dst);
                     vpmovusdb(op, vmm_dst);
                 } else {
                     uni_vpackusdw(vmm_dst, vmm_dst, vmm_dst);


### PR DESCRIPTION
### Details:
 - *Eltwise should use "vmax(value, 0)" for U8 storing not for I8. So I have changed behavior for these types*
 - *Tests don't catch this case [Why]*

### Tickets:
 - *N/A*
