### PR TITLE
[TF FE] Fix conversion of NetVLAD model

### DIFF
--- a/src/frontends/tensorflow/src/op/conv_2d.cpp
+++ b/src/frontends/tensorflow/src/op/conv_2d.cpp
@@ -51,7 +51,7 @@ OutputVector translate_conv_2d_op(const NodeContext& node) {
     auto& ng_filter_shape = ng_filter.get_shape();
     ng_kernel_shape[0] = ng_filter_shape[0];
     ng_kernel_shape[1] = ng_filter_shape[1];
-    transpose<3, 2, 0, 1>(ng_filter);
+    ng_filter = make_transpose(ng_filter, {3, 2, 0, 1});
 
     CoordinateDiff ng_padding_below;
     CoordinateDiff ng_padding_above;

--- a/src/frontends/tensorflow/src/op/conv_2d_backprop.cpp
+++ b/src/frontends/tensorflow/src/op/conv_2d_backprop.cpp
@@ -64,7 +64,7 @@ OutputVector translate_conv_2d_backprop_input_op(const NodeContext& node) {
     auto& ng_filter_shape = ng_filter.get_shape();
     ng_kernel_shape[0] = ng_filter_shape[0];
     ng_kernel_shape[1] = ng_filter_shape[1];
-    transpose<3, 2, 0, 1>(ng_filter);
+    ng_filter = make_transpose(ng_filter, {3, 2, 0, 1});
 
     CoordinateDiff ng_padding_below;
     CoordinateDiff ng_padding_above;

--- a/src/frontends/tensorflow/src/op/conv_3d.cpp
+++ b/src/frontends/tensorflow/src/op/conv_3d.cpp
@@ -54,7 +54,7 @@ OutputVector translate_conv_3d_op(const NodeContext& node) {
     ng_kernel_shape[0] = ng_filter_shape[0];
     ng_kernel_shape[1] = ng_filter_shape[1];
     ng_kernel_shape[2] = ng_filter_shape[2];
-    transpose_3d<4, 3, 0, 1, 2>(ng_filter);
+    ng_filter = make_transpose(ng_filter, {4, 3, 0, 1, 2});
 
     CoordinateDiff ng_padding_below;
     CoordinateDiff ng_padding_above;

--- a/src/frontends/tensorflow/src/op/conv_3d_backprop.cpp
+++ b/src/frontends/tensorflow/src/op/conv_3d_backprop.cpp
@@ -70,7 +70,7 @@ OutputVector translate_conv_3d_backprop_input_v2_op(const NodeContext& node) {
     ng_kernel_shape[0] = ng_filter_shape[0];
     ng_kernel_shape[1] = ng_filter_shape[1];
     ng_kernel_shape[2] = ng_filter_shape[2];
-    transpose_3d<4, 3, 0, 1, 2>(ng_filter);
+    ng_filter = make_transpose(ng_filter, {4, 3, 0, 1, 2});
 
     ov::CoordinateDiff ng_padding_below;
     ov::CoordinateDiff ng_padding_above;

--- a/src/frontends/tensorflow/src/op/crop_and_resize.cpp
+++ b/src/frontends/tensorflow/src/op/crop_and_resize.cpp
@@ -123,10 +123,10 @@ OutputVector translate_crop_and_resize_op(const NodeContext& node) {
                 interpolate_attrs.mode = Interpolate::InterpolateMode::NEAREST;
             }
 
-            transpose<0, 3, 1, 2>(ng_crop);
+            ng_crop = make_transpose(ng_crop, {0, 3, 1, 2});
             auto ng_output =
                 make_shared<Interpolate>(ng_crop, ng_size, ng_scales, ng_axes, interpolate_attrs)->output(0);
-            transpose<0, 2, 3, 1>(ng_output);
+            ng_output = make_transpose(ng_output, {0, 2, 3, 1});
             ng_crop_outputs.at(i) = ng_output;
         }
 

--- a/src/frontends/tensorflow/src/op/fake_quant_min_max_vars.cpp
+++ b/src/frontends/tensorflow/src/op/fake_quant_min_max_vars.cpp
@@ -51,11 +51,13 @@ OutputVector translate_fake_quant_op(const NodeContext& node) {
     auto max_adj = make_shared<Add>(maximum, adjustment);
 
     auto ng_input_shape = ng_input.get_shape();
-    if (ng_input_shape.size() == 4)
-        transpose<0, 3, 1, 2>(ng_input);
+    if (ng_input_shape.size() == 4) {
+        ng_input = make_transpose(ng_input, {0, 3, 1, 2});
+    }
     auto res = make_shared<FakeQuantize>(ng_input, min_adj, max_adj, min_adj, max_adj, levels)->output(0);
-    if (ng_input_shape.size() == 4)
-        transpose<0, 2, 3, 1>(res);
+    if (ng_input_shape.size() == 4) {
+        res = make_transpose(res, {0, 2, 3, 1});
+    }
 
     set_node_name(node.get_name(), res.get_node_shared_ptr());
     return {res};

--- a/src/frontends/tensorflow/src/op/interpolate.cpp
+++ b/src/frontends/tensorflow/src/op/interpolate.cpp
@@ -36,9 +36,9 @@ ov::OutputVector translate_interpolate_op(const NodeContext& node) {
     auto ng_scales = make_shared<Divide>(ng_sizes, ng_spatial_shape);
     auto ng_axes = make_shared<Constant>(element::i32, Shape{2}, std::vector<int>({2, 3}));
 
-    transpose<0, 3, 1, 2>(input);
+    input = make_transpose(input, {0, 3, 1, 2});
     auto res = make_shared<Interpolate>(input, input_sizes, ng_scales, ng_axes, interpolate_attrs)->output(0);
-    transpose<0, 2, 3, 1>(res);
+    res = make_transpose(res, {0, 2, 3, 1});
     set_node_name(node.get_name(), res.get_node_shared_ptr());
     return {res};
 }

--- a/src/frontends/tensorflow/src/openvino_conversions.cpp
+++ b/src/frontends/tensorflow/src/openvino_conversions.cpp
@@ -14,9 +14,9 @@ void convert_nhwc_to_nchw(const std::string& op_name, bool need_convert, ov::Out
     if (need_convert) {
         auto rank = node.get_shape().size();
         if (rank == 4) {
-            transpose<0, 3, 1, 2>(node);
+            node = make_transpose(node, {0, 3, 1, 2});
         } else if (rank == 5) {
-            transpose_3d<0, 4, 1, 2, 3>(node);
+            node = make_transpose(node, {0, 4, 1, 2, 3});
         }
     }
 }
@@ -25,11 +25,18 @@ void convert_nchw_to_nhwc(const std::string& op_name, bool need_convert, ov::Out
     if (need_convert) {
         auto rank = node.get_shape().size();
         if (rank == 4) {
-            transpose<0, 2, 3, 1>(node);
+            node = make_transpose(node, {0, 2, 3, 1});
         } else if (rank == 5) {
-            transpose_3d<0, 2, 3, 4, 1>(node);
+            node = make_transpose(node, {0, 2, 3, 4, 1});
         }
     }
+}
+
+std::shared_ptr<ov::opset8::Transpose> make_transpose(const ov::Output<ov::Node>& arg,
+                                                      const ov::AxisVector& input_order) {
+    auto order = std::make_shared<ov::opset8::Constant>(element::i64, Shape{input_order.size()}, input_order);
+    auto transpose = std::make_shared<ov::opset8::Transpose>(arg, order);
+    return transpose;
 }
 
 }  // namespace tensorflow

--- a/src/frontends/tensorflow/src/openvino_conversions.hpp
+++ b/src/frontends/tensorflow/src/openvino_conversions.hpp
@@ -16,36 +16,8 @@ namespace tensorflow {
 
 using ::tensorflow::DataType;
 
-template <size_t a, size_t b, size_t c, size_t d>
-void transpose(ov::Output<ov::Node>& node) {
-    static_assert(a < 4 && b < 4 && c < 4 && d < 4, "Number of dimensions cannot exceed 4");
-    static_assert(a != b && a != c && a != d && b != c && b != d && c != d, "Dimensions indices cannot be equal");
-    ov::Shape transpose_order{a, b, c, d};
-    auto input_order =
-        std::make_shared<ov::opset8::Constant>(ov::element::u64, ov::Shape{transpose_order.size()}, transpose_order);
-    node = std::make_shared<ov::opset8::Transpose>(node, input_order);
-}
-
-template <size_t a, size_t b, size_t c, size_t d>
-void transpose(std::shared_ptr<ov::Node>& node) {
-    transpose<a, b, c, d>(node->get_default_output());
-}
-
-template <size_t a, size_t b, size_t c, size_t d, size_t e>
-void transpose_3d(ov::Output<ov::Node>& node) {
-    static_assert(a < 5 && b < 5 && c < 5 && d < 5 && e < 5, "Number of dimensions cannot exceed 5");
-    static_assert(a != b && a != c && a != d && a != e && b != c && b != d && b != e && c != d && c != e && d != e,
-                  "Dimensions indices cannot be equal");
-    ov::Shape transpose_order{a, b, c, d, e};
-    auto input_order =
-        std::make_shared<ov::opset8::Constant>(ov::element::u64, ov::Shape{transpose_order.size()}, transpose_order);
-    node = std::make_shared<ov::opset8::Transpose>(node, input_order);
-}
-
-template <size_t a, size_t b, size_t c, size_t d, size_t e>
-void transpose_3d(std::shared_ptr<ov::Node>& node) {
-    transpose_3d<a, b, c, d, e>(node->get_default_output());
-}
+std::shared_ptr<ov::opset8::Transpose> make_transpose(const ov::Output<ov::Node>& arg,
+                                                      const ov::AxisVector& input_order);
 
 namespace detail {
 template <typename T>

--- a/src/frontends/tensorflow/src/pass/transpose_sinking.cpp
+++ b/src/frontends/tensorflow/src/pass/transpose_sinking.cpp
@@ -8,10 +8,12 @@
 #include "openvino/opsets/opset8.hpp"
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/util/common_util.hpp"
+#include "openvino_conversions.hpp"
 #include "utils.hpp"
 
 using namespace std;
 using namespace ov;
+using namespace ov::frontend::tensorflow;
 using namespace opset8;
 
 using TransposeMap = unordered_map<string, shared_ptr<Transpose>>;
@@ -56,15 +58,8 @@ static string describe(shared_ptr<Node> node) {
     return ss.str();
 }
 
-static shared_ptr<Transpose> make_transpose(const Output<Node>& arg, const AxisVector& input_order) {
-    auto order = std::make_shared<Constant>(element::u64, Shape{input_order.size()}, input_order);
-    auto transpose = make_shared<Transpose>(arg, order);
-    OPENVINO_DEBUG << "Make Transpose " << describe<Transpose>(transpose);
-    return transpose;
-}
-
 static shared_ptr<Reshape> make_reshape(const Output<Node>& arg, const AxisVector& input_order) {
-    auto order = std::make_shared<Constant>(element::u64, Shape{input_order.size()}, input_order);
+    auto order = std::make_shared<Constant>(element::i64, Shape{input_order.size()}, input_order);
     auto transpose = make_shared<Reshape>(arg, order, false);
     OPENVINO_DEBUG << "Make Reshape " << describe<Reshape>(transpose);
     return transpose;
@@ -132,7 +127,7 @@ static void mark_transpose_for_deletion(const shared_ptr<Node>& transpose,
 
 static shared_ptr<Transpose> create_default_transpose(const Output<Node>& n) {
     auto default_order = get_default_order(n.get_shape().size());
-    auto order = std::make_shared<Constant>(element::u64, Shape{default_order.size()}, default_order);
+    auto order = std::make_shared<Constant>(element::i64, Shape{default_order.size()}, default_order);
     return make_shared<Transpose>(n, order);
 }
 
@@ -160,7 +155,6 @@ static void convert_binary_to_default_order(const shared_ptr<Node>& binary,
         left_shape.insert(left_shape.begin(), perm_to_def.size() - left_shape.size(), 1);
 
         auto new_shape = apply_permutation(left_shape, perm_to_def);
-
         new_node = make_reshape(left, new_shape);
     } else if (left_shape.size() == perm_to_def.size()) {
         new_node = make_transpose(left, perm_to_def);


### PR DESCRIPTION
**Details:** Currently the conversion for NetVLAD model (from e2e scope) fails due to no support of `Gather` evaluate method for `u64` type that is triggered during `TransposeToReshape` common transformation. `u64` type appears during creation IR by TensorFlow frontend. The TF frontend uses `u64` type for creation of Transpose nodes in a graph.
Now I changed this type into `i64` and refactor the code to have the single routine for Transpose node creation.

Now the model is converted and inferred successfully. 

**Ticket:** 88446

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
