### PR TITLE
[GPU] Add a parameter for reshape primitive to ensure the rank of output_shape

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reshape.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reshape.hpp
@@ -26,18 +26,23 @@ struct reshape : public primitive_base<reshape> {
     /// @param id This primitive id.
     /// @param input Input primitive id.
     /// @param output_shape Requested memory shape (excluding padding).
+    /// @param output_shape_rank The rank of output_shape
     /// A dimension could be 0, in this case,  the value is taken from the input tensor.
     /// At most one dimension of the new shape can be -1. In this case, the value is inferred from the size of the tensor and the remaining dimensions.
     /// @param output_padding Requested memory padding.
     reshape(const primitive_id& id,
             const primitive_id& input,
             const tensor& output_shape,
+            const size_t& output_shape_rank,
             const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), output_shape(output_shape) {}
+        : primitive_base(id, {input}, ext_prim_id, output_padding), output_shape(output_shape), output_shape_rank(output_shape_rank) {}
 
     /// @brief Requested memory shape.
     tensor output_shape;
+
+    /// @brief The rank of output_shape
+    size_t output_shape_rank;
 };
 
 /// @}

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/graph_initializations.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/graph_initializations.cpp
@@ -313,7 +313,7 @@ void graph_initializations::handle_lstm_node(program& p, lstm_node& node) {
                                static_cast<int32_t>(concatenate_len),
                                hidden_size.spatial[0],
                                (int32_t)directions};
-            auto reshape_primitive = std::make_shared<reshape>(node.id() + ":reshape", concatenation_id, output_size);
+            auto reshape_primitive = std::make_shared<reshape>(node.id() + ":reshape", concatenation_id, output_size, 4);
             auto& reshape_node = p.get_or_create(reshape_primitive);
             p.add_connection(concatenation_node, reshape_node);
             p.replace_all_usages(node, reshape_node);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/handle_reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/handle_reshape.cpp
@@ -89,7 +89,6 @@ void handle_reshape::run(program& p) {
             if (!reorder_node_to_split.empty()) {
                 auto& prim_node = node->as<reshape>();
                 const auto& prim = prim_node.get_primitive();
-                auto output_shape = prim->output_shape;
 
                 // vector for storing reshape nodes to connect to new reorder nodes (if needed)
                 std::vector<program_node*> reorder_reshape_nodes;
@@ -111,7 +110,8 @@ void handle_reshape::run(program& p) {
                         reorder_node_to_split.end()) {
                         auto new_reshape = std::make_shared<reshape>("reorder:_reshape_split_" + user->id() + "_" + node->id(),
                                                                      input_node.id(),
-                                                                     output_shape);
+                                                                     prim->output_shape,
+                                                                     prim->output_shape_rank);
                         auto& new_reshape_node = p.get_or_create(new_reshape);
                         user->replace_dependency(0, input_node);
                         p.add_intermediate(new_reshape_node, *user, 0);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -696,7 +696,7 @@ void reorder_inputs::run(program& p, layout_optimizer& lo, reorder_factory& rf) 
             auto new_tensor = input_layout.size;
             new_tensor.feature[0] = input_layout.size.spatial[0];
             new_tensor.spatial[0] = 1;
-            auto new_reshape = std::make_shared<reshape>("reorder:Reshape_bf_" + fc_node.id() + "_for_input", input.id(), new_tensor);
+            auto new_reshape = std::make_shared<reshape>("reorder:Reshape_bf_" + fc_node.id() + "_for_input", input.id(), new_tensor, input_layout.get_rank());
             auto& new_reorder_node = p.get_or_create(new_reshape);
             p.add_intermediate(new_reorder_node, fc_node, 0);
         }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/strided_slice_optimize.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/strided_slice_optimize.cpp
@@ -61,7 +61,8 @@ void strided_slice_optimize::run(program& p) {
             auto reshape_prim = std::make_shared<reshape>(
                 "reshape_" + node->id(),
                 node->get_dependency(0).get_primitive()->id,
-                tensor(output_dims_sizes[0], output_dims_sizes[1], output_dims_sizes[3], output_dims_sizes[2]));
+                tensor(output_dims_sizes[0], output_dims_sizes[1], output_dims_sizes[3], output_dims_sizes[2]),
+                4);
 
             auto& reshape_prim_node = p.get_or_create(reshape_prim);
 

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -229,7 +229,6 @@ bool program::analyze_output_size_handling_need() {
                 1);
 
             auto filter_size = prim_node.weights(0).get_output_layout().size;
-
             auto inputSize = prim_node.input().get_output_layout().size;
             auto calc_output_range =
                 calc_sliding_window_output_range<swor_mode::all>(inputSize,

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -42,8 +42,24 @@ layout reshape_inst::calc_output_layout(reshape_node const& node) {
     if (need_recalc)
         sizes[need_recalc] = static_cast<int>(input_layout.size.count()) / shape_count;
 
-    input_layout.size = tensor(sizes);
-    return input_layout;
+    auto output_format = input_layout.format;
+    auto output_dims_size = node.get_primitive()->output_shape_rank;
+
+    if (output_dims_size == 6) {
+        if (input_layout.get_rank() != 6) {
+            output_format = cldnn::format::bfwzyx;
+        }
+    } else if (output_dims_size == 5) {
+        if (input_layout.get_rank() != 5) {
+            output_format = cldnn::format::bfzyx;
+        }
+    } else if (output_dims_size <= 4) {
+        if (input_layout.get_rank() != 4) {
+            output_format = cldnn::format::bfyx;
+        }
+    }
+
+    return layout{input_layout.data_type, output_format, tensor(sizes)};
 }
 
 std::string reshape_inst::to_string(reshape_node const& node) {

--- a/src/plugins/intel_gpu/src/plugin/ops/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/broadcast.cpp
@@ -73,7 +73,7 @@ static void CreateCommonBroadcastOp(Program& p, const std::shared_ptr<ngraph::No
 
         auto targetShape = tensor_from_dims(inputShape);
 
-        auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitive, targetShape, op->get_friendly_name());
+        auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitive, targetShape, inputShape.size(), op->get_friendly_name());
         p.AddPrimitive(reshapePrim);
         p.AddInnerPrimitiveToProfiler(reshapeName, layerName, op);
 

--- a/src/plugins/intel_gpu/src/plugin/ops/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/eltwise.cpp
@@ -69,7 +69,7 @@ void CreateElementwiseOp(Program& p, const std::shared_ptr<ngraph::Node>& op, cl
 
             auto targetShape = tensor_from_dims(inputShape);
 
-            auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape, op->get_friendly_name());
+            auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape, inputShape.size(), op->get_friendly_name());
             p.AddPrimitive(reshapePrim);
             p.AddInnerPrimitiveToProfiler(reshapeName, layerName, op);
 

--- a/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
@@ -129,6 +129,7 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
             auto reshapeInPrim = cldnn::reshape(reshapeInName,
                                                 inputName,
                                                 tensor_from_dims(reshapeSize),
+                                                reshapeSize.size(),
                                                 op->get_friendly_name());
             p.AddPrimitive(reshapeInPrim);
             p.AddInnerPrimitiveToProfiler(reshapeInName, layerName, op);
@@ -157,9 +158,10 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
 
         auto lastLayerName = layerName;
         if (reshape_fc) {
-            auto outputShape = tensor_from_dims(op->get_output_shape(0));
+            auto outputShape = op->get_output_shape(0);
+            auto outputTensor = tensor_from_dims(outputShape);
             auto outReshapeName = layerName + "_cldnn_out_reshape";
-            auto outReshapePrim = cldnn::reshape(outReshapeName, layerName, outputShape, op->get_friendly_name());
+            auto outReshapePrim = cldnn::reshape(outReshapeName, layerName, outputTensor, outputShape.size(), op->get_friendly_name());
 
             p.AddPrimitive(outReshapePrim);
             p.AddInnerPrimitiveToProfiler(outReshapeName, layerName, op);
@@ -239,7 +241,7 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
 
                 auto targetShape = gemmSpecificTensor(inputDims);
 
-                auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape, op->get_friendly_name());
+                auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape, inputDims.size(), op->get_friendly_name());
 
                 p.AddPrimitive(reshapePrim);
                 p.AddInnerPrimitiveToProfiler(reshapeName, layerName, op);
