### PR TITLE
Tbb: download only if system libraries are not found

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -165,9 +165,7 @@ function(ov_download_tbb)
     debug_message(STATUS "tbb_dir=" ${TBB_DIR})
     debug_message(STATUS "tbbroot=" ${TBBROOT})
 
-    if(DEFINED IE_PATH_TO_DEPS)
-        unset(IE_PATH_TO_DEPS)
-    endif()
+    set(TBB "${TBB}" PARENT_SCOPE)
 endfunction()
 
 ## TBBBind_2_5 package
@@ -182,6 +180,8 @@ function(ov_download_tbbbind_2_5)
         return()
     endif()
     set(_ov_download_tbbbind_2_5_done ON CACHE BOOL "Whether prebuilt TBBBind_2_5 is already downloaded")
+
+    reset_deps_cache(TBBBIND_2_5_DIR)
 
     if(DEFINED ENV{THIRDPARTY_SERVER_PATH})
         set(IE_PATH_TO_DEPS "$ENV{THIRDPARTY_SERVER_PATH}")
@@ -210,9 +210,7 @@ Build oneTBB from sources and set TBBROOT environment var before OpenVINO cmake 
 
     update_deps_cache(TBBBIND_2_5_DIR "${TBBBIND_2_5}/cmake" "Path to TBBBIND_2_5 cmake folder")
 
-    if(DEFINED IE_PATH_TO_DEPS)
-        unset(IE_PATH_TO_DEPS)
-    endif()
+    set(TBBBIND_2_5 "${TBBBIND_2_5}" PARENT_SCOPE)
 endfunction()
 
 ## OpenCV

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -91,7 +91,19 @@ if(THREADING STREQUAL "OMP")
 endif()
 
 ## TBB package
-if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO" AND NOT ENABLE_SYSTEM_TBB)
+unset(_ov_download_tbb_done CACHE)
+
+#
+# The function downloads prebuilt TBB package
+# NOTE: the function should be used if system TBB is not found
+# or ENABLE_SYSTEM_TBB is OFF
+#
+function(ov_download_tbb)
+    if(_ov_download_tbb_done OR NOT THREADING MATCHES "^(TBB|TBB_AUTO)$")
+        return()
+    endif()
+    set(_ov_download_tbb_done ON CACHE BOOL "Whether prebuilt TBB is already downloaded")
+
     reset_deps_cache(TBBROOT TBB_DIR)
 
     if(DEFINED ENV{THIRDPARTY_SERVER_PATH})
@@ -156,10 +168,21 @@ if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO" AND NOT ENABLE_SYST
     if(DEFINED IE_PATH_TO_DEPS)
         unset(IE_PATH_TO_DEPS)
     endif()
-endif()
+endfunction()
 
 ## TBBBind_2_5 package
-if(ENABLE_TBBBIND_2_5)
+unset(_ov_download_tbbbind_2_5_done CACHE)
+
+#
+# The function downloads static prebuilt TBBBind_2_5 package
+# NOTE: the function should be called only we have TBB with version less 2021
+#
+function(ov_download_tbbbind_2_5)
+    if(_ov_download_tbbbind_2_5_done OR NOT ENABLE_TBBBIND_2_5)
+        return()
+    endif()
+    set(_ov_download_tbbbind_2_5_done ON CACHE BOOL "Whether prebuilt TBBBind_2_5 is already downloaded")
+
     if(DEFINED ENV{THIRDPARTY_SERVER_PATH})
         set(IE_PATH_TO_DEPS "$ENV{THIRDPARTY_SERVER_PATH}")
     elseif(DEFINED THIRDPARTY_SERVER_PATH)
@@ -190,7 +213,7 @@ Build oneTBB from sources and set TBBROOT environment var before OpenVINO cmake 
     if(DEFINED IE_PATH_TO_DEPS)
         unset(IE_PATH_TO_DEPS)
     endif()
-endif()
+endfunction()
 
 ## OpenCV
 if(ENABLE_OPENCV)

