### PR TITLE
Fix saving report in dir with more than one non-existing level

### DIFF
--- a/src/tests/ie_test_utils/common_test_utils/file_utils.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/file_utils.hpp
@@ -185,8 +185,8 @@ inline int createDirectoryRecursive(const std::string& dirPath) {
         copyDirPath = copyDirPath.substr(0, pos);
     }
     while (!nested_dir_names.empty()) {
-        std::string a = copyDirPath + nested_dir_names.back();
-        if (createDirectory(a) != 0) {
+        copyDirPath = copyDirPath + nested_dir_names.back();
+        if (createDirectory(copyDirPath) != 0) {
             return -1;
         }
         nested_dir_names.pop_back();


### PR DESCRIPTION
### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
