### PR TITLE
[ngraph] Fix -Winfinite-recursion error reported by compiler

### DIFF
--- a/src/core/include/ngraph/opsets/opset.hpp
+++ b/src/core/include/ngraph/opsets/opset.hpp
@@ -26,7 +26,7 @@ public:
     OpSet() = default;
     /// \brief Insert an op into the opset with a particular name and factory
     void insert(const std::string& name, const NodeTypeInfo& type_info, FactoryRegistry<Node>::Factory factory) {
-        return insert(name, type_info, std::move(factory));
+        return ov::OpSet::insert(name, type_info, std::move(factory));
     }
     /// \brief Insert OP_TYPE into the opset with a special name and the default factory
     template <typename OP_TYPE>


### PR DESCRIPTION
### Details:
If ov based application includes opset.hpp file, clang compiler will report the follow error during build process

In file included from /build/ironhide/tmp/portage/chromeos-base/intel-openvino-9999/work/intel-openvino-9999/src/plugins/vpux-plugin/samples/kmb_classification_sample/main.cpp:20:
In file included from /build/ironhide/tmp/portage/chromeos-base/intel-openvino-9999/work/intel-openvino-9999/src/inference/include/ie/inference_engine.hpp:12:
In file included from /build/ironhide/tmp/portage/chromeos-base/intel-openvino-9999/work/intel-openvino-9999/src/inference/include/ie/ie_core.hpp:19:
In file included from /build/ironhide/tmp/portage/chromeos-base/intel-openvino-9999/work/intel-openvino-9999/src/inference/include/ie/ie_extension.h:17:
In file included from /build/ironhide/tmp/portage/chromeos-base/intel-openvino-9999/work/intel-openvino-9999/src/inference/include/ie/ie_iextension.h:22:
/build/ironhide/tmp/portage/chromeos-base/intel-openvino-9999/work/intel-openvino-9999/src/core/include/ngraph/opsets/opset.hpp:28:113: error: all paths through this function will call itself [-Werror,-Winfinite-recursion]

### Tickets:
