### PR TITLE
Getting of python version depend on the used shell

### DIFF
--- a/scripts/setupvars/setupvars.sh
+++ b/scripts/setupvars/setupvars.sh
@@ -72,10 +72,17 @@ if [ -z "$python_version" ]; then
     python_version=$(python3 -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))')
 fi
 
-version_arr=(${python_version//./ })
+# splitting Python version variable depending on the used shell 
+if [ -n "$ZSH_VERSION" ]; then
+    version_arr=(${(@s:.:)python_version})
+else
+    version_arr=(${python_version//./ })
+fi
+
 if [ "${#version_arr[@]}" -ge "2" ]; then
-    python_version_major=${version_arr[0]}
-    python_version_minor=${version_arr[1]}
+    # Use negative indices because zsh starts indexing from 1 instead of 0
+    python_version_major=${version_arr[-2]}
+    python_version_minor=${version_arr[-1]}
 fi
 
 PYTHON_VERSION_MAJOR="3"

--- a/scripts/setupvars/setupvars.sh
+++ b/scripts/setupvars/setupvars.sh
@@ -75,14 +75,17 @@ fi
 # splitting Python version variable depending on the used shell 
 if [ -n "$ZSH_VERSION" ]; then
     version_arr=(${(@s:.:)python_version})
+    if [ "${#version_arr[@]}" -ge "2" ]; then
+        # zsh starts indexing from 1
+        python_version_major=${version_arr[1]}
+        python_version_minor=${version_arr[2]}
+    fi
 else
     version_arr=(${python_version//./ })
-fi
-
-if [ "${#version_arr[@]}" -ge "2" ]; then
-    # Use negative indices because zsh starts indexing from 1 instead of 0
-    python_version_major=${version_arr[-2]}
-    python_version_minor=${version_arr[-1]}
+    if [ "${#version_arr[@]}" -ge "2" ]; then
+        python_version_major=${version_arr[0]}
+        python_version_minor=${version_arr[1]}
+    fi
 fi
 
 PYTHON_VERSION_MAJOR="3"


### PR DESCRIPTION
Based on #11579 

The splitting of Python version to array works differently on the `zsh` which is default shell on Mac

Solution tested on:
- zsh 5.8 (x86_64-ubuntu-linux-gnu)
- bash  5.0.17(1)-release (x86_64-pc-linux-gnu)