### PR TITLE
[CPU] [DEBUG CAPS] Revert DNNL_VERBOSE

### DIFF
--- a/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
+++ b/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
@@ -29,7 +29,11 @@ function(ie_add_mkldnn)
     set(DNNL_CPU_RUNTIME "${THREADING}" CACHE STRING "" FORCE)
     set(DNNL_GPU_RUNTIME "NONE" CACHE STRING "" FORCE)
     set(DNNL_BLAS_VENDOR "NONE" CACHE STRING "" FORCE)
-    set(DNNL_VERBOSE "OFF" CACHE STRING "" FORCE)
+    if (ENABLE_CPU_DEBUG_CAPS)
+        set(DNNL_VERBOSE "ON" CACHE STRING "" FORCE)
+    else()
+        set(DNNL_VERBOSE "OFF" CACHE STRING "" FORCE)
+    endif()
     set(SDL_cmake_included ON)  ## to skip internal SDL flags. SDL flags are already set on IE level
     if (ANDROID OR ((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") AND NOT (THREADING STREQUAL "OMP")))
         set(OpenMP_cmake_included ON) ## to skip "omp simd" inside a code. Lead to some crashes inside NDK LLVM..


### PR DESCRIPTION
### Details:
- Compilation with ENABLE_CPU_DEBUG_CAPS was fixed.
Previous to this change it failed due to undefined dnnl::impl::md2dim_str
(since DNNL_VERBOSE was disabled in the scope of PR #11244).
 
