### PR TITLE
River/tbb unload bug fixing

### DIFF
--- a/src/cmake/ie_parallel.cmake
+++ b/src/cmake/ie_parallel.cmake
@@ -72,17 +72,21 @@ function(set_ie_threading_interface_for TARGET_NAME)
 
     if(target_type STREQUAL "INTERFACE_LIBRARY")
         set(LINK_TYPE "INTERFACE")
+        set(COMPILE_DEF_TYPE "INTERFACE")
     elseif(target_type STREQUAL "EXECUTABLE" OR target_type STREQUAL "OBJECT_LIBRARY" OR
            target_type STREQUAL "MODULE_LIBRARY")
         set(LINK_TYPE "PRIVATE")
+        set(COMPILE_DEF_TYPE "PUBLIC")
     elseif(target_type STREQUAL "STATIC_LIBRARY")
         # Affected libraries: inference_engine_s, openvino_gapi_preproc_s
         # they don't have TBB in public headers => PRIVATE
         set(LINK_TYPE "PRIVATE")
+        set(COMPILE_DEF_TYPE "PUBLIC")
     elseif(target_type STREQUAL "SHARED_LIBRARY")
         # Affected libraries: inference_engine only
         # TODO: why TBB propogates its headers to inference_engine?
         set(LINK_TYPE "PRIVATE")
+        set(COMPILE_DEF_TYPE "PUBLIC")
     else()
         message(WARNING "Unknown target type")
     endif()
@@ -113,6 +117,7 @@ function(set_ie_threading_interface_for TARGET_NAME)
         if (TBB_FOUND)
             set(IE_THREAD_DEFINE "IE_THREAD_TBB")
             ie_target_link_libraries(${TARGET_NAME} ${LINK_TYPE} ${TBB_IMPORTED_TARGETS})
+            target_compile_definitions(${TARGET_NAME} ${COMPILE_DEF_TYPE} TBB_PREVIEW_WAITING_FOR_WORKERS=1)
         else ()
             set(THREADING "SEQ" PARENT_SCOPE)
             message(WARNING "TBB was not found by the configured TBB_DIR path.\

--- a/src/core/include/openvino/op/constant.hpp
+++ b/src/core/include/openvino/op/constant.hpp
@@ -713,6 +713,8 @@ private:
         return shape_size(m_shape) * m_element_type.size();
     }
 
+    friend class frontend::FrontEnd;
+    std::shared_ptr<void> m_shared_object{};
     element::Type m_element_type;
     Shape m_shape{};
     std::shared_ptr<ngraph::runtime::AlignedBuffer> m_data;

--- a/src/frontends/common/src/frontend.cpp
+++ b/src/frontends/common/src/frontend.cpp
@@ -9,8 +9,8 @@
 #include "openvino/frontend/extension/op.hpp"
 #include "openvino/frontend/manager.hpp"
 #include "openvino/frontend/place.hpp"
-#include "plugin_loader.hpp"
 #include "openvino/op/constant.hpp"
+#include "plugin_loader.hpp"
 #include "so_extension.hpp"
 #include "utils.hpp"
 

--- a/src/frontends/common/src/frontend.cpp
+++ b/src/frontends/common/src/frontend.cpp
@@ -10,6 +10,7 @@
 #include "openvino/frontend/manager.hpp"
 #include "openvino/frontend/place.hpp"
 #include "plugin_loader.hpp"
+#include "openvino/op/constant.hpp"
 #include "so_extension.hpp"
 #include "utils.hpp"
 
@@ -26,6 +27,11 @@ std::shared_ptr<ov::Model> FrontEnd::create_copy(const std::shared_ptr<ov::Model
                                         ov_model->get_friendly_name());
     copy->m_shared_object = shared_object;
     copy->get_rt_info() = ov_model->get_rt_info();
+    for (auto& op : copy->get_ordered_ops()) {
+        if (auto c = std::dynamic_pointer_cast<ov::op::v0::Constant>(op)) {
+            c->m_shared_object = shared_object;
+        }
+    }
     return copy;
 }
 

