### PR TITLE
Update the ambiguous warning information 

### DIFF
--- a/samples/cpp/benchmark_app/CMakeLists.txt
+++ b/samples/cpp/benchmark_app/CMakeLists.txt
@@ -22,7 +22,10 @@ else()
 endif()
 
 if(SAMPLES_ENABLE_OPENCL)
-    find_package(OpenCL)
+    find_package(OpenCL QUIET)
+    if(NOT OpenCL_FOUND)
+        MESSAGE(WARNING "OpenCL is disabled or not found, ${TARGET_NAME} will be built without OpenCL support. Install OpenCL.")
+    endif()
 
     find_path(OpenCL_HPP_INCLUDE_DIR
         NAMES
@@ -49,6 +52,8 @@ if(SAMPLES_ENABLE_OPENCL)
         # Append OpenCL CPP headers to C headers and use both
         set(OpenCL_HEADERS ${OpenCL_INCLUDE_DIR} ${OpenCL_HPP_INCLUDE_DIR})
         set(OpenCL_LIB "OpenCL::OpenCL")
+    else()
+        MESSAGE(WARNING "OpenCL CPP header is not found, ${TARGET_NAME} will be built without OpenCL support. Download it from: https://github.com/KhronosGroup/OpenCL-CLHPP and set -Dopencl_root_hints=[PATH]/OpenCL-CLHPP/include to cmake.")
     endif()
 
     if(OpenCL_FOUND AND OpenCL_HEADERS)


### PR DESCRIPTION
Signed-off-by: Yan, Xiping <xiping.yan@intel.com>

### Details:
 - *Fine tune the warning message for OpenCL not found.*
 - *Windows: Need to install "Intel® SDK for OpenCL™ Applications for Windows" in order to enable OpenCL.*
 - *Ubuntu: Need to "sudo apt-get install ocl-icd-opencl-dev" in order to enable OpenCL.*

### Tickets:
 - *85937*
