### PR TITLE
Enable MO unit-tests but bom tests

### DIFF
--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -262,7 +262,6 @@ jobs:
       . $(SETUPVARS) -pyver 3.8 && python3 -m pytest -s $(INSTALL_DIR)/tests/mo/unit_tests --junitxml=TEST-ModelOptimizer.xml
     displayName: 'Model Optimizer UT'
     continueOnError: false
-    enabled: false
 
   - script: . $(SETUPVARS) && $(INSTALL_TEST_DIR)/ov_core_unit_tests --gtest_print_time=1 --gtest_filter=-*IE_GPU* --gtest_output=xml:TEST-NGraphUT.xml
     workingDirectory: $(INSTALL_TEST_DIR)

--- a/tools/mo/unit_tests/mo/bom_test.py
+++ b/tools/mo/unit_tests/mo/bom_test.py
@@ -42,6 +42,7 @@ class TestBOMFile(unittest.TestCase):
             r'^# SPDX-License-Identifier: Apache-2.0$',
         ]]
 
+    @unittest.skip("83076 - test infra change affects bom tests")
     def test_bom_file(self):
         missing_files = list()
         for src_dir in dirs_to_search:
@@ -67,10 +68,12 @@ class TestBOMFile(unittest.TestCase):
                 print(f.replace('\\', '/'))
         self.assertTrue(not len(missing_files), '{} files missed in BOM'.format(len(missing_files)))
 
+    @unittest.skip("83076 - test infra change affects bom tests")
     def test_bom_does_not_contain_unittest_files(self):
         for file_name in self.existing_files:
             self.assertFalse(file_name.endswith('_test.py'), 'BOM file contains test file {}'.format(file_name))
 
+    @unittest.skip("83076 - test infra change affects bom tests")
     def test_deleted_files_still_stored_in_bom(self):
         deleted = list()
         for file in self.existing_files:
@@ -82,6 +85,7 @@ class TestBOMFile(unittest.TestCase):
                 print(f)
         self.assertTrue(not len(deleted), '{} files deleted but still stored in BOM'.format(len(deleted)))
 
+    @unittest.skip("83076 - test infra change affects bom tests")
     def test_alphabetical_order_and_duplicates(self):
         sorted_bom = sorted([x for x in self.existing_files if self.existing_files.count(x) == 1], key=str.lower)
         if self.existing_files != sorted_bom:
@@ -89,6 +93,7 @@ class TestBOMFile(unittest.TestCase):
             print(*sorted_bom, sep='\n')
             self.assertTrue(False)
 
+    @unittest.skip("83076 - test infra change affects bom tests")
     def test_missed_intel_header(self):
         missing_files = list()
         for src_dir in dirs_to_search:


### PR DESCRIPTION
**Description:** Recent test infrastructure changes affected MO unit-tests and they were disabled. Now it returns them to CI but bom tests. The BOM tests will be fixed in separate PR.

**Ticket:** 83076

Signed-off-by: Roman Kazantsev <roman.kazantsev@intel.com>
