### PR TITLE
[PYTHON][BENCHMARK_APP] Add BGR covert to Gray function

### DIFF
--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -168,7 +168,12 @@ def get_image_tensors(image_paths, info, batch_sizes):
                     red = np.divide(red, info.scale[2])
                 image = cv2.merge([blue, green, red])
 
-            if str(info.layout) in ['[N,C,H,W]', '[C,H,W]']:
+            model_channel = shape[1]
+            image_channel = image.shape[-1]
+            if model_channel == 1 and image_channel == 3:
+                image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+
+            if model_channel == image_channel and str(info.layout) in ['[N,C,H,W]', '[C,H,W]']:
                 image = image.transpose((2, 0, 1))
 
             if process_with_original_shapes:


### PR DESCRIPTION
### Details:
 - *Solve the problem caused by the mismatch between the channels of the input model and the input image in benchmark_app.py.*
 - *Add the function of converting images from BRG to Gray*

### Tickets:
 - *80700*
