### PR TITLE
Fixed Windows backslash paths

### DIFF
--- a/cmake/templates/OpenVINOConfig.cmake.in
+++ b/cmake/templates/OpenVINOConfig.cmake.in
@@ -150,12 +150,16 @@ if((THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO") AND NOT TBB_FOUND
     set(enable_system_tbb "@ENABLE_SYSTEM_TBB@")
     if(NOT enable_system_tbb)
         set_and_check(_tbb_dir "@PACKAGE_IE_TBB_DIR@")
+        if(DEFINED ENV{TBBROOT})
+            # see https://stackoverflow.com/questions/28070810/cmake-generate-error-on-windows-as-it-uses-as-escape-seq
+            file(TO_CMAKE_PATH $ENV{TBBROOT} ENV_TBBROOT)
+        endif()
         set(find_package_tbb_extra_args
             CONFIG
             PATHS
                 # oneTBB case exposed via export TBBROOT=<custom TBB root>
-                "$ENV{TBBROOT}/lib64/cmake/TBB"
-                "$ENV{TBBROOT}/lib/cmake/TBB"
+                "${ENV_TBBROOT}/lib64/cmake/TBB"
+                "${ENV_TBBROOT}/lib/cmake/TBB"
                 # "$ENV{TBB_DIR}"
                 # for custom TBB exposed via cmake -DTBBROOT=<custom TBB root>
                 "${TBBROOT}/cmake"

--- a/src/cmake/install_tbb.cmake
+++ b/src/cmake/install_tbb.cmake
@@ -78,6 +78,9 @@ if(THREADING MATCHES "^(TBB|TBB_AUTO)$" AND
                 endif()
             endforeach()
         endforeach()
+
+        # remember TBBROOT path or system one
+        set(IE_TBB_DIR_INSTALL "${TBB_DIR}")
     elseif(tbb_downloaded)
         set(IE_TBB_DIR_INSTALL "runtime/3rdparty/tbb/")
 


### PR DESCRIPTION
### Details:
 - On Windows we have to convert env variables values to cmake native path with forward slashes. 

### Tickets:
 - CVS-87872
