### PR TITLE
[GPU] Fix allocation for cached USM remote blobs

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
@@ -117,7 +117,8 @@ public:
 
     void allocate() noexcept override {
         try {
-            _impl.allocate();
+            if (!_impl.is_allocated())
+                _impl.allocate();
         } catch (...) {}
     }
     bool deallocate() noexcept override { return _impl.deallocate(); }


### PR DESCRIPTION
### Details:
 - *prevent calling additional blob.allocate() for blobs that already have been cached. This fixes the assert during multiple RemoteBlob constructions using the same USM or CL buffer*

### Tickets:
 - *81366*
