### PR TITLE
[GPU] Support implicit crop in input transposition.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -164,7 +164,7 @@ bool concat_in_place_optimization::match(concatenation_node& node) {
         // reverted condition - if any of this node's inputs is used by more than one primitive
         // and is not optimized concatenation then do not fuse buffers
         // todo: we need add padding support for all optimized kernels to remove this condition
-        if (!input->is_type<pooling>() && !input->is_type<convolution>() &&
+        if (!input->is_type<pooling>() && !input->is_type<convolution>() && !input->is_type<quantize>() &&
             !input->is_type<activation>() && !input->is_type<deconvolution>() &&
             !input->is_type<concatenation>() && !input->is_type<crop>() && !input->is_type<scale>() && !input->is_type<eltwise>() &&
             !input->is_type<resample>())
@@ -353,7 +353,7 @@ void prepare_buffer_fusing::run(program& p) {
                 // do not optimize crop if paddings are not properly aligned
                 for (auto& usr : node.get_users()) {
                     auto usr_layout = usr->get_output_layout();
-                    if (usr_layout.format == format::b_fs_yx_fsv16 &&
+                    if (!usr->is_type<quantize>() && usr_layout.format == format::b_fs_yx_fsv16 &&
                         (opt_lower_pad % 16 != 0 || opt_upper_pad % 16 != 0))
                         return;
                     if (input_layout.data_padding.lower_size().batch[0] != 0 || input_layout.data_padding.upper_size().batch[0] != 0 ||

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -353,7 +353,7 @@ void prepare_buffer_fusing::run(program& p) {
                 // do not optimize crop if paddings are not properly aligned
                 for (auto& usr : node.get_users()) {
                     auto usr_layout = usr->get_output_layout();
-                    if (!usr->is_type<quantize>() && usr_layout.format == format::b_fs_yx_fsv16 &&
+                    if (usr_layout.format == format::b_fs_yx_fsv16 &&
                         (opt_lower_pad % 16 != 0 || opt_upper_pad % 16 != 0))
                         return;
                     if (input_layout.data_padding.lower_size().batch[0] != 0 || input_layout.data_padding.upper_size().batch[0] != 0 ||

--- a/src/plugins/intel_gpu/src/graph/include/quantize_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/quantize_inst.h
@@ -17,6 +17,10 @@ template <>
 struct typed_program_node<quantize> : public typed_program_node_base<quantize> {
     using parent = typed_program_node_base<quantize>;
 
+    typed_program_node(std::shared_ptr<quantize> prim, program& prog) : parent(prim, prog) {
+        support_padding_all(true);
+    }
+
 public:
     using parent::parent;
 

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -23,6 +23,7 @@
 #include "mvn_inst.h"
 #include "depth_to_space_inst.h"
 #include "region_yolo_inst.h"
+#include "crop_inst.h"
 #include <vector>
 #include <memory>
 #include <utility>
@@ -1596,6 +1597,13 @@ format layout_optimizer::get_preferred_format(program_node& node) {
                 if (layout.format.spatial_num() == 2 && layout.feature() % 32 == 0 && expected_conv_fmt == format::b_fs_yx_fsv32)
                     expected = expected_conv_fmt;
             }
+        }
+
+        // In case of input -> ... -> quantize -> concat
+        if (expected == format::any
+            && (node.get_users().size() == 1 && node.get_users().front()->is_type<concatenation>())
+            && (layout.batch() < 4 && layout.feature() < 4)) {
+                expected = format::get_default_format(layout.get_rank(), false, false);
         }
     } else if (node.is_type<reorder>() || node.is_type<input_layout>()) {
         expected = node.get_output_layout().format;

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -23,7 +23,6 @@
 #include "mvn_inst.h"
 #include "depth_to_space_inst.h"
 #include "region_yolo_inst.h"
-#include "crop_inst.h"
 #include <vector>
 #include <memory>
 #include <utility>

--- a/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
@@ -16,6 +16,7 @@
 #include <intel_gpu/primitives/crop.hpp>
 #include <intel_gpu/primitives/mvn.hpp>
 #include <intel_gpu/primitives/permute.hpp>
+#include <intel_gpu/primitives/concatenation.hpp>
 
 #include <cmath>
 
@@ -3569,6 +3570,109 @@ TEST_P(onednn_multiple_binary_add_full_tensor, basic) {
 INSTANTIATE_TEST_SUITE_P(multiple_eltwise_sum_fusings_gpu, onednn_multiple_binary_add_full_tensor, ::testing::ValuesIn(std::vector<convolution_eltw_sum_test_params>{
     convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_BINARY_ADD_1, 2, 7 },
     convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_SUM_1, 2, 7 },
+}));
+
+struct implicit_crop_concat_convolution_test_params {
+    tensor in_shape;
+    tensor out_shape;
+    tensor kernel;
+    ov::Strides stride;
+    ov::CoordinateDiff pad;
+    ov::Strides dilation;
+    uint32_t groups;
+    data_types data_type;
+    format input_format;
+    data_types weights_type;
+    format weights_format;
+    data_types output_data_type;
+    format output_format;
+    data_types default_type;
+    format default_format;
+    size_t expected_fused_primitives;
+    size_t expected_not_fused_primitives;
+};
+
+class ImplicitCropConcatTestOneDNN: public BaseFusingTest<implicit_crop_concat_convolution_test_params> {
+public:
+    void execute(implicit_crop_concat_convolution_test_params& p) {
+        auto input_prim = p.data_type == data_types::u8 ? get_mem(get_input_layout(p), 0, 10) : get_mem(get_input_layout(p));
+
+        bo_not_fused = bo_fused;
+        // implementation_desc quantize_impl = { p.output_format, "quantize_gpu_ref", impl_types::ocl };
+        bo_not_fused.set_option(build_option::force_implementations({
+            { "quantize1", { p.output_format, "quantize_gpu_scale_shift_opt", impl_types::ocl } },
+            { "quantize2", { p.output_format, "quantize_gpu_scale_shift_opt", impl_types::ocl } },
+            { "quantize3", { p.output_format, "quantize_gpu_scale_shift_opt", impl_types::ocl } } }));
+
+        network network_not_fused(this->engine, this->topology_non_fused, bo_not_fused);
+        network network_fused(this->engine, this->topology_fused, bo_fused);
+        network_fused.set_input_data("input", input_prim);
+        network_not_fused.set_input_data("input", input_prim);
+        compare(network_not_fused, network_fused, p);
+    }
+
+    layout get_input_layout(implicit_crop_concat_convolution_test_params& p) {
+        auto pad = p.pad;
+        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[0]), static_cast<int>(pad[1]) };
+        return layout{ p.data_type, p.input_format, p.in_shape, padding{ pad_ } };
+    }
+
+    layout get_per_channel_layout(implicit_crop_concat_convolution_test_params& p) {
+        return layout{ p.default_type, p.default_format, tensor{ 1, p.out_shape.feature[0], 1, 1 } };
+    }
+};
+
+class implicit_crop_concat_bfyx_input_tensor : public ImplicitCropConcatTestOneDNN {};
+
+TEST_P(implicit_crop_concat_bfyx_input_tensor, basic) {
+    auto p = GetParam();
+
+    tensor crop_output = get_input_layout(p).size;
+    crop_output.feature[0] = 1;
+    auto crop_offset1 = tensor(batch(0), feature(0), spatial(0, 0));
+    auto crop_offset2 = tensor(batch(0), feature(1), spatial(0, 0));
+    auto crop_offset3 = tensor(batch(0), feature(2), spatial(0, 0));
+
+    create_topologies(
+        input_layout("input", get_input_layout(p)),
+        data("weights", get_mem(get_weights_layout(p))),
+        data("bias", get_mem(get_bias_layout(p))),
+
+        data("in_lo1", get_mem(get_single_element_layout(p), 0)),
+        data("in_hi1", get_mem(get_single_element_layout(p), 100)),
+        data("out_lo1", get_mem(get_single_element_layout(p), -127)),
+        data("out_hi1", get_mem(get_single_element_layout(p), 127)),
+
+        data("in_lo2", get_mem(get_single_element_layout(p), 0)),
+        data("in_hi2", get_mem(get_single_element_layout(p), 100)),
+        data("out_lo2", get_mem(get_single_element_layout(p), -127)),
+        data("out_hi2", get_mem(get_single_element_layout(p), 127)),
+
+        data("in_lo3", get_mem(get_single_element_layout(p), 0)),
+        data("in_hi3", get_mem(get_single_element_layout(p), 100)),
+        data("out_lo3", get_mem(get_single_element_layout(p), -127)),
+        data("out_hi3", get_mem(get_single_element_layout(p), 127)),
+
+        crop("crop1", "input", crop_output, crop_offset1),
+        quantize("quantize1", "crop1", "in_lo1", "in_hi1", "out_lo1", "out_hi1", 255, data_types::i8),
+        crop("crop2", "input", crop_output, crop_offset2),
+        quantize("quantize2", "crop2", "in_lo2", "in_hi2", "out_lo2", "out_hi2", 255, data_types::i8),
+        crop("crop3", "input", crop_output, crop_offset3),
+        quantize("quantize3", "crop3", "in_lo3", "in_hi3", "out_lo3", "out_hi3", 255, data_types::i8),
+        concatenation("concat", {"quantize1", "quantize2", "quantize3"}, 1),
+        convolution("conv_prim", "concat", { "weights" }, { "bias" }, p.groups, p.stride, p.pad, p.dilation, false),
+        reorder("reorder_bfyx", "conv_prim", p.default_format, p.default_type)
+    );
+
+    tolerance = 1.f;
+    execute(p);
+}
+
+// in_shape; out_shape; kernel; stride; pad; dilation; groups; input_data_type; input_format; weights_type; weights_format; output_data_type; output_format; default_type; default_format;
+#define CASE_CROP_FQ_CONCAT_1 { 1, 3, 10, 10 }, { 1, 16, 10, 10 }, { 1, 1, 3, 3 }, { 1, 1 }, { 0, 0 }, { 1, 1 }, 1, data_types::u8, format::bfyx, data_types::i8, format::bfyx, data_types::i8, format::b_fs_yx_fsv16, data_types::f32, format::bfyx
+
+INSTANTIATE_TEST_SUITE_P(implicit_crop_concat_conv_fusings_gpu, implicit_crop_concat_bfyx_input_tensor, ::testing::ValuesIn(std::vector<implicit_crop_concat_convolution_test_params>{
+    implicit_crop_concat_convolution_test_params{ CASE_CROP_FQ_CONCAT_1, 5, 9 },
 }));
 
 #endif  // ENABLE_ONEDNN_FOR_GPU


### PR DESCRIPTION
+ Make the crop in front of quantize implicit by changing output format to bfyx.
+ Choose onednn jit:ir as a kernel of first convolution, if feature size of input tensor is less than or equal to 4.

Ticket
- *82742*