### PR TITLE
[GPU] Improve int8 FC performance 

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -862,15 +862,12 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             should_fuse |= input_data.is_type<pooling>() && quantize_node.get_scale_shift_opt() &&
                            pooling_supports_fusings(input_data.as<pooling>());
 
-            should_fuse |= input_data.is_type<fully_connected>() && fc_supports_fusings(input_data.as<fully_connected>()) &&
-                           quantize_node.get_scale_shift_opt() &&
-                           out_dt_is_i8_u8;
+            should_fuse |= input_data.is_type<fully_connected>() && quantize_node.get_scale_shift_opt();
 
             should_fuse |= input_data.is_type<lrn>() && quantize_node.get_scale_shift_opt();
 
             should_fuse |= input_data.is_type<gemm>() && gemm_supports_fusings(input_data.as<gemm>()) &&
-                           quantize_node.get_scale_shift_opt() &&
-                           out_dt_is_i8_u8;
+                           quantize_node.get_scale_shift_opt();
 
             should_fuse |= input_data.is_type<resample>() &&
                            quantize_node.get_scale_shift_opt() &&

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
@@ -77,11 +77,10 @@ void prepare_primitive_fusing_through::run(program& p) {
             auto& quantize_node = node->as<quantize>();
             bool per_tensor_values = quantize_node.get_scale_shift_opt() &&
                                      quantize_node.get_per_tensor_input_scale() &&
-                                     ((quantize_node.get_per_tensor_input_shift() && quantize_node.get_need_pre_shift())
-                                      || !quantize_node.get_need_pre_shift()) &&
+                                     (quantize_node.get_per_tensor_input_shift() || !quantize_node.get_need_pre_shift()) &&
                                      quantize_node.get_per_tensor_input_range() &&
                                      quantize_node.get_per_tensor_output_scale() &&
-                                     quantize_node.get_per_tensor_output_shift() &&
+                                     (quantize_node.get_per_tensor_output_shift() || !quantize_node.get_need_post_shift()) &&
                                      quantize_node.get_per_tensor_output_range();
 
             if (!per_tensor_values)

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
@@ -77,7 +77,8 @@ void prepare_primitive_fusing_through::run(program& p) {
             auto& quantize_node = node->as<quantize>();
             bool per_tensor_values = quantize_node.get_scale_shift_opt() &&
                                      quantize_node.get_per_tensor_input_scale() &&
-                                     quantize_node.get_per_tensor_input_shift() &&
+                                     ((quantize_node.get_per_tensor_input_shift() && quantize_node.get_need_pre_shift())
+                                      || !quantize_node.get_need_pre_shift()) &&
                                      quantize_node.get_per_tensor_input_range() &&
                                      quantize_node.get_per_tensor_output_scale() &&
                                      quantize_node.get_per_tensor_output_shift() &&

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -445,7 +445,10 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             return false;
         });
 
-        auto params = LayerTransformation::Params(true, element::f32, defaultPrecisions, false);
+        bool reshapeIgnorePerTensorQuantizationCheck = false;
+        if (device_info.supports_immad) // Disable reshape transform until onednn i8 fc is optimized
+            reshapeIgnorePerTensorQuantizationCheck = true;
+        auto params = LayerTransformation::Params(true, element::f32, defaultPrecisions, reshapeIgnorePerTensorQuantizationCheck);
         lptManager.register_pass<LowPrecision>(supportedPrecisions, perTensorQuantization, params);
         lptManager.run_passes(func);
     }

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -445,7 +445,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             return false;
         });
 
-        auto params = LayerTransformation::Params(true, element::f32, defaultPrecisions, true);
+        auto params = LayerTransformation::Params(true, element::f32, defaultPrecisions, false);
         lptManager.register_pass<LowPrecision>(supportedPrecisions, perTensorQuantization, params);
         lptManager.run_passes(func);
     }


### PR DESCRIPTION
### Details:
 - Enable FP quant fusing for FC and gemm 
 - Enable more region can be mapped to int8 (disabled ignoreReshape flag for cldnn path. The flag is still turned on for onednn since onednn FC is not optimized for int8 yet. ).
 - Enabled more quantization can be fused through reshape/reorder

### Tickets:
 - 84106
 - 81451
