### PR TITLE
[GNA] Change Constants' precision in MVN decomposition

### DIFF
--- a/src/plugins/intel_gna/transformations/decompose_mvn.cpp
+++ b/src/plugins/intel_gna/transformations/decompose_mvn.cpp
@@ -115,22 +115,22 @@ static std::shared_ptr<Node> NormalizeVariance(const std::shared_ptr<opset8::MVN
 
     // Calculate sum of the squares
     auto squared_diff_reshape = std::make_shared<opset8::Reshape>(squared_diff,
-        opset8::Constant::create(element::i32, Shape{4}, Shape{mvn_data.N, combined_C_H * mvn_data.num_parts, 1ull, mvn_data.W / mvn_data.num_parts}), false);
-    auto transposed_input_3 = std::make_shared<opset8::Transpose>(squared_diff_reshape, opset8::Constant::create(element::i32, Shape{4}, {0, 3, 1, 2}));
+        opset8::Constant::create(element::i64, Shape{4}, Shape{mvn_data.N, combined_C_H * mvn_data.num_parts, 1ull, mvn_data.W / mvn_data.num_parts}), false);
+    auto transposed_input_3 = std::make_shared<opset8::Transpose>(squared_diff_reshape, opset8::Constant::create(element::i64, Shape{4}, {0, 3, 1, 2}));
     auto transposed_avg_conv_3 = std::make_shared<opset8::Convolution>(transposed_input_3, avg_weights_const,
         Strides{1, 1}, CoordinateDiff{0, 0}, CoordinateDiff{0, 0}, Strides{1, 1}, op::PadType::VALID);
     transposed_avg_conv_3->set_friendly_name(mvn_data.name + "_Avg3");
-    auto avg_conv_3 = std::make_shared<opset8::Transpose>(transposed_avg_conv_3, opset8::Constant::create(element::i32, Shape{4}, {0, 2, 3, 1}));
+    auto avg_conv_3 = std::make_shared<opset8::Transpose>(transposed_avg_conv_3, opset8::Constant::create(element::i64, Shape{4}, {0, 2, 3, 1}));
     auto reshape_avg_conv_3 = std::make_shared<opset8::Reshape>(avg_conv_3,
-        opset8::Constant::create(element::i32, Shape{4}, Shape{mvn_data.N, 1ull, combined_C_H, 8 * mvn_data.num_parts}), false);
-    auto transposed_input_4 = std::make_shared<opset8::Transpose>(reshape_avg_conv_3, opset8::Constant::create(element::i32, Shape{4}, {0, 3, 1, 2}));
+        opset8::Constant::create(element::i64, Shape{4}, Shape{mvn_data.N, 1ull, combined_C_H, 8 * mvn_data.num_parts}), false);
+    auto transposed_input_4 = std::make_shared<opset8::Transpose>(reshape_avg_conv_3, opset8::Constant::create(element::i64, Shape{4}, {0, 3, 1, 2}));
     auto transposed_avg_conv_4 = std::make_shared<opset8::Convolution>(transposed_input_4,
         avg_broadcast_const, Strides{1, 1}, CoordinateDiff{0, 0}, CoordinateDiff{0, 0}, Strides{1, 1}, op::PadType::VALID);
     transposed_avg_conv_4->set_friendly_name(mvn_data.name + "_Avg4");
     auto avg_conv_4 = std::make_shared<opset8::Transpose>(transposed_avg_conv_4,
-        opset8::Constant::create(element::i32, Shape{4}, {0, 2, 3, 1}));
+        opset8::Constant::create(element::i64, Shape{4}, {0, 2, 3, 1}));
     auto reshape_avg_conv_4 = std::make_shared<opset8::Reshape>(avg_conv_4,
-        opset8::Constant::create(element::i32, Shape{2}, Shape{1ull, combined_C_H * mvn_data.W}), false);
+        opset8::Constant::create(element::i64, Shape{2}, Shape{1ull, combined_C_H * mvn_data.W}), false);
     std::shared_ptr<Node> inv_stdev;
 
     // Create normalization part of the graph
