### PR TITLE
[TF FE] Handle optional attributes for Convolutional operations

### DIFF
--- a/src/frontends/tensorflow/src/op/conv_2d.cpp
+++ b/src/frontends/tensorflow/src/op/conv_2d.cpp
@@ -16,10 +16,13 @@ namespace op {
 OutputVector translate_conv_2d_op(const NodeContext& node) {
     auto ng_input = node.get_input(0), ng_filter = node.get_input(1);
 
+    // retrieve attributes for Conv2D
     auto tf_strides = node.get_attribute<std::vector<int64_t>>("strides");
-    auto tf_dilations = node.get_attribute<std::vector<int64_t>>("dilations");
     auto tf_padding_type = node.get_attribute<std::string>("padding");
-    auto tf_data_format = node.get_attribute<std::string>("data_format");
+
+    // retrieve optional attributes
+    auto tf_data_format = node.get_attribute<std::string>("data_format", "NHWC");
+    auto tf_dilations = node.get_attribute<std::vector<int64_t>>("dilations", {1, 1, 1, 1});
 
     TENSORFLOW_OP_VALIDATION(node,
                              tf_data_format == "NHWC" || tf_data_format == "NCHW",

--- a/src/frontends/tensorflow/src/op/conv_2d_backprop.cpp
+++ b/src/frontends/tensorflow/src/op/conv_2d_backprop.cpp
@@ -16,11 +16,14 @@ namespace op {
 OutputVector translate_conv_2d_backprop_input_op(const NodeContext& node) {
     auto ng_filter = node.get_input(1), ng_out_backprop = node.get_input(2);
 
-    // TODO: refactor me to be less redundant with other convolution ops
+
+    // retrieve attributes for Conv2DBackpropInput
     auto tf_strides = node.get_attribute<std::vector<int64_t>>("strides");
-    auto tf_dilations = node.get_attribute<std::vector<int64_t>>("dilations");
     auto tf_padding_type = node.get_attribute<std::string>("padding");
-    auto tf_data_format = node.get_attribute<std::string>("data_format");
+
+    // retrieve optional attributes
+    auto tf_dilations = node.get_attribute<std::vector<int64_t>>("dilations", {1, 1, 1, 1});
+    auto tf_data_format = node.get_attribute<std::string>("data_format", "NHWC");
 
     TENSORFLOW_OP_VALIDATION(node,
                              tf_data_format == "NHWC" || tf_data_format == "NCHW",

--- a/src/frontends/tensorflow/src/op/conv_2d_backprop.cpp
+++ b/src/frontends/tensorflow/src/op/conv_2d_backprop.cpp
@@ -16,7 +16,6 @@ namespace op {
 OutputVector translate_conv_2d_backprop_input_op(const NodeContext& node) {
     auto ng_filter = node.get_input(1), ng_out_backprop = node.get_input(2);
 
-
     // retrieve attributes for Conv2DBackpropInput
     auto tf_strides = node.get_attribute<std::vector<int64_t>>("strides");
     auto tf_padding_type = node.get_attribute<std::string>("padding");

--- a/src/frontends/tensorflow/src/op/conv_3d.cpp
+++ b/src/frontends/tensorflow/src/op/conv_3d.cpp
@@ -17,7 +17,6 @@ namespace op {
 OutputVector translate_conv_3d_op(const NodeContext& node) {
     auto ng_input = node.get_input(0), ng_filter = node.get_input(1);
 
-
     // retrieve attributes for Conv3D
     auto tf_strides = node.get_attribute<std::vector<int64_t>>("strides");
     auto tf_padding_type = node.get_attribute<std::string>("padding");

--- a/src/frontends/tensorflow/src/op/conv_3d.cpp
+++ b/src/frontends/tensorflow/src/op/conv_3d.cpp
@@ -17,10 +17,14 @@ namespace op {
 OutputVector translate_conv_3d_op(const NodeContext& node) {
     auto ng_input = node.get_input(0), ng_filter = node.get_input(1);
 
+
+    // retrieve attributes for Conv3D
     auto tf_strides = node.get_attribute<std::vector<int64_t>>("strides");
-    auto tf_dilations = node.get_attribute<std::vector<int64_t>>("dilations");
     auto tf_padding_type = node.get_attribute<std::string>("padding");
-    auto tf_data_format = node.get_attribute<std::string>("data_format");
+
+    // retrieve optional attributes
+    auto tf_data_format = node.get_attribute<std::string>("data_format", "NDHWC");
+    auto tf_dilations = node.get_attribute<std::vector<int64_t>>("dilations", {1, 1, 1, 1, 1});
 
     TENSORFLOW_OP_VALIDATION(node,
                              tf_data_format == "NDHWC" || tf_data_format == "NCDHW",

--- a/src/frontends/tensorflow/src/op/conv_3d_backprop.cpp
+++ b/src/frontends/tensorflow/src/op/conv_3d_backprop.cpp
@@ -17,11 +17,13 @@ OutputVector translate_conv_3d_backprop_input_v2_op(const NodeContext& node) {
     auto ng_filter = node.get_input(1);
     auto ng_out_backprop = node.get_input(2);
 
-    // TODO: refactor me to be less redundant with other convolution ops
+    // retrieve attributes for Conv3DBackpropInputV2
     auto tf_strides = node.get_attribute<std::vector<int64_t>>("strides");
-    auto tf_dilations = node.get_attribute<std::vector<int64_t>>("dilations");
     auto tf_padding_type = node.get_attribute<std::string>("padding");
-    auto tf_data_format = node.get_attribute<std::string>("data_format");
+
+    // retrieve optional attributes
+    auto tf_data_format = node.get_attribute<std::string>("data_format", "NDHWC");
+    auto tf_dilations = node.get_attribute<std::vector<int64_t>>("dilations", {1, 1, 1, 1, 1});
 
     TENSORFLOW_OP_VALIDATION(node,
                              tf_data_format == "NDHWC" || tf_data_format == "NCDHW",


### PR DESCRIPTION
**Details:** TensorFlow convolution operations have two optional attributes with default values: *data_format* and *dilations*. See the specifications for them: [Conv2D](https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/conv2-d), [Conv2DBackpropInput](https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/conv2-d-backprop-input), etc. This fix will top up e2e passrate for DeepLapv3/inception models.

**Ticket:** 88012

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