@@ -269,9 +271,9 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
 
         // Reshape output if gemm specific shape does not match default one
         if (outDimsN < 4) {
-            auto outputShape = tensor_from_dims(outDims);
+            auto outputTensor = tensor_from_dims(outDims);
             auto outReshapeName = layerName + "_cldnn_out_reshape";
-            auto outReshapePrim = cldnn::reshape(outReshapeName, layerName, outputShape, op->get_friendly_name());
+            auto outReshapePrim = cldnn::reshape(outReshapeName, layerName, outputTensor, outDims.size(), op->get_friendly_name());
 
             p.AddPrimitive(outReshapePrim);
             p.AddInnerPrimitiveToProfiler(outReshapeName, layerName, op);

--- a/src/plugins/intel_gpu/src/plugin/ops/reduce.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reduce.cpp
@@ -99,7 +99,7 @@ static void CreateReduceOp(Program& p, const std::shared_ptr<ngraph::Node>& op, 
                 outTensor = cldnn::tensor(TensorValue(out_shape[0]), TensorValue(out_shape[1]),
                                           1, TensorValue(out_shape[2]));
         }
-        auto reshape_prim = cldnn::reshape(resultLayerName, layerName, outTensor, op->get_friendly_name());
+        auto reshape_prim = cldnn::reshape(resultLayerName, layerName, outTensor, rank, op->get_friendly_name());
         p.AddPrimitive(reshape_prim);
         p.AddPrimitiveToProfiler(op, resultLayerName);
     }

--- a/src/plugins/intel_gpu/src/plugin/ops/reshape.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reshape.cpp
@@ -54,7 +54,9 @@ static void CreateCommonReshapeOp(Program& p, const std::shared_ptr<ngraph::Node
     auto reshapePrim = cldnn::reshape(layerName,
                                       reshapeInputId,
                                       outTensor,
-                                      op->get_friendly_name());
+                                      outDims.size(),
+                                      op->get_friendly_name(),
+                                      cldnn::padding());
 
     p.AddPrimitive(reshapePrim);
     p.AddPrimitiveToProfiler(op);

