### PR TITLE
Don't execute reference::strided_slice if input/output tensor is empty

### DIFF
--- a/docs/template_plugin/tests/functional/op_reference/strided_slice.cpp
+++ b/docs/template_plugin/tests/functional/op_reference/strided_slice.cpp
@@ -368,6 +368,20 @@ std::vector<StridedSliceStrideOptionalParams> generateStrideOptionalParams() {
             std::vector<int64_t>{0, 0, 0},
             reference_tests::Tensor(IN_ET, {1, 4}, std::vector<T>{20, 21, 22, 23}),
             "strided_slice_stride_optional_dynamic"),
+        // strided_slice_stride_optional_dynamic_empty_output_tensor
+        StridedSliceStrideOptionalParams(
+            PartialShape::dynamic(),
+            reference_tests::Tensor(IN_ET, {2, 3, 4}, std::vector<T>{0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                                                    12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}),
+            reference_tests::Tensor(element::i64, {2}, std::vector<int64_t>{0, 0}),
+            reference_tests::Tensor(element::i64, {2}, std::vector<int64_t>{-1, 0}),
+            std::vector<int64_t>{1, 0},
+            std::vector<int64_t>{1, 0},
+            std::vector<int64_t>{},
+            std::vector<int64_t>{},
+            std::vector<int64_t>{},
+            reference_tests::Tensor(IN_ET, {2, 0, 4}, std::vector<T>{}),
+            "strided_slice_stride_optional_dynamic_empty_output_tensor"),
     };
     return params;
 }

--- a/src/core/reference/src/runtime/reference/strided_slice.cpp
+++ b/src/core/reference/src/runtime/reference/strided_slice.cpp
@@ -18,6 +18,15 @@ void runtime::reference::strided_slice(const char* arg,
                                        const Shape& arg_shape,
                                        const SlicePlan& sp,
                                        size_t elem_type) {
+    auto hasZeroDims = [](const ov::Shape& shape) -> bool {
+        return std::any_of(shape.begin(), shape.end(), [](const size_t& dim) {
+            return dim == 0;
+        });
+    };
+    if (hasZeroDims(sp.reshape_in_shape) || hasZeroDims(sp.reshape_out_shape)) {
+        return;
+    }
+
     runtime::AlignedBuffer slice_out_buffer(shape_size(sp.reshape_in_shape) * elem_type);
     slice(reinterpret_cast<const char*>(arg),
           slice_out_buffer.get_ptr<char>(),


### PR DESCRIPTION
### Details:
If reference::strided_slice execute with empty (zero dims) input/output tensor we get sefgaul. According to [this comment](https://github.com/openvinotoolkit/openvino/blob/master/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp#L89) reference implementations don't work with empty tensors.
 
 For model from ticket problem doesn't reproduce for static model because `RemoveConcatZeroDimInput` remove `StridedSlice` from model. But in dynamic case we still have `StridedSlice` with non constant `begin_mask` and `end_mask`. This case is unsupported by CPU plug-in and we fallback on ngraph reference implementation.

### Tickets:
 - *80923*