--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -139,22 +139,8 @@ ie_dependent_option (ENABLE_SYSTEM_PUGIXML "use the system copy of pugixml" OFF 
 get_linux_name(LINUX_OS_NAME)
 if(LINUX_OS_NAME MATCHES "^Ubuntu [0-9]+\.[0-9]+$" AND NOT DEFINED ENV{TBBROOT})
     # Debian packages are enabled on Ubuntu systems
+    # so, system TBB can be tried for usage
     set(ENABLE_SYSTEM_TBB_DEFAULT ON)
-
-    # check whether "default" (customly provided or system one) is available
-    find_package(TBB QUIET)
-    if(NOT TBB_FOUND)
-        message(WARNING "System TBB is not found, custom TBB version will be downloaded from shared drive")
-        # we still need to download prebuilt version of TBB
-        set(ENABLE_SYSTEM_TBB_DEFAULT OFF)
-    endif()
-
-    # remove found TBB (or invalid TBB_DIR-NOTFOUND) from cache
-    unset(TBB_DIR CACHE)
-    unset(TBB_DIR)
-    unset(TBB_FOUND)
-    unset(TBB_IMPORTED_TARGETS)
-    unset(TBB_VERSION)
 else()
     set(ENABLE_SYSTEM_TBB_DEFAULT OFF)
 endif()

--- a/src/cmake/ie_parallel.cmake
+++ b/src/cmake/ie_parallel.cmake
@@ -2,25 +2,32 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-macro(ov_find_tbb)
+macro(ov_find_package_tbb)
     if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO" AND NOT TBB_FOUND)
-        find_package(TBB QUIET COMPONENTS tbb tbbmalloc)
+        if(NOT ENABLE_SYSTEM_TBB)
+            set(_find_package_no_args NO_SYSTEM_ENVIRONMENT_PATH
+                                      NO_CMAKE_SYSTEM_PATH)
+        endif()
 
-        # try to find TBB via custom scripts if have not found by default
-        if(NOT TBB_FOUND AND IEDevScripts_DIR)
+        find_package(TBB QUIET COMPONENTS tbb tbbmalloc
+                     ${_find_package_no_args})
+
+        if(NOT TBB_FOUND)
             # remove invalid TBB_DIR=TBB_DIR-NOTFOUND from cache
             unset(TBB_DIR CACHE)
             unset(TBB_DIR)
 
-            # use our custom scripts for old TBB versions
-            # which are exposed via `export TBBROOT=<tbbroot>`
-            # see https://github.com/openvinotoolkit/openvino/pull/1288
-            find_package(TBB COMPONENTS tbb tbbmalloc
+            # TBB on system is not found, download prebuilt one
+            # if TBBROOT env variable is not defined
+            ov_download_tbb()
+
+            # try to find one more time
+            find_package(TBB QUIET COMPONENTS tbb tbbmalloc
+                         # can be provided by ov_download_tbb
+                         HINTS ${TBB_DIR}
+                         # fallback variant for TBB 2018 and older
                          PATHS ${IEDevScripts_DIR}
-                         NO_CMAKE_FIND_ROOT_PATH
-                         NO_DEFAULT_PATH)
-        else()
-            message(STATUS "TBB (${TBB_VERSION}) is found at ${TBB_DIR}")
+                         ${_find_package_no_args})
         endif()
 
         # WA for oneTBB: it does not define TBB_IMPORTED_TARGETS
@@ -37,17 +44,23 @@ macro(ov_find_tbb)
         set(TBB_FOUND ${TBB_FOUND} PARENT_SCOPE)
         set(TBB_IMPORTED_TARGETS ${TBB_IMPORTED_TARGETS} PARENT_SCOPE)
         set(TBB_VERSION ${TBB_VERSION} PARENT_SCOPE)
+        set(TBB_DIR ${TBB_DIR} PARENT_SCOPE)
+
         if (NOT TBB_FOUND)
             set(THREADING "SEQ" PARENT_SCOPE)
             message(WARNING "TBB was not found by the configured TBB_DIR/TBBROOT path.\
                              SEQ method will be used.")
-        endif ()
+        else()
+            message(STATUS "TBB (${TBB_VERSION}) is found at ${TBB_DIR}")
+        endif()
+
+        unset(_find_package_no_args)
     endif()
 endmacro()
 
 function(set_ie_threading_interface_for TARGET_NAME)
     # find TBB
-    ov_find_tbb()
+    ov_find_package_tbb()
 
     get_target_property(target_type ${TARGET_NAME} TYPE)
 

--- a/src/cmake/ie_parallel.cmake
+++ b/src/cmake/ie_parallel.cmake
@@ -13,6 +13,9 @@ macro(ov_find_package_tbb)
                      ${_find_package_no_args})
 
         if(NOT TBB_FOUND)
+            # system TBB failed to be found
+            set(ENABLE_SYSTEM_TBB OFF)
+
             # remove invalid TBB_DIR=TBB_DIR-NOTFOUND from cache
             unset(TBB_DIR CACHE)
             unset(TBB_DIR)
@@ -39,13 +42,6 @@ macro(ov_find_package_tbb)
             endforeach()
         endif()
 
