### PR TITLE
[GPU] Enable tensor offset to GemmKernelRef for input padding support

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/gemm/gemm_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/gemm/gemm_kernel_ref.cpp
@@ -26,6 +26,7 @@ ParamsKey GemmKernelRef::GetSupportedKey() const {
     k.EnableBatching();
     k.EnableDifferentTypes();
     k.EnableTensorPitches();
+    k.EnableTensorOffset();
     k.EnableQuantization(QuantizationType::SYMMETRIC);
 
     return k;


### PR DESCRIPTION
### Details:
 - Enable tensor offset to `GemmKernelRef` for input padding support from in-place crop optimization

### Tickets:
 - 87144
