### PR TITLE
Fixed build_samples.sh not to call setupvars.sh for Debian package case

### DIFF
--- a/samples/cpp/build_samples.sh
+++ b/samples/cpp/build_samples.sh
@@ -57,15 +57,17 @@ SAMPLES_PATH="$( cd "$( dirname "${BASH_SOURCE[0]-$0}" )" && pwd )"
 printf "\nSetting environment variables for building samples...\n"
 
 if [ -z "$INTEL_OPENVINO_DIR" ]; then
-    if [ -e "$SAMPLES_PATH/../../setupvars.sh" ]; then
+    if [[ "$SAMPLES_PATH" = "/usr/share/openvino"* ]]; then
+        true
+    elif [ -e "$SAMPLES_PATH/../../setupvars.sh" ]; then
         setvars_path="$SAMPLES_PATH/../../setupvars.sh"
+        source "$setvars_path" || true
     else
         printf "Error: Failed to set the environment variables automatically. To fix, run the following command:\n source <INSTALL_DIR>/setupvars.sh\n where INSTALL_DIR is the OpenVINO installation directory.\n\n"
         exit 1
     fi
-    source "$setvars_path" || true
 else
-    # case for run with `sudo -E` 
+    # case for run with `sudo -E`
     source "$INTEL_OPENVINO_DIR/setupvars.sh" || true
 fi
 

--- a/scripts/install_dependencies/install_NCS_udev_rules.sh
+++ b/scripts/install_dependencies/install_NCS_udev_rules.sh
@@ -17,5 +17,5 @@ if [ -f "$SCRIPT_DIR/97-myriad-usbboot.rules" ]; then
     echo "Udev rules have been successfully installed."
 else
     echo "File '97-myriad-usbboot.rules' is missing. Please make sure you installed 'Inference Engine Runtime for Intel® Movidius™ VPU'."
-    exit -1
+    exit 1
 fi 

--- a/scripts/setupvars/setupvars.sh
+++ b/scripts/setupvars/setupvars.sh
@@ -79,7 +79,7 @@ if [ -z "$python_version" ]; then
     python_version=$(python3 -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))')
 fi
 
-# splitting Python version variable depending on the used shell 
+# splitting Python version variable depending on the used shell
 if [ -n "$ZSH_VERSION" ]; then
     version_arr=(${(@s:.:)python_version})
     if [ "${#version_arr[@]}" -ge "2" ]; then

--- a/src/tests/functional/plugin/myriad/run_tests_myriad_multistick.sh
+++ b/src/tests/functional/plugin/myriad/run_tests_myriad_multistick.sh
@@ -26,7 +26,7 @@ else
         TEST_DIR="$TEST_DIR/Debug/"
     else
         echo "Directory with binaries not found!"
-        exit -1
+        exit 1
     fi
 
 fi


### PR DESCRIPTION
### Details:
 - Fixed build_samples.sh not to call setupvars.sh for Debian package case

### Tickets:
 - CVS-79402
