### PR TITLE
[MO] Support TensorFlow Grouped Conv2DBackpropInput

### DIFF
--- a/tools/mo/openvino/tools/mo/ops/deconvolution.py
+++ b/tools/mo/openvino/tools/mo/ops/deconvolution.py
@@ -60,6 +60,9 @@ class Deconvolution(Op):
         if not node.has_valid('dilation'):
             node['dilation'] = np.full([len(output_shape)], 1, dtype=np.int64)
 
+        if node.has_valid('get_group'):
+            node['group'] = node.get_group(node)
+
         spatial_dims = node.spatial_dims
         output_spatial = shape_array(output_shape[spatial_dims])
         stride_spatial = shape_array(node.stride[spatial_dims])


### PR DESCRIPTION
**Root cause analysis:** TensorFlow Conv2DBackpropInput operation covers Grouped Deconvolution case that is omitted in Model Optimizer Support

**Solution:** Add group number computation function

**Ticket:** 72871

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names

Validation:
* []  Unit tests
* [x]  Framework operation tests - Didn't add because Grouped Conv2DBackpropInput is not supported by TF-CPU
* [x]  Transformation tests - N/A
* []  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list - Already updated
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A

Signed-off-by: Roman Kazantsev <roman.kazantsev@intel.com>
