### PR TITLE
[CPU] revert pr 11990 and enable brgconv avx512 on SPR by default

### DIFF
--- a/samples/cpp/benchmark_app/README.md
+++ b/samples/cpp/benchmark_app/README.md
@@ -101,7 +101,6 @@ Options:
                                 letting the runtime to decide on the threads->different core types("HYBRID_AWARE", which is default on the hybrid CPUs)
                                 threads->(NUMA)nodes("NUMA") or
                                 completely disable("NO") CPU inference threads pinning
-    -cpu_experimental ("<brgconv>")          Optional. Enable experimental setting for CPU plugin.
 
   Statistics dumping options:
     -report_type "<type>"       Optional. Enable collecting statistics report. "no_counters" report contains configuration options specified, resulting FPS and latency.

--- a/samples/cpp/benchmark_app/benchmark_app.hpp
+++ b/samples/cpp/benchmark_app/benchmark_app.hpp
@@ -232,9 +232,6 @@ static constexpr char inference_only_message[] =
 
 static const char denormals_optimization_message[] = "Optional. Denormals is optimized by treating as zero";
 
-static constexpr char cpu_experimental_message[] =
-    "Optional. Enable experimental setting for CPU plugin. Setting should be 'brgconv' etc.";
-
 /// @brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
@@ -371,9 +368,6 @@ DEFINE_bool(inference_only, true, inference_only_message);
 /// @brief Define flag for denormals handling mode <br>
 DEFINE_bool(dopt, false, denormals_optimization_message);
 
-/// @brief Define flag for using experimental setting for CPU plugin <br>
-DEFINE_string(cpu_experimental, "", cpu_experimental_message);
-
 /**
  * @brief This function show a help message
  */
@@ -408,7 +402,6 @@ static void show_usage() {
     std::cout << "    -nthreads \"<integer>\"     " << infer_num_threads_message << std::endl;
     std::cout << "    -pin (\"YES\"|\"CORE\")/\"HYBRID_AWARE\"/(\"NO\"|\"NONE\")/\"NUMA\"   "
               << infer_threads_pinning_message << std::endl;
-    std::cout << "    -cpu_experimental         " << cpu_experimental_message << std::endl;
 #ifdef HAVE_DEVICE_MEM_SUPPORT
     std::cout << "    -use_device_mem           " << use_device_mem_message << std::endl;
 #endif

--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -390,11 +390,6 @@ int main(int argc, char* argv[]) {
                     }
                 }
 
-                // use experimental setting
-                if (isFlagSetInCommandLine("cpu_experimental")) {
-                    device_config.emplace(ov::cpu_experimental(FLAGS_cpu_experimental));
-                }
-
                 // for CPU execution, more throughput-oriented execution via streams
                 setThroughputStreams();
                 set_infer_precision();

