### PR TITLE
Fixed registration of template plugin

### DIFF
--- a/cmake/developer_package/options.cmake
+++ b/cmake/developer_package/options.cmake
@@ -11,6 +11,11 @@ macro (ie_option variable description value)
     list(APPEND IE_OPTIONS ${variable})
 endmacro()
 
+# Usage: ov_option(<option_variable> "description" <initial value or boolean expression> [IF <condition>])
+macro (ov_option variable description value)
+    ie_option(${variable} "${description}" ${value})
+endmacro()
+
 macro (ie_dependent_option variable description def_value condition fallback_value)
     cmake_dependent_option(${variable} "${description}" ${def_value} "${condition}" ${fallback_value})
     list(APPEND IE_OPTIONS ${variable})

--- a/cmake/developer_package/plugins/plugins.cmake
+++ b/cmake/developer_package/plugins/plugins.cmake
@@ -147,7 +147,7 @@ function(ie_add_plugin)
         endif()
     endif()
 
-    if(NOT IE_PLUGIN_SKIP_REGISTRATION)
+    if(NOT IE_PLUGIN_SKIP_REGISTRATION OR NOT BUILD_SHARED_LIBS)
         # check that plugin with such name is not registered
         foreach(plugin_entry IN LISTS PLUGIN_FILES)
             string(REPLACE ":" ";" plugin_entry "${plugin_entry}")

--- a/cmake/developer_package/plugins/plugins.cmake
+++ b/cmake/developer_package/plugins/plugins.cmake
@@ -27,11 +27,12 @@ endif()
 #               [OBJECT_LIBRARIES <object_libs>]
 #               [VERSION_DEFINES_FOR <source>]
 #               [SKIP_INSTALL]
+#               [SKIP_REGISTRATION]
 #               [ADD_CLANG_FORMAT]
 #               )
 #
 function(ie_add_plugin)
