### PR TITLE
Docs: Add links to specific examples - port (#11618)

### DIFF
--- a/docs/MO_DG/prepare_model/convert_model/Convert_Model_From_ONNX.md
+++ b/docs/MO_DG/prepare_model/convert_model/Convert_Model_From_ONNX.md
@@ -3,7 +3,7 @@
 ## Introduction to ONNX
 [ONNX*](https://github.com/onnx/onnx) is a representation format for deep learning models. ONNX allows AI developers easily transfer models between different frameworks that helps to choose the best combination for them. Today, PyTorch\*, Caffe2\*, Apache MXNet\*, Microsoft Cognitive Toolkit\* and other tools are developing ONNX support.
 
-This page gives instructions on how to convert a model from ONNX format to OpenVINO IR format using Model Optimizer. To use Model Optimizer, install OpenVINO Development Tools by following the [installation instructions here](https://docs.openvino.ai/latest/openvino_docs_install_guides_install_dev_tools.html).
+This page provides instructions on how to convert a model from the ONNX format to the OpenVINO IR format using Model Optimizer. To use Model Optimizer, install OpenVINO Development Tools by following the [installation instructions](https://docs.openvino.ai/latest/openvino_docs_install_guides_install_dev_tools.html).
 
 ## Convert an ONNX* Model <a name="Convert_From_ONNX"></a>
 The Model Optimizer process assumes you have an ONNX model that was directly downloaded from a public repository or converted from any framework that supports exporting to the ONNX format.
@@ -19,8 +19,8 @@ There are no ONNX\* specific parameters, so only framework-agnostic parameters a
 ## Supported ONNX\* Layers
 Refer to [Supported Framework Layers](../Supported_Frameworks_Layers.md) for the list of supported standard layers.
 
-## See Also
-This page provided general instructions for converting ONNX models. See the [Model Conversion Tutorials](Convert_Model_Tutorials.md) page for a set of tutorials that give step-by-step instructions for converting specific ONNX models. Here are some example tutorials:
+## Additional Resources
+See the [Model Conversion Tutorials](Convert_Model_Tutorials.md) page for a set of tutorials providing step-by-step instructions for converting specific ONNX models. Here are some examples:
 * [Convert ONNX* Faster R-CNN Model](onnx_specific/Convert_Faster_RCNN.md)
 * [Convert ONNX* GPT-2 Model](onnx_specific/Convert_GPT2.md)
 * [Convert ONNX* Mask R-CNN Model](onnx_specific/Convert_Mask_RCNN.md)

--- a/docs/MO_DG/prepare_model/convert_model/Convert_Model_From_ONNX.md
+++ b/docs/MO_DG/prepare_model/convert_model/Convert_Model_From_ONNX.md
@@ -3,6 +3,8 @@
 ## Introduction to ONNX
 [ONNX*](https://github.com/onnx/onnx) is a representation format for deep learning models. ONNX allows AI developers easily transfer models between different frameworks that helps to choose the best combination for them. Today, PyTorch\*, Caffe2\*, Apache MXNet\*, Microsoft Cognitive Toolkit\* and other tools are developing ONNX support.
 
+This page gives instructions on how to convert a model from ONNX format to OpenVINO IR format using Model Optimizer. To use Model Optimizer, install OpenVINO Development Tools by following the [installation instructions here](https://docs.openvino.ai/latest/openvino_docs_install_guides_install_dev_tools.html).
+
 ## Convert an ONNX* Model <a name="Convert_From_ONNX"></a>
 The Model Optimizer process assumes you have an ONNX model that was directly downloaded from a public repository or converted from any framework that supports exporting to the ONNX format.
 
@@ -18,4 +20,8 @@ There are no ONNX\* specific parameters, so only framework-agnostic parameters a
 Refer to [Supported Framework Layers](../Supported_Frameworks_Layers.md) for the list of supported standard layers.
 
 ## See Also
-[Model Conversion Tutorials](Convert_Model_Tutorials.md)
+This page provided general instructions for converting ONNX models. See the [Model Conversion Tutorials](Convert_Model_Tutorials.md) page for a set of tutorials that give step-by-step instructions for converting specific ONNX models. Here are some example tutorials:
+* [Convert ONNX* Faster R-CNN Model](onnx_specific/Convert_Faster_RCNN.md)
+* [Convert ONNX* GPT-2 Model](onnx_specific/Convert_GPT2.md)
+* [Convert ONNX* Mask R-CNN Model](onnx_specific/Convert_Mask_RCNN.md)
+

--- a/docs/OV_Runtime_UG/integrate_with_your_application.md
+++ b/docs/OV_Runtime_UG/integrate_with_your_application.md
@@ -259,10 +259,10 @@ You can also specify additional build options (e.g. to build CMake project on Wi
 
 Congratulations, you have made your first application with OpenVINO™ toolkit, now you may run it.
 
-This page showed how to implement a typical inference pipeline with OpenVINO. See the [OpenVINO Samples](Samples_Overview.md) page or the [Open Model Zoo Demos](https://docs.openvino.ai/latest/omz_demos.html) page for specific examples of how OpenVINO pipelines are implemented for applications like image classification, text prediction, and many others.
 
-## See also
+## Additional Resources
 
+ - See the [OpenVINO Samples](Samples_Overview.md) page or the [Open Model Zoo Demos](https://docs.openvino.ai/latest/omz_demos.html) page for specific examples of how OpenVINO pipelines are implemented for applications like image classification, text prediction, and many others.
  - [OpenVINO™ Runtime Preprocessing](./preprocessing_overview.md)
  - [Using Encrypted Models with OpenVINO&trade;](./protecting_model_guide.md)
  - [OpenVINO Samples](Samples_Overview.md)

--- a/docs/OV_Runtime_UG/integrate_with_your_application.md
+++ b/docs/OV_Runtime_UG/integrate_with_your_application.md
@@ -12,7 +12,7 @@
 
 @endsphinxdirective
 
-> **NOTE**: Before start using OpenVINO™ Runtime, make sure you set all environment variables during the installation. If you did not, follow the instructions from the _Set the Environment Variables_ section in the installation guides:
+> **NOTE**: Before start using OpenVINO™ Runtime, make sure you set all environment variables during the installation. To do so, follow the instructions from the _Set the Environment Variables_ section in the installation guides:
 > * [For Windows* 10](../install_guides/installing-openvino-windows.md)
 > * [For Linux*](../install_guides/installing-openvino-linux.md)
 > * [For macOS*](../install_guides/installing-openvino-macos.md)
@@ -20,7 +20,7 @@
 
 ## Use OpenVINO™ Runtime API to Implement Inference Pipeline
 
-This section provides step-by-step instructions to implement a typical inference pipeline with the OpenVINO™ Runtime C++ API:
+This section provides step-by-step instructions to implement a typical inference pipeline with the OpenVINO™ Runtime C++ or Python API:
 
 ![ie_api_use_cpp]
 
@@ -64,7 +64,7 @@ Use the following code to create OpenVINO™ Core to manage available devices an
 
 ### Step 2. Compile the Model
 
-`ov::CompiledModel` class represents a device specific compiled model. `ov::CompiledModel` allows you to get information inputs or output ports by a tensor name or index, this approach is aligned with the majority of frameworks.
+`ov::CompiledModel` class represents a device specific compiled model. `ov::CompiledModel` allows you to get information inputs or output ports by a tensor name or index. This approach is aligned with the majority of frameworks.
 
 Compile the model for a specific device using `ov::Core::compile_model()`:
 
@@ -185,7 +185,7 @@ You can use external memory to create `ov::Tensor` and use the `ov::InferRequest
 
 ### Step 5. Start Inference
 
-OpenVINO™ Runtime supports inference in either synchronous or asynchronous mode. Using the Async API can improve application's overall frame-rate, because rather than wait for inference to complete, the app can keep working on the host, while the accelerator is busy. You can use `ov::InferRequest::start_async` to start model inference in the asynchronous mode and call `ov::InferRequest::wait` to wait for the inference results:
+OpenVINO™ Runtime supports inference in either synchronous or asynchronous mode. Using the Async API can improve application's overall frame-rate: instead of waiting for inference to complete, the app can keep working on the host while the accelerator is busy. You can use `ov::InferRequest::start_async` to start model inference in the asynchronous mode and call `ov::InferRequest::wait` to wait for the inference results:
 
 @sphinxtabset
 
@@ -203,7 +203,7 @@ OpenVINO™ Runtime supports inference in either synchronous or asynchronous mod
 
 @endsphinxtabset
 
-This section demonstrates a simple pipeline, to get more information about other ways to perform inference, read the dedicated ["Run inference" section](./ov_infer_request.md).
+This section demonstrates a simple pipeline. To get more information about other ways to perform inference, read the dedicated ["Run inference" section](./ov_infer_request.md).
 
 ### Step 6. Process the Inference Results 
 
@@ -253,16 +253,20 @@ cd build/
 cmake ../project
 cmake --build .
 ```
-It's allowed to specify additional build options (e.g. to build CMake project on Windows with a specific build tools). Please refer to the [CMake page](https://cmake.org/cmake/help/latest/manual/cmake.1.html#manual:cmake(1)) for details.
+You can also specify additional build options (e.g. to build CMake project on Windows with a specific build tools). Please refer to the [CMake page](https://cmake.org/cmake/help/latest/manual/cmake.1.html#manual:cmake(1)) for details.
 
 ## Run Your Application
 
 Congratulations, you have made your first application with OpenVINO™ toolkit, now you may run it.
 
+This page showed how to implement a typical inference pipeline with OpenVINO. See the [OpenVINO Samples](Samples_Overview.md) page or the [Open Model Zoo Demos](https://docs.openvino.ai/latest/omz_demos.html) page for specific examples of how OpenVINO pipelines are implemented for applications like image classification, text prediction, and many others.
+
 ## See also
 
  - [OpenVINO™ Runtime Preprocessing](./preprocessing_overview.md)
  - [Using Encrypted Models with OpenVINO&trade;](./protecting_model_guide.md)
+ - [OpenVINO Samples](Samples_Overview.md)
+ - [Open Model Zoo Demos](https://docs.openvino.ai/latest/omz_demos.html)
 
 [ie_api_flow_cpp]: img/BASIC_IE_API_workflow_Cpp.svg
 [ie_api_use_cpp]: img/IMPLEMENT_PIPELINE_with_API_C.svg


### PR DESCRIPTION
port to master from 22.1 merge 

* Update docs/OV_Runtime_UG/integrate_with_your_application.md
* Add links to specific examples

This edit adds links to more example applications, making it easier for users to discover how to build an OpenVINO application around their specific model.

