### PR TITLE
Support config option for time_tests suite

### DIFF
--- a/tests/time_tests/include/timetests_helper/parse.h
+++ b/tests/time_tests/include/timetests_helper/parse.h
@@ -1,0 +1,4 @@
+#include <map>
+#include <fstream>
+
+std::map<std::string, std::string> parseConfigFile(char comment = '#');

--- a/tests/time_tests/include/timetests_helper/parse.h
+++ b/tests/time_tests/include/timetests_helper/parse.h
@@ -1,3 +1,9 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
 #include <map>
 #include <fstream>
 

--- a/tests/time_tests/scripts/run_timetest.py
+++ b/tests/time_tests/scripts/run_timetest.py
@@ -138,6 +138,10 @@ def cli_parser():
                         dest="model_cache",
                         action="store_true",
                         help="Enable model cache usage")
+    parser.add_argument("-f",
+                        dest="config_message",
+                        type=Path,
+                        help="Path to configuration file")
 
     args = parser.parse_args()
 

--- a/tests/time_tests/scripts/run_timetest.py
+++ b/tests/time_tests/scripts/run_timetest.py
@@ -62,7 +62,9 @@ def prepare_executable_cmd(args: dict):
         str(args["executable"].resolve(strict=True)),
         "-m", str(args["model"].resolve(strict=True)),
         "-d", args["device"],
-        "-c" if args["model_cache"] else ""
+        "-c" if args["model_cache"] else "",
+        "-f" if args["config_message"] else "",
+        str(args["config_message"].resolve(strict=True)) if args["config_message"] else ""
     ]
 
 

--- a/tests/time_tests/src/timetests/timetest_infer.cpp
+++ b/tests/time_tests/src/timetests/timetest_infer.cpp
@@ -7,14 +7,14 @@
 #include "common_utils.h"
 #include "timetests_helper/timer.h"
 #include "timetests_helper/utils.h"
-
+#include "timetests_helper/parse.h"
 
 /**
  * @brief Function that contain executable pipeline which will be called from
  * main(). The function should not throw any exceptions and responsible for
  * handling it by itself.
  */
-int runPipeline(const std::string &model, const std::string &device, const bool isCacheEnabled,
+int runPipeline(const std::string &model, const std::string &device, const std::string & config, const bool isCacheEnabled,
                 std::map<std::string, ov::PartialShape> reshapeShapes,
                 std::map<std::string, std::vector<size_t>> dataShapes) {
     auto pipeline = [](const std::string &model, const std::string &device, const bool isCacheEnabled,
@@ -52,13 +52,13 @@ int runPipeline(const std::string &model, const std::string &device, const bool 
                         }
                         {
                             SCOPED_TIMER(load_network);
-                            exeNetwork = ie.LoadNetwork(cnnNetwork, device);
+                            exeNetwork = ie.LoadNetwork(cnnNetwork, device, parseConfigFile());
                         }
                     }
                 }
                 else {
                     SCOPED_TIMER(load_network_cache);
-                    exeNetwork = ie.LoadNetwork(model, device);
+                    exeNetwork = ie.LoadNetwork(model, device, parseConfigFile());
                 }
             }
             inferRequest = exeNetwork.CreateInferRequest();

--- a/tests/time_tests/src/timetests/timetest_infer_api_2.cpp
+++ b/tests/time_tests/src/timetests/timetest_infer_api_2.cpp
@@ -9,14 +9,14 @@
 #include "reshape_utils.h"
 #include "timetests_helper/timer.h"
 #include "timetests_helper/utils.h"
-
+#include "timetests_helper/parse.h"
 
 /**
  * @brief Function that contain executable pipeline which will be called from
  * main(). The function should not throw any exceptions and responsible for
  * handling it by itself.
  */
