### PR TITLE
[GPU] Add reorder between FC matmal and reshape

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1597,7 +1597,13 @@ format layout_optimizer::get_preferred_format(program_node& node) {
         };
         if (only_gemm_users(node)) {
             // TODO: Gemm is not supporting fsv layouts
-            expected = format::bfyx;
+            if (node.get_output_layout().format.dimension() == 6) {
+                expected = format::bfwzyx;
+            } else if (node.get_output_layout().format.dimension() == 5) {
+                expected = format::bfzyx;
+            } else if (node.get_output_layout().format.dimension() == 4) {
+                expected = format::bfyx;
+            }
         } else if (use_onednn_impls  && needs_all_usr_onednn_small_ic_to_blocked(node)) {
             // All user nodes are convolutions which satisfy options for onednn first conv
             if (layout.data_type == data_types::f16) {

--- a/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
@@ -157,12 +157,38 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
 
         auto lastLayerName = layerName;
         if (reshape_fc) {
-            auto outputShape = tensor_from_dims(op->get_output_shape(0));
             auto outReshapeName = layerName + "_cldnn_out_reshape";
-            auto outReshapePrim = cldnn::reshape(outReshapeName, layerName, outputShape, op->get_friendly_name());
+
+            // add reorder
+            auto outDims = op->get_output_shape(0);
+            auto outTensor = tensor_from_dims(outDims);
+
+            if (outDims.size() > 4) {
+                cldnn::format outputFormat = cldnn::format::bfyx;
+                switch (outDims.size()) {
+                case 5: outputFormat = cldnn::format::bfzyx; break;
+                case 6: outputFormat = cldnn::format::bfwzyx; break;
+                default: break;
+                }
+
+                cldnn::primitive_id reorderId = "reorder:" + outReshapeName + "_reorder";
+                cldnn::layout outputLayout(DataTypeFromPrecision(op->get_output_element_type(0)), outputFormat, outTensor);
+                p.AddPrimitive(cldnn::reorder(reorderId,
+                                            layerName,
+                                            outputLayout,
+                                            std::vector<float>(),
+                                            cldnn::reorder_mean_mode::subtract,
+                                            op->get_friendly_name()));
+                p.InitProfileInfo(reorderId, "Reorder", false, InferenceEngine::InferenceEngineProfileInfo::EXECUTED, layerName);
+                p.AddInnerPrimitiveToProfiler(reorderId, layerName, op);
+                lastLayerName = reorderId;
+            }
+
+            // add reshape
+            auto outReshapePrim = cldnn::reshape(outReshapeName, lastLayerName, outTensor, op->get_friendly_name());
 
             p.AddPrimitive(outReshapePrim);
-            p.AddInnerPrimitiveToProfiler(outReshapeName, layerName, op);
+            p.AddInnerPrimitiveToProfiler(outReshapeName, lastLayerName, op);
 
             lastLayerName = outReshapeName;
         }

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/mat_mul.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/mat_mul.cpp
@@ -16,6 +16,8 @@ const std::vector<InferenceEngine::Precision> inputPrecisions = {
 };
 
 const std::vector<ShapeRelatedParams> shapeRelatedParams = {
+        { { {2, 1, 1, 5, 6}, false }, { {1, 1, 6, 4}, false } },
+        { { {2, 1, 2, 3, 5, 6}, false }, { {1, 1, 6, 4}, false } },
         { { {1, 4, 5, 6}, false }, { {1, 4, 6, 4}, false } },
         { { {1, 16, 128}, false }, { {1, 64, 128}, true } },
         { { {4, 5, 6}, false }, { {6, 3}, false } },


### PR DESCRIPTION
### Fix input layout of reshape primitive:
 - *Add reorder between FC matmal and reshape*
 - *Add 5d/6d format for only_gemm_users in case of int8 model*
### Tickets:
 - *84182*