@@ -175,26 +175,26 @@ static void Decompose(const std::shared_ptr<opset8::MVN> mvn, const MVNData& mvn
     // We assume C = 1 case (combined channels)
     const auto input = mvn->input_value(0);
     auto reshape = std::make_shared<opset8::Reshape>(input,
-        opset8::Constant::create(element::i32, Shape{4}, Shape{mvn_data.N, 1ull, combined_C_H, mvn_data.W}), false);
+        opset8::Constant::create(element::i64, Shape{4}, Shape{mvn_data.N, 1ull, combined_C_H, mvn_data.W}), false);
     auto input_4d = std::make_shared<opset8::Reshape>(reshape,
-        opset8::Constant::create(element::i32, Shape{4}, Shape{mvn_data.N, combined_C_H * mvn_data.num_parts, 1ull, mvn_data.W / mvn_data.num_parts}), false);
+        opset8::Constant::create(element::i64, Shape{4}, Shape{mvn_data.N, combined_C_H * mvn_data.num_parts, 1ull, mvn_data.W / mvn_data.num_parts}), false);
     auto input_2d = std::make_shared<opset8::Reshape>(reshape,
-        opset8::Constant::create(element::i32, Shape{2}, Shape{1ull, combined_C_H * mvn_data.W}), false);
-    auto transposed_input_1 = std::make_shared<opset8::Transpose>(input_4d, opset8::Constant::create(element::i32, Shape{4}, {0, 3, 1, 2}));
+        opset8::Constant::create(element::i64, Shape{2}, Shape{1ull, combined_C_H * mvn_data.W}), false);
+    auto transposed_input_1 = std::make_shared<opset8::Transpose>(input_4d, opset8::Constant::create(element::i64, Shape{4}, {0, 3, 1, 2}));
     auto transposed_avg_conv_1 = std::make_shared<opset8::Convolution>(transposed_input_1, neg_avg_weights_const,
         Strides{1, 1}, CoordinateDiff{0, 0}, CoordinateDiff{0, 0}, Strides{1, 1}, op::PadType::VALID);
     transposed_avg_conv_1->set_friendly_name(mvn_data.name + "_Avg1");
-    auto avg_conv_1 = std::make_shared<opset8::Transpose>(transposed_avg_conv_1, opset8::Constant::create(element::i32, Shape{4}, {0, 2, 3, 1}));
+    auto avg_conv_1 = std::make_shared<opset8::Transpose>(transposed_avg_conv_1, opset8::Constant::create(element::i64, Shape{4}, {0, 2, 3, 1}));
     auto reshape_avg_conv_1 = std::make_shared<opset8::Reshape>(avg_conv_1,
-        opset8::Constant::create(element::i32, Shape{4}, Shape{mvn_data.N, 1ull, combined_C_H, 8 * mvn_data.num_parts}), false);
-    auto transposed_input_2 = std::make_shared<opset8::Transpose>(reshape_avg_conv_1, opset8::Constant::create(element::i32, Shape{4}, {0, 3, 1, 2}));
+        opset8::Constant::create(element::i64, Shape{4}, Shape{mvn_data.N, 1ull, combined_C_H, 8 * mvn_data.num_parts}), false);
+    auto transposed_input_2 = std::make_shared<opset8::Transpose>(reshape_avg_conv_1, opset8::Constant::create(element::i64, Shape{4}, {0, 3, 1, 2}));
     auto transposed_avg_conv_2 = std::make_shared<opset8::Convolution>(transposed_input_2,
         avg_broadcast_const, Strides{1, 1}, CoordinateDiff{0, 0}, CoordinateDiff{0, 0}, Strides{1, 1}, op::PadType::VALID);
     transposed_avg_conv_2->set_friendly_name(mvn_data.name + "_Avg2");
     auto avg_conv_2 = std::make_shared<opset8::Transpose>(transposed_avg_conv_2,
-        opset8::Constant::create(element::i32, Shape{4}, {0, 2, 3, 1}));
+        opset8::Constant::create(element::i64, Shape{4}, {0, 2, 3, 1}));
     auto avg_conv_2_2d = std::make_shared<opset8::Reshape>(avg_conv_2,
-        opset8::Constant::create(element::i32, Shape{2}, Shape{1ull, combined_C_H * mvn_data.W}), false);
+        opset8::Constant::create(element::i64, Shape{2}, Shape{1ull, combined_C_H * mvn_data.W}), false);
     auto subtract_mean = std::make_shared<opset8::Add>(input_2d, avg_conv_2_2d);
     subtract_mean->set_friendly_name(mvn_data.name + "_SubMean");
 