--- a/src/inference/dev_api/threading/ie_executor_manager.hpp
+++ b/src/inference/dev_api/threading/ie_executor_manager.hpp
@@ -66,6 +66,15 @@ public:
      */
     INFERENCE_ENGINE_DEPRECATED("Use IInferencePlugin::executorManager() instead")
     static ExecutorManager* getInstance();
+
+    /**
+     * @brief Set TBB terminate flag
+     * @param flag A boolean value:
+     * True to explicitly terminate tbb when ExecutorManager destructing
+     * False to not explicitly terminate tbb when ExecutorManager destructing
+     * @return void
+     */
+    virtual void setTbbFlag(bool flag) = 0;
 };
 
 INFERENCE_ENGINE_API_CPP(ExecutorManager::Ptr) executorManager();

--- a/src/inference/dev_api/threading/ie_istreams_executor.hpp
+++ b/src/inference/dev_api/threading/ie_istreams_executor.hpp
@@ -91,10 +91,11 @@ public:
                                                                          //!< No binding by default
         int _threadBindingStep = 1;                                      //!< In case of @ref CORES binding offset type
                                                                          //!< thread binded to cores with defined step
-        int _threadBindingOffset = 0;  //!< In case of @ref CORES binding offset type thread binded to cores
-                                       //!< starting from offset
-        int _threads = 0;              //!< Number of threads distributed between streams.
-                                       //!< Reserved. Should not be used.
+        int _threadBindingOffset = 0;   //!< In case of @ref CORES binding offset type thread binded to cores
+                                        //!< starting from offset
+        int _threads = 0;               //!< Number of threads distributed between streams.
+                                        //!< Reserved. Should not be used.
+        bool _tbbTerminateFlag = true;  //!< Whether terminate tbb during executor destructing
         enum PreferredCoreType {
             ANY,
             LITTLE,

--- a/src/inference/include/ie/ie_plugin_config.hpp
+++ b/src/inference/include/ie/ie_plugin_config.hpp
@@ -450,6 +450,14 @@ DECLARE_CONFIG_KEY(ENFORCE_BF16);
  */
 DECLARE_CONFIG_KEY(CACHE_DIR);
 
+/**
+ * @brief The key for setting to whether terminate tbb when plugin executor destructing
+ * value type: boolean
+ *   - YES will explicitly terminate tbb when plugin executor destructing
+ *   - NO will not explicitly terminate tbb when plugin executor destructing
+ */
+DECLARE_CONFIG_KEY(TBB_TERMINATE_ENABLE);
+
 }  // namespace PluginConfigParams
 
 /**

--- a/src/inference/src/ie_core.cpp
+++ b/src/inference/src/ie_core.cpp
@@ -255,7 +255,6 @@ class CoreImpl : public ie::ICore, public std::enable_shared_from_this<ie::ICore
     };
 
     ExecutorManager::Ptr executorManagerPtr;
-    mutable ov::frontend::FrontEndManager frontEndManager;
     mutable std::unordered_set<std::string> opsetNames;
     // TODO: make extensions to be optional with conditional compilation
     mutable std::vector<ie::IExtensionPtr> extensions;
@@ -529,25 +528,14 @@ public:
 
     ie::CNNNetwork ReadNetwork(const std::string& modelPath, const std::string& binPath) const override {
         OV_ITT_SCOPE(FIRST_INFERENCE, ov::itt::domains::IE_RT, "CoreImpl::ReadNetwork from file");
-        return InferenceEngine::details::ReadNetwork(modelPath,
-                                                     binPath,
-                                                     extensions,
-                                                     ov_extensions,
-                                                     newAPI,
-                                                     frontEndManager);
+        return InferenceEngine::details::ReadNetwork(modelPath, binPath, extensions, ov_extensions, newAPI);
     }
 
     ie::CNNNetwork ReadNetwork(const std::string& model,
                                const ie::Blob::CPtr& weights,
                                bool frontendMode = false) const override {
         OV_ITT_SCOPE(FIRST_INFERENCE, ov::itt::domains::IE_RT, "CoreImpl::ReadNetwork from memory");
-        return InferenceEngine::details::ReadNetwork(model,
-                                                     weights,
-                                                     extensions,
-                                                     ov_extensions,
-                                                     newAPI,
-                                                     frontEndManager,
-                                                     frontendMode);
+        return InferenceEngine::details::ReadNetwork(model, weights, extensions, ov_extensions, newAPI, frontendMode);
     }
 
     bool isNewAPI() const override {

--- a/src/inference/src/ie_core.cpp
+++ b/src/inference/src/ie_core.cpp
@@ -546,7 +546,8 @@ public:
                                                      extensions,
                                                      ov_extensions,
                                                      newAPI,
-                                                     frontEndManager);
+                                                     frontEndManager,
+                                                     frontendMode);
     }
 
     bool isNewAPI() const override {
@@ -1204,6 +1205,13 @@ public:
                 });
             if (config_is_device_name_in_regestry) {
                 SetConfigForPlugins(any_copy(config.second.as<ov::AnyMap>()), config.first);
+            }
+            if (config.first == CONFIG_KEY(TBB_TERMINATE_ENABLE)) {
+                if (config.second == CONFIG_VALUE(NO)) {
+                    executorManagerPtr->setTbbFlag(false);
+                } else {
+                    executorManagerPtr->setTbbFlag(true);
+                }
             }
         }
     }

--- a/src/inference/src/ie_core.cpp
+++ b/src/inference/src/ie_core.cpp
@@ -30,6 +30,7 @@
 #include "ie_ngraph_utils.hpp"
 #include "ie_plugin_config.hpp"
 #include "ie_remote_context.hpp"
+#include "ie_singleton_object.hpp"
 #include "ngraph/graph_util.hpp"
 #include "ngraph/ngraph.hpp"
 #include "ngraph/opsets/opset.hpp"

--- a/src/inference/src/ie_core.cpp
+++ b/src/inference/src/ie_core.cpp
@@ -10,7 +10,6 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <threading/ie_executor_manager.hpp>
 #include <vector>
 
 #include "any_copy.hpp"
@@ -45,6 +44,7 @@
 #include "openvino/util/file_util.hpp"
 #include "openvino/util/shared_object.hpp"
 #include "so_extension.hpp"
+#include "threading/ie_executor_manager.hpp"
 #include "xml_parse_utils.h"
 
 #ifdef OPENVINO_STATIC_LIBRARY
@@ -1196,7 +1196,7 @@ public:
                 SetConfigForPlugins(any_copy(config.second.as<ov::AnyMap>()), config.first);
             }
             if (config.first == CONFIG_KEY(TBB_TERMINATE_ENABLE)) {
-                if (config.second == CONFIG_VALUE(NO)) {
+                if (config.second == ov::Any(CONFIG_VALUE(NO))) {
                     executorManagerPtr->setTbbFlag(false);
                 } else {
                     executorManagerPtr->setTbbFlag(true);

--- a/src/inference/src/ie_network_reader.cpp
+++ b/src/inference/src/ie_network_reader.cpp
@@ -440,6 +440,11 @@ CNNNetwork convert_to_cnnnetwork(std::shared_ptr<ngraph::Function>& function,
     OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
+ov::frontend::FrontEndManager& get_frontend_manager() {
+    static ov::frontend::FrontEndManager manager;
+    return manager;
+}
+
 std::vector<ov::Extension::Ptr> wrap_old_extensions(const std::vector<InferenceEngine::IExtensionPtr>& exts) {
     std::vector<ov::Extension::Ptr> extensions;
     for (const auto& ext : exts) {
@@ -458,8 +463,7 @@ CNNNetwork details::ReadNetwork(const std::string& modelPath,
                                 const std::string& binPath,
                                 const std::vector<IExtensionPtr>& exts,
                                 const std::vector<ov::Extension::Ptr>& ov_exts,
-                                bool newAPI,
-                                ov::frontend::FrontEndManager& frontEndManager) {
+                                bool newAPI) {
 #ifdef ENABLE_IR_V7_READER
     // IR v7 obsolete code
     {
@@ -484,6 +488,7 @@ CNNNetwork details::ReadNetwork(const std::string& modelPath,
 #endif
 
     // Try to load with FrontEndManager
+    auto& manager = get_frontend_manager();
     ov::frontend::FrontEnd::Ptr FE;
     ov::frontend::InputModel::Ptr inputModel;
 
@@ -498,7 +503,7 @@ CNNNetwork details::ReadNetwork(const std::string& modelPath,
         params.emplace_back(weights_path);
     }
 
-    FE = frontEndManager.load_by_model(params);
+    FE = manager.load_by_model(params);
     if (FE) {
         FE->add_extension(ov_exts);
         if (!exts.empty())
@@ -513,7 +518,7 @@ CNNNetwork details::ReadNetwork(const std::string& modelPath,
 
     const auto fileExt = modelPath.substr(modelPath.find_last_of(".") + 1);
     std::string FEs;
-    for (const auto& fe_name : frontEndManager.get_available_front_ends())
+    for (const auto& fe_name : manager.get_available_front_ends())
         FEs += fe_name + " ";
     IE_THROW(NetworkNotRead) << "Unable to read the model: " << modelPath
                              << " Please check that model format: " << fileExt
@@ -526,7 +531,6 @@ CNNNetwork details::ReadNetwork(const std::string& model,
                                 const std::vector<IExtensionPtr>& exts,
                                 const std::vector<ov::Extension::Ptr>& ov_exts,
                                 bool newAPI,
-                                ov::frontend::FrontEndManager& frontEndManager,
                                 bool frontendMode) {
     std::istringstream modelStringStream(model);
     std::istream& modelStream = modelStringStream;
@@ -551,6 +555,7 @@ CNNNetwork details::ReadNetwork(const std::string& model,
 #endif  // ENABLE_IR_V7_READER
 
     // Try to load with FrontEndManager
+    auto& manager = get_frontend_manager();
     ov::frontend::FrontEnd::Ptr FE;
     ov::frontend::InputModel::Ptr inputModel;
 
@@ -562,7 +567,7 @@ CNNNetwork details::ReadNetwork(const std::string& model,
         params.emplace_back(weights_buffer);
     }
 
-    FE = frontEndManager.load_by_model(params);
+    FE = manager.load_by_model(params);
     if (FE) {
         FE->add_extension(ov_exts);
         if (!exts.empty())

--- a/src/inference/src/ie_network_reader.cpp
+++ b/src/inference/src/ie_network_reader.cpp
@@ -440,11 +440,6 @@ CNNNetwork convert_to_cnnnetwork(std::shared_ptr<ngraph::Function>& function,
     OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
-ov::frontend::FrontEndManager& get_frontend_manager() {
-    static ov::frontend::FrontEndManager manager;
-    return manager;
-}
-
 std::vector<ov::Extension::Ptr> wrap_old_extensions(const std::vector<InferenceEngine::IExtensionPtr>& exts) {
     std::vector<ov::Extension::Ptr> extensions;
     for (const auto& ext : exts) {
@@ -488,7 +483,7 @@ CNNNetwork details::ReadNetwork(const std::string& modelPath,
 #endif
 
     // Try to load with FrontEndManager
-    auto& manager = get_frontend_manager();
+    auto manager = FrontEndManagerHolder::instance()->get();
     ov::frontend::FrontEnd::Ptr FE;
     ov::frontend::InputModel::Ptr inputModel;
 
@@ -503,7 +498,7 @@ CNNNetwork details::ReadNetwork(const std::string& modelPath,
         params.emplace_back(weights_path);
     }
 
-    FE = manager.load_by_model(params);
+    FE = manager->load_by_model(params);
     if (FE) {
         FE->add_extension(ov_exts);
         if (!exts.empty())
@@ -518,7 +513,7 @@ CNNNetwork details::ReadNetwork(const std::string& modelPath,
 
     const auto fileExt = modelPath.substr(modelPath.find_last_of(".") + 1);
     std::string FEs;
-    for (const auto& fe_name : manager.get_available_front_ends())
+    for (const auto& fe_name : manager->get_available_front_ends())
         FEs += fe_name + " ";
     IE_THROW(NetworkNotRead) << "Unable to read the model: " << modelPath
                              << " Please check that model format: " << fileExt
@@ -555,7 +550,7 @@ CNNNetwork details::ReadNetwork(const std::string& model,
 #endif  // ENABLE_IR_V7_READER
 
     // Try to load with FrontEndManager
-    auto& manager = get_frontend_manager();
+    auto manager = FrontEndManagerHolder::instance()->get();
     ov::frontend::FrontEnd::Ptr FE;
     ov::frontend::InputModel::Ptr inputModel;
 
@@ -567,7 +562,7 @@ CNNNetwork details::ReadNetwork(const std::string& model,
         params.emplace_back(weights_buffer);
     }
 
-    FE = manager.load_by_model(params);
+    FE = manager->load_by_model(params);
     if (FE) {
         FE->add_extension(ov_exts);
         if (!exts.empty())

--- a/src/inference/src/ie_network_reader.cpp
+++ b/src/inference/src/ie_network_reader.cpp
@@ -526,7 +526,8 @@ CNNNetwork details::ReadNetwork(const std::string& model,
                                 const std::vector<IExtensionPtr>& exts,
                                 const std::vector<ov::Extension::Ptr>& ov_exts,
                                 bool newAPI,
-                                ov::frontend::FrontEndManager& frontEndManager) {
+                                ov::frontend::FrontEndManager& frontEndManager,
+                                bool frontendMode) {
     std::istringstream modelStringStream(model);
     std::istream& modelStream = modelStringStream;
 

--- a/src/inference/src/ie_network_reader.hpp
+++ b/src/inference/src/ie_network_reader.hpp
@@ -23,15 +23,13 @@ namespace details {
  * @param exts vector with extensions
  * @param ov_exts vector with OpenVINO extensions
  * @param newAPI Whether this function is called from OpenVINO 2.0 API
- * @param frontEndManager FrontEndManager to load corresponding frontend plugin
  * @return CNNNetwork
  */
 CNNNetwork ReadNetwork(const std::string& modelPath,
                        const std::string& binPath,
                        const std::vector<IExtensionPtr>& exts,
                        const std::vector<ov::Extension::Ptr>& ov_exts,
-                       bool newAPI,
-                       ov::frontend::FrontEndManager& frontEndManager);
+                       bool newAPI);
 /**
  * @brief Reads IR xml and bin (with the same name) files
  * @param model string with IR
@@ -39,7 +37,6 @@ CNNNetwork ReadNetwork(const std::string& modelPath,
  * @param exts vector with extensions
  * @param ov_exts vector with OpenVINO extensions
  * @param newAPI Whether this function is called from OpenVINO 2.0 API
- * @param frontEndManager FrontEndManager to load corresponding frontend plugin
  * @param frontendMode read network without post-processing or other transformations
  * @return CNNNetwork
  */
