### PR TITLE
[CPU] [WA] Use config to enable brgconv f32 kernel

### DIFF
--- a/samples/cpp/benchmark_app/README.md
+++ b/samples/cpp/benchmark_app/README.md
@@ -100,6 +100,8 @@ Options:
                                 letting the runtime to decide on the threads->different core types("HYBRID_AWARE", which is default on the hybrid CPUs)
                                 threads->(NUMA)nodes("NUMA") or
                                 completely disable("NO") CPU inference threads pinning
+    -expconv                  Optional. Enable new experiment convolution algorithm. Only valid in CPU
+    plugin.
 
   Statistics dumping options:
     -report_type "<type>"       Optional. Enable collecting statistics report. "no_counters" report contains configuration options specified, resulting FPS and latency.

--- a/samples/cpp/benchmark_app/README.md
+++ b/samples/cpp/benchmark_app/README.md
@@ -100,8 +100,7 @@ Options:
                                 letting the runtime to decide on the threads->different core types("HYBRID_AWARE", which is default on the hybrid CPUs)
                                 threads->(NUMA)nodes("NUMA") or
                                 completely disable("NO") CPU inference threads pinning
-    -expconv                  Optional. Enable new experiment convolution algorithm. Only valid in CPU
-    plugin.
+    -cpu_experimental ("<brgconv>")          Optional. Enable experimental setting for CPU plugin.
 
   Statistics dumping options:
     -report_type "<type>"       Optional. Enable collecting statistics report. "no_counters" report contains configuration options specified, resulting FPS and latency.

--- a/samples/cpp/benchmark_app/benchmark_app.hpp
+++ b/samples/cpp/benchmark_app/benchmark_app.hpp
@@ -230,6 +230,9 @@ static constexpr char inference_only_message[] =
     " To enable full mode for static models pass \"false\" value to this argument:"
     " ex. \"-inference_only=false\".\n";
 
+static constexpr char experiment_convolution_message[] =
+    "Optional. Enable new experiment convolution algorithm. Only valid in CPU plugin.";
+
 /// @brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
@@ -363,6 +366,9 @@ DEFINE_string(imean, "", input_image_mean_message);
 /// @brief Define flag for inference only mode <br>
 DEFINE_bool(inference_only, true, inference_only_message);
 
+/// @brief Define flag for using experiment convolution <br>
+DEFINE_bool(expconv, false, experiment_convolution_message);
+
 /**
  * @brief This function show a help message
  */