@@ -208,10 +208,10 @@ static void Decompose(const std::shared_ptr<opset8::MVN> mvn, const MVNData& mvn
     // Reshape (combined channels) back to get the final output
     if (mvn->get_output_shape(0).size() == 3) {
         mvn_output = std::make_shared<opset8::Reshape>(pre_output,
-            opset8::Constant::create(element::i32, Shape{3}, {mvn_data.C, mvn_data.H, mvn_data.W}), false);
+            opset8::Constant::create(element::i64, Shape{3}, {mvn_data.C, mvn_data.H, mvn_data.W}), false);
     } else {
         mvn_output = std::make_shared<opset8::Reshape>(pre_output,
-            opset8::Constant::create(element::i32, Shape{4}, {mvn_data.N, mvn_data.C, mvn_data.H, mvn_data.W}), false);
+            opset8::Constant::create(element::i64, Shape{4}, {mvn_data.N, mvn_data.C, mvn_data.H, mvn_data.W}), false);
     }
 
     copy_runtime_info(mvn, {reshape, input_4d, input_2d, transposed_input_1, transposed_avg_conv_1, avg_conv_1, reshape_avg_conv_1,

--- a/src/tests/unit/gna/ngraph/transformations/gna_decompose_mvn.cpp
+++ b/src/tests/unit/gna/ngraph/transformations/gna_decompose_mvn.cpp
@@ -42,11 +42,11 @@ static std::shared_ptr<ngraph::Node> NormalizeVariance(const MVNParams& mvn_data
     auto combined_C_H = mvn_data.C * mvn_data.H;
 
     std::vector<float> avg_weights(8 * mvn_data.W / mvn_data.num_parts, 1.0f / mvn_data.W);
-    auto avg_weights_const = ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{8, mvn_data.W / mvn_data.num_parts, 1, 1}, avg_weights);
+    auto avg_weights_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{8, mvn_data.W / mvn_data.num_parts, 1, 1}, avg_weights);
     std::vector<float> eps_tensor(combined_C_H * mvn_data.W, mvn_data.eps);
-    auto eps_tensor_const = ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{1, combined_C_H * mvn_data.W}, eps_tensor);
+    auto eps_tensor_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{1, combined_C_H * mvn_data.W}, eps_tensor);
     std::vector<float> minus_half(combined_C_H * mvn_data.W, -0.5f);
-    auto minus_half_const = ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{1, combined_C_H * mvn_data.W}, minus_half);
+    auto minus_half_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{1, combined_C_H * mvn_data.W}, minus_half);
 
     // Calculate square of the difference between input and its mean
     auto squared_diff = std::make_shared<ngraph::opset8::Multiply>(subtract_mean, subtract_mean);
@@ -54,28 +54,28 @@ static std::shared_ptr<ngraph::Node> NormalizeVariance(const MVNParams& mvn_data
 
     // Calculate sum of the squares
     auto squared_diff_reshape = std::make_shared<ngraph::opset8::Reshape>(squared_diff,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{4},
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{4},
             ngraph::Shape{mvn_data.N, combined_C_H * mvn_data.num_parts, 1ull, mvn_data.W / mvn_data.num_parts}), false);
     auto transposed_input_3 = std::make_shared<ngraph::opset8::Transpose>(squared_diff_reshape,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {0, 3, 1, 2}));
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 3, 1, 2}));
     auto transposed_avg_conv_3 = std::make_shared<ngraph::opset8::Convolution>(transposed_input_3, avg_weights_const,
         ngraph::Strides{1, 1}, ngraph::CoordinateDiff{0, 0}, ngraph::CoordinateDiff{0, 0}, ngraph::Strides{1, 1}, ngraph::op::PadType::VALID);
     transposed_avg_conv_3->set_friendly_name("MvnAvg3");
     auto avg_conv_3 = std::make_shared<ngraph::opset8::Transpose>(transposed_avg_conv_3,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {0, 2, 3, 1}));
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 2, 3, 1}));
     auto reshape_avg_conv_3 = std::make_shared<ngraph::opset8::Reshape>(avg_conv_3,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{4},
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{4},
             ngraph::Shape{mvn_data.N, 1ull, combined_C_H, 8 * mvn_data.num_parts}), false);
     auto transposed_input_4 = std::make_shared<ngraph::opset8::Transpose>(reshape_avg_conv_3,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {0, 3, 1, 2}));
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 3, 1, 2}));
     auto transposed_avg_conv_4 = std::make_shared<ngraph::opset8::Convolution>(transposed_input_4,
         avg_broadcast_const, ngraph::Strides{1, 1}, ngraph::CoordinateDiff{0, 0}, ngraph::CoordinateDiff{0, 0},
         ngraph::Strides{1, 1}, ngraph::op::PadType::VALID);
     transposed_avg_conv_4->set_friendly_name("MvnAvg4");
     auto avg_conv_4 = std::make_shared<ngraph::opset8::Transpose>(transposed_avg_conv_4,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {0, 2, 3, 1}));
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 2, 3, 1}));
     auto reshape_avg_conv_4 = std::make_shared<ngraph::opset8::Reshape>(avg_conv_4,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{2}, ngraph::Shape{1ull, combined_C_H * mvn_data.W}), false);
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{2}, ngraph::Shape{1ull, combined_C_H * mvn_data.W}), false);
     std::shared_ptr<ngraph::Node> inv_stdev;
 
     // Create normalization part of the graph
