### PR TITLE
[MO] Support TensorFlow Grouped Conv2DBackpropInput

### DIFF
--- a/model-optimizer/extensions/front/tf/deconv_ext.py
+++ b/model-optimizer/extensions/front/tf/deconv_ext.py
@@ -17,6 +17,7 @@ class Conv2DBackpropInputFrontExtractor(FrontExtractorOp):
     def extract(cls, node):
         attrs = tf_create_attrs(node, 3, 2)
         attrs.update({'op': cls.op,
+                      'get_group': get_conv_backprop_groups,
                       'get_weights_permute': PermuteAttrs.Permutation(perm=int64_array([3, 2, 0, 1]),
                                                                       inv=int64_array([2, 3, 1, 0])),
                       'swap_0_and_2_inputs': True,
@@ -36,6 +37,7 @@ class Conv3DBackpropInputV2InputFrontExtractor(FrontExtractorOp):
     def extract(cls, node):
         attrs = tf_create_attrs(node, 4, 3)
         attrs.update({'op': cls.op,
+                      'get_group': get_conv_backprop_groups,
                       'get_weights_permute': PermuteAttrs.Permutation(perm=int64_array([4, 3, 0, 1, 2]),
                                                                       inv=int64_array([2, 3, 4, 1, 0])),
                       'swap_0_and_2_inputs': True,
@@ -69,3 +71,18 @@ def tf_create_attrs(node, input_feature_channel, output_feature_channel):
         'input_feature_channel': input_feature_channel,
         'output_feature_channel': output_feature_channel,
     }
+
+
+def get_conv_backprop_groups(node):
+    # output shape is required input for TensorFlow ConvBackpropInput operation and contains output shape values
+    # in the form [batch_size, output_height, output_width, output_channel], so that
+    # groups number = output_channel // kernel_out_channels, where
+    # kernel shape is given as [kernel_height, kernel_width, kernel_out_channels, in_channels]
+    output_shape = node.in_port(2).data.get_value()
+    kernel_shape = node.in_port(1).data.get_shape()
+    if node.has_and_set('group'):
+        return node.group
+    elif output_shape is not None and kernel_shape is not None:
+        return output_shape[node.channel_dims] // kernel_shape[node.output_feature_channel]
+    else:
+        return 1

--- a/model-optimizer/mo/ops/deconvolution.py
+++ b/model-optimizer/mo/ops/deconvolution.py
@@ -61,6 +61,9 @@ class Deconvolution(Op):
         if not node.has_valid('dilation'):
             node['dilation'] = np.full([len(output_shape)], 1, dtype=np.int64)
 
+        if node.has_valid('get_group'):
+            node['group'] = node.get_group(node)
+
         spatial_dims = node.spatial_dims
         output_spatial = np.array(output_shape[spatial_dims])
         stride_spatial = np.array(node.stride[spatial_dims])

--- a/model-optimizer/unit_tests/mo/ops/deconvolution_test.py
+++ b/model-optimizer/unit_tests/mo/ops/deconvolution_test.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+import numpy as np
+
+from extensions.front.tf.deconv_ext import get_conv_backprop_groups
+from mo.front.common.partial_infer.utils import int64_array
+from mo.graph.graph import Node
+from mo.ops.deconvolution import Deconvolution
+from unit_tests.utils.graph import build_graph
+
+nodes_attributes = {'deconv_input': {'value': None, 'kind': 'data'},
+                    'deconv_weights': {'value': None, 'kind': 'data'},
+                    'deconv_output_shape': {'value': None, 'kind': 'data'},
+                    'deconv_node': {'type': 'Deconvolution', 'op': 'Deconvolution', 'kind': 'op'},
+                    'deconv_output': {'value': None, 'kind': 'data'},
+                    'op_output': {'kind': 'op', 'op': 'Result'}
+                    }
+
+
+def create_deconv_graph(input_shape: int64_array, weights_shape: int64_array, output_shape: int64_array):
+    graph = build_graph(nodes_attributes,
+                        [('deconv_input', 'deconv_node'),
+                         ('deconv_weights', 'deconv_node'),
+                         ('deconv_output_shape', 'deconv_node'),
+                         ('deconv_node', 'deconv_output'),
+                         ('deconv_output', 'op_output')
+                         ],
+                        {'deconv_input': {'shape': input_shape},
+                         'deconv_weights': {'shape': weights_shape,
+                                            'dim_attrs': ['spatial_dims', 'channel_dims', 'batch_dims', 'axis']},
+                         'deconv_output_shape': {'value': output_shape},
+                         'deconv_node': {'channel_dims': int64_array([1]),
+                                         'batch_dims': int64_array([0]),
+                                         'spatial_dims': int64_array([2, 3]),
+                                         'pad_spatial_shape': int64_array([[0, 0], [0, 0]]),
+                                         'kernel_spatial': int64_array([4, 4]),
+                                         'kernel_spatial_idx': int64_array([2, 3]),
+                                         'input_feature_channel': 0,
+                                         'output_feature_channel': 1,
+                                         'auto_pad': 'same_lower',
+                                         'output_padding': int64_array([0, 0, 1, 1]),
+                                         'type': 'Deconvolution',
+                                         'dilation': int64_array([1, 1, 1, 1]),
+                                         'stride': int64_array([1, 1, 2, 2]),
+                                         'pad': None,
+                                         'output': None,
+                                         'output_shape': None,
+                                         'get_group': get_conv_backprop_groups},
+                         'deconv_output': {'shape': None},
+                         })
+    return graph
+
+
+class TestConvolutionPartialInfer(unittest.TestCase):
+    def test_deconv_infer_one_group(self):
+        graph = create_deconv_graph(int64_array([1, 21, 18, 18]), int64_array([21, 50, 4, 4]),
+                                    int64_array([1, 50, 35, 35]))
+
+        Deconvolution.infer(Node(graph, 'deconv_node'))
+        res_shape = graph.node['deconv_output']['shape']
+        exp_shape = np.array([1, 50, 35, 35])
+
+        res_group = graph.node['deconv_node']['group']
+        exp_group = int64_array([1])
+
+        self.assertTrue(np.array_equal(exp_shape, res_shape),
+                        'values do not match expected: {} and computed: {}'.format(exp_shape, res_shape))
+
+        self.assertTrue(np.array_equal(exp_group, res_group),
+                        'group number values do not match expected: {} and computed: {}'.format(exp_group, res_group))
+
+    def test_deconv_infer_several_groups(self):
+        graph = create_deconv_graph(int64_array([1, 21, 18, 18]), int64_array([21, 50, 4, 4]),
+                                    int64_array([1, 350, 35, 35]))
+
+        Deconvolution.infer(Node(graph, 'deconv_node'))
+        res_shape = graph.node['deconv_output']['shape']
+        exp_shape = np.array([1, 350, 35, 35])
+
+        res_group = graph.node['deconv_node']['group']
+        exp_group = int64_array([7])
+
+        self.assertTrue(np.array_equal(exp_shape, res_shape),
+                        'values do not match expected: {} and computed: {}'.format(exp_shape, res_shape))
+
+        self.assertTrue(np.array_equal(exp_group, res_group),
+                        'group number values do not match expected: {} and computed: {}'.format(exp_group, res_group))


### PR DESCRIPTION
**Root cause analysis:** [TensorFlow Conv2DBackpropInput](https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/conv2-d-backprop-input) operation covers Grouped Deconvolution case that has been omitted in Model Optimizer Support.

**Solution:** Add group number computation function. TF does not support Grouped ConvBackpropInput on CPU so the layer tests are not added. In the meantime, I did manual check on the customer inpainting model by collecting reference results on GPU and OV results match them.

**Ticket:** 72871

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names

Validation:
* [x]  Unit tests - Added a couple of shape inference tests to cover the single and multiple group cases
* [x]  Framework operation tests - Didn't add because Grouped Conv2DBackpropInput is not supported by TF-CPU
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check - Checked on custom Inpainting model. See the ticket.

Documentation:
* [x]  Supported frameworks operations list - Already updated
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A

Signed-off-by: Roman Kazantsev <roman.kazantsev@intel.com>
