### PR TITLE
[TF FE] Implement LinSpace and BatchMatMul translators

### DIFF
--- a/src/frontends/tensorflow/src/op/linspace.cpp
+++ b/src/frontends/tensorflow/src/op/linspace.cpp
@@ -53,8 +53,8 @@ OutputVector translate_linspace_op(const NodeContext& node) {
     auto delta = make_shared<Divide>(make_shared<Subtract>(stop, start), num_minus_1);
 
     auto zero = make_shared<Constant>(num.get_element_type(), Shape{}, 0);
-    auto range_0_num_minus_1 = make_shared<ConvertLike>(make_shared<Range>(zero, num, one,
-        num.get_element_type()), start);
+    auto range_0_num_minus_1 =
+        make_shared<ConvertLike>(make_shared<Range>(zero, num, one, num.get_element_type()), start);
 
     // convert a case with scalar inputs
     if (axis.empty() && start_rank == 0) {

--- a/src/frontends/tensorflow/src/op/linspace.cpp
+++ b/src/frontends/tensorflow/src/op/linspace.cpp
@@ -27,17 +27,17 @@ OutputVector translate_linspace_op(const NodeContext& node) {
     auto num = node.get_input(2);
 
     TENSORFLOW_OP_VALIDATION(node, start.get_partial_shape().rank().is_static(), "Input rank must be static.");
-    int64_t rank = start.get_partial_shape().rank().get_length();
+    int64_t start_rank = start.get_partial_shape().rank().get_length();
 
     // retrieve axis from Constant node and compute a range of axes except given axis
     // for unsqueezing start and delta tensors
     std::vector<int64_t> axis;
     std::vector<int64_t> except_axis_range;
-    if (num_inputs > 3 && rank > 0) {
+    if (num_inputs > 3 && start_rank > 0) {
         get_const_input(node, 3, &axis);
         TENSORFLOW_OP_VALIDATION(node, axis.size() == 1, "Axis must be a scalar for LinSpace operation.");
-        axis[0] = axis[0] >= 0 ? axis[0] : rank + 1 + axis[0];
-        for (int64_t dim_ind = 0; dim_ind < rank + 1; ++dim_ind) {
+        axis[0] = axis[0] >= 0 ? axis[0] : start_rank + 1 + axis[0];
+        for (int64_t dim_ind = 0; dim_ind < start_rank + 1; ++dim_ind) {
             if (dim_ind != axis[0]) {
                 except_axis_range.push_back(dim_ind);
             }
@@ -45,18 +45,18 @@ OutputVector translate_linspace_op(const NodeContext& node) {
     }
 
     TENSORFLOW_OP_VALIDATION(node,
-                             axis.empty() && rank == 0 || axis.size() == 1 && rank > 0,
+                             axis.empty() && start_rank == 0 || axis.size() == 1 && start_rank > 0,
                              "Axis must be used only if input for LinSpace operation is ND tensor.");
 
-    auto one = make_shared<ConvertLike>(make_shared<Constant>(element::i64, Shape{}, 1), num);
+    auto one = make_shared<Constant>(num.get_element_type(), Shape{}, 1);
     auto num_minus_1 = make_shared<ConvertLike>(make_shared<Subtract>(num, one), start);
     auto delta = make_shared<Divide>(make_shared<Subtract>(stop, start), num_minus_1);
 
-    auto zero = make_shared<ConvertLike>(make_shared<Constant>(element::i64, Shape{}, 0), num);
-    auto range_0_num_minus_1 = make_shared<ConvertLike>(make_shared<Range>(zero, num, one, element::i64), start);
+    auto zero = make_shared<Constant>(num.get_element_type(), Shape{}, 0);
+    auto range_0_num_minus_1 = make_shared<ConvertLike>(make_shared<Range>(zero, num, one, num.get_element_type()), start);
 
     // convert a case with scalar inputs
-    if (axis.empty() && rank == 0) {
+    if (axis.empty() && start_rank == 0) {
         auto delta_mul_range = make_shared<Multiply>(delta, range_0_num_minus_1);
         auto result = make_shared<Add>(start, delta_mul_range);
         set_node_name(node.get_name(), result);

--- a/src/frontends/tensorflow/src/op/linspace.cpp
+++ b/src/frontends/tensorflow/src/op/linspace.cpp
@@ -52,7 +52,7 @@ OutputVector translate_linspace_op(const NodeContext& node) {
     auto num_minus_1 = make_shared<ConvertLike>(make_shared<Subtract>(num, one), start);
     auto delta = make_shared<Divide>(make_shared<Subtract>(stop, start), num_minus_1);
 
-    auto zero = make_shared<ConvertLike>(make_shared<Constant>(element::i64, Shape{}, 1), num);
+    auto zero = make_shared<ConvertLike>(make_shared<Constant>(element::i64, Shape{}, 0), num);
     auto range_0_num_minus_1 = make_shared<ConvertLike>(make_shared<Range>(zero, num, one, element::i64), start);
 
     // convert a case with scalar inputs

--- a/src/frontends/tensorflow/src/op/linspace.cpp
+++ b/src/frontends/tensorflow/src/op/linspace.cpp
@@ -1,0 +1,81 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "op_table.hpp"
+#include "openvino/opsets/opset8.hpp"
+
+using namespace std;
+using namespace ov::opset8;
+
+namespace ov {
+namespace frontend {
+namespace tensorflow {
+namespace op {
+OutputVector translate_linspace_op(const NodeContext& node) {
+    /* LinSpace operation can be expressed in the following form:
+     * 1) Compute deltas by which each element will be increased in each slice
+     * through new dimension as delta = (stop - start) / (num - 1)
+     * 2) Generate a range of numbers by which times delta will be added to start to
+     * compute new elements in each slide as range = [0, 1, ..., num - 1]
+     * 3) Unsqueeze start and delta by new axis. And unsqueeze range by axes except given axis
+     * 4) Compute the result of the operation as result = start + delta * range
+     */
+    auto num_inputs = node.get_input_size();
+    auto start = node.get_input(0);
+    auto stop = node.get_input(1);
+    auto num = node.get_input(2);
+
+    TENSORFLOW_OP_VALIDATION(node, start.get_partial_shape().rank().is_static(), "Input rank must be static.");
+    int64_t rank = start.get_partial_shape().rank().get_length();
+
+    // retrieve axis from Constant node and compute a range of axes except given axis
+    // for unsqueezing start and delta tensors
+    std::vector<int64_t> axis;
+    std::vector<int64_t> except_axis_range;
+    if (num_inputs > 3 && rank > 0) {
+        get_const_input(node, 3, &axis);
+        TENSORFLOW_OP_VALIDATION(node, axis.size() == 1, "Axis must be a scalar for LinSpace operation.");
+        axis[0] = axis[0] >= 0 ? axis[0] : rank + 1 + axis[0];
+        for (int64_t dim_ind = 0; dim_ind < rank + 1; ++dim_ind) {
+            if (dim_ind != axis[0]) {
+                except_axis_range.push_back(dim_ind);
+            }
+        }
+    }
+
+    TENSORFLOW_OP_VALIDATION(node,
+                             axis.empty() && rank == 0 || axis.size() == 1 && rank > 0,
+                             "Axis must be used only if input for LinSpace operation is ND tensor.");
+
+    auto one = make_shared<ConvertLike>(make_shared<Constant>(element::i64, Shape{}, 1), num);
+    auto num_minus_1 = make_shared<ConvertLike>(make_shared<Subtract>(num, one), start);
+    auto delta = make_shared<Divide>(make_shared<Subtract>(stop, start), num_minus_1);
+
+    auto zero = make_shared<ConvertLike>(make_shared<Constant>(element::i64, Shape{}, 1), num);
+    auto range_0_num_minus_1 = make_shared<ConvertLike>(make_shared<Range>(zero, num, one, element::i64), start);
+
+    // convert a case with scalar inputs
+    if (axis.empty() && rank == 0) {
+        auto delta_mul_range = make_shared<Multiply>(delta, range_0_num_minus_1);
+        auto result = make_shared<Add>(start, delta_mul_range);
+        set_node_name(node.get_name(), result);
+        return result->outputs();
+    }
+
+    auto const_axis = make_shared<Constant>(element::i64, Shape{axis.size()}, axis);
+    auto const_except_axis = make_shared<Constant>(element::i64, Shape{except_axis_range.size()}, except_axis_range);
+
+    auto unsqueeze_start = make_shared<Unsqueeze>(start, const_axis);
+    auto unsqueeze_delta = make_shared<Unsqueeze>(delta, const_axis);
+    auto unsqueeze_range = make_shared<Unsqueeze>(range_0_num_minus_1, const_except_axis);
+
+    auto delta_mul_range = make_shared<Multiply>(unsqueeze_delta, unsqueeze_range);
+    auto result = make_shared<Add>(unsqueeze_start, delta_mul_range);
+    set_node_name(node.get_name(), result);
+    return result->outputs();
+}
+}  // namespace op
+}  // namespace tensorflow
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/tensorflow/src/op/linspace.cpp
+++ b/src/frontends/tensorflow/src/op/linspace.cpp
@@ -53,7 +53,8 @@ OutputVector translate_linspace_op(const NodeContext& node) {
     auto delta = make_shared<Divide>(make_shared<Subtract>(stop, start), num_minus_1);
 
     auto zero = make_shared<Constant>(num.get_element_type(), Shape{}, 0);
-    auto range_0_num_minus_1 = make_shared<ConvertLike>(make_shared<Range>(zero, num, one, num.get_element_type()), start);
+    auto range_0_num_minus_1 = make_shared<ConvertLike>(make_shared<Range>(zero, num, one,
+        num.get_element_type()), start);
 
     // convert a case with scalar inputs
     if (axis.empty() && start_rank == 0) {

--- a/src/frontends/tensorflow/src/op/matmul.cpp
+++ b/src/frontends/tensorflow/src/op/matmul.cpp
@@ -23,6 +23,18 @@ OutputVector translate_mat_mul_op(const NodeContext& node) {
     set_node_name(node.get_name(), res);
     return res->outputs();
 }
+
+OutputVector translate_batch_mat_mul_op(const NodeContext& node) {
+    auto x = node.get_input(0);
+    auto y = node.get_input(1);
+
+    auto adj_x = node.get_attribute<bool>("adj_x", false);
+    auto adj_y = node.get_attribute<bool>("adj_y", false);
+
+    auto result = make_shared<MatMul>(x, y, false, false);
+    set_node_name(node.get_name(), result);
+    return result->outputs();
+}
 }  // namespace op
 }  // namespace tensorflow
 }  // namespace frontend

--- a/src/frontends/tensorflow/src/op/matmul.cpp
+++ b/src/frontends/tensorflow/src/op/matmul.cpp
@@ -31,7 +31,7 @@ OutputVector translate_batch_mat_mul_op(const NodeContext& node) {
     auto adj_x = node.get_attribute<bool>("adj_x", false);
     auto adj_y = node.get_attribute<bool>("adj_y", false);
 
-    auto result = make_shared<MatMul>(x, y, false, false);
+    auto result = make_shared<MatMul>(x, y, adj_x, adj_y);
     set_node_name(node.get_name(), result);
     return result->outputs();
 }

--- a/src/frontends/tensorflow/src/op_table.cpp
+++ b/src/frontends/tensorflow/src/op_table.cpp
@@ -25,8 +25,9 @@ OP_CONVERTER(translate_add_n_op);
 OP_CONVERTER(translate_arg_max_op);
 OP_CONVERTER(translate_arg_min_op);
 OP_CONVERTER(translate_avg_pool_op);
-OP_CONVERTER(translate_bias_add_op);
+OP_CONVERTER(translate_batch_mat_mul_op);
 OP_CONVERTER(translate_batch_nd_and_space_nd_op);
+OP_CONVERTER(translate_bias_add_op);
 OP_CONVERTER(translate_cast_op);
 OP_CONVERTER(translate_concat_op);
 OP_CONVERTER(translate_const_op);
@@ -51,6 +52,7 @@ OP_CONVERTER(translate_identity_op);
 OP_CONVERTER(translate_interpolate_op);
 OP_CONVERTER(translate_is_finite_op);
 OP_CONVERTER(translate_l2_loss_op);
+OP_CONVERTER(translate_linspace_op);
 OP_CONVERTER(translate_leaky_relu_op);
 OP_CONVERTER(translate_log_softmax_op);
 OP_CONVERTER(translate_log_1p_op);
@@ -160,6 +162,8 @@ const std::map<std::string, CreatorFunction> get_supported_ops() {
         {"ArgMin", translate_arg_min_op},
         {"AvgPool", translate_avg_pool_op},
         {"AvgPool3D", translate_avg_pool_op},
+        {"BatchMatMul", translate_batch_mat_mul_op},
+        {"BatchMatMulV2", translate_batch_mat_mul_op},
         {"BatchToSpaceND", translate_batch_nd_and_space_nd_op},
         {"BiasAdd", translate_bias_add_op},
         {"Cast", translate_cast_op},
@@ -190,6 +194,7 @@ const std::map<std::string, CreatorFunction> get_supported_ops() {
         {"IsFinite", translate_is_finite_op},
         {"L2Loss", translate_l2_loss_op},
         {"LeakyRelu", translate_leaky_relu_op},
+        {"LinSpace", translate_linspace_op},
         {"LogSoftmax", translate_log_softmax_op},
         {"Log1p", translate_log_1p_op},
         {"LRN", translate_lrn_op},


### PR DESCRIPTION
**Details:** TensorFlow frontend lacks [LinSpace](https://www.tensorflow.org/api_docs/python/tf/linspace) and [BatchMatMul](https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/batch-mat-mul-v2) translators for conversion of STN model (from e2e testing). Make a note that LinSpace translator is missed in legacy frontend and MO fallbacks a native call for constant folding for LinSpace operation. BatchMatMul translator is trivial because it easily maps to our MatMul specification.
LinSpace translation has a bit tricky implementation and based on the following scheme:
1) Compute deltas by which each element will be increased in each slice through new dimension as delta = (stop - start) / (num - 1)
2) Generate a range of numbers by which times delta will be added to start to compute new elements in each slide as range = [0, 1, ..., num - 1]
3) Unsqueeze start and delta by new axis. And unsqueeze range by axes except given axis
4) Compute the result of the operation as result = start + delta * range

The implementation for LinSpace translator was validated on STN model. The model is converted using new TF frontend and inferred successfully.

**Tickets:** 88222

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