@@ -397,6 +403,7 @@ static void show_usage() {
     std::cout << "    -nthreads \"<integer>\"     " << infer_num_threads_message << std::endl;
     std::cout << "    -pin (\"YES\"|\"CORE\")/\"HYBRID_AWARE\"/(\"NO\"|\"NONE\")/\"NUMA\"   "
               << infer_threads_pinning_message << std::endl;
+    std::cout << "    -expconv                    " << experiment_convolution_message << std::endl;
 #ifdef HAVE_DEVICE_MEM_SUPPORT
     std::cout << "    -use_device_mem           " << use_device_mem_message << std::endl;
 #endif

--- a/samples/cpp/benchmark_app/benchmark_app.hpp
+++ b/samples/cpp/benchmark_app/benchmark_app.hpp
@@ -230,8 +230,8 @@ static constexpr char inference_only_message[] =
     " To enable full mode for static models pass \"false\" value to this argument:"
     " ex. \"-inference_only=false\".\n";
 
-static constexpr char experiment_convolution_message[] =
-    "Optional. Enable new experiment convolution algorithm. Only valid in CPU plugin.";
+static constexpr char cpu_experimental_message[] =
+    "Optional. Enable experimental setting for CPU plugin. Setting should be 'brgconv' etc.";
 
 /// @brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
@@ -366,8 +366,8 @@ DEFINE_string(imean, "", input_image_mean_message);
 /// @brief Define flag for inference only mode <br>
 DEFINE_bool(inference_only, true, inference_only_message);
 
-/// @brief Define flag for using experiment convolution <br>
-DEFINE_bool(expconv, false, experiment_convolution_message);
+/// @brief Define flag for using experimental setting for CPU plugin <br>
+DEFINE_string(cpu_experimental, "", cpu_experimental_message);
 
 /**
  * @brief This function show a help message
@@ -403,7 +403,7 @@ static void show_usage() {
     std::cout << "    -nthreads \"<integer>\"     " << infer_num_threads_message << std::endl;
     std::cout << "    -pin (\"YES\"|\"CORE\")/\"HYBRID_AWARE\"/(\"NO\"|\"NONE\")/\"NUMA\"   "
               << infer_threads_pinning_message << std::endl;
-    std::cout << "    -expconv                    " << experiment_convolution_message << std::endl;
+    std::cout << "    -cpu_experimental         " << cpu_experimental_message << std::endl;
 #ifdef HAVE_DEVICE_MEM_SUPPORT
     std::cout << "    -use_device_mem           " << use_device_mem_message << std::endl;
 #endif

--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -386,9 +386,9 @@ int main(int argc, char* argv[]) {
                     }
                 }
 
-                // use experiment convolution
-                if (isFlagSetInCommandLine("expconv")) {
-                    device_config.emplace(ov::enforce_experiment_convolution(true));
+                // use experimental setting
+                if (isFlagSetInCommandLine("cpu_experimental")) {
+                    device_config.emplace(ov::cpu_experimental(FLAGS_cpu_experimental));
                 }
 
                 // for CPU execution, more throughput-oriented execution via streams

--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -386,6 +386,11 @@ int main(int argc, char* argv[]) {
                     }
                 }
 
+                // use experiment convolution
+                if (isFlagSetInCommandLine("expconv")) {
+                    device_config.emplace(ov::enforce_experiment_convolution(true));
+                }
+
                 // for CPU execution, more throughput-oriented execution via streams
                 setThroughputStreams();
                 set_infer_precision();

--- a/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
@@ -29,6 +29,7 @@ void regmodule_properties(py::module m) {
     wrap_property_RW(m_properties, ov::compilation_num_threads, "compilation_num_threads");
     wrap_property_RW(m_properties, ov::affinity, "affinity");
     wrap_property_RW(m_properties, ov::force_tbb_terminate, "force_tbb_terminate");
+    wrap_property_RW(m_properties, ov::enforce_experiment_convolution, "experiment_convolution");
 
     wrap_property_RO(m_properties, ov::supported_properties, "supported_properties");
     wrap_property_RO(m_properties, ov::available_devices, "available_devices");

--- a/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
@@ -29,7 +29,7 @@ void regmodule_properties(py::module m) {
     wrap_property_RW(m_properties, ov::compilation_num_threads, "compilation_num_threads");
     wrap_property_RW(m_properties, ov::affinity, "affinity");
     wrap_property_RW(m_properties, ov::force_tbb_terminate, "force_tbb_terminate");
-    wrap_property_RW(m_properties, ov::enforce_experiment_convolution, "experiment_convolution");
+    wrap_property_RW(m_properties, ov::cpu_experimental, "cpu_experimental");
 
     wrap_property_RO(m_properties, ov::supported_properties, "supported_properties");
     wrap_property_RO(m_properties, ov::available_devices, "available_devices");

--- a/src/inference/include/ie/ie_plugin_config.hpp
+++ b/src/inference/include/ie/ie_plugin_config.hpp
@@ -431,14 +431,9 @@ DECLARE_CONFIG_KEY(DUMP_EXEC_GRAPH_AS_DOT);
 DECLARE_CONFIG_KEY(ENFORCE_BF16);
 
 /**
- * @brief Use experiment convolution algorithm whenever it is possible
- *
- * This option let CPU plugin to use experiment convolution algorithm if hardware supports
- * AVX512.
- * By default, the option is set to NO, set to YES will try to use the experiment convolution
- * algorithm.
+ * @brief Use experimental setting for CPU plugin.
  */
-DECLARE_CONFIG_KEY(ENFORCE_EXPERIMENT_CONVOLUTION);
+DECLARE_CONFIG_KEY(CPU_EXPERIMENTAL);
 
 /**
  * @brief This key defines the directory which will be used to store any data cached by plugins.

--- a/src/inference/include/ie/ie_plugin_config.hpp
+++ b/src/inference/include/ie/ie_plugin_config.hpp
@@ -431,6 +431,16 @@ DECLARE_CONFIG_KEY(DUMP_EXEC_GRAPH_AS_DOT);
 DECLARE_CONFIG_KEY(ENFORCE_BF16);
 
 /**
+ * @brief Use experiment convolution algorithm whenever it is possible
+ *
+ * This option let CPU plugin to use experiment convolution algorithm if hardware supports
+ * AVX512.
+ * By default, the option is set to NO, set to YES will try to use the experiment convolution
+ * algorithm.
+ */
+DECLARE_CONFIG_KEY(ENFORCE_EXPERIMENT_CONVOLUTION);
+
+/**
  * @brief This key defines the directory which will be used to store any data cached by plugins.
  *
  * The underlying cache structure is not defined and might differ between OpenVINO releases

--- a/src/inference/include/openvino/runtime/properties.hpp
+++ b/src/inference/include/openvino/runtime/properties.hpp
@@ -458,10 +458,10 @@ static constexpr Property<Level> level{"LOG_LEVEL"};
 static constexpr Property<std::string> cache_dir{"CACHE_DIR"};
 
 /**
- * @brief The name for setting if using experiment convolution algorithm.
+ * @brief The name for experimental setting for CPU plugin.
  * @ingroup ov_runtime_cpp_prop_api
  */
-static constexpr Property<bool> enforce_experiment_convolution{"ENFORCE_EXPERIMENT_CONVOLUTION"};
+static constexpr Property<std::string> cpu_experimental{"CPU_EXPERIMENTAL"};
 
 /**
  * @brief Read-only property to provide information about a range for streams on platforms where streams are supported.

--- a/src/inference/include/openvino/runtime/properties.hpp
+++ b/src/inference/include/openvino/runtime/properties.hpp
@@ -458,6 +458,12 @@ static constexpr Property<Level> level{"LOG_LEVEL"};
 static constexpr Property<std::string> cache_dir{"CACHE_DIR"};
 
 /**
+ * @brief The name for setting if using experiment convolution algorithm.
+ * @ingroup ov_runtime_cpp_prop_api
+ */
+static constexpr Property<bool> enforce_experiment_convolution{"ENFORCE_EXPERIMENT_CONVOLUTION"};
+
+/**
  * @brief Read-only property to provide information about a range for streams on platforms where streams are supported.
  * @ingroup ov_runtime_cpp_prop_api
  *

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -17,6 +17,7 @@
 #include "openvino/core/type/element_type_traits.hpp"
 #include "openvino/runtime/properties.hpp"
 #include <cpu/x64/cpu_isa_traits.hpp>
+#include "utils/general_utils.h"
 
 namespace ov {
 namespace intel_cpu {
@@ -121,18 +122,20 @@ void Config::readProperties(const std::map<std::string, std::string> &prop) {
                     << ". Expected only YES/NO";
             }
         } else if (key == PluginConfigParams::KEY_CPU_EXPERIMENTAL) {
-            if (val == cpu_experimental_brgconv) {
-                if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
-                    enforceExperimentConv = true;
-                } else {
-                    IE_THROW() << "Platform doesn't support brgconv algorithm";
+            const auto elements = split(val, ',');
+            std::set<std::string> newConfig;
+            for (const auto& element : elements) {
+                if (element == EXPERIMENTAL_KEY_BRGCONV) {
+                    if (!dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
+                        IE_THROW() << "Platform doesn't support " EXPERIMENTAL_KEY_BRGCONV " algorithm";
+                    }
+                } else if (!val.empty()) {
+                    IE_THROW() << "Wrong value for property key " << PluginConfigParams::KEY_CPU_EXPERIMENTAL
+                        << ". Expected only " << EXPERIMENTAL_KEY_BRGCONV;
                 }
-            } else if (val.empty()) {
-                enforceExperimentConv = false;
-            } else {
-                IE_THROW() << "Wrong value for property key " << PluginConfigParams::KEY_CPU_EXPERIMENTAL
-                    << ". Expected only " << cpu_experimental_brgconv;
+                newConfig.insert(element);
             }
+            cpuExperimental = std::move(newConfig);
         } else if (key == ov::hint::inference_precision.name()) {
             if (val == "bf16") {
                 if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
@@ -221,8 +224,8 @@ void Config::updateProperties() {
     } else {
         _config.insert({ PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO });
     }
-    if (enforceExperimentConv) {
-        _config.insert({ PluginConfigParams::KEY_CPU_EXPERIMENTAL, cpu_experimental_brgconv });
+    if (!cpuExperimental.empty()) {
+        _config.insert({ PluginConfigParams::KEY_CPU_EXPERIMENTAL, join(cpuExperimental, ',') });
     }
     _config.insert({ PluginConfigParams::KEY_PERFORMANCE_HINT, perfHintsConfig.ovPerfHint });
     _config.insert({ PluginConfigParams::KEY_PERFORMANCE_HINT_NUM_REQUESTS,

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -120,6 +120,19 @@ void Config::readProperties(const std::map<std::string, std::string> &prop) {
                 IE_THROW() << "Wrong value for property key " << PluginConfigParams::KEY_ENFORCE_BF16
                     << ". Expected only YES/NO";
             }
+        } else if (key == PluginConfigParams::KEY_ENFORCE_EXPERIMENT_CONVOLUTION) {
+            if (val == PluginConfigParams::YES) {
+                if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
+                    enforceExperimentConv = true;
+                } else {
+                    IE_THROW() << "Platform doesn't support experiment convolution algorithm";
+                }
+            } else if (val == PluginConfigParams::NO) {
+                enforceExperimentConv = false;
+            } else {
+                IE_THROW() << "Wrong value for property key " << PluginConfigParams::KEY_ENFORCE_EXPERIMENT_CONVOLUTION
+                    << ". Expected only YES/NO";
+            }
         } else if (key == ov::hint::inference_precision.name()) {
             if (val == "bf16") {
                 if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
@@ -207,6 +220,11 @@ void Config::updateProperties() {
         _config.insert({ PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES });
     } else {
         _config.insert({ PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO });
+    }
+    if (enforceExperimentConv) {
+        _config.insert({ PluginConfigParams::KEY_ENFORCE_EXPERIMENT_CONVOLUTION, PluginConfigParams::YES });
+    } else {
+        _config.insert({ PluginConfigParams::KEY_ENFORCE_EXPERIMENT_CONVOLUTION, PluginConfigParams::NO });
     }
     _config.insert({ PluginConfigParams::KEY_PERFORMANCE_HINT, perfHintsConfig.ovPerfHint });
     _config.insert({ PluginConfigParams::KEY_PERFORMANCE_HINT_NUM_REQUESTS,

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -125,11 +125,14 @@ void Config::readProperties(const std::map<std::string, std::string> &prop) {
             const auto elements = split(val, ',');
             std::set<std::string> newConfig;
             for (const auto& element : elements) {
+                if (element.empty()) {
+                    continue;
+                }
                 if (element == EXPERIMENTAL_KEY_BRGCONV) {
                     if (!dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
-                        IE_THROW() << "Platform doesn't support " EXPERIMENTAL_KEY_BRGCONV " algorithm";
+                        continue;
                     }
-                } else if (!val.empty()) {
+                } else {
                     IE_THROW() << "Wrong value for property key " << PluginConfigParams::KEY_CPU_EXPERIMENTAL
                         << ". Expected only " << EXPERIMENTAL_KEY_BRGCONV;
                 }

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -120,18 +120,18 @@ void Config::readProperties(const std::map<std::string, std::string> &prop) {
                 IE_THROW() << "Wrong value for property key " << PluginConfigParams::KEY_ENFORCE_BF16
                     << ". Expected only YES/NO";
             }
-        } else if (key == PluginConfigParams::KEY_ENFORCE_EXPERIMENT_CONVOLUTION) {
-            if (val == PluginConfigParams::YES) {
+        } else if (key == PluginConfigParams::KEY_CPU_EXPERIMENTAL) {
+            if (val == cpu_experimental_brgconv) {
                 if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
                     enforceExperimentConv = true;
                 } else {
-                    IE_THROW() << "Platform doesn't support experiment convolution algorithm";
+                    IE_THROW() << "Platform doesn't support brgconv algorithm";
                 }
-            } else if (val == PluginConfigParams::NO) {
+            } else if (val.empty()) {
                 enforceExperimentConv = false;
             } else {
-                IE_THROW() << "Wrong value for property key " << PluginConfigParams::KEY_ENFORCE_EXPERIMENT_CONVOLUTION
-                    << ". Expected only YES/NO";
+                IE_THROW() << "Wrong value for property key " << PluginConfigParams::KEY_CPU_EXPERIMENTAL
+                    << ". Expected only " << cpu_experimental_brgconv;
             }
         } else if (key == ov::hint::inference_precision.name()) {
             if (val == "bf16") {
@@ -222,9 +222,7 @@ void Config::updateProperties() {
         _config.insert({ PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO });
     }
     if (enforceExperimentConv) {
-        _config.insert({ PluginConfigParams::KEY_ENFORCE_EXPERIMENT_CONVOLUTION, PluginConfigParams::YES });
-    } else {
-        _config.insert({ PluginConfigParams::KEY_ENFORCE_EXPERIMENT_CONVOLUTION, PluginConfigParams::NO });
+        _config.insert({ PluginConfigParams::KEY_CPU_EXPERIMENTAL, cpu_experimental_brgconv });
     }
     _config.insert({ PluginConfigParams::KEY_PERFORMANCE_HINT, perfHintsConfig.ovPerfHint });
     _config.insert({ PluginConfigParams::KEY_PERFORMANCE_HINT_NUM_REQUESTS,

--- a/src/plugins/intel_cpu/src/config.h
+++ b/src/plugins/intel_cpu/src/config.h
@@ -40,6 +40,7 @@ struct Config {
     bool manualEnforceBF16 = false;
     bool enforceExperimentConv = false;
 #endif
+    std::string cpu_experimental_brgconv = "brgconv";
 
     std::string cache_dir{};
 

--- a/src/plugins/intel_cpu/src/config.h
+++ b/src/plugins/intel_cpu/src/config.h
@@ -9,10 +9,13 @@
 #include "utils/debug_capabilities.h"
 
 #include <string>
+#include <set>
 #include <map>
 
 namespace ov {
 namespace intel_cpu {
+
+#define EXPERIMENTAL_KEY_BRGCONV "brgconv"
 
 struct Config {
     Config();
@@ -38,9 +41,8 @@ struct Config {
     LPTransformsMode lpTransformsMode = LPTransformsMode::On;
     bool enforceBF16 = true;
     bool manualEnforceBF16 = false;
-    bool enforceExperimentConv = false;
 #endif
-    std::string cpu_experimental_brgconv = "brgconv";
+    std::set<std::string> cpuExperimental;
 
     std::string cache_dir{};
 

--- a/src/plugins/intel_cpu/src/config.h
+++ b/src/plugins/intel_cpu/src/config.h
@@ -38,6 +38,7 @@ struct Config {
     LPTransformsMode lpTransformsMode = LPTransformsMode::On;
     bool enforceBF16 = true;
     bool manualEnforceBF16 = false;
+    bool enforceExperimentConv = false;
 #endif
 
     std::string cache_dir{};

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -153,7 +153,7 @@ void Graph::Replicate(const std::shared_ptr<const ov::Model> &subgraph, const Ex
         if (isQuantized()) {
             node->setQuantizedGraphFlag(true);
         }
-        node->setUseExperimentConvAlgorithm(config.enforceExperimentConv);
+        node->setCPUExperimental(config.cpuExperimental);
         node->setRuntimeCache(rtParamsCache);
 
         graphNodes.push_back(node);
@@ -266,7 +266,7 @@ void Graph::Replicate(const CNNNetwork &network, const ExtensionManager::Ptr& ex
         if (isQuantized()) {
             node->setQuantizedGraphFlag(true);
         }
-        node->setUseExperimentConvAlgorithm(config.enforceExperimentConv);
+        node->setCPUExperimental(config.cpuExperimental);
         node->setRuntimeCache(rtParamsCache);
         graphNodes.push_back(node);
 

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -153,6 +153,7 @@ void Graph::Replicate(const std::shared_ptr<const ov::Model> &subgraph, const Ex
         if (isQuantized()) {
             node->setQuantizedGraphFlag(true);
         }
+        node->setUseExperimentConvAlgorithm(config.enforceExperimentConv);
         node->setRuntimeCache(rtParamsCache);
 
         graphNodes.push_back(node);
@@ -265,6 +266,7 @@ void Graph::Replicate(const CNNNetwork &network, const ExtensionManager::Ptr& ex
         if (isQuantized()) {
             node->setQuantizedGraphFlag(true);
         }
+        node->setUseExperimentConvAlgorithm(config.enforceExperimentConv);
         node->setRuntimeCache(rtParamsCache);
         graphNodes.push_back(node);
 

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -884,9 +884,8 @@ const std::vector<impl_desc_type>& Node::getPrimitivesPriority() {
             impl_desc_type::jit_avx512_amx_dw,
             impl_desc_type::jit_avx512_amx_1x1,
             impl_desc_type::jit_avx512_amx,
-            // Brgconv kernels disabled in order to prevent perf degradations on non AMX HW
-            // impl_desc_type::brgconv_avx512_1x1,
-            // impl_desc_type::brgconv_avx512,
+            impl_desc_type::brgconv_avx512_1x1,
+            impl_desc_type::brgconv_avx512,
             impl_desc_type::jit_uni_dw,
             impl_desc_type::jit_uni_1x1,
             impl_desc_type::jit_uni,

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -884,8 +884,9 @@ const std::vector<impl_desc_type>& Node::getPrimitivesPriority() {
             impl_desc_type::jit_avx512_amx_dw,
             impl_desc_type::jit_avx512_amx_1x1,
             impl_desc_type::jit_avx512_amx,
-            impl_desc_type::brgconv_avx512_1x1,
-            impl_desc_type::brgconv_avx512,
+            // Brgconv kernels disabled in order to prevent perf degradations on non AMX HW
+            // impl_desc_type::brgconv_avx512_1x1,
+            // impl_desc_type::brgconv_avx512,
             impl_desc_type::jit_uni_dw,
             impl_desc_type::jit_uni_1x1,
             impl_desc_type::jit_uni,

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -517,6 +517,10 @@ public:
         algorithm = alg;
     }
 
+    void setUseExperimentConvAlgorithm(bool use) {
+        useExperimentConv = use;
+    }
+
     virtual bool canFuse(const NodePtr& node) const {
         return false;
     }
@@ -636,6 +640,8 @@ protected:
     WeightsSharing::Ptr weightCache;
 
     Algorithm algorithm = Algorithm::Default;
+
+    bool useExperimentConv = false;
 
     bool isInQuantizedGraph = false;
 

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -517,8 +517,8 @@ public:
         algorithm = alg;
     }
 
-    void setUseExperimentConvAlgorithm(bool use) {
-        useExperimentConv = use;
+    void setCPUExperimental(const std::set<std::string>& experimental) {
+        cpuExperimental = experimental;
     }
 
     virtual bool canFuse(const NodePtr& node) const {
@@ -641,7 +641,7 @@ protected:
 
     Algorithm algorithm = Algorithm::Default;
 
-    bool useExperimentConv = false;
+    std::set<std::string> cpuExperimental;
 
     bool isInQuantizedGraph = false;
 

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -312,7 +312,7 @@ InferenceEngine::Precision Convolution::fusedEltwisePrecision(const NodePtr& fus
 }
 
 const std::vector<impl_desc_type>& Convolution::getPrimitivesPriority() {
-    if (!useExperimentConv)
+    if (!cpuExperimental.count(EXPERIMENTAL_KEY_BRGCONV))
         return Node::getPrimitivesPriority();
 
     std::vector<impl_desc_type> priorities = {
@@ -517,7 +517,7 @@ void Convolution::getSupportedDescriptors() {
             auto outputShape = getOutputShapeAtPort(0);
 
             bool acceptedFormat = inputDataType == memory::data_type::bf16;
-            acceptedFormat |= useExperimentConv && inputDataType == memory::data_type::f32;
+            acceptedFormat |= cpuExperimental.count(EXPERIMENTAL_KEY_BRGCONV) && inputDataType == memory::data_type::f32;
             if (acceptedFormat && impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core)) {
                 in_candidate = std::make_shared<DnnlBlockedMemoryDesc>(inputShape, inputDataType, nspc);
                 out_candidate = std::make_shared<DnnlBlockedMemoryDesc>(outputShape, outputDataType, nspc);
@@ -762,9 +762,9 @@ void Convolution::initSupportedPrimitiveDescriptors() {
     // attr[0] - depthwise, quantize
     // attr[1] - binary
     dnnl::primitive_attr attrs[2];
-    auto attrsNum = useExperimentConv ? 2 : 1;
+    auto attrsNum = cpuExperimental.count(EXPERIMENTAL_KEY_BRGCONV) ? 2 : 1;
     setPostOps(attrs[0], MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), true);
-    if (useExperimentConv) {
+    if (cpuExperimental.count(EXPERIMENTAL_KEY_BRGCONV)) {
         setPostOps(attrs[1], MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), false);
     }
 
@@ -989,9 +989,9 @@ void Convolution::initDescriptor(const NodeConfig& config) {
     // attr[0] - depthwise, quantize
     // attr[1] - binary
     dnnl::primitive_attr attrs[2];
-    auto attrsNum = useExperimentConv ? 2 : 1;
+    auto attrsNum = cpuExperimental.count(EXPERIMENTAL_KEY_BRGCONV) ? 2 : 1;
     setPostOps(attrs[0], MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), true);
-    if (useExperimentConv) {
+    if (cpuExperimental.count(EXPERIMENTAL_KEY_BRGCONV)) {
         setPostOps(attrs[1], MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), false);
     }
 

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -471,8 +471,8 @@ void Convolution::getSupportedDescriptors() {
             auto inputShape = getInputShapeAtPort(0);
             auto outputShape = getOutputShapeAtPort(0);
 
-            if (one_of(inputDataType, memory::data_type::bf16) &&
-                    impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core_amx)) {
+            if (one_of(inputDataType, memory::data_type::f32, memory::data_type::bf16) &&
+                    impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core)) {
                 in_candidate = std::make_shared<DnnlBlockedMemoryDesc>(inputShape, inputDataType, nspc);
                 out_candidate = std::make_shared<DnnlBlockedMemoryDesc>(outputShape, outputDataType, nspc);
                 createDescriptor({ in_candidate }, { out_candidate });
@@ -502,8 +502,8 @@ void Convolution::getSupportedDescriptors() {
             createDescriptor({ in_candidate }, { out_candidate });
 
             if ((inputDataType != memory::data_type::bf16 && isNspcAvailable()) ||
-                    (one_of(inputDataType, memory::data_type::bf16) &&
-                    impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core_amx))) {
+                    (one_of(inputDataType, memory::data_type::f32, memory::data_type::bf16) &&
+                    impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core))) {
                 in_candidate = std::make_shared<DnnlBlockedMemoryDesc>(inputShape, inputDataType, nspc);
                 out_candidate = std::make_shared<DnnlBlockedMemoryDesc>(outputShape, outputDataType, nspc);
                 createDescriptor({ in_candidate }, { out_candidate });

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -311,6 +311,51 @@ InferenceEngine::Precision Convolution::fusedEltwisePrecision(const NodePtr& fus
     return eltwisePrecision;
 }
 
+const std::vector<impl_desc_type>& Convolution::getPrimitivesPriority() {
+    if (!useExperimentConv)
+        return Node::getPrimitivesPriority();
+
+    std::vector<impl_desc_type> priorities = {
+            impl_desc_type::unknown,
+            impl_desc_type::brgconv_avx512_amx_1x1,
+            impl_desc_type::brgconv_avx512_amx,
+            impl_desc_type::jit_avx512_amx_dw,
+            impl_desc_type::jit_avx512_amx_1x1,
+            impl_desc_type::jit_avx512_amx,
+            impl_desc_type::brgconv_avx512_1x1,
+            impl_desc_type::brgconv_avx512,
+            impl_desc_type::jit_uni_dw,
+            impl_desc_type::jit_uni_1x1,
+            impl_desc_type::jit_uni,
+            impl_desc_type::jit_avx512_dw,
+            impl_desc_type::jit_avx512_1x1,
+            impl_desc_type::jit_avx512,
+            impl_desc_type::jit_avx2_dw,
+            impl_desc_type::jit_avx2_1x1,
+            impl_desc_type::jit_avx2,
+            impl_desc_type::jit_avx_dw,
+            impl_desc_type::jit_avx_1x1,
+            impl_desc_type::jit_avx,
+            impl_desc_type::jit_sse42_dw,
+            impl_desc_type::jit_sse42_1x1,
+            impl_desc_type::jit_sse42,
+            impl_desc_type::gemm_any,
+            impl_desc_type::gemm_blas,
+            impl_desc_type::gemm_avx512,
+            impl_desc_type::gemm_avx2,
+            impl_desc_type::gemm_avx,
+            impl_desc_type::gemm_sse42,
+            impl_desc_type::jit_gemm,
+            impl_desc_type::ref_any,
+            impl_desc_type::ref,
+    };
+    for (const auto& impl : priorities) {
+        if (std::find(implPriorities.begin(), implPriorities.end(), impl) == implPriorities.end())
+            implPriorities.push_back(impl);
+    }
+    return implPriorities;
+}
+
 void Convolution::getSupportedDescriptors() {
     if (!descs.empty())
         return;
@@ -471,8 +516,9 @@ void Convolution::getSupportedDescriptors() {
             auto inputShape = getInputShapeAtPort(0);
             auto outputShape = getOutputShapeAtPort(0);
 
-            if (one_of(inputDataType, memory::data_type::f32, memory::data_type::bf16) &&
-                    impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core)) {
+            bool acceptedFormat = inputDataType == memory::data_type::bf16;
+            acceptedFormat |= useExperimentConv && inputDataType == memory::data_type::f32;
+            if (acceptedFormat && impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core)) {
                 in_candidate = std::make_shared<DnnlBlockedMemoryDesc>(inputShape, inputDataType, nspc);
                 out_candidate = std::make_shared<DnnlBlockedMemoryDesc>(outputShape, outputDataType, nspc);
                 createDescriptor({ in_candidate }, { out_candidate });
@@ -502,8 +548,7 @@ void Convolution::getSupportedDescriptors() {
             createDescriptor({ in_candidate }, { out_candidate });
 
             if ((inputDataType != memory::data_type::bf16 && isNspcAvailable()) ||
-                    (one_of(inputDataType, memory::data_type::f32, memory::data_type::bf16) &&
-                    impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core))) {
+                    (acceptedFormat && impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core))) {
                 in_candidate = std::make_shared<DnnlBlockedMemoryDesc>(inputShape, inputDataType, nspc);
                 out_candidate = std::make_shared<DnnlBlockedMemoryDesc>(outputShape, outputDataType, nspc);
                 createDescriptor({ in_candidate }, { out_candidate });

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -69,6 +69,7 @@ protected:
     InferenceEngine::Precision fusedEltwisePrecision(const NodePtr& fusingNode) const;
     void redefineOutputMemory(const std::vector<VectorDims> &newOutputShapes) override;
     void addFusedNode(const NodePtr &fusingNode) override;
+    const std::vector<impl_desc_type>& getPrimitivesPriority() override;
 
 private:
     class FusedSubgraph;

--- a/src/plugins/intel_cpu/src/utils/general_utils.h
+++ b/src/plugins/intel_cpu/src/utils/general_utils.h
@@ -133,5 +133,29 @@ inline InferenceEngine::Precision getMaxPrecision(std::vector<InferenceEngine::P
     return InferenceEngine::Precision::UNSPECIFIED;
 }
 
+inline std::vector<std::string> split(const std::string &str, char delim) {
+    std::stringstream ss(str);
+    std::string item;
+    std::vector<std::string> elements;
+    while (std::getline(ss, item, delim)) {
+        elements.emplace_back(item);
+    }
+    return elements;
+}
+
+template<class Container>
+inline std::string join(const Container& strs, char delim) {
+    if (strs.empty())
+        return std::string();
+
+    std::stringstream result;
+    auto it = strs.begin();
+    result << *it++;
+    for (; it != strs.end(); it++) {
+        result << delim << *it;
+    }
+    return result.str();
+}
+
 }   // namespace intel_cpu
 }   // namespace ov

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -199,9 +199,12 @@ void SubgraphBaseTest::compile_model() {
         functionRefs = ov::clone_model(*function);
     }
 
-    // Within the test scope we don't need any implicit bf16 optimisations, so let's run the network as is.
-    if (targetDevice == CommonTestUtils::DEVICE_CPU && !configuration.count(InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16)) {
-        configuration.insert({InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16, InferenceEngine::PluginConfigParams::NO});
+    if (targetDevice == CommonTestUtils::DEVICE_CPU) {
+        // Within the test scope we don't need any implicit bf16 optimisations, so let's run the network as is.
+        if (!configuration.count(InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16))
+            configuration.insert({InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16, InferenceEngine::PluginConfigParams::NO});
+        // we will test brgconv kernels even it's disabled default
+        configuration.insert({InferenceEngine::PluginConfigParams::KEY_CPU_EXPERIMENTAL, "brgconv"});
     }
 
     compiledModel = core->compile_model(function, targetDevice, configuration);

--- a/tools/benchmark_tool/README.md
+++ b/tools/benchmark_tool/README.md
@@ -159,6 +159,7 @@ Options:
                         Optional. Enable model caching to specified directory
   -lfile [LOAD_FROM_FILE], --load_from_file [LOAD_FROM_FILE]
                         Optional. Loads model from file directly without read_network.
+  -expconv              Optional. Enable new experiment convolution algorithm. Only valid in CPU plugin.
 ```
 Running the application with the empty list of options yields the usage message given above and an error message.
 

--- a/tools/benchmark_tool/README.md
+++ b/tools/benchmark_tool/README.md
@@ -159,7 +159,7 @@ Options:
                         Optional. Enable model caching to specified directory
   -lfile [LOAD_FROM_FILE], --load_from_file [LOAD_FROM_FILE]
                         Optional. Loads model from file directly without read_network.
-  -expconv              Optional. Enable new experiment convolution algorithm. Only valid in CPU plugin.
+  -cpu_experimental SETTING     Optional. Enable experimental setting for CPU plugin. SETTING should be "brgconv" etc.
 ```
 Running the application with the empty list of options yields the usage message given above and an error message.
 

--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -189,8 +189,8 @@ def run(args):
                 if args.number_threads and is_flag_set_in_command_line("nthreads"):
                     config[device]['CPU_THREADS_NUM'] = str(args.number_threads)
 
-                if is_flag_set_in_command_line('expconv'):
-                    config[device]['ENFORCE_EXPERIMENT_CONVOLUTION'] = 'YES'
+                if is_flag_set_in_command_line('cpu_experimental'):
+                    config[device]['CPU_EXPERIMENTAL'] = args.cpu_experimental
 
                 if is_flag_set_in_command_line('pin'):
                     ## set to user defined value

--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -189,6 +189,9 @@ def run(args):
                 if args.number_threads and is_flag_set_in_command_line("nthreads"):
                     config[device]['CPU_THREADS_NUM'] = str(args.number_threads)
 
+                if is_flag_set_in_command_line('expconv'):
+                    config[device]['ENFORCE_EXPERIMENT_CONVOLUTION'] = 'YES'
+
                 if is_flag_set_in_command_line('pin'):
                     ## set to user defined value
                     config[device]['CPU_BIND_THREAD'] = args.infer_threads_pinning

--- a/tools/benchmark_tool/openvino/tools/benchmark/parameters.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/parameters.py
@@ -152,6 +152,8 @@ def parse_args():
     args.add_argument('-imean', '--input_mean', type=str, required=False, default='',
                       help="Optional. Mean values to be used for the input image per channel.\n Values to be provided in the [R, G, B] format. Can be defined for desired input of the model.\n"
                            "Example: -imean data[255,255,255],info[255,255,255]\n")
+    args.add_argument('-expconv', '--experiment_convolution', type=str2bool, required=False, default=False, nargs='?', const=True,
+                      help="Optional. Enable new experiment convolution algorithm. Only valid in CPU plugin.")
     parsed_args = parser.parse_args()
 
     return parsed_args

--- a/tools/benchmark_tool/openvino/tools/benchmark/parameters.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/parameters.py
@@ -152,8 +152,8 @@ def parse_args():
     args.add_argument('-imean', '--input_mean', type=str, required=False, default='',
                       help="Optional. Mean values to be used for the input image per channel.\n Values to be provided in the [R, G, B] format. Can be defined for desired input of the model.\n"
                            "Example: -imean data[255,255,255],info[255,255,255]\n")
-    args.add_argument('-expconv', '--experiment_convolution', type=str2bool, required=False, default=False, nargs='?', const=True,
-                      help="Optional. Enable new experiment convolution algorithm. Only valid in CPU plugin.")
+    args.add_argument('-cpu_experimental', '--cpu_experimental', type=str, required=False, default='',
+                      help="Optional. Enable experimental setting for CPU plugin.")
     parsed_args = parser.parse_args()
 
     return parsed_args


### PR DESCRIPTION
### Details:
 - *Use config 'ENFORCE_EXPERIMENT_CONVOLUTION' to enable brgconv f32 for avx512 f32. Relevant PR #11866*
 - *...*

### Tickets:
- 86301