### PR TITLE
Add C test sample for OV API 2.0 in CI test

### DIFF
--- a/tests/samples_tests/smoke_tests/common/samples_common_test_clas.py
+++ b/tests/samples_tests/smoke_tests/common/samples_common_test_clas.py
@@ -160,8 +160,10 @@ class SamplesCommonTestClass():
                 executable_path = 'python ' + executable_path
             else:
                 executable_path = 'python3 ' + executable_path
-        elif 'c' in sample_type.lower() and not 'c++' in sample_type.lower():
+        elif 'c' in sample_type.lower() and not 'c++' in sample_type.lower() and not '2.0' in sample_type:
             executable_path += '_c'
+        elif '2.0' in sample_type:
+            executable_path += '_ov_c'
         if is_windows and not 'python' in sample_type.lower():
             executable_path += '.exe'
 

--- a/tests/samples_tests/smoke_tests/test_hello_classification.py
+++ b/tests/samples_tests/smoke_tests/test_hello_classification.py
@@ -28,13 +28,13 @@ log.basicConfig(format="[ %(levelname)s ] %(message)s", level=log.INFO, stream=s
 test_data_fp32 = get_tests(cmd_params={'i': [os.path.join('227x227', 'dog.bmp')],
                                        'm': [os.path.join('squeezenet1.1', 'FP32', 'squeezenet1.1.xml')],
                                        'd': ['CPU'],
-                                       'sample_type': ['C++', 'C']},
+                                       'sample_type': ['C++', 'C', 'C2.0']},
                            use_device=['d'])
 
 test_data_fp32_unicode = get_tests(cmd_params={'i': [os.path.join('227x227', 'dog.bmp')],
                                                'm': [os.path.join('squeezenet1.1', 'FP32', 'squeezenet1.1.xml')],
                                                'd': ['CPU'],
-                                               'sample_type': ['C++', 'C']},
+                                               'sample_type': ['C++', 'C', 'C2.0']},
                                    use_device=['d'])
 
 


### PR DESCRIPTION
### Details:
 - *Add C API test sample(hello_classification) for OV API 2.0 in CI test* 

### Tickets:
 - *72178*