-int runPipeline(const std::string &model, const std::string &device, const bool isCacheEnabled,
+int runPipeline(const std::string &model, const std::string &device, const std::string & config, const bool isCacheEnabled,
                 std::map<std::string, ov::PartialShape> reshapeShapes,
                 std::map<std::string, std::vector<size_t>> dataShapes) {
     auto pipeline = [](const std::string &model, const std::string &device, const bool isCacheEnabled,
@@ -33,6 +33,8 @@ int runPipeline(const std::string &model, const std::string &device, const bool 
         if (!reshapeShapes.empty()) {
             reshape = true;
         }
+
+        auto configs = parseConfigFile();
 
          // first_inference_latency = time_to_inference + first_inference
         {
@@ -67,13 +69,13 @@ int runPipeline(const std::string &model, const std::string &device, const bool 
                         }
                         {
                             SCOPED_TIMER(load_network);
-                            exeNetwork = ie.compile_model(cnnNetwork, device);
+                            exeNetwork = ie.compile_model(cnnNetwork, device, {configs.begin(), configs.end()});
                         }
                     }
                 }
                 else {
                     SCOPED_TIMER(load_network_cache);
-                    exeNetwork = ie.compile_model(model, device);
+                    exeNetwork = ie.compile_model(model, device, {configs.begin(), configs.end()});
                 }
             }
             inferRequest = exeNetwork.create_infer_request();

--- a/tests/time_tests/src/timetests_helper/cli.h
+++ b/tests/time_tests/src/timetests_helper/cli.h
@@ -9,6 +9,8 @@
 #include <string>
 #include <vector>
 
+#include "timetests_helper/parse.h"
+
 /// @brief message for help argument
 static const char help_message[] =
         "Print a usage message.";
@@ -46,6 +48,10 @@ static const char data_shapes_message[] =
 static const char statistics_path_message[] =
         "Required. Path to a file to write statistics.";
 
+/// @brief message for configuration file path argument
+static const char configuration_path_message[] =
+        "Not Required. Path to a configuration file to read config message.";
+
 /// @brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
@@ -76,6 +82,10 @@ DEFINE_bool(c, false, model_cache_message);
 /// It is a required parameter
 DEFINE_string(s, "", statistics_path_message);
 
+/// @brief Define parameter for set path to a file to read configuration <br>
+/// It is a non-required parameter
+DEFINE_string(f, "", configuration_path_message);
+
 /**
  * @brief This function show a help message
  */
@@ -91,4 +101,27 @@ static void showUsage() {
     std::cout << "    -c                   " << model_cache_message << std::endl;
     std::cout << "    -reshape_shapes      " << reshape_shapes_message << std::endl;
     std::cout << "    -data_shapes         " << data_shapes_message << std::endl;
+    std::cout << "    -f \"<path>\"        " << configuration_path_message << std::endl;
+}
+
+std::map<std::string, std::string> parseConfigFile(char comment) {
+    std::map<std::string, std::string> config;
+
+    std::ifstream file(FLAGS_f);
+    if (file.is_open()) {
+        std::string option;
+        while (std::getline(file, option)) {
+            if (option.empty() || option[0] == comment) {
+                continue;
+            }
+            size_t spacePos = option.find(' ');
+            std::string key, value;
+            if (spacePos != std::string::npos) {
+                key = option.substr(0, spacePos);
+                value = option.substr(spacePos + 1);
+                config[key] = value;
+            }
+        }
+    }
+    return config;
 }

--- a/tests/time_tests/src/timetests_helper/main.cpp
+++ b/tests/time_tests/src/timetests_helper/main.cpp
@@ -9,8 +9,7 @@
 
 #include <iostream>
 
-
-int runPipeline(const std::string &model, const std::string &device, const bool isCacheEnabled,
+int runPipeline(const std::string &model, const std::string &device, const std::string &config, const bool isCacheEnabled,
                 std::map<std::string, ov::PartialShape> reshapeShapes,
                 std::map<std::string, std::vector<size_t>> dataShapes);
 
@@ -45,7 +44,7 @@ bool parseAndCheckCommandLine(int argc, char **argv) {
 int _runPipeline(std::map<std::string, ov::PartialShape> dynamicShapes,
                  std::map<std::string, std::vector<size_t>> staticShapes) {
     SCOPED_TIMER(full_run);
-    return runPipeline(FLAGS_m, FLAGS_d, FLAGS_c, dynamicShapes, staticShapes);
+    return runPipeline(FLAGS_m, FLAGS_d, FLAGS_f, FLAGS_c, dynamicShapes, staticShapes);
 }
 
 /**


### PR DESCRIPTION
### Details:
 - Support reading config options from file for timetest_infer and timetest_infer_api_2 with `-f <path_to_configfile>`, the format of config file is the same as compile_tool
 - Support running script run_timetest.py with parameter `-f <path_to_configfile>`

### Tickets:
 - [EISW-39369](https://jira.devtools.intel.com/browse/EISW-39369)