-        # set variables to parent scope to prevent multiple invocations of find_package(TBB)
-        # at the same CMakeLists.txt; invocations in different directories are allowed
-        set(TBB_FOUND ${TBB_FOUND} PARENT_SCOPE)
-        set(TBB_IMPORTED_TARGETS ${TBB_IMPORTED_TARGETS} PARENT_SCOPE)
-        set(TBB_VERSION ${TBB_VERSION} PARENT_SCOPE)
-        set(TBB_DIR ${TBB_DIR} PARENT_SCOPE)
-
         if (NOT TBB_FOUND)
             set(THREADING "SEQ" PARENT_SCOPE)
             message(WARNING "TBB was not found by the configured TBB_DIR/TBBROOT path.\
@@ -59,8 +55,18 @@ macro(ov_find_package_tbb)
 endmacro()
 
 function(set_ie_threading_interface_for TARGET_NAME)
-    # find TBB
-    ov_find_package_tbb()
+    if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO" AND NOT TBB_FOUND)
+        # find TBB
+        ov_find_package_tbb()
+
+        # set variables to parent scope to prevent multiple invocations of find_package(TBB)
+        # at the same CMakeLists.txt; invocations in different directories are allowed
+        set(TBB_FOUND ${TBB_FOUND} PARENT_SCOPE)
+        set(TBB_IMPORTED_TARGETS ${TBB_IMPORTED_TARGETS} PARENT_SCOPE)
+        set(TBB_VERSION ${TBB_VERSION} PARENT_SCOPE)
+        set(TBB_DIR ${TBB_DIR} PARENT_SCOPE)
+        set(ENABLE_SYSTEM_TBB ${ENABLE_SYSTEM_TBB} PARENT_SCOPE)
+    endif()
 
     get_target_property(target_type ${TARGET_NAME} TYPE)
 

--- a/src/cmake/install_tbb.cmake
+++ b/src/cmake/install_tbb.cmake
@@ -10,11 +10,11 @@ ov_find_package_tbb()
 if(TBB_FOUND AND TBB_VERSION VERSION_GREATER_EQUAL 2021)
     message(STATUS "Static tbbbind_2_5 package usage is disabled, since oneTBB is used")
     set(ENABLE_TBBBIND_2_5 OFF)
-endif()
-
-if(ENABLE_TBBBIND_2_5)
-    # try to find prebuilt version of tbbbind_2_5
+elseif(ENABLE_TBBBIND_2_5)
+    # download and find a prebuilt version of TBBBind_2_5
+    ov_download_tbbbind_2_5()
     find_package(TBBBIND_2_5 QUIET)
+
     if(TBBBIND_2_5_FOUND)
         message(STATUS "Static tbbbind_2_5 package is found")
         set_target_properties(${TBBBIND_2_5_IMPORTED_TARGETS} PROPERTIES

--- a/src/cmake/install_tbb.cmake
+++ b/src/cmake/install_tbb.cmake
@@ -5,7 +5,7 @@
 include(cmake/ie_parallel.cmake)
 
 # pre-find TBB: need to provide TBB_IMPORTED_TARGETS used for installation
-ov_find_tbb()
+ov_find_package_tbb()
 
 if(TBB_FOUND AND TBB_VERSION VERSION_GREATER_EQUAL 2021)
     message(STATUS "Static tbbbind_2_5 package usage is disabled, since oneTBB is used")

--- a/src/cmake/install_tbb.cmake
+++ b/src/cmake/install_tbb.cmake
@@ -22,8 +22,6 @@ elseif(ENABLE_TBBBIND_2_5)
         if(NOT BUILD_SHARED_LIBS)
             set(install_tbbbind ON)
         endif()
-    else()
-        message(WARNING "Static tbbbind_2_5 package is not found")
     endif()
 endif()
 
@@ -36,7 +34,7 @@ if(THREADING MATCHES "^(TBB|TBB_AUTO)$")
 endif()
 
 if(install_tbbbind)
-    set(IE_TBBBIND_DIR "${TBBBIND_2_5}")
+    set(IE_TBBBIND_DIR "${TBBBIND_2_5_DIR}")
     list(APPEND PATH_VARS "IE_TBBBIND_DIR")
 endif()
 

--- a/src/plugins/intel_myriad/third_party/XLink/XLink.cmake
+++ b/src/plugins/intel_myriad/third_party/XLink/XLink.cmake
@@ -33,7 +33,7 @@ else()
     find_library(LIBUSB_LIBRARY NAMES usb-1.0 PATH_SUFFIXES "lib")
 
     if(NOT LIBUSB_INCLUDE_DIR OR NOT LIBUSB_LIBRARY)
-        message(FATAL_ERROR "libusb is required")
+        message(FATAL_ERROR "libusb is required, please install it")
     endif()
 
     set(XLINK_PLATFORM_INCLUDE


### PR DESCRIPTION
### Details:
 - If `TBB_DIR` or `TBBROOT` env vars are set, they are used
 - If no, and `ENABLE_SYSTEM_TBB` is set in cmake, it's used and TBB from system is found
 - If all steps above are failed, try to search with custom TBBConfig.cmake which is explicitly created for old TBB versions (like 2017) with no cmake configs. Such custom cmake TBBCoonfig.cmake respects `TBBROOT` env var
 - If no, prebuilt TBB is downloaded and used
 - The same for TBBBind, it's downloaded only for TBB version less 2021 (and with respect to cmake var `ENABLE_TBBBIND_2_5`)
