### PR TITLE
[GPU] Use int64_t type for axis in ScatterElementsUpdate

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/scatter_elements_update.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/scatter_elements_update.hpp
@@ -19,15 +19,6 @@ namespace cldnn {
 struct scatter_elements_update : public primitive_base<scatter_elements_update> {
     CLDNN_DECLARE_PRIMITIVE(scatter_elements_update)
 
-    enum scatter_elements_update_axis {
-        along_b,
-        along_f,
-        along_x,
-        along_y,
-        along_z,
-        along_w
-    };
-
     /// @brief Constructs scatter_elements_update primitive.
     /// @param id This primitive id.
     /// @param dict Input data primitive id.
@@ -38,13 +29,13 @@ struct scatter_elements_update : public primitive_base<scatter_elements_update> 
                             const primitive_id& data,
                             const primitive_id& idx,
                             const primitive_id& idupd,
-                            const scatter_elements_update_axis axis,
+                            const int64_t axis,
                             const primitive_id& ext_prim_id = "",
                             const padding& output_padding = padding())
         : primitive_base(id, {data, idx, idupd}, ext_prim_id, output_padding), axis(axis) {}
 
     /// @brief ScatterElementsUpdate axis
-    scatter_elements_update_axis axis;
+    int64_t axis;
 };
 /// @}
 /// @}

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
@@ -14,22 +14,27 @@ using namespace cldnn;
 
 namespace cldnn {
 namespace ocl {
-kernel_selector::scatter_update_axis convert_axis(scatter_elements_update::scatter_elements_update_axis axis, const scatter_elements_update_node& arg) {
-    switch (axis) {
-        case scatter_elements_update::along_x:
-            return kernel_selector::scatter_update_axis::X;
-        case scatter_elements_update::along_y:
-            return kernel_selector::scatter_update_axis::Y;
-        case scatter_elements_update::along_z:
-            return kernel_selector::scatter_update_axis::Z;
-        case scatter_elements_update::along_w:
-            return kernel_selector::scatter_update_axis::W;
-        case scatter_elements_update::along_f:
-            return kernel_selector::scatter_update_axis::FEATURE;
-        case scatter_elements_update::along_b:
-            return kernel_selector::scatter_update_axis::BATCH;
-        default:
-            CLDNN_ERROR_MESSAGE(arg.id(), "Unsupported Axis");
+kernel_selector::scatter_update_axis convert_axis(int64_t axis, const scatter_elements_update_node& arg) {
+    auto rank = arg.input(0).get_output_layout().get_rank();
+    if (axis < 0) {
+        axis += rank;
+    }
+    auto cldnn_axis = axis;
+    if (axis >= 2) {
+        auto spatial_axis = axis - 2;
+        const size_t default_dims = 4; // Default and minimum number of dimensions is 4
+        auto spatial_size = std::max(rank, default_dims) - 2;
+        cldnn_axis = spatial_size - spatial_axis - 1 + 2;
+    }
+
+    switch (cldnn_axis) {
+        case 0: return kernel_selector::scatter_update_axis::BATCH;
+        case 1: return kernel_selector::scatter_update_axis::FEATURE;
+        case 2: return kernel_selector::scatter_update_axis::X;
+        case 3: return kernel_selector::scatter_update_axis::Y;
+        case 4: return kernel_selector::scatter_update_axis::Z;
+        case 5: return kernel_selector::scatter_update_axis::W;
+        default: CLDNN_ERROR_MESSAGE(arg.id(), "Unsupported Axis");
     }
     return kernel_selector::scatter_update_axis::X;
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scatter_elements_update.cpp
@@ -13,35 +13,6 @@
 namespace ov {
 namespace intel_gpu {
 
-static inline cldnn::scatter_elements_update::scatter_elements_update_axis GetScatterElementsUpdateAxis(int axis, unsigned rank) {
-    if (axis < 0)
-        axis += rank;
-    if (axis < 0 || axis >= static_cast<int32_t>(rank))
-        IE_THROW() << "ScatterElementsUpdate axis is not correspond to number of dimensions";
-
-    // Difference in dimension ordering between IE and GPU plugin,
-    // reverse spatial dimensions after batch and feature.
-    unsigned cldnn_axis = axis;
-    if (axis >= 2) {
-        auto spatial_axis = axis - 2;
-        // Default and minimum number of dimensions is 4
-        auto spatial_size = std::max(rank, 4u) - 2;
-        cldnn_axis = spatial_size - spatial_axis - 1 + 2;
-    }
-
-    switch (cldnn_axis) {
-        case 0: return cldnn::scatter_elements_update::scatter_elements_update_axis::along_b;
-        case 1: return cldnn::scatter_elements_update::scatter_elements_update_axis::along_f;
-        case 2: return cldnn::scatter_elements_update::scatter_elements_update_axis::along_x;
-        case 3: return cldnn::scatter_elements_update::scatter_elements_update_axis::along_y;
-        case 4: return cldnn::scatter_elements_update::scatter_elements_update_axis::along_z;
-        case 5: return cldnn::scatter_elements_update::scatter_elements_update_axis::along_w;
-        default: IE_THROW() << "Unsupported ScatterElementsUpdate axis: " << axis;
-    }
-
-    return cldnn::scatter_elements_update::scatter_elements_update_axis::along_f;  // shouldn't get here
-}
-
 static void CreateScatterElementsUpdateOp(Program& p, const std::shared_ptr<ngraph::op::v3::ScatterElementsUpdate>& op) {
     p.ValidateInputs(op, {4});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
@@ -50,15 +21,19 @@ static void CreateScatterElementsUpdateOp(Program& p, const std::shared_ptr<ngra
     size_t rank = op->get_input_shape(0).size();
     auto axes_constant = std::dynamic_pointer_cast<ngraph::op::Constant>(op->get_input_node_shared_ptr(3));
     if (!axes_constant) {
-        IE_THROW() << "Unsupported parameter nodes type in " << op->get_friendly_name() << " (" << op->get_type_name() << ")";
+        OPENVINO_ASSERT("Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
     }
-    int32_t axis = axes_constant->cast_vector<int32_t>()[0];
+    int64_t axis = axes_constant->cast_vector<int64_t>()[0];
+    if (axis < 0)
+        axis += rank;
+    if (axis < 0 || axis >= static_cast<int64_t>(rank))
+        OPENVINO_ASSERT("ScatterElementsUpdate axis is not correspond to number of dimensions");
 
     auto primitive = cldnn::scatter_elements_update(layerName,
                                                     inputPrimitives[0],
                                                     inputPrimitives[1],
                                                     inputPrimitives[2],
-                                                    GetScatterElementsUpdateAxis(axis, rank),
+                                                    axis,
                                                     op->get_friendly_name());
 
     p.AddPrimitive(primitive);

--- a/src/plugins/intel_gpu/tests/fusions/scatter_elements_update_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/scatter_elements_update_fusion_test.cpp
@@ -20,7 +20,7 @@ namespace {
 struct scatter_elements_update_test_params {
     tensor input_shape;
     tensor indices_shape;
-    cldnn::scatter_elements_update::scatter_elements_update_axis axis;
+    int64_t axis;
     data_types data_type;
     format input_format;
     data_types default_type;
@@ -54,22 +54,8 @@ public:
     }
 
     size_t get_axis_dim(scatter_elements_update_test_params& p) {
-        switch (p.axis) {
-            case cldnn::scatter_elements_update::scatter_elements_update_axis::along_x:
-                return p.input_shape.spatial[0];
-            case cldnn::scatter_elements_update::scatter_elements_update_axis::along_y:
-                return p.input_shape.spatial[1];
-            case cldnn::scatter_elements_update::scatter_elements_update_axis::along_z:
-                return p.input_shape.spatial[2];
-            case cldnn::scatter_elements_update::scatter_elements_update_axis::along_w:
-                return p.input_shape.spatial[3];
-            case cldnn::scatter_elements_update::scatter_elements_update_axis::along_f:
-                return p.input_shape.feature[0];
-            case cldnn::scatter_elements_update::scatter_elements_update_axis::along_b:
-                return p.input_shape.batch[0];
-            default:
-                return 1;
-        }
+        auto shapes = p.input_shape.sizes(p.input_format);
+        return shapes[p.axis];
     }
 
     layout get_per_channel_layout(scatter_elements_update_test_params& p) {
@@ -84,19 +70,19 @@ public:
 
 // input shape along the update axis should be larger than the total number of elements in the update tensor.
 // This is not a limitation of operation itself, but a limitation of test implementation.
-#define CASE_SCATTER_ELEMENTS_UPDATE_FP32_1 { 8, 4, 1, 1 }, { 2, 4, 1, 1 }, cldnn::scatter_elements_update::scatter_elements_update_axis::along_b, data_types::f32, format::bfyx, data_types::f32, format::bfyx
-#define CASE_SCATTER_ELEMENTS_UPDATE_FP32_2 { 2, 8, 1, 2 }, { 2, 2, 1, 2 }, cldnn::scatter_elements_update::scatter_elements_update_axis::along_f, data_types::f32, format::bfyx, data_types::f32, format::bfyx
-#define CASE_SCATTER_ELEMENTS_UPDATE_FP32_3 { 2, 3, 10, 10 }, { 2, 2, 1, 2 }, cldnn::scatter_elements_update::scatter_elements_update_axis::along_y, data_types::f32, format::bfyx, data_types::f32, format::bfyx
+#define CASE_SCATTER_ELEMENTS_UPDATE_FP32_1 { 8, 4, 1, 1 }, { 2, 4, 1, 1 }, 0, data_types::f32, format::bfyx, data_types::f32, format::bfyx
+#define CASE_SCATTER_ELEMENTS_UPDATE_FP32_2 { 2, 8, 1, 2 }, { 2, 2, 1, 2 }, 1, data_types::f32, format::bfyx, data_types::f32, format::bfyx
+#define CASE_SCATTER_ELEMENTS_UPDATE_FP32_3 { 2, 3, 10, 10 }, { 2, 2, 1, 2 }, 2, data_types::f32, format::bfyx, data_types::f32, format::bfyx
 
-#define CASE_SCATTER_ELEMENTS_UPDATE_FP16_1 { 2, 2, 14, 12 }, { 2, 2, 3, 1 }, cldnn::scatter_elements_update::scatter_elements_update_axis::along_x, data_types::f16, format::bfyx, data_types::f16, format::bfyx
+#define CASE_SCATTER_ELEMENTS_UPDATE_FP16_1 { 2, 2, 14, 12 }, { 2, 2, 3, 1 }, 3, data_types::f16, format::bfyx, data_types::f16, format::bfyx
 
-#define CASE_SCATTER_ELEMENTS_UPDATE_5D_FP32_1 { 24, 3, 1, 4, 1 }, { 4, 3, 1, 2, 1 }, cldnn::scatter_elements_update::scatter_elements_update_axis::along_b, data_types::f32, format::bfzyx, data_types::f32, format::bfzyx
-#define CASE_SCATTER_ELEMENTS_UPDATE_5D_FP32_2 { 2, 17, 2, 2, 2 }, { 1, 2, 2, 2, 2 }, cldnn::scatter_elements_update::scatter_elements_update_axis::along_f, data_types::f32, format::bfzyx, data_types::f32, format::bfzyx
-#define CASE_SCATTER_ELEMENTS_UPDATE_5D_FP32_3 { 5, 3, 2, 20, 22 }, { 5, 1, 1, 2, 2 }, cldnn::scatter_elements_update::scatter_elements_update_axis::along_y, data_types::f32, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_SCATTER_ELEMENTS_UPDATE_5D_FP32_1 { 24, 3, 1, 4, 1 }, { 4, 3, 1, 2, 1 }, 0, data_types::f32, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_SCATTER_ELEMENTS_UPDATE_5D_FP32_2 { 2, 17, 2, 2, 2 }, { 1, 2, 2, 2, 2 }, 1, data_types::f32, format::bfzyx, data_types::f32, format::bfzyx
+#define CASE_SCATTER_ELEMENTS_UPDATE_5D_FP32_3 { 5, 3, 2, 20, 22 }, { 5, 1, 1, 2, 2 }, 3, data_types::f32, format::bfzyx, data_types::f32, format::bfzyx
 
-#define CASE_SCATTER_ELEMENTS_UPDATE_5D_FP16_1 { 13, 2, 1, 2, 1 }, { 2, 2, 1, 2, 1 }, cldnn::scatter_elements_update::scatter_elements_update_axis::along_b, data_types::f16, format::bfzyx, data_types::f16, format::bfzyx
-#define CASE_SCATTER_ELEMENTS_UPDATE_5D_FP16_2 { 1, 13, 1, 2, 1 }, { 1, 2, 1, 2, 1 }, cldnn::scatter_elements_update::scatter_elements_update_axis::along_f, data_types::f16, format::bfzyx, data_types::f16, format::bfzyx
-#define CASE_SCATTER_ELEMENTS_UPDATE_5D_FP16_3 { 2, 3, 1, 13, 13 }, { 2, 3, 1, 2, 1 }, cldnn::scatter_elements_update::scatter_elements_update_axis::along_y, data_types::f16, format::bfzyx, data_types::f16, format::bfzyx
+#define CASE_SCATTER_ELEMENTS_UPDATE_5D_FP16_1 { 13, 2, 1, 2, 1 }, { 2, 2, 1, 2, 1 }, 0, data_types::f16, format::bfzyx, data_types::f16, format::bfzyx
+#define CASE_SCATTER_ELEMENTS_UPDATE_5D_FP16_2 { 1, 13, 1, 2, 1 }, { 1, 2, 1, 2, 1 }, 1, data_types::f16, format::bfzyx, data_types::f16, format::bfzyx
+#define CASE_SCATTER_ELEMENTS_UPDATE_5D_FP16_3 { 2, 3, 1, 13, 13 }, { 2, 3, 1, 2, 1 }, 3, data_types::f16, format::bfzyx, data_types::f16, format::bfzyx
 
 class scatter_elements_update_quantize : public ScatterElementsUpdatePrimitiveFusingTest {};
 TEST_P(scatter_elements_update_quantize, basic) {

--- a/src/plugins/intel_gpu/tests/test_cases/scatter_elements_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/scatter_elements_update_gpu_test.cpp
@@ -42,10 +42,10 @@ TEST(scatter_elements_update_gpu_fp16, d2411_axisF) {
 
     auto& engine = get_test_engine();
 
-    auto input1 = engine.allocate_memory({ data_types::f16, format::bfyx, { 2, 4, 1, 1 } }); // Dictionary
-    auto input2 = engine.allocate_memory({ data_types::f16, format::bfyx, { 2, 2, 1, 1 } }); // Indexes
-    auto input3 = engine.allocate_memory({ data_types::f16, format::bfyx, { 2, 2, 1, 1 } }); // Updates
-    auto axis = cldnn::scatter_elements_update::scatter_elements_update_axis::along_f;
+    auto input1 = engine.allocate_memory({ data_types::f16, format::bfyx, tensor{ 2, 4, 1, 1 } }); // Dictionary
+    auto input2 = engine.allocate_memory({ data_types::f16, format::bfyx, tensor{ 2, 2, 1, 1 } }); // Indexes
+    auto input3 = engine.allocate_memory({ data_types::f16, format::bfyx, tensor{ 2, 2, 1, 1 } }); // Updates
+    auto axis = 1;
 
     set_values(input1, {
         FLOAT16(3.0f), FLOAT16(6.0f), FLOAT16(5.0f), FLOAT16(4.0f),


### PR DESCRIPTION
### Details:
 - *Enum changed to int64_t for scatter_elements_update primitive.*
