### PR TITLE
[GNA] Use node name as tensor name on import previous format where tensor n…

### DIFF
--- a/src/plugins/intel_gna/gna_model_serial.cpp
+++ b/src/plugins/intel_gna/gna_model_serial.cpp
@@ -558,6 +558,11 @@ void GNAModelSerial::ImportInputs(std::istream &is, void* basePtr, GNAPluginNS::
         for (uint8_t tId = 0; tId < ep.tensor_names_count; ++tId) {
             input.tensor_names.insert(readString(is));
         }
+
+        // To support importing of <= 2.7 format where tensor_names were not present
+        if (model_header_.version.major == 2 && model_header_.version.minor <= 7 && ep.tensor_names_count == 0) {
+            input.tensor_names.insert(input.name);
+        }
     }
 }
 
@@ -583,6 +588,11 @@ void GNAModelSerial::ImportOutputs(std::istream &is, void* basePtr, GNAPluginNS:
         // read tensor names
         for (uint8_t tId = 0; tId < ep.tensor_names_count; ++tId) {
             output.tensor_names.insert(readString(is));
+        }
+
+        // To support importing of <= 2.7 format where tensor_names were not present
+        if (model_header_.version.major == 2 && model_header_.version.minor <= 7 && ep.tensor_names_count == 0) {
+            output.tensor_names.insert(output.name);
         }
     }
 }

--- a/src/plugins/intel_gna/gna_model_serial.hpp
+++ b/src/plugins/intel_gna/gna_model_serial.hpp
@@ -40,6 +40,12 @@ private:
 
     void ExportTranspositionInfo(std::ostream &os, const TranspositionInfoMap &transpositionInfoMap) const;
 
+    /**
+     * @brief Update input or output description to support importing of < 2.8 format where tensor_names were not present
+     * @param nodeDesc input or output description to be appended
+     */
+    void AppendTensorNameIfNeeded(GNAPluginNS::GnaDesc& nodeDesc) const;
+
  public:
     GNAModelSerial(Gna2Model * model, MemoryType & states_holder)
         : gna2model_(model), pstates_(&states_holder) {

--- a/src/plugins/intel_gna/serial/headers/latest/gna_model_header.hpp
+++ b/src/plugins/intel_gna/serial/headers/latest/gna_model_header.hpp
@@ -10,5 +10,10 @@ namespace GNAPluginNS {
 namespace HeaderLatest {
 using ModelHeader = GNAPluginNS::Header2dot8::ModelHeader;
 using RuntimeEndPoint = GNAPluginNS::Header2dot8::RuntimeEndPoint;
+
+template <typename A, typename B>
+bool IsFirstVersionLower(const A& first, const B& second) {
+    return first.major < second.major || (first.major == second.major && first.minor < second.minor);
 }
-}
+} // namespace HeaderLatest
+} // namespace GNAPluginNS


### PR DESCRIPTION
[GNA] Use node name as tensor name on import previous format where tensor names were not stored

### Details:
 - [GNA] Use node name as tensor name on import previous format where tensor names were not stored

### Tickets:
 - 85004
