### PR TITLE
Puts page switch parameters in alphabetic order to support S3

### DIFF
--- a/docs/_static/js/gsearch.js
+++ b/docs/_static/js/gsearch.js
@@ -265,7 +265,7 @@ function addPagination(query, selectedVersion, currentPage, previousPage, nextPa
         var $previous = $('<a>', {
           'text': 'Previous',
           'class': 'gs-cursor-page-previous',
-          'href': 'search.html?query=' + query + '&page=' + previousPage + '&version=' + selectedVersion
+          'href': 'search.html?page=' + previousPage + '&query=' + query + '&version=' + selectedVersion
         });
         $cursor.append($previous);
     }
@@ -274,7 +274,7 @@ function addPagination(query, selectedVersion, currentPage, previousPage, nextPa
     for(var i = 0; i < pageList.length; i++) {
         $page = $('<a>', {
           'class': 'gs-cursor-page',
-          'href': 'search.html?query=' + query + '&page=' + pageList[i] + '&version=' + selectedVersion,
+          'href': 'search.html?page=' + pageList[i] + '&query=' + query + '&version=' + selectedVersion
           'text': pageList[i]
         });
         if (currentPage === pageList[i]) {
@@ -287,7 +287,7 @@ function addPagination(query, selectedVersion, currentPage, previousPage, nextPa
         var $next = $('<a>', {
           'text': 'Next',
           'class': 'gs-cursor-page-next',
-          'href': 'search.html?query=' + query + '&page=' + nextPage + '&version=' + selectedVersion
+          'href': 'search.html?page=' + nextPage + '&query=' + query + '&version=' + selectedVersion
         });
         $cursor.append($next);
     }


### PR DESCRIPTION
Signed-off-by: intelkevinputnam <intelkevinputnam@github.com>

### Details:

**root cause**: S3 expects the Query string to be sorted alphabetically

* Current page request will fail signature validation: https://docs.openvino.ai/nightly/search.html?query=aI&page=4&version=ALL

* Reorganizing the query strings succeeds: https://docs.openvino.ai/nightly/search.html?page=4&query=aI&version=ALL

Akamai docs address it here: https://techdocs.akamai.com/object-delivery/docs/origin-characteristics-and-od under the Additional considerations

> "Only the "Authorization" header is supported (AWS, only). If you're using query string parameters with this authentication, each query parameter in the incoming client request must be sorted alphabetically, and URL encoded."”
