### PR TITLE
ov 2.0 c api ci test enable

### DIFF
--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -341,6 +341,13 @@ jobs:
     displayName: 'IE CAPITests'
     continueOnError: false
 
+  - script: |
+      export DATA_PATH=$(MODELS_PATH)
+      export MODELS_PATH=$(MODELS_PATH)
+      . $(SETUPVARS) && $(INSTALL_TEST_DIR)/OpenVinoCAPITests --gtest_output=xml:TEST-OpenVinoCAPITests.xml
+    displayName: 'OV CAPITests'
+    continueOnError: false
+
   - task: CMake@1
     inputs:
       cmakeArgs: >

--- a/.ci/azure/mac.yml
+++ b/.ci/azure/mac.yml
@@ -212,6 +212,14 @@ jobs:
     continueOnError: false
     enabled: false
 
+  - script: |
+      export DATA_PATH=$(MODELS_PATH)
+      export MODELS_PATH=$(MODELS_PATH)
+      . $(SETUPVARS) && $(INSTALL_TEST_DIR)/OpenVinoCAPITests --gtest_output=xml:TEST-OpenVinoCAPITests.xml
+    displayName: 'IE CAPITests'
+    continueOnError: false
+    enabled: false
+
   - task: PublishTestResults@2
     condition: always()
     inputs:

--- a/.ci/azure/windows.yml
+++ b/.ci/azure/windows.yml
@@ -285,6 +285,13 @@ jobs:
     displayName: 'IE CAPITests'
     continueOnError: false
 
+  - script: |
+      set DATA_PATH=$(MODELS_PATH)
+      set MODELS_PATH=$(MODELS_PATH)
+      call $(SETUPVARS) && $(INSTALL_TEST_DIR)\OpenVinoCAPITests --gtest_output=xml:TEST-OpenVinoCAPITests.xml
+    displayName: 'OV CAPITests'
+    continueOnError: false
+
   - task: PublishTestResults@2
     condition: always()
     inputs:


### PR DESCRIPTION
### Details:
 - Enable CI to run OV 2.0 C API unit test


### Tickets:
