### PR TITLE
[GPU] Fix unsupported fused_activation in oneDNN issue

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -246,8 +246,29 @@ void prepare_primitive_fusing::fuse_activations(program &p) {
                     return;
             }
 
-            if (input.is_type<reshape>() && use_onednn_impls)
-                return;
+            if (use_onednn_impls) {
+                if (input.is_type<reshape>())
+                    return;
+
+                std::vector<cldnn::activation_func> supported_onednn_activations = {
+                    cldnn::activation_func::relu,
+                    cldnn::activation_func::relu_negative_slope,
+                    cldnn::activation_func::gelu,
+                    cldnn::activation_func::elu,
+                    cldnn::activation_func::mish,
+                    cldnn::activation_func::swish,
+                    cldnn::activation_func::hswish,
+                    cldnn::activation_func::abs,
+                    cldnn::activation_func::exp,
+                    cldnn::activation_func::logistic,
+                    cldnn::activation_func::clamp,
+                    cldnn::activation_func::hyperbolic_tan,
+                };
+
+                auto af = node.get_primitive()->activation_function;
+                if (std::find(supported_onednn_activations.begin(), supported_onednn_activations.end(), af) == supported_onednn_activations.end())
+                    return;
+            }
 
             if (input.get_fused_primitives().empty()) {
                 input.add_fused_activation(node.get_primitive()->activation_function, node.get_primitive()->additional_params);


### PR DESCRIPTION
Supported fused_activations in oneDNN has limitation.
So check available fused_activation in case oneDNN in prepare_primitivie_fusing.

Signed-off-by: hyunback <hyunback.kim@intel.com>



### Tickets:
 - *81412*
