### PR TITLE
[GPU] Pass lrn unit tests on DG2

### DIFF
--- a/src/plugins/intel_gpu/src/graph/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/activation.cpp
@@ -30,7 +30,8 @@ layout activation_inst::calc_output_layout(activation_node const& node) {
         activation_func::floor,
         activation_func::clamp };
 
-    if (input_node_layout.data_type == data_types::i8 || input_node_layout.data_type == data_types::i32) {
+    if (input_node_layout.data_type == data_types::i8 || input_node_layout.data_type == data_types::u8 ||
+        input_node_layout.data_type == data_types::i32) {
         if (std::find(activations_int8.begin(), activations_int8.end(), func) == activations_int8.end())
             CLDNN_ERROR_MESSAGE(node.id(), "Requested activation is not supported for integer type.");
     }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -976,6 +976,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                                       (parents[i]->is_type<pooling>() && pooling_supports_fusings(parents[i]->as<pooling>())) ||
                                       (parents[i]->is_type<depth_to_space>() && dts_supports_fusings(parents[i]->as<depth_to_space>())) ||
                                       (parents[i]->is_type<reduce>() && reduce_supports_fusings(parents[i]->as<reduce>())) ||
+                                      (parents[i]->is_type<lrn>()) ||
                                       (parents[i]->is_type<activation>());
             }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -126,6 +126,7 @@ attach_eltwise_impl::attach_eltwise_impl() {
         std::make_tuple(data_types::f32, format::yxfb),
         std::make_tuple(data_types::f16, format::yxfb),
         std::make_tuple(data_types::i8, format::yxfb),
+        std::make_tuple(data_types::u8, format::yxfb),
         std::make_tuple(data_types::i32, format::yxfb),
         std::make_tuple(data_types::i64, format::yxfb),
 
@@ -139,6 +140,7 @@ attach_eltwise_impl::attach_eltwise_impl() {
         std::make_tuple(data_types::f32, format::byxf),
         std::make_tuple(data_types::f16, format::byxf),
         std::make_tuple(data_types::i8, format::byxf),
+        std::make_tuple(data_types::u8, format::byxf),
         std::make_tuple(data_types::i32, format::byxf),
         std::make_tuple(data_types::i64, format::byxf),
 

--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/lrn/lrn_kernel_across_channel_multiple_features.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/lrn/lrn_kernel_across_channel_multiple_features.h
@@ -21,7 +21,7 @@ protected:
     DispatchData SetDefault(const lrn_params& params) const override;
     std::vector<FusedOpType> GetSupportedFusedOps() const override {
         return { FusedOpType::QUANTIZE,
-                 FusedOpType::SCALE,
+                 FusedOpType::ELTWISE,
                  FusedOpType::ACTIVATION };
     }
     bool Validate(const Params& params, const optional_params& options) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/lrn/lrn_kernel_across_channel_opt_b8.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/lrn/lrn_kernel_across_channel_opt_b8.h
@@ -22,7 +22,7 @@ private:
     DispatchData SetDefault(const lrn_params& params) const override;
     std::vector<FusedOpType> GetSupportedFusedOps() const override {
         return { FusedOpType::QUANTIZE,
-                 FusedOpType::SCALE,
+                 FusedOpType::ELTWISE,
                  FusedOpType::ACTIVATION };
     }
     bool Validate(const Params& params, const optional_params& options) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/lrn/lrn_kernel_across_channel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/lrn/lrn_kernel_across_channel_ref.h
@@ -22,7 +22,7 @@ protected:
     DispatchData SetDefault(const lrn_params& params) const override;
     std::vector<FusedOpType> GetSupportedFusedOps() const override {
         return { FusedOpType::QUANTIZE,
-                 FusedOpType::SCALE,
+                 FusedOpType::ELTWISE,
                  FusedOpType::ACTIVATION };
     }
     JitConstants GetJitConstants(const lrn_params& params, const DispatchData& dispatchData) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/lrn/lrn_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/lrn/lrn_kernel_ref.h
@@ -22,7 +22,7 @@ private:
     DispatchData SetDefault(const lrn_params& params) const override;
     std::vector<FusedOpType> GetSupportedFusedOps() const override {
         return { FusedOpType::QUANTIZE,
-                 FusedOpType::SCALE,
+                 FusedOpType::ELTWISE,
                  FusedOpType::ACTIVATION };
     }
     JitConstants GetJitConstants(const lrn_params& params, const DispatchData& dispatchData) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/lrn/lrn_kernel_within_channel_byxf_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/lrn/lrn_kernel_within_channel_byxf_opt.h
@@ -22,7 +22,7 @@ private:
     DispatchData SetDefault(const lrn_params& params) const override;
     std::vector<FusedOpType> GetSupportedFusedOps() const override {
         return { FusedOpType::QUANTIZE,
-                 FusedOpType::SCALE,
+                 FusedOpType::ELTWISE,
                  FusedOpType::ACTIVATION };
     }
     bool Validate(const Params& params, const optional_params& options) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/lrn/lrn_kernel_within_channel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/lrn/lrn_kernel_within_channel_ref.h
@@ -22,7 +22,7 @@ private:
     DispatchData SetDefault(const lrn_params& params) const override;
     std::vector<FusedOpType> GetSupportedFusedOps() const override {
         return { FusedOpType::QUANTIZE,
-                 FusedOpType::SCALE,
+                 FusedOpType::ELTWISE,
                  FusedOpType::ACTIVATION };
     }
     bool Validate(const Params& params, const optional_params& options) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/lrn/lrn_kernel_within_channel_ref_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/lrn/lrn_kernel_within_channel_ref_opt.h
@@ -21,7 +21,7 @@ private:
     DispatchData SetDefault(const lrn_params& params) const override;
     std::vector<FusedOpType> GetSupportedFusedOps() const override {
         return { FusedOpType::QUANTIZE,
-                 FusedOpType::SCALE,
+                 FusedOpType::ELTWISE,
                  FusedOpType::ACTIVATION };
     }
     bool Validate(const Params& params, const optional_params& options) const override;


### PR DESCRIPTION
### Details:
 - Change Scale to Eltwise(mode::prod) in unit test topologies.
 - Change ScaleWithBias to Eltwise(mode::prod)+Eltwise(mode::sum) in unit test topologies.
 - Support Gather-Eltwise fusing.

### Tickets:
 - 67491
