### PR TITLE
[Do Not Review] changed the condition under which a node can be fused to an activation node

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -634,6 +634,16 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             return false;
         };
 
+        auto activation_supports_fusings= [&](activation_node& node) -> bool {
+            auto& input = node.input();
+
+            // Check if this activation node can be fused as an activation of its parent's node
+            if (input.get_users().size() == 1)
+                return false;
+
+            return true;
+        };
+
         auto eltwise_supports_fusings = [&](eltwise_node& node) -> bool {
             auto out_layout = node.get_output_layout();
             if (out_layout.data_type == data_types::f16 && out_layout.batch() > 1 &&
@@ -977,7 +987,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                                       (parents[i]->is_type<gather>()) ||
                                       (parents[i]->is_type<reduce>() && reduce_supports_fusings(parents[i]->as<reduce>())) ||
                                       (parents[i]->is_type<lrn>()) ||
-                                      (parents[i]->is_type<activation>());
+                                      (parents[i]->is_type<activation>() && activation_supports_fusings(parents[i]->as<activation>()));
             }
 
             // Disable fusion to a node on constant path when second input is in data flow

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -634,7 +634,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             return false;
         };
 
-        auto activation_supports_fusings= [&](activation_node& node) -> bool {
+        auto activation_supports_fusings = [&](activation_node& node) -> bool {
             auto& input = node.input();
 
             // Check if this activation node can be fused as an activation of its parent's node


### PR DESCRIPTION
### Details:
 - In some cases, not fused activation node causes performance degradation.
 - This PR makes an activation node to be fused into an its predecessor if the predecessor has only one user node.

### Tickets:
 - *ticket-id*
