### PR TITLE
Fixed detection of sample type c / cpp

### DIFF
--- a/samples/cpp/build_samples.sh
+++ b/samples/cpp/build_samples.sh
@@ -14,7 +14,7 @@ usage() {
     exit 1
 }
 
-samples_type=$(basename "$PWD")
+samples_type=$(basename "$( dirname "${BASH_SOURCE[0]-$0}" )" )
 build_dir="$HOME/inference_engine_${samples_type}_samples_build"
 sample_install_dir=""
 


### PR DESCRIPTION
### Details:
 - If the `build_samples.sh` is run not from `samples/cpp`, it prints wrong samples type based on PWD, but not on folder where the script is located

### Tickets:
 - [CVS-83065](https://jira.devtools.intel.com/browse/CVS-83065)
