### PR TITLE
ctput enable perf_count

### DIFF
--- a/src/plugins/auto/auto_schedule.cpp
+++ b/src/plugins/auto/auto_schedule.cpp
@@ -161,6 +161,9 @@ void AutoSchedule::init(const ScheduleContext::Ptr& sContext) {
 
         _loadContext[ACTUALDEVICE].deviceInfo.deviceName = deviceName;
         _loadContext[ACTUALDEVICE].deviceInfo.config[CONFIG_KEY(PERFORMANCE_HINT)] = InferenceEngine::PluginConfigParams::THROUGHPUT;
+        _loadContext[ACTUALDEVICE].deviceInfo.config[CONFIG_KEY(PERF_COUNT)] =
+            _autoSContext->_needPerfCounters ? InferenceEngine::PluginConfigParams::YES
+                                             : InferenceEngine::PluginConfigParams::NO;
         if (_autoSContext->_bindBuffer)
             _loadContext[ACTUALDEVICE].deviceInfo.config[ov::intel_auto::device_bind_buffer.name()] = InferenceEngine::PluginConfigParams::YES;
     } else {


### PR DESCRIPTION
### Details:
 - *fix issue: benchmark_app -d AUTO -hint ctput -pc does not give perfcount data*

### Tickets:
 - *ticket-86026*
