### PR TITLE
[GPU] MVN optimization for blocked formats.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -11,6 +11,7 @@
 #include <list>
 #include <utility>
 
+#include "mvn_inst.h"
 #include "reshape_inst.h"
 #include "one_hot_inst.h"
 #include "permute_inst.h"
@@ -96,7 +97,7 @@ void remove_redundant_reorders::run(program& p) {
                     break;
                 }
 
-                if (usr->is_type<fully_connected>())
+                if (usr->is_type<fully_connected>() || usr->is_type<mvn>())
                     recalc_list.push_back(usr);
             }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
@@ -100,6 +100,13 @@ attach_mvn_impl::attach_mvn_impl() {
         std::make_tuple(data_types::i8, format::bs_fs_yx_bsv32_fsv32),
 
         std::make_tuple(data_types::f16, format::bs_fs_yx_bsv32_fsv16),
+        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv32_fsv16),
+
+        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv16_fsv16),
+        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv16_fsv16),
+
+        std::make_tuple(data_types::u8, format::b_fs_yx_fsv32),
+        std::make_tuple(data_types::i8, format::b_fs_yx_fsv32),
     });
 }
 

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -382,6 +382,18 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
             }
             return true;
         }
+
+        if (next.is_type<mvn>() && fmt_next == format::bfyx) {
+            if ((fmt_prev == format::bs_fs_yx_bsv16_fsv16
+              || fmt_prev == format::bs_fs_yx_bsv32_fsv16
+              || fmt_prev == format::bs_fs_yx_bsv32_fsv32)
+                && (prev_output_layout.data_padding.upper_size().spatial[0] == 0
+                 && prev_output_layout.data_padding.lower_size().spatial[0] == 0
+                 && prev_output_layout.data_padding.upper_size().spatial[1] == 0
+                 && prev_output_layout.data_padding.lower_size().spatial[1] == 0)) {
+                return true;
+            }
+        }
     }
 
     return false;


### PR DESCRIPTION
+ Supports bs_fs_yx_bsv16_fsv16 format of fp16/fp32 data type.
+ Supports b_fs_yx_fsv16 format of fp16/fp32 data type.
+ Supports b_fs_yx_fsv32 format of i8/u8 data type.

Ticket
- 75190