### PR TITLE
[GPU]fix kernel select validate in deconv kernel fsv16 for fs=8 input

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16.cpp
@@ -126,6 +126,10 @@ bool DeconvolutionKernel_b_fs_zyx_fsv16::Validate(const Params& p, const optiona
     const auto& params = static_cast<const deconvolution_params&>(p);
     const auto feature_block_size = 16;
 
+    // Check whether feature size of input is aligned with 16 or not
+    if (params.inputs[0].Feature().v % feature_block_size != 0)
+        return false;
+
     // Check that padding features doesn't miss-align the blocks
     if (params.inputs[0].Feature().pad.before % feature_block_size != 0 || params.outputs[0].Feature().pad.before % feature_block_size != 0)
         return false;


### PR DESCRIPTION
### Details:
 - DeconvolutionKernel_b_fs_zyx_fsv16(en9_common_conv_bwd_data.cl) assumes that feature size of input should be 16 aligned. But it doesn't have a validation module to check it. So I added the condition in validate() so ref kernel will be selected.


### Tickets:
 - 85092