--- a/src/plugins/intel_gpu/src/plugin/ops/select.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/select.cpp
@@ -65,7 +65,7 @@ static void CreateSelectOp(Program& p, const std::shared_ptr<ngraph::op::v1::Sel
 
                 auto targetShape = tensor_from_dims(inputDims);
 
-                auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape, op->get_friendly_name());
+                auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape, inputDims.size(), op->get_friendly_name());
 
                 p.AddPrimitive(reshapePrim);
                 p.AddInnerPrimitiveToProfiler(reshapeName, layerName, op);

--- a/src/plugins/intel_gpu/src/plugin/ops/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/strided_slice.cpp
@@ -191,7 +191,7 @@ static void CreateStridedSliceOp(Program& p, const std::shared_ptr<ngraph::op::v
         if (!new_axis_mask.empty()) {
             auto targetShape = tensor_from_dims(reshape_pattern);
             auto reshapeInName = op->get_friendly_name() + "/Reshape_before";
-            auto reshapePrim = cldnn::reshape(reshapeInName, inputPrimitives[0], targetShape, op->get_friendly_name());
+            auto reshapePrim = cldnn::reshape(reshapeInName, inputPrimitives[0], targetShape, reshape_pattern.size(), op->get_friendly_name());
             p.AddPrimitive(reshapePrim);
             p.AddInnerPrimitiveToProfiler(reshapeInName, layerName, op);
             inPrimitive = reshapeInName;
@@ -225,7 +225,7 @@ static void CreateStridedSliceOp(Program& p, const std::shared_ptr<ngraph::op::v
         if (!shrink_axis_mask.empty()) {
             auto targetShape = tensor_from_dims(output_shape);
             auto reshapeOutName = op->get_friendly_name() + "/Crop";
-            auto reshapePrim = cldnn::reshape(reshapeOutName, layerName, targetShape, op->get_friendly_name());
+            auto reshapePrim = cldnn::reshape(reshapeOutName, layerName, targetShape, output_shape.size(), op->get_friendly_name());
             p.AddPrimitive(reshapePrim);
             p.AddInnerPrimitiveToProfiler(reshapeOutName, layerName, op);
             last_layer_primitive = reshapeOutName;

--- a/src/plugins/intel_gpu/tests/fusions/resample_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/resample_fusion_test.cpp
@@ -48,6 +48,10 @@ public:
         return layout{ p.data_type, p.input_format, p.in_shape, padding{} };
     }
 
+    layout get_output_layout(resample_test_params& p) {
+        return layout{ p.data_type, p.default_format, p.out_shape, padding{} };
+    }
+
     layout get_per_channel_layout(resample_test_params& p) {
         return layout{ p.default_type, p.default_format, tensor{ 1, p.out_shape.feature[0], 1, 1 } };
     }
@@ -322,7 +326,7 @@ TEST_P(resample_scale_fusing_through, reshape) {
         input_layout("input", get_input_layout(p)),
         data("scale_data", get_mem(layout{ p.default_type, p.default_format, tensor{ 1, 1, 1, 1 } })),
         resample("resample_prim", "input", p.out_shape, p.in_shape.feature[0], p.type),
-        reshape("reshape", "resample_prim", reshape_shape),
+        reshape("reshape", "resample_prim", reshape_shape, get_output_layout(p).get_rank()),
         eltwise("scale", "reshape", "scale_data", eltwise_mode::prod),
         reorder("reorder_bfyx", "scale", p.default_format, data_types::f32)
     );
@@ -372,7 +376,7 @@ TEST_P(resample_scale_fusing_through_not_allowed, reshape_two_users) {
         input_layout("input", get_input_layout(p)),
         data("scale_data", get_mem(layout{ p.default_type, p.default_format, tensor{ 1, 1, 1, 1 } })),
         resample("resample_prim", "input", p.out_shape, p.in_shape.feature[0], p.type),
-        reshape("reshape", "resample_prim", reshape_shape),
+        reshape("reshape", "resample_prim", reshape_shape, get_output_layout(p).get_rank()),
         eltwise("scale", "reshape", "scale_data", eltwise_mode::prod),
         eltwise("sum", "reshape", "scale", eltwise_mode::sum),
         reorder("reorder_bfyx", "sum", p.default_format, data_types::f32)

--- a/src/plugins/intel_gpu/tests/fusions/softmax_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/softmax_fusion_test.cpp
@@ -110,7 +110,7 @@ TEST_P(softmax_quantize_fusing_through, reshape) {
         data("out_lo", get_mem(get_single_element_layout(p), -127)),
         data("out_hi", get_mem(get_single_element_layout(p), 127)),
         softmax("softmax", "input", p.dimension),
-        reshape("reshape", "softmax", get_reshape_shape(p)),
+        reshape("reshape", "softmax", get_reshape_shape(p), get_input_layout(p).get_rank()),
         quantize("quantize", "reshape", "in_lo", "in_hi", "out_lo", "out_hi", 255, data_types::i8),
         reorder("reorder_bfyx", "quantize", get_output_layout(p))
     );
@@ -146,9 +146,9 @@ TEST_P(softmax_quantize_fusing_through, chain) {
         data("out_lo", get_mem(get_single_element_layout(p), -127)),
         data("out_hi", get_mem(get_single_element_layout(p), 127)),
         softmax("softmax", "input", p.dimension),
-        reshape("reshape_first", "softmax", get_reshape_shape(p)),
+        reshape("reshape_first", "softmax", get_reshape_shape(p), get_input_layout(p).get_rank()),
         reorder("reorder", "reshape_first", reorder_layout),
-        reshape("reshape_second", "reorder", get_reshape_shape(p)),
+        reshape("reshape_second", "reorder", get_reshape_shape(p), get_input_layout(p).get_rank()),
         quantize("quantize", "reshape_second", "in_lo", "in_hi", "out_lo", "out_hi", 255, data_types::i8),
         reorder("reorder_bfyx", "quantize", get_output_layout(p))
     );

--- a/src/plugins/intel_gpu/tests/module_tests/graph_manipulation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/module_tests/graph_manipulation_gpu_test.cpp
@@ -43,7 +43,7 @@ TEST(basic, test1) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(data("weights1", weights1));
     topology.add(data("weights2", weights2));
-    topology.add(reshape("reshape1", "weights1", tensor(spatial(1, 2))));
+    topology.add(reshape("reshape1", "weights1", tensor(spatial(1, 2)), 2));
     topology.add(reorder("reorder2", "input", layout(data_types::f32, format::byxf, tensor(4))));
     topology.add(reorder("reorder1", "reshape1", layout(data_types::f32, format::byxf, tensor(4))));
     topology.add(concatenation("concat", { "reorder1", "weights2" }, 3));

--- a/src/plugins/intel_gpu/tests/test_cases/add_reorders_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/add_reorders_gpu_test.cpp
@@ -106,7 +106,7 @@ TEST(add_reorders_gpu, basic_reshape_and_tile) {
 
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(reshape("reshape", "input", tensor(2, 1, 2, 1)));
+    topology.add(reshape("reshape", "input", tensor(2, 1, 2, 1), 4));
     topology.add(tile("tile", "reshape", tensor(2, 1, 2, 4)));
 
     std::vector<float> input_vec = { 1.f, 0.f, 5.f, 1.5f };

--- a/src/plugins/intel_gpu/tests/test_cases/depth_concatenate_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/depth_concatenate_gpu_test.cpp
@@ -391,8 +391,8 @@ TEST(depth_concatenate_f32_gpu, test05_different_formats) {
     topology topology;
     topology.add(input_layout("input1", input1->get_layout()));
     topology.add(input_layout("input2", input2->get_layout()));
-    topology.add(reshape("reshape1", "input1", {1, 3, 2, 2}));
-    topology.add(reshape("reshape2", "input2", {1, 3, 2, 2}));
+    topology.add(reshape("reshape1", "input1", {1, 3, 2, 2}, 4));
+    topology.add(reshape("reshape2", "input2", {1, 3, 2, 2}, 4));
     topology.add(concatenation("depth1", {"reshape1", "reshape2"}, 1));
     topology.add(reorder("output", "depth1", format::bfyx, data_types::f32));
 
@@ -719,7 +719,7 @@ TEST(depth_concatenate_f32_gpu, concat_with_reshape_input) {
 
     topology topology;
     topology.add(input_layout("input1", input1->get_layout()));
-    topology.add(reshape("reshape", "input1", tensor(2, 1, 4, 2)));
+    topology.add(reshape("reshape", "input1", tensor(2, 1, 4, 2), 4));
     topology.add(concatenation("depth1", { "reshape" }, 1));
     topology.add(concatenation("depth2", { "depth1" }, 1));
 

--- a/src/plugins/intel_gpu/tests/test_cases/depth_to_space_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/depth_to_space_gpu_test.cpp
@@ -238,13 +238,13 @@ TEST(depth_to_space_fp32_gpu, d112960540_bs2) {
     topology_ref.add(reorder("reorder1", "Input0", { data_types::f16, format::bfwzyx, tensor{ batch(1), feature(12), spatial(1, 1, 960, 540) }
         }));
     topology_ref.add(
-        reshape("reshape", "reorder1", tensor{ batch(1), feature(2), spatial(960, 540, 3, 2) })
+        reshape("reshape", "reorder1", tensor{ batch(1), feature(2), spatial(960, 540, 3, 2) }, 6)
     );
     topology_ref.add(
         permute("perm", "reshape", perm)
     );
     topology_ref.add(
-        reshape("reshape2", "perm", tensor(1, 3, 2 * 960, 2 * 540))
+        reshape("reshape2", "perm", tensor(1, 3, 2 * 960, 2 * 540), 4)
     );
 
     build_options build_opt;

--- a/src/plugins/intel_gpu/tests/test_cases/memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/memory_test.cpp
@@ -472,7 +472,7 @@ TEST(memory_pool, non_opt_intermidate_opt_after) {
     auto input = cldnn::input_layout("input1", input_layout1);
     auto input2 = cldnn::input_layout("input2", input_layout2);
     auto concat = cldnn::concatenation("concat", { "input1", "input2" }, 0);
-    auto reshape = cldnn::reshape("reshape", "concat", reshape_tensor);
+    auto reshape = cldnn::reshape("reshape", "concat", reshape_tensor, 4);
     auto crop1 = cldnn::crop("crop1", "reshape", { 1, 1, 1, 1 }, { 0, 0, 0, 0 });
     auto crop2 = cldnn::crop("crop2", "reshape", { 1, 1, 1, 1 }, { 1, 0, 0, 0 });
     auto eltwise1 = cldnn::scale("elt1", "crop1", "scale_mem");

--- a/src/plugins/intel_gpu/tests/test_cases/permute_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/permute_gpu_test.cpp
@@ -631,7 +631,7 @@ TEST(fc_permute_crop_gpu, basic_0)
         data("weights", weights_mem),
         data("bias", bias_mem),
         fully_connected("fully_connected", "input", "weights", "bias"),  // yxfb {5, 512, 1, 1}
-        reshape("reshape", "fully_connected", { 1, 5, 1, 512 }),           // yxfb {1, 5, 1, 512}
+        reshape("reshape", "fully_connected", { 1, 5, 1, 512 }, 4),           // yxfb {1, 5, 1, 512}
         permute("permute", "reshape", { 1, 0, 2, 3 }),                     // yxfb {5, 1, 1, 512}        --- without permute fix yxfb {1, 5, 512, 1}
         crop("crop", "permute", { 1, 1, 1, 512 }, { 4, 0, 0 ,0 })           // without permute fix it will fail "Tensor pitches didn't set correctly"
     );
@@ -812,9 +812,9 @@ TEST(permute_gpu_f32, 6D_reshape_permute_reshape)
     topology topology(
         input_layout("input", input_mem->get_layout()),
         reorder("input_6d", "input", { data_types::f32, format::bfwzyx, cldnn::tensor(batch(b), feature(f), spatial(x, y)) }),
-        reshape("reshape_4_to_6", "input_6d", cldnn::tensor(batch(b), feature(f_reshape), spatial(x, y, z_reshape, w_reshape))),
+        reshape("reshape_4_to_6", "input_6d", cldnn::tensor(batch(b), feature(f_reshape), spatial(x, y, z_reshape, w_reshape)), 6),
         permute("permute", "reshape_4_to_6", permute_order),
-        reshape("reshape_6_to_4", "permute", cldnn::tensor(batch(b), feature(f), spatial(x, y))),
+        reshape("reshape_6_to_4", "permute", cldnn::tensor(batch(b), feature(f), spatial(x, y)), 4),
         reorder("output_4d", "reshape_6_to_4", { data_types::f32, format::bfyx, cldnn::tensor(batch(b), feature(f), spatial(x, y)) })
     );
 

--- a/src/plugins/intel_gpu/tests/test_cases/propagate_constants_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/propagate_constants_gpu_test.cpp
@@ -32,7 +32,7 @@ TEST(propagate_constants, copy_dependecies_from_nodes) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(data("weights1", weights1));
     topology.add(data("weights2", weights2));
-    topology.add(reshape("reshape1", "weights1", tensor(spatial(1, 2))));
+    topology.add(reshape("reshape1", "weights1", tensor(spatial(1, 2)), 2));
     topology.add(reorder("reorder2", "input", layout(data_types::f32, format::byxf, tensor(4))));
     topology.add(reorder("reorder1", "reshape1", layout(data_types::f32, format::byxf, tensor(4))));
     topology.add(concatenation("concat", { "reorder1", "weights2" }, 3));

--- a/src/plugins/intel_gpu/tests/test_cases/removing_output_node_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/removing_output_node_test.cpp
@@ -52,7 +52,7 @@ TEST(removing_output_node, multiple_outputs) {
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
     topology.add(shuffle_channels("shuffle_channels", "input", group, axis));
-    topology.add(reshape("reshape", "shuffle_channels", after_reshape));
+    topology.add(reshape("reshape", "shuffle_channels", after_reshape, 4));
     topology.add(data("input2", begin));
     topology.add(data("input3", end));
     topology.add(data("input4", strides));

--- a/src/plugins/intel_gpu/tests/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reorder_gpu_test.cpp
@@ -1814,10 +1814,10 @@ TEST(reorder_gpu_f32, bfwzyx_bfyx_chain)
     topology topology(
         input_layout("input", input->get_layout()),
         reorder("reorder1", "input", format::bfwzyx, data_types::f32),
-        reshape("reshape1", "reorder1", tensor(batch(2), feature(2), spatial(1, 1, 2, 2) )),
+        reshape("reshape1", "reorder1", tensor(batch(2), feature(2), spatial(1, 1, 2, 2)), 6),
         reorder("reorder2", "reshape1", format::bfwzyx, data_types::f32, sub_bfwzyx),
-        reshape("reshape2", "reorder2", tensor(batch(4), feature(2), spatial(1, 1, 1, 2))),
-        reshape("reshape3", "reshape2", tensor(batch(1), feature(4), spatial(2, 2))),
+        reshape("reshape2", "reorder2", tensor(batch(4), feature(2), spatial(1, 1, 1, 2)), 6),
+        reshape("reshape3", "reshape2", tensor(batch(1), feature(4), spatial(2, 2)), 4),
         reorder("reorder3", "reshape3", format::bfyx, data_types::f32, sub_bfyx),
         reorder("out_reorder", "reorder3", format::bfwzyx, data_types::f32)
         );

--- a/src/plugins/intel_gpu/tests/test_cases/reshape_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reshape_gpu_test.cpp
@@ -23,7 +23,7 @@ void verify_int(const int32_t& output_value, const int32_t& value) {
 }
 
 template <class ElemType>
-void generic_reshape_test(format fmt, tensor const& input_size, tensor const& reshape_size,
+void generic_reshape_test(format fmt, tensor const& input_size, tensor const& reshape_size, size_t const& reshape_size_rank,
     bool /* in_place */, padding const& input_padd = padding(),
     padding const& output_padd = padding()) {
     auto& engine = get_test_engine();
@@ -62,7 +62,7 @@ void generic_reshape_test(format fmt, tensor const& input_size, tensor const& re
         tpl.add(reorder("reorder", "input", padded_input_layout));
         reshape_input = "reorder";
     }
-    tpl.add(reshape("reshape", reshape_input, reshape_size, "", output_padd));
+    tpl.add(reshape("reshape", reshape_input, reshape_size, reshape_size_rank, "", output_padd));
 
     build_options bo;
     bo.set_option(build_option::outputs({reshape_input, "reshape"}));
@@ -131,6 +131,7 @@ TEST(reshape_gpu_f32, basic_2dim_in_place) {
         format::bfyx,
         tensor(1, 1, 2, 2),
         tensor(1, 1, 4, 1),
+        4,
         true);
 }
 
@@ -139,6 +140,7 @@ TEST(reshape_gpu_f16, basic_2dim_in_place) {
         format::bfyx,
         tensor(1, 1, 2, 2),
         tensor(1, 1, 1, 4),
+        4,
         true);
 }
 
@@ -147,6 +149,7 @@ TEST(reshape_gpu_i8, basic_2dim_in_place) {
         format::bfyx,
         tensor(1, 1, 2, 2),
         tensor(1, 1, 1, 4),
+        4,
         true);
 }
 
@@ -155,6 +158,7 @@ TEST(reshape_gpu_i32, basic_2dim_in_place) {
         format::bfyx,
         tensor(1, 1, 2, 2),
         tensor(1, 1, 1, 4),
+        4,
         true);
 }
 
@@ -163,6 +167,7 @@ TEST(reshape_gpu_i64, basic_2dim_in_place) {
         format::bfyx,
         tensor(1, 1, 2, 2),
         tensor(1, 1, 1, 4),
+        4,
         true);
 }
 
@@ -171,6 +176,7 @@ TEST(reshape_gpu_f32, basic_4dim_in_place) {
         format::yxfb,
         tensor(9, 9, 2, 4),
         tensor(27, 2, 3, 4),
+        4,
         true);
 }
 
@@ -179,6 +185,7 @@ TEST(reshape_gpu_f16, basic_4dim_in_place) {
         format::yxfb,
         tensor(9, 9, 2, 4),
         tensor(3, 4, 27, 2),
+        4,
         true);
 }
 
@@ -187,6 +194,7 @@ TEST(reshape_gpu_i32, basic_4dim_in_place) {
         format::yxfb,
         tensor(9, 9, 2, 4),
         tensor(3, 4, 27, 2),
+        4,
         true);
 }
 
@@ -195,6 +203,7 @@ TEST(reshape_gpu_i64, basic_4dim_in_place) {
         format::yxfb,
         tensor(9, 9, 2, 4),
         tensor(3, 4, 27, 2),
+        4,
         true);
 }
 
@@ -203,6 +212,7 @@ TEST(reshpape_gpu_f32, basic_2dim_output_padd) {
         format::byxf,
         tensor(1, 1, 4, 2),
         tensor(1, 1, 8, 1),
+        4,
         false,
         padding(),
         padding(std::vector<int>{0, 0, 1, 1}));
@@ -213,6 +223,7 @@ TEST(reshape_gpu_f16, basic_2dim_output_padd) {
         format::byxf,
         tensor(1, 1, 3, 4),
         tensor(1, 1, 2, 6),
+        4,
         false,
         padding(),
         padding(std::vector<int>{0, 0, 2, 2}));
@@ -223,6 +234,7 @@ TEST(reshape_gpu_i8, basic_2dim_output_padd) {
         format::byxf,
         tensor(1, 1, 3, 4),
         tensor(1, 1, 2, 6),
+        4,
         false,
         padding(),
         padding(std::vector<int>{0, 0, 2, 2}));
@@ -233,6 +245,7 @@ TEST(reshape_gpu_i32, basic_2dim_output_padd) {
         format::byxf,
         tensor(1, 1, 3, 4),
         tensor(1, 1, 2, 6),
+        4,
         false,
         padding(),
         padding(std::vector<int>{0, 0, 2, 2}));
@@ -243,6 +256,7 @@ TEST(reshape_gpu_i64, basic_2dim_output_padd) {
         format::byxf,
         tensor(1, 1, 3, 4),
         tensor(1, 1, 2, 6),
+        4,
         false,
         padding(),
         padding(std::vector<int>{0, 0, 2, 2}));
@@ -253,6 +267,7 @@ TEST(reshape_gpu_f32, basic_2dim_input_padd) {
         format::fyxb,
         tensor(1, 1, 2, 5),
         tensor(1, 1, 5, 2),
+        4,
         false,
         padding({0, 0, 3, 2}, {0, 0, 1, 4}));
 }
@@ -262,6 +277,7 @@ TEST(reshape_gpu_f16, basic_2dim_input_padd) {
         format::fyxb,
         tensor(1, 1, 3, 3),
         tensor(1, 1, 1, 9),
+        4,
         false,
         padding({0, 0, 4, 1}, {0, 0, 2, 3}));
 }
