### PR TITLE
[CPU] [WA] Disable avx512 brgconv kernel

### DIFF
--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -875,8 +875,9 @@ const std::vector<impl_desc_type>& Node::getPrimitivesPriority() {
             impl_desc_type::jit_avx512_amx_dw,
             impl_desc_type::jit_avx512_amx_1x1,
             impl_desc_type::jit_avx512_amx,
-            impl_desc_type::brgconv_avx512_1x1,
-            impl_desc_type::brgconv_avx512,
+            // Brgconv kernels disabled in order to prevent perf degradations on non AMX HW
+            // impl_desc_type::brgconv_avx512_1x1,
+            // impl_desc_type::brgconv_avx512,
             impl_desc_type::jit_uni_dw,
             impl_desc_type::jit_uni_1x1,
             impl_desc_type::jit_uni,

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -471,8 +471,8 @@ void Convolution::getSupportedDescriptors() {
             auto inputShape = getInputShapeAtPort(0);
             auto outputShape = getOutputShapeAtPort(0);
 
-            if (one_of(inputDataType, memory::data_type::f32, memory::data_type::bf16) &&
-                    impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core)) {
+            if (one_of(inputDataType, memory::data_type::bf16) &&
+                    impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core_amx)) {
                 in_candidate = std::make_shared<DnnlBlockedMemoryDesc>(inputShape, inputDataType, nspc);
                 out_candidate = std::make_shared<DnnlBlockedMemoryDesc>(outputShape, outputDataType, nspc);
                 createDescriptor({ in_candidate }, { out_candidate });
@@ -502,8 +502,8 @@ void Convolution::getSupportedDescriptors() {
             createDescriptor({ in_candidate }, { out_candidate });
 
             if ((inputDataType != memory::data_type::bf16 && isNspcAvailable()) ||
-                    (one_of(inputDataType, memory::data_type::f32, memory::data_type::bf16) &&
-                    impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core))) {
+                    (one_of(inputDataType, memory::data_type::bf16) &&
+                    impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core_amx))) {
                 in_candidate = std::make_shared<DnnlBlockedMemoryDesc>(inputShape, inputDataType, nspc);
                 out_candidate = std::make_shared<DnnlBlockedMemoryDesc>(outputShape, outputDataType, nspc);
                 createDescriptor({ in_candidate }, { out_candidate });


### PR DESCRIPTION
### Details:
 - *Disable avx512 brgconv kernel due to tests regression*
