### PR TITLE
Fix setting default affinity property in cpuFuncTests

### DIFF
--- a/src/tests/functional/plugin/cpu/shared_tests_instances/behavior/ov_executable_network/properties.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/behavior/ov_executable_network/properties.cpp
@@ -66,7 +66,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_AutoBatch_BehaviorTests, OVCompiledModelPropertie
 #if (defined(__APPLE__) || defined(_WIN32))
 auto default_affinity = [] {
         auto numaNodes = InferenceEngine::getAvailableNUMANodes();
-        if (numaNodes.size() > 1) {
+        auto coreTypes = InferenceEngine::getAvailableCoresTypes();
+        if (coreTypes.size() > 1) {
+                return ov::Affinity::HYBRID_AWARE;
+        } else if (numaNodes.size() > 1) {
                 return ov::Affinity::NUMA;
         } else {
                 return ov::Affinity::NONE;

--- a/src/tests/functional/plugin/cpu/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
@@ -144,14 +144,20 @@ TEST(OVClassBasicTest, smoke_SetConfigAffinity) {
 
 #if (defined(__APPLE__) || defined(_WIN32))
     auto numaNodes = InferenceEngine::getAvailableNUMANodes();
-    auto defaultBindThreadParameter = numaNodes.size() > 1 ? ov::Affinity::NUMA : ov::Affinity::NONE;
+    auto coreTypes = InferenceEngine::getAvailableCoresTypes();
+    auto defaultBindThreadParameter = ov::Affinity::NONE;
+    if (coreTypes.size() > 1) {
+        defaultBindThreadParameter = ov::Affinity::HYBRID_AWARE;
+    } else if (numaNodes.size() > 1) {
+        defaultBindThreadParameter = ov::Affinity::NUMA;
+    }
 #else
     auto defaultBindThreadParameter = ov::Affinity::CORE;
 #endif
     OV_ASSERT_NO_THROW(value = ie.get_property("CPU", ov::affinity));
     ASSERT_EQ(defaultBindThreadParameter, value);
 
-    const ov::Affinity affinity = ov::Affinity::HYBRID_AWARE;
+    const ov::Affinity affinity = defaultBindThreadParameter == ov::Affinity::HYBRID_AWARE ? ov::Affinity::NUMA : ov::Affinity::HYBRID_AWARE;
     OV_ASSERT_NO_THROW(ie.set_property("CPU", ov::affinity(affinity)));
     OV_ASSERT_NO_THROW(value = ie.get_property("CPU", ov::affinity));
     ASSERT_EQ(affinity, value);

--- a/src/tests/functional/plugin/cpu/shared_tests_instances/behavior/plugin/configuration_tests.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/behavior/plugin/configuration_tests.cpp
@@ -12,7 +12,10 @@ namespace {
     #if (defined(__APPLE__) || defined(_WIN32))
     auto defaultBindThreadParameter = InferenceEngine::Parameter{[] {
         auto numaNodes = InferenceEngine::getAvailableNUMANodes();
-        if (numaNodes.size() > 1) {
+        auto coreTypes = InferenceEngine::getAvailableCoresTypes();
+        if (coreTypes.size() > 1) {
+                return std::string{CONFIG_VALUE(HYBRID_AWARE)};
+        } else if (numaNodes.size() > 1) {
             return std::string{CONFIG_VALUE(NUMA)};
         } else {
             return std::string{CONFIG_VALUE(NO)};


### PR DESCRIPTION
CPU plugin sets default affinity to HYBRID_AWARE if it's running on AlderLake,.
So we need to reflect that in cpuFuncTests.