@@ -271,6 +287,7 @@ TEST(reshape_gpu_i8, basic_2dim_input_padd) {
         format::fyxb,
         tensor(1, 1, 3, 3),
         tensor(1, 1, 1, 9),
+        4,
         false,
         padding({0, 0, 4, 1}, {0, 0, 2, 3}));
 }
@@ -280,6 +297,7 @@ TEST(reshape_gpu_i32, basic_2dim_input_padd) {
         format::fyxb,
         tensor(1, 1, 3, 3),
         tensor(1, 1, 1, 9),
+        4,
         false,
         padding({0, 0, 4, 1}, {0, 0, 2, 3}));
 }
@@ -289,6 +307,7 @@ TEST(reshape_gpu_i64, basic_2dim_input_padd) {
         format::fyxb,
         tensor(1, 1, 3, 3),
         tensor(1, 1, 1, 9),
+        4,
         false,
         padding({0, 0, 4, 1}, {0, 0, 2, 3}));
 }
@@ -298,6 +317,7 @@ TEST(reshape_gpu_f32, basic_2dim_input_output_padd) {
         format::byxf,
         tensor(1, 1, 5, 7),
         tensor(1, 1, 7, 5),
+        4,
         false,
         padding({0, 0, 4, 4}, {0, 0, 1, 1}),
         padding({0, 0, 0, 0}, {0, 0, 3, 0}));
