### PR TITLE
Revert "Disable fc_int8_inputs_fused_fp32_sum (#11709)"

### DIFF
--- a/src/plugins/intel_gpu/tests/fusions/fully_connected_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/fully_connected_fusion_test.cpp
@@ -391,7 +391,6 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, fc_int8_inputs_fused_fp32_sum, ::testing::
     // OneDNN has issue with small shapes - ticket 7064
     // fully_connected_test_params{ CASE_FC_U8S8_3D_1, 2, 4 },
     // fully_connected_test_params{ CASE_FC_U8S8_3D_2, 2, 4 },
-    // fails with 'Invalid input shapes'
-    // fully_connected_test_params{ CASE_FC_U8S8_3D_4, 2, 4 },
+    fully_connected_test_params{ CASE_FC_U8S8_3D_4, 2, 4 },
 }));
 #endif


### PR DESCRIPTION
### Details:
 - Enable "fc_int8_inputs_fused_fp32_sum" again.
 - This issue was resolved by https://github.com/openvinotoolkit/openvino/commit/98f989302a5ca1d33434a14a8eb4f6f806938220

### Tickets:
 - 85210
