### PR TITLE
ipython removal from the dependencies of the docs [2022/2]

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,7 +11,6 @@ idna==2.10
 imagesize==1.2.0
 importlib-metadata==3.10.0
 iniconfig==1.1.1
-ipython==7.22.0
 Jinja2==2.11.3
 lxml>=4.6.5
 MarkupSafe==1.1.1


### PR DESCRIPTION
### Details:
 - backport of https://github.com/openvinotoolkit/openvino/pull/12168 to the release branch
