### PR TITLE
Added shell for Eye-9

### DIFF
--- a/docs/ops/generation/Eye_9.md
+++ b/docs/ops/generation/Eye_9.md
@@ -11,17 +11,7 @@
 *Eye* operation generates an identity matrix or a batch matrices with ones on the diagonal and zeros everywhere else. The index of the diagonal to be populated with ones is given by `diagonal_index`: `output[..., i, i + diagonal_index] = 1`.
 
 
-Example 1. *Eye* output with `output_type` = `f32`:
-
-``` 
-num_rows = 3
-
-output  = [[1. 0. 0.]
-           [0. 1. 0.]
-           [0. 0. 1.]]
-```
-
-Example 2. *Eye* output with `output_type` = `i32`:
+Example 1. *Eye* output with `output_type` = `i32`:
 
 ``` 
 num_rows = 3
@@ -35,7 +25,7 @@ output  = [[0 0 1 0]
            [0 0 0 0]]
 ```
 
-Example 3. *Eye* output with `output_type` = `i32`:
+Example 2. *Eye* output with `output_type` = `i32`:
 
 ``` 
 num_rows = 3
@@ -49,7 +39,7 @@ output  = [[0 0 0 0]
            [0 1 0 0]]
 ```
 
-Example 4. *Eye* output with `output_type` = `f16`:
+Example 3. *Eye* output with `output_type` = `f16`:
 
 ``` 
 num_rows = 2
@@ -78,9 +68,9 @@ output  = [[[[0. 0.]
 
 *   **1**: `num_rows` - scalar or 1D tensor with 1 non-negative element of type *T_NUM* describing the number of rows in matrix. **Required.**
 
-*   **2**: `num_columns` - scalar or 1D tensor with 1 non-negative element of type *T_NUM* describing the number of columns in matrix. This input is optional, and its default value equals to `num_rows`.
+*   **2**: `num_columns` - scalar or 1D tensor with 1 non-negative element of type *T_NUM* describing the number of columns in matrix. **Required.**
 
-*   **3**: `diagonal_index` - scalar or 1D tensor with element of type *T_NUM* describing the index of the diagonal to be populated. A positive value refers to an upper diagonal and a negative value refers to a lower diagonal. Value `0` populates the main diagonal. If `diagonal_index` is a positive value and is not smaller than `num_rows` or if `diagonal_index` is a negative value and is not larger than `num_columns`, the matrix will be filled with only zeros. This input is optional, and its default value equals to `0`.
+*   **3**: `diagonal_index` - scalar or 1D tensor with element of type *T_NUM* describing the index of the diagonal to be populated. A positive value refers to an upper diagonal and a negative value refers to a lower diagonal. Value `0` populates the main diagonal. If `diagonal_index` is a positive value and is not smaller than `num_rows` or if `diagonal_index` is a negative value and is not larger than `num_columns`, the matrix will be filled with only zeros. **Required.**
 
 *   **4**: `batch_shape` - 1D tensor with non-negative values of type *T_NUM* defines leading batch dimensions of output shape. If `batch_shape` is an empty list, *Eye* operation generates a 2D tensor (matrix). This input is optional, and its default value equal to an empty tensor.
 
@@ -99,14 +89,16 @@ output  = [[[[0. 0.]
 
 ```xml
 <layer ... name="Eye" type="Eye">
-    <data output_type="i32"/>
+    <data output_type="i8"/>
     <input>
-        <port id="0" precision="I32"/>  <!-- num rows : 10-->
+        <port id="0" precision="I32"/>  <!-- num rows: 5 -->
+        <port id="1" precision="I32"/>  <!-- num columns: 5 -->
+        <port id="2" precision="I32"/>  <!-- diagonal index -->
     </input>
     <output>
-        <port id="3" precision="I32" names="Eye:0">
-            <dim>10</dim>
-            <dim>10</dim>
+        <port id="3" precision="I8" names="Eye:0">
+            <dim>5</dim>
+            <dim>5</dim>
         </port>
     </output>
 </layer>
