### PR TITLE
Add const fold check in operators instead pass

### DIFF
--- a/src/common/legacy/src/graph_transformer.cpp
+++ b/src/common/legacy/src/graph_transformer.cpp
@@ -223,8 +223,7 @@ static std::vector<std::string> skipConstInfer = {
     "Squeeze",
     "TensorIterator",
     "LSTMSequence",
-    "MVN",
-    "Reshape"};
+    "MVN"};
 
 const std::map<std::string, bool> ConstTransformer::getConstLayers(const std::vector<CNNLayerPtr>& sortedLayers) {
     std::map<std::string, bool> mapConstLayers;

--- a/src/common/legacy/src/graph_transformer.cpp
+++ b/src/common/legacy/src/graph_transformer.cpp
@@ -216,15 +216,15 @@ std::vector<CNNLayerPtr> ConstTransformer::foldConstSubgraphsInternal(const std:
 static std::vector<std::string> skipConstInfer = {
     "FakeQuantize",
     "Quantize",
-    "CumSum",     // Const inference function for CumSum is not implemented
-    "Convolution", // Const inference function for Convolution is not implemented
-    "Eltwise",  // Const inference function for Eltwise is not implemented
+    "CumSum",       // Const inference function for CumSum is not implemented
+    "Convolution",  // Const inference function for Convolution is not implemented
+    "Eltwise",      // Const inference function for Eltwise is not implemented
     "FullyConnected",
     "Squeeze",
     "TensorIterator",
     "LSTMSequence",
-    "MVN"
-};
+    "MVN",
+    "Reshape"};
 
 const std::map<std::string, bool> ConstTransformer::getConstLayers(const std::vector<CNNLayerPtr>& sortedLayers) {
     std::map<std::string, bool> mapConstLayers;

--- a/src/core/include/openvino/core/node.hpp
+++ b/src/core/include/openvino/core/node.hpp
@@ -494,6 +494,12 @@ public:
 
     virtual bool match_node(ov::pass::pattern::Matcher* matcher, const Output<Node>& graph_value);
 
+protected:
+    /// \brief Check constant folding disabled attribute.
+    ///
+    /// \return true if constant folding disabled otherwise false.
+    bool is_const_fold_disabled() const;
+
 private:
     friend class ov::NodeAccessor;
     std::vector<Node*> m_control_dependents;

--- a/src/core/include/openvino/pass/constant_folding.hpp
+++ b/src/core/include/openvino/pass/constant_folding.hpp
@@ -19,13 +19,13 @@ namespace pass {
 class OPENVINO_API ConstantFolding : public ModelPass {
 public:
     OPENVINO_RTTI("ConstantFolding");
-    bool run_on_model(const std::shared_ptr<ov::Model>& f) override;
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
 
 protected:
     void copy_runtime_info_to_target_inputs(const std::shared_ptr<Node>& node, const Output<Node>& replacement);
     /// \brief Folds pre-calculated output tensor values to constants in case lower and
     /// upper estimations are equal. Traverses graph backwards starting from the results.
-    bool pre_calculated_values_folding(const std::shared_ptr<ov::Model>& f);
+    bool pre_calculated_values_folding(const std::shared_ptr<ov::Model>& model);
 };
 
 /**
@@ -43,7 +43,25 @@ OPENVINO_API void disable_constant_folding(const std::shared_ptr<Node>& node);
 
 OPENVINO_API void enable_constant_folding(const std::shared_ptr<Node>& node);
 
+/**
+ * @brief Check if constant folding is disabled on @ref Node.
+ *
+ * @param node  Smart pointer to the node.
+ *
+ * @return true if attribute constant folding set otherwise false.
+ * @ingroup ov_pass_cpp_api
+ */
 OPENVINO_API bool constant_folding_is_disabled(const std::shared_ptr<Node>& node);
+
+/**
+ * @brief Check if constant folding is disabled on @ref Node.
+ *
+ * @param node  Pointer to the node.
+ *
+ * @return true if attribute constant folding set otherwise false.
+ * @ingroup ov_pass_cpp_api
+ */
+OPENVINO_API bool constant_folding_is_disabled(const Node* const node);
 
 class OPENVINO_API DisableConstantFolding : public ov::RuntimeAttribute {
 public:

--- a/src/core/src/node.cpp
+++ b/src/core/src/node.cpp
@@ -803,7 +803,7 @@ bool ov::Node::evaluate_label(TensorLabelVector& output_labels) const {
 bool ov::Node::constant_fold(OutputVector& output_values, const OutputVector& input_values) {
     OV_ITT_SCOPED_TASK(ov::itt::domains::nGraph, "Node::constant_fold");
 
-    if (m_rt_info.count(ov::pass::DisableConstantFolding::get_type_info_static())) {
+    if (is_const_fold_disabled()) {
         return false;
     }
 
@@ -835,6 +835,10 @@ bool ov::Node::constant_fold(OutputVector& output_values, const OutputVector& in
     }
     OPENVINO_SUPPRESS_DEPRECATED_END
     return false;
+}
+
+bool ov::Node::is_const_fold_disabled() const {
+    return ov::pass::constant_folding_is_disabled(this);
 }
 
 namespace ov {

--- a/src/core/src/op/convert_like.cpp
+++ b/src/core/src/op/convert_like.cpp
@@ -37,6 +37,10 @@ shared_ptr<Node> op::v1::ConvertLike::clone_with_new_inputs(const OutputVector& 
 
 bool op::v1::ConvertLike::constant_fold(OutputVector& output_values, const OutputVector& input_values) {
     OV_ITT_SCOPED_TASK(ov::itt::domains::nGraph, "op::v1::ConvertLike::constant_fold");
+    if (is_const_fold_disabled()) {
+        return false;
+    }
+
     if (auto data_const = std::dynamic_pointer_cast<op::v0::Constant>(input_values[0].get_node_shared_ptr())) {
         auto convert = make_shared<ov::op::v0::Convert>(input_values[0], input_values[1].get_element_type());
         return convert->constant_fold(output_values, OutputVector{data_const});

--- a/src/core/src/op/convert_like.cpp
+++ b/src/core/src/op/convert_like.cpp
@@ -39,8 +39,7 @@ bool op::v1::ConvertLike::constant_fold(OutputVector& output_values, const Outpu
     OV_ITT_SCOPED_TASK(ov::itt::domains::nGraph, "op::v1::ConvertLike::constant_fold");
     if (auto data_const = std::dynamic_pointer_cast<op::v0::Constant>(input_values[0].get_node_shared_ptr())) {
         auto convert = make_shared<ov::op::v0::Convert>(input_values[0], input_values[1].get_element_type());
-        convert->constant_fold(output_values, OutputVector{data_const});
-        return true;
+        return convert->constant_fold(output_values, OutputVector{data_const});
     }
     return false;
 }

--- a/src/core/src/op/reshape.cpp
+++ b/src/core/src/op/reshape.cpp
@@ -225,7 +225,7 @@ bool op::v1::Reshape::evaluate_label(TensorLabelVector& output_labels) const {
 }
 
 bool op::v1::Reshape::constant_fold(OutputVector& output_values, const OutputVector& inputs_values) {
-    if (get_output_partial_shape(0).is_dynamic()) {
+    if (get_output_partial_shape(0).is_dynamic() || is_const_fold_disabled()) {
         return false;
     }
 

--- a/src/core/src/op/shape_of.cpp
+++ b/src/core/src/op/shape_of.cpp
@@ -17,7 +17,6 @@
 #include "ngraph/runtime/host_tensor.hpp"
 #include "ngraph/runtime/reference/shape_of.hpp"
 #include "ngraph/type/element_type_traits.hpp"
-#include "openvino/pass/constant_folding.hpp"
 
 using namespace std;
 using namespace ngraph;
@@ -202,8 +201,9 @@ bool op::v3::ShapeOf::evaluate_label(TensorLabelVector& output_labels) const {
 
 bool op::v3::ShapeOf::constant_fold(OutputVector& output_values, const OutputVector& input_values) {
     OV_ITT_SCOPED_TASK(ov::itt::domains::nGraph, "op::v3::ShapeOf::constant_fold");
-    if (get_rt_info().count(ov::pass::DisableConstantFolding::get_type_info_static()))
+    if (is_const_fold_disabled()) {
         return false;
+    }
     return shape_of::constant_fold_shape_of(this, output_values[0], input_values[0]);
 }
 
@@ -261,8 +261,9 @@ bool op::v0::ShapeOf::has_evaluate() const {
 
 bool op::v0::ShapeOf::constant_fold(OutputVector& output_values, const OutputVector& input_values) {
     OV_ITT_SCOPED_TASK(ov::itt::domains::nGraph, "op::v0::ShapeOf::constant_fold");
-    if (get_rt_info().count(ov::pass::DisableConstantFolding::get_type_info_static()))
+    if (is_const_fold_disabled()) {
         return false;
+    }
     return shape_of::constant_fold_shape_of(this, output_values[0], input_values[0]);
 }
 

--- a/src/core/src/op/squeeze.cpp
+++ b/src/core/src/op/squeeze.cpp
@@ -270,7 +270,7 @@ bool op::v0::Squeeze::evaluate_label(TensorLabelVector& output_labels) const {
 
 bool op::v0::Squeeze::constant_fold(OutputVector& output_values, const OutputVector& inputs_values) {
     NGRAPH_OP_SCOPE(v0_Squeeze_constant_fold);
-    if (get_output_partial_shape(0).is_dynamic()) {
+    if (get_output_partial_shape(0).is_dynamic() || is_const_fold_disabled()) {
         return false;
     }
 

--- a/src/core/src/op/unsqueeze.cpp
+++ b/src/core/src/op/unsqueeze.cpp
@@ -168,7 +168,7 @@ bool op::v0::Unsqueeze::evaluate_label(TensorLabelVector& output_labels) const {
 }
 
 bool op::v0::Unsqueeze::constant_fold(OutputVector& output_values, const OutputVector& inputs_values) {
-    if (get_output_partial_shape(0).is_dynamic()) {
+    if (get_output_partial_shape(0).is_dynamic() || is_const_fold_disabled()) {
         return false;
     }
 

--- a/src/core/src/pass/constant_folding.cpp
+++ b/src/core/src/pass/constant_folding.cpp
@@ -2,46 +2,76 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ngraph/pass/constant_folding.hpp"
+#include "openvino/pass/constant_folding.hpp"
 
-#include <ngraph/op/constant.hpp>
-
-#include "ngraph/op/util/sub_graph_base.hpp"
-#include "ngraph/opsets/opset1.hpp"
-#include "ngraph/opsets/opset3.hpp"
-#include "ngraph/rt_info.hpp"
-#include "ngraph/validation_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/core/validation_util.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/util/sub_graph_base.hpp"
+#include "openvino/opsets/opset1.hpp"
+#include "openvino/opsets/opset3.hpp"
 
 using namespace std;
 
-bool ov::pass::ConstantFolding::run_on_model(const std::shared_ptr<ov::Model>& f) {
-    bool rewritten = pre_calculated_values_folding(f);
+/**
+ * \brief Check if \ref ov::Output<ov::Node> can be folded base on `can_be_folded` attribute.
+ *
+ * \param output  Node to check.
+ *
+ * \return true if output can be folded otherwise false.
+ */
+const auto is_output_foldable = [](const ov::Output<ov::Node>& output) {
+    const auto& rt_info = output.get_node()->get_rt_info();
+    return !rt_info.count("can_be_folded") || rt_info.at("can_be_folded").as<bool>();
+};
 
-    for (const auto& node : f->get_ordered_ops()) {
+/**
+ * \brief Create new friendly name from node.
+ *
+ * New friendly name has format:
+ * - {node friendly name}        if output_count 1
+ * - {node friendly name}.{idx}  if output count not 1.
+ *
+ * \param node          Node to get friendly name.
+ * \param output_count  Node output count (before folding).
+ * \param idx           Node current output index.
+ *
+ * \return std::string with new friendly name.
+ */
+const auto friendly_name_from = [](const ov::Node& node, const size_t output_count, const size_t idx) {
+    constexpr auto single_output = static_cast<size_t>(1);
+
+    if (single_output == output_count) {
+        return node.get_friendly_name();
+    } else {
+        return node.get_friendly_name() + "." + std::to_string(idx);
+    }
+};
+
+bool ov::pass::ConstantFolding::run_on_model(const std::shared_ptr<ov::Model>& model) {
+    bool rewritten = pre_calculated_values_folding(model);
+
+    for (const auto& node : model->get_ordered_ops()) {
         if (rewritten) {
             node->validate_and_infer_types();
         }
 
         OutputVector replacements(node->get_output_size());
 
-        // We have to check node for DisableConstantFolding because operations can override constant_folding
-        // method, so we can't always rely on attribute check inside default node->constant_fold method
-        if (node->get_rt_info().count(DisableConstantFolding::get_type_info_static()) == 0 &&
-            node->constant_fold(replacements, node->input_values())) {
-            NGRAPH_CHECK(replacements.size() == node->get_output_size(),
-                         "constant_fold_default returned incorrect number of replacements for ",
-                         node);
+        if (node->constant_fold(replacements, node->input_values())) {
+            OPENVINO_ASSERT(!constant_folding_is_disabled(node),
+                            "Node folded but constant folding disabled. Check constant_fold implementation for ",
+                            node);
+            OPENVINO_ASSERT(replacements.size() == node->get_output_size(),
+                            "constant_fold_default returned incorrect number of replacements for ",
+                            node);
 
             for (size_t i = 0; i < replacements.size(); ++i) {
                 auto node_output = node->output(i);
                 auto replacement = replacements.at(i);
                 if (replacement.get_node_shared_ptr() && (node_output != replacement)) {
-                    if (replacements.size() == 1) {
-                        replacement.get_node_shared_ptr()->set_friendly_name(node->get_friendly_name());
-                    } else {
-                        replacement.get_node_shared_ptr()->set_friendly_name(node->get_friendly_name() + "." +
-                                                                             std::to_string(i));
-                    }
+                    replacement.get_node()->set_friendly_name(friendly_name_from(*node, replacements.size(), i));
+
                     node_output.replace(replacement);
                     // Propagate runtime info attributes to replacement consumer nodes
                     copy_runtime_info_to_target_inputs(node, replacement);
@@ -51,7 +81,7 @@ bool ov::pass::ConstantFolding::run_on_model(const std::shared_ptr<ov::Model>& f
             }
         } else {
             // recursively constant fold operators containing subgraphs (ie: TensorIterator, Loop)
-            if (auto sub_graph_node = std::dynamic_pointer_cast<ngraph::op::util::MultiSubGraphOp>(node)) {
+            if (auto sub_graph_node = std::dynamic_pointer_cast<ov::op::util::MultiSubGraphOp>(node)) {
                 size_t sub_graphs_num = sub_graph_node->get_internal_subgraphs_size();
                 for (size_t sub_graph_ind = 0; sub_graph_ind < sub_graphs_num; ++sub_graph_ind) {
                     rewritten |= run_on_model(sub_graph_node->get_function(sub_graph_ind));
@@ -63,67 +93,60 @@ bool ov::pass::ConstantFolding::run_on_model(const std::shared_ptr<ov::Model>& f
     return rewritten;
 }
 
-void ngraph::pass::ConstantFolding::copy_runtime_info_to_target_inputs(const std::shared_ptr<Node>& node,
-                                                                       const Output<Node>& replacement) {
+void ov::pass::ConstantFolding::copy_runtime_info_to_target_inputs(const std::shared_ptr<Node>& node,
+                                                                   const Output<Node>& replacement) {
     for (auto& input : replacement.get_target_inputs()) {
         auto consumer = input.get_node()->shared_from_this();
         copy_runtime_info({node, consumer}, consumer);
     }
 }
 
-bool ngraph::pass::ConstantFolding::pre_calculated_values_folding(const std::shared_ptr<ngraph::Function>& f) {
+bool ov::pass::ConstantFolding::pre_calculated_values_folding(const std::shared_ptr<ov::Model>& model) {
+    // IsOutputNodeFoldable is_output_foldable;
     // To avoid excess graph traversals we have to manually propagate DisableConstantFolding with some
     // temporary attribute which indicates that the node which is marked with this attribute can't be folded because
     // it is included into not foldable sub-graph.
-    for (auto&& node : f->get_ordered_ops()) {
-        const auto& inputs = node->input_values();
-        auto& rt_info = node->get_rt_info();
-        bool can_be_folded = true;
-        if (rt_info.count(DisableConstantFolding::get_type_info_static())) {
+    for (auto&& node : model->get_ordered_ops()) {
+        const auto& input_values = node->input_values();
+        bool can_be_folded;
+
+        if (constant_folding_is_disabled(node)) {
             can_be_folded = false;
-        } else if (is_type<ngraph::opset1::ShapeOf>(node) || is_type<ngraph::opset3::ShapeOf>(node)) {
+        } else if (is_type<ov::opset1::ShapeOf>(node) || is_type<ov::opset3::ShapeOf>(node)) {
             // In case if node is ShapeOf operation we stop propagation of can_be_folded attribute. We have to limit
             // propagation because we can't detect borders of shape_of sub-graphs, so we propagate can_be_folded
             // attribute through all nodes including nodes on data path. So to limit the spread of attribute to other
             // shape-of sub-graphs we do not propagate it through ShapeOf nodes.
             can_be_folded = true;
-        } else if (std::any_of(inputs.cbegin(), inputs.cend(), [](const Output<Node>& output) {
-                       const auto& rt_info = output.get_node()->get_rt_info();
-                       return rt_info.count("can_be_folded") && !rt_info.at("can_be_folded").as<bool>();
-                   })) {
-            can_be_folded = false;
+        } else {
+            can_be_folded = std::all_of(input_values.cbegin(), input_values.cend(), is_output_foldable);
         }
-        rt_info["can_be_folded"] = can_be_folded;
+        node->get_rt_info()["can_be_folded"] = can_be_folded;
     }
 
     deque<shared_ptr<Node>> nodes;
     set<shared_ptr<Node>> visited;
-    for (auto& r : f->get_results())
+    for (auto& r : model->get_results())
         nodes.push_back(r);
-    for (auto& r : f->get_sinks())
+    for (auto& r : model->get_sinks())
         nodes.emplace_back(r);
 
     bool rewritten = false;
     while (!nodes.empty()) {
         auto curr_node = nodes.front();
         nodes.pop_front();
-        if (visited.count(curr_node) || ov::is_type<ngraph::op::Constant>(curr_node))
+        if (visited.count(curr_node) || ov::is_type<ov::op::v0::Constant>(curr_node))
             continue;
         visited.insert(curr_node);
 
         for (auto& output : curr_node->input_values()) {
-            const auto& rt_info = output.get_node()->get_rt_info();
-            auto can_be_folded = !rt_info.count("can_be_folded") || rt_info.at("can_be_folded").as<bool>();
-            if (can_be_folded && output.get_tensor().has_and_set_bound()) {
+            if (is_output_foldable(output) && output.get_tensor().has_and_set_bound()) {
                 auto input_node = output.get_node_shared_ptr();
-                auto replacement = std::make_shared<ngraph::op::Constant>(output.get_tensor().get_lower_value());
-                if (replacement && !ov::is_type<ngraph::op::Constant>(input_node)) {
-                    if (input_node->get_output_size() == 1) {
-                        replacement->set_friendly_name(input_node->get_friendly_name());
-                    } else {
-                        replacement->set_friendly_name(input_node->get_friendly_name() + "." +
-                                                       std::to_string(output.get_index()));
-                    }
+                auto replacement = std::make_shared<ov::op::v0::Constant>(output.get_tensor().get_lower_value());
+                if (replacement && !ov::is_type<ov::op::v0::Constant>(input_node)) {
+                    replacement->set_friendly_name(
+                        friendly_name_from(*input_node, input_node->get_output_size(), output.get_index()));
+
                     output.replace(replacement);
                     // Propagate runtime info attributes to replacement consumer nodes
                     copy_runtime_info_to_target_inputs(input_node, replacement);
@@ -149,5 +172,10 @@ void ov::pass::enable_constant_folding(const std::shared_ptr<Node>& node) {
 }
 
 bool ov::pass::constant_folding_is_disabled(const std::shared_ptr<Node>& node) {
+    return constant_folding_is_disabled(node.get());
+}
+
+bool ov::pass::constant_folding_is_disabled(const Node* const node) {
+    OPENVINO_ASSERT(node, "node is nullptr");
     return node->get_rt_info().count(DisableConstantFolding::get_type_info_static());
 }


### PR DESCRIPTION

### Details:
- Constant fold check in operators not only in pass to be more consistent that if constant fold attribute set then node constant 
  fold on happens if this attribute is supported.
- Refactor constant fold pass to using ov instead of ngraph namespaces and includes.
- Add constant_folding_is_disabled overload for raw pointer

### Tickets:
 - *75563*
