### PR TITLE
[POT] Sanity reference metrics update for VNNI CI hosts

### DIFF
--- a/tools/pot/tests/test_sanity.py
+++ b/tools/pot/tests/test_sanity.py
@@ -23,26 +23,26 @@ from .utils.config import get_engine_config, merge_configs, \
     get_dataset_info, PATHS2DATASETS_CONFIG, make_algo_config
 
 TEST_MODELS = [
-    ('mobilenet-v2-pytorch', 'pytorch', 'DefaultQuantization', 'performance', 300, {'accuracy@top1': 0.737,
-                                                                                    'accuracy@top5': 0.909},
+    ('mobilenet-v2-pytorch', 'pytorch', 'DefaultQuantization', 'performance', 300, {'accuracy@top1': 0.729,
+                                                                                    'accuracy@top5': 0.907},
      {}, 'CPU'),
 
-    ('mobilenet-v2-pytorch', 'pytorch', 'DefaultQuantization', 'mixed', 300, {'accuracy@top1': 0.731,
-                                                                              'accuracy@top5': 0.908},
+    ('mobilenet-v2-pytorch', 'pytorch', 'DefaultQuantization', 'mixed', 300, {'accuracy@top1': 0.734,
+                                                                              'accuracy@top5': 0.91},
      {}, 'CPU'),
 
     ('mobilenet-v1-1.0-224-tf', 'tf', 'DefaultQuantization', 'performance', 100, {'accuracy@top1': 0.728,
                                                                                   'accuracy@top5': 0.909},
      {'use_fast_bias': False}, 'CPU'),
 
-    ('mobilenet-v1-1.0-224-tf', 'tf', 'DefaultQuantization', 'performance', 100, {'accuracy@top1': 0.728,
-                                                                                  'accuracy@top5': 0.911},
+    ('mobilenet-v1-1.0-224-tf', 'tf', 'DefaultQuantization', 'performance', 100, {'accuracy@top1': 0.723,
+                                                                                  'accuracy@top5': 0.907},
      {}, 'CPU'),
 
-    ('mobilenet-ssd', 'caffe', 'AccuracyAwareQuantization', 'performance', 300, {'map': 0.6801},
+    ('mobilenet-ssd', 'caffe', 'AccuracyAwareQuantization', 'performance', 300, {'map': 0.6741},
      {'metric_subset_ratio': 1.0, 'max_iter_num': 1, 'metrics': [{'name': 'map', 'baseline_value': 0.669}]}, 'CPU'),
 
-    ('mobilenet-ssd', 'caffe', 'AccuracyAwareQuantization', 'performance', 300, {'map': 0.6801},
+    ('mobilenet-ssd', 'caffe', 'AccuracyAwareQuantization', 'performance', 300, {'map': 0.6741},
      {'metric_subset_ratio': 1.0, 'max_iter_num': 1, 'tune_hyperparams': True,
       'metrics': [{'name': 'map', 'baseline_value': 0.669}]}, 'CPU'),
 
@@ -53,7 +53,7 @@ TEST_MODELS = [
 
     ('mtcnn', 'caffe', 'DefaultQuantization', 'performance', 1, {'recall': 0.76, 'map': 0.6618}, {}, 'CPU'),
 
-    ('mtcnn', 'caffe', 'DefaultQuantization', 'performance', 2, {'recall': 0.68, 'map': 0.4406},
+    ('mtcnn', 'caffe', 'DefaultQuantization', 'performance', 2, {'recall': 0.76, 'map': 0.5101},
      {'use_fast_bias': False}, 'CPU'),
     ('octave-resnet-26-0.25', 'mxnet', 'DefaultQuantization', 'performance', 300,
      {'accuracy@top1': 0.766, 'accuracy@top5': 0.927}, {'use_fast_bias': False}, 'CPU'),
@@ -173,7 +173,7 @@ SIMPLIFIED_TEST_MODELS = [
     ('mobilenet-v2-pytorch', 'pytorch', 'DefaultQuantization', 'performance',
      {'accuracy@top1': 0.701, 'accuracy@top5': 0.91}, []),
     ('mobilenet-v2-pytorch', 'pytorch', 'DefaultQuantization', 'performance',
-     {'accuracy@top1': 0.712, 'accuracy@top5': 0.906}, ['--input_shape=[1,3,?,?]'])
+     {'accuracy@top1': 0.703, 'accuracy@top5': 0.904}, ['--input_shape=[1,3,?,?]'])
 ]
 
 


### PR DESCRIPTION
### Details:
As CI environment migrated to machines with VNNI instructions, reference POT metrics was updated accordingly 

### Tickets:
86929