### PR TITLE
EISW-40557: fix build ov wheel package

### DIFF
--- a/src/bindings/python/wheel/setup.py
+++ b/src/bindings/python/wheel/setup.py
@@ -175,8 +175,8 @@ class CustomBuild(build):
             self.announce(f'Configuring cmake project: {openvino_root_dir}', level=3)
             self.spawn(['cmake', '-H' + str(openvino_root_dir), '-B' + self.build_temp,
                         '-DCMAKE_BUILD_TYPE={type}'.format(type=self.config),
-                        '-DENABLE_PYTHON=ON',
-                        '-DENABLE_OV_ONNX_FRONTEND=ON'])
+                        '-DENABLE_PYTHON=OFF',
+                        '-DENABLE_OV_ONNX_FRONTEND=OFF'])
 
             self.announce('Building binaries', level=3)
             self.spawn(['cmake', '--build', self.build_temp,


### PR DESCRIPTION
### Details:
- this pr is to fix build issue on generated wheel package for openvino.
- which can be preproduced by below steps
 cd openvino/src/bindings/python/wheel/
 python3 setup.py bdist_wheel

### Tickets:
 - EISW-40557
