### PR TITLE
Only clone weights when DAZ is not set

### DIFF
--- a/src/plugins/intel_cpu/src/config.h
+++ b/src/plugins/intel_cpu/src/config.h
@@ -61,6 +61,11 @@ struct Config {
 
     DenormalsOptMode denormalsOptMode = DenormalsOptMode::DO_Keep;
 
+    // The denormals-are-zeros flag was introduced in the Pentium 4 and Intel Xeon processor
+    // In earlier IA-32 processors and in some models of the Pentium 4 processor, this flag (bit 6)
+    // is reserved.
+    bool DAZOn = false;
+
     void readProperties(const std::map<std::string, std::string> &config);
     void updateProperties();
 

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -255,6 +255,14 @@ void Input::cloneBlobIfRequired() {
     const size_t size = shape.getElementsCount();
     DnnlBlockedMemoryDesc memDesc(prec, shape);
 
+    bool needFlushDenormalsToZero = true;
+    if (context->getConfig().DAZOn) {
+        // DAZ has been set, processor automatically converts all denormal source operands
+        // to a zero with the sign of the original operand before performing any
+        // computations on them, thus no need to flush them to zero manually
+        needFlushDenormalsToZero = false;
+    }
+
     auto cloneBlob = [&, this] () {
         Memory memory{ getEngine() };
 
@@ -271,7 +279,7 @@ void Input::cloneBlobIfRequired() {
 
         MemoryPtr ptr = MemoryPtr(new Memory(getEngine()));
         ptr->Create(memDesc);
-        ptr->SetData(memory);
+        ptr->SetData(memory, needFlushDenormalsToZero);
 
         return ptr;
     };
@@ -357,7 +365,7 @@ void Input::cloneBlobIfRequired() {
         memoryPtr = std::const_pointer_cast<const Memory>(ptr);
     // IRs already have all subnormals flushed to zero, but in
     // read_model scenario with directly loaded original model still can have subnormals
-    } else if (isBlobAligned() && !hasSubnormals() && !isWA()) {
+    } else if (isBlobAligned() && (!needFlushDenormalsToZero || !hasSubnormals()) && !isWA()) {
         auto ptr = new Memory(getEngine());
         ptr->Create(memDesc, constOp->get_data_ptr());
         memoryPtr = MemoryCPtr(ptr);

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -445,7 +445,7 @@ Engine::LoadExeNetworkImpl(const InferenceEngine::CNNNetwork &network, const std
     if (cpu.has(Xbyak::util::Cpu::tSSE)) {
         if (conf.denormalsOptMode == Config::DenormalsOptMode::DO_On) {
             flush_to_zero(true);
-            denormals_as_zero(true);
+            conf.DAZOn = denormals_as_zero(true);
         } else if (conf.denormalsOptMode == Config::DenormalsOptMode::DO_Off) {
             flush_to_zero(false);
             denormals_as_zero(false);


### PR DESCRIPTION
### Details:
 - Optimize weights memory usage by avoiding cloning weights with sub-normals when DAZ is set
 - Introduce a util function `is_denormals_as_zero_set()`
 - fix duplicate definitions issue by separate `denormals.hpp` into a hpp and cpp

### Tickets:
 - CVS-82367
