### PR TITLE
Patch 6

### DIFF
--- a/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_EfficientDet_Models.md
+++ b/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_EfficientDet_Models.md
@@ -67,8 +67,15 @@ The attribute names are self-explanatory or match the name in the `hparams_confi
 
 > **NOTE**: The color channel order (RGB or BGR) of an input data should match the channel order of the model training dataset. If they are different, perform the `RGB<->BGR` conversion specifying the command-line parameter: `--reverse_input_channels`. Otherwise, inference results may be incorrect. For more information about the parameter, refer to **When to Reverse Input Channels** section of [Converting a Model to Intermediate Representation (IR)](../Converting_Model.md).
 
-OpenVINO&trade; toolkit provides samples that can be used to infer EfficientDet model. For more information, refer to
-[Open Model Zoo Demos](@ref omz_demos) and
+## OpenVINO™ Toolkit Samples and Open Model Zoo Demos
+OpenVINO&trade; toolkit provides samples that can be used to infer EfficientDet models. For more information, refer to the following pages:
+* [OpenVINO Samples](../../../../OV_Runtime_UG/Samples_Overview.md)
+    * [Hello Reshape SSD - Python](../../../../../samples/python/hello_reshape_ssd/README.md)
+    * [Hello Reshape SSD - C++](../../../../../samples/cpp/hello_reshape_ssd/README.md)
+* [Open Model Zoo Demos](@ref omz_demos)
+    * [Object Detection Python Demo](https://github.com/openvinotoolkit/open_model_zoo/blob/master/demos/object_detection_demo/python)
+    * [Object Detection C++ Demo](https://github.com/openvinotoolkit/open_model_zoo/tree/master/demos/object_detection_demo/cpp)
+* [Hello Object Detection Jupyter notebook](https://docs.openvino.ai/latest/notebooks/004-hello-detection-with-output.html)
 
 ## <a name="efficientdet-ir-results-interpretation"></a>Interpreting Results of the TensorFlow Model and the IR
 

--- a/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_Object_Detection_API_Models.md
+++ b/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_Object_Detection_API_Models.md
@@ -64,7 +64,11 @@ Speech Recognition, Natural Language Processing and others. Refer to the links b
 
 
 * [OpenVINO Samples](../../../../OV_Runtime_UG/Samples_Overview.md)
+    * [Hello Reshape SSD - Python](../../../../../samples/python/hello_reshape_ssd/README.md)
+    * [Hello Reshape SSD - C++](../../../../../samples/cpp/hello_reshape_ssd/README.md)
 * [Open Model Zoo Demos](@ref omz_demos)
+    * [Object Detection Python Demo](https://github.com/openvinotoolkit/open_model_zoo/blob/master/demos/object_detection_demo/python)
+    * [Object Detection C++ Demo](https://github.com/openvinotoolkit/open_model_zoo/tree/master/demos/object_detection_demo/cpp)
 
 ## Important Notes About Feeding Input Images to the Samples
 

--- a/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_YOLO_From_Tensorflow.md
+++ b/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_YOLO_From_Tensorflow.md
@@ -229,3 +229,9 @@ The model was trained with input values in the range `[0,1]`. OpenVINO&trade; to
 For other applicable parameters, refer to [Convert Model from TensorFlow](../Convert_Model_From_TensorFlow.md).
 
 > **NOTE**: The color channel order (RGB or BGR) of an input data should match the channel order of the model training dataset. If they are different, perform the `RGB<->BGR` conversion specifying the command-line parameter: `--reverse_input_channels`. Otherwise, inference results may be incorrect. For more information about the parameter, refer to **When to Reverse Input Channels** section of [Converting a Model to Intermediate Representation (IR)](../Converting_Model.md).
+
+
+## <a name="yolo-examples"></a>YOLO Sample Application
+The OpenVINO™ [Open Model Zoo Demos](@ref omz_demos) provide a sample application showing how to run inferencing on a video input with object detection models. The sample is compatible with YOLOv1, YOLOv2, YOLOv3, and YOLOv4 full-size and tiny-size models:
+* [Object Detection Python Demo](https://github.com/openvinotoolkit/open_model_zoo/blob/master/demos/object_detection_demo/python)
+* [Object Detection C++ Demo](https://github.com/openvinotoolkit/open_model_zoo/tree/master/demos/object_detection_demo/cpp)


### PR DESCRIPTION
### Details:
 Add links to specific object detection examples on pages that are related to object detection models. This makes it easier for users to find examples of how to use their object detection model in an OpenVINO application.

NOTE: I used direct hyperlinks to GitHub for the Open Model Zoo examples. Please let me know if there's another way you'd prefer to link to examples in the [open_model_zoo](https://github.com/openvinotoolkit/open_model_zoo) repository.

Pages modified:
 - Convert TensorFlow EfficientDet Models
 - Convert TensorFlow Object Detection API Models
 - Convert TensorFlow YOLO Models

### Tickets:
 N/A
