### PR TITLE
Fixing for tbb unload issue

### DIFF
--- a/src/cmake/ie_parallel.cmake
+++ b/src/cmake/ie_parallel.cmake
@@ -47,17 +47,21 @@ function(set_ie_threading_interface_for TARGET_NAME)
 
     if(target_type STREQUAL "INTERFACE_LIBRARY")
         set(LINK_TYPE "INTERFACE")
+        set(COMPILE_DEF_TYPE "INTERFACE")
     elseif(target_type STREQUAL "EXECUTABLE" OR target_type STREQUAL "OBJECT_LIBRARY" OR
            target_type STREQUAL "MODULE_LIBRARY")
         set(LINK_TYPE "PRIVATE")
+        set(COMPILE_DEF_TYPE "PUBLIC")
     elseif(target_type STREQUAL "STATIC_LIBRARY")
         # Affected libraries: inference_engine_s, openvino_gapi_preproc_s
         # they don't have TBB in public headers => PRIVATE
         set(LINK_TYPE "PRIVATE")
+        set(COMPILE_DEF_TYPE "PUBLIC")
     elseif(target_type STREQUAL "SHARED_LIBRARY")
         # Affected libraries: inference_engine only
         # TODO: why TBB propogates its headers to inference_engine?
         set(LINK_TYPE "PRIVATE")
+        set(COMPILE_DEF_TYPE "PUBLIC")
     else()
         ext_message(WARNING "Unknown target type")
     endif()
@@ -106,6 +110,7 @@ function(set_ie_threading_interface_for TARGET_NAME)
         if (TBB_FOUND)
             set(IE_THREAD_DEFINE "IE_THREAD_TBB")
             ie_target_link_libraries(${TARGET_NAME} ${LINK_TYPE} ${TBB_IMPORTED_TARGETS})
+            target_compile_definitions(${TARGET_NAME} ${COMPILE_DEF_TYPE} TBB_PREVIEW_WAITING_FOR_WORKERS=1)
         else ()
             set(THREADING "SEQ" PARENT_SCOPE)
             ext_message(WARNING "TBB was not found by the configured TBB_DIR path.\

--- a/src/frontends/common/include/openvino/frontend/manager.hpp
+++ b/src/frontends/common/include/openvino/frontend/manager.hpp
@@ -22,6 +22,8 @@ using FrontEndFactory = std::function<FrontEnd::Ptr()>;
 /// frontends This is a main frontend entry point for client applications
 class FRONTEND_API FrontEndManager final {
 public:
+    using Ptr = std::shared_ptr<FrontEndManager>;
+
     /// \brief Default constructor. Searches and loads of available frontends
     FrontEndManager();
 
@@ -79,6 +81,9 @@ private:
 
 template <>
 FRONTEND_API FrontEnd::Ptr FrontEndManager::load_by_model(const std::vector<ov::Any>& variants);
+
+FRONTEND_API void release_frontend_manager();
+FRONTEND_API FrontEndManager::Ptr get_frontend_manager();
 
 // --------- Plugin exporting information --------------
 

--- a/src/inference/dev_api/threading/ie_executor_manager.hpp
+++ b/src/inference/dev_api/threading/ie_executor_manager.hpp
@@ -66,8 +66,18 @@ public:
      */
     INFERENCE_ENGINE_DEPRECATED("Use IInferencePlugin::executorManager() instead")
     static ExecutorManager* getInstance();
+
+    /**
+     * @brief Set TBB terminate flag
+     * @param flag A boolean value:
+     * True to explicitly terminate tbb when ExecutorManager destructing
+     * False to not explicitly terminate tbb when ExecutorManager destructing
+     * @return void
+     */
+    virtual void setTbbFlag(bool flag) = 0;
 };
 
-INFERENCE_ENGINE_API_CPP(ExecutorManager::Ptr) executorManager();
+INFERENCE_ENGINE_API_CPP(ExecutorManager::Ptr) executorManager(bool addRef = false);
+INFERENCE_ENGINE_API_CPP(void) resetExecutorManager();
 
 }  // namespace InferenceEngine

--- a/src/inference/dev_api/threading/ie_istreams_executor.hpp
+++ b/src/inference/dev_api/threading/ie_istreams_executor.hpp
@@ -91,10 +91,11 @@ public:
                                                                          //!< No binding by default
         int _threadBindingStep = 1;                                      //!< In case of @ref CORES binding offset type
                                                                          //!< thread binded to cores with defined step