@@ -308,6 +328,7 @@ TEST(reshape_gpu_f16, basic_2dim_input_output_padd) {
         format::byxf,
         tensor(1, 1, 6, 6),
         tensor(1, 1, 3, 12),
+        4,
         false,
         padding({0, 0, 1, 1}, {0, 0, 0, 0}),
         padding({0, 0, 2, 1}, {0, 0, 1, 2}));
@@ -318,6 +339,7 @@ TEST(reshape_gpu_i8, basic_2dim_input_output_padd) {
         format::byxf,
         tensor(1, 1, 5, 7),
         tensor(1, 1, 7, 5),
+        4,
         false,
         padding({0, 0, 4, 4}, {0, 0, 1, 1}),
         padding({0, 0, 0, 0}, {0, 0, 3, 0}));
@@ -328,6 +350,7 @@ TEST(reshape_gpu_i32, basic_2dim_input_output_padd) {
         format::byxf,
         tensor(1, 1, 5, 7),
         tensor(1, 1, 7, 5),
+        4,
         false,
         padding({0, 0, 4, 4}, {0, 0, 1, 1}),
         padding({0, 0, 0, 0}, {0, 0, 3, 0}));
@@ -338,6 +361,7 @@ TEST(reshape_gpu_i64, basic_2dim_input_output_padd) {
         format::byxf,
         tensor(1, 1, 5, 7),
         tensor(1, 1, 7, 5),
+        4,
         false,
         padding({0, 0, 4, 4}, {0, 0, 1, 1}),
         padding({0, 0, 0, 0}, {0, 0, 3, 0}));