@@ -48,7 +45,6 @@ CNNNetwork ReadNetwork(const std::string& model,
                        const std::vector<IExtensionPtr>& exts,
                        const std::vector<ov::Extension::Ptr>& ov_exts,
                        bool newAPI,
-                       ov::frontend::FrontEndManager& frontEndManager,
                        bool frontendMode = false);
 
 }  // namespace details

--- a/src/inference/src/ie_network_reader.hpp
+++ b/src/inference/src/ie_network_reader.hpp
@@ -10,6 +10,7 @@
 #include "ie_blob.h"
 #include "ie_iextension.h"
 #include "openvino/core/extension.hpp"
+#include "openvino/frontend/manager.hpp"
 
 namespace InferenceEngine {
 namespace details {
@@ -22,13 +23,15 @@ namespace details {
  * @param exts vector with extensions
  * @param ov_exts vector with OpenVINO extensions
  * @param newAPI Whether this function is called from OpenVINO 2.0 API
+ * @param frontEndManager FrontEndManager to load corresponding frontend plugin
  * @return CNNNetwork
  */
 CNNNetwork ReadNetwork(const std::string& modelPath,
                        const std::string& binPath,
                        const std::vector<IExtensionPtr>& exts,
                        const std::vector<ov::Extension::Ptr>& ov_exts,
-                       bool newAPI);
+                       bool newAPI,
+                       ov::frontend::FrontEndManager& frontEndManager);
 /**
  * @brief Reads IR xml and bin (with the same name) files
  * @param model string with IR
@@ -36,7 +39,7 @@ CNNNetwork ReadNetwork(const std::string& modelPath,
  * @param exts vector with extensions
  * @param ov_exts vector with OpenVINO extensions
  * @param newAPI Whether this function is called from OpenVINO 2.0 API
- * @param frontendMode read network without post-processing or other transformations
+ * @param frontEndManager FrontEndManager to load corresponding frontend plugin
  * @return CNNNetwork
  */
 CNNNetwork ReadNetwork(const std::string& model,
@@ -44,7 +47,7 @@ CNNNetwork ReadNetwork(const std::string& model,
                        const std::vector<IExtensionPtr>& exts,
                        const std::vector<ov::Extension::Ptr>& ov_exts,
                        bool newAPI,
-                       bool frontendMode = false);
+                       ov::frontend::FrontEndManager& frontEndManager);
 
 }  // namespace details
 }  // namespace InferenceEngine

--- a/src/inference/src/ie_network_reader.hpp
+++ b/src/inference/src/ie_network_reader.hpp
@@ -40,6 +40,7 @@ CNNNetwork ReadNetwork(const std::string& modelPath,
  * @param ov_exts vector with OpenVINO extensions
  * @param newAPI Whether this function is called from OpenVINO 2.0 API
  * @param frontEndManager FrontEndManager to load corresponding frontend plugin
+ * @param frontendMode read network without post-processing or other transformations
  * @return CNNNetwork
  */
 CNNNetwork ReadNetwork(const std::string& model,
@@ -47,7 +48,8 @@ CNNNetwork ReadNetwork(const std::string& model,
                        const std::vector<IExtensionPtr>& exts,
                        const std::vector<ov::Extension::Ptr>& ov_exts,
                        bool newAPI,
-                       ov::frontend::FrontEndManager& frontEndManager);
+                       ov::frontend::FrontEndManager& frontEndManager,
+                       bool frontendMode = false);
 
 }  // namespace details
 }  // namespace InferenceEngine

--- a/src/inference/src/ie_singleton_object.cpp
+++ b/src/inference/src/ie_singleton_object.cpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ie_singleton_object.hpp"
+
+namespace InferenceEngine {
+std::list<std::shared_ptr<SingletonMem>> SingletonMem::m_pointers[MAX_SUPPORTED_SINGLETON_PRIORITY];
+std::mutex SingletonMem::m_mutex;
+
+void SingletonMem::releaseSingltons() {
+    std::lock_guard<std::mutex> lockGuard(m_mutex);
+    for (int i = MAX_SUPPORTED_SINGLETON_PRIORITY - 1; i >= 0; i--) {
+        while (!m_pointers[i].empty()) {
+            m_pointers[i].pop_front();
+        }
+    }
+}
+}  // namespace InferenceEngine

--- a/src/inference/src/ie_singleton_object.hpp
+++ b/src/inference/src/ie_singleton_object.hpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cassert>
+#include <list>
+#include <memory>
+#include <mutex>
+
+namespace InferenceEngine {
+
+#define MAX_SUPPORTED_SINGLETON_PRIORITY 4
+
+class NonCopyableObject {
+public:
+    NonCopyableObject(const NonCopyableObject&) = delete;
+    NonCopyableObject(NonCopyableObject&&) = delete;
+
+    NonCopyableObject& operator=(const NonCopyableObject&) = delete;
+    NonCopyableObject& operator=(NonCopyableObject&&) = delete;
+
+protected:
+    NonCopyableObject() = default;
+    virtual ~NonCopyableObject() = default;
+};
+
+class SingletonMem {
+public:
+    SingletonMem() = default;
+    virtual ~SingletonMem() = default;
+    virtual void setPriority(int priority = 3) {
+        std::lock_guard<std::mutex> lockGuard(m_mutex);
+        if (m_hasSetPriority) {
+            return;
+        }
+
+        m_pointers[priority].push_front(std::shared_ptr<SingletonMem>(this, [](SingletonMem* p) {
+            delete p;
+        }));
+        m_hasSetPriority = true;
+    }
+
+    static void releaseSingltons();
+
+private:
+    static std::mutex m_mutex;
+    static std::list<std::shared_ptr<SingletonMem>> m_pointers[MAX_SUPPORTED_SINGLETON_PRIORITY];
+    bool m_hasSetPriority{false};
+};
+
+template <typename Type>
+class SingletonObject : public NonCopyableObject, public SingletonMem {
+public:
+    static Type* instance() {
+        static Type* obj = nullptr;
+        std::call_once(m_onceFlag, [&]() {
+            obj = new Type();
+            assert(obj != nullptr);
+            obj->setPriority();
+        });
+        return obj;
+    }
+
+protected:
+    static std::once_flag m_onceFlag;
+    SingletonObject() = default;
+    virtual ~SingletonObject() = default;
+};
+
+template <typename Type>
+std::once_flag SingletonObject<Type>::m_onceFlag;
+}  // namespace InferenceEngine

