### PR TITLE
Remove the config key MULTI_WORK_MODE_AS_AUTO from the AUTO/MULTI plugin

### DIFF
--- a/src/inference/dev_api/cpp_interfaces/interface/ie_internal_plugin_config.hpp
+++ b/src/inference/dev_api/cpp_interfaces/interface/ie_internal_plugin_config.hpp
@@ -61,11 +61,6 @@ DECLARE_CONFIG_KEY(CPU_RUNTIME_CACHE_CAPACITY);
 DECLARE_CONFIG_KEY(FORCE_DISABLE_CACHE);
 
 /**
- * @brief The name for setting work mode internal in MULTI device plugin option.
- */
-DECLARE_CONFIG_KEY(MULTI_WORK_MODE_AS_AUTO);
-
-/**
  * @brief Internal device id for particular device (like GPU.0, GPU.1 etc)
  */
 DECLARE_CONFIG_KEY(CONFIG_DEVICE_ID);

--- a/src/plugins/auto/CMakeLists.txt
+++ b/src/plugins/auto/CMakeLists.txt
@@ -14,14 +14,12 @@ if(ENABLE_AUTO AND ENABLE_MULTI)
 
     ie_add_plugin(NAME ${TARGET_NAME}
                   DEVICE_NAME "AUTO"
-                  PSEUDO_PLUGIN_FOR "MULTI"
-                  DEFAULT_CONFIG "MULTI_WORK_MODE_AS_AUTO:YES")
+                  PSEUDO_PLUGIN_FOR "MULTI")
 elseif(ENABLE_AUTO)
     ie_add_plugin(NAME ${TARGET_NAME}
                   DEVICE_NAME "AUTO"
                   SOURCES ${SOURCES}
-                  VERSION_DEFINES_FOR plugin.cpp
-                  DEFAULT_CONFIG "MULTI_WORK_MODE_AS_AUTO:YES")
+                  VERSION_DEFINES_FOR plugin.cpp)
 elseif(ENABLE_MULTI)
     ie_add_plugin(NAME ${TARGET_NAME}
                   DEVICE_NAME "MULTI"

--- a/src/plugins/auto/plugin.cpp
+++ b/src/plugins/auto/plugin.cpp
@@ -63,7 +63,6 @@ namespace {
     std::vector<std::string> supported_configKeys = []() -> decltype(PerfHintsConfig::SupportedKeys()) {
                     auto res = PerfHintsConfig::SupportedKeys();
                     res.push_back(ov::device::priorities.name());
-                    res.push_back(CONFIG_KEY_INTERNAL(MULTI_WORK_MODE_AS_AUTO));
                     res.push_back(ov::enable_profiling.name());
                     res.push_back(PluginConfigParams::KEY_EXCLUSIVE_ASYNC_REQUESTS);
                     res.push_back(ov::hint::model_priority.name());
@@ -338,8 +337,7 @@ IExecutableNetworkInternal::Ptr MultiDeviceInferencePlugin::LoadNetworkImpl(cons
     // collect the settings that are applicable to the devices we are loading the network to
     std::unordered_map<std::string, InferenceEngine::Parameter> multiNetworkConfig;
     std::vector<DeviceInformation> metaDevices;
-    auto workMode = fullConfig.find(CONFIG_KEY_INTERNAL(MULTI_WORK_MODE_AS_AUTO));
-    bool workModeAuto = workMode != fullConfig.end() && workMode->second == InferenceEngine::PluginConfigParams::YES;
+    bool workModeAuto = GetName() == "AUTO";
     auto priorities = fullConfig.find(MultiDeviceConfigParams::KEY_MULTI_DEVICE_PRIORITIES);
     // if workMode is AUTO
     if (workModeAuto) {

--- a/src/tests/unit/auto/auto_release_helper_test.cpp
+++ b/src/tests/unit/auto/auto_release_helper_test.cpp
@@ -131,7 +131,7 @@ TEST_P(AutoReleaseHelperTest, releaseResource) {
     std::tie(cpuSuccess, accSuccess) = this->GetParam();
     size_t decreaseCount = 0;
     // test auto plugin
-    config.insert({CONFIG_KEY_INTERNAL(MULTI_WORK_MODE_AS_AUTO), InferenceEngine::PluginConfigParams::YES});
+    plugin->SetName("AUTO");
     const std::string strDevices = CommonTestUtils::DEVICE_GPU + std::string(",") +
         CommonTestUtils::DEVICE_CPU;
 

--- a/src/tests/unit/auto/auto_select_device_failed_test.cpp
+++ b/src/tests/unit/auto/auto_select_device_failed_test.cpp
@@ -179,7 +179,7 @@ TEST_P(AutoLoadFailedTest, LoadCNNetWork) {
              loadCount, loadSuccessCount) = this->GetParam();
 
     // test auto plugin
-    config.insert({CONFIG_KEY_INTERNAL(MULTI_WORK_MODE_AS_AUTO), InferenceEngine::PluginConfigParams::YES});
+    plugin->SetName("AUTO");
     std::string devicesStr = "";
     int selDevsSize = deviceConfigs.size();
     for (auto iter = deviceConfigs.begin(); iter != deviceConfigs.end(); selDevsSize--) {

--- a/src/tests/unit/auto/exec_network_get_metrics.cpp
+++ b/src/tests/unit/auto/exec_network_get_metrics.cpp
@@ -165,7 +165,7 @@ public:
        EXPECT_CALL(*core, GetMetric(_, _, _)).Times(AnyNumber());
 
        // test auto plugin
-       config.insert({CONFIG_KEY_INTERNAL(MULTI_WORK_MODE_AS_AUTO), InferenceEngine::PluginConfigParams::YES});
+       plugin->SetName("AUTO");
     }
 };
 


### PR DESCRIPTION
Remove the config key MULTI_WORK_MODE_AS_AUTO from the AUTO/MULTI plugin

Signed-off-by: Wang, Yang <yang4.wang@intel.com>

### Details:
 - Remove the config key MULTI_WORK_MODE_AS_AUTO

### Tickets:
 - CVS-84417
