### PR TITLE
installing-openvino-yocto: remove reference to staticdev

### DIFF
--- a/docs/install_guides/installing-openvino-yocto.md
+++ b/docs/install_guides/installing-openvino-yocto.md
@@ -88,7 +88,6 @@ openvino-inference-engine-dev
 openvino-inference-engine-python3
 openvino-inference-engine-samples
 openvino-inference-engine-src
-openvino-inference-engine-staticdev
 openvino-inference-engine-vpu-firmware
 openvino-model-optimizer
 openvino-model-optimizer-dbg


### PR DESCRIPTION
This is no longer generated or required.

Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>