### PR TITLE
Backport of: Mark get_type_info_static() op class methods as hidden #10691

### DIFF
--- a/samples/cpp/hello_reshape_ssd/main.cpp
+++ b/samples/cpp/hello_reshape_ssd/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char* argv[]) {
         // try to find it.
         ov::NodeVector ops = model->get_ops();
         auto it = std::find_if(ops.begin(), ops.end(), [](std::shared_ptr<ov::Node> node) {
-            return node->get_type_info().name == ngraph::op::DetectionOutput::get_type_info_static().name;
+            return node->get_type_info() == ngraph::op::DetectionOutput::get_type_info_static();
         });
         if (it == ops.end()) {
             throw std::logic_error("model does not contain DetectionOutput layer");

--- a/src/core/include/openvino/core/model.hpp
+++ b/src/core/include/openvino/core/model.hpp
@@ -46,8 +46,8 @@ class OPENVINO_API Model : public std::enable_shared_from_this<Model> {
     std::shared_ptr<void> m_shared_object;  // Frontend plugin shared object handle.
 
 public:
-    static const ::ov::DiscreteTypeInfo& get_type_info_static() {
-        static const ::ov::DiscreteTypeInfo type_info_static{"Model", 0};
+    _OPENVINO_HIDDEN_METHOD static const ::ov::DiscreteTypeInfo& get_type_info_static() {
+        static const ::ov::DiscreteTypeInfo type_info_static{"Model", static_cast<uint64_t>(0)};
         return type_info_static;
     }
     const ::ov::DiscreteTypeInfo& get_type_info() const {

--- a/src/core/include/openvino/core/rtti.hpp
+++ b/src/core/include/openvino/core/rtti.hpp
@@ -5,20 +5,21 @@
 #pragma once
 
 #include "openvino/core/type.hpp"
+#include "openvino/core/visibility.hpp"
 
 #define _OPENVINO_RTTI_EXPAND(X)                                      X
 #define _OPENVINO_RTTI_DEFINITION_SELECTOR(_1, _2, _3, _4, NAME, ...) NAME
 
 #define _OPENVINO_RTTI_WITH_TYPE(TYPE_NAME) _OPENVINO_RTTI_WITH_TYPE_VERSION(TYPE_NAME, "util")
 
-#define _OPENVINO_RTTI_WITH_TYPE_VERSION(TYPE_NAME, VERSION_NAME)                   \
-    static const ::ov::DiscreteTypeInfo& get_type_info_static() {                   \
-        static ::ov::DiscreteTypeInfo type_info_static{TYPE_NAME, 0, VERSION_NAME}; \
-        type_info_static.hash();                                                    \
-        return type_info_static;                                                    \
-    }                                                                               \
-    const ::ov::DiscreteTypeInfo& get_type_info() const override {                  \
-        return get_type_info_static();                                              \
+#define _OPENVINO_RTTI_WITH_TYPE_VERSION(TYPE_NAME, VERSION_NAME)                         \
+    _OPENVINO_HIDDEN_METHOD static const ::ov::DiscreteTypeInfo& get_type_info_static() { \
+        static ::ov::DiscreteTypeInfo type_info_static{TYPE_NAME, 0, VERSION_NAME};       \
+        type_info_static.hash();                                                          \
+        return type_info_static;                                                          \
+    }                                                                                     \
+    const ::ov::DiscreteTypeInfo& get_type_info() const override {                        \
+        return get_type_info_static();                                                    \
     }
 
 #define _OPENVINO_RTTI_WITH_TYPE_VERSION_PARENT(TYPE_NAME, VERSION_NAME, PARENT_CLASS) \

--- a/src/core/include/openvino/core/runtime_attribute.hpp
+++ b/src/core/include/openvino/core/runtime_attribute.hpp
@@ -19,8 +19,8 @@ class Any;
 
 class OPENVINO_API RuntimeAttribute {
 public:
-    static const DiscreteTypeInfo& get_type_info_static() {
-        static const ::ov::DiscreteTypeInfo type_info_static{"RuntimeAttribute", 0};
+    _OPENVINO_HIDDEN_METHOD static const DiscreteTypeInfo& get_type_info_static() {
+        static const ::ov::DiscreteTypeInfo type_info_static{"RuntimeAttribute", static_cast<uint64_t>(0)};
         return type_info_static;
     }
     virtual const DiscreteTypeInfo& get_type_info() const {

--- a/src/core/include/openvino/core/visibility.hpp
+++ b/src/core/include/openvino/core/visibility.hpp
@@ -34,10 +34,13 @@
 #if defined _WIN32 || defined __CYGWIN__
 #    define OPENVINO_CORE_IMPORTS __declspec(dllimport)
 #    define OPENVINO_CORE_EXPORTS __declspec(dllexport)
+#    define _OPENVINO_HIDDEN_METHOD
 #elif defined(__GNUC__) && __GNUC__ >= 4
-#    define OPENVINO_CORE_IMPORTS __attribute__((visibility("default")))
-#    define OPENVINO_CORE_EXPORTS __attribute__((visibility("default")))
+#    define OPENVINO_CORE_IMPORTS   __attribute__((visibility("default")))
+#    define OPENVINO_CORE_EXPORTS   __attribute__((visibility("default")))
+#    define _OPENVINO_HIDDEN_METHOD __attribute__((visibility("hidden")))
 #else
 #    define OPENVINO_CORE_IMPORTS
 #    define OPENVINO_CORE_EXPORTS
+#    define _OPENVINO_HIDDEN_METHOD
 #endif

--- a/src/core/include/openvino/op/if.hpp
+++ b/src/core/include/openvino/op/if.hpp
@@ -17,7 +17,7 @@ namespace v8 {
 /// \ingroup ov_ops_cpp_api
 class OPENVINO_API If : public util::MultiSubGraphOp {
 public:
-    OPENVINO_OP("If", "opset8", MultiSubGraphOp);
+    OPENVINO_OP("If", "opset8", util::MultiSubGraphOp);
     BWDCMP_RTTI_DECLARATION;
 
     enum BodyIndexes { THEN_BODY_INDEX = 0, ELSE_BODY_INDEX = 1 };

--- a/src/core/include/openvino/op/op.hpp
+++ b/src/core/include/openvino/op/op.hpp
@@ -31,7 +31,7 @@ protected:
     Op(const OutputVector& arguments);
 
 public:
-    static const ::ov::Node::type_info_t& get_type_info_static() {
+    _OPENVINO_HIDDEN_METHOD static const ::ov::Node::type_info_t& get_type_info_static() {
         static ::ov::Node::type_info_t info{"Op", 0, "util"};
         info.hash();
         return info;

--- a/src/core/tests/frontend/decoder_transformation_extension.cpp
+++ b/src/core/tests/frontend/decoder_transformation_extension.cpp
@@ -34,18 +34,22 @@ TEST(DecoderTransformation, FunctionPass) {
     EXPECT_EQ(flag, true);
 }
 
+namespace _decoder_transformation_test {
+class TestPass : public ov::pass::ModelPass {
+public:
+    OPENVINO_RTTI("ov::pass::TestPass");
+    TestPass() = default;
+    TestPass(const TestPass& tp) = default;
+    bool run_on_model(const std::shared_ptr<ov::Model>&) override {
+        *m_flag = true;
+        return *m_flag;
+    }
+    std::shared_ptr<bool> m_flag = std::make_shared<bool>(false);
+};
+}  // namespace _decoder_transformation_test
+
 TEST(DecoderTransformation, TestPass) {
-    class TestPass : public ov::pass::ModelPass {
-    public:
-        OPENVINO_RTTI("ov::pass::TestPass");
-        TestPass() = default;
-        TestPass(const TestPass& tp) = default;
-        bool run_on_model(const std::shared_ptr<ov::Model>&) override {
-            *m_flag = true;
-            return *m_flag;
-        }
-        std::shared_ptr<bool> m_flag = std::make_shared<bool>(false);
-    } test_pass;
+    _decoder_transformation_test::TestPass test_pass;
     DecoderTransformationExtension decoder_ext(test_pass);
 
     ov::pass::Manager manager;


### PR DESCRIPTION
Backport of https://github.com/openvinotoolkit/openvino/pull/10691 to the 2022/1 release branch
