### PR TITLE
[PYTHON] Add lower bound for wheel package

### DIFF
--- a/src/bindings/python/requirements_test.txt
+++ b/src/bindings/python/requirements_test.txt
@@ -32,4 +32,4 @@ radon
 retrying
 tox
 types-pkg_resources
-wheel
+wheel>=0.36.2


### PR DESCRIPTION
### Details:
 - If system was using build-in wheel version which was lower than `0.36.2`, it was resulting in CMake errors due to dependency on `wheel.vendored` module. Adding lower bound solves the issue.

### Tickets:
 - *84294*
