### PR TITLE
Fix BatchToSpace Conformance tests for Template plugin

### DIFF
--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -79,6 +79,7 @@ void SubgraphBaseTest::run() {
                                              CommonTestUtils::vec2str(targetStaticShapeVec) + " " + ex.what());
                 }
                 infer();
+                generate_inputs(targetStaticShapeVec);
                 validate();
             }
             status = LayerTestsUtils::PassRate::Statuses::PASSED;


### PR DESCRIPTION
### Details:
 - Interpreter infer() changes data inputs, so I added inputs regeneration after that

### Tickets:
 - *82033*
