### PR TITLE
[CPU] Correct TensorIterator dumping for execution graph

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.h
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.h
@@ -108,6 +108,13 @@ public:
 
     void setExtManager(const ExtensionManager::Ptr& extMgr) { ext_mng = extMgr; }
 
+    Graph getSubGraph() const {
+        return sub_graph;
+    }
+    std::shared_ptr<ov::Node> getOriginalOp() const {
+        return ngraphOp;
+    }
+
 protected:
     //  needShapeInfer() should return false
     //  because we cannot resolve the output dimensions before the inference is completed


### PR DESCRIPTION
### Details:
 - Background: TensorIterator was dumped as single node without body. This led to the error when opening with netron and basically TensorIterator body was missing from dumped exec graph.
 - Only TensorIteratorCommon is supported by now