@@ -104,46 +104,46 @@ static std::shared_ptr<ngraph::opset8::Result> Decompose(const std::shared_ptr<n
     auto combined_C_H = mvn_data.C * mvn_data.H;
 
     std::vector<float> neg_avg_weights(8 * mvn_data.W / mvn_data.num_parts, -1.0f / mvn_data.W);
-    auto neg_avg_weights_const = ngraph::opset8::Constant::create(ngraph::element::i32,
+    auto neg_avg_weights_const = ngraph::opset8::Constant::create(ngraph::element::i64,
         ngraph::Shape{8, mvn_data.W / mvn_data.num_parts, 1, 1}, neg_avg_weights);
 
     std::vector<float> avg_broadcast(8 * mvn_data.W * mvn_data.num_parts, 0.0f);
     for (size_t i = 0; i < mvn_data.W * mvn_data.num_parts; i++) {
         avg_broadcast[i * 8] = 1.0f;
     }
-    auto avg_broadcast_const = ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{mvn_data.W, 8 * mvn_data.num_parts, 1, 1}, avg_broadcast);
+    auto avg_broadcast_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{mvn_data.W, 8 * mvn_data.num_parts, 1, 1}, avg_broadcast);
 
     // Create average calculation part of the graph
     // We assume C = 1 case (combined channels)
     auto reshape = std::make_shared<ngraph::opset8::Reshape>(input_node,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{4},
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{4},
             ngraph::Shape{mvn_data.N, 1ull, combined_C_H, mvn_data.W}), false);
     auto input_4d = std::make_shared<ngraph::opset8::Reshape>(reshape,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{4},
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{4},
             ngraph::Shape{mvn_data.N, combined_C_H * mvn_data.num_parts, 1ull, mvn_data.W / mvn_data.num_parts}), false);
     auto input_2d = std::make_shared<ngraph::opset8::Reshape>(reshape,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{2},
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{2},
             ngraph::Shape{1ull, combined_C_H * mvn_data.W}), false);
     auto transposed_input_1 = std::make_shared<ngraph::opset8::Transpose>(input_4d,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {0, 3, 1, 2}));
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 3, 1, 2}));
     auto transposed_avg_conv_1 = std::make_shared<ngraph::opset8::Convolution>(transposed_input_1, neg_avg_weights_const,
         ngraph::Strides{1, 1}, ngraph::CoordinateDiff{0, 0}, ngraph::CoordinateDiff{0, 0}, ngraph::Strides{1, 1}, ngraph::op::PadType::VALID);
     transposed_avg_conv_1->set_friendly_name("MvnAvg1");
     auto avg_conv_1 = std::make_shared<ngraph::opset8::Transpose>(transposed_avg_conv_1,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {0, 2, 3, 1}));
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 2, 3, 1}));
     auto reshape_avg_conv_1 = std::make_shared<ngraph::opset8::Reshape>(avg_conv_1,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{4},
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{4},
             ngraph::Shape{mvn_data.N, 1ull, combined_C_H, 8 * mvn_data.num_parts}), false);
     auto transposed_input_2 = std::make_shared<ngraph::opset8::Transpose>(reshape_avg_conv_1,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {0, 3, 1, 2}));
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 3, 1, 2}));
     auto transposed_avg_conv_2 = std::make_shared<ngraph::opset8::Convolution>(transposed_input_2,
         avg_broadcast_const, ngraph::Strides{1, 1}, ngraph::CoordinateDiff{0, 0}, ngraph::CoordinateDiff{0, 0},
         ngraph::Strides{1, 1}, ngraph::op::PadType::VALID);
     transposed_avg_conv_2->set_friendly_name("MvnAvg2");
     auto avg_conv_2 = std::make_shared<ngraph::opset8::Transpose>(transposed_avg_conv_2,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {0, 2, 3, 1}));
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {0, 2, 3, 1}));
     auto avg_conv_2_2d = std::make_shared<ngraph::opset8::Reshape>(avg_conv_2,
-        ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{2}, ngraph::Shape{1ull, combined_C_H * mvn_data.W}), false);
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{2}, ngraph::Shape{1ull, combined_C_H * mvn_data.W}), false);
     auto subtract_mean = std::make_shared<ngraph::opset8::Add>(input_2d, avg_conv_2_2d);
     subtract_mean->set_friendly_name("MvnSubMean");
 
