### PR TITLE
Fixes for system libraries pugixml, tbb

### DIFF
--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -47,6 +47,7 @@ if [ -f /etc/lsb-release ]; then
             patchelf \
             `# openvino` \
             libtbb-dev \
+            libpugixml-dev \
             `# python` \
             python3-pip \
             python3-enchant \

--- a/scripts/install_dependencies/install_openvino_dependencies.sh
+++ b/scripts/install_dependencies/install_openvino_dependencies.sh
@@ -8,7 +8,7 @@ set -e
 #===================================================================================================
 # Option parsing
 
-default_comp=(dev python myriad cl_compiler)
+default_comp=(core dev python myriad cl_compiler)
 all_comp=(${default_comp[@]} opencv_req opencv_opt)
 os=${os:-auto}
 
@@ -99,6 +99,7 @@ extra_repos=()
 
 if [ "$os" == "ubuntu18.04" ] ; then
 
+    pkgs_core=(libtbb2 libpugixml1v5)
     pkgs_opencv_req=(libgtk-3-0 libgl1)
     pkgs_python=(python3 python3-venv python3-pip)
     pkgs_dev=(cmake pkg-config libgflags-dev zlib1g-dev nlohmann-json-dev g++ gcc libc6-dev make curl sudo)
@@ -120,6 +121,7 @@ if [ "$os" == "ubuntu18.04" ] ; then
 
 elif [ "$os" == "ubuntu20.04" ] || [ "$os" == "ubuntu21.10" ] || [ "$os" == "ubuntu22.04" ] ; then
 
+    pkgs_core=(libtbb2 libpugixml1v5)
     pkgs_opencv_req=(libgtk-3-0 libgl1)
     pkgs_python=(python3 python3-venv python3-pip)
     pkgs_dev=(cmake pkg-config g++ gcc libc6-dev libgflags-dev zlib1g-dev nlohmann-json3-dev make curl sudo)
@@ -144,6 +146,7 @@ elif [ "$os" == "ubuntu20.04" ] || [ "$os" == "ubuntu21.10" ] || [ "$os" == "ubu
 
 elif [ "$os" == "rhel8" ] ; then
 
+    pkgs_core=(libtbb2 libpugixml1v5)
     pkgs_opencv_req=(gtk3)
     pkgs_python=(python3 python3-pip)
     pkgs_dev=(gcc gcc-c++ make glibc libstdc++ libgcc cmake pkg-config gflags-devel.i686 zlib-devel.i686 curl sudo)

--- a/src/cmake/ie_parallel.cmake
+++ b/src/cmake/ie_parallel.cmake
@@ -4,6 +4,7 @@
 
 macro(ov_find_package_tbb)
     if(THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO" AND NOT TBB_FOUND)
+
         if(NOT ENABLE_SYSTEM_TBB)
             set(_find_package_no_args NO_SYSTEM_ENVIRONMENT_PATH
                                       NO_CMAKE_SYSTEM_PATH)
@@ -104,11 +105,19 @@ function(set_ie_threading_interface_for TARGET_NAME)
                         if(NOT "${include_directory}" MATCHES "^/usr.*$")
                             target_include_directories(${TARGET_NAME} SYSTEM BEFORE
                                 ${LINK_TYPE} $<BUILD_INTERFACE:${include_directory}>)
+                        else()
+                            set(_system_library ON)
                         endif()
                     endforeach()
                 endif()
             endif()
         endforeach()
+
+        if(_system_library)
+            # if we deal with system library (e.i. having /usr/include as header paths)
+            # we cannot use SYSTEM key word for such library
+            set_target_properties(${TARGET_NAME} PROPERTIES NO_SYSTEM_FROM_IMPORTED ON)
+        endif()
     endfunction()
 
     set(IE_THREAD_DEFINE "IE_THREAD_SEQ")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -58,6 +58,12 @@ ov_install_static_lib(ov_core_dev core)
 
 add_library(ngraph_obj OBJECT ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 
+if(ENABLE_SYSTEM_PUGIXML)
+    # system pugixml has /usr/include as include directories
+    # we cannot use them as system ones, leads to compilation errors
+    set_target_properties(ngraph_obj PROPERTIES NO_SYSTEM_FROM_IMPORTED ON)
+endif()
+
 target_compile_definitions(ngraph_obj PRIVATE IMPLEMENT_OPENVINO_API)
 
 ie_faster_build(ngraph_obj


### PR DESCRIPTION
### Details:
 - For libraries with `/usr/include` paths we cannot use `SYSTEM` to include their headers

### Tickets:
 - CVS-79566
