### PR TITLE
setupvars.sh: Removing extra semicolon, which breaks glibc build

### DIFF
--- a/scripts/setupvars/setupvars.sh
+++ b/scripts/setupvars/setupvars.sh
@@ -51,7 +51,7 @@ if [ -e "$INSTALLDIR/runtime/3rdparty/tbb" ]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
         export DYLD_LIBRARY_PATH=$INSTALLDIR/runtime/3rdparty/tbb/lib:${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}
     fi
-    export LD_LIBRARY_PATH=$INSTALLDIR/runtime/3rdparty/tbb/lib:${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+    export LD_LIBRARY_PATH=$INSTALLDIR/runtime/3rdparty/tbb/lib:${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH}
     export TBB_DIR=$INSTALLDIR/runtime/3rdparty/tbb/cmake
 fi
 


### PR DESCRIPTION
This extra semicolon creates output as in the example below. The extra
'::' is equivalent to adding '.' to the LD_LIBRARY_PATH. This breaks
glibc build, and very often creates weird issues when launching
commands from a different path.

...inference_engine/external/tbb/lib::/opt/intel/openvino_2021/...

We also noticed that ':${parameter:+:$parameter}' is widely used in
this file. Please review the code and fix it as needed.

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