@@ -348,6 +372,7 @@ TEST(reshpape_gpu_f32, basic_4dim_output_padd) {
         format::bfyx,
         tensor(2, 5, 7, 3),
         tensor(1, 14, 15, 1),
+        4,
         false,
         padding(),
         padding({1, 0, 0, 1}, {0, 2, 3, 0}));
@@ -358,6 +383,7 @@ TEST(reshape_gpu_f16, basic_4dim_output_padd) {
         format::bfyx,
         tensor(5, 4, 2, 2),
         tensor(40, 2, 1, 1),
+        4,
         false,
         padding(),
         padding({0, 2, 0, 1}, {0, 2, 3, 0}));
@@ -368,6 +394,7 @@ TEST(reshape_gpu_f32, basic_4dim_input_padd) {
         format::yxfb,
         tensor(8, 128, 3, 3),
         tensor(16, 8, 8, 9),
+        4,
         false,
         padding({0, 1, 3, 3}, {0, 1, 1, 1}));
 }
@@ -377,6 +404,7 @@ TEST(reshape_gpu_f16, basic_4dim_input_padd) {
         format::yxfb,
         tensor(2, 32, 8, 8),
         tensor(8, 128, 1, 4),
+        4,
         false,
         padding({2, 2, 1, 0}, {1, 2, 2, 0}));
 }
