### PR TITLE
updated to fuse activation in eltwise_vload8

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_vload8.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/eltwise/eltwise_kernel_vload8.h
@@ -15,6 +15,11 @@ public:
     KernelsData GetKernelsData(const Params& params, const optional_params& options) const override;
     KernelsPriority GetKernelsPriority(const Params& params, const optional_params& options) const override;
     ParamsKey GetSupportedKey() const override;
+    std::vector<FusedOpType> GetSupportedFusedOps() const override {
+        return {
+            FusedOpType::ACTIVATION
+        };
+    }
 
 protected:
     bool Validate(const Params& p, const optional_params& o) const override;


### PR DESCRIPTION
### Details:
 - Currently, the 'eltwise_kernel_vload8' does not support operation fusing.
 - It prevents an activation layer to be processed by eltwise_vload8.
 - This PR makes 'eltwise_vload8' to process an activation layer.

### Tickets:
 - 87395

The same change is also submitted to master by https://github.com/openvinotoolkit/openvino/pull/12084
