### PR TITLE
Fix broken xml in case of skip before setting deviceName

### DIFF
--- a/src/tests/ie_test_utils/functional_test_utils/src/layer_test_utils/summary.cpp
+++ b/src/tests/ie_test_utils/functional_test_utils/src/layer_test_utils/summary.cpp
@@ -260,6 +260,9 @@ void Summary::saveReport() {
 
     auto &summary = Summary::getInstance();
     auto stats = summary.getOPsStats();
+    if (stats.empty()) {
+        return;
+    }
 
     pugi::xml_document doc;
 


### PR DESCRIPTION
### Details:
 - *It is added check that device name is set, becase if device name is not set it is added tag <:anonymous>*

### Tickets:
 - *ticket-id*
