### PR TITLE
[CPU]Fix rnn cache missing issue

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -119,6 +119,8 @@ struct RNNKey {
     const std::vector<DnnlBlockedMemoryDescPtr> outDataDescs;
     const std::vector<dnnl::memory::desc> wDescs;
     dnnl::algorithm cellType;
+    dnnl::algorithm cellAct;
+    dnnl::rnn_direction direction;
 
     size_t hash() const;
     bool operator==(const RNNKey& rhs) const;
@@ -142,13 +144,16 @@ size_t RNNKey::hash() const {
         seed = hash_combine(seed, get_md_hash(desc.data));
     }
     seed = hash_combine(seed, cellType);
+    seed = hash_combine(seed, cellAct);
+    seed = hash_combine(seed, direction);
     return seed;
 }
 
 bool RNNKey::operator==(const RNNKey& rhs) const {
     if (inDataDescs.size() != rhs.inDataDescs.size() || outDataDescs.size() != rhs.outDataDescs.size() || wDescs.size() != rhs.wDescs.size() ||
-            cellType != rhs.cellType)
+            cellType != rhs.cellType || cellAct != rhs.cellAct || direction != rhs.direction) {
         return false;
+    }
 
     for (size_t i = 0lu; i < inDataDescs.size(); i++) {
         if (inDataDescs[i] != rhs.inDataDescs[i] && (inDataDescs[i] == nullptr || rhs.inDataDescs[i] == nullptr ||
@@ -826,7 +831,7 @@ void RNN::prepareParams() {
         wDescs[1] = dnnl::memory::desc(statesDims, dataType, wFormat);
     }
 
-    RNNKey key = { inDataDescs, outDataDescs, wDescs, cell_type };
+    RNNKey key = { inDataDescs, outDataDescs, wDescs, cell_type, cell_act, direction };
 
     auto builder = [this](const RNNKey& key) -> std::shared_ptr<dnnl::primitive> {
         fillDescs();

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -156,8 +156,8 @@ bool RNNKey::operator==(const RNNKey& rhs) const {
             return false;
     }
     for (size_t i = 0lu; i < outDataDescs.size(); i++) {
-        if (outDataDescs[i] != rhs.outDataDescs[i] && (outDataDescs[i] == nullptr || rhs.outDataDescs[i] ||
-                outDataDescs[i]->getDnnlDesc() == rhs.outDataDescs[i]->getDnnlDesc()))
+        if (outDataDescs[i] != rhs.outDataDescs[i] && (outDataDescs[i] == nullptr || rhs.outDataDescs[i] == nullptr ||
+                outDataDescs[i]->getDnnlDesc() != rhs.outDataDescs[i]->getDnnlDesc()))
             return false;
     }
     for (size_t i = 0lu; i < wDescs.size(); i++) {

--- a/src/plugins/intel_cpu/src/nodes/rnn.h
+++ b/src/plugins/intel_cpu/src/nodes/rnn.h
@@ -66,10 +66,10 @@ private:
     dnnl::rnn_direction direction = dnnl::rnn_direction::unidirectional;
 
     /** RNN Cell type (type/activation_alg/clip)*/
-    dnnl::algorithm cell_type = dnnl::algorithm::vanilla_lstm;
+    dnnl::algorithm cell_type = dnnl::algorithm::undef;
 
     /** activation type for vanilla RNN cell */
-    dnnl::algorithm cell_act = dnnl::algorithm::eltwise_tanh;
+    dnnl::algorithm cell_act = dnnl::algorithm::undef;
 
     /** Weights data and state memory format: ldigo or any */
     dnnl::memory::format_tag wFormat = dnnl::memory::format_tag::any;


### PR DESCRIPTION
### Details:
 - Memory size will quickly increase with inference iterations during running OCR dynamic shape model inference. The root cause comes from the rnn cache, almost all cache are missing, it was caused by incorrect match criteria.  

### Tickets:
 - 87097
