### PR TITLE
Limit ONNX version

### DIFF
--- a/tools/mo/requirements.txt
+++ b/tools/mo/requirements.txt
@@ -5,7 +5,7 @@ networkx~=2.5; python_version <= "3.6"
 networkx<2.8.1; python_version > "3.6"
 numpy>=1.16.6,<1.20
 protobuf>=3.15.6
-onnx>=1.8.1
+onnx>=1.8.1,<1.12
 defusedxml>=0.7.1
 urllib3>=1.26.4
 requests>=2.25.1

--- a/tools/mo/requirements_onnx.txt
+++ b/tools/mo/requirements_onnx.txt
@@ -1,4 +1,4 @@
-onnx>=1.8.1
+onnx>=1.8.1,<1.12
 networkx~=2.5; python_version <= "3.6"
 networkx<2.8.1; python_version > "3.6"
 numpy>=1.16.6,<1.20


### PR DESCRIPTION
### Details:
 OV does not currently support opset 17 introduced in onnx 1.12 release.

### Tickets:
 86511
