### PR TITLE
[GPU] Align OneHot primitive parameters with ngraph

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/one_hot.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/one_hot.hpp
@@ -49,13 +49,18 @@ struct one_hot : public primitive_base<one_hot> {
     one_hot(const primitive_id& id,
             const primitive_id& input,
             const tensor& shape,
-            const uint16_t& one_hot_axis,
+            const int64_t& one_hot_axis,
+            const int64_t& depth,
             const float& on_value = 1.0f,
             const float& off_value = 0.0f,
             const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), shape(shape), one_hot_axis(one_hot_axis),
-          on_value(on_value), off_value(off_value) {}
+        : primitive_base(id, {input}, ext_prim_id, output_padding)
+        , shape(shape)
+        , one_hot_axis(one_hot_axis)
+        , depth(depth)
+        , on_value(on_value)
+        , off_value(off_value) {}
 
     /// @brief Constructs one-hot primitive layer.
     /// @param id              An identifier of new primitive.
@@ -68,18 +73,25 @@ struct one_hot : public primitive_base<one_hot> {
             const primitive_id& input,
             const tensor& shape,
             const data_types output_dt,
-            const uint16_t& one_hot_axis,
+            const int64_t& one_hot_axis,
+            const int64_t& depth,
             const float& on_value = 1.0f,
             const float& off_value = 0.0f,
             const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type{output_dt}), shape(shape), one_hot_axis(one_hot_axis),
-          on_value(on_value), off_value(off_value) {}
+        : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type{output_dt})
+        , shape(shape)
+        , one_hot_axis(one_hot_axis)
+        , depth(depth)
+        , on_value(on_value)
+        , off_value(off_value) {}
 
     /// @brief Output size reference.
     tensor shape;
     /// @brief One-hot axis position in output shape (0-based, from left to right).
