### PR TITLE
return device infer request in passthrough mode

### DIFF
--- a/src/plugins/auto/executable_network.cpp
+++ b/src/plugins/auto/executable_network.cpp
@@ -91,6 +91,8 @@ MultiDeviceExecutableNetwork::MultiDeviceExecutableNetwork(const DeviceMap<Infer
         auto& network = networkValue.second;
         GenerateWorkers(device, network);
     }
+    if (_networksPerDevice.size() == 1)
+        _passthroughExeNet = _networksPerDevice.begin()->second;
 }
 
 void MultiDeviceExecutableNetwork::GenerateWorkers(const std::string& device, const SoExecutableNetworkInternal& executableNetwork) {
@@ -328,6 +330,7 @@ MultiDeviceExecutableNetwork::MultiDeviceExecutableNetwork(const std::string&   
     } else {
         // only one device need to load network, do not need to load it async
         _loadContext[ACTUALDEVICE].task();
+        _passthroughExeNet = _loadContext[ACTUALDEVICE].executableNetwork;
     }
     WaitFirstNetworkReady();
 }
@@ -706,6 +709,11 @@ InferenceEngine::IInferRequestInternal::Ptr MultiDeviceExecutableNetwork::Create
 }
 
 IInferRequestInternal::Ptr MultiDeviceExecutableNetwork::CreateInferRequest() {
+    if (_passthroughExeNet) {
+        auto res = _passthroughExeNet->CreateInferRequest();
+        res->setPointerToExecutableNetworkInternal(shared_from_this());
+        return res;
+    }
     IInferRequestInternal::Ptr syncRequestImpl;
     if (this->_plugin) {
         const auto& core = _plugin->GetCore();

--- a/src/plugins/auto/executable_network.hpp
+++ b/src/plugins/auto/executable_network.hpp
@@ -165,6 +165,7 @@ private:
     unsigned int                                                        _cpuHelpInferCount = 0;
     double                                                              _cpuHelpFps = 0.0;
     Time                                                                _cpuHelpReleaseTime;
+    InferenceEngine::SoExecutableNetworkInternal                        _passthroughExeNet;
 };
 
 }  // namespace MultiDevicePlugin


### PR DESCRIPTION
Signed-off-by: fishbell <bell.song@intel.com>

### Details:
decouple createInferRequest() for single/multi device situation
