### PR TITLE
ONNX Resize - sizes/scales inputs handling

### DIFF
--- a/src/frontends/onnx/frontend/src/op/resize.cpp
+++ b/src/frontends/onnx/frontend/src/op/resize.cpp
@@ -9,6 +9,7 @@
 #include "default_opset.hpp"
 #include "exceptions.hpp"
 #include "ngraph/op/util/op_types.hpp"
+#include "onnx_import/core/null_node.hpp"
 #include "utils/common.hpp"
 
 namespace ngraph {
@@ -145,8 +146,10 @@ OutputVector resize(const onnx_import::Node& node) {
 
     auto attrs = get_resize_attrs(node);
 
-    if (inputs.size() == 4)  // sizes input is provided
-    {
+    const auto use_sizes_input =
+        inputs.size() == 4 && std::dynamic_pointer_cast<NullNode>(inputs[3].get_node_shared_ptr()) == nullptr;
+
+    if (use_sizes_input) {
         attrs.shape_calculation_mode = default_opset::Interpolate::ShapeCalcMode::SIZES;
         const auto& sizes = inputs.at(3);
         const auto scales = calculate_scales_based_on_sizes(data, sizes);


### PR DESCRIPTION
### Details:
 - the sizes input was handled incorrectly when `scales` was supposed to be used
 - the sizes input should only be takend into account when it's not a `NullNode` (which gets created for an ONNX input with empty name)

### Tickets:
 - https://github.com/openvinotoolkit/openvino/issues/11676
