### PR TITLE
Additional tensor names for ONNX variadic ops

### DIFF
--- a/src/frontends/onnx/frontend/src/core/graph.cpp
+++ b/src/frontends/onnx/frontend/src/core/graph.cpp
@@ -376,7 +376,7 @@ OutputVector Graph::make_ng_nodes(const Node& onnx_node) {
 }
 
 void Graph::set_friendly_names(const Node& onnx_node, const OutputVector& ng_subgraph_outputs) const {
-    if (onnx_node.op_type() == "Identity") {
+    if (std::all_of(std::begin(ng_subgraph_outputs), std::end(ng_subgraph_outputs), common::is_optimized_out)) {
         for (size_t i = 0; i < ng_subgraph_outputs.size(); ++i) {
             ng_subgraph_outputs[i].get_tensor().add_names({onnx_node.output(i)});
             ng_subgraph_outputs[i].get_node_shared_ptr()->set_friendly_name(onnx_node.output(i));

--- a/src/frontends/onnx/frontend/src/op/identity.hpp
+++ b/src/frontends/onnx/frontend/src/op/identity.hpp
@@ -9,13 +9,18 @@
 #include "default_opset.hpp"
 #include "ngraph/node.hpp"
 #include "onnx_import/core/node.hpp"
+#include "utils/common.hpp"
 
 namespace ngraph {
 namespace onnx_import {
 namespace op {
 namespace set_1 {
 inline OutputVector identity(const Node& node) {
-    return node.get_ng_inputs();
+    OutputVector outputs = node.get_ng_inputs();
+    for (auto& out : outputs) {
+        common::mark_as_optimized_out(out);
+    }
+    return outputs;
 }
 }  // namespace set_1
 

--- a/src/frontends/onnx/frontend/src/utils/common.cpp
+++ b/src/frontends/onnx/frontend/src/utils/common.cpp
@@ -129,6 +129,17 @@ bool is_failsafe_node(const std::shared_ptr<ov::Node>& node) {
     return rt_info.find(FAILSAFE_NODE) != rt_info.end();
 }
 
+const std::string OPTIMIZED_OUT_NODE = "OPTIMIZED_OUT_NODE";
+
+void mark_as_optimized_out(Output<ov::Node>& node_output) {
+    node_output.get_rt_info()[OPTIMIZED_OUT_NODE] = true;
+}
+
+bool is_optimized_out(const Output<ov::Node>& node_output) {
+    const auto& rt_info = node_output.get_rt_info();
+    return rt_info.find(OPTIMIZED_OUT_NODE) != rt_info.end();
+}
+
 }  // namespace  common
 }  // namespace onnx_import
 }  // namespace ngraph

--- a/src/frontends/onnx/frontend/src/utils/common.hpp
+++ b/src/frontends/onnx/frontend/src/utils/common.hpp
@@ -142,6 +142,14 @@ std::shared_ptr<default_opset::Constant> make_failsafe_constant(const ngraph::el
 /// \brief Checks the node's runtime info object and returns true if this node represents
 ///        a dummy failsafe node created instead of an incorrect node found in the original model
 bool is_failsafe_node(const std::shared_ptr<ov::Node>& node);
+
+/// \brief Marks an output of a node as "optimized out" meaning that during the import of an ONNX operation
+///        no OV nodes have been created and the ONNX operator returns its inputs as its outputs.
+///        This information is later used to add extra names to the tensors associated with such outputs.
+void mark_as_optimized_out(Output<ov::Node>& node_output);
+
+/// \brief Checks if a given output was marked as optimized out byt the function above.
+bool is_optimized_out(const Output<ov::Node>& node_output);
 }  // namespace  common
 }  // namespace onnx_import
 }  // namespace ngraph

--- a/src/frontends/onnx/frontend/src/utils/variadic.hpp
+++ b/src/frontends/onnx/frontend/src/utils/variadic.hpp
@@ -11,6 +11,7 @@
 #include "ngraph/op/add.hpp"
 #include "ngraph/shape.hpp"
 #include "onnx_import/core/node.hpp"
+#include "utils/common.hpp"
 
 namespace ngraph {
 namespace onnx_import {
@@ -36,10 +37,14 @@ inline OutputVector make_ng_variadic_op(
     };
 
     // Create a result node as a series of binary operations
-    const auto result = std::accumulate(std::next(std::begin(ng_inputs)),  // First operand value - the second input
-                                        std::end(ng_inputs),               // Last value - final input
-                                        ng_inputs.front(),                 // Initial value - first input
-                                        binary_operation);
+    auto result = std::accumulate(std::next(std::begin(ng_inputs)),  // First operand value - the second input
+                                  std::end(ng_inputs),               // Last value - final input
+                                  ng_inputs.front(),                 // Initial value - first input
+                                  binary_operation);
+
+    if (ng_inputs.size() == 1) {
+        common::mark_as_optimized_out(result);
+    }
 
     return {result};
 }


### PR DESCRIPTION
### Details:
 - ONNX variadic ops are optimized out when they contain only one input
 - Such models produce an OV representation containing just 2 nodes: Parameter->Result
 - Those nodes reuse a single tensor which now contains both names from the model (both input and output of the model)
 - The OV user can access the name of such tensor with both strings now

### Tickets:
 - 85962
