### PR TITLE
Missing backslashes right after mo

### DIFF
--- a/docs/MO_DG/prepare_model/convert_model/onnx_specific/Convert_Faster_RCNN.md
+++ b/docs/MO_DG/prepare_model/convert_model/onnx_specific/Convert_Faster_RCNN.md
@@ -6,7 +6,7 @@ These instructions are applicable only to the Faster R-CNN model converted to th
 
 **Step 2**. To generate the Intermediate Representation (IR) of the model, change your current working directory to the Model Optimizer installation directory and run the Model Optimizer with the following parameters:
 ```sh
- mo
+ mo \
 --input_model FasterRCNN-10.onnx \
 --input_shape [1,3,800,800] \
 --input 0:2 \

--- a/docs/MO_DG/prepare_model/convert_model/onnx_specific/Convert_Mask_RCNN.md
+++ b/docs/MO_DG/prepare_model/convert_model/onnx_specific/Convert_Mask_RCNN.md
@@ -6,7 +6,7 @@ These instructions are applicable only to the Mask R-CNN model converted to the 
 
 **Step 2**. To generate the Intermediate Representation (IR) of the model, change your current working directory to the Model Optimizer installation directory and run the Model Optimizer with the following parameters:
 ```sh
- mo
+ mo \
 --input_model mask_rcnn_R_50_FPN_1x.onnx \
 --input "0:2" \
 --input_shape [1,3,800,800] \


### PR DESCRIPTION
### Details:
 - A backslash "\\" is missed right after `mo` in the command example.
 - The missing backslash is required to run the command with just copy and paste.
