### PR TITLE
[CPU] Remove vmaxps in store_vector.

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -736,7 +736,6 @@ private:
                 break;
             case Precision::I8:
                 if (isa == x64::avx512_core) {
-                    vmaxps(vmm_dst, vmm_zero, vmm_dst);
                     vpmovsdb(op, vmm_dst);
                 } else {
                     uni_vpackssdw(vmm_dst, vmm_dst, vmm_dst);

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -722,7 +722,7 @@ private:
                 break;
             case Precision::U16:
                 if (isa == x64::avx512_core) {
-                    vmaxsd(vmm_dst, vmm_zero, vmm_dst);
+                    vpmaxsd(vmm_dst, vmm_zero, vmm_dst);
                     vpmovusdw(op, vmm_dst);
                 } else {
                     uni_vpackusdw(vmm_dst, vmm_dst, vmm_dst);
@@ -750,6 +750,7 @@ private:
                 break;
             case Precision::U8:
                 if (isa == x64::avx512_core) {
+                    vpmaxsd(vmm_dst, vmm_zero, vmm_dst);
                     vpmovusdb(op, vmm_dst);
                 } else {
                     uni_vpackusdw(vmm_dst, vmm_dst, vmm_dst);

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -921,7 +921,6 @@ private:
                 break;
             case memory::data_type::s8:
                 if (isa == cpu::x64::avx512_core) {
-                    vmaxps(vmm_dst, vmm_zero, vmm_dst);
                     vpmovsdb(op, vmm_dst);
                 } else {
                     uni_vpackssdw(vmm_dst, vmm_dst, vmm_dst);
@@ -1540,7 +1539,6 @@ private:
                 break;
             case memory::data_type::s8:
                 if (isa == cpu::x64::avx512_core) {
-                    vmaxps(vmm_dst, vmm_zero, vmm_dst);
                     vpmovsdb(op, vmm_dst);
                 } else {
                     uni_vpackssdw(vmm_dst, vmm_dst, vmm_dst);

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -935,6 +935,7 @@ private:
                 break;
             case memory::data_type::u8:
                 if (isa == cpu::x64::avx512_core) {
+                    vpmaxsd(vmm_dst, vmm_zero, vmm_dst);
                     vpmovusdb(op, vmm_dst);
                 } else {
                     uni_vpackusdw(vmm_dst, vmm_dst, vmm_dst);
@@ -1553,6 +1554,7 @@ private:
                 break;
             case memory::data_type::u8:
                 if (isa == cpu::x64::avx512_core) {
+                    vpmaxsd(vmm_dst, vmm_zero, vmm_dst);
                     vpmovusdb(op, vmm_dst);
                 } else {
                     uni_vpackusdw(vmm_dst, vmm_dst, vmm_dst);


### PR DESCRIPTION

### Details:
 - *Remove vmaxps in store_vector. This instruction is not needed for dst_prc int8. And it may lead to wrong result with denormals optimization is on.*

### Tickets:
 - *86900*
