### PR TITLE
Fixes for cases when TBB_DIR env var is set

### DIFF
--- a/samples/cpp/build_samples.sh
+++ b/samples/cpp/build_samples.sh
@@ -75,11 +75,11 @@ if ! command -v cmake &>/dev/null; then
 fi
 
 OS_PATH=$(uname -m)
-NUM_THREADS="-j2"
+NUM_THREADS=2
 
 if [ "$OS_PATH" == "x86_64" ]; then
   OS_PATH="intel64"
-  NUM_THREADS="-j8"
+  NUM_THREADS=8
 fi
 
 if [ -e "$build_dir/CMakeCache.txt" ]; then
@@ -87,14 +87,12 @@ if [ -e "$build_dir/CMakeCache.txt" ]; then
 fi
 
 mkdir -p "$build_dir"
-cd "$build_dir"
-cmake -DCMAKE_BUILD_TYPE=Release "$SAMPLES_PATH"
-make $NUM_THREADS
+cmake -DCMAKE_BUILD_TYPE=Release -S "$SAMPLES_PATH" -B "$build_dir"
+cmake --build "$build_dir" --config Release --parallel $NUM_THREADS
 
 if [ "$sample_install_dir" != "" ]; then
-    cmake -DCMAKE_INSTALL_PREFIX="$sample_install_dir" -DCOMPONENT=samples_bin -P cmake_install.cmake
+    cmake -DCMAKE_INSTALL_PREFIX="$sample_install_dir" -DCOMPONENT=samples_bin -P "$build_dir/cmake_install.cmake"
     printf "\nBuild completed, you can find binaries for all samples in the %s/samples_bin subfolder.\n\n" "$sample_install_dir"
 else
     printf "\nBuild completed, you can find binaries for all samples in the $build_dir/%s/Release subfolder.\n\n" "$OS_PATH"
 fi
-

--- a/src/cmake/install_tbb.cmake
+++ b/src/cmake/install_tbb.cmake
@@ -43,13 +43,13 @@ endif()
 # - custom TBB provided by users, needs to be a part of wheel packages
 # - TODO: system TBB also needs to be a part of wheel packages
 if(THREADING MATCHES "^(TBB|TBB_AUTO)$" AND
-    (TBB MATCHES ${TEMP} OR DEFINED ENV{TBBROOT} OR ENABLE_SYSTEM_TBB))
+    (TBB MATCHES ${TEMP} OR DEFINED ENV{TBBROOT} OR DEFINED ENV{TBB_DIR} OR ENABLE_SYSTEM_TBB))
     ie_cpack_add_component(tbb REQUIRED)
     list(APPEND core_components tbb)
 
     if(TBB MATCHES ${TEMP})
         set(tbb_downloaded ON)
-    elseif(DEFINED ENV{TBBROOT})
+    elseif(DEFINED ENV{TBBROOT} OR DEFINED ENV{TBB_DIR})
         set(tbb_custom ON)
     endif()
 
@@ -87,6 +87,22 @@ if(THREADING MATCHES "^(TBB|TBB_AUTO)$" AND
         # for custom TBB we need to install it to our package
         # to simplify life for our customers
         set(IE_TBBROOT_INSTALL "runtime/3rdparty/tbb")
+
+        # TBBROOT is not defined if ENV{TBBROOT} is not found
+        # so, we have to deduce this value outselves
+        if(NOT DEFINED TBBROOT AND DEFINED ENV{TBBROOT})
+            file(TO_CMAKE_PATH $ENV{TBBROOT} TBBROOT)
+        endif()
+        if(NOT DEFINED TBBROOT)
+            get_target_property(_tbb_include_dir TBB::tbb INTERFACE_INCLUDE_DIRECTORIES)
+            get_filename_component(TBBROOT ${_tbb_include_dir} PATH)
+        endif()
+        if(DEFINED TBBROOT)
+            set(TBBROOT "${TBBROOT}" CACHE PATH "TBBROOT path" FORCE)
+        else()
+            message(FATAL_ERROR "Failed to deduce TBBROOT, please define env var TBBROOT")
+        endif()
+
         file(RELATIVE_PATH IE_TBB_DIR_INSTALL "${TBBROOT}" "${TBB_DIR}")
         set(IE_TBB_DIR_INSTALL "${IE_TBBROOT_INSTALL}/${IE_TBB_DIR_INSTALL}")
 

--- a/src/cmake/install_tbb.cmake
+++ b/src/cmake/install_tbb.cmake
@@ -43,13 +43,16 @@ endif()
 # - custom TBB provided by users, needs to be a part of wheel packages
 # - TODO: system TBB also needs to be a part of wheel packages
 if(THREADING MATCHES "^(TBB|TBB_AUTO)$" AND
-    (TBB MATCHES ${TEMP} OR DEFINED ENV{TBBROOT} OR DEFINED ENV{TBB_DIR} OR ENABLE_SYSTEM_TBB))
+       ( (DEFINED TBB AND TBB MATCHES ${TEMP}) OR
+         (DEFINED TBBROOT OR DEFINED TBB_DIR OR DEFINED ENV{TBBROOT} OR
+          DEFINED ENV{TBB_DIR}) OR ENABLE_SYSTEM_TBB ) )
     ie_cpack_add_component(tbb REQUIRED)
     list(APPEND core_components tbb)
 
     if(TBB MATCHES ${TEMP})
         set(tbb_downloaded ON)
-    elseif(DEFINED ENV{TBBROOT} OR DEFINED ENV{TBB_DIR})
+    elseif(DEFINED ENV{TBBROOT} OR DEFINED ENV{TBB_DIR} OR
+           DEFINED TBBROOT OR DEFINED TBB_DIR)
         set(tbb_custom ON)
     endif()
 


### PR DESCRIPTION
### Details:
 - When `TBB_DIR` env var is set, no `TBBROOT` is defined then by cmake. We have deduce this value by ourselves.

### Tickets:
 - CVS-87872
