### PR TITLE
[POT] Additional config check in algoritm sections

### DIFF
--- a/tools/pot/openvino/tools/pot/configs/config.py
+++ b/tools/pot/openvino/tools/pot/configs/config.py
@@ -275,7 +275,12 @@ class Config(Dict):
 
         # check algorithm parameters
         for algo in self['compression']['algorithms']:
+
             algo_name = algo['name']
+            unsupported_params = [key for key in algo if key not in ['name', 'params']]
+            if unsupported_params:
+                raise RuntimeError(f'Unsupported params for {algo_name} algorithm section: ' + ', '.join(unsupported_params))
+
             if algo_name in supported_params:
                 if algo_name == 'AccuracyAwareQuantization':
                     backup = deepcopy(supported_params['AccuracyAwareQuantization'])

--- a/tools/pot/tests/test_wrong_config.py
+++ b/tools/pot/tests/test_wrong_config.py
@@ -141,6 +141,14 @@ ALGORITHM_SETTINGS = {
             }
         },
         'Algorithm AccuracyAwareQuantization. Unknown parameter: max_drop'
+    ),
+    'wrong_algo_keys': (
+        {
+            "name": "FastBiasCorrection",
+            "stat_subset_size": 10,
+            "target_device": "ANY",
+        },
+        'Unsupported params for FastBiasCorrection algorithm section: stat_subset_size, target_device'
     )
 }
 


### PR DESCRIPTION
### Details:
Check on possible keys in algo sections was added. Without such check it's possible to launch pot with not valid config keys, which are skipped during config validation. (Motivation: I personally was caught specifying `stat_subsed_size` in `algo` section instead of  `params` section of `algo` and was waiting for calibration on whole imagenet val set)
