### PR TITLE
Add build flag for GCC (for SDL: preventing GCC optimizing out security checks)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "CMake build type" FORCE)
 endif()
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    add_compile_options(-fno-strict-overflow -fno-delete-null-pointer-checks -fwrapv)
+endif()
+
 find_package(IEDevScripts REQUIRED
              PATHS "${OpenVINO_SOURCE_DIR}/cmake/developer_package"
              NO_CMAKE_FIND_ROOT_PATH


### PR DESCRIPTION
### Details:
 - *Add build flag for GCC. Because some compiler flags restrict the compiler from making arbitrary decisions while handling undefined C/C++ behaviors.*

### Tickets:
 - 85228
