### PR TITLE
Revert the mmap-ed constants to the original buffer load

### DIFF
--- a/src/frontends/ir/src/frontend.cpp
+++ b/src/frontends/ir/src/frontend.cpp
@@ -198,7 +198,27 @@ InputModel::Ptr FrontEnd::load_impl(const std::vector<ov::Any>& variants) const 
         }
     }
     if (!weights_path.empty()) {
-        weights = ov::load_mmap_object(weights_path);
+        std::ifstream bin_stream;
+        bin_stream.open(weights_path, std::ios::binary);
+        if (!bin_stream.is_open())
+#if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
+            IE_THROW() << "Weights file " + ov::util::wstring_to_string(weights_path) + " cannot be opened!";
+#else
+            IE_THROW() << "Weights file " + weights_path + " cannot be opened!";
+#endif
+
+        bin_stream.seekg(0, std::ios::end);
+        size_t file_size = bin_stream.tellg();
+        bin_stream.seekg(0, std::ios::beg);
+
+        auto aligned_weights_buffer = std::make_shared<ngraph::runtime::AlignedBuffer>(file_size);
+        bin_stream.read(aligned_weights_buffer->get_ptr<char>(), aligned_weights_buffer->size());
+        bin_stream.close();
+
+        weights = std::make_shared<ngraph::runtime::SharedBuffer<std::shared_ptr<ngraph::runtime::AlignedBuffer>>>(
+            aligned_weights_buffer->get_ptr<char>(),
+            aligned_weights_buffer->size(),
+            aligned_weights_buffer);
     }
 
     return create_input_model();


### PR DESCRIPTION
### Details:
 - This reverts the mmap-ed constants in commit https://github.com/openvinotoolkit/openvino/commit/4b3dd808df47f857d3bf879e60a735afc571de10.
- The original PR https://github.com/openvinotoolkit/openvino/pull/10907 will be reapplied after more aggressive validation & analysis being conducted
### Tickets:
 - 68937
