### PR TITLE
Fix conformance test runner handling of input directories

### DIFF
--- a/src/tests/functional/plugin/conformance/test_runner/conformance_infra/include/conformance.hpp
+++ b/src/tests/functional/plugin/conformance/test_runner/conformance_infra/include/conformance.hpp
@@ -48,10 +48,10 @@ inline std::vector<std::string> getModelPaths(const std::vector<std::string>& co
     std::vector<std::string> result;
     for (const auto& conformance_ir_path : conformance_ir_paths) {
         std::vector<std::string> tmp_buf;
-        if (CommonTestUtils::fileExists(conformance_ir_path)) {
-            tmp_buf = CommonTestUtils::readListFiles({conformance_ir_path});
-        } else if (CommonTestUtils::directoryExists(conformance_ir_path)) {
+        if (CommonTestUtils::directoryExists(conformance_ir_path)) {
             tmp_buf = CommonTestUtils::getFileListByPatternRecursive({conformance_ir_path}, {std::regex(R"(.*\.xml)")});
+        } else if (CommonTestUtils::fileExists(conformance_ir_path)) {
+            tmp_buf = CommonTestUtils::readListFiles({conformance_ir_path});
         } else {
             continue;
         }


### PR DESCRIPTION
Check first whether the path specified by --input_dirs is a directory.

Otherwise the argument is always treated as a .lst file,
and in case it is a directory it silently fails,
which causes the test runner to not execute any tests intended.