### PR TITLE
Docs: Add link to NNCF post-training quantization tutorial

### DIFF
--- a/docs/optimization_guide/nncf_introduction.md
+++ b/docs/optimization_guide/nncf_introduction.md
@@ -39,6 +39,7 @@ NNCF provides various examples and tutorials that demonstrate usage of optimizat
 ### Tutorials
 - [Quantization-aware training of PyTorch model](https://github.com/openvinotoolkit/openvino_notebooks/tree/main/notebooks/302-pytorch-quantization-aware-training)
 - [Quantization-aware training of TensorFlow model](https://github.com/openvinotoolkit/openvino_notebooks/tree/main/notebooks/305-tensorflow-quantization-aware-training)
+- [Post-training quantization of PyTorch model](https://github.com/openvinotoolkit/openvino_notebooks/tree/main/notebooks/112-pytorch-post-training-quantization-nncf)
 
 ### Samples
 - PyTorch: 


### PR DESCRIPTION
### Details:
 - Added a link to the [NNCF post-training quantization tutorial](https://github.com/openvinotoolkit/openvino_notebooks/tree/main/notebooks/112-pytorch-post-training-quantization-nncf), since it's a great tutorial and will be useful for readers to look at.

### Tickets:
 - N/A