@@ -157,10 +157,10 @@ static std::shared_ptr<ngraph::opset8::Result> Decompose(const std::shared_ptr<n
     // Reshape (combined channels) back to get the final output
     if (input_node->get_output_shape(0).size() == 3) {
         mvn_output = std::make_shared<ngraph::opset8::Reshape>(pre_output,
-            ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{3}, {mvn_data.C, mvn_data.H, mvn_data.W}), false);
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{3}, {mvn_data.C, mvn_data.H, mvn_data.W}), false);
     } else {
         mvn_output = std::make_shared<ngraph::opset8::Reshape>(pre_output,
-            ngraph::opset8::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {mvn_data.N, mvn_data.C, mvn_data.H, mvn_data.W}), false);
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {mvn_data.N, mvn_data.C, mvn_data.H, mvn_data.W}), false);
     }
 
     return std::make_shared<ngraph::opset8::Result>(mvn_output);
@@ -193,7 +193,7 @@ std::shared_ptr<ngraph::Function> getReferenceFunction(const ngraph::Shape& inpu
     }
 
     // Create decomposed reference function
-    auto input_params = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::i32, input_shape);
+    auto input_params = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::i64, input_shape);
     std::shared_ptr<ngraph::opset8::Result> result = Decompose(input_params, mvn_data);
 
     return std::make_shared<ngraph::Function>(ngraph::ResultVector{result}, ngraph::ParameterVector{input_params});
@@ -202,11 +202,11 @@ std::shared_ptr<ngraph::Function> getReferenceFunction(const ngraph::Shape& inpu
 std::shared_ptr<ngraph::Function> getInitialFunction(const ngraph::Shape& input_shape, const bool& normalize_variance,
     const float& eps, const ngraph::op::MVNEpsMode& eps_mode, const InferenceEngine::SizeVector& axes,
     const bool& across_channels, const bool& mvn_version_6) {
-    auto input_params = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::i32, input_shape);
+    auto input_params = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::i64, input_shape);
     std::shared_ptr<ngraph::Node> mvn;
 
     if (mvn_version_6) {
-        const auto axesConst = std::make_shared<ngraph::opset8::Constant>(ngraph::element::i32, ngraph::Shape{axes.size()}, axes);
+        const auto axesConst = std::make_shared<ngraph::opset8::Constant>(ngraph::element::i64, ngraph::Shape{axes.size()}, axes);
         mvn = std::make_shared<ngraph::opset8::MVN>(input_params, axesConst, normalize_variance, eps, eps_mode);
     } else {
         mvn = std::make_shared<ngraph::opset2::MVN>(input_params, across_channels, normalize_variance, eps);
@@ -250,4 +250,3 @@ TEST(TransformationTests, DecomposeMVNTest) {
         }
     }
 }
-


### PR DESCRIPTION
### Details:
 - align precisions of Constant layers created during MVN decomposition with other passes (i32 -> i64).

### Tickets:
 - 84785