-        int _threadBindingOffset = 0;  //!< In case of @ref CORES binding offset type thread binded to cores
-                                       //!< starting from offset
-        int _threads = 0;              //!< Number of threads distributed between streams.
-                                       //!< Reserved. Should not be used.
+        int _threadBindingOffset = 0;     //!< In case of @ref CORES binding offset type thread binded to cores
+                                          //!< starting from offset
+        int _threads = 0;                 //!< Number of threads distributed between streams.
+                                          //!< Reserved. Should not be used.
+        bool _forceTbbTerminate = false;  //!< Whether terminate tbb during executor destructing
         enum PreferredCoreType {
             ANY,
             LITTLE,

--- a/src/inference/include/openvino/runtime/properties.hpp
+++ b/src/inference/include/openvino/runtime/properties.hpp
@@ -503,6 +503,15 @@ static constexpr Property<std::tuple<unsigned int, unsigned int, unsigned int>, 
     range_for_async_infer_requests{"RANGE_FOR_ASYNC_INFER_REQUESTS"};
 
 /**
+ * @brief Read-write property to set whether force terminate tbb when ov core destruction
+ * value type: boolean
+ *   - True explicitly terminate tbb when ov core destruction
+ *   - False will not involve additional tbb operations when core destruction
+ * @ingroup ov_runtime_cpp_prop_api
+ */
+static constexpr Property<bool, PropertyMutability::RW> force_tbb_terminate{"FORCE_TBB_TERMINATE"};
+
+/**
  * @brief Namespace with device properties
  */
 namespace device {

--- a/src/inference/src/ie_core.cpp
+++ b/src/inference/src/ie_core.cpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <threading/ie_executor_manager.hpp>
 #include <vector>
 
 #include "any_copy.hpp"
@@ -34,6 +35,7 @@
 #include "ngraph/opsets/opset.hpp"
 #include "ngraph/pass/constant_folding.hpp"
 #include "openvino/core/except.hpp"
+#include "openvino/frontend/manager.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/result.hpp"
 #include "openvino/runtime/compiled_model.hpp"
@@ -204,6 +206,7 @@ class CoreImpl : public ie::ICore, public std::enable_shared_from_this<ie::ICore
         }
     };
 
+    ExecutorManager::Ptr executorManagerPtr;
     mutable std::unordered_set<std::string> opsetNames;
     // TODO: make extensions to be optional with conditional compilation
     mutable std::vector<ie::IExtensionPtr> extensions;
@@ -372,7 +375,7 @@ class CoreImpl : public ie::ICore, public std::enable_shared_from_this<ie::ICore
     }
 
 public:
