### PR TITLE
[CPU] Revert enable ReduceSum -> AvgPool transformation due to perf issues

### DIFF
--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -407,7 +407,7 @@ static void TransformationUpToCPUSpecificOpSet(std::shared_ptr<ngraph::Function>
     pass_config->disable<ngraph::pass::ConvertGather8ToGather7>();
     pass_config->disable<ngraph::pass::ConvertMinimum>();
     pass_config->disable<ngraph::pass::ConvertBroadcastToTiles>();
-//    pass_config->disable<ngraph::pass::ConvertReduceMeanToPooling>();
+    pass_config->disable<ngraph::pass::ConvertReduceMeanToPooling>();
     pass_config->disable<ngraph::pass::ConvertReduceMaxToPooling>();
     pass_config->disable<ngraph::pass::ConvertReduceSumToPooling>();
     pass_config->disable<ngraph::pass::SliceToStridedSlice>();

--- a/src/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/reduce_mean_transformation.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/low_precision_transformations/reduce_mean_transformation.cpp
@@ -144,8 +144,7 @@ const std::vector<LayerTestsDefinitions::ReduceMeanTransformationParam> params =
         "FP32"
     },
 };
-// WR: Remove to pass the test because ReductionMeanToPoolingTranformation enabling.
-/*
+
 INSTANTIATE_TEST_SUITE_P(smoke_LPT, ReduceMeanTransformation,
     ::testing::Combine(
         ::testing::ValuesIn(netPrecisions),
@@ -154,5 +153,4 @@ INSTANTIATE_TEST_SUITE_P(smoke_LPT, ReduceMeanTransformation,
         ::testing::ValuesIn(trasformationParamValues),
         ::testing::ValuesIn(params)),
     ReduceMeanTransformation::getTestCaseName);
-*/
 }  // namespace

--- a/src/tests/functional/plugin/cpu/single_layer_tests/reduce_ops.cpp
+++ b/src/tests/functional/plugin/cpu/single_layer_tests/reduce_ops.cpp
@@ -249,8 +249,7 @@ std::vector<CommonTestUtils::OpType> opTypes = {
 };
 
 const std::vector<ngraph::helpers::ReductionType> reductionTypes = {
-// WR: Remove to pass the test because ReductionMeanToPoolingTranformation enabling.
-       // ngraph::helpers::ReductionType::Mean,
+        ngraph::helpers::ReductionType::Mean,
         ngraph::helpers::ReductionType::Max,
         ngraph::helpers::ReductionType::Sum,
         ngraph::helpers::ReductionType::Min,
@@ -260,8 +259,7 @@ const std::vector<ngraph::helpers::ReductionType> reductionTypes = {
 };
 
 const std::vector<ngraph::helpers::ReductionType> reductionTypesFusing = {
-// WR: Remove to pass the test because ReductionMeanToPoolingTranformation enabling.
-        //ngraph::helpers::ReductionType::Mean,
+        ngraph::helpers::ReductionType::Mean,
         ngraph::helpers::ReductionType::Max,
         ngraph::helpers::ReductionType::L2,
 };


### PR DESCRIPTION
### Details:
 - *Revert 21f3555f59b47317c5f5334424a5fef344e6d317 [[WA] Enabled ReduceSum -> AvgPool transformation due to perf issues](https://github.com/openvinotoolkit/openvino/pull/11627/commits/21f3555f59b47317c5f5334424a5fef344e6d317)*
 Tests show disable the transformation will have positive impact.

### Tickets:
 - **
