### PR TITLE
[Core] Make destructor of ov::AllocatorImpl virtual

### DIFF
--- a/src/core/include/openvino/runtime/allocator.hpp
+++ b/src/core/include/openvino/runtime/allocator.hpp
@@ -53,7 +53,7 @@ struct AllocatorImpl : public std::enable_shared_from_this<AllocatorImpl> {
     virtual bool is_equal(const AllocatorImpl& other) const = 0;
 
 protected:
-    ~AllocatorImpl() = default;
+    virtual ~AllocatorImpl() = default;
 };
 
 class Tensor;


### PR DESCRIPTION
In OMZ [ SharedTensorAllocator](https://github.com/openvinotoolkit/open_model_zoo/blob/98d967b057dadb760ff4e292cddadd2f26d8c99f/demos/common/cpp/utils/include/utils/shared_tensor_allocator.hpp#L22) class is inherited from `ov::AllocatorImpl`, OMZ demos build with `clang` produces warnings about absence of virtual destructor which may lead to memory leaks:
```
warning: destructor called on non-final 'SharedTensorAllocator' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
```