### PR TITLE
[GNA] Add automatic model splitting for compiled graphs

### DIFF
--- a/src/plugins/intel_gna/gna_api_wrapper.hpp
+++ b/src/plugins/intel_gna/gna_api_wrapper.hpp
@@ -56,6 +56,14 @@ class CPPWrapper<Gna2Model> {
             obj.Operations[i].NumberOfParameters = 0;
         }
     }
+    static void moveOperation(Gna2Operation * dst, Gna2Operation * src) {
+        *dst = *src;
+        src->Type = Gna2OperationTypeNone;
+        src->Operands = nullptr;
+        src->NumberOfOperands = 0;
+        src->Parameters = nullptr;
+        src->NumberOfParameters = 0;
+    }
     ~CPPWrapper() {
         if (obj.Operations != nullptr) {
             for (uint32_t i = 0; i < obj.NumberOfOperations; i++) {

--- a/src/plugins/intel_gna/gna_device.cpp
+++ b/src/plugins/intel_gna/gna_device.cpp
@@ -105,6 +105,11 @@ std::string GNADeviceHelper::GetGnaLibraryVersion() {
     return gnaLibraryVersion;
 }
 
+
+uint16_t GNADeviceHelper::getLayerCountMax() {
+    return layersCountMax;
+}
+
 void GNADeviceHelper::setUpActiveList(const uint32_t requestConfigId, uint32_t layerIndex, uint32_t* ptr_active_indices, uint32_t num_active_indices) {
     std::unique_lock<std::mutex> lockGnaCalls{ acrossPluginsSync };
     const auto status = Gna2RequestConfigEnableActiveList(requestConfigId, layerIndex, num_active_indices, ptr_active_indices);

--- a/src/plugins/intel_gna/gna_device.hpp
+++ b/src/plugins/intel_gna/gna_device.hpp
@@ -44,7 +44,6 @@ class GNADeviceHelper {
         static std::string gnaLibraryVersion{ ", GNA library version: " + GNADeviceHelper::GetGnaLibraryVersion() };
         return gnaLibraryVersion;
     }
-
     std::string modeOfOperation = "default";
     GnaAllocations allAllocations;
     uint32_t nGnaDeviceIndex = 0;
@@ -54,6 +53,7 @@ class GNADeviceHelper {
     std::string compileTarget;
     bool useDeviceEmbeddedExport = false;
     Gna2DeviceVersion exportGeneration = Gna2DeviceVersionEmbedded1_0;
+    uint16_t layersCountMax = 1;
 
     static const uint32_t TotalGna2InstrumentationPoints = 2;
     Gna2InstrumentationPoint gna2InstrumentationPoints[TotalGna2InstrumentationPoints] = {
@@ -87,6 +87,22 @@ public:
 
         // check GNA Library version
         const auto gnaLibVersion = GetGnaLibraryVersion();
+
+        // set maximal layers amount depending on HW version
+        switch (getTargetDevice(true)) {
+            case Gna2DeviceVersion1_0 :
+                layersCountMax = 1023;
+                break;
+            case Gna2DeviceVersion2_0 :
+                layersCountMax = 4086;
+                break;
+            case Gna2DeviceVersion3_0 :
+            case Gna2DeviceVersion3_5 :
+                layersCountMax = 8191;
+                break;
+            default:
+                layersCountMax = 8191;
+        }
     }
 
     GNADeviceHelper(const GNADeviceHelper&) = delete;
@@ -105,6 +121,7 @@ public:
     uint32_t createModel(Gna2Model& gnaModel) const;
     void releaseModel(const uint32_t model_id);
     uint32_t createRequestConfig(const uint32_t model_id);
+    uint16_t getLayerCountMax();
     static uint32_t getNumberOfGnaDevices();
     static uint32_t selectGnaDevice();
     static bool isGnaHw(const Gna2DeviceVersion dev) {
@@ -134,7 +151,6 @@ public:
     void dumpXnnForDeviceVersion(const uint32_t modelId,
         std::ostream & outStream,
         Gna2DeviceVersion targetDeviceVersion);
-
     void dumpTLVForDeviceVersion(const uint32_t modelId, std::ostream& outStream,
         uint32_t input_size, uint32_t output_size,
         float inSF, float outSF);

--- a/src/plugins/intel_gna/gna_executable_network.hpp
+++ b/src/plugins/intel_gna/gna_executable_network.hpp
@@ -47,7 +47,7 @@ class GNAExecutableNetwork : public InferenceEngine::IExecutableNetworkInternal 
         setOutputs(plg->GetOutputs());
     }
 
-    GNAExecutableNetwork(InferenceEngine::CNNNetwork &network, std::shared_ptr<GNAPlugin> plg)
+    GNAExecutableNetwork(const InferenceEngine::CNNNetwork &network, std::shared_ptr<GNAPlugin> plg)
         : plg(plg) {
         plg->LoadNetwork(network);
     }

--- a/src/plugins/intel_gna/gna_plugin.hpp
+++ b/src/plugins/intel_gna/gna_plugin.hpp
@@ -82,7 +82,7 @@ class GNAPlugin : public InferenceEngine::IInferencePlugin {
     std::string GetName() const noexcept override;
     void SetName(const std::string & pluginName) noexcept override;
 
-    void LoadNetwork(InferenceEngine::CNNNetwork &network);
+    void LoadNetwork(const InferenceEngine::CNNNetwork &network);
 
     bool Infer(const InferenceEngine::BlobMap &input, InferenceEngine::BlobMap &result);
     std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> GetPerformanceCounts();
@@ -205,7 +205,7 @@ class GNAPlugin : public InferenceEngine::IInferencePlugin {
     void UpdateFieldsFromConfig();
     void UpdateInputScaleFromNetwork(InferenceEngine::CNNNetwork& network);
     void UpdateInputsAndOutputsInfoFromNetwork(InferenceEngine::CNNNetwork &);
-    void UpdateInputsAndOutputsInfoFromModel(const std::shared_ptr<ov::Model> &model);
+    void UpdateInputsAndOutputsInfoFromModel(std::shared_ptr<const ov::Model> model);
     /**
      * @brief Tries to init an output on the base of a layer data
      * @param portId output port identificator

--- a/src/plugins/intel_gna/gna_plugin_internal.hpp
+++ b/src/plugins/intel_gna/gna_plugin_internal.hpp
@@ -41,8 +41,8 @@ public:
         updated_config.UpdateFromMap(config);
         auto plg = std::make_shared<GNAPlugin>(updated_config.keyConfigMap);
         plgPtr = plg;
-        InferenceEngine::CNNNetwork clonedNetwork(InferenceEngine::cloneNetwork(network));
-        return std::make_shared<GNAExecutableNetwork>(clonedNetwork, plg);
+
+        return std::make_shared<GNAExecutableNetwork>(network, plg);
     }
 
     void SetConfig(const std::map<std::string, std::string> &config) override {

--- a/src/tests/functional/plugin/gna/limitations/layers_limit.cpp
+++ b/src/tests/functional/plugin/gna/limitations/layers_limit.cpp
@@ -1,0 +1,139 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "openvino/opsets/opset8.hpp"
+#include "common_test_utils/common_utils.hpp"
+#include "shared_test_classes/base/layer_test_utils.hpp"
+
+using namespace InferenceEngine;
+// using namespace ov::test;
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+        std::string,            // Device name
+        std::map<std::string, std::string>, //common config
+        std::map<std::string, std::string>,  // Configuration
+        size_t // number of layers
+> GNALayersLimitTestParams;
+
+class GNALayersLimitTest : public testing::WithParamInterface<GNALayersLimitTestParams>,
+                           public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<GNALayersLimitTestParams>& obj) {
+        std::string target_device;
+        std::map<std::string, std::string> common_conf, conf;
+        size_t layers_number;
+
+        std::tie(target_device, common_conf, conf, layers_number) = obj.param;
+
+        std::ostringstream result;
+        result << "layerNumber=" << layers_number;
+        result << "_trgDev=" << target_device;
+        for (auto const &conf_i : conf) {
+            result << "_configItem=" << conf_i.first.c_str() << "_" << conf_i.second.c_str();
+        }
+        return result.str();
+    }
+protected:
+    void SetUp() override {
+        ov::element::Type net_type = ov::element::f32;
+        auto params = ngraph::builder::makeParams(net_type, { {1, 2}, {1, 2} });
+        std::map<std::string, std::string> common_conf, conf;
+        size_t layers_number;
+        std::tie(targetDevice, common_conf, conf, layers_number) = this->GetParam();
+
+        configuration.insert(common_conf.begin(), common_conf.end());
+        configuration.insert(conf.begin(), conf.end());
+
+        auto add_const = ngraph::builder::makeConstant(net_type, ngraph::Shape{1}, std::vector<float>{0.01f});
+        auto add_x = std::make_shared<ngraph::opset8::Add>(add_const, params[0]);
+        auto add_y = std::make_shared<ngraph::opset8::Add>(add_const, params[1]);
+
+        std::vector<std::shared_ptr<ov::op::v1::Add>> add_nodes_x;
+        std::vector<std::shared_ptr<ov::op::v1::Add>> add_nodes_y;
+        add_nodes_x.push_back(add_x);
+        add_nodes_y.push_back(add_y);
+
+        for (size_t i = 0; i < (layers_number - 2) / 2; ++i) {
+            auto add_next_x = std::make_shared<ngraph::opset8::Add>(add_nodes_x.back(), params[0]);
+            auto add_next_y = std::make_shared<ngraph::opset8::Add>(add_nodes_y.back(), params[1]);
+            add_nodes_x.push_back(add_next_x);
+            add_nodes_y.push_back(add_next_y);
+        }
+
+        ngraph::ResultVector results{std::make_shared<ngraph::opset8::Result>(add_nodes_x.back()),
+                                     std::make_shared<ngraph::opset8::Result>(add_nodes_y.back())};
+
+        function = std::make_shared<ngraph::Function>(results, params, "layers_limit");
+    }
+};
+
+class GNALayersLimit10Test : public GNALayersLimitTest {};
+class GNALayersLimit20Test : public GNALayersLimitTest {};
+class GNALayersLimit30Test : public GNALayersLimitTest {};
+
+TEST_P(GNALayersLimitTest, CompareWithRefs) {
+    Run();
+}
+TEST_P(GNALayersLimit10Test, CompareWithRefs) {
+    Run();
+}
+TEST_P(GNALayersLimit20Test, CompareWithRefs) {
+    Run();
+}
+TEST_P(GNALayersLimit30Test, CompareWithRefs) {
+    Run();
+}
+
+std::map<std::string, std::string> common_config {
+    {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+    {"GNA_SCALE_FACTOR_0", "1"},
+    {"GNA_SCALE_FACTOR_1", "1"}
+};
+
+std::vector<std::map<std::string, std::string>> configs_20 {
+    {{"GNA_EXEC_TARGET", "GNA_TARGET_2_0"}},
+    {{"GNA_COMPILE_TARGET", "GNA_TARGET_2_0"}}
+};
+
+std::vector<std::map<std::string, std::string>> configs_30 {
+    {{"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}},
+    {{"GNA_COMPILE_TARGET", "GNA_TARGET_3_0"}}
+};
+
+// for GNA v2.0 limit is 4086
+std::vector<size_t> layer_limits_20 {4085, 4086, 4087};
+// for GNA v3.0 limit is 8191
+std::vector<size_t> layer_limits_30 {8190, 8191, 8192};
+// small and big values
+std::vector<size_t> layer_numbers { 2, 9000 };
+
+INSTANTIATE_TEST_SUITE_P(smoke_GNALimits, GNALayersLimitTest,
+                         ::testing::Combine(
+                                ::testing::Values(CommonTestUtils::DEVICE_GNA),
+                                ::testing::Values(common_config),
+                                ::testing::Values(common_config),
+                                ::testing::ValuesIn(layer_numbers)),
+                         GNALayersLimitTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_GNALimits, GNALayersLimit20Test,
+                         ::testing::Combine(
+                                ::testing::Values(CommonTestUtils::DEVICE_GNA),
+                                ::testing::Values(common_config),
+                                ::testing::ValuesIn(configs_20),
+                                ::testing::ValuesIn(layer_limits_20)),
+                         GNALayersLimitTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_GNALimits, GNALayersLimit30Test,
+                         ::testing::Combine(
+                                ::testing::Values(CommonTestUtils::DEVICE_GNA),
+                                ::testing::Values(common_config),
+                                ::testing::ValuesIn(configs_30),
+                                ::testing::ValuesIn(layer_limits_30)),
+                         GNALayersLimitTest::getTestCaseName);
+
+} // namespace LayerTestsDefinitions


### PR DESCRIPTION

### Details:
- Added mechanism of splitting models exceeding HW limitations
 to the sequence of smaller models for the the GNA plugin.
- Added tests for splitting mechanism

### Tickets:
 - 77408

PR created based on reference PR:
https://github.com/openvinotoolkit/openvino/pull/11365