@@ -386,6 +414,7 @@ TEST(reshape_gpu_f32, basic_4dim_input_output_padd) {
         format::fyxb,
         tensor(8, 1024, 25, 25),
         tensor(8, 64, 100, 100),
+        4,
         false,
         padding({2, 0, 2, 1}, {0, 1, 4, 0}),
         padding({1, 2, 3, 4}, {0, 4, 1, 1}));
@@ -396,6 +425,7 @@ TEST(reshape_gpu_f16, basic_4dim_input_output_padd) {
         format::byxf,
         tensor(32, 3, 227, 227),
         tensor(8, 12, 227, 227),
+        4,
         false,
         padding({0, 1, 4, 4}, {0, 1, 1, 1}),
         padding({0, 29, 29, 0}, {0, 0, 0, 0}));
@@ -406,6 +436,7 @@ TEST(reshape_gpu_f32, basic_5dim_in_place) {
         format::bfzyx,
         tensor(9, 9, 2, 4, 2),
         tensor(27, 2, 1, 4, 6),
+        5,
         true);
 }
 
@@ -445,7 +476,7 @@ TEST(reshape_gpu_f32, multiple_users_with_reorder) {
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
     topology.add(activation("relu", "input", activation_func::relu));
-    topology.add(reshape("reshape", "relu", tensor(batch(4))));
+    topology.add(reshape("reshape", "relu", tensor(batch(4)), 1));
     topology.add(reorder("reorder1", "reshape", format::yxfb, data_types::f32));
     topology.add(activation("relu1", "reorder1", activation_func::relu));
     topology.add(activation("relu2", "reshape", activation_func::relu));
@@ -489,7 +520,7 @@ TEST(reshape_gpu_f32, calc_output_shape) {
 
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(reshape("reshape", "input", tensor(1, 1, 0, -1)));
+    topology.add(reshape("reshape", "input", tensor(1, 1, 0, -1), 4));
 
     set_values(input, {-1.f, 2.f, -3.f, 4.f});
 
@@ -525,7 +556,7 @@ TEST(reshape_gpu_f32, basic_bfwzyx) {
 
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(reshape("reshape", "input", tensor(batch(1), feature(1), spatial(2, 2, 3, 3)), "", padding({0, 0, 0, 0, 0, 1}, 0.f)));
+    topology.add(reshape("reshape", "input", tensor(batch(1), feature(1), spatial(2, 2, 3, 3)), 6, "", padding({0, 0, 0, 0, 0, 1}, 0.f)));
 
     // clang-format off
     std::vector<float> input_data = {
@@ -600,9 +631,9 @@ TEST(reshape_gpu_f32, shrink_chain_partial) {
     topology.add(data("scale_in", scale_in));
     topology.add(data("shift_in", shift_in));
     topology.add(activation("relu", "input", activation_func::relu));
-    topology.add(reshape("reshape", "relu", tensor(spatial(2, 2))));
+    topology.add(reshape("reshape", "relu", tensor(spatial(2, 2)), 2));
     topology.add(reorder("reorder", "reshape", format::bfyx, data_types::f32));
-    topology.add(reshape("reshape1", "reorder", tensor(feature(4))));
+    topology.add(reshape("reshape1", "reorder", tensor(feature(4)), 1));
     topology.add(scale("scale", "reshape1", "scale_in", "shift_in"));
     topology.add(reorder("out_reorder", "scale", format::yxfb, data_types::f32));
 
@@ -639,9 +670,9 @@ TEST(reshape_gpu_f32, shrink_chain_full) {
     topology.add(data("scale_in", scale_in));
     topology.add(data("shift_in", shift_in));
     topology.add(activation("relu", "input", activation_func::relu));
-    topology.add(reshape("reshape", "relu", tensor(spatial(2, 2))));
+    topology.add(reshape("reshape", "relu", tensor(spatial(2, 2)), 2));
     topology.add(reorder("reorder", "reshape", format::bfyx, data_types::f32));
-    topology.add(reshape("reshape1", "reorder", tensor(feature(4))));
+    topology.add(reshape("reshape1", "reorder", tensor(feature(4)), 1));
     topology.add(scale("scale", "reshape1", "scale_in", "shift_in"));
     topology.add(reorder("out_reorder", "scale", format::yxfb, data_types::f32));
 
@@ -676,9 +707,9 @@ TEST(reshape_gpu_f32, shrink_chain_out) {
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
     topology.add(activation("relu", "input", activation_func::relu));
-    topology.add(reshape("reshape", "relu", tensor(spatial(2, 2))));
+    topology.add(reshape("reshape", "relu", tensor(spatial(2, 2)), 2));
     topology.add(reorder("reorder", "reshape", format::bfyx, data_types::f32));
-    topology.add(reshape("reshape1", "reorder", tensor(feature(4))));
+    topology.add(reshape("reshape1", "reorder", tensor(feature(4)), 1));
 
     std::vector<float> input_vec = {-1.f, 2.f, -3.f, 4.f};
     std::vector<float> out = {0.f, 2.f, 0.f, 4.0f};

--- a/src/plugins/intel_gpu/tests/test_cases/set_output_memory_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/set_output_memory_gpu_test.cpp
@@ -309,10 +309,10 @@ TEST(set_output_memory_gpu, basic_opt) {
     topology.add(activation("clamp1", "input1", activation_func::clamp, params1));
     topology.add(input_layout("input2", il));
     topology.add(activation("clamp2", "input2", activation_func::clamp, params2));
-    topology.add(reshape("reshape1", "clamp1", ishape));
-    topology.add(reshape("reshape2", "clamp2", ishape));
+    topology.add(reshape("reshape1", "clamp1", ishape, 4));
+    topology.add(reshape("reshape2", "clamp2", ishape, 4));
     topology.add(concatenation("concat", { "reshape1", "reshape2" }, 0, data_types::f32));
-    topology.add(reshape("reshape3", "concat", oshape));
+    topology.add(reshape("reshape3", "concat", oshape, 4));
     topology.add(reorder("reorder", "reshape3", ol));
     topology.add(reorder("reorder2", "reorder", ol));
 


### PR DESCRIPTION
### Fix output layout of reshape primitive:
 - *Add a parameter for reshape primitive to ensure the rank of output_shape*
 - *Return output format by using added output_shape_rank for reshape op*
 - *Update multiple primitives and unittests which uses reshape op*

### Tickets:
 - *84182*
