### PR TITLE
Implement GetConfig/SetConfig for IExecutableNetworkInternal

### DIFF
--- a/src/inference/dev_api/cpp_interfaces/interface/ie_iexecutable_network_internal.hpp
+++ b/src/inference/dev_api/cpp_interfaces/interface/ie_iexecutable_network_internal.hpp
@@ -177,6 +177,7 @@ protected:
     InferenceEngine::OutputsDataMap _networkOutputs;  //!< Holds information about network outputs data
     std::vector<std::shared_ptr<const ov::Node>> _parameters;
     std::vector<std::shared_ptr<const ov::Node>> _results;
+    std::map<std::string, InferenceEngine::Parameter> _config; //!< Holds compilation parameters like PERFORMANCE_HINT and PERF_COUNT
 
     /**
      * @brief A pointer to a IInferencePlugin interface.

--- a/src/inference/src/cpp_interfaces/interface/ie_iexecutable_network_internal.cpp
+++ b/src/inference/src/cpp_interfaces/interface/ie_iexecutable_network_internal.cpp
@@ -91,12 +91,17 @@ void IExecutableNetworkInternal::SetPointerToPlugin(const std::shared_ptr<IInfer
     _plugin = plugin;
 }
 
-void IExecutableNetworkInternal::SetConfig(const std::map<std::string, Parameter>&) {
-    IE_THROW(NotImplemented);
+void IExecutableNetworkInternal::SetConfig(const std::map<std::string, Parameter>& config) {
+    _config = config;
 }
 
-Parameter IExecutableNetworkInternal::GetConfig(const std::string&) const {
-    IE_THROW(NotImplemented);
+Parameter IExecutableNetworkInternal::GetConfig(const std::string& key) const {
+    const auto it = _config.find(key);
+    if (it != _config.end()) {
+        return it->second;
+    }
+
+    IE_THROW(NotFound) << key <<" not found in the IExecutableNetworkInternal config";
 }
 
 Parameter IExecutableNetworkInternal::GetMetric(const std::string&) const {

--- a/src/plugins/auto/plugin.cpp
+++ b/src/plugins/auto/plugin.cpp
@@ -444,6 +444,7 @@ IExecutableNetworkInternal::Ptr MultiDeviceInferencePlugin::LoadNetworkImpl(cons
                 });
                 exec_net = GetCore()->LoadNetwork(network, deviceName, deviceConfig);
             }
+            exec_net->SetConfig({{"PERF_COUNT", "YES"}});
             std::unique_lock<std::mutex> lock{load_mutex};
             executableNetworkPerDevice.insert({deviceName, exec_net});
             multiNetworkConfig.insert(deviceConfig.begin(), deviceConfig.end());
@@ -466,7 +467,8 @@ IExecutableNetworkInternal::Ptr MultiDeviceInferencePlugin::LoadNetworkImpl(cons
                 num_plugins_supporting_perf_counters +=
                         n.second->GetConfig(PluginConfigParams::KEY_PERF_COUNT).as<std::string>() ==
                         PluginConfigParams::YES;
-            } catch (...) {
+            } catch (Exception& ex) {
+                LOG_DEBUG("[AUTOPLUGIN] Error while parsing KEY_PERF_COUNT. %s", ex.what());
             }
     }
     // MULTI can enable the perf counters only if all  devices support/enable that

--- a/src/plugins/auto/plugin.cpp
+++ b/src/plugins/auto/plugin.cpp
@@ -444,7 +444,7 @@ IExecutableNetworkInternal::Ptr MultiDeviceInferencePlugin::LoadNetworkImpl(cons
                 });
                 exec_net = GetCore()->LoadNetwork(network, deviceName, deviceConfig);
             }
-            exec_net->SetConfig({{"PERF_COUNT", "YES"}});
+            exec_net->SetConfig(deviceConfig);
             std::unique_lock<std::mutex> lock{load_mutex};
             executableNetworkPerDevice.insert({deviceName, exec_net});
             multiNetworkConfig.insert(deviceConfig.begin(), deviceConfig.end());

--- a/src/plugins/intel_cpu/src/exec_network.cpp
+++ b/src/plugins/intel_cpu/src/exec_network.cpp
@@ -247,7 +247,7 @@ Parameter ExecNetwork::GetConfigLegacy(const std::string &name) const {
 
 /**
  * Only legacy parameters are supported.
- * No RW peroperties supported for new API.
+ * No RW properties supported for new API.
  * All the RO properties are covered with GetMetric() method and
  * GetConfig() is not expected to be called by new API with params from new configuration API.
  */


### PR DESCRIPTION
### Details:
Implement GetConfig/SetConfig for IExecutableNetworkInternal
It is required to get profiling counters from AUTO/MULTI plugins.