-    set(options SKIP_INSTALL ADD_CLANG_FORMAT AS_EXTENSION)
+    set(options SKIP_INSTALL ADD_CLANG_FORMAT AS_EXTENSION SKIP_REGISTRATION)
     set(oneValueArgs NAME DEVICE_NAME VERSION_DEFINES_FOR PSEUDO_PLUGIN_FOR)
     set(multiValueArgs DEFAULT_CONFIG SOURCES OBJECT_LIBRARIES CPPLINT_FILTERS)
     cmake_parse_arguments(IE_PLUGIN "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -146,25 +147,26 @@ function(ie_add_plugin)
         endif()
     endif()
 
-    # check that plugin with such name is not registered
+    if(NOT IE_PLUGIN_SKIP_REGISTRATION)
+        # check that plugin with such name is not registered
+        foreach(plugin_entry IN LISTS PLUGIN_FILES)
+            string(REPLACE ":" ";" plugin_entry "${plugin_entry}")
+            list(GET plugin_entry -1 library_name)
+            list(GET plugin_entry 0 plugin_name)
+            if(plugin_name STREQUAL "${IE_PLUGIN_DEVICE_NAME}" AND
+                    NOT library_name STREQUAL ${IE_PLUGIN_NAME})
+                message(FATAL_ERROR "${IE_PLUGIN_NAME} and ${library_name} are both registered as ${plugin_name}")
+            endif()
+        endforeach()
 
-    foreach(plugin_entry IN LISTS PLUGIN_FILES)
-        string(REPLACE ":" ";" plugin_entry "${plugin_entry}")
-        list(GET plugin_entry -1 library_name)
-        list(GET plugin_entry 0 plugin_name)
-        if(plugin_name STREQUAL "${IE_PLUGIN_DEVICE_NAME}" AND
-           NOT library_name STREQUAL ${IE_PLUGIN_NAME})
-            message(FATAL_ERROR "${IE_PLUGIN_NAME} and ${library_name} are both registered as ${plugin_name}")
-        endif()
-    endforeach()
+        # append plugin to the list to register
 
-    # append plugin to the list to register
-
-    list(APPEND PLUGIN_FILES "${IE_PLUGIN_DEVICE_NAME}:${IE_PLUGIN_NAME}")
-    set(PLUGIN_FILES "${PLUGIN_FILES}" CACHE INTERNAL "" FORCE)
-    set(${IE_PLUGIN_DEVICE_NAME}_CONFIG "${IE_PLUGIN_DEFAULT_CONFIG}" CACHE INTERNAL "" FORCE)
-    set(${IE_PLUGIN_DEVICE_NAME}_PSEUDO_PLUGIN_FOR "${IE_PLUGIN_PSEUDO_PLUGIN_FOR}" CACHE INTERNAL "" FORCE)
-    set(${IE_PLUGIN_DEVICE_NAME}_AS_EXTENSION "${IE_PLUGIN_AS_EXTENSION}" CACHE INTERNAL "" FORCE)
+        list(APPEND PLUGIN_FILES "${IE_PLUGIN_DEVICE_NAME}:${IE_PLUGIN_NAME}")
+        set(PLUGIN_FILES "${PLUGIN_FILES}" CACHE INTERNAL "" FORCE)
+        set(${IE_PLUGIN_DEVICE_NAME}_CONFIG "${IE_PLUGIN_DEFAULT_CONFIG}" CACHE INTERNAL "" FORCE)
+        set(${IE_PLUGIN_DEVICE_NAME}_PSEUDO_PLUGIN_FOR "${IE_PLUGIN_PSEUDO_PLUGIN_FOR}" CACHE INTERNAL "" FORCE)
+        set(${IE_PLUGIN_DEVICE_NAME}_AS_EXTENSION "${IE_PLUGIN_AS_EXTENSION}" CACHE INTERNAL "" FORCE)
+    endif()
 endfunction()
 
 function(ov_add_plugin)
@@ -172,13 +174,12 @@ function(ov_add_plugin)
 endfunction()
 
 #
-# ie_register_plugins_dynamic(MAIN_TARGET <main target name>
-#                             POSSIBLE_PLUGINS <list of plugins which can be build by this repo>)
+# ie_register_plugins_dynamic(MAIN_TARGET <main target name>)
 #
 macro(ie_register_plugins_dynamic)
     set(options)
     set(oneValueArgs MAIN_TARGET)
-    set(multiValueArgs POSSIBLE_PLUGINS)
+    set(multiValueArgs)
     cmake_parse_arguments(IE_REGISTER "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if(NOT IE_REGISTER_MAIN_TARGET)
@@ -219,10 +220,6 @@ macro(ie_register_plugins_dynamic)
         endif()
         list(GET name 0 device_name)
         list(GET name 1 name)
-        # Skip plugins which don't exist in the possible plugins list
-        if (IE_REGISTER_POSSIBLE_PLUGINS AND NOT name IN_LIST IE_REGISTER_POSSIBLE_PLUGINS)
-            continue()
-        endif()
 
         # create plugin file
         set(config_file_name "${CMAKE_BINARY_DIR}/plugins/${device_name}.xml")
@@ -260,6 +257,15 @@ endmacro()
 # ie_register_plugins()
 #
 macro(ie_register_plugins)
+    if(BUILD_SHARED_LIBS)
+        ie_register_plugins_dynamic(${ARGN})
+    endif()
+endmacro()
+
+#
+# ov_register_plugins()
+#
+macro(ov_register_plugins)
     if(BUILD_SHARED_LIBS)
         ie_register_plugins_dynamic(${ARGN})
     endif()

--- a/docs/template_plugin/CMakeLists.txt
+++ b/docs/template_plugin/CMakeLists.txt
@@ -11,6 +11,8 @@ set(TEMPLATE_PLUGIN_SOURCE_DIR ${OpenVINOTemplatePlugin_SOURCE_DIR})
 
 find_package(OpenVINODeveloperPackage REQUIRED)
 
+ov_option(ENABLE_TEMPLATE_REGISTRATION "Enables registration of TEMPLATE plugin" OFF)
+
 if(CMAKE_COMPILER_IS_GNUCXX)
     ov_add_compiler_flags(-Wall)
 endif()

--- a/docs/template_plugin/README.md
+++ b/docs/template_plugin/README.md
@@ -6,14 +6,14 @@ As a backend for actual computations OpenVINO reference implementations is used,
 ## How to build
 
 ```bash
-$ cd $OPENVINO_HOME
-$ mkdir $OPENVINO_HOME/build
-$ cd $OPENVINO_HOME/build
+$ cd <openvino_dir>
+$ mkdir <openvino_dir>/build
+$ cd <openvino_dir>/build
 $ cmake -DENABLE_TESTS=ON -DENABLE_FUNCTIONAL_TESTS=ON ..
 $ make -j8
-$ cd $TEMPLATE_PLUGIN_HOME
-$ mkdir $TEMPLATE_PLUGIN_HOME/build
-$ cd $TEMPLATE_PLUGIN_HOME/build
-$ cmake -DOpenVINODeveloperPackage_DIR=$OPENVINO_HOME/build ..
+$ cd <template_plugin_dir>
+$ mkdir <template_plugin_dir>/build
+$ cd <template_plugin_dir>/build
+$ cmake -DOpenVINODeveloperPackage_DIR=<openvino_dir>/build ..
 $ make -j8
 ```

--- a/docs/template_plugin/README.md
+++ b/docs/template_plugin/README.md
@@ -14,6 +14,6 @@ $ make -j8
 $ cd $TEMPLATE_PLUGIN_HOME
 $ mkdir $TEMPLATE_PLUGIN_HOME/build
 $ cd $TEMPLATE_PLUGIN_HOME/build
-$ cmake -DOpenVINODeveloperPackage_DIR=$DLDT_HOME/build ..
+$ cmake -DOpenVINODeveloperPackage_DIR=$OPENVINO_HOME/build ..
 $ make -j8
 ```

--- a/docs/template_plugin/README.md
+++ b/docs/template_plugin/README.md
@@ -1,19 +1,19 @@
-# template-plugin
+# OpenVINO Template Plugin
 
-Template Plugin for Inference Engine which demonstrates basics of how Inference Engine plugin can be built and implemented on top of Inference Engine Developer Package and Plugin API.
-As a backend for actual computations ngraph reference implementations is used, so the Template plugin is fully functional.
+Template Plugin for OpenVINO™ Runtime which demonstrates basics of how OpenVINO™ Runtime plugin can be built and implemented on top of OpenVINO Developer Package and Plugin API.
+As a backend for actual computations OpenVINO reference implementations is used, so the Template plugin is fully functional.
 
 ## How to build
 
 ```bash
-$ cd $DLDT_HOME
-$ mkdir $DLDT_HOME/build
-$ cd $DLDT_HOME/build
+$ cd $OPENVINO_HOME
+$ mkdir $OPENVINO_HOME/build
+$ cd $OPENVINO_HOME/build
 $ cmake -DENABLE_TESTS=ON -DENABLE_FUNCTIONAL_TESTS=ON ..
 $ make -j8
 $ cd $TEMPLATE_PLUGIN_HOME
 $ mkdir $TEMPLATE_PLUGIN_HOME/build
 $ cd $TEMPLATE_PLUGIN_HOME/build
-$ cmake -DInferenceEngineDeveloperPackage_DIR=$DLDT_HOME/build ..
+$ cmake -DOpenVINODeveloperPackage_DIR=$DLDT_HOME/build ..
 $ make -j8
 ```

--- a/docs/template_plugin/src/CMakeLists.txt
+++ b/docs/template_plugin/src/CMakeLists.txt
@@ -12,7 +12,8 @@ file(GLOB_RECURSE HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
 ov_add_plugin(NAME ${TARGET_NAME}
               DEVICE_NAME "TEMPLATE"
               SOURCES ${SOURCES} ${HEADERS}
-              SKIP_INSTALL # ATTENTION: uncomment to install component
+              SKIP_INSTALL # ATTENTION: comment to install component
+              SKIP_REGISTRATION # ATTENTION: comment to register component
               VERSION_DEFINES_FOR template_plugin.cpp
               ADD_CLANG_FORMAT)
 
@@ -30,7 +31,6 @@ target_link_libraries(${TARGET_NAME} PRIVATE
 
 set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
 
-# ATTENTION: uncomment to register a plugin in the plugins.xml file
-# ie_register_plugins(MAIN_TARGET ${TARGET_NAME}
-#                     POSSIBLE_PLUGINS ${TARGET_NAME})
+# ATTENTION: uncomment to register plugins in the plugins.xml file
+# ov_register_plugins(MAIN_TARGET ${TARGET_NAME})
 # [cmake:plugin]

--- a/docs/template_plugin/src/CMakeLists.txt
+++ b/docs/template_plugin/src/CMakeLists.txt
@@ -8,12 +8,18 @@ set(TARGET_NAME "openvino_template_plugin")
 file(GLOB_RECURSE SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 file(GLOB_RECURSE HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
 
+set(skip_plugin)
+
+if (NOT ENABLE_TEMPLATE_REGISTRATION)
+    # Skip install and registration of template component
+    set(skip_plugin SKIP_INSTALL SKIP_REGISTRATION)
+endif()
+
 # adds a shared library with plugin
 ov_add_plugin(NAME ${TARGET_NAME}
               DEVICE_NAME "TEMPLATE"
               SOURCES ${SOURCES} ${HEADERS}
-              SKIP_INSTALL # ATTENTION: comment to install component
-              SKIP_REGISTRATION # ATTENTION: comment to register component
+              ${skip_plugin}
               VERSION_DEFINES_FOR template_plugin.cpp
               ADD_CLANG_FORMAT)
 
@@ -31,6 +37,8 @@ target_link_libraries(${TARGET_NAME} PRIVATE
 
 set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
 
-# ATTENTION: uncomment to register plugins in the plugins.xml file
-# ov_register_plugins(MAIN_TARGET ${TARGET_NAME})
+if (ENABLE_TEMPLATE_REGISTRATION)
+    # Update the plugins.xml file
+    ov_register_plugins(MAIN_TARGET ${TARGET_NAME})
+endif()
 # [cmake:plugin]

--- a/src/cmake/openvino.cmake
+++ b/src/cmake/openvino.cmake
@@ -47,8 +47,7 @@ ie_mark_target_as_cc(${TARGET_NAME})
 # LTO
 set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
 
-ie_register_plugins(MAIN_TARGET ${TARGET_NAME}
-                    POSSIBLE_PLUGINS openvino_auto_plugin openvino_auto_batch_plugin openvino_hetero_plugin openvino_intel_gpu_plugin openvino_intel_gna_plugin openvino_intel_cpu_plugin openvino_intel_myriad_plugin)
+ie_register_plugins(MAIN_TARGET ${TARGET_NAME})
 
 # Export for build tree
 


### PR DESCRIPTION
### Details:
 - Changed approach for plugins registration
 - Fix:
 ```
# Skip plugins which don't exist in the possible plugins list
if (IE_REGISTER_POSSIBLE_PLUGINS AND NOT name IN_LIST IE_REGISTER_POSSIBLE_PLUGINS)
    continue()
endif()
```
Removes all registered plugins from plugins.xml if new plugin is registered