### PR TITLE
Added arm64 architecture condition for wheel creation

### DIFF
--- a/src/bindings/python/wheel/setup.py
+++ b/src/bindings/python/wheel/setup.py
@@ -36,7 +36,7 @@ elif machine == "X86":
     ARCH = "ia32"
 elif machine == "arm":
     ARCH = "arm"
-elif machine == "aarch64" or machine == 'arm64':
+elif machine == "aarch64" or machine == "arm64":
     ARCH = "arm64"
 
 # The following variables can be defined in environment or .env file

--- a/src/bindings/python/wheel/setup.py
+++ b/src/bindings/python/wheel/setup.py
@@ -36,7 +36,7 @@ elif machine == "X86":
     ARCH = "ia32"
 elif machine == "arm":
     ARCH = "arm"
-elif machine == "aarch64":
+elif machine == "aarch64" or machine == 'arm64':
     ARCH = "arm64"
 
 # The following variables can be defined in environment or .env file


### PR DESCRIPTION
### Details:
Added `arm64` identifier to architecture decision in wheel setup.
This allows Mac Silicon users to build the wheel package with ninja. 

#### Reason
`platform.machine()` returns `arm64` on a Mac Silicon.
Without the extra condition, the `ARCH` variable would not be set and python crashes while building the wheel.