-    uint16_t one_hot_axis;
+    int64_t one_hot_axis;
+    /// @brief The number of classes and thus the size of the one-hot dimension
+    int64_t depth;
     /// @brief The locations represented by indices in indices take this value.
     float on_value;
     /// @brief all other locations take value this value.

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/one_hot.cpp
@@ -32,9 +32,7 @@ struct one_hot_impl : typed_primitive_impl_ocl<one_hot> {
         oh_params.on_value = arg.get_primitive()->on_value;
         oh_params.off_value = arg.get_primitive()->off_value;
 
-        auto output_sizes = arg.get_output_layout().format == format::bfzyx ?
-                            arg.get_output_layout().size.sizes(format::bfzyx) :
-                            arg.get_output_layout().size.sizes(format::bfyx);
+        auto output_sizes = arg.get_output_layout().get_dims();
 
         oh_params.one_hot_limit = output_sizes[oh_params.one_hot_axis];
 

--- a/src/plugins/intel_gpu/src/plugin/ops/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/one_hot.cpp
@@ -19,12 +19,13 @@ static void CreateOneHotOp(Program& p, const std::shared_ptr<ngraph::op::v1::One
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
-    int16_t axis = op->get_axis();
+    int64_t axis = op->get_axis();
+    auto depth_value_node = std::dynamic_pointer_cast<ngraph::op::v0::Constant>(op->get_input_node_shared_ptr(1));
     auto on_value_node = std::dynamic_pointer_cast<ngraph::op::v0::Constant>(op->get_input_node_shared_ptr(2));
     auto off_value_node = std::dynamic_pointer_cast<ngraph::op::v0::Constant>(op->get_input_node_shared_ptr(3));
 
-    if (on_value_node == nullptr || off_value_node == nullptr)
-        IE_THROW() << "Unsupported on/off node type in " << op->get_friendly_name() << " (" << op->get_type_name() << ")";
+    if (on_value_node == nullptr || off_value_node == nullptr || depth_value_node == nullptr)
+        IE_THROW() << "Unsupported on/off/depth node type in " << op->get_friendly_name() << " (" << op->get_type_name() << ")";
 
     float on_value;
     float off_value;
@@ -34,7 +35,7 @@ static void CreateOneHotOp(Program& p, const std::shared_ptr<ngraph::op::v1::One
         IE_THROW() << "Unsupported parameter size in " << op->get_friendly_name() << " (" << op->get_type_name() << ")";
     }
 
-    auto dims = op->get_input_shape(0);
+    auto dims = op->get_input_partial_shape(0);
 
     if (axis < -1 || axis > static_cast<int16_t>(dims.size()))
         IE_THROW() << op->get_friendly_name() << " Incorrect OneHot axis value: " << axis << ". Should be between -1 and " << dims.size();
@@ -49,11 +50,20 @@ static void CreateOneHotOp(Program& p, const std::shared_ptr<ngraph::op::v1::One
         }
     }
 
+    int64_t depth = depth_value_node->cast_vector<int64_t>()[0];
+
+    auto out_pshape = op->get_output_partial_shape(0);
+    if (out_pshape.is_dynamic()) {
+        IE_THROW() << "OneHot doesn't support dynamic shapes yet";
+    }
+    auto out_tensor = tensor_from_dims(out_pshape.to_shape());
+
     auto oneHotPrim = cldnn::one_hot(layerName,
                                      inputPrimitives[0],
-                                     tensor_from_dims(op->get_output_shape(0)),
+                                     out_tensor,
                                      DataTypeFromPrecision(op->get_output_element_type(0)),
-                                     static_cast<uint16_t>(axis),
+                                     axis,
+                                     depth,
                                      on_value,
                                      off_value,
                                      op->get_friendly_name());

--- a/src/plugins/intel_gpu/tests/test_cases/one_hot_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/one_hot_gpu_test.cpp
@@ -84,7 +84,7 @@ void generic_one_hot_test_int(cldnn::format test_input_fmt, int input_b, int inp
 
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output", "input", shape, one_hot_axis));
+    topology.add(one_hot("output", "input", shape, one_hot_axis, one_hot_limit));
 
     network network(engine, topology);
     network.set_input_data("input", input);
@@ -165,7 +165,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax4) {
     auto input = engine.allocate_memory({ data_types::i32, format::bfyx, input_tensor });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output","input", shape, one_hot_axis));
+    topology.add(one_hot("output","input", shape, one_hot_axis, 5));
 
     set_values(input, input_rnd_vec);
 
@@ -224,7 +224,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax4) {
     auto input = engine.allocate_memory({ data_types::i64, format::bfyx, input_tensor });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output","input", shape, one_hot_axis));
+    topology.add(one_hot("output","input", shape, one_hot_axis, 5));
 
     set_values(input, input_rnd_vec);
 
@@ -283,7 +283,7 @@ TEST(one_hot_gpu_i32_to_f32, bfyx_ax4) {
     auto input = engine.allocate_memory({ data_types::i32, format::bfyx, input_tensor });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output","input", shape, data_types::f32, one_hot_axis));
+    topology.add(one_hot("output","input", shape, data_types::f32, one_hot_axis, 5));
 
     set_values(input, input_rnd_vec);
 
@@ -297,12 +297,11 @@ TEST(one_hot_gpu_i32_to_f32, bfyx_ax4) {
     auto output_layout = output_memory->get_layout();
     cldnn::mem_lock<float> output_ptr(output_memory, get_test_stream());
 
-    tensor output_tensor = output_layout.get_buffer_size();
-    int z_size = output_tensor.spatial[2];
-    int y_size = output_tensor.spatial[1];
-    int x_size = output_tensor.spatial[0];
-    int f_size = output_tensor.feature[0];
-    int b_size = output_tensor.batch[0];
+    int z_size = output_layout.spatial(2);
+    int y_size = output_layout.spatial(1);
+    int x_size = output_layout.spatial(0);
+    int f_size = output_layout.feature();
+    int b_size = output_layout.batch();
     EXPECT_EQ(z_size, 2);
     EXPECT_EQ(y_size, 1);
     EXPECT_EQ(x_size, 5);
@@ -337,7 +336,7 @@ TEST(one_hot_gpu_i64_to_f32, bfyx_ax4) {
     auto input = engine.allocate_memory({ data_types::i64, format::bfyx, input_tensor });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output","input", shape, data_types::f32, one_hot_axis));
+    topology.add(one_hot("output","input", shape, data_types::f32, one_hot_axis, 5));
 
     set_values(input, input_rnd_vec);
 
@@ -388,7 +387,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax0) {
     auto input = engine.allocate_memory({ data_types::i32, format::bfyx, input_tensor });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output","input", shape, one_hot_axis));
+    topology.add(one_hot("output","input", shape, one_hot_axis, 3));
 
     set_values(input, input_rnd_vec);
 
@@ -443,7 +442,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax0) {
     auto input = engine.allocate_memory({ data_types::i64, format::bfyx, input_tensor });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output","input", shape, one_hot_axis));
+    topology.add(one_hot("output","input", shape, one_hot_axis, 3));
 
     set_values(input, input_rnd_vec);
 
@@ -498,7 +497,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax1) {
     auto input = engine.allocate_memory({ data_types::i32, format::bfyx, input_tensor });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output","input", shape, one_hot_axis));
+    topology.add(one_hot("output","input", shape, one_hot_axis, 3));
 
     set_values(input, input_rnd_vec);
 
@@ -553,7 +552,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax1) {
     auto input = engine.allocate_memory({ data_types::i64, format::bfyx, input_tensor });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output","input", shape, one_hot_axis));
+    topology.add(one_hot("output","input", shape, one_hot_axis, 3));
 
     set_values(input, input_rnd_vec);
 
@@ -608,7 +607,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax2) {
     auto input = engine.allocate_memory({ data_types::i32, format::bfyx, input_tensor });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output","input", shape, one_hot_axis));
+    topology.add(one_hot("output","input", shape, one_hot_axis, 3));
 
     set_values(input, input_rnd_vec);
 
@@ -663,7 +662,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax2) {
     auto input = engine.allocate_memory({ data_types::i64, format::bfyx, input_tensor });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output","input", shape, one_hot_axis));
+    topology.add(one_hot("output","input", shape, one_hot_axis, 3));
 
     set_values(input, input_rnd_vec);
 
@@ -718,7 +717,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax3) {
     auto input = engine.allocate_memory({ data_types::i32, format::bfyx, input_tensor });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output","input", shape, one_hot_axis));
+    topology.add(one_hot("output","input", shape, one_hot_axis, 3));
 
     set_values(input, input_rnd_vec);
 
@@ -773,7 +772,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax3) {
     auto input = engine.allocate_memory({ data_types::i64, format::bfyx, input_tensor });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output","input", shape, one_hot_axis));
+    topology.add(one_hot("output","input", shape, one_hot_axis, 3));
 
     set_values(input, input_rnd_vec);
 
@@ -787,12 +786,11 @@ TEST(one_hot_gpu_i64, bfzyx_ax3) {
     auto output_layout = output_memory->get_layout();
     cldnn::mem_lock<int64_t> output_ptr(output_memory, get_test_stream());
 
-    tensor output_tensor = output_layout.get_buffer_size();
-    int z_size = output_tensor.spatial[2];
-    int y_size = output_tensor.spatial[1];
-    int x_size = output_tensor.spatial[0];
-    int f_size = output_tensor.feature[0];
-    int b_size = output_tensor.batch[0];
+    int z_size = output_layout.spatial(2);
+    int y_size = output_layout.spatial(1);
+    int x_size = output_layout.spatial(0);
+    int f_size = output_layout.feature();
+    int b_size = output_layout.batch();
     EXPECT_EQ(z_size, 1);
     EXPECT_EQ(y_size, 3);
     EXPECT_EQ(x_size, 2);
@@ -813,11 +811,11 @@ TEST(one_hot_gpu_i64, bfzyx_ax3) {
 
 TEST(one_hot_error, basic_error_wrong_axis) {
     auto& engine = get_test_engine();
-    auto input = engine.allocate_memory({ data_types::i32, format::bfyx,{ 1, 1, 1, 1 } });
+    auto input = engine.allocate_memory({ data_types::i32, format::bfyx, tensor{ 1, 1, 1, 1 } });
 
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output", "input", tensor(1, 1, 1, 50), 5));
+    topology.add(one_hot("output", "input", tensor(1, 1, 1, 50), 5, 2));
 
     std::string msg_to_find = "Incorrect parameters configuration: one_hot_axis should be less or equal to 4.";
     EXPECT_ANY_THROW(check_exception_massage(engine, topology, msg_to_find));
@@ -825,11 +823,11 @@ TEST(one_hot_error, basic_error_wrong_axis) {
 
 TEST(one_hot_error, basic_error_bad_shape) {
     auto& engine = get_test_engine();
-    auto input = engine.allocate_memory({ data_types::i32, format::bfyx,{ 1, 1, 1, 1 } });
+    auto input = engine.allocate_memory({ data_types::i32, format::bfyx, tensor{ 1, 1, 1, 1 } });
 
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(one_hot("output", "input", tensor(1, 5, 1, 50), 2));
+    topology.add(one_hot("output", "input", tensor(1, 5, 1, 50), 2, 2));
 
     std::string msg_to_find = "Incorrect parameters configuration: shape does not fit input size.";
     EXPECT_ANY_THROW(check_exception_massage(engine, topology, msg_to_find));


### PR DESCRIPTION
### Details:
 - Align one_hot_axis and depth parameters of one_hot primitive to reuse ngraph shape inference further