--- a/src/inference/src/threading/ie_executor_manager.cpp
+++ b/src/inference/src/threading/ie_executor_manager.cpp
@@ -39,6 +39,7 @@ void ExecutorManagerImpl::setTbbFlag(bool flag) {
 }
 
 ExecutorManagerImpl::~ExecutorManagerImpl() {
+    clear();
     if (tbbTerminateFlag == true) {
         init.blocking_terminate();
     }
@@ -109,7 +110,7 @@ namespace {
 
 class ExecutorManagerHolder {
     std::mutex _mutex;
-    std::weak_ptr<ExecutorManager> _manager;
+    std::shared_ptr<ExecutorManager> _manager = NULL;
 
     ExecutorManagerHolder(const ExecutorManagerHolder&) = delete;
     ExecutorManagerHolder& operator=(const ExecutorManagerHolder&) = delete;
@@ -119,10 +120,9 @@ public:
 
     ExecutorManager::Ptr get() {
         std::lock_guard<std::mutex> lock(_mutex);
-        auto manager = _manager.lock();
-        if (!manager)
-            _manager = manager = std::make_shared<ExecutorManagerImpl>();
-        return manager;
+        if (!_manager)
+            _manager = std::make_shared<ExecutorManagerImpl>();
+        return _manager;
     }
 };
 

--- a/src/inference/src/threading/ie_executor_manager.cpp
+++ b/src/inference/src/threading/ie_executor_manager.cpp
@@ -21,9 +21,11 @@ public:
     size_t getExecutorsNumber() const override;
     size_t getIdleCPUStreamsExecutorsNumber() const override;
     void clear(const std::string& id = {}) override;
+    void setTbbFlag(bool flag) override;
 
 private:
     tbb::task_scheduler_init init;
+    bool tbbTerminateFlag = true;
     std::unordered_map<std::string, ITaskExecutor::Ptr> executors;
     std::vector<std::pair<IStreamsExecutor::Config, IStreamsExecutor::Ptr>> cpuStreamsExecutors;
     mutable std::mutex streamExecutorMutex;
@@ -32,8 +34,14 @@ private:
 
 }  // namespace
 
+void ExecutorManagerImpl::setTbbFlag(bool flag) {
+    tbbTerminateFlag = flag;
+}
+
 ExecutorManagerImpl::~ExecutorManagerImpl() {
-    init.blocking_terminate();
+    if (tbbTerminateFlag == true) {
+        init.blocking_terminate();
+    }
 }
 
 ITaskExecutor::Ptr ExecutorManagerImpl::getExecutor(const std::string& id) {

--- a/src/inference/src/threading/ie_istreams_executor.cpp
+++ b/src/inference/src/threading/ie_istreams_executor.cpp
@@ -27,6 +27,7 @@ std::vector<std::string> IStreamsExecutor::Config::SupportedKeys() const {
         CONFIG_KEY(CPU_BIND_THREAD),
         CONFIG_KEY(CPU_THREADS_NUM),
         CONFIG_KEY_INTERNAL(CPU_THREADS_PER_STREAM),
+        CONFIG_KEY(TBB_TERMINATE_ENABLE),
         ov::num_streams.name(),
         ov::inference_num_threads.name(),
         ov::affinity.name(),
@@ -150,6 +151,12 @@ void IStreamsExecutor::Config::SetConfig(const std::string& key, const std::stri
                        << ". Expected only non negative numbers (#threads)";
         }
         _threadsPerStream = val_i;
+    } else if (key == CONFIG_KEY(TBB_TERMINATE_ENABLE)) {
+        if (value == CONFIG_VALUE(NO)) {
+            _tbbTerminateFlag = false;
+        } else {
+            _tbbTerminateFlag = true;
+        }
     } else {
         IE_THROW() << "Wrong value for property key " << key;
     }
@@ -188,6 +195,12 @@ Parameter IStreamsExecutor::Config::GetConfig(const std::string& key) const {
         return decltype(ov::inference_num_threads)::value_type{_threads};
     } else if (key == CONFIG_KEY_INTERNAL(CPU_THREADS_PER_STREAM)) {
         return {std::to_string(_threadsPerStream)};
+    } else if (key == CONFIG_KEY(TBB_TERMINATE_ENABLE)) {
+        if (_tbbTerminateFlag) {
+            return CONFIG_VALUE(YES);
+        } else {
+            return CONFIG_VALUE(NO);
+        }
     } else {
         IE_THROW() << "Wrong value for property key " << key;
     }

--- a/src/inference/src/threading/ie_istreams_executor.cpp
+++ b/src/inference/src/threading/ie_istreams_executor.cpp
@@ -197,9 +197,9 @@ Parameter IStreamsExecutor::Config::GetConfig(const std::string& key) const {
         return {std::to_string(_threadsPerStream)};
     } else if (key == CONFIG_KEY(TBB_TERMINATE_ENABLE)) {
         if (_tbbTerminateFlag) {
-            return CONFIG_VALUE(YES);
+            return {CONFIG_VALUE(YES)};
         } else {
-            return CONFIG_VALUE(NO);
+            return {CONFIG_VALUE(NO)};
         }
     } else {
         IE_THROW() << "Wrong value for property key " << key;

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -779,6 +779,8 @@ Parameter Engine::GetConfig(const std::string& name, const std::map<std::string,
     } else if (name == ov::hint::num_requests) {
         const auto perfHintNumRequests = engConfig.perfHintsConfig.ovPerfHintNumRequests;
         return decltype(ov::hint::num_requests)::value_type(perfHintNumRequests);
+    } else if (name == CONFIG_KEY(TBB_TERMINATE_ENABLE)) {
+        return engConfig.streamExecutorConfig.GetConfig(name);
     }
     /* Internally legacy parameters are used with new API as part of migration procedure.
      * This fallback can be removed as soon as migration completed */


### PR DESCRIPTION
### Details:
Windows run inference on CPU, tbb library cannot be unloaded, which cause memory leak and unload/lingering threads.
This PR contains:
1) Explicitly to terminate tbb task scheduler during openvino destruction.
2) Add a new config to control whether call init.blocking_terminate(), define a new CONFIG_KEY named "TBB_TERMINATE_ENABLE", it is ON by default
3) Provide a global static object management mechanism to control static object destruction order, which is used to manage FrondEndManager and ExecutorManager to guard that ExecutorManager is destruction after FrondEndManager

### Tickets:
82487
