### PR TITLE
Unbreak CPU functional tests for DFT operation

### DIFF
--- a/src/core/reference/src/runtime/reference/utils/fft_common.cpp
+++ b/src/core/reference/src/runtime/reference/utils/fft_common.cpp
@@ -50,7 +50,7 @@ std::vector<int64_t> coords_from_index(int64_t index, const std::vector<int64_t>
 }
 
 int64_t offset_from_coords_and_strides(const std::vector<int64_t>& coords, const std::vector<int64_t>& strides) {
-    assert(coords.size() < strides.size());
+    assert(coords.size() <= strides.size());
     int64_t offset = 0;
     int64_t num_of_axes = coords.size();
     for (int64_t i = 0; i < num_of_axes; ++i) {


### PR DESCRIPTION
### Details:
cpuFuncTests --gtest_filter=*DFT* currently fails due to assertion in fft_common.cpp, line 53
The change adjusts assertion check, so all DFT tests will pass.
