### PR TITLE
Install 97-myriad-usbboot.rules to install_dependencies

### DIFF
--- a/scripts/install_dependencies/install_NCS_udev_rules.sh
+++ b/scripts/install_dependencies/install_NCS_udev_rules.sh
@@ -3,17 +3,14 @@
 # Copyright (C) 2018-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]-$0}" )" >/dev/null 2>&1 && pwd )"
+
 echo "Updating udev rules..."
 
-if [ -z "$INTEL_OPENVINO_DIR" ]; then
-    echo "Please set up your environment. Run 'source <OPENVINO_INSTALLDIR>/setupvars.sh'."
-    exit -1
-fi
-
-if [ -f "$INTEL_OPENVINO_DIR/runtime/3rdparty/97-myriad-usbboot.rules" ]; then
+if [ -f "$SCRIPT_DIR/97-myriad-usbboot.rules" ]; then
     sudo usermod -a -G users "$(whoami)"
 
-    sudo cp "$INTEL_OPENVINO_DIR/runtime/3rdparty/97-myriad-usbboot.rules" /etc/udev/rules.d/
+    sudo cp "$SCRIPT_DIR/97-myriad-usbboot.rules" /etc/udev/rules.d/
     sudo udevadm control --reload-rules
     sudo udevadm trigger
     sudo ldconfig

--- a/src/plugins/intel_myriad/CMakeLists.txt
+++ b/src/plugins/intel_myriad/CMakeLists.txt
@@ -13,9 +13,9 @@ endif()
 add_subdirectory(common)
 
 if(ENABLE_INTEL_MYRIAD)
+    add_subdirectory(third_party)
     add_subdirectory(graph_transformer)
     add_subdirectory(myriad_plugin)
-    add_subdirectory(third_party)
 
     if(DEFINED VPU_CLC_MA2X8X_ROOT)
         install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/custom_kernels/

--- a/src/plugins/intel_myriad/myriad_plugin/CMakeLists.txt
+++ b/src/plugins/intel_myriad/myriad_plugin/CMakeLists.txt
@@ -42,8 +42,7 @@ target_link_libraries(${TARGET_NAME}
         mvnc inference_engine_legacy vpu_graph_transformer)
 
 # MyriadPlugin is not safe to unload it at runtime
-if((LINUX AND LINUX_OS_NAME MATCHES "Ubuntu")
-   OR ARM)
+if((LINUX AND LINUX_OS_NAME MATCHES "Ubuntu") OR ARM)
     set_target_properties(${TARGET_NAME} PROPERTIES LINK_OPTIONS "-Wl,-z,nodelete")
 endif()
 
@@ -54,8 +53,8 @@ ie_add_api_validator_post_build_step(TARGET ${TARGET_NAME})
 set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
 
 # install
-if (LINUX)
-    install(FILES ${OpenVINO_SOURCE_DIR}/src/plugins/intel_myriad/third_party/mvnc/src/97-myriad-usbboot.rules
-        DESTINATION runtime/3rdparty
-        COMPONENT myriad)
+if(LINUX)
+    install(FILES ${mvnc_SOURCE_DIR}/src/97-myriad-usbboot.rules
+            DESTINATION install_dependencies
+            COMPONENT myriad)
 endif()


### PR DESCRIPTION
### Details:
 - Install `97-myriad-usbboot.rules` to the same location as `install_NCS_udev_rules.sh` which installs this file
 - Because of that, `install_NCS_udev_rules.sh` does not depend on `setupvars.sh` script

### Tickets:
 - *ticket-id*
