### PR TITLE
[GPU] Fix implementation map includes to fix the dependency

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/implementation_desc.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/implementation_desc.hpp
@@ -4,10 +4,11 @@
 
 #pragma once
 
-#include "intel_gpu/runtime/tensor.hpp"
-
 #include <map>
 #include <ostream>
+
+#include "intel_gpu/primitives/primitive.hpp"
+#include "intel_gpu/runtime/tensor.hpp"
 
 namespace cldnn {
 

--- a/src/plugins/intel_gpu/src/graph/impls/implementation_map.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/implementation_map.hpp
@@ -4,12 +4,15 @@
 
 #pragma once
 
-#include <map>
 #include <functional>
-#include <typeinfo>
-#include <tuple>
-#include <string>
+#include <map>
 #include <sstream>
+#include <string>
+#include <tuple>
+#include <typeinfo>
+
+#include "intel_gpu/primitives/implementation_desc.hpp"
+#include "to_string_utils.h"
 #include "kernel_selector_helper.h"
 
 namespace cldnn {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
@@ -3,8 +3,8 @@
 //
 
 #include "activation_inst.h"
-#include "primitive_base.hpp"
 #include "impls/implementation_map.hpp"
+#include "primitive_base.hpp"
 #include "intel_gpu/runtime/error_handler.hpp"
 #include "kernel_selector_helper.h"
 #include "activation/activation_kernel_selector.h"

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "activation/activation_kernel_base.h"
+#include "activation/activation_kernel_selector.h"
 #include "activation_inst.h"
 #include "impls/implementation_map.hpp"
-#include "primitive_base.hpp"
 #include "intel_gpu/runtime/error_handler.hpp"
 #include "kernel_selector_helper.h"
-#include "activation/activation_kernel_selector.h"
-#include "activation/activation_kernel_base.h"
+#include "primitive_base.hpp"
 
 namespace cldnn {
 namespace ocl {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
@@ -3,14 +3,13 @@
 //
 
 #include "intel_gpu/primitives/adaptive_pooling.hpp"
+
+#include "adaptive_pooling/adaptive_pooling_kernel_ref.h"
+#include "adaptive_pooling/adaptive_pooling_kernel_selector.h"
 #include "adaptive_pooling_inst.h"
-#include "primitive_base.hpp"
 #include "impls/implementation_map.hpp"
 #include "kernel_selector_helper.h"
-
-#include "adaptive_pooling/adaptive_pooling_kernel_selector.h"
-#include "adaptive_pooling/adaptive_pooling_kernel_ref.h"
-
+#include "primitive_base.hpp"
 
 namespace cldnn {
 namespace ocl {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
@@ -2,16 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-// We have problem with includes when ENABLE_ONEDNN_FOR_GPU is OFF,
-// "impl_types" enum is not accessible if "implementation_map.hpp" is included first
-// so, a "fix" for now is to turn off clang-format for these include
-// clang-format off
-#include "primitive_base.hpp"
-#include "impls/implementation_map.hpp"
-// clang-format on
 #include "bucketize/bucketize_kernel_ref.hpp"
 #include "bucketize/bucketize_kernel_selector.hpp"
 #include "bucketize_inst.hpp"
+#include "impls/implementation_map.hpp"
+#include "primitive_base.hpp"
 
 namespace cldnn {
 namespace ocl {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
@@ -1,14 +1,8 @@
 // Copyright (C) 2022 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-
-// We have problem with includes when ENABLE_ONEDNN_FOR_GPU is OFF,
-// "impl_types" enum is not accessible if "implementation_map.hpp" is included first
-// so, a "fix" for now is to turn off clang-format for these include
-// clang-format off
 #include "impls/implementation_map.hpp"
 #include "primitive_base.hpp"
-// clang-format on
 #include "roll/roll_kernel_ref.hpp"
 #include "roll/roll_kernel_selector.hpp"
 #include "roll_inst.hpp"

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
@@ -6,8 +6,8 @@
 // "impl_types" enum is not accessible if "implementation_map.hpp" is included first
 // so, a "fix" for now is to turn off clang-format for these include
 // clang-format off
-#include "primitive_base.hpp"
 #include "impls/implementation_map.hpp"
+#include "primitive_base.hpp"
 // clang-format on
 #include "roll/roll_kernel_ref.hpp"
 #include "roll/roll_kernel_selector.hpp"


### PR DESCRIPTION
Now we have issue on declaring new primitive impl, when build depends on include order,  where
`#include "primitive_base.hpp"`
should be always before
`#include "impls/implementation_map.hpp"`
to pass the windows build.

This PR fixes this dependency in build