### PR TITLE
DOCS-code-reference-css-style-change (#12109)

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -10,6 +10,12 @@ main img {
     margin-bottom: 0;
 }
 
+/* code reference text formatting override */
+code {
+    color: black !important;
+    font-weight: bold;
+}
+
 /* Performance Benchmark Graphs */
 
 .chart {


### PR DESCRIPTION
port from master
code formatting changed from blue to black, to distinguish from links