-    CoreImpl(bool _newAPI) : newAPI(_newAPI) {
+    CoreImpl(bool _newAPI) : executorManagerPtr(executorManager(true)), newAPI(_newAPI) {
         opsetNames.insert("opset1");
         opsetNames.insert("opset2");
         opsetNames.insert("opset3");
@@ -383,7 +386,9 @@ public:
         opsetNames.insert("opset8");
     }
 
-    ~CoreImpl() override = default;
+    ~CoreImpl() {
+        resetExecutorManager();
+    }
 
     /**
      * @brief Register plugins for devices which are located in .xml configuration file.

--- a/src/inference/src/ie_network_reader.cpp
+++ b/src/inference/src/ie_network_reader.cpp
@@ -31,6 +31,7 @@
 #include "openvino/core/except.hpp"
 #include "openvino/core/preprocess/pre_post_process.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/frontend/manager.hpp"
 #include "openvino/util/shared_object.hpp"
 #include "so_ptr.hpp"
 #include "transformations/rt_info/old_api_map_order_attribute.hpp"
@@ -436,11 +437,6 @@ CNNNetwork convert_to_cnnnetwork(std::shared_ptr<ngraph::Function>& function,
     OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
-ov::frontend::FrontEndManager& get_frontend_manager() {
-    static ov::frontend::FrontEndManager manager;
-    return manager;
-}
-
 std::vector<ov::Extension::Ptr> wrap_old_extensions(const std::vector<InferenceEngine::IExtensionPtr>& exts) {
     std::vector<ov::Extension::Ptr> extensions;
     for (const auto& ext : exts) {
@@ -484,7 +480,7 @@ CNNNetwork details::ReadNetwork(const std::string& modelPath,
 #endif
 
     // Try to load with FrontEndManager
-    auto& manager = get_frontend_manager();
+    auto frontEndManager = ov::frontend::get_frontend_manager();
     ov::frontend::FrontEnd::Ptr FE;
     ov::frontend::InputModel::Ptr inputModel;
 
@@ -499,7 +495,7 @@ CNNNetwork details::ReadNetwork(const std::string& modelPath,
         params.emplace_back(weights_path);
     }
 
-    FE = manager.load_by_model(params);
+    FE = frontEndManager->load_by_model(params);
     if (FE) {
         FE->add_extension(ov_exts);
         if (!exts.empty())
@@ -514,7 +510,7 @@ CNNNetwork details::ReadNetwork(const std::string& modelPath,
 
     const auto fileExt = modelPath.substr(modelPath.find_last_of(".") + 1);
     std::string FEs;
-    for (const auto& fe_name : manager.get_available_front_ends())
+    for (const auto& fe_name : frontEndManager->get_available_front_ends())
         FEs += fe_name + " ";
     IE_THROW(NetworkNotRead) << "Unable to read the model: " << modelPath
                              << " Please check that model format: " << fileExt
@@ -550,7 +546,7 @@ CNNNetwork details::ReadNetwork(const std::string& model,
 #endif  // ENABLE_IR_V7_READER
 
     // Try to load with FrontEndManager
-    auto& manager = get_frontend_manager();
+    auto frontEndManager = ov::frontend::get_frontend_manager();
     ov::frontend::FrontEnd::Ptr FE;
     ov::frontend::InputModel::Ptr inputModel;
 
@@ -562,7 +558,7 @@ CNNNetwork details::ReadNetwork(const std::string& model,
         params.emplace_back(weights_buffer);
     }
 
-    FE = manager.load_by_model(params);
+    FE = frontEndManager->load_by_model(params);
     if (FE) {
         FE->add_extension(ov_exts);
         if (!exts.empty())

--- a/src/inference/src/threading/ie_executor_manager.cpp
+++ b/src/inference/src/threading/ie_executor_manager.cpp
@@ -55,7 +55,6 @@ void ExecutorManagerImpl::setTbbFlag(bool flag) {
 }
 
 ExecutorManagerImpl::~ExecutorManagerImpl() {
-    clear();
     std::lock_guard<std::mutex> guard(tbbMutex);
     if (tbbTerminateFlag) {
 #if IE_THREAD == IE_THREAD_TBB || IE_THREAD == IE_THREAD_TBB_AUTO

--- a/src/inference/src/threading/ie_istreams_executor.cpp
+++ b/src/inference/src/threading/ie_istreams_executor.cpp
@@ -17,6 +17,7 @@
 #include "ie_system_conf.h"
 #include "openvino/runtime/properties.hpp"
 #include "openvino/util/common_util.hpp"
+#include "threading/ie_executor_manager.hpp"
 
 namespace InferenceEngine {
 IStreamsExecutor::~IStreamsExecutor() {}
@@ -30,6 +31,7 @@ std::vector<std::string> IStreamsExecutor::Config::SupportedKeys() const {
         ov::num_streams.name(),
         ov::inference_num_threads.name(),
         ov::affinity.name(),
+        ov::force_tbb_terminate.name(),
     };
 }
 int IStreamsExecutor::Config::GetDefaultNumStreams() {
@@ -150,6 +152,14 @@ void IStreamsExecutor::Config::SetConfig(const std::string& key, const std::stri
                        << ". Expected only non negative numbers (#threads)";
         }
         _threadsPerStream = val_i;
+    } else if (key == ov::force_tbb_terminate) {
+        if (value == CONFIG_VALUE(YES)) {
+            _forceTbbTerminate = true;
+            executorManager()->setTbbFlag(true);
+        } else {
+            _forceTbbTerminate = false;
+            executorManager()->setTbbFlag(false);
+        }
     } else {
         IE_THROW() << "Wrong value for property key " << key;
     }
@@ -188,6 +198,12 @@ Parameter IStreamsExecutor::Config::GetConfig(const std::string& key) const {
         return decltype(ov::inference_num_threads)::value_type{_threads};
     } else if (key == CONFIG_KEY_INTERNAL(CPU_THREADS_PER_STREAM)) {
         return {std::to_string(_threadsPerStream)};
+    } else if (key == ov::force_tbb_terminate) {
+        if (_forceTbbTerminate) {
+            return {CONFIG_VALUE(YES)};
+        } else {
+            return {CONFIG_VALUE(NO)};
+        }
     } else {
         IE_THROW() << "Wrong value for property key " << key;
     }

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -770,6 +770,9 @@ Parameter Engine::GetConfig(const std::string& name, const std::map<std::string,
     } else if (name == ov::hint::num_requests) {
         const auto perfHintNumRequests = engConfig.perfHintsConfig.ovPerfHintNumRequests;
         return decltype(ov::hint::num_requests)::value_type(perfHintNumRequests);
+    } else if (name == ov::force_tbb_terminate.name()) {
+        const auto force = engConfig.streamExecutorConfig.GetConfig(name);
+        return decltype(ov::force_tbb_terminate)::value_type(force);
     }
     /* Internally legacy parameters are used with new API as part of migration procedure.
      * This fallback can be removed as soon as migration completed */


### PR DESCRIPTION
### Details:
Windows run inference on CPU, tbb library cannot be unloaded, which cause memory leak and unload/lingering threads.

This PR contains:
1. Add a new property to control whether force to terminate tbb threads.
2. Property key is "FORCE_TBB_TERMINATE", default value is false.
3. Explicitly to terminate tbb task scheduler during unload openvino dll if this property is set true.
    e.g: core.set_property(device, ov::force_tbb_terminate(true));
4. If not set FORCE_TBB_TERMINATE, there will be no any additional tbb operations.
5. Remove static FrondEndManager, use a global shared FrondEndManager
6. Replace static ExecutorManager with a global shared ExecutorManager.

### Tickets:
82487