@@ -116,45 +108,10 @@ output  = [[[[0. 0.]
 
 ```xml
 <layer ... name="Eye" type="Eye">
-    <data output_type="i64"/>
-    <input>
-        <port id="0" precision="I32"/>  <!-- num rows : 5 -->
-        <port id="1" precision="I32"/>  <!-- num columns -->
-    </input>
-    <output>
-        <port id="3" precision="I64" names="Eye:0">
-            <dim>5</dim>
-            <dim>-1</dim>
-        </port>
-    </output>
-</layer>
-```
-
-*Example 3*
-
-```xml
-<layer ... name="Eye" type="Eye">
-    <data output_type="i64"/>
-    <input>
-        <port id="0" precision="I32"/>  <!-- num rows -->
-        <port id="2" precision="I32"/>  <!-- diagonal index -->
-    </input>
-    <output>
-        <port id="3" precision="I64" names="Eye:0">
-            <dim>-1</dim>
-            <dim>-1</dim>
-        </port>
-    </output>
-</layer>
-```
-
-*Example 4*
-
-```xml
-<layer ... name="Eye" type="Eye">
     <data output_type="f32"/>
     <input>
         <port id="0" precision="I32"/>  <!-- num rows -->
+        <port id="1" precision="I32"/>  <!-- num columns -->
         <port id="2" precision="I32"/>  <!-- diagonal index -->
         <port id="3" precision="I32"/>  <!-- batch_shape : [2, 3] -->
     </input>

--- a/src/core/include/ngraph/op/eye.hpp
+++ b/src/core/include/ngraph/op/eye.hpp
@@ -1,0 +1,18 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "ngraph/node.hpp"
+#include "ngraph/op/op.hpp"
+#include "ngraph/op/util/attr_types.hpp"
+#include "openvino/op/eye.hpp"
+
+namespace ngraph {
+namespace op {
+namespace v9 {
+using ov::op::v9::Eye;
+}  // namespace v9
+}  // namespace op
+}  // namespace ngraph

--- a/src/core/include/ngraph/ops.hpp
+++ b/src/core/include/ngraph/ops.hpp
@@ -57,6 +57,7 @@
 #include "ngraph/op/experimental_detectron_roi_feature.hpp"
 #include "ngraph/op/experimental_detectron_topkrois.hpp"
 #include "ngraph/op/extractimagepatches.hpp"
+#include "ngraph/op/eye.hpp"
 #include "ngraph/op/fake_quantize.hpp"
 #include "ngraph/op/floor.hpp"
 #include "ngraph/op/floor_mod.hpp"

--- a/src/core/include/openvino/op/eye.hpp
+++ b/src/core/include/openvino/op/eye.hpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/op.hpp"
+
+namespace ov {
+namespace op {
+namespace v9 {
+/// \brief Tensor Eye operation.
+/// \ingroup ov_ops_cpp_api
+class OPENVINO_API Eye : public Op {
+public:
+    OPENVINO_OP("Eye", "opset9");
+
+    Eye() = default;
+
+    /// \brief      Constructs a Eye operation.
+    ///
+    /// \param      num_rows          Node producing the tensor with row number.
+    /// \param      num_columns       Node producing the tensor with column number.
+    /// \param      diagonal_index    Node producing the tensor with the index of diagonal with ones.
+    /// \param      batch_shape       Node producing the tensor with batch shape.
+    /// \param      out_type          Output type of the tensor.
+    Eye(const Output<Node>& num_rows,
+        const Output<Node>& num_columns,
+        const Output<Node>& diagonal_index,
+        const Output<Node>& batch_shape,
+        const ov::element::Type& out_type);
+
+    /// \brief      Constructs a Eye operation without batch_shape.
+    ///
+    /// \param      num_rows          Node producing the tensor with row number.
+    /// \param      num_columns       Node producing the tensor with column number.
+    /// \param      diagonal_index    Node producing the tensor with the index of diagonal with ones.
+    /// \param      out_type          Output type of the tensor.
+    Eye(const Output<Node>& num_rows,
+        const Output<Node>& num_columns,
+        const Output<Node>& diagonal_index,
+        const ov::element::Type& out_type);
+
+    void validate_and_infer_types() override;
+
+    bool visit_attributes(AttributeVisitor& visitor) override;
+
+    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
+
+    /// \return The output tensor type.
+    const ov::element::Type& get_out_type() const {
+        return m_output_type;
+    }
+    void set_out_type(const ov::element::Type& output_type) {
+        m_output_type = output_type;
+    }
+
+protected:
+    ov::element::Type m_output_type;
+};
+}  // namespace v9
+}  // namespace op
+}  // namespace ov

--- a/src/core/include/openvino/op/ops.hpp
+++ b/src/core/include/openvino/op/ops.hpp
@@ -56,6 +56,7 @@
 #include "openvino/op/experimental_detectron_roi_feature.hpp"
 #include "openvino/op/experimental_detectron_topkrois.hpp"
 #include "openvino/op/extractimagepatches.hpp"
+#include "openvino/op/eye.hpp"
 #include "openvino/op/fake_quantize.hpp"
 #include "openvino/op/floor.hpp"
 #include "openvino/op/floor_mod.hpp"

--- a/src/core/include/openvino/opsets/opset9_tbl.hpp
+++ b/src/core/include/openvino/opsets/opset9_tbl.hpp
@@ -192,3 +192,4 @@ _OPENVINO_OP_REG(PriorBox, ov::op::v8)
 // New operations added in opset9
 _OPENVINO_OP_REG(IRDFT, ov::op::v9)
 _OPENVINO_OP_REG(RDFT, ov::op::v9)
+_OPENVINO_OP_REG(Eye, ov::op::v9)

--- a/src/core/shape_inference/include/eye_shape_inference.hpp
+++ b/src/core/shape_inference/include/eye_shape_inference.hpp
@@ -6,16 +6,51 @@
 #include <openvino/opsets/opset9.hpp>
 #include "utils.hpp"
 
+namespace ov {
+namespace op {
+namespace util {
+
+template<class T>
+void check_1D_or_scalar_shape(const ov::op::v9::Eye* op, const T& input_shape, const std::string name) {
+    if (input_shape.is_static()) {
+        const auto& num_rows_rank = input_shape.rank().get_length();
+        NODE_VALIDATION_CHECK(op, num_rows_rank <= 1, name + " value must be a scalar or 1D tensor.");
+
+        if (num_rows_rank == 1) {
+            NODE_VALIDATION_CHECK(op,
+                                  input_shape.compatible(ov::Shape{1}),
+                                  name + " value input should have 1 element.");
+        }
+    }
+}
+
+template<class T>
+void check_batch_shape_shape(const ov::op::v9::Eye* op, const T& input_shape) {
+    if (input_shape.is_static()) {
+        const auto& diagonal_index_rank = input_shape.rank().get_length();
+        NODE_VALIDATION_CHECK(op, diagonal_index_rank == 1, "'batch_shape' value must be a 1D tensor.");
+    } else {
+        NODE_VALIDATION_CHECK(op, input_shape.rank().is_static(), "'batch_shape' should have static shape rank");
+        NODE_VALIDATION_CHECK(op, input_shape.rank() == 1, "'batch_shape' value must be a 1D tensor.");
+    }
+}
+
+}  // namespace util
+
 template<class T>
 void shape_infer(const ov::op::v9::Eye* op, const std::vector<T> &input_shapes, std::vector<T> &output_shapes,
                  const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == op->get_input_size() && output_shapes.size() == 1);
     // output_shape = dims_batch_shape + dims_matrix
-    std::vector<ov::Dimension> dims_batch_shape;
-    std::vector<ov::Dimension> dims_matrix = {ov::Dimension::dynamic(), ov::Dimension::dynamic()};
+    T batch_shape;
+    T dims_matrix = {ov::Dimension::dynamic(), ov::Dimension::dynamic()};
     auto& dim_num_rows = dims_matrix[0];
     auto& dim_num_columns = dims_matrix[1];
     auto& output_shape = output_shapes[0];
+
+    util::check_1D_or_scalar_shape(op, input_shapes[0], "'num_rows'");
+    util::check_1D_or_scalar_shape(op, input_shapes[1], "'num_columns'");
+    util::check_1D_or_scalar_shape(op, input_shapes[2], "'diagonal_index'");
 
     std::vector<int64_t> num_rows;
     if (get_data_as_int64<T>(0, op, num_rows, constant_data)) {
@@ -45,19 +80,12 @@ void shape_infer(const ov::op::v9::Eye* op, const std::vector<T> &input_shapes, 
 
     if (op->get_input_size() == 4) {
         const auto batch_shape_pshape = input_shapes[3];
+        util::check_batch_shape_shape(op, batch_shape_pshape);
         if (batch_shape_pshape.is_static()) {
-            dims_batch_shape.resize(batch_shape_pshape[0].get_length(), ov::Dimension::dynamic());
-            std::vector<int64_t> batch_shape;
-            if (get_data_as_int64<T>(3, op, batch_shape, constant_data)) {
-                NODE_VALIDATION_CHECK(op, batch_shape_pshape[0].get_length() == batch_shape.size());
-                dims_batch_shape.resize(batch_shape.size());
-                for (auto i = 0; i < batch_shape.size(); i++) {
-                    NODE_VALIDATION_CHECK(op, batch_shape[i] >= 0,
-                                          "'batch_shape' must have non-negative values. Got: ",
-                                          batch_shape[i]);
-
-                    dims_batch_shape[i] = batch_shape[i];
-                }
+            if (get_data_as_shape<T>(3, op, batch_shape, constant_data)) {
+                NODE_VALIDATION_CHECK(op, batch_shape_pshape[0].get_length() == batch_shape.rank().get_length());
+            } else {
+                batch_shape = ov::PartialShape::dynamic(batch_shape_pshape[0].get_length());
             }
         } else {
             output_shape = ov::PartialShape::dynamic();
@@ -65,13 +93,9 @@ void shape_infer(const ov::op::v9::Eye* op, const std::vector<T> &input_shapes, 
         }
     }
 
-    std::vector<ov::Dimension> output_dims(std::move(dims_batch_shape));
-    output_dims.insert(output_dims.end(), dims_matrix.begin(), dims_matrix.end());
-    if (std::any_of(output_dims.begin(), output_dims.end(), [](const ov::Dimension& dim){return dim.is_dynamic(); })) {
-        // For PartialShape, Set the output to be dynamic
-        // For StaticShape, throw error caused by implicitly constructing StaticShape with PartialShape argument
-        output_shape = ov::PartialShape(output_dims);
-    } else {
-        output_shape = output_dims;
-    }
+    output_shape = batch_shape;
+    output_shape.insert(output_shape.end(), dims_matrix.begin(), dims_matrix.end());
 }
+
+}  // namespace op
+}  // namespace ov

--- a/src/core/shape_inference/include/eye_shape_inference.hpp
+++ b/src/core/shape_inference/include/eye_shape_inference.hpp
@@ -1,0 +1,77 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+#include <openvino/core/validation_util.hpp>
+#include <openvino/opsets/opset9.hpp>
+#include "utils.hpp"
+
+template<class T>
+void shape_infer(const ov::op::v9::Eye* op, const std::vector<T> &input_shapes, std::vector<T> &output_shapes,
+                 const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
+    NODE_VALIDATION_CHECK(op, input_shapes.size() == op->get_input_size() && output_shapes.size() == 1);
+    // output_shape = dims_batch_shape + dims_matrix
+    std::vector<ov::Dimension> dims_batch_shape;
+    std::vector<ov::Dimension> dims_matrix = {ov::Dimension::dynamic(), ov::Dimension::dynamic()};
+    auto& dim_num_rows = dims_matrix[0];
+    auto& dim_num_columns = dims_matrix[1];
+    auto& output_shape = output_shapes[0];
+
+    std::vector<int64_t> num_rows;
+    if (get_data_as_int64<T>(0, op, num_rows, constant_data)) {
+        NODE_VALIDATION_CHECK(op,
+                              num_rows.size() == 1,
+                              "'num_rows' value must be a scalar or 1D tensor. Got: ",
+                              num_rows.size());
+        NODE_VALIDATION_CHECK(op,
+                              num_rows.front() >= 0,
+                              "'num_rows' must be non-negative value. Got: ",
+                              num_rows.front());
+        dim_num_rows = num_rows.front();
+    }
+
+    std::vector<int64_t> num_columns;
+    if (get_data_as_int64<T>(1, op, num_columns, constant_data)) {
+        NODE_VALIDATION_CHECK(op,
+                              num_columns.size() == 1,
+                              "'num_columns' value must be a scalar or 1D tensor. Got: ",
+                              num_columns.size());
+        NODE_VALIDATION_CHECK(op,
+                              num_columns.front() >= 0,
+                              "'num_columns' must be non-negative value. Got: ",
+                              num_columns.front());
+        dim_num_columns = num_columns.front();
+    }
+
+    if (op->get_input_size() == 4) {
+        const auto batch_shape_pshape = input_shapes[3];
+        if (batch_shape_pshape.is_static()) {
+            dims_batch_shape.resize(batch_shape_pshape[0].get_length(), ov::Dimension::dynamic());
+            std::vector<int64_t> batch_shape;
+            if (get_data_as_int64<T>(3, op, batch_shape, constant_data)) {
+                NODE_VALIDATION_CHECK(op, batch_shape_pshape[0].get_length() == batch_shape.size());
+                dims_batch_shape.resize(batch_shape.size());
+                for (auto i = 0; i < batch_shape.size(); i++) {
+                    NODE_VALIDATION_CHECK(op, batch_shape[i] >= 0,
+                                          "'batch_shape' must have non-negative values. Got: ",
+                                          batch_shape[i]);
+
+                    dims_batch_shape[i] = batch_shape[i];
+                }
+            }
+        } else {
+            output_shape = ov::PartialShape::dynamic();
+            return;
+        }
+    }
+
+    std::vector<ov::Dimension> output_dims(std::move(dims_batch_shape));
+    output_dims.insert(output_dims.end(), dims_matrix.begin(), dims_matrix.end());
+    if (std::any_of(output_dims.begin(), output_dims.end(), [](const ov::Dimension& dim){return dim.is_dynamic(); })) {
+        // For PartialShape, Set the output to be dynamic
+        // For StaticShape, throw error caused by implicitly constructing StaticShape with PartialShape argument
+        output_shape = ov::PartialShape(output_dims);
+    } else {
+        output_shape = output_dims;
+    }
+}

--- a/src/core/src/op/eye.cpp
+++ b/src/core/src/op/eye.cpp
@@ -33,51 +33,20 @@ void ov::op::v9::Eye::validate_and_infer_types() {
                           num_rows_et == element::i32 || num_rows_et == element::i64,
                           "Type of the 'num_rows' should be int32 or int64. Got: ",
                           num_rows_et);
-
-    const auto& num_rows_pshape = get_input_partial_shape(0);
-    if (num_rows_pshape.is_static()) {
-        const auto& num_rows_rank = num_rows_pshape.rank().get_length();
-        NODE_VALIDATION_CHECK(this, num_rows_rank <= 1, "'num_rows' value must be a scalar or 1D tensor.");
-
-        if (num_rows_rank == 1) {
-            NODE_VALIDATION_CHECK(this, num_rows_pshape.compatible(ov::Shape{1}), "'num_rows' should have 1 element.");
-        }
-    }
-
     const auto& num_columns_et = get_input_element_type(1);
     NODE_VALIDATION_CHECK(this,
                           num_columns_et == element::i32 || num_columns_et == element::i64,
                           "Type of the 'num_columns' should be int32 or int64. Got: ",
                           num_columns_et);
-
-    const auto& num_columns_pshape = get_input_partial_shape(1);
-    if (num_columns_pshape.is_static()) {
-        const auto& num_columns_rank = num_columns_pshape.rank().get_length();
-        NODE_VALIDATION_CHECK(this, num_columns_rank <= 1, "'num_columns' value must be a scalar or 1D tensor.");
-        if (num_columns_rank == 1) {
-            NODE_VALIDATION_CHECK(this,
-                                  num_columns_pshape.compatible(ov::Shape{1}),
-                                  "'num_columns' should have 1 element.");
-        }
-    }
-
     const auto& diagonal_index_et = get_input_element_type(2);
     NODE_VALIDATION_CHECK(this,
                           diagonal_index_et == element::i32 || diagonal_index_et == element::i64,
                           "Type of the 'diagonal_index' should be int32 or int64. Got: ",
                           diagonal_index_et);
+
+    const auto& num_rows_pshape = get_input_partial_shape(0);
+    const auto& num_columns_pshape = get_input_partial_shape(1);
     const auto& diagonal_index_pshape = get_input_partial_shape(2);
-    if (diagonal_index_pshape.is_static()) {
-        const auto& diagonal_index_rank = diagonal_index_pshape.rank().get_length();
-        NODE_VALIDATION_CHECK(this, diagonal_index_rank <= 1, "'diagonal_index' value must be a scalar or 1D tensor.");
-
-        if (diagonal_index_rank == 1) {
-            NODE_VALIDATION_CHECK(this,
-                                  diagonal_index_pshape.compatible(ov::Shape{1}),
-                                  "'diagonal_index' should have 1 element.");
-        }
-    }
-
     std::vector<ov::PartialShape> input_shapes = {num_rows_pshape, num_columns_pshape, diagonal_index_pshape};
 
     if (get_input_size() == 4) {
@@ -87,16 +56,6 @@ void ov::op::v9::Eye::validate_and_infer_types() {
                               "Type of the 'batch_shape' should be int32 or int64. Got: ",
                               batch_shape_et);
         const auto& batch_shape_pshape = get_input_partial_shape(3);
-        if (batch_shape_pshape.is_static()) {
-            const auto& diagonal_index_rank = batch_shape_pshape.rank().get_length();
-            NODE_VALIDATION_CHECK(this, diagonal_index_rank == 1, "'batch_shape' value must be a 1D tensor.");
-        } else {
-            NODE_VALIDATION_CHECK(this,
-                                  batch_shape_pshape.rank().is_static(),
-                                  "'batch_shape' should have static shape rank");
-            NODE_VALIDATION_CHECK(this, batch_shape_pshape.rank() == 1, "'batch_shape' value must be a 1D tensor.");
-        }
-
         input_shapes.push_back(batch_shape_pshape);
     }
 

--- a/src/core/src/op/eye.cpp
+++ b/src/core/src/op/eye.cpp
@@ -1,0 +1,124 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/eye.hpp"
+
+#include "eye_shape_inference.hpp"
+#include "itt.hpp"
+
+ov::op::v9::Eye::Eye(const Output<Node>& num_rows,
+                     const Output<Node>& num_columns,
+                     const Output<Node>& diagonal_index,
+                     const Output<Node>& batch_shape,
+                     const ov::element::Type& out_type)
+    : Op({num_rows, num_columns, diagonal_index, batch_shape}),
+      m_output_type(out_type) {
+    constructor_validate_and_infer_types();
+}
+
+ov::op::v9::Eye::Eye(const Output<Node>& num_rows,
+                     const Output<Node>& num_columns,
+                     const Output<Node>& diagonal_index,
+                     const ov::element::Type& out_type)
+    : Op({num_rows, num_columns, diagonal_index}),
+      m_output_type(out_type) {
+    constructor_validate_and_infer_types();
+}
+
+void ov::op::v9::Eye::validate_and_infer_types() {
+    NGRAPH_OP_SCOPE(v9_Eye_validate_and_infer_types);
+    const auto& num_rows_et = get_input_element_type(0);
+    NODE_VALIDATION_CHECK(this,
+                          num_rows_et == element::i32 || num_rows_et == element::i64,
+                          "Type of the 'num_rows' should be int32 or int64. Got: ",
+                          num_rows_et);
+
+    const auto& num_rows_pshape = get_input_partial_shape(0);
+    if (num_rows_pshape.is_static()) {
+        const auto& num_rows_rank = num_rows_pshape.rank().get_length();
+        NODE_VALIDATION_CHECK(this, num_rows_rank <= 1, "'num_rows' value must be a scalar or 1D tensor.");
+
+        if (num_rows_rank == 1) {
+            NODE_VALIDATION_CHECK(this, num_rows_pshape.compatible(ov::Shape{1}), "'num_rows' should have 1 element.");
+        }
+    }
+
+    const auto& num_columns_et = get_input_element_type(1);
+    NODE_VALIDATION_CHECK(this,
+                          num_columns_et == element::i32 || num_columns_et == element::i64,
+                          "Type of the 'num_columns' should be int32 or int64. Got: ",
+                          num_columns_et);
+
+    const auto& num_columns_pshape = get_input_partial_shape(1);
+    if (num_columns_pshape.is_static()) {
+        const auto& num_columns_rank = num_columns_pshape.rank().get_length();
+        NODE_VALIDATION_CHECK(this, num_columns_rank <= 1, "'num_columns' value must be a scalar or 1D tensor.");
+        if (num_columns_rank == 1) {
+            NODE_VALIDATION_CHECK(this,
+                                  num_columns_pshape.compatible(ov::Shape{1}),
+                                  "'num_columns' should have 1 element.");
+        }
+    }
+
+    const auto& diagonal_index_et = get_input_element_type(2);
+    NODE_VALIDATION_CHECK(this,
+                          diagonal_index_et == element::i32 || diagonal_index_et == element::i64,
+                          "Type of the 'diagonal_index' should be int32 or int64. Got: ",
+                          diagonal_index_et);
+    const auto& diagonal_index_pshape = get_input_partial_shape(2);
+    if (diagonal_index_pshape.is_static()) {
+        const auto& diagonal_index_rank = diagonal_index_pshape.rank().get_length();
+        NODE_VALIDATION_CHECK(this, diagonal_index_rank <= 1, "'diagonal_index' value must be a scalar or 1D tensor.");
+
+        if (diagonal_index_rank == 1) {
+            NODE_VALIDATION_CHECK(this,
+                                  diagonal_index_pshape.compatible(ov::Shape{1}),
+                                  "'diagonal_index' should have 1 element.");
+        }
+    }
+
+    std::vector<ov::PartialShape> input_shapes = {num_rows_pshape, num_columns_pshape, diagonal_index_pshape};
+
+    if (get_input_size() == 4) {
+        const auto& batch_shape_et = get_input_element_type(3);
+        NODE_VALIDATION_CHECK(this,
+                              batch_shape_et == element::i32 || batch_shape_et == element::i64,
+                              "Type of the 'batch_shape' should be int32 or int64. Got: ",
+                              batch_shape_et);
+        const auto& batch_shape_pshape = get_input_partial_shape(3);
+        if (batch_shape_pshape.is_static()) {
+            const auto& diagonal_index_rank = batch_shape_pshape.rank().get_length();
+            NODE_VALIDATION_CHECK(this, diagonal_index_rank == 1, "'batch_shape' value must be a 1D tensor.");
+        } else {
+            NODE_VALIDATION_CHECK(this,
+                                  batch_shape_pshape.rank().is_static(),
+                                  "'batch_shape' should have static shape rank");
+            NODE_VALIDATION_CHECK(this, batch_shape_pshape.rank() == 1, "'batch_shape' value must be a 1D tensor.");
+        }
+
+        input_shapes.push_back(batch_shape_pshape);
+    }
+
+    std::vector<ov::PartialShape> output_shapes = {ov::PartialShape::dynamic()};
+    shape_infer(this, input_shapes, output_shapes);
+    set_output_type(0, get_out_type(), output_shapes[0]);
+}
+
+bool ov::op::v9::Eye::visit_attributes(ov::AttributeVisitor& visitor) {
+    NGRAPH_OP_SCOPE(v9_Eye_visit_attributes);
+    visitor.on_attribute("output_type", m_output_type);
+    return true;
+}
+
+std::shared_ptr<ov::Node> ov::op::v9::Eye::clone_with_new_inputs(const ov::OutputVector& new_args) const {
+    NGRAPH_OP_SCOPE(v9_Eye_clone_with_new_inputs);
+    check_new_args_count(this, new_args);
+    if (new_args.size() == 3) {
+        return std::make_shared<v9::Eye>(new_args[0], new_args[1], new_args[2], m_output_type);
+    } else if (new_args.size() == 4) {
+        return std::make_shared<v9::Eye>(new_args[0], new_args[1], new_args[2], new_args[3], m_output_type);
+    } else {
+        throw ov::Exception("Eye has incorrect input number: " + std::to_string(new_args.size()));
+    }
+}

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -143,6 +143,7 @@ set(SRC
     type_prop/extractimagepatches.cpp
     type_prop/embeddingbag_packedsum.cpp
     type_prop/embedding_segments_sum.cpp
+    type_prop/eye.cpp
     type_prop/fake_quantize.cpp
     type_prop/floor.cpp
     type_prop/floor_mod.cpp
@@ -304,6 +305,7 @@ set(SRC
     visitors/op/experimental_detectron_generate_proposals.cpp
     visitors/op/experimental_detectron_prior_grid_generator.cpp
     visitors/op/experimental_detectron_topkrois.cpp
+    visitors/op/eye.cpp
     visitors/op/extractimagepatches.cpp
     visitors/op/fake_quantize.cpp
     visitors/op/floor_mod.cpp

--- a/src/core/tests/type_prop/eye.cpp
+++ b/src/core/tests/type_prop/eye.cpp
@@ -1,0 +1,276 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "gtest/gtest.h"
+#include "ngraph/ngraph.hpp"
+#include "ngraph/opsets/opset9.hpp"
+#include "type_prop.hpp"
+
+using namespace std;
+using namespace ngraph;
+
+TEST(type_prop, eye_constant) {
+    auto num_rows = op::v0::Constant::create(element::i64, Shape{}, {6});
+    auto num_columns = op::v0::Constant::create(element::i64, Shape{}, {3});
+    auto diagonal_index = op::v0::Constant::create(element::i64, Shape{}, {0});
+
+    auto eye = std::make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::bf16);
+
+    EXPECT_EQ(eye->get_output_element_type(0), element::bf16);
+    EXPECT_TRUE(eye->get_output_partial_shape(0).same_scheme(PartialShape{6, 3}));
+}
+
+TEST(type_prop, eye_batchshape_constant) {
+    auto num_rows = op::v0::Constant::create(element::i64, Shape{}, {6});
+    auto num_columns = op::v0::Constant::create(element::i64, Shape{}, {3});
+    auto diagonal_index = op::v0::Constant::create(element::i64, Shape{}, {0});
+    auto batch_shape = op::v0::Constant::create(element::i64, Shape{1}, {2});
+
+    auto eye = std::make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, batch_shape, element::bf16);
+
+    EXPECT_EQ(eye->get_output_element_type(0), element::bf16);
+    EXPECT_TRUE(eye->get_output_partial_shape(0).same_scheme(PartialShape{2, 6, 3}));
+}
+
+TEST(type_prop, eye_rows_param) {
+    auto num_rows = make_shared<op::v0::Parameter>(element::i64, PartialShape{1});
+    auto num_columns = op::v0::Constant::create(element::i64, Shape{}, {10});
+    auto diagonal_index = op::v0::Constant::create(element::i64, Shape{}, {2});
+
+    auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::f32);
+
+    EXPECT_EQ(eye->get_output_element_type(0), element::f32);
+    EXPECT_TRUE(eye->get_output_partial_shape(0).same_scheme(PartialShape{Dimension::dynamic(), 10}));
+}
+
+TEST(type_prop, eye_rows_const) {
+    auto num_rows = op::v0::Constant::create(element::i64, Shape{}, {10});
+    auto num_columns = make_shared<op::v0::Parameter>(element::i64, PartialShape{1});
+    auto diagonal_index = make_shared<op::v0::Parameter>(element::i64, PartialShape{1});
+
+    auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::f32);
+
+    EXPECT_EQ(eye->get_output_element_type(0), element::f32);
+    EXPECT_TRUE(eye->get_output_partial_shape(0).same_scheme(PartialShape{10, Dimension::dynamic()}));
+}
+
+TEST(type_prop, eye_batchshape_const) {
+    auto num_rows = make_shared<op::v0::Parameter>(element::i64, PartialShape{1});
+    auto num_columns = num_rows;
+    auto diagonal_index = op::v0::Constant::create(element::i64, Shape{}, {0});
+    auto batch_shape = op::v0::Constant::create(element::i64, Shape{2}, {2, 3});
+
+    auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, batch_shape, element::f32);
+
+    EXPECT_EQ(eye->get_output_element_type(0), element::f32);
+    EXPECT_TRUE(
+        eye->get_output_partial_shape(0).same_scheme(PartialShape{2, 3, Dimension::dynamic(), Dimension::dynamic()}));
+}
+
+TEST(type_prop, eye_batchshape_params) {
+    auto num_rows = make_shared<op::v0::Parameter>(element::i64, PartialShape{1});
+    auto num_columns = make_shared<op::v0::Parameter>(element::i64, PartialShape{1});
+    auto diagonal_index = make_shared<op::v0::Parameter>(element::i64, PartialShape{1});
+    auto batch_shape = make_shared<op::v0::Parameter>(element::i64, PartialShape{2});
+
+    auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, batch_shape, element::f64);
+
+    EXPECT_EQ(eye->get_output_element_type(0), element::f64);
+    EXPECT_TRUE(eye->get_output_partial_shape(0).same_scheme(PartialShape().dynamic(4)));
+}
+
+TEST(type_prop, eye_invalid_num_rows_value) {
+    auto num_rows = op::v0::Constant::create(element::i64, Shape{1}, {-6});
+    auto num_columns = op::v0::Constant::create(element::i64, Shape{}, {2});
+    auto diagonal_index = op::v0::Constant::create(element::i64, Shape{}, {2});
+
+    try {
+        auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::i32);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Unexpected pass with invalid num rows value.";
+    } catch (const NodeValidationFailure& error) {
+        EXPECT_HAS_SUBSTRING(error.what(), std::string("'num_rows' must be non-negative value. Got: -6"));
+    } catch (...) {
+        FAIL() << "Check failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, eye_invalid_num_columns_value) {
+    auto num_rows = op::v0::Constant::create(element::i64, Shape{1}, {6});
+    auto num_columns = op::v0::Constant::create(element::i64, Shape{}, {-6});
+    auto diagonal_index = op::v0::Constant::create(element::i64, Shape{}, {2});
+
+    try {
+        auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::i32);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Unexpected pass with invalid num columns value.";
+    } catch (const NodeValidationFailure& error) {
+        EXPECT_HAS_SUBSTRING(error.what(), std::string("'num_columns' must be non-negative value. Got: -6"));
+    } catch (...) {
+        FAIL() << "Check failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, eye_invalid_num_rows_type) {
+    auto num_rows = op::v0::Constant::create(element::bf16, Shape{}, {1.2});
+    auto num_columns = op::v0::Constant::create(element::i64, Shape{}, {2});
+    auto diagonal_index = op::v0::Constant::create(element::i64, Shape{}, {2});
+
+    try {
+        auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::i32);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Unexpected pass with invalid num rows value.";
+    } catch (const NodeValidationFailure& error) {
+        EXPECT_HAS_SUBSTRING(error.what(), std::string("Type of the 'num_rows' should be int32 or int64. Got: bf16"));
+    } catch (...) {
+        FAIL() << "Check failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, eye_invalid_num_columns_type) {
+    auto num_rows = op::v0::Constant::create(element::i64, Shape{}, {6});
+    auto num_columns = op::v0::Constant::create(element::bf16, Shape{}, {6.5});
+    auto diagonal_index = op::v0::Constant::create(element::i64, Shape{}, {2});
+
+    try {
+        auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::i32);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Unexpected pass with invalid num columns value.";
+    } catch (const NodeValidationFailure& error) {
+        EXPECT_HAS_SUBSTRING(error.what(),
+                             std::string("Type of the 'num_columns' should be int32 or int64. Got: bf16"));
+    } catch (...) {
+        FAIL() << "Check failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, eye_invalid_diagonal_index_type) {
+    auto num_rows = op::v0::Constant::create(element::i64, Shape{}, {6});
+    auto num_columns = op::v0::Constant::create(element::i64, Shape{}, {6});
+    auto diagonal_index = op::v0::Constant::create(element::bf16, Shape{}, {6.5});
+
+    try {
+        auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::i32);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Unexpected pass with invalid diagonal index value.";
+    } catch (const NodeValidationFailure& error) {
+        EXPECT_HAS_SUBSTRING(error.what(),
+                             std::string("Type of the 'diagonal_index' should be int32 or int64. Got: bf16"));
+    } catch (...) {
+        FAIL() << "Check failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, eye_invalid_num_rows_shape) {
+    auto num_rows = op::v0::Constant::create(element::i32, Shape{}, {6});
+    auto num_columns = op::v0::Constant::create(element::i32, Shape{3}, {1, 1, 1});
+    auto diagonal_index = op::v0::Constant::create(element::i64, Shape{}, {2});
+
+    try {
+        auto Eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::i32);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Unexpected pass with invalid num rows value.";
+    } catch (const NodeValidationFailure& error) {
+        EXPECT_HAS_SUBSTRING(error.what(), std::string("'num_columns' should have 1 element."));
+    } catch (...) {
+        FAIL() << "Check failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, eye_invalid_num_columns_shape) {
+    auto num_rows = op::v0::Constant::create(element::i32, Shape{}, {6});
+    auto num_columns = op::v0::Constant::create(element::i32, Shape{3}, {1, 1, 1});
+    auto diagonal_index = op::v0::Constant::create(element::i64, Shape{}, {2});
+
+    try {
+        auto Eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::i32);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Unexpected pass with invalid num columns value.";
+    } catch (const NodeValidationFailure& error) {
+        EXPECT_HAS_SUBSTRING(error.what(), std::string("'num_columns' should have 1 element."));
+    } catch (...) {
+        FAIL() << "Check failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, eye_invalid_diagonal_index_shape) {
+    auto num_rows = op::v0::Constant::create(element::i32, Shape{}, {6});
+    auto num_columns = op::v0::Constant::create(element::i32, Shape{}, {6});
+    auto diagonal_index = op::v0::Constant::create(element::i32, Shape{3}, {1, 1, 1});
+
+    try {
+        auto Eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::i32);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Unexpected pass with invalid diagonal index value.";
+    } catch (const NodeValidationFailure& error) {
+        EXPECT_HAS_SUBSTRING(error.what(), std::string("'diagonal_index' should have 1 element."));
+    } catch (...) {
+        FAIL() << "Check failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, eye_invalid_num_rows_rank) {
+    auto num_rows = op::v0::Constant::create(element::i32, Shape{1, 1}, {6});
+    auto num_columns = op::v0::Constant::create(element::i32, Shape{1}, {1});
+    auto diagonal_index = op::v0::Constant::create(element::i64, Shape{}, {2});
+
+    try {
+        auto Eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::i32);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Unexpected pass with invalid num rows value.";
+    } catch (const NodeValidationFailure& error) {
+        EXPECT_HAS_SUBSTRING(error.what(), std::string("'num_rows' value must be a scalar or 1D tensor."));
+    } catch (...) {
+        FAIL() << "Check failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, eye_invalid_num_columns_rank) {
+    auto num_rows = op::v0::Constant::create(element::i32, Shape{}, {6});
+    auto num_columns = op::v0::Constant::create(element::i32, Shape{2, 1}, {1, 2});
+    auto diagonal_index = op::v0::Constant::create(element::i64, Shape{}, {2});
+
+    try {
+        auto Eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::i32);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Unexpected pass with invalid num columns value.";
+    } catch (const NodeValidationFailure& error) {
+        EXPECT_HAS_SUBSTRING(error.what(), std::string("'num_columns' value must be a scalar or 1D tensor."));
+    } catch (...) {
+        FAIL() << "Check failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, eye_invalid_diagonal_index_rank) {
+    auto num_rows = op::v0::Constant::create(element::i32, Shape{}, {6});
+    auto num_columns = op::v0::Constant::create(element::i32, Shape{}, {2});
+    auto diagonal_index = op::v0::Constant::create(element::i64, Shape{1, 2, 1}, {2, 8});
+
+    try {
+        auto Eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::i32);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Unexpected pass with invalid diagonal index value.";
+    } catch (const NodeValidationFailure& error) {
+        EXPECT_HAS_SUBSTRING(error.what(), std::string("'diagonal_index' value must be a scalar or 1D tensor."));
+    } catch (...) {
+        FAIL() << "Check failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, eye_invalid_dynamic_batch_shape_rank) {
+    auto num_rows = op::v0::Constant::create(element::i32, Shape{}, {6});
+    auto num_columns = op::v0::Constant::create(element::i32, Shape{}, {2});
+    auto diagonal_index = op::v0::Constant::create(element::i64, Shape{}, {2});
+    auto batch_shape = make_shared<op::v0::Parameter>(element::i64, PartialShape().dynamic());
+
+    try {
+        auto Eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, batch_shape, element::i32);
+        // Should have thrown, so fail if it didn't
+        FAIL() << "Unexpected pass with invalid 'batch_shape' value.";
+    } catch (const NodeValidationFailure& error) {
+        EXPECT_HAS_SUBSTRING(error.what(), std::string("'batch_shape' should have static shape rank"));
+    } catch (...) {
+        FAIL() << "Check failed for unexpected reason";
+    }
+}

--- a/src/core/tests/type_prop/eye.cpp
+++ b/src/core/tests/type_prop/eye.cpp
@@ -18,7 +18,7 @@ TEST(type_prop, eye_constant) {
     auto eye = std::make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::bf16);
 
     EXPECT_EQ(eye->get_output_element_type(0), element::bf16);
-    EXPECT_TRUE(eye->get_output_partial_shape(0).same_scheme(PartialShape{6, 3}));
+    EXPECT_EQ(eye->get_output_partial_shape(0), ov::PartialShape({6, 3}));
 }
 
 TEST(type_prop, eye_batchshape_constant) {
@@ -30,7 +30,7 @@ TEST(type_prop, eye_batchshape_constant) {
     auto eye = std::make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, batch_shape, element::bf16);
 
     EXPECT_EQ(eye->get_output_element_type(0), element::bf16);
-    EXPECT_TRUE(eye->get_output_partial_shape(0).same_scheme(PartialShape{2, 6, 3}));
+    EXPECT_EQ(eye->get_output_partial_shape(0), PartialShape({2, 6, 3}));
 }
 
 TEST(type_prop, eye_rows_param) {
@@ -41,7 +41,7 @@ TEST(type_prop, eye_rows_param) {
     auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::f32);
 
     EXPECT_EQ(eye->get_output_element_type(0), element::f32);
-    EXPECT_TRUE(eye->get_output_partial_shape(0).same_scheme(PartialShape{Dimension::dynamic(), 10}));
+    EXPECT_EQ(eye->get_output_partial_shape(0), PartialShape({Dimension::dynamic(), 10}));
 }
 
 TEST(type_prop, eye_rows_const) {
@@ -52,7 +52,7 @@ TEST(type_prop, eye_rows_const) {
     auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::f32);
 
     EXPECT_EQ(eye->get_output_element_type(0), element::f32);
-    EXPECT_TRUE(eye->get_output_partial_shape(0).same_scheme(PartialShape{10, Dimension::dynamic()}));
+    EXPECT_EQ(eye->get_output_partial_shape(0), PartialShape({10, Dimension::dynamic()}));
 }
 
 TEST(type_prop, eye_batchshape_const) {
@@ -64,8 +64,7 @@ TEST(type_prop, eye_batchshape_const) {
     auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, batch_shape, element::f32);
 
     EXPECT_EQ(eye->get_output_element_type(0), element::f32);
-    EXPECT_TRUE(
-        eye->get_output_partial_shape(0).same_scheme(PartialShape{2, 3, Dimension::dynamic(), Dimension::dynamic()}));
+    EXPECT_EQ(eye->get_output_partial_shape(0), PartialShape({2, 3, Dimension::dynamic(), Dimension::dynamic()}));
 }
 
 TEST(type_prop, eye_batchshape_params) {
@@ -77,7 +76,20 @@ TEST(type_prop, eye_batchshape_params) {
     auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, batch_shape, element::f64);
 
     EXPECT_EQ(eye->get_output_element_type(0), element::f64);
-    EXPECT_TRUE(eye->get_output_partial_shape(0).same_scheme(PartialShape().dynamic(4)));
+    EXPECT_EQ(eye->get_output_partial_shape(0), PartialShape().dynamic(4));
+}
+
+TEST(type_prop, eye_batchshape_shapeof) {
+    auto num_rows = op::v0::Constant::create(element::i64, Shape{}, {10});
+    auto num_columns = num_rows;
+    auto diagonal_index = make_shared<op::v0::Parameter>(element::i64, PartialShape{1});
+    auto batch_shape = make_shared<op::v0::Parameter>(element::i64, PartialShape({{1, 10}, {10, 25}}));
+    auto shape_of = make_shared<op::v0::ShapeOf>(batch_shape);
+
+    auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, shape_of, element::f64);
+
+    EXPECT_EQ(eye->get_output_element_type(0), element::f64);
+    EXPECT_EQ(eye->get_output_partial_shape(0), PartialShape({{1, 10}, {10, 25}, 10, 10}));
 }
 
 TEST(type_prop, eye_invalid_num_rows_value) {
@@ -172,7 +184,7 @@ TEST(type_prop, eye_invalid_num_rows_shape) {
         // Should have thrown, so fail if it didn't
         FAIL() << "Unexpected pass with invalid num rows value.";
     } catch (const NodeValidationFailure& error) {
-        EXPECT_HAS_SUBSTRING(error.what(), std::string("'num_columns' should have 1 element."));
+        EXPECT_HAS_SUBSTRING(error.what(), std::string("'num_columns' value input should have 1 element."));
     } catch (...) {
         FAIL() << "Check failed for unexpected reason";
     }
@@ -188,7 +200,7 @@ TEST(type_prop, eye_invalid_num_columns_shape) {
         // Should have thrown, so fail if it didn't
         FAIL() << "Unexpected pass with invalid num columns value.";
     } catch (const NodeValidationFailure& error) {
-        EXPECT_HAS_SUBSTRING(error.what(), std::string("'num_columns' should have 1 element."));
+        EXPECT_HAS_SUBSTRING(error.what(), std::string("'num_columns' value input should have 1 element."));
     } catch (...) {
         FAIL() << "Check failed for unexpected reason";
     }
@@ -204,7 +216,7 @@ TEST(type_prop, eye_invalid_diagonal_index_shape) {
         // Should have thrown, so fail if it didn't
         FAIL() << "Unexpected pass with invalid diagonal index value.";
     } catch (const NodeValidationFailure& error) {
-        EXPECT_HAS_SUBSTRING(error.what(), std::string("'diagonal_index' should have 1 element."));
+        EXPECT_HAS_SUBSTRING(error.what(), std::string("'diagonal_index' value input should have 1 element."));
     } catch (...) {
         FAIL() << "Check failed for unexpected reason";
     }

--- a/src/core/tests/visitors/op/eye.cpp
+++ b/src/core/tests/visitors/op/eye.cpp
@@ -1,0 +1,45 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "gtest/gtest.h"
+#include "ngraph/ngraph.hpp"
+#include "ngraph/op/util/attr_types.hpp"
+#include "openvino/opsets/opset9.hpp"
+#include "util/visitor.hpp"
+
+using namespace std;
+using namespace ov;
+using ngraph::test::NodeBuilder;
+using ngraph::test::ValueMap;
+
+TEST(attributes, eye_op) {
+    NodeBuilder::get_ops().register_factory<op::v9::Eye>();
+    auto num_rows = make_shared<op::v0::Constant>(element::i32, Shape{}, 10);
+    auto num_columns = make_shared<op::v0::Constant>(element::i32, Shape{}, 2);
+    auto diagonal_index = make_shared<op::v0::Constant>(element::i32, Shape{}, 0);
+
+    const auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, element::Type_t::u8);
+    NodeBuilder builder(eye);
+    auto g_eye = ov::as_type_ptr<op::v9::Eye>(builder.create());
+
+    const auto expected_attr_count = 1;
+    EXPECT_EQ(builder.get_value_map_size(), expected_attr_count);
+    EXPECT_EQ(g_eye->get_out_type(), eye->get_out_type());
+}
+
+TEST(attributes, eye_batch_shape_op) {
+    NodeBuilder::get_ops().register_factory<op::v9::Eye>();
+    auto num_rows = make_shared<op::v0::Constant>(element::i32, Shape{}, 2);
+    auto num_columns = make_shared<op::v0::Constant>(element::i32, Shape{}, 5);
+    auto diagonal_index = make_shared<op::v0::Constant>(element::i32, Shape{}, 1);
+    auto batch_shape = make_shared<op::v0::Constant>(element::i32, Shape{3}, std::vector<int32_t>{1, 2, 3});
+
+    const auto eye = make_shared<op::v9::Eye>(num_rows, num_columns, diagonal_index, batch_shape, element::Type_t::i32);
+    NodeBuilder builder(eye);
+    auto g_eye = ov::as_type_ptr<op::v9::Eye>(builder.create());
+
+    const auto expected_attr_count = 1;
+    EXPECT_EQ(builder.get_value_map_size(), expected_attr_count);
+    EXPECT_EQ(g_eye->get_out_type(), eye->get_out_type());
+}

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.cpp
@@ -80,6 +80,7 @@
 #include "utils.hpp"
 #include "variadic_split_shape_inference.hpp"
 #include "matmul_shape_inference.hpp"
+#include "eye_shape_inference.hpp"
 
 namespace ov {
 namespace intel_cpu {
@@ -549,6 +550,8 @@ std::shared_ptr<IShapeInfer> make_shape_inference(const std::shared_ptr<ngraph::
     } else if (auto node = ov::as_type_ptr<ov::opset4::Broadcast>(op)) {
         return make_shared_entryIOC(node);
     } else if (auto node = ov::as_type_ptr<ov::opset1::Broadcast>(op)) {
+        return make_shared_entryIOC(node);
+    } else if (auto node = ov::as_type_ptr<ov::opset9::Eye>(op)) {
         return make_shared_entryIOC(node);
     } else if (auto node = ov::as_type_ptr<ov::op::v8::MaxPool>(op)) {
         return std::make_shared<entryFallbackWithPadding<ov::op::v8::MaxPool>>(node);

--- a/src/tests/functional/inference_engine/transformations/op_conversions/detection_output_downgrade_test.cpp
+++ b/src/tests/functional/inference_engine/transformations/op_conversions/detection_output_downgrade_test.cpp
@@ -41,6 +41,7 @@ void create_attributes_vectors(std::vector<opset1::DetectionOutput::Attributes>&
                             variance_encoded_in_target;
                         attrs_v1.share_location = attrs_v8.share_location = share_location;
                         attrs_v1.normalized = attrs_v8.normalized = normalized;
+                        attrs_v1.nms_threshold = attrs_v8.nms_threshold = 0.5f;
                         attrs_v1_vector.push_back(attrs_v1);
                         attrs_v8_vector.push_back(attrs_v8);
                     }

--- a/src/tests/functional/inference_engine/transformations/op_conversions/detection_output_upgrade_test.cpp
+++ b/src/tests/functional/inference_engine/transformations/op_conversions/detection_output_upgrade_test.cpp
@@ -39,6 +39,7 @@ void create_attributes_vectors(std::vector<opset1::DetectionOutput::Attributes>&
                             variance_encoded_in_target;
                         attrs_v1.share_location = attrs_v8.share_location = share_location;
                         attrs_v1.normalized = attrs_v8.normalized = normalized;
+                        attrs_v1.nms_threshold = attrs_v8.nms_threshold = 0.5f;
                         attrs_v1_vector.push_back(attrs_v1);
                         attrs_v8_vector.push_back(attrs_v8);
                     }


### PR DESCRIPTION
### Details:
 - *nGraph shell for Eye-9*
 - *Covered all exceptions by tests*
 - *[PR](https://github.com/openvinotoolkit/openvino/pull/11104) with specification*
 - *Updated spec: 3 inputs are required to avoid ctor conflicts*
 - *Fixed DetectionOutput conversion op tests - not initialized attribute `nms_threshold` (BTW, Valgrind shows this error in this test). [Failed tests are in CI](https://dev.azure.com/openvinoci/dldt/_build/results?buildId=319331&view=results)*


### Tickets:
 - *82301*
 
 
