### PR TITLE
[CPU][BF16] Functional filures fixes for 2022 R2

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1361,7 +1361,7 @@ void Graph::EnforceBF16() {
         if (nodesToSkip.count(node) && !node->enforceBF16evenForGraphTail)
             continue;
 
-        if (node->getType() != Type::Input && node->getType() != Type::Output) {
+        if (!ov::intel_cpu::one_of(node->getType(), Type::Input, Type::Output, Type::MemoryInput, Type::MemoryOutput)) {
             for (size_t i = 0; i < node->getOriginalInputsNumber(); i++) {
                 const auto &parent = node->getParentEdgesAtPort(i)[0]->getParent();
                 /* Skip BF16 enforcement for nodes after Constant Inputs for maintaining precision for fusing.

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -295,6 +295,9 @@ void Deconvolution::getSupportedDescriptors() {
        inputDataType = outputDataType = memory::data_type::bf16;
     if (!fusedWith.empty()) {
         outputDataType = DnnlExtensionUtils::IEPrecisionToDataType(fusedWith[fusedWith.size() - 1]->getOriginalOutputPrecisionAtPort(0));
+        // TODO: We have to extend jit_avx512_core_x8s8s32x_deconv_fwd_kernel from oneDNN to support BF16 output data type
+        if (isInt8 && outputDataType == memory::data_type::bf16)
+            outputDataType = memory::data_type::f32;
     }
 
     if (getParentEdges().size() != 2 && getParentEdges().size() != 3)


### PR DESCRIPTION
### Details:
 - *bf16_ref_pooling from oneDNN was included*
 - *InputMemory and OutputMemory were adjusted by FP32 precision*
 - *Deconvolution fusing with FakeQuantize was disabled*
 - *Deconvolution function and fusing precision inconsistence was resolved*

oneDNN related PR: https://github.com/openvinotoolkit/oneDNN/pull/124

### Tickets:
 - *83170*
