### PR TITLE
[GPU] Pass reduce unit tests on DG2

### DIFF
--- a/src/plugins/intel_gpu/tests/fusions/reduce_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/reduce_fusion_test.cpp
@@ -234,8 +234,8 @@ TEST_P(reduce_scale_activation, basic) {
         input_layout("input", get_input_layout(p)),
         data("scale_data", get_mem(get_single_element_layout(p), -0.125f)),
         reduce("reduce", "input", p.reduce_mode, p.reduce_axes, p.keep_dims),
-        scale("scale", "reduce", "scale_data"),
-        activation("activation", "scale", activation_func::cos),
+        eltwise("scale", { "reduce", "scale_data" }, eltwise_mode::prod),
+        activation("activation", "scale", activation_func::hyperbolic_tan),
         reorder("output_reorder", "activation", p.default_format, data_types::f32)
     );
 
@@ -249,8 +249,8 @@ TEST_P(reduce_scale_activation, per_channel) {
         input_layout("input", get_input_layout(p)),
         data("scale_data", get_mem(get_per_channel_layout(p), -0.125f)),
         reduce("reduce", "input", p.reduce_mode, p.reduce_axes, p.keep_dims),
-        scale("scale", "reduce", "scale_data"),
-        activation("activation", "scale", activation_func::cos),
+        eltwise("scale", { "reduce", "scale_data" }, eltwise_mode::prod),
+        activation("activation", "scale", activation_func::hyperbolic_tan),
         reorder("output_reorder", "activation", p.default_format, data_types::f32)
     );
 

--- a/src/plugins/intel_gpu/tests/fusions/reduce_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/reduce_fusion_test.cpp
@@ -235,7 +235,7 @@ TEST_P(reduce_scale_activation, basic) {
         data("scale_data", get_mem(get_single_element_layout(p), -0.125f)),
         reduce("reduce", "input", p.reduce_mode, p.reduce_axes, p.keep_dims),
         eltwise("scale", { "reduce", "scale_data" }, eltwise_mode::prod),
-        activation("activation", "scale", activation_func::hyperbolic_tan),
+        activation("activation", "scale", activation_func::cos),
         reorder("output_reorder", "activation", p.default_format, data_types::f32)
     );
 
@@ -250,7 +250,7 @@ TEST_P(reduce_scale_activation, per_channel) {
         data("scale_data", get_mem(get_per_channel_layout(p), -0.125f)),
         reduce("reduce", "input", p.reduce_mode, p.reduce_axes, p.keep_dims),
         eltwise("scale", { "reduce", "scale_data" }, eltwise_mode::prod),
-        activation("activation", "scale", activation_func::hyperbolic_tan),
+        activation("activation", "scale", activation_func::cos),
         reorder("output_reorder", "activation", p.default_format, data_types::f32)
     );
 


### PR DESCRIPTION
### Details:
 - Change Scale to Eltwise( mode::prod ) in unit test topologies.
 - Change Activation::cos to Activation::hyperbolic_tangent in unit test topologies. (onednn not support cos activation)

### Tickets:
 - 67491