--- a/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
@@ -30,7 +30,6 @@ void regmodule_properties(py::module m) {
     wrap_property_RW(m_properties, ov::affinity, "affinity");
     wrap_property_RW(m_properties, ov::force_tbb_terminate, "force_tbb_terminate");
     wrap_property_RW(m_properties, ov::denormals_optimization, "denormals_optimization");
-    wrap_property_RW(m_properties, ov::cpu_experimental, "cpu_experimental");
 
     wrap_property_RO(m_properties, ov::supported_properties, "supported_properties");
     wrap_property_RO(m_properties, ov::available_devices, "available_devices");

--- a/src/inference/include/ie/ie_plugin_config.hpp
+++ b/src/inference/include/ie/ie_plugin_config.hpp
@@ -431,11 +431,6 @@ DECLARE_CONFIG_KEY(DUMP_EXEC_GRAPH_AS_DOT);
 DECLARE_CONFIG_KEY(ENFORCE_BF16);
 
 /**
- * @brief Use experimental setting for CPU plugin.
- */
-DECLARE_CONFIG_KEY(CPU_EXPERIMENTAL);
-
-/**
  * @brief This key defines the directory which will be used to store any data cached by plugins.
  *
  * The underlying cache structure is not defined and might differ between OpenVINO releases

--- a/src/inference/include/openvino/runtime/properties.hpp
+++ b/src/inference/include/openvino/runtime/properties.hpp
@@ -464,12 +464,6 @@ static constexpr Property<std::string> cache_dir{"CACHE_DIR"};
 static constexpr Property<bool> denormals_optimization{"DENORMALS_OPTIMIZATION"};
 
 /**
- * @brief The name for experimental setting for CPU plugin.
- * @ingroup ov_runtime_cpp_prop_api
- */
-static constexpr Property<std::string> cpu_experimental{"CPU_EXPERIMENTAL"};
-
-/**
  * @brief Read-only property to provide information about a range for streams on platforms where streams are supported.
  * @ingroup ov_runtime_cpp_prop_api
  *

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -17,7 +17,6 @@
 #include "openvino/core/type/element_type_traits.hpp"
 #include "openvino/runtime/properties.hpp"
 #include <cpu/x64/cpu_isa_traits.hpp>
-#include "utils/general_utils.h"
 
 namespace ov {
 namespace intel_cpu {
@@ -121,24 +120,6 @@ void Config::readProperties(const std::map<std::string, std::string> &prop) {
                 IE_THROW() << "Wrong value for property key " << PluginConfigParams::KEY_ENFORCE_BF16
                     << ". Expected only YES/NO";
             }
-        } else if (key == PluginConfigParams::KEY_CPU_EXPERIMENTAL) {
-            const auto elements = split(val, ',');
-            std::set<std::string> newConfig;
-            for (const auto& element : elements) {
-                if (element.empty()) {
-                    continue;
-                }
-                if (element == EXPERIMENTAL_KEY_BRGCONV) {
-                    if (!dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
-                        continue;
-                    }
-                } else {
-                    IE_THROW() << "Wrong value for property key " << PluginConfigParams::KEY_CPU_EXPERIMENTAL
-                        << ". Expected only " << EXPERIMENTAL_KEY_BRGCONV;
-                }
-                newConfig.insert(element);
-            }
-            cpuExperimental = std::move(newConfig);
         } else if (key == ov::hint::inference_precision.name()) {
             if (val == "bf16") {
                 if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
@@ -236,9 +217,6 @@ void Config::updateProperties() {
         _config.insert({ PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::YES });
     } else {
         _config.insert({ PluginConfigParams::KEY_ENFORCE_BF16, PluginConfigParams::NO });
-    }
-    if (!cpuExperimental.empty()) {
-        _config.insert({ PluginConfigParams::KEY_CPU_EXPERIMENTAL, join(cpuExperimental, ',') });
     }
     _config.insert({ PluginConfigParams::KEY_PERFORMANCE_HINT, perfHintsConfig.ovPerfHint });
     _config.insert({ PluginConfigParams::KEY_PERFORMANCE_HINT_NUM_REQUESTS,

--- a/src/plugins/intel_cpu/src/config.h
+++ b/src/plugins/intel_cpu/src/config.h
@@ -9,13 +9,10 @@
 #include "utils/debug_capabilities.h"
 
 #include <string>
-#include <set>
 #include <map>
 
 namespace ov {
 namespace intel_cpu {
-
-#define EXPERIMENTAL_KEY_BRGCONV "brgconv"
 
 struct Config {
     Config();
@@ -48,7 +45,6 @@ struct Config {
     bool enforceBF16 = true;
     bool manualEnforceBF16 = false;
 #endif
-    std::set<std::string> cpuExperimental;
 
     std::string cache_dir{};
 

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -153,7 +153,6 @@ void Graph::Replicate(const std::shared_ptr<const ov::Model> &subgraph, const Ex
         if (isQuantized()) {
             node->setQuantizedGraphFlag(true);
         }
-        node->setCPUExperimental(config.cpuExperimental);
         node->setRuntimeCache(rtParamsCache);
 
         graphNodes.push_back(node);
@@ -266,7 +265,6 @@ void Graph::Replicate(const CNNNetwork &network, const ExtensionManager::Ptr& ex
         if (isQuantized()) {
             node->setQuantizedGraphFlag(true);
         }
-        node->setCPUExperimental(config.cpuExperimental);
         node->setRuntimeCache(rtParamsCache);
         graphNodes.push_back(node);
 

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -517,10 +517,6 @@ public:
         algorithm = alg;
     }
 
-    void setCPUExperimental(const std::set<std::string>& experimental) {
-        cpuExperimental = experimental;
-    }
-
     virtual bool canFuse(const NodePtr& node) const {
         return false;
     }
@@ -640,8 +636,6 @@ protected:
     WeightsSharing::Ptr weightCache;
 
     Algorithm algorithm = Algorithm::Default;
-
-    std::set<std::string> cpuExperimental;
 
     bool isInQuantizedGraph = false;
 

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -355,7 +355,7 @@ const std::vector<impl_desc_type>& Convolution::getPrimitivesPriority() {
     if (!shouldTryBrgconv) {
         // remove brgconv_avx512_amx_1x1/brgconv_avx512_amx/brgconv_avx512/brgconv_avx512_1x1
         for (auto it = priorities.begin(); it != priorities.end(); ) {
-            if ((*it) & brgconv_avx512)
+            if (((*it) & brgconv_avx512) == brgconv_avx512)
                 it = priorities.erase(it);
             else
                 ++it;

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -280,7 +280,11 @@ Convolution::Convolution(const std::shared_ptr<ngraph::Node>& op, const dnnl::en
         autoPadding = one_of(groupConvolutionOp->get_auto_pad(), ov::op::PadType::SAME_UPPER, ov::op::PadType::SAME_LOWER);
     }
 
-    shouldTryBrgconv = dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx);
+    // Due to performance issue, brgconv will only be enabled by default:
+    // 1, support amx
+    // 2, static shape(dynamic shape may change weights layout if the input shape changes and cause performance issue: 86948)
+    shouldTryBrgconv = dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx) &&
+        op->get_input_partial_shape(0).is_static();
 }
 
 bool Convolution::canBeExecutedInInt8() const {
@@ -314,11 +318,40 @@ InferenceEngine::Precision Convolution::fusedEltwisePrecision(const NodePtr& fus
 }
 
 const std::vector<impl_desc_type>& Convolution::getPrimitivesPriority() {
-    if (!shouldTryBrgconv)
-        return Node::getPrimitivesPriority();
-
-    // this list we add brgconv_avx512/brgconv_avx512_1x1
     std::vector<impl_desc_type> priorities = {
+            impl_desc_type::unknown,
+            impl_desc_type::jit_avx512_amx_dw,
+            impl_desc_type::jit_avx512_amx_1x1,
+            impl_desc_type::jit_avx512_amx,
+            impl_desc_type::jit_uni_dw,
+            impl_desc_type::jit_uni_1x1,
+            impl_desc_type::jit_uni,
+            impl_desc_type::jit_avx512_dw,
+            impl_desc_type::jit_avx512_1x1,
+            impl_desc_type::jit_avx512,
+            impl_desc_type::jit_avx2_dw,
+            impl_desc_type::jit_avx2_1x1,
+            impl_desc_type::jit_avx2,
+            impl_desc_type::jit_avx_dw,
+            impl_desc_type::jit_avx_1x1,
+            impl_desc_type::jit_avx,
+            impl_desc_type::jit_sse42_dw,
+            impl_desc_type::jit_sse42_1x1,
+            impl_desc_type::jit_sse42,
+            impl_desc_type::gemm_any,
+            impl_desc_type::gemm_blas,
+            impl_desc_type::gemm_avx512,
+            impl_desc_type::gemm_avx2,
+            impl_desc_type::gemm_avx,
+            impl_desc_type::gemm_sse42,
+            impl_desc_type::jit_gemm,
+            impl_desc_type::ref_any,
+            impl_desc_type::ref,
+    };
+
+    if (shouldTryBrgconv) {
+        // add brgconv_avx512_amx_1x1/brgconv_avx512_amx/brgconv_avx512/brgconv_avx512_1x1
+        priorities = {
             impl_desc_type::unknown,
             impl_desc_type::brgconv_avx512_amx_1x1,
             impl_desc_type::brgconv_avx512_amx,
@@ -351,7 +384,8 @@ const std::vector<impl_desc_type>& Convolution::getPrimitivesPriority() {
             impl_desc_type::jit_gemm,
             impl_desc_type::ref_any,
             impl_desc_type::ref,
-    };
+        };
+    }
     for (const auto& impl : priorities) {
         if (std::find(implPriorities.begin(), implPriorities.end(), impl) == implPriorities.end())
             implPriorities.push_back(impl);

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -137,7 +137,7 @@ private:
 
     bool isWino = false;
     // if we have amx support or user specified we will try brgconv avx512
-    bool shouldTryBrgconvAVX512 = false;
+    bool shouldTryBrgconv = false;
     AttrPtr pAttr;
     bool autoPadding = false;
     FusedSubgraphPtr subgraph;

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -136,6 +136,8 @@ private:
     const size_t Y_AXIS = 1;
 
     bool isWino = false;
+    // if we have amx support or user specified we will try brgconv avx512
+    bool shouldTryBrgconvAVX512 = false;
     AttrPtr pAttr;
     bool autoPadding = false;
     FusedSubgraphPtr subgraph;

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -136,7 +136,7 @@ private:
     const size_t Y_AXIS = 1;
 
     bool isWino = false;
-    // if we have amx support or user specified we will try brgconv avx512
+    // if we have amx support and shape is static or user specified we will try brgconv
     bool shouldTryBrgconv = false;
     AttrPtr pAttr;
     bool autoPadding = false;

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -199,12 +199,9 @@ void SubgraphBaseTest::compile_model() {
         functionRefs = ov::clone_model(*function);
     }
 
-    if (targetDevice == CommonTestUtils::DEVICE_CPU) {
-        // Within the test scope we don't need any implicit bf16 optimisations, so let's run the network as is.
-        if (!configuration.count(InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16))
-            configuration.insert({InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16, InferenceEngine::PluginConfigParams::NO});
-        // we will test brgconv kernels even it's disabled default
-        configuration.insert({InferenceEngine::PluginConfigParams::KEY_CPU_EXPERIMENTAL, "brgconv"});
+    // Within the test scope we don't need any implicit bf16 optimisations, so let's run the network as is.
+    if (targetDevice == CommonTestUtils::DEVICE_CPU && !configuration.count(InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16)) {
+        configuration.insert({InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16, InferenceEngine::PluginConfigParams::NO});
     }
 
     compiledModel = core->compile_model(function, targetDevice, configuration);

--- a/tools/benchmark_tool/README.md
+++ b/tools/benchmark_tool/README.md
@@ -161,7 +161,6 @@ Options:
                         Optional. Loads model from file directly without read_network.
   -dopt [DENORMALS_OPTIMIZATION], --denormals_optimization [DENORMALS_OPTIMIZATION]
                         Optional. Denormals is optimized by treating as zeros.
-  -cpu_experimental SETTING     Optional. Enable experimental setting for CPU plugin. SETTING should be "brgconv" etc.
 ```
 Running the application with the empty list of options yields the usage message given above and an error message.
 

--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -192,9 +192,6 @@ def run(args):
                 if args.number_threads and is_flag_set_in_command_line("nthreads"):
                     config[device]['CPU_THREADS_NUM'] = str(args.number_threads)
 
-                if is_flag_set_in_command_line('cpu_experimental'):
-                    config[device]['CPU_EXPERIMENTAL'] = args.cpu_experimental
-
                 if is_flag_set_in_command_line('pin'):
                     ## set to user defined value
                     config[device]['CPU_BIND_THREAD'] = args.infer_threads_pinning

--- a/tools/benchmark_tool/openvino/tools/benchmark/parameters.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/parameters.py
@@ -154,8 +154,6 @@ def parse_args():
                            "Example: -imean data[255,255,255],info[255,255,255]\n")
     args.add_argument('-dopt', '--denormals_optimization', type=str2bool, required=False, default=False, nargs='?', const=True,
                       help='Optional. Denormals is optimized by treating as zeros.', )
-    args.add_argument('-cpu_experimental', '--cpu_experimental', type=str, required=False, default='',
-                      help="Optional. Enable experimental setting for CPU plugin.")
     parsed_args = parser.parse_args()
 
     return parsed_args


### PR DESCRIPTION
### Details:
 - *Remove the config 'CPU_EXPERIMENTAL' for CPU plugin: #11990*
 - *Enable brgconv avx512 on SPR by default*
 - *PR to 2022/2: #12134*

### Tickets:
 - *87535*
 - *86948*