### PR TITLE
[POT] Unused hyperopt dependency which broke python3.6 support is commented

### DIFF
--- a/tools/pot/setup.py
+++ b/tools/pot/setup.py
@@ -78,7 +78,7 @@ INSTALL_REQUIRES = [
 ]
 
 ALGO_EXTRAS = [
-    'hyperopt~=0.1.2',
+    #'hyperopt~=0.1.2',
 ]
 
 DEV_EXTRAS = ['pytest==4.5.0', 'openpyxl==2.6.4', 'pytest-mock==3.1.1']


### PR DESCRIPTION
### Details:
Unused hyperopt dependency which broke python3.6 support is commented

### Tickets:
 
