### PR TITLE
Update date in MO update message

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/get_ov_update_message.py
+++ b/tools/mo/openvino/tools/mo/utils/get_ov_update_message.py
@@ -3,15 +3,15 @@
 
 import datetime
 
-msg_fmt = 'It\'s been a while, check for a new version of ' + \
-          'Intel(R) Distribution of OpenVINO(TM) toolkit here {0} or on the GitHub*'
+msg_fmt = 'Check for a new version of Intel(R) Distribution of OpenVINO(TM) toolkit here {0} ' \
+          'or on https://github.com/openvinotoolkit/openvino'
 
 
 def get_ov_update_message():
-    expected_update_date = datetime.date(year=2022, month=4, day=30)
+    expected_update_date = datetime.date(year=2022, month=10, day=31)
     current_date = datetime.date.today()
 
-    link = 'https://software.intel.com/content/www/us/en/develop/tools/openvino-toolkit/download.html?cid=other&source=prod&campid=ww_2022_bu_IOTG_OpenVINO-2022-1&content=upg_all&medium=organic'
+    link = 'https://software.intel.com/content/www/us/en/develop/tools/openvino-toolkit/download.html?cid=other&source=prod&campid=ww_2022_bu_IOTG_OpenVINO-2022-2&content=upg_all&medium=organic'
 
     return msg_fmt.format(link) if current_date >= expected_update_date else None
 


### PR DESCRIPTION
Do not show the message to check for OpenVINO updates in MO until October 31. This is a bit later than the expected update date, which is better than much earlier, which we had for the past two releases. 

Slightly change update message, remove "It's been a while" because that really depends. You now get this message on the day of install, which is not a great user experience.