### PR TITLE
[GPU] Fix implicit concat padding offset issue in OneDNN

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
@@ -156,13 +156,13 @@ protected:
 
         {
             auto& input = instance.input_memory(0);
-            auto offset = onednn::get_offset(_pd.dnnl::primitive_desc_base::src_desc(0));
+            auto offset = onednn::get_f_offset(instance.node.input().get_output_layout(), _pd.dnnl::primitive_desc_base::src_desc(0));
             args.insert({DNNL_ARG_SRC, input.get_onednn_memory(_pd.dnnl::primitive_desc_base::src_desc(0), offset)});
         }
 
         {
             auto& output = instance.output_memory();
-            auto offset = onednn::get_offset(_pd.dnnl::primitive_desc_base::dst_desc(0));
+            auto offset = onednn::get_f_offset(instance.node.get_output_layout(), _pd.dnnl::primitive_desc_base::dst_desc(0));
             args.insert({DNNL_ARG_DST, output.get_onednn_memory(_pd.dnnl::primitive_desc_base::dst_desc(0), offset)});
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
@@ -33,7 +33,7 @@ dnnl::memory::desc layout_to_memory_desc(cldnn::layout l, dnnl::memory::format_t
 dnnl::algorithm convert_activation_func(cldnn::activation_func func);
 cldnn::format find_format(dnnl::memory::desc desc, bool is_grouped = false);
 
-int64_t get_offset(dnnl::memory::desc desc);
+int64_t get_f_offset(cldnn::layout l, dnnl::memory::desc desc);
 
 // If the values in the tensor are identical, make it as per-tensor value
 template <typename T>


### PR DESCRIPTION
Inserting padding into oneDNN primitive has issue with implicit concat behavior.
Deconv onedNN initialized output buffer to 0 including padding area. Padding area should be reserved.
Use oneDNN offset from program_node in/out lower_padding instead of oneDNN memory desc.

Signed-off-by: hyunback <hyunback.kim@intel.com>



### Tickets:
 - *7616*
