### PR TITLE
[GPU] Fix calc_output_layout not to dependent on program_node

### DIFF
--- a/src/plugins/intel_gpu/src/graph/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/activation.cpp
@@ -15,12 +15,13 @@ primitive_type_id activation::type_id() {
     return &instance;
 }
 
-layout activation_inst::calc_output_layout(activation_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout activation_inst::calc_output_layout(activation_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for activation_node!");
 
-    auto input_node_layout = node.input().get_non_padded_output_layout();
-    auto func = node.get_primitive()->activation_function;
+    auto input_node_layout = impl_param.get_non_padded_input_layout();
+    auto desc = impl_param.typed_desc<activation>();
+    auto func = desc->activation_function;
 
     std::vector<activation_func> activations_int8 = {
         activation_func::none,
@@ -33,11 +34,11 @@ layout activation_inst::calc_output_layout(activation_node const& node) {
     if (input_node_layout.data_type == data_types::i8 || input_node_layout.data_type == data_types::u8 ||
         input_node_layout.data_type == data_types::i32) {
         if (std::find(activations_int8.begin(), activations_int8.end(), func) == activations_int8.end())
-            CLDNN_ERROR_MESSAGE(node.id(), "Requested activation is not supported for integer type.");
+            CLDNN_ERROR_MESSAGE(desc->id, "Requested activation is not supported for integer type.");
     }
 
-    if (node.has_fused_primitives()) {
-        input_node_layout.data_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        input_node_layout.data_type = impl_param.get_fused_output_layout().data_type;
     }
 
     return input_node_layout;

--- a/src/plugins/intel_gpu/src/graph/adaptive_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/adaptive_pooling.cpp
@@ -14,9 +14,9 @@ primitive_type_id adaptive_pooling::type_id() {
     return &instance;
 }
 
-layout adaptive_pooling_inst::calc_output_layout(const adaptive_pooling_node& node) {
-    const auto data_layout = node.input().get_output_layout();
-    const auto prim = node.get_primitive();
+layout adaptive_pooling_inst::calc_output_layout(const adaptive_pooling_node& node, kernel_impl_params const& impl_param) {
+    const auto data_layout = impl_param.input_layouts[0];
+    const auto prim = impl_param.typed_desc<adaptive_pooling>();
     return {data_layout.data_type, data_layout.format, prim->output_size};
 }
 

--- a/src/plugins/intel_gpu/src/graph/arg_max_min.cpp
+++ b/src/plugins/intel_gpu/src/graph/arg_max_min.cpp
@@ -16,15 +16,15 @@ primitive_type_id arg_max_min::type_id() {
     return &instance;
 }
 
-layout arg_max_min_inst::calc_output_layout(arg_max_min_node const& node) {
-    auto desc = node.get_primitive();
-    auto input_layout = node.input().get_output_layout();
+layout arg_max_min_inst::calc_output_layout(arg_max_min_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<arg_max_min>();
+    auto input_layout = impl_param.input_layouts[0];
     bool values_first = desc->values_first;
     data_types output_data_type;
     data_types output_idx_type;
     output_data_type = desc->output_data_type ? *desc->output_data_type : input_layout.data_type;
-    if (node.get_dependencies().size() == 3) {
-        output_idx_type = node.get_dependency(2).get_output_layout().data_type;
+    if (impl_param.input_layouts.size() == 3) {
+        output_idx_type = impl_param.input_layouts[2].data_type;
     } else {
         output_idx_type = *(desc->output_data_type);
     }
@@ -48,7 +48,7 @@ layout arg_max_min_inst::calc_output_layout(arg_max_min_node const& node) {
         }
 
         if (tensor_size > max_size) {
-            CLDNN_ERROR_GREATER_THAN(node.id(),
+            CLDNN_ERROR_GREATER_THAN(desc->id,
                                      "Reduced tensor size",
                                      tensor_size,
                                      "Maximum output data type value",

--- a/src/plugins/intel_gpu/src/graph/assign.cpp
+++ b/src/plugins/intel_gpu/src/graph/assign.cpp
@@ -20,8 +20,8 @@ assign_inst::typed_primitive_inst(network& network, const assign_node& node) :
     memory_state::variable{node.get_primitive()->variable_id} {
 }
 
-layout assign_inst::calc_output_layout(const assign_node& node) {
-    return node.get_primitive()->output_layout;
+layout assign_inst::calc_output_layout(const assign_node& node, kernel_impl_params const& impl_param) {
+    return impl_param.typed_desc<assign>()->output_layout;
 }
 
 std::string assign_inst::to_string(const assign_node& node) {

--- a/src/plugins/intel_gpu/src/graph/average_unpooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/average_unpooling.cpp
@@ -15,36 +15,36 @@ primitive_type_id average_unpooling::type_id() {
     return &instance;
 }
 
-layout average_unpooling_inst::calc_output_layout(average_unpooling_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout average_unpooling_inst::calc_output_layout(average_unpooling_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for "
            "average_unpooling_node!");
-    auto desc = node.get_primitive();
+    auto desc = impl_param.typed_desc<average_unpooling>();
 
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
 
     auto stride = desc->stride;
     auto window_size = desc->size;
 
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "stride spatial X",
                                    stride.spatial[0],
                                    "",
                                    0,
                                    "Stride spatial X must be positive (>= 1)");
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "stride spatial Y",
                                    stride.spatial[1],
                                    "",
                                    0,
                                    "Stride spatial Y must be positive (>= 1)");
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "window size spatial X",
                                    window_size.spatial[0],
                                    "",
                                    0,
                                    "Size X (of pooling window) must be positive (>= 1)");
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "window size spatial Y",
                                    window_size.spatial[1],
                                    "",

--- a/src/plugins/intel_gpu/src/graph/batch_to_space.cpp
+++ b/src/plugins/intel_gpu/src/graph/batch_to_space.cpp
@@ -17,16 +17,16 @@ primitive_type_id cldnn::batch_to_space::type_id() {
     return &instance;
 }
 
-layout batch_to_space_inst::calc_output_layout(batch_to_space_node const& node) {
-    auto desc = node.get_primitive();
+layout batch_to_space_inst::calc_output_layout(batch_to_space_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<batch_to_space>();
 
-    auto input_layout = node.input(0).get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     auto input_format = input_layout.format;
 
     auto output_type = desc->output_data_type ? *desc->output_data_type : input_layout.data_type;
 
-    if (node.has_fused_primitives())
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives())
+        output_type = impl_param.get_fused_output_layout().data_type;
 
     const size_t spatial_num = format::spatial_num(input_format);
 
@@ -35,17 +35,17 @@ layout batch_to_space_inst::calc_output_layout(batch_to_space_node const& node) 
     const auto& crops_end = desc->crops_end;
 
     if (block_shape.batch[0] != 1)
-        CLDNN_ERROR_MESSAGE(node.id(),
+        CLDNN_ERROR_MESSAGE(desc->id,
             "block_shape[0] is expected to be 1. Actual block_shape[0] is " +
             std::to_string(block_shape.batch[0]));
 
     if (crops_begin.batch[0] != 0)
-        CLDNN_ERROR_MESSAGE(node.id(),
+        CLDNN_ERROR_MESSAGE(desc->id,
             "crops_begin[0] is expected to be 0. Actual crops_begin[0] is " +
             std::to_string(crops_begin.batch[0]));
 
     if (crops_end.batch[0] != 0)
-        CLDNN_ERROR_MESSAGE(node.id(),
+        CLDNN_ERROR_MESSAGE(desc->id,
             "crops_end[0] is expected to be 0. Actual crops_end[0] is " +
             std::to_string(crops_end.batch[0]));
 
@@ -54,17 +54,17 @@ layout batch_to_space_inst::calc_output_layout(batch_to_space_node const& node) 
         block_sizes_multiplied *= block_shape.spatial[i];
 
     if (input_layout.batch() % block_sizes_multiplied != 0)
-        CLDNN_ERROR_MESSAGE(node.id(),
+        CLDNN_ERROR_MESSAGE(desc->id,
             "The batch of the input tensor must be divisible by multiplied block sizes = " +
             std::to_string(block_sizes_multiplied));
 
     if (crops_begin.feature[0] + crops_end.feature[0] >= block_shape.feature[0] * input_layout.feature())
-            CLDNN_ERROR_MESSAGE(node.id(),
+            CLDNN_ERROR_MESSAGE(desc->id,
                 "Output dimensions must be positive");
 
     for (size_t i = 0; i < spatial_num; ++i)
         if (crops_begin.spatial[i] + crops_end.spatial[i] >= block_shape.spatial[i] * input_layout.spatial(i))
-            CLDNN_ERROR_MESSAGE(node.id(),
+            CLDNN_ERROR_MESSAGE(desc->id,
                 "Output dimensions must be positive");
 
     return layout{output_type, input_format, desc->out_size};

--- a/src/plugins/intel_gpu/src/graph/binary_convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/binary_convolution.cpp
@@ -17,14 +17,14 @@ primitive_type_id binary_convolution::type_id() {
     return &instance;
 }
 
-layout binary_convolution_inst::calc_output_layout(binary_convolution_node const& node) {
-    auto desc = node.get_primitive();
+layout binary_convolution_inst::calc_output_layout(binary_convolution_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<binary_convolution>();
 
-    auto output_type = *node.get_primitive()->output_data_type;
+    auto output_type = *desc->output_data_type;
     auto output_size = desc->output_size;
     auto layout = cldnn::layout{output_type, format::bfyx, output_size};
-    if (node.has_fused_primitives()) {
-        layout = node.get_fused_output_layout();
+    if (impl_param.has_fused_primitives()) {
+        layout = impl_param.get_fused_output_layout();
     }
 
     auto users = node.get_users();

--- a/src/plugins/intel_gpu/src/graph/border.cpp
+++ b/src/plugins/intel_gpu/src/graph/border.cpp
@@ -16,11 +16,11 @@ primitive_type_id border::type_id() {
     return &instance;
 }
 
-layout border_inst::calc_output_layout(border_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout border_inst::calc_output_layout(border_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for border_node!");
-    auto input_layout = node.input().get_output_layout();
-    auto desc = node.get_primitive();
+    auto input_layout = impl_param.input_layouts[0];
+    auto desc = impl_param.typed_desc<border>();
 
     auto new_size = input_layout.get_tensor();
     new_size += desc->left_top_sizes.sub(tensor(0));

--- a/src/plugins/intel_gpu/src/graph/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/broadcast.cpp
@@ -17,11 +17,11 @@ primitive_type_id broadcast::type_id() {
     return &instance;
 }
 
-layout broadcast_inst::calc_output_layout(broadcast_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout broadcast_inst::calc_output_layout(broadcast_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for broadcast_node!");
-    auto input_layout = node.input().get_output_layout();
-    auto desc = node.get_primitive();
+    auto input_layout = impl_param.input_layouts[0];
+    auto desc = impl_param.typed_desc<broadcast>();
 
     return {input_layout.data_type, input_layout.format, desc->broadcast_sizes};
 }

--- a/src/plugins/intel_gpu/src/graph/bucketize.cpp
+++ b/src/plugins/intel_gpu/src/graph/bucketize.cpp
@@ -16,9 +16,9 @@ primitive_type_id bucketize::type_id() {
     return &instance;
 }
 
-layout bucketize_inst::calc_output_layout(const bucketize_node& node) {
-    auto input_layout = node.input().get_output_layout();
-    auto primitive = node.get_primitive();
+layout bucketize_inst::calc_output_layout(const bucketize_node& node, kernel_impl_params const& impl_param) {
+    auto input_layout = impl_param.input_layouts[0];
+    auto primitive = impl_param.desc;
     return {*primitive->output_data_type, input_layout.format, input_layout.get_tensor()};
 }
 

--- a/src/plugins/intel_gpu/src/graph/concatenation.cpp
+++ b/src/plugins/intel_gpu/src/graph/concatenation.cpp
@@ -17,22 +17,22 @@ primitive_type_id concatenation::type_id() {
     return &instance;
 }
 
-layout concatenation_inst::calc_output_layout(concatenation_node const& node) {
-    auto desc = node.get_primitive();
+layout concatenation_inst::calc_output_layout(concatenation_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<concatenation>();
 
-    auto input_layout = node.input(0).get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     auto output_format = input_layout.format;
     auto result_sizes = input_layout.get_dims();
 
     auto output_dt = desc->output_data_type ? *desc->output_data_type : input_layout.data_type;
 
-    auto axis_index = node.get_primitive()->axis;
+    auto axis_index = desc->axis;
 
     // calculate sum of features from all inputs
     result_sizes[axis_index] = 0;
     for (size_t i = 0; i < desc->input.size(); ++i) {
-        auto input_sizes = node.input(i).get_output_layout().get_dims();
-        if (node.input(i).get_output_layout().format == format::b_fs_yx_fsv16)
+        auto input_sizes = impl_param.input_layouts[i].get_dims();
+        if (impl_param.input_layouts[i].format == format::b_fs_yx_fsv16)
             output_format = format::b_fs_yx_fsv16;
 
         result_sizes[axis_index] += input_sizes[axis_index];

--- a/src/plugins/intel_gpu/src/graph/condition.cpp
+++ b/src/plugins/intel_gpu/src/graph/condition.cpp
@@ -22,20 +22,20 @@ primitive_type_id condition::type_id() {
     In this both cases, we need to recalc branch_true and branch_false.
     !* We can be sure, that this method was called AT LEAST once during graph compilation.*!
 */
-layout condition_inst::calc_output_layout(condition_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout condition_inst::calc_output_layout(condition_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for condition_node!");
     node.set_branches();
 
     auto branch_true_output = node.get_branch_true()->get_outputs();
     auto branch_false_output = node.get_branch_false()->get_outputs();
-    CLDNN_ERROR_NOT_EQUAL(node.id(),
+    CLDNN_ERROR_NOT_EQUAL(impl_param.desc->id,
                           "Count of branch true outputs",
                           branch_true_output.size(),
                           "expected outputs size",
                           1,
                           "Branch true should have one output.");
-    CLDNN_ERROR_NOT_EQUAL(node.id(),
+    CLDNN_ERROR_NOT_EQUAL(impl_param.desc->id,
                           "Count of branch false outputs",
                           branch_false_output.size(),
                           "expected outputs size",
@@ -44,7 +44,7 @@ layout condition_inst::calc_output_layout(condition_node const& node) {
 
     auto layout_true = branch_true_output.at(0)->get_output_layout();
     auto layout_false = branch_false_output.at(0)->get_output_layout();
-    CLDNN_ERROR_LAYOUT_MISMATCH(node.id(),
+    CLDNN_ERROR_LAYOUT_MISMATCH(impl_param.desc->id,
                                 "Branch true output layout",
                                 layout_true,
                                 "branch false output layout",

--- a/src/plugins/intel_gpu/src/graph/convert_color.cpp
+++ b/src/plugins/intel_gpu/src/graph/convert_color.cpp
@@ -15,8 +15,8 @@ primitive_type_id convert_color::type_id() {
     return &instance;
 }
 
-layout convert_color_inst::calc_output_layout(convert_color_node const& node) {
-    auto desc = node.get_primitive();
+layout convert_color_inst::calc_output_layout(convert_color_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<convert_color>();
     return desc->output_layout;
 }
 

--- a/src/plugins/intel_gpu/src/graph/convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/convolution.cpp
@@ -59,11 +59,12 @@ static format get_recommended_format(layout input_layout, data_types output_type
     return format::any;
 }
 
-layout convolution_inst::calc_output_layout(convolution_node const& node) {
-    auto desc = node.get_primitive();
+layout convolution_inst::calc_output_layout(convolution_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<convolution>();
 
-    auto input_layout = node.input().get_output_layout();
-    auto weights_layout = node.weights(0).get_output_layout().convert_to_weights_layout(desc->grouped_weights_shape);
+    auto input_layout = impl_param.input_layouts[0];
+    auto weights_layout = *impl_param.weights_layout;
+    weights_layout = weights_layout.convert_to_weights_layout(desc->grouped_weights_shape);
 
     auto pad = desc->pad;
     auto stride = desc->stride;
@@ -77,12 +78,12 @@ layout convolution_inst::calc_output_layout(convolution_node const& node) {
     auto input_type = input_layout.data_type;
 
     auto output_type = input_type;
-    if (node.has_fused_primitives()) {
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        output_type = impl_param.get_fused_output_layout().data_type;
     }
 
     if ((input_type == data_types::u8 || input_type == data_types::i8) &&
-         !node.has_fused_primitives()) {
+         !impl_param.has_fused_primitives()) {
         output_type = data_types::f32;
     }
 
@@ -95,25 +96,25 @@ layout convolution_inst::calc_output_layout(convolution_node const& node) {
     uint32_t dilation_x = dilation.size() >= 1 ? dilation[dilation.size() - 1] : 1;
 
     // TODO: Consider moving general parameter verification to arguments constructor.
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "Stride spatial X",
                                    stride_x,
                                    "value",
                                    0,
                                    "Stride spatial X must be positive (>= 1)");
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "Stride spatial Y",
                                    stride_y,
                                    "value",
                                    0,
                                    "Stride spatial Y must be positive (>= 1)");
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "Dilatation spatial X",
                                    dilation_x,
                                    "value",
                                    0,
                                    "Dilatation patial X must be positive (>= 1)");
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "Dilatation spatial Y",
                                    dilation_y,
                                    "value",
@@ -122,13 +123,13 @@ layout convolution_inst::calc_output_layout(convolution_node const& node) {
 
     if (input_layout.format.spatial_num() == 3) {
         // convolution 3D
-        CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+        CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                        "Stride spatial Z",
                                        stride_z,
                                        "value",
                                        0,
                                        "Stride spatial Z must be positive (>= 1)");
-        CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+        CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                        "Dilatation spatial Z",
                                        dilation_z,
                                        "value",
@@ -142,54 +143,54 @@ layout convolution_inst::calc_output_layout(convolution_node const& node) {
         input_layout.format == format::image_2d_weights_winograd_6x3_s1_fbxyb ||
         input_layout.format == format::image_2d_weights_winograd_6x3_s1_xfbyb)
         CLDNN_ERROR_MESSAGE(
-            node.id(),
+            desc->id,
             "Input for convolution should not be in winograd weights format - it is reserved for weights only");
 
     if (input_layout.format == format::winograd_2x3_s1_data) {
-        CLDNN_ERROR_NOT_EQUAL(node.id(),
+        CLDNN_ERROR_NOT_EQUAL(desc->id,
                               "convolution split",
                               split,
                               "expected value",
                               1,
                               "Convolution with winograd input only supports split == 1");
-        CLDNN_ERROR_NOT_EQUAL(node.id(),
+        CLDNN_ERROR_NOT_EQUAL(desc->id,
                               "stride spatial X",
                               stride_x,
                               "expected value",
                               1,
                               "Convolution's input in winograd_2x3_s1_data format can only be used with stride 1x1");
-        CLDNN_ERROR_NOT_EQUAL(node.id(),
+        CLDNN_ERROR_NOT_EQUAL(desc->id,
                               "stride spatial Y",
                               stride_y,
                               "expected value",
                               1,
                               "Convolution's input in winograd_2x3_s1_data format can only be used with stride 1x1");
-        CLDNN_ERROR_NOT_EQUAL(node.id(),
+        CLDNN_ERROR_NOT_EQUAL(desc->id,
                               "Dilatation spatial X",
                               dilation_x,
                               "expected value",
                               1,
                               "Winograd 2x3 convolution does not support dilatation");
-        CLDNN_ERROR_NOT_EQUAL(node.id(),
+        CLDNN_ERROR_NOT_EQUAL(desc->id,
                               "Dilatation spatial Y",
                               dilation_y,
                               "expected value",
                               1,
                               "Winograd 2x3 convolution does not support dilatation");
         if (input_layout.feature() % 32 != 0)
-            CLDNN_ERROR_MESSAGE(node.id(),
+            CLDNN_ERROR_MESSAGE(desc->id,
                                 "Input for winograd 2x3 convolution should have features count divisable by 32");
         if (weights_layout.ofm() % 32 != 0)
-            CLDNN_ERROR_MESSAGE(node.id(),
+            CLDNN_ERROR_MESSAGE(desc->id,
                                 "Number of filters (OFM) for winograd 2x3 convolution should be divisable by 32");
 
-        CLDNN_ERROR_LESS_THAN(node.id(),
+        CLDNN_ERROR_LESS_THAN(desc->id,
                               "input width",
                               input_layout.spatial(0),
                               "filter width",
                               3,
                               "Convolution input is smaller than weights");
-        CLDNN_ERROR_LESS_THAN(node.id(),
+        CLDNN_ERROR_LESS_THAN(desc->id,
                               "input height",
                               input_layout.spatial(1),
                               "filter height",
@@ -222,19 +223,19 @@ layout convolution_inst::calc_output_layout(convolution_node const& node) {
     // get output feature map from weights. It should be the same as number of biases. Will be verifed in
     // convolution::create()
     if (desc->with_output_size) {
-        CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+        CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                        "User defined output spatial X",
                                        desc->output_size.spatial[0],
                                        "value",
                                        0,
                                        "must be positive(>= 1)");
-        CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+        CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                        "User defined output spatial Y",
                                        desc->output_size.spatial[1],
                                        "value",
                                        0,
                                        "must be positive(>= 1)");
-        CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+        CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                        "User defined output spatial Z",
                                        desc->output_size.spatial[2],
                                        "value",

--- a/src/plugins/intel_gpu/src/graph/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/crop.cpp
@@ -15,13 +15,14 @@ primitive_type_id crop::type_id() {
     return &instance;
 }
 
-layout crop_inst::calc_output_layout(crop_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout crop_inst::calc_output_layout(crop_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for crop_node!");
-    const auto& ref_in_sizes = node.get_primitive()->reference_input;
-    const auto in_layout = node.input().get_output_layout();
+    auto desc = impl_param.typed_desc<crop>();
+    const auto& ref_in_sizes = desc->reference_input;
+    const auto in_layout = impl_param.input_layouts[0];
     const auto& in_sizes = in_layout.get_tensor();
-    const auto& offsets = node.get_primitive()->offsets;
+    const auto& offsets = desc->offsets;
 
     // Check for borders variant of crop.
     if (ref_in_sizes.batch[0] < 0 || ref_in_sizes.feature[0] < 0 || ref_in_sizes.spatial[0] < 0 ||

--- a/src/plugins/intel_gpu/src/graph/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_gpu/src/graph/ctc_greedy_decoder.cpp
@@ -13,9 +13,9 @@ primitive_type_id ctc_greedy_decoder::type_id() {
     return &instance;
 }
 
-layout ctc_greedy_decoder_inst::calc_output_layout(ctc_greedy_decoder_node const& node) {
-    auto input_node_layout = node.input().get_non_padded_output_layout();
-    auto prim = node.get_primitive();
+layout ctc_greedy_decoder_inst::calc_output_layout(ctc_greedy_decoder_node const& node, kernel_impl_params const& impl_param) {
+    auto input_node_layout = impl_param.input_layouts[0];
+    auto prim = impl_param.typed_desc<ctc_greedy_decoder>();
     auto output_type = prim->output_data_type ? *prim->output_data_type : input_node_layout.data_type;
 
     return layout(output_type, input_node_layout.format, prim->output_tensor);

--- a/src/plugins/intel_gpu/src/graph/cum_sum.cpp
+++ b/src/plugins/intel_gpu/src/graph/cum_sum.cpp
@@ -15,8 +15,8 @@ primitive_type_id cum_sum::type_id() {
     return &instance;
 }
 
-layout cum_sum_inst::calc_output_layout(cum_sum_node const& node) {
-    return node.input(0).get_output_layout();
+layout cum_sum_inst::calc_output_layout(cum_sum_node const& node, kernel_impl_params const& impl_param) {
+    return impl_param.input_layouts[0];
 }
 
 std::string cum_sum_inst::to_string(cum_sum_node const& node) {

--- a/src/plugins/intel_gpu/src/graph/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/deconvolution.cpp
@@ -18,21 +18,22 @@ primitive_type_id deconvolution::type_id() {
     return &instance;
 }
 
-layout deconvolution_inst::calc_output_layout(deconvolution_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout deconvolution_inst::calc_output_layout(deconvolution_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for deconvolution_node!");
-    auto desc = node.get_primitive();
+    auto desc = impl_param.typed_desc<deconvolution>();
 
-    auto input_layout = node.input().get_output_layout();
-    auto weights_layout = node.weights(0).get_output_layout().convert_to_weights_layout(desc->grouped_weights_shape);
+    auto input_layout = impl_param.input_layouts[0];
+    auto weights_layout = *impl_param.weights_layout;
+    weights_layout = weights_layout.convert_to_weights_layout(desc->grouped_weights_shape);
 
     auto data_type = input_layout.data_type;
-    if ((input_layout.data_type == data_types::i8 || input_layout.data_type == data_types::u8) && !node.has_fused_primitives()) {
+    if ((input_layout.data_type == data_types::i8 || input_layout.data_type == data_types::u8) && !impl_param.has_fused_primitives()) {
         data_type = data_types::f32;
     }
 
-    if (node.has_fused_primitives()) {
-        data_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        data_type = impl_param.get_fused_output_layout().data_type;
     }
 
     auto pad = desc->pad;
@@ -41,19 +42,19 @@ layout deconvolution_inst::calc_output_layout(deconvolution_node const& node) {
     int32_t number_of_features = weights_layout.group() * weights_layout.ofm();
 
     if (desc->with_output_size) {
-        CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+        CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                        "User-defined output spatial X",
                                        desc->output_size.spatial[0],
                                        "value 0",
                                        0,
                                        "User-defined size of output layout must be positive (>= 1)");
-        CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+        CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                        "User-defined output spatial Y",
                                        desc->output_size.spatial[1],
                                        "value 0",
                                        0,
                                        "User-defined size of output layout must be positive (>= 1)");
-        CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+        CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                        "User-defined output spatial Z",
                                        desc->output_size.spatial[2],
                                        "value 0",
@@ -70,7 +71,7 @@ layout deconvolution_inst::calc_output_layout(deconvolution_node const& node) {
 
     int32_t off_factor = -2;
     size_t spatial_dims = input_layout.get_spatial_rank();
-    CLDNN_ERROR_GREATER_THAN(node.id(),
+    CLDNN_ERROR_GREATER_THAN(desc->id,
                              "number of spatial dimensions",
                              spatial_dims,
                              "expected number of dimensions",

--- a/src/plugins/intel_gpu/src/graph/deformable_convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/deformable_convolution.cpp
@@ -15,13 +15,13 @@ primitive_type_id deformable_conv::type_id() {
     return &instance;
 }
 
-layout deformable_conv_inst::calc_output_layout(deformable_conv_node const& node) {
-    auto desc = node.get_primitive();
+layout deformable_conv_inst::calc_output_layout(deformable_conv_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<deformable_conv>();
 
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
 
     auto input_type = input_layout.data_type;
-    auto output_type = node.get_primitive()->output_data_type ? *node.get_primitive()->output_data_type : input_type;
+    auto output_type = desc->output_data_type ? *desc->output_data_type : input_type;
 
     tensor output_size(input_layout.batch(),
                        desc->output_size.feature[0],
@@ -61,7 +61,7 @@ primitive_type_id deformable_interp::type_id() {
     return &instance;
 }
 
-layout deformable_interp_inst::calc_output_layout(deformable_interp_node const& node) {
+layout deformable_interp_inst::calc_output_layout(deformable_interp_node const& node, kernel_impl_params const& impl_param) {
     auto desc = node.get_primitive();
 
     auto input_layout = node.input().get_output_layout();

--- a/src/plugins/intel_gpu/src/graph/depth_to_space.cpp
+++ b/src/plugins/intel_gpu/src/graph/depth_to_space.cpp
@@ -15,22 +15,22 @@ primitive_type_id depth_to_space::type_id() {
     return &instance;
 }
 
-layout depth_to_space_inst::calc_output_layout(depth_to_space_node const& node) {
-    auto desc = node.get_primitive();
+layout depth_to_space_inst::calc_output_layout(depth_to_space_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<depth_to_space>();
 
-    auto input_layout = node.input(0).get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     auto input_format = input_layout.format;
 
     const size_t block_size = desc->block_size;
 
     if (block_size < 2)
-        CLDNN_ERROR_MESSAGE(node.id(),
+        CLDNN_ERROR_MESSAGE(desc->id,
                             "Invalid depthToSpace block_size value (should equal at least two). Actual block size is" +
                                 std::to_string(block_size));
 
     if (input_layout.feature() % (block_size * block_size) != 0)
         CLDNN_ERROR_MESSAGE(
-            node.id(),
+            desc->id,
             "The depth of the input tensor must be divisible by squared block size. Actual block size is " +
                 std::to_string(block_size));
 
@@ -48,8 +48,8 @@ layout depth_to_space_inst::calc_output_layout(depth_to_space_node const& node) 
         out_size = tensor(TensorValue(input_layout.batch()), TensorValue(feature), TensorValue(x), TensorValue(y));
     }
 
-    if (node.has_fused_primitives()) {
-        input_layout.data_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        input_layout.data_type = impl_param.get_fused_output_layout().data_type;
     }
 
     return layout{input_layout.data_type, input_format, out_size};

--- a/src/plugins/intel_gpu/src/graph/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/detection_output.cpp
@@ -14,18 +14,19 @@ primitive_type_id detection_output::type_id() {
     return &instance;
 }
 
-layout detection_output_inst::calc_output_layout(detection_output_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout detection_output_inst::calc_output_layout(detection_output_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for "
            "detection_output_node!");
-    CLDNN_ERROR_NOT_EQUAL(node.id(),
+    auto desc = impl_param.typed_desc<detection_output>();
+    CLDNN_ERROR_NOT_EQUAL(desc->id,
                           "Detection output layer input number",
-                          node.get_dependencies().size(),
+                          impl_param.input_layouts.size(),
                           "expected number of inputs",
                           static_cast<size_t>(3),
                           "");
 
-    auto input_layout = node.location().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
 
     // Batch size and feature size are 1.
     // Number of bounding boxes to be kept is set to keep_top_k*batch size.
@@ -33,16 +34,16 @@ layout detection_output_inst::calc_output_layout(detection_output_node const& no
     // Each row is a 7 dimension vector, which stores:
     // [image_id, label, confidence, xmin, ymin, xmax, ymax]
     int output_size = static_cast<int>(input_layout.get_linear_size()) / PRIOR_BOX_SIZE;
-    int num_classes = node.get_primitive()->num_classes;
+    int num_classes = desc->num_classes;
 
-    if (node.get_primitive()->share_location) {
-        num_classes = (node.get_primitive()->background_label_id == 0) ? node.get_primitive()->num_classes - 1
-                                                                       : node.get_primitive()->num_classes;
+    if (desc->share_location) {
+        num_classes = (desc->background_label_id == 0) ? desc->num_classes - 1
+                                                       : desc->num_classes;
         output_size *= num_classes;
     }
 
-    if (node.get_primitive()->top_k != -1) {
-        int top_k = node.get_primitive()->top_k * num_classes * input_layout.batch();
+    if (desc->top_k != -1) {
+        int top_k = desc->top_k * num_classes * input_layout.batch();
         if (top_k < output_size) {
             output_size = top_k;
         }
@@ -53,7 +54,7 @@ layout detection_output_inst::calc_output_layout(detection_output_node const& no
     output_size += ((input_layout.batch() + 15) / 16) * 16;
 
     return {input_layout.data_type, cldnn::format::bfyx,
-            cldnn::tensor(1, 1, DETECTION_OUTPUT_ROW_SIZE, node.get_primitive()->keep_top_k * input_layout.batch())};
+            cldnn::tensor(1, 1, DETECTION_OUTPUT_ROW_SIZE, desc->keep_top_k * input_layout.batch())};
 }
 
 std::string detection_output_inst::to_string(detection_output_node const& node) {

--- a/src/plugins/intel_gpu/src/graph/dft.cpp
+++ b/src/plugins/intel_gpu/src/graph/dft.cpp
@@ -14,9 +14,9 @@ primitive_type_id dft::type_id() {
     return &instance;
 }
 
-layout typed_primitive_inst<dft>::calc_output_layout(const dft_node& node) {
-    auto primitive = node.get_primitive();
-    auto input_layout = node.input().get_output_layout();
+layout typed_primitive_inst<dft>::calc_output_layout(const dft_node& node, kernel_impl_params const& impl_param) {
+    auto primitive = impl_param.typed_desc<dft>();
+    auto input_layout = impl_param.input_layouts[0];
 
     std::vector<tensor::value_type> dims_converted(primitive->output_shape.begin(), primitive->output_shape.end());
     auto output_format = input_layout.format;

--- a/src/plugins/intel_gpu/src/graph/embedding_bag.cpp
+++ b/src/plugins/intel_gpu/src/graph/embedding_bag.cpp
@@ -15,10 +15,10 @@ primitive_type_id embedding_bag::type_id() {
     return &instance;
 }
 
-layout embedding_bag_inst::calc_output_layout(embedding_bag_node const& node) {
-    auto desc = node.get_primitive();
+layout embedding_bag_inst::calc_output_layout(embedding_bag_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<embedding_bag>();
 
-    auto input_layout = node.input(0).get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     auto output_format = input_layout.format;
 
     auto output_shape = desc->output_shape;

--- a/src/plugins/intel_gpu/src/graph/experimental_detectron_detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/experimental_detectron_detection_output.cpp
@@ -16,9 +16,9 @@ primitive_type_id experimental_detectron_detection_output::type_id() {
 }
 
 layout experimental_detectron_detection_output_inst::calc_output_layout(
-    const experimental_detectron_detection_output_node& node) {
-    const layout data_layout = node.input().get_output_layout();
-    auto desc = node.get_primitive();
+    const experimental_detectron_detection_output_node& node, kernel_impl_params const& impl_param) {
+    const layout data_layout = impl_param.input_layouts[0];
+    auto desc = impl_param.typed_desc<experimental_detectron_detection_output>();
 
     return layout(data_layout.data_type, format::bfyx, {static_cast<int>(desc->max_detections_per_image), 4, 1, 1});
 }

--- a/src/plugins/intel_gpu/src/graph/experimental_detectron_generate_proposal_single_image.cpp
+++ b/src/plugins/intel_gpu/src/graph/experimental_detectron_generate_proposal_single_image.cpp
@@ -15,9 +15,9 @@ primitive_type_id experimental_detectron_generate_proposals_single_image::type_i
 }
 
 layout experimental_detectron_generate_proposals_single_image_inst::calc_output_layout(
-        const experimental_detectron_generate_proposals_single_image_node& node) {
-    const layout data_layout = node.input().get_output_layout();
-    auto desc = node.get_primitive();
+        const experimental_detectron_generate_proposals_single_image_node& node, kernel_impl_params const& impl_param) {
+    const layout data_layout = impl_param.input_layouts[0];
+    auto desc = impl_param.typed_desc<experimental_detectron_generate_proposals_single_image>();
 
     return layout(data_layout.data_type, format::bfyx, {static_cast<int>(desc->post_nms_count), 4, 1, 1});
 }

--- a/src/plugins/intel_gpu/src/graph/experimental_detectron_prior_grid_generator.cpp
+++ b/src/plugins/intel_gpu/src/graph/experimental_detectron_prior_grid_generator.cpp
@@ -15,9 +15,9 @@ primitive_type_id experimental_detectron_prior_grid_generator::type_id() {
 }
 
 layout experimental_detectron_prior_grid_generator_inst::calc_output_layout(
-    const experimental_detectron_prior_grid_generator_node& node) {
-    const layout data_layout = node.input().get_output_layout();
-    auto desc = node.get_primitive();
+    const experimental_detectron_prior_grid_generator_node& node, kernel_impl_params const& impl_param) {
+    const layout data_layout = impl_param.input_layouts[0];
+    auto desc = impl_param.typed_desc<experimental_detectron_prior_grid_generator>();
     if (desc->flatten) {
         return layout(data_layout.data_type,
                       format::bfyx,

--- a/src/plugins/intel_gpu/src/graph/experimental_detectron_roi_feature_extractor.cpp
+++ b/src/plugins/intel_gpu/src/graph/experimental_detectron_roi_feature_extractor.cpp
@@ -30,14 +30,15 @@ void experimental_detectron_roi_feature_extractor_inst::copy_rois_input_to_secon
     second_output_memory()->copy_from(get_network().get_stream(), *rois_memory());
 }
 
-layout experimental_detectron_roi_feature_extractor_inst::calc_output_layout(experimental_detectron_roi_feature_extractor_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout experimental_detectron_roi_feature_extractor_inst::calc_output_layout(
+    experimental_detectron_roi_feature_extractor_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for roi_pooling_node!");
-    layout rois_layout = node.input(0).get_output_layout();
-    layout data_layout = node.input(1).get_output_layout();
+    layout rois_layout = impl_param.input_layouts[0];
+    layout data_layout = impl_param.input_layouts[1];
     int num_rois = rois_layout.batch();
     int num_channels = data_layout.feature();
-    auto desc = node.get_primitive();
+    auto desc = impl_param.typed_desc<experimental_detectron_roi_feature_extractor>();
 
     return layout(data_layout.data_type, format::bfyx, {num_rois, num_channels, desc->output_dim, desc->output_dim});
 }

--- a/src/plugins/intel_gpu/src/graph/experimental_detectron_topk_rois.cpp
+++ b/src/plugins/intel_gpu/src/graph/experimental_detectron_topk_rois.cpp
@@ -19,11 +19,12 @@ experimental_detectron_topk_rois_inst::typed_primitive_inst(network& network, ex
 : parent(network, node) {
 }
 
-layout experimental_detectron_topk_rois_inst::calc_output_layout(experimental_detectron_topk_rois_node const &node) {
-    auto primitive = node.get_primitive();
-    auto input_layout = node.input(0).get_output_layout();
+layout experimental_detectron_topk_rois_inst::calc_output_layout(
+    experimental_detectron_topk_rois_node const &node, kernel_impl_params const& impl_param) {
+    auto input_layout = impl_param.input_layouts[0];
+    auto desc = impl_param.typed_desc<experimental_detectron_topk_rois>();
 
-    int32_t roi_num = std::min(input_layout.get_tensor().sizes()[0], static_cast<int32_t>(node.get_primitive()->max_rois));
+    int32_t roi_num = std::min(input_layout.get_tensor().sizes()[0], static_cast<int32_t>(desc->max_rois));
 
     return {input_layout.data_type, input_layout.format,  {roi_num,
                                                                  input_layout.get_tensor().sizes()[1], 1, 1 }};

--- a/src/plugins/intel_gpu/src/graph/extract_image_patches.cpp
+++ b/src/plugins/intel_gpu/src/graph/extract_image_patches.cpp
@@ -15,10 +15,10 @@ primitive_type_id extract_image_patches::type_id() {
     return &instance;
 }
 
-layout extract_image_patches_inst::calc_output_layout(extract_image_patches_node const& node) {
-    auto desc = node.get_primitive();
+layout extract_image_patches_inst::calc_output_layout(extract_image_patches_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<extract_image_patches>();
 
-    auto input_layout = node.input(0).get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     auto input_format = input_layout.format;
 
     auto output_shape = desc->output_shape;

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -39,11 +39,11 @@ bool is_batch_after_spatial(const std::string order) {
     return false;
 }
 
-format::type get_preferred_format(const fully_connected_node& node) {
-    auto input_layout = node.input().get_output_layout();
+format::type get_preferred_format(const fully_connected_node& node, const kernel_impl_params& impl_param) {
+    auto input_layout = impl_param.input_layouts[0];
 
     // for 3d output we have to chose bfyx format
-    if (node.get_primitive()->input_size == 3)
+    if (impl_param.typed_desc<fully_connected>()->input_size == 3)
         return format::bfyx;
 
     if (data_type_traits::is_floating_point(input_layout.data_type) &&
@@ -88,24 +88,24 @@ format::type get_preferred_format(const fully_connected_node& node) {
 
 }  // namespace
 
-layout fully_connected_inst::calc_output_layout(fully_connected_node const& node) {
-    auto desc = node.get_primitive();
+layout fully_connected_inst::calc_output_layout(fully_connected_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<fully_connected>();
 
-    auto input_layout = node.input().get_output_layout();
-    auto weights_layout = node.weights().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
+    auto weights_layout = *impl_param.weights_layout;
     auto output_type = input_layout.data_type;
     if ((output_type == data_types::u8 || output_type == data_types::i8) && desc->output_data_type)
         output_type = *desc->output_data_type;
 
-    if (node.has_fused_primitives()) {
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        output_type = impl_param.get_fused_output_layout().data_type;
     }
 
     auto output_size = tensor(input_layout.batch(), weights_layout.batch(), 1, 1);
     if (desc->input_size == 3) {
         output_size = tensor(input_layout.batch(), input_layout.feature(), 1, weights_layout.batch());
     }
-    format output_format = get_preferred_format(node);
+    format output_format = get_preferred_format(node, impl_param);
 
     return layout(output_type, output_format, output_size);
 }

--- a/src/plugins/intel_gpu/src/graph/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/gather.cpp
@@ -15,10 +15,10 @@ primitive_type_id gather::type_id() {
     return &instance;
 }
 
-layout gather_inst::calc_output_layout(gather_node const& node) {
-    auto desc = node.get_primitive();
+layout gather_inst::calc_output_layout(gather_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<gather>();
 
-    auto input_layout = node.input(0).get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     std::vector<tensor::value_type> dims_converted(desc->output_shape.begin(), desc->output_shape.end());
     // extend shape to 4d
     for (size_t i = dims_converted.size(); i < 4; i++)
@@ -53,8 +53,8 @@ layout gather_inst::calc_output_layout(gather_node const& node) {
         }
     }
     auto output_type = input_layout.data_type;
-    if (node.has_fused_primitives()) {
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        output_type = impl_param.get_fused_output_layout().data_type;
     }
 
     return layout{output_type,

--- a/src/plugins/intel_gpu/src/graph/gather_elements.cpp
+++ b/src/plugins/intel_gpu/src/graph/gather_elements.cpp
@@ -15,16 +15,16 @@ primitive_type_id gather_elements::type_id() {
     return &instance;
 }
 
-layout gather_elements_inst::calc_output_layout(gather_elements_node const& node) {
-    auto op = node.get_primitive();
+layout gather_elements_inst::calc_output_layout(gather_elements_node const& node, kernel_impl_params const& impl_param) {
+    auto op = impl_param.typed_desc<gather_elements>();
 
-    auto input_layout_origin = node.input(0).get_output_layout();
-    auto indices_layout_origin = node.input(1).get_output_layout();
+    auto input_layout_origin = impl_param.input_layouts[0];
+    auto indices_layout_origin = impl_param.input_layouts[1];
 
     auto input_layout = input_layout_origin.get_tensor().sizes(input_layout_origin.format);
     auto indices_layout = indices_layout_origin.get_tensor().sizes(indices_layout_origin.format);
 
-    auto output_type = (node.has_fused_primitives()) ? node.get_fused_output_layout().data_type :
+    auto output_type = (impl_param.has_fused_primitives()) ? impl_param.get_fused_output_layout().data_type :
                        input_layout_origin.data_type;
     auto output_shape = op->output_shape;
     auto output_format = op->output_format;
@@ -41,7 +41,7 @@ std::string gather_elements_inst::to_string(gather_elements_node const& node) {
 
     json_composite gather_elements_info;
     gather_elements_info.add("input id", input.id());
-    gather_elements_info.add("output format", calc_output_layout(node).format);
+    gather_elements_info.add("output format", calc_output_layout(node, *node.get_kernel_impl_params()).format);
     gather_elements_info.add("axis", desc->axis);
 
     node_info->add("gather_elements info", gather_elements_info);

--- a/src/plugins/intel_gpu/src/graph/gather_nd.cpp
+++ b/src/plugins/intel_gpu/src/graph/gather_nd.cpp
@@ -15,11 +15,11 @@ primitive_type_id gather_nd::type_id() {
     return &instance;
 }
 
-layout gather_nd_inst::calc_output_layout(gather_nd_node const& node) {
-    auto op = node.get_primitive();
+layout gather_nd_inst::calc_output_layout(gather_nd_node const& node, kernel_impl_params const& impl_param) {
+    auto op = impl_param.typed_desc<gather_nd>();
 
-    auto input_layout_origin = node.input(0).get_output_layout();
-    auto indices_layout_origin = node.input(1).get_output_layout();
+    auto input_layout_origin = impl_param.input_layouts[0];
+    auto indices_layout_origin = impl_param.input_layouts[1];
 
     auto input_layout = input_layout_origin.get_tensor().sizes(input_layout_origin.format);
     auto indices_layout = indices_layout_origin.get_tensor().sizes(indices_layout_origin.format);
@@ -75,8 +75,8 @@ layout gather_nd_inst::calc_output_layout(gather_nd_node const& node) {
     auto output_sizes_tensor = tensor(tensor(final_output_sizes).sizes(output_format));
     auto padding = op->output_padding;
 
-    if (node.has_fused_primitives()) {
-        input_layout_origin.data_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        input_layout_origin.data_type = impl_param.get_fused_output_layout().data_type;
     }
 
     return layout(input_layout_origin.data_type, output_format, output_sizes_tensor, padding);

--- a/src/plugins/intel_gpu/src/graph/gather_tree.cpp
+++ b/src/plugins/intel_gpu/src/graph/gather_tree.cpp
@@ -16,10 +16,10 @@ primitive_type_id gather_tree::type_id() {
     return &instance;
 }
 
-layout gather_tree_inst::calc_output_layout(gather_tree_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout gather_tree_inst::calc_output_layout(gather_tree_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
         "Output data type forcing is not supported for gather_tree_node!");
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     return input_layout;
 }
 

--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -17,11 +17,11 @@ primitive_type_id gemm::type_id() {
     return &instance;
 }
 
-layout gemm_inst::calc_output_layout(gemm_node const& node) {
-    auto prim = node.get_primitive();
+layout gemm_inst::calc_output_layout(gemm_node const& node, kernel_impl_params const& impl_param) {
+    auto prim = impl_param.typed_desc<gemm>();
 
-    auto input0_layout = node.input(0).get_output_layout();
-    auto input1_layout = node.input(1).get_output_layout();
+    auto input0_layout = impl_param.input_layouts[0];
+    auto input1_layout = impl_param.input_layouts[1];
     bool transpose_input0 = prim->transpose_input0;
     bool transpose_input1 = prim->transpose_input1;
 
@@ -30,8 +30,8 @@ layout gemm_inst::calc_output_layout(gemm_node const& node) {
 
     auto output_size = input0_layout.get_tensor();
 
-    for (size_t i = 1; i < node.inputs_count(); ++i) {
-        auto input_layout = node.input(i).get_output_layout();
+    for (size_t i = 1; i < prim->input_size(); ++i) {
+        auto input_layout = impl_param.input_layouts[i];
         output_size = tensor::max(output_size, input_layout.get_tensor());
     }
 
@@ -41,8 +41,8 @@ layout gemm_inst::calc_output_layout(gemm_node const& node) {
     if ((output_type == data_types::u8 || output_type == data_types::i8) && prim->output_data_type)
         output_type = *prim->output_data_type;
 
-    if (node.has_fused_primitives()) {
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        output_type = impl_param.get_fused_output_layout().data_type;
     }
 
     auto output_format = input0_layout.format;

--- a/src/plugins/intel_gpu/src/graph/grn.cpp
+++ b/src/plugins/intel_gpu/src/graph/grn.cpp
@@ -13,9 +13,9 @@ primitive_type_id grn::type_id() {
     return &instance;
 }
 
-layout grn_inst::calc_output_layout(grn_node const& node) {
-    auto input_node_layout = node.input().get_non_padded_output_layout();
-    auto output_type = node.get_primitive()->output_data_type ? *node.get_primitive()->output_data_type : input_node_layout.data_type;
+layout grn_inst::calc_output_layout(grn_node const& node, kernel_impl_params const& impl_param) {
+    auto input_node_layout = impl_param.get_non_padded_input_layout();
+    auto output_type = impl_param.desc->output_data_type ? *impl_param.desc->output_data_type : input_node_layout.data_type;
 
     return layout(output_type, input_node_layout.format, input_node_layout.get_tensor());
 }

--- a/src/plugins/intel_gpu/src/graph/include/activation_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/activation_inst.h
@@ -44,7 +44,7 @@ class typed_primitive_inst<activation> : public typed_primitive_inst_base<activa
     using parent = typed_primitive_inst_base<activation>;
 
 public:
-    static layout calc_output_layout(activation_node const& node);
+    static layout calc_output_layout(activation_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(activation_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/adaptive_pooling_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/adaptive_pooling_inst.h
@@ -35,7 +35,7 @@ class typed_primitive_inst<adaptive_pooling> : public typed_primitive_inst_base<
     using parent = typed_primitive_inst_base<adaptive_pooling>;
 
 public:
-    static layout calc_output_layout(const adaptive_pooling_node& node);
+    static layout calc_output_layout(const adaptive_pooling_node& node, kernel_impl_params const& impl_param);
     static std::string to_string(const adaptive_pooling_node& node);
 
     typed_primitive_inst(network& network, const adaptive_pooling_node& node)

--- a/src/plugins/intel_gpu/src/graph/include/arg_max_min_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/arg_max_min_inst.h
@@ -28,7 +28,7 @@ class typed_primitive_inst<arg_max_min> : public typed_primitive_inst_base<arg_m
     using parent = typed_primitive_inst_base<arg_max_min>;
 
 public:
-    static layout calc_output_layout(arg_max_min_node const& node);
+    static layout calc_output_layout(arg_max_min_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(arg_max_min_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/assign_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/assign_inst.h
@@ -39,7 +39,7 @@ class typed_primitive_inst<assign> : public typed_primitive_inst_base<assign>, p
     using parent = typed_primitive_inst_base<assign>;
 
 public:
-    static layout calc_output_layout(const assign_node& node);
+    static layout calc_output_layout(const assign_node& node, kernel_impl_params const& impl_param);
 
     static std::string to_string(const assign_node& node);
 

--- a/src/plugins/intel_gpu/src/graph/include/average_unpooling_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/average_unpooling_inst.h
@@ -28,7 +28,7 @@ class typed_primitive_inst<average_unpooling> : public typed_primitive_inst_base
 
 public:
     typed_primitive_inst(network& network, average_unpooling_node const& desc);
-    static layout calc_output_layout(average_unpooling_node const& node);
+    static layout calc_output_layout(average_unpooling_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(average_unpooling_node const& node);
 };
 

--- a/src/plugins/intel_gpu/src/graph/include/batch_to_space_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/batch_to_space_inst.h
@@ -27,7 +27,7 @@ class typed_primitive_inst<batch_to_space> : public typed_primitive_inst_base<ba
     using parent = typed_primitive_inst_base<batch_to_space>;
 
 public:
-    static layout calc_output_layout(batch_to_space_node const& node);
+    static layout calc_output_layout(batch_to_space_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(batch_to_space_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/binary_convolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/binary_convolution_inst.h
@@ -61,7 +61,7 @@ class typed_primitive_inst<binary_convolution> : public typed_primitive_inst_bas
     using parent = typed_primitive_inst_base<binary_convolution>;
 
 public:
-    static layout calc_output_layout(binary_convolution_node const& node);
+    static layout calc_output_layout(binary_convolution_node const& node, kernel_impl_params const& impl_param);
 
     static std::string to_string(binary_convolution_node const& node);
 

--- a/src/plugins/intel_gpu/src/graph/include/border_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/border_inst.h
@@ -32,7 +32,7 @@ class typed_primitive_inst<border> : public typed_primitive_inst_base<border> {
     using parent = typed_primitive_inst_base<border>;
 
 public:
-    static layout calc_output_layout(border_node const& node);
+    static layout calc_output_layout(border_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(border_node const& node);
     typed_primitive_inst(network& network, border_node const& node);
 };

--- a/src/plugins/intel_gpu/src/graph/include/broadcast_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/broadcast_inst.h
@@ -33,7 +33,7 @@ class typed_primitive_inst<broadcast> : public typed_primitive_inst_base<broadca
     using parent = typed_primitive_inst_base<broadcast>;
 
 public:
-    static layout calc_output_layout(broadcast_node const& node);
+    static layout calc_output_layout(broadcast_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(broadcast_node const& node);
     typed_primitive_inst(network& network, broadcast_node const& node);
 };

--- a/src/plugins/intel_gpu/src/graph/include/bucketize_inst.hpp
+++ b/src/plugins/intel_gpu/src/graph/include/bucketize_inst.hpp
@@ -29,7 +29,7 @@ public:
     using parent = typed_primitive_inst_base<bucketize>;
     using parent::parent;
 
-    static layout calc_output_layout(const bucketize_node& node);
+    static layout calc_output_layout(const bucketize_node& node, kernel_impl_params const& impl_param);
     static std::string to_string(const bucketize_node& node);
 };
 

--- a/src/plugins/intel_gpu/src/graph/include/concatenation_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/concatenation_inst.h
@@ -34,7 +34,7 @@ class typed_primitive_inst<concatenation> : public typed_primitive_inst_base<con
     using parent = typed_primitive_inst_base<concatenation>;
 
 public:
-    static layout calc_output_layout(concatenation_node const& node);
+    static layout calc_output_layout(concatenation_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(concatenation_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/condition_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/condition_inst.h
@@ -85,7 +85,7 @@ class typed_primitive_inst<condition> : public typed_primitive_inst_base<conditi
     using parent = typed_primitive_inst_base<condition>;
 
 public:
-    static layout calc_output_layout(condition_node const& node);
+    static layout calc_output_layout(condition_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(condition_node const& node);
     typed_primitive_inst(network& network, condition_node const& node);
 

--- a/src/plugins/intel_gpu/src/graph/include/convert_color_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/convert_color_inst.h
@@ -25,7 +25,7 @@ class typed_primitive_inst<convert_color> : public typed_primitive_inst_base<con
     using parent = typed_primitive_inst_base<convert_color>;
 
 public:
-    static layout calc_output_layout(convert_color_node const& node);
+    static layout calc_output_layout(convert_color_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(convert_color_node const& node);
     typed_primitive_inst(network& network, convert_color_node const& desc);
 };

--- a/src/plugins/intel_gpu/src/graph/include/convolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/convolution_inst.h
@@ -147,7 +147,7 @@ class typed_primitive_inst<convolution> : public typed_primitive_inst_base<convo
     using parent = typed_primitive_inst_base<convolution>;
 
 public:
-    static layout calc_output_layout(convolution_node const& node);
+    static layout calc_output_layout(convolution_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(convolution_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/crop_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/crop_inst.h
@@ -33,7 +33,7 @@ class typed_primitive_inst<crop> : public typed_primitive_inst_base<crop> {
     using parent = typed_primitive_inst_base<crop>;
 
 public:
-    static layout calc_output_layout(crop_node const& node);
+    static layout calc_output_layout(crop_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(crop_node const& node);
     typed_primitive_inst(network& network, crop_node const& node);
 

--- a/src/plugins/intel_gpu/src/graph/include/ctc_greedy_decoder_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/ctc_greedy_decoder_inst.h
@@ -32,7 +32,7 @@ class typed_primitive_inst<ctc_greedy_decoder> : public typed_primitive_inst_bas
     using parent = typed_primitive_inst_base<ctc_greedy_decoder>;
 
 public:
-    static layout calc_output_layout(ctc_greedy_decoder_node const& node);
+    static layout calc_output_layout(ctc_greedy_decoder_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(ctc_greedy_decoder_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/cum_sum_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/cum_sum_inst.h
@@ -26,7 +26,7 @@ class typed_primitive_inst<cum_sum> : public typed_primitive_inst_base<cum_sum> 
     using parent = typed_primitive_inst_base<cum_sum>;
 
 public:
-    static layout calc_output_layout(cum_sum_node const& node);
+    static layout calc_output_layout(cum_sum_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(cum_sum_node const& node);
     typed_primitive_inst(network& network, cum_sum_node const& desc);
 };

--- a/src/plugins/intel_gpu/src/graph/include/custom_gpu_primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/custom_gpu_primitive_inst.h
@@ -28,16 +28,16 @@ class typed_primitive_inst<custom_gpu_primitive> : public typed_primitive_inst_b
     using parent = typed_primitive_inst_base<custom_gpu_primitive>;
 
 public:
-    static layout calc_output_layout(custom_gpu_primitive_node const& node) {
-        assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+    static layout calc_output_layout(custom_gpu_primitive_node const& node, kernel_impl_params const& impl_param) {
+        assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
                "Output data type forcing is not supported for "
                "custom_gpu_primitive_node!");
-        layout output_layout = node.get_primitive()->output_layout;
+        layout output_layout = impl_param.typed_desc<custom_gpu_primitive>()->output_layout;
 
         // if the output layout format was set to any, it means the layer output format will be the same as the first
         // input
         if (output_layout.format == format::any) {
-            output_layout.format = node.get_dependency(0).get_output_layout().format;
+            output_layout.format = impl_param.input_layouts[0].format;
         }
         return output_layout;
     }

--- a/src/plugins/intel_gpu/src/graph/include/data_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/data_inst.h
@@ -33,7 +33,10 @@ class typed_primitive_inst<data> : public typed_primitive_inst_base<data> {
     using parent = typed_primitive_inst_base<data>;
 
 public:
-    static layout calc_output_layout(data_node const& node) { return node.get_attached_memory().get_layout(); }
+    static layout calc_output_layout(data_node const& node, kernel_impl_params const& impl_param) {
+        return node.get_attached_memory().get_layout();
+    }
+
     static std::string to_string(data_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
@@ -95,7 +95,7 @@ class typed_primitive_inst<deconvolution> : public typed_primitive_inst_base<dec
     using parent = typed_primitive_inst_base<deconvolution>;
 
 public:
-    static layout calc_output_layout(deconvolution_node const& node);
+    static layout calc_output_layout(deconvolution_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(deconvolution_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/deformable_convolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/deformable_convolution_inst.h
@@ -79,7 +79,7 @@ class typed_primitive_inst<deformable_conv> : public typed_primitive_inst_base<d
     using parent = typed_primitive_inst_base<deformable_conv>;
 
 public:
-    static layout calc_output_layout(deformable_conv_node const& node);
+    static layout calc_output_layout(deformable_conv_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(deformable_conv_node const& node);
 
 public:
@@ -159,7 +159,7 @@ class typed_primitive_inst<deformable_interp> : public typed_primitive_inst_base
     using parent = typed_primitive_inst_base<deformable_interp>;
 
 public:
-    static layout calc_output_layout(deformable_interp_node const& node);
+    static layout calc_output_layout(deformable_interp_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(deformable_interp_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/depth_to_space_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/depth_to_space_inst.h
@@ -32,7 +32,7 @@ class typed_primitive_inst<depth_to_space> : public typed_primitive_inst_base<de
     using parent = typed_primitive_inst_base<depth_to_space>;
 
 public:
-    static layout calc_output_layout(depth_to_space_node const& node);
+    static layout calc_output_layout(depth_to_space_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(depth_to_space_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/detection_output_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/detection_output_inst.h
@@ -35,7 +35,7 @@ class typed_primitive_inst<detection_output> : public typed_primitive_inst_base<
     using parent = typed_primitive_inst_base<detection_output>;
 
 public:
-    static layout calc_output_layout(detection_output_node const& node);
+    static layout calc_output_layout(detection_output_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(detection_output_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/dft_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/dft_inst.h
@@ -26,7 +26,7 @@ class typed_primitive_inst<dft> : public typed_primitive_inst_base<dft> {
 public:
     using typed_primitive_inst_base::typed_primitive_inst_base;
 
-    static layout calc_output_layout(const dft_node& node);
+    static layout calc_output_layout(const dft_node& node, kernel_impl_params const& impl_param);
     static std::string to_string(const dft_node& node);
 };
 

--- a/src/plugins/intel_gpu/src/graph/include/eltwise_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/eltwise_inst.h
@@ -85,7 +85,7 @@ class typed_primitive_inst<eltwise> : public typed_primitive_inst_base<eltwise> 
     static void check_inputs_count(eltwise_node const& node);
 
 public:
-    static layout calc_output_layout(eltwise_node const& node);
+    static layout calc_output_layout(eltwise_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(eltwise_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/embedding_bag_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/embedding_bag_inst.h
@@ -28,7 +28,7 @@ class typed_primitive_inst<embedding_bag> : public typed_primitive_inst_base<emb
     using parent = typed_primitive_inst_base<embedding_bag>;
 
 public:
-    static layout calc_output_layout(embedding_bag_node const& node);
+    static layout calc_output_layout(embedding_bag_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(embedding_bag_node const& node);
     typed_primitive_inst(network& network, embedding_bag_node const& desc);
 };

--- a/src/plugins/intel_gpu/src/graph/include/experimental_detectron_detection_output_inst.hpp
+++ b/src/plugins/intel_gpu/src/graph/include/experimental_detectron_detection_output_inst.hpp
@@ -47,7 +47,7 @@ class typed_primitive_inst<experimental_detectron_detection_output>
     using parent = typed_primitive_inst_base<experimental_detectron_detection_output>;
 
 public:
-    static layout calc_output_layout(const experimental_detectron_detection_output_node& node);
+    static layout calc_output_layout(const experimental_detectron_detection_output_node& node, kernel_impl_params const& impl_param);
     static std::string to_string(const experimental_detectron_detection_output_node& node);
 
     typed_primitive_inst(network& network, const experimental_detectron_detection_output_node& node)

--- a/src/plugins/intel_gpu/src/graph/include/experimental_detectron_generate_proposals_single_image_inst.hpp
+++ b/src/plugins/intel_gpu/src/graph/include/experimental_detectron_generate_proposals_single_image_inst.hpp
@@ -34,7 +34,7 @@ class typed_primitive_inst<experimental_detectron_generate_proposals_single_imag
     using parent = typed_primitive_inst_base<experimental_detectron_generate_proposals_single_image>;
 
 public:
-    static layout calc_output_layout(const experimental_detectron_generate_proposals_single_image_node& node);
+    static layout calc_output_layout(const experimental_detectron_generate_proposals_single_image_node& node, kernel_impl_params const& impl_param);
     static std::string to_string(const experimental_detectron_generate_proposals_single_image_node& node);
 
     typed_primitive_inst(network& network, const experimental_detectron_generate_proposals_single_image_node& node)

--- a/src/plugins/intel_gpu/src/graph/include/experimental_detectron_prior_grid_generator_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/experimental_detectron_prior_grid_generator_inst.h
@@ -27,7 +27,7 @@ class typed_primitive_inst<experimental_detectron_prior_grid_generator>
 public:
     using typed_primitive_inst_base::typed_primitive_inst_base;
 
-    static layout calc_output_layout(experimental_detectron_prior_grid_generator_node const& node);
+    static layout calc_output_layout(experimental_detectron_prior_grid_generator_node const& node, kernel_impl_params const& impl_param);
 
     static std::string to_string(experimental_detectron_prior_grid_generator_node const& node);
 };

--- a/src/plugins/intel_gpu/src/graph/include/experimental_detectron_roi_feature_extractor_inst.hpp
+++ b/src/plugins/intel_gpu/src/graph/include/experimental_detectron_roi_feature_extractor_inst.hpp
@@ -28,7 +28,7 @@ public:
     size_t inputs_memory_count() const;
     void copy_rois_input_to_second_output() const;
 
-    static layout calc_output_layout(experimental_detectron_roi_feature_extractor_node const& node);
+    static layout calc_output_layout(experimental_detectron_roi_feature_extractor_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(experimental_detectron_roi_feature_extractor_node const& node);
 
 private:

--- a/src/plugins/intel_gpu/src/graph/include/experimental_detectron_topk_rois_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/experimental_detectron_topk_rois_inst.h
@@ -26,7 +26,7 @@ class typed_primitive_inst<experimental_detectron_topk_rois> : public typed_prim
     using parent = typed_primitive_inst_base<experimental_detectron_topk_rois>;
 
 public:
-    static layout calc_output_layout(experimental_detectron_topk_rois_node const &node);
+    static layout calc_output_layout(experimental_detectron_topk_rois_node const &node, kernel_impl_params const& impl_param);
 
     static std::string to_string(experimental_detectron_topk_rois_node const &node);
 

--- a/src/plugins/intel_gpu/src/graph/include/extract_image_patches_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/extract_image_patches_inst.h
@@ -25,7 +25,7 @@ class typed_primitive_inst<extract_image_patches> : public typed_primitive_inst_
     using parent = typed_primitive_inst_base<extract_image_patches>;
 
 public:
-    static layout calc_output_layout(extract_image_patches_node const& node);
+    static layout calc_output_layout(extract_image_patches_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(extract_image_patches_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/fully_connected_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/fully_connected_inst.h
@@ -40,7 +40,7 @@ class typed_primitive_inst<fully_connected> : public typed_primitive_inst_base<f
     using parent = typed_primitive_inst_base<fully_connected>;
 
 public:
-    static layout calc_output_layout(fully_connected_node const& node);
+    static layout calc_output_layout(fully_connected_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(fully_connected_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/gather_elements_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/gather_elements_inst.h
@@ -38,7 +38,7 @@ class typed_primitive_inst<gather_elements> : public typed_primitive_inst_base<g
     using parent = typed_primitive_inst_base<gather_elements>;
 
 public:
-    static layout calc_output_layout(gather_elements_node const& node);
+    static layout calc_output_layout(gather_elements_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(gather_elements_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/gather_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/gather_inst.h
@@ -27,7 +27,7 @@ class typed_primitive_inst<gather> : public typed_primitive_inst_base<gather> {
     using parent = typed_primitive_inst_base<gather>;
 
 public:
-    static layout calc_output_layout(gather_node const& node);
+    static layout calc_output_layout(gather_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(gather_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/gather_nd_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/gather_nd_inst.h
@@ -25,7 +25,7 @@ class typed_primitive_inst<gather_nd> : public typed_primitive_inst_base<gather_
     using parent = typed_primitive_inst_base<gather_nd>;
 
 public:
-    static layout calc_output_layout(gather_nd_node const& node);
+    static layout calc_output_layout(gather_nd_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(gather_nd_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/gather_tree_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/gather_tree_inst.h
@@ -28,7 +28,7 @@ class typed_primitive_inst<gather_tree> : public typed_primitive_inst_base<gathe
     using parent = typed_primitive_inst_base<gather_tree>;
 
 public:
-    static layout calc_output_layout(gather_tree_node const& node);
+    static layout calc_output_layout(gather_tree_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(gather_tree_node const& node);
     typed_primitive_inst(network& network, gather_tree_node const& node);
 };

--- a/src/plugins/intel_gpu/src/graph/include/gemm_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/gemm_inst.h
@@ -28,7 +28,7 @@ class typed_primitive_inst<gemm> : public typed_primitive_inst_base<gemm> {
     using parent = typed_primitive_inst_base<gemm>;
 
 public:
-    static layout calc_output_layout(gemm_node const& node);
+    static layout calc_output_layout(gemm_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(gemm_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/generic_layer_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/generic_layer_inst.h
@@ -30,7 +30,9 @@ class typed_primitive_inst<generic_layer> : public typed_primitive_inst_base<gen
     using parent = typed_primitive_inst_base<generic_layer>;
 
 public:
-    static layout calc_output_layout(generic_layer_node const& node) { return node.get_primitive()->output_layout; }
+    static layout calc_output_layout(generic_layer_node const& node, kernel_impl_params const& impl_param) {
+        return impl_param.typed_desc<generic_layer>()->output_layout;
+    }
 
     static std::string to_string(generic_layer_node const& node);
 

--- a/src/plugins/intel_gpu/src/graph/include/grn_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/grn_inst.h
@@ -28,7 +28,7 @@ class typed_primitive_inst<grn> : public typed_primitive_inst_base<grn> {
     using parent = typed_primitive_inst_base<grn>;
 
 public:
-    static layout calc_output_layout(grn_node const& node);
+    static layout calc_output_layout(grn_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(grn_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/input_layout_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/input_layout_inst.h
@@ -28,7 +28,9 @@ class typed_primitive_inst<input_layout> : public typed_primitive_inst_base<inpu
     using parent = typed_primitive_inst_base<input_layout>;
 
 public:
-    static layout calc_output_layout(input_layout_node const& node) { return node.get_primitive()->layout; }
+    static layout calc_output_layout(input_layout_node const& node, kernel_impl_params const& impl_param) {
+        return impl_param.typed_desc<input_layout>()->layout;
+    }
     static std::string to_string(input_layout_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/kernel_selector_helper.h
+++ b/src/plugins/intel_gpu/src/graph/include/kernel_selector_helper.h
@@ -144,6 +144,20 @@ struct kernel_impl_params {
                          activations_zero_points_layout(_activations_zero_points_layout),
                          compensation_layout(_compensation_layout) {}
 
+    layout get_non_padded_input_layout(size_t idx = 0) const {
+        auto input_layout = input_layouts[idx];
+        auto result = layout({input_layout.data_type, input_layout.format, input_layout.get_tensor()});
+        return result;
+    }
+
+    bool has_fused_primitives() const { return !fused_desc.empty(); }
+
+    layout get_fused_output_layout() const {
+        if (fused_desc.empty())
+            return layout(data_types::f32, format::bfyx, tensor());
+        return fused_desc.back().output_layout;
+    }
+
     template <class PType>
     std::shared_ptr<const PType> typed_desc() const { return std::static_pointer_cast<const PType>(desc); }
 };

--- a/src/plugins/intel_gpu/src/graph/include/loop_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/loop_inst.h
@@ -548,7 +548,7 @@ private:
         const int64_t bytes_iteration_initial_offset;
     };
 
-    static layout calc_output_layout(const loop_node& node);
+    static layout calc_output_layout(const loop_node& node, kernel_impl_params const& impl_param);
     bool preproc_memories_done;
     std::vector<backedge_memory_mapping> backedge_memory_mappings;
     std::vector<concatenated_memory_mapping> concatenated_input_mem_mappings;

--- a/src/plugins/intel_gpu/src/graph/include/lrn_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/lrn_inst.h
@@ -18,7 +18,7 @@ class typed_primitive_inst<lrn> : public typed_primitive_inst_base<lrn> {
     using parent = typed_primitive_inst_base<lrn>;
 
 public:
-    static layout calc_output_layout(lrn_node const& node);
+    static layout calc_output_layout(lrn_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(lrn_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/lstm_dynamic_input_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/lstm_dynamic_input_inst.h
@@ -41,7 +41,7 @@ class typed_primitive_inst<lstm_dynamic_input> : public typed_primitive_inst_bas
     using parent = typed_primitive_inst_base<lstm_dynamic_input>;
 
 public:
-    static layout calc_output_layout(lstm_dynamic_input_node const& node);
+    static layout calc_output_layout(lstm_dynamic_input_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(lstm_dynamic_input_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/lstm_dynamic_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/lstm_dynamic_inst.h
@@ -37,7 +37,7 @@ class typed_primitive_inst<lstm_dynamic> : public typed_primitive_inst_base<lstm
     using parent = typed_primitive_inst_base<lstm_dynamic>;
 
 public:
-    static layout calc_output_layout(lstm_dynamic_node const& node);
+    static layout calc_output_layout(lstm_dynamic_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(lstm_dynamic_node const& node);
 
     typed_primitive_inst(network& network, lstm_dynamic_node const& node);

--- a/src/plugins/intel_gpu/src/graph/include/lstm_dynamic_timeloop_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/lstm_dynamic_timeloop_inst.h
@@ -62,7 +62,7 @@ class typed_primitive_inst<lstm_dynamic_timeloop> : public typed_primitive_inst_
     using parent = typed_primitive_inst_base<lstm_dynamic_timeloop>;
 
 public:
-    static layout calc_output_layout(lstm_dynamic_timeloop_node const& node);
+    static layout calc_output_layout(lstm_dynamic_timeloop_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(lstm_dynamic_timeloop_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/lstm_elt_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/lstm_elt_inst.h
@@ -38,7 +38,7 @@ class typed_primitive_inst<lstm_elt> : public typed_primitive_inst_base<lstm_elt
     using parent = typed_primitive_inst_base<lstm_elt>;
 
 public:
-    static layout calc_output_layout(lstm_elt_node const& node);
+    static layout calc_output_layout(lstm_elt_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(lstm_elt_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/lstm_gemm_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/lstm_gemm_inst.h
@@ -34,7 +34,7 @@ class typed_primitive_inst<lstm_gemm> : public typed_primitive_inst_base<lstm_ge
     using parent = typed_primitive_inst_base<lstm_gemm>;
 
 public:
-    static layout calc_output_layout(lstm_gemm_node const& node);
+    static layout calc_output_layout(lstm_gemm_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(lstm_gemm_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/lstm_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/lstm_inst.h
@@ -46,7 +46,7 @@ class typed_primitive_inst<lstm> : public typed_primitive_inst_base<lstm> {
     using parent = typed_primitive_inst_base<lstm>;
 
 public:
-    static layout calc_output_layout(lstm_node const& node);
+    static layout calc_output_layout(lstm_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(lstm_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/max_unpooling_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/max_unpooling_inst.h
@@ -31,7 +31,7 @@ class typed_primitive_inst<max_unpooling> : public typed_primitive_inst_base<max
 
 public:
     typed_primitive_inst(network& network, max_unpooling_node const& desc);
-    static layout calc_output_layout(max_unpooling_node const& node);
+    static layout calc_output_layout(max_unpooling_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(max_unpooling_node const& node);
 };
 

--- a/src/plugins/intel_gpu/src/graph/include/mutable_data_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/mutable_data_inst.h
@@ -35,7 +35,10 @@ class typed_primitive_inst<mutable_data> : public typed_primitive_inst_base<muta
     using parent = typed_primitive_inst_base<mutable_data>;
 
 public:
-    static layout calc_output_layout(mutable_data_node const& node) { return node.get_attached_memory().get_layout(); }
+    static layout calc_output_layout(mutable_data_node const& node, kernel_impl_params const& impl_param) {
+        return node.get_attached_memory().get_layout();
+    }
+
     static std::string to_string(mutable_data_node const& node);
 
     typed_primitive_inst(network& network, mutable_data_node const& node);

--- a/src/plugins/intel_gpu/src/graph/include/mvn_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/mvn_inst.h
@@ -28,7 +28,7 @@ class typed_primitive_inst<mvn> : public typed_primitive_inst_base<mvn> {
     using parent = typed_primitive_inst_base<mvn>;
 
 public:
-    static layout calc_output_layout(mvn_node const& node);
+    static layout calc_output_layout(mvn_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(mvn_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/non_max_suppression_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/non_max_suppression_inst.h
@@ -93,7 +93,7 @@ public:
         : parent(network, node)
     {}
 
-    static layout calc_output_layout(non_max_suppression_node const& node);
+    static layout calc_output_layout(non_max_suppression_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(non_max_suppression_node const& node);
 
     memory::ptr input_boxes_mem() const {

--- a/src/plugins/intel_gpu/src/graph/include/normalize_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/normalize_inst.h
@@ -29,7 +29,7 @@ class typed_primitive_inst<normalize> : public typed_primitive_inst_base<normali
     using parent = typed_primitive_inst_base<normalize>;
 
 public:
-    static layout calc_output_layout(normalize_node const& node);
+    static layout calc_output_layout(normalize_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(normalize_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/one_hot_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/one_hot_inst.h
@@ -32,7 +32,7 @@ class typed_primitive_inst<one_hot> : public typed_primitive_inst_base<one_hot> 
     using parent = typed_primitive_inst_base<one_hot>;
 
 public:
-    static layout calc_output_layout(one_hot_node const& node);
+    static layout calc_output_layout(one_hot_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(one_hot_node const& node);
     typed_primitive_inst(network& network, one_hot_node const& node);
 };

--- a/src/plugins/intel_gpu/src/graph/include/permute_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/permute_inst.h
@@ -45,7 +45,7 @@ class typed_primitive_inst<permute> : public typed_primitive_inst_base<permute> 
     using parent = typed_primitive_inst_base<permute>;
 
 public:
-    static layout calc_output_layout(permute_node const& node);
+    static layout calc_output_layout(permute_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(permute_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/pooling_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/pooling_inst.h
@@ -32,7 +32,7 @@ class typed_primitive_inst<pooling> : public typed_primitive_inst_base<pooling> 
     using parent = typed_primitive_inst_base<pooling>;
 
 public:
-    static layout calc_output_layout(pooling_node const& node);
+    static layout calc_output_layout(pooling_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(pooling_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/primitive_type.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_type.h
@@ -36,7 +36,7 @@ struct primitive_type {
     virtual bool does_possible_implementation_exist(const program_node& node) const = 0;
     virtual bool does_possible_implementation_exist(const program_node& node, std::shared_ptr<kernel_impl_params> params) const = 0;
 
-    virtual layout calc_output_layout(const program_node& node) const = 0;
+    virtual layout calc_output_layout(const program_node& node, const kernel_impl_params& params) const = 0;
     virtual std::string to_string(const program_node& node) const = 0;
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/include/primitive_type_base.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_type_base.h
@@ -70,11 +70,11 @@ struct primitive_type_base : primitive_type {
         return implementation_map<PType>::check_io_eq(node, impl_param);
     }
 
-    cldnn::layout calc_output_layout(const cldnn::program_node& node) const override {
+    cldnn::layout calc_output_layout(const cldnn::program_node& node, const kernel_impl_params& impl_param) const override {
         if (node.type() != this)
             throw std::invalid_argument("primitive_type_base::calc_output_layout: primitive type mismatch");
 
-        return typed_primitive_inst<PType>::calc_output_layout(node);
+        return typed_primitive_inst<PType>::calc_output_layout(node, impl_param);
     }
 
     std::string to_string(const cldnn::program_node& node) const override {

--- a/src/plugins/intel_gpu/src/graph/include/prior_box_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/prior_box_inst.h
@@ -35,7 +35,7 @@ class typed_primitive_inst<prior_box> : public typed_primitive_inst_base<prior_b
     using parent = typed_primitive_inst_base<prior_box>;
 
 public:
-    static layout calc_output_layout(prior_box_node const& node);
+    static layout calc_output_layout(prior_box_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(prior_box_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/proposal_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/proposal_inst.h
@@ -63,7 +63,7 @@ public:
         image_info_scale_depth_index,
     };
 
-    static layout calc_output_layout(proposal_node const& node);
+    static layout calc_output_layout(proposal_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(proposal_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/pyramid_roi_align_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/pyramid_roi_align_inst.h
@@ -32,7 +32,7 @@ class typed_primitive_inst<pyramid_roi_align> : public typed_primitive_inst_base
     using parent = typed_primitive_inst_base<pyramid_roi_align>;
 
 public:
-    static layout calc_output_layout(pyramid_roi_align_node const& node);
+    static layout calc_output_layout(pyramid_roi_align_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(pyramid_roi_align_node const& node);
     typed_primitive_inst(network& network, pyramid_roi_align_node const& node);
 

--- a/src/plugins/intel_gpu/src/graph/include/quantize_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/quantize_inst.h
@@ -134,7 +134,7 @@ class typed_primitive_inst<quantize> : public typed_primitive_inst_base<quantize
     using parent = typed_primitive_inst_base<quantize>;
 
 public:
-    static layout calc_output_layout(quantize_node const& node);
+    static layout calc_output_layout(quantize_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(quantize_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/random_uniform_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/random_uniform_inst.h
@@ -26,7 +26,7 @@ class typed_primitive_inst<random_uniform> : public typed_primitive_inst_base<ra
     using parent = typed_primitive_inst_base<random_uniform>;
 
 public:
-    static layout calc_output_layout(random_uniform_node const &node);
+    static layout calc_output_layout(random_uniform_node const &node, kernel_impl_params const& impl_param);
 
     static std::string to_string(random_uniform_node const &node);
 

--- a/src/plugins/intel_gpu/src/graph/include/range_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/range_inst.h
@@ -21,7 +21,7 @@ using range_node = typed_program_node<range>;
 template <>
 class typed_primitive_inst<range> : public typed_primitive_inst_base<range> {
 public:
-    static layout calc_output_layout(range_node const& node);
+    static layout calc_output_layout(range_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(range_node const& node);
 
     typed_primitive_inst(network& network, range_node const& desc);

--- a/src/plugins/intel_gpu/src/graph/include/read_value_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/read_value_inst.h
@@ -27,7 +27,7 @@ class typed_primitive_inst<read_value> : public typed_primitive_inst_base<read_v
     using parent = typed_primitive_inst_base<read_value>;
 
 public:
-    static layout calc_output_layout(const read_value_node& node);
+    static layout calc_output_layout(const read_value_node& node, kernel_impl_params const& impl_param);
 
     static std::string to_string(const read_value_node& node);
 

--- a/src/plugins/intel_gpu/src/graph/include/reduce_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reduce_inst.h
@@ -27,7 +27,7 @@ class typed_primitive_inst<reduce> : public typed_primitive_inst_base<reduce> {
     using parent = typed_primitive_inst_base<reduce>;
 
 public:
-    static layout calc_output_layout(reduce_node const& node);
+    static layout calc_output_layout(reduce_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(reduce_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/region_yolo_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/region_yolo_inst.h
@@ -17,7 +17,7 @@ class typed_primitive_inst<region_yolo> : public typed_primitive_inst_base<regio
     using parent = typed_primitive_inst_base<region_yolo>;
 
 public:
-    static layout calc_output_layout(region_yolo_node const& node);
+    static layout calc_output_layout(region_yolo_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(region_yolo_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/reorder_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reorder_inst.h
@@ -54,7 +54,7 @@ class typed_primitive_inst<reorder> : public typed_primitive_inst_base<reorder> 
     using parent = typed_primitive_inst_base<reorder>;
 
 public:
-    static layout calc_output_layout(reorder_node const& node);
+    static layout calc_output_layout(reorder_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(reorder_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/reorg_yolo_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reorg_yolo_inst.h
@@ -17,7 +17,7 @@ class typed_primitive_inst<reorg_yolo> : public typed_primitive_inst_base<reorg_
     using parent = typed_primitive_inst_base<reorg_yolo>;
 
 public:
-    static layout calc_output_layout(reorg_yolo_node const& node);
+    static layout calc_output_layout(reorg_yolo_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(reorg_yolo_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/resample_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/resample_inst.h
@@ -32,7 +32,7 @@ class typed_primitive_inst<resample> : public typed_primitive_inst_base<resample
     using parent = typed_primitive_inst_base<resample>;
 
 public:
-    static layout calc_output_layout(resample_node const& node);
+    static layout calc_output_layout(resample_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(resample_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
@@ -42,7 +42,7 @@ class typed_primitive_inst<reshape> : public typed_primitive_inst_base<reshape> 
     using parent = typed_primitive_inst_base<reshape>;
 
 public:
-    static layout calc_output_layout(reshape_node const& node);
+    static layout calc_output_layout(reshape_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(reshape_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/reverse_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reverse_inst.h
@@ -29,7 +29,7 @@ class typed_primitive_inst<reverse> : public typed_primitive_inst_base<reverse> 
     using parent = typed_primitive_inst_base<reverse>;
 
 public:
-    static layout calc_output_layout(reverse_node const& node);
+    static layout calc_output_layout(reverse_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(reverse_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/reverse_sequence_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reverse_sequence_inst.h
@@ -27,7 +27,7 @@ class typed_primitive_inst<reverse_sequence> : public typed_primitive_inst_base<
     using parent = typed_primitive_inst_base<reverse_sequence>;
 
 public:
-    static layout calc_output_layout(reverse_sequence_node const& node);
+    static layout calc_output_layout(reverse_sequence_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(reverse_sequence_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/roi_align_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/roi_align_inst.h
@@ -26,7 +26,7 @@ class typed_primitive_inst<roi_align> : public typed_primitive_inst_base<roi_ali
     using parent = typed_primitive_inst_base<roi_align>;
 
 public:
-    static layout calc_output_layout(roi_align_node const& node);
+    static layout calc_output_layout(roi_align_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(roi_align_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/roi_pooling_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/roi_pooling_inst.h
@@ -29,7 +29,7 @@ class typed_primitive_inst<roi_pooling> : public typed_primitive_inst_base<roi_p
     using parent = typed_primitive_inst_base<roi_pooling>;
 
 public:
-    static layout calc_output_layout(roi_pooling_node const& node);
+    static layout calc_output_layout(roi_pooling_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(roi_pooling_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/roll_inst.hpp
+++ b/src/plugins/intel_gpu/src/graph/include/roll_inst.hpp
@@ -26,7 +26,7 @@ public:
     using parent = typed_primitive_inst_base<roll>;
     using parent::parent;
 
-    static layout calc_output_layout(const roll_node& node);
+    static layout calc_output_layout(const roll_node& node, kernel_impl_params const& impl_param);
     static std::string to_string(const roll_node& node);
 };
 

--- a/src/plugins/intel_gpu/src/graph/include/scale_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/scale_inst.h
@@ -42,7 +42,7 @@ class typed_primitive_inst<scale> : public typed_primitive_inst_base<scale> {
     using parent = typed_primitive_inst_base<scale>;
 
 public:
-    static layout calc_output_layout(scale_node const& node);
+    static layout calc_output_layout(scale_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(scale_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/scatter_elements_update_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/scatter_elements_update_inst.h
@@ -26,7 +26,7 @@ class typed_primitive_inst<scatter_elements_update> : public typed_primitive_ins
     using parent = typed_primitive_inst_base<scatter_elements_update>;
 
 public:
-    static layout calc_output_layout(scatter_elements_update_node const& node);
+    static layout calc_output_layout(scatter_elements_update_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(scatter_elements_update_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/scatter_nd_update_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/scatter_nd_update_inst.h
@@ -26,7 +26,7 @@ class typed_primitive_inst<scatter_nd_update> : public typed_primitive_inst_base
     using parent = typed_primitive_inst_base<scatter_nd_update>;
 
 public:
-    static layout calc_output_layout(scatter_nd_update_node const& node);
+    static layout calc_output_layout(scatter_nd_update_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(scatter_nd_update_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/scatter_update_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/scatter_update_inst.h
@@ -27,7 +27,7 @@ class typed_primitive_inst<scatter_update> : public typed_primitive_inst_base<sc
     using parent = typed_primitive_inst_base<scatter_update>;
 
 public:
-    static layout calc_output_layout(scatter_update_node const& node);
+    static layout calc_output_layout(scatter_update_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(scatter_update_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/select_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/select_inst.h
@@ -28,7 +28,7 @@ class typed_primitive_inst<select> : public typed_primitive_inst_base<select> {
     using parent = typed_primitive_inst_base<select>;
 
 public:
-    static layout calc_output_layout(select_node const& node);
+    static layout calc_output_layout(select_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(select_node const& node);
     typed_primitive_inst(network& network, select_node const& node);
 };

--- a/src/plugins/intel_gpu/src/graph/include/shape_of_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/shape_of_inst.h
@@ -32,7 +32,7 @@ class typed_primitive_inst<shape_of> : public typed_primitive_inst_base<shape_of
     using parent = typed_primitive_inst_base<shape_of>;
 
 public:
-    static layout calc_output_layout(shape_of_node const& node);
+    static layout calc_output_layout(shape_of_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(shape_of_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/shuffle_channels_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/shuffle_channels_inst.h
@@ -27,7 +27,7 @@ class typed_primitive_inst<shuffle_channels> : public typed_primitive_inst_base<
     using parent = typed_primitive_inst_base<shuffle_channels>;
 
 public:
-    static layout calc_output_layout(shuffle_channels_node const& node);
+    static layout calc_output_layout(shuffle_channels_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(shuffle_channels_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/slice_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/slice_inst.h
@@ -26,7 +26,7 @@ class typed_primitive_inst<slice> : public typed_primitive_inst_base<slice> {
     using parent = typed_primitive_inst_base<slice>;
 
 public:
-    static layout calc_output_layout(slice_node const& node);
+    static layout calc_output_layout(slice_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(slice_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/softmax_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/softmax_inst.h
@@ -17,7 +17,7 @@ class typed_primitive_inst<softmax> : public typed_primitive_inst_base<softmax> 
     using parent = typed_primitive_inst_base<softmax>;
 
 public:
-    static layout calc_output_layout(softmax_node const& node);
+    static layout calc_output_layout(softmax_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(softmax_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/space_to_batch_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/space_to_batch_inst.h
@@ -28,7 +28,7 @@ class typed_primitive_inst<space_to_batch> : public typed_primitive_inst_base<sp
     using parent = typed_primitive_inst_base<space_to_batch>;
 
 public:
-    static layout calc_output_layout(space_to_batch_node const& node);
+    static layout calc_output_layout(space_to_batch_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(space_to_batch_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/space_to_depth_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/space_to_depth_inst.h
@@ -28,7 +28,7 @@ class typed_primitive_inst<space_to_depth> : public typed_primitive_inst_base<sp
     using parent = typed_primitive_inst_base<space_to_depth>;
 
 public:
-    static layout calc_output_layout(space_to_depth_node const& node);
+    static layout calc_output_layout(space_to_depth_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(space_to_depth_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/split_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/split_inst.h
@@ -29,7 +29,7 @@ class typed_primitive_inst<split> : public typed_primitive_inst_base<split> {
     using parent = typed_primitive_inst_base<split>;
 
 public:
-    static layout calc_output_layout(split_node const& node);
+    static layout calc_output_layout(split_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(split_node const& node);
     typed_primitive_inst(network& network, split_node const& node);
 };

--- a/src/plugins/intel_gpu/src/graph/include/strided_slice_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/strided_slice_inst.h
@@ -78,7 +78,7 @@ class typed_primitive_inst<strided_slice> : public typed_primitive_inst_base<str
     using parent = typed_primitive_inst_base<strided_slice>;
 
 public:
-    static layout calc_output_layout(strided_slice_node const& node);
+    static layout calc_output_layout(strided_slice_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(strided_slice_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/include/tile_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/tile_inst.h
@@ -29,7 +29,7 @@ class typed_primitive_inst<tile> : public typed_primitive_inst_base<tile> {
     using parent = typed_primitive_inst_base<tile>;
 
 public:
-    static layout calc_output_layout(tile_node const& node);
+    static layout calc_output_layout(tile_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(tile_node const& node);
 
 public:

--- a/src/plugins/intel_gpu/src/graph/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/loop.cpp
@@ -78,7 +78,7 @@ static void validate_backedges(loop_node const & node) {
     }
 }
 
-layout loop_inst::calc_output_layout(loop_node const & node) {
+layout loop_inst::calc_output_layout(loop_node const & node, kernel_impl_params const& impl_param) {
     // body program should be built here to calculate body input layout
     // from outputs of loop's dependency and calculate loop output layout
     // from the outputs of body program
@@ -106,7 +106,7 @@ layout loop_inst::calc_output_layout(loop_node const & node) {
         return output->id() == output_internal_id;
     });
     if (target == body_outputs.end()) {
-        CLDNN_ERROR_MESSAGE(node.id(), "output not found");
+        CLDNN_ERROR_MESSAGE(impl_param.desc->id, "output not found");
     }
 
     // set body output layout

--- a/src/plugins/intel_gpu/src/graph/lrn.cpp
+++ b/src/plugins/intel_gpu/src/graph/lrn.cpp
@@ -14,17 +14,17 @@ primitive_type_id lrn::type_id() {
     return &instance;
 }
 
-layout lrn_inst::calc_output_layout(lrn_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout lrn_inst::calc_output_layout(lrn_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for lrn_node!");
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     auto output_type = input_layout.data_type;
 
-    if (node.has_fused_primitives()) {
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        output_type = impl_param.get_fused_output_layout().data_type;
     }
 
-    auto result = node.input().get_non_padded_output_layout();
+    auto result = impl_param.get_non_padded_input_layout();
     result.data_type = output_type;
 
     return result;

--- a/src/plugins/intel_gpu/src/graph/lstm.cpp
+++ b/src/plugins/intel_gpu/src/graph/lstm.cpp
@@ -15,10 +15,10 @@ primitive_type_id lstm::type_id() {
     return &instance;
 }
 
-layout lstm_inst::calc_output_layout(lstm_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout lstm_inst::calc_output_layout(lstm_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for lstm_node!");
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     auto hidden_layout = node.inital_hidden().get_output_layout();
 
     // input     = [ batch,  sequence,       direction,      input_size ]

--- a/src/plugins/intel_gpu/src/graph/lstm_dynamic.cpp
+++ b/src/plugins/intel_gpu/src/graph/lstm_dynamic.cpp
@@ -21,13 +21,13 @@ primitive_type_id lstm_dynamic::type_id() {
 // init_hidden:    [b: batch, f: 1, x: hidden_size, y: direction]
 // init_cell:      [b: batch, f: 1, x: hidden_size, y: direction]
 // output_tensor:  [b: batch, f: max_sequence_length, x: hidden_size, y: direction]
-layout lstm_dynamic_inst::calc_output_layout(lstm_dynamic_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout lstm_dynamic_inst::calc_output_layout(lstm_dynamic_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for lstm_dynamic_node!");
     /*
         This program node is just placeholder for input + timeloop combinations, thus this is returning dummy layout.
         */
-    return node.get_dependency(0).get_output_layout();
+    return impl_param.input_layouts[0];
 }
 
 std::string lstm_dynamic_inst::to_string(lstm_dynamic_node const& node) {

--- a/src/plugins/intel_gpu/src/graph/lstm_dynamic_input.cpp
+++ b/src/plugins/intel_gpu/src/graph/lstm_dynamic_input.cpp
@@ -18,13 +18,13 @@ primitive_type_id lstm_dynamic_input::type_id() {
 // input_tensor:   [b: batch, f: max_sequence_length, x: input_size, y: direction]
 // weights_tensor: [b: 1, f: direction, x: input_size, y: 4 * hidden_size]
 // output_tensor:  [b: batch, f: max_sequence_length, x: 4 * hidden_size, y: direction]
-layout lstm_dynamic_input_inst::calc_output_layout(lstm_dynamic_input_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout lstm_dynamic_input_inst::calc_output_layout(lstm_dynamic_input_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for lstm_dynamic_node!");
-    auto input_layout = node.input().get_output_layout();
-    auto weight_layout = node.weights().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
+    auto weight_layout = impl_param.input_layouts[2];
     auto batch = input_layout.batch();
-    auto direction = node.direction();
+    auto direction = weight_layout.feature();
     auto output_sequence = input_layout.feature();
     return layout(input_layout.data_type,
                   input_layout.format,

--- a/src/plugins/intel_gpu/src/graph/lstm_dynamic_timeloop.cpp
+++ b/src/plugins/intel_gpu/src/graph/lstm_dynamic_timeloop.cpp
@@ -82,10 +82,10 @@ size_t lstm_dynamic_timeloop_node::get_dependency_idx(std::string val) const {
 // recurr_tensor:  [b: 1, f: direction, x: hidden_size, y: 4 * hidden_size]
 // init_cell:      [b: batch, f: 1, x: hidden_size, y: direction]
 // output_tensor:  [b: batch, f: max_sequence_length, x: hidden_size, y: direction]
-layout lstm_dynamic_timeloop_inst::calc_output_layout(lstm_dynamic_timeloop_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout lstm_dynamic_timeloop_inst::calc_output_layout(lstm_dynamic_timeloop_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for lstm_dynamic_node!");
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     auto batch = input_layout.batch();
     auto output_sequence = input_layout.feature();
     auto reccurent_layout = node.recurrent().get_output_layout();

--- a/src/plugins/intel_gpu/src/graph/lstm_elt.cpp
+++ b/src/plugins/intel_gpu/src/graph/lstm_elt.cpp
@@ -15,11 +15,10 @@ primitive_type_id lstm_elt::type_id() {
     return &instance;
 }
 
-layout lstm_elt_inst::calc_output_layout(lstm_elt_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout lstm_elt_inst::calc_output_layout(lstm_elt_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for lstm_elt_node!");
-    auto desc = node.get_primitive();
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
 
     // tempGEMM{bfyx} = [b: batch, f: direction, x: 1,         y: 4 * hidden_size ] input
     // cell{bfyx}     = [b: batch, f: direction, x: 1,         y: hidden_size ] optional

--- a/src/plugins/intel_gpu/src/graph/lstm_gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/lstm_gemm.cpp
@@ -15,12 +15,11 @@ primitive_type_id lstm_gemm::type_id() {
     return &instance;
 }
 
-layout lstm_gemm_inst::calc_output_layout(lstm_gemm_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout lstm_gemm_inst::calc_output_layout(lstm_gemm_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for lstm_gemm_node!");
-    auto desc = node.get_primitive();
-    auto input_layout = node.input().get_output_layout();
-    auto weights_layout = node.weights().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
+    auto weights_layout = impl_param.input_layouts[1];
 
     //   input{bfyx}     = [b: batch, f: sequence,   x: input_size,      y: 1]
     //   weights{bfyx}   = [b: 1,     f: direction,  x: 4 * hidden_size, y: input_size ]

--- a/src/plugins/intel_gpu/src/graph/max_unpooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/max_unpooling.cpp
@@ -21,15 +21,15 @@ max_unpooling_node::typed_program_node(const std::shared_ptr<max_unpooling> prim
     can_share_buffer(false);  // for max_unpooling initial zero values are significant
 }
 
-layout max_unpooling_inst::calc_output_layout(max_unpooling_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout max_unpooling_inst::calc_output_layout(max_unpooling_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for max_unpooling_node!");
-    auto desc = node.get_primitive();
+    auto desc = impl_param.typed_desc<max_unpooling>();
 
-    auto input_layout = node.input().get_output_layout();
-    auto argmax_layout = node.argmax().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
+    auto argmax_layout = impl_param.input_layouts[1];
 
-    CLDNN_ERROR_NOT_EQUAL(node.id(),
+    CLDNN_ERROR_NOT_EQUAL(desc->id,
                           "Argmax data type",
                           static_cast<size_t>(argmax_layout.data_type),
                           "expected to be fp32",
@@ -48,25 +48,25 @@ layout max_unpooling_inst::calc_output_layout(max_unpooling_node const& node) {
     auto stride = desc->stride;
     auto window_size = desc->size;
 
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "stride spatial X",
                                    stride.spatial[0],
                                    "",
                                    0,
                                    "Stride spatial X must be positive (>= 1)");
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "stride spatial Y",
                                    stride.spatial[1],
                                    "",
                                    0,
                                    "Stride spatial Y must be positive (>= 1)");
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "window size spatial X",
                                    window_size.spatial[0],
                                    "",
                                    0,
                                    "Size X (of pooling window) must be positive (>= 1)");
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "window size spatial Y",
                                    window_size.spatial[1],
                                    "",

--- a/src/plugins/intel_gpu/src/graph/mvn.cpp
+++ b/src/plugins/intel_gpu/src/graph/mvn.cpp
@@ -13,12 +13,12 @@ primitive_type_id mvn::type_id() {
     return &instance;
 }
 
-layout mvn_inst::calc_output_layout(mvn_node const& node) {
-    auto input_node_layout = node.input().get_non_padded_output_layout();
-    auto output_type = node.get_primitive()->output_data_type ? *node.get_primitive()->output_data_type : input_node_layout.data_type;
+layout mvn_inst::calc_output_layout(mvn_node const& node, kernel_impl_params const& impl_param) {
+    auto input_node_layout = impl_param.get_non_padded_input_layout();
+    auto output_type = impl_param.desc->output_data_type ? *impl_param.desc->output_data_type : input_node_layout.data_type;
 
-    if (node.has_fused_primitives()) {
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        output_type = impl_param.get_fused_output_layout().data_type;
     } else if (input_node_layout.data_type == data_types::u8 || input_node_layout.data_type == data_types::i8) {
         output_type = data_types::f32;
     }

--- a/src/plugins/intel_gpu/src/graph/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/graph/non_max_suppression.cpp
@@ -14,13 +14,13 @@ primitive_type_id non_max_suppression::type_id() {
     return &instance;
 }
 
-layout non_max_suppression_inst::calc_output_layout(non_max_suppression_node const& node) {
-    auto desc = node.get_primitive();
+layout non_max_suppression_inst::calc_output_layout(non_max_suppression_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<non_max_suppression>();
 
     auto output_type = desc->output_data_type ? *desc->output_data_type : data_types::i32;
 
     auto output_size = tensor(batch(desc->selected_indices_num), feature(3));
-    return layout(output_type, node.input().get_output_layout().format, output_size);
+    return layout(output_type, impl_param.input_layouts[0].format, output_size);
 }
 
 std::string non_max_suppression_inst::to_string(non_max_suppression_node const& node) {

--- a/src/plugins/intel_gpu/src/graph/normalize.cpp
+++ b/src/plugins/intel_gpu/src/graph/normalize.cpp
@@ -14,14 +14,14 @@ primitive_type_id normalize::type_id() {
     return &instance;
 }
 
-layout normalize_inst::calc_output_layout(normalize_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout normalize_inst::calc_output_layout(normalize_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for normalize_node!");
-    auto input_node_layout = node.input().get_non_padded_output_layout();
+    auto input_node_layout = impl_param.get_non_padded_input_layout();
     auto output_type = input_node_layout.data_type;
 
-    if (node.has_fused_primitives()) {
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        output_type = impl_param.get_fused_output_layout().data_type;
     } else if (input_node_layout.data_type == data_types::u8 || input_node_layout.data_type == data_types::i8) {
         output_type = data_types::f32;
     }

--- a/src/plugins/intel_gpu/src/graph/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/graph/one_hot.cpp
@@ -27,15 +27,15 @@ static bool is_output_bfzyx(const layout& input, int32_t axis) {
     return false;
 }
 
-layout one_hot_inst::calc_output_layout(one_hot_node const& node) {
-    auto input_layout = node.input().get_output_layout();
-    auto desc = node.get_primitive();
+layout one_hot_inst::calc_output_layout(one_hot_node const& node, kernel_impl_params const& impl_param) {
+    auto input_layout = impl_param.input_layouts[0];
+    auto desc = impl_param.typed_desc<one_hot>();
 
     auto dt = desc->output_data_type ? *desc->output_data_type : input_layout.data_type;
     auto format = input_layout.format;
 
     if (desc->one_hot_axis > 4) {
-        CLDNN_ERROR_MESSAGE(node.id(),
+        CLDNN_ERROR_MESSAGE(desc->id,
                             "Incorrect parameters configuration: one_hot_axis should be less or equal to 4.");
     }
 

--- a/src/plugins/intel_gpu/src/graph/permute.cpp
+++ b/src/plugins/intel_gpu/src/graph/permute.cpp
@@ -19,11 +19,12 @@ primitive_type_id permute::type_id() {
     return &instance;
 }
 
-layout permute_inst::calc_output_layout(permute_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout permute_inst::calc_output_layout(permute_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for permute_node!");
-    auto input_layout = node.input().get_output_layout();
-    auto permute_order = node.get_primitive()->permute_order;
+    auto desc = impl_param.typed_desc<permute>();
+    auto input_layout = impl_param.input_layouts[0];
+    auto permute_order = desc->permute_order;
     std::vector<tensor::value_type> output_shape;
 
     auto input_shape = input_layout.get_dims();
@@ -37,10 +38,10 @@ layout permute_inst::calc_output_layout(permute_node const& node) {
     }
 
     auto output_size = tensor(format::get_default_format(input_layout.get_rank()), output_shape);
-    auto op = node.get_primitive()->output_padding;
+    auto op = desc->output_padding;
 
-    if (node.has_fused_primitives()) {
-        input_layout.data_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        input_layout.data_type = impl_param.get_fused_output_layout().data_type;
     }
 
     return layout(input_layout.data_type, input_layout.format, output_size, op);

--- a/src/plugins/intel_gpu/src/graph/pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/pooling.cpp
@@ -17,10 +17,10 @@ primitive_type_id pooling::type_id() {
     return &instance;
 }
 
-layout pooling_inst::calc_output_layout(parent::typed_node const& node) {
-    auto desc = node.get_primitive();
+layout pooling_inst::calc_output_layout(parent::typed_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<pooling>();
 
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
 
     auto pad = desc->pad;
     auto stride = desc->stride;
@@ -36,8 +36,8 @@ layout pooling_inst::calc_output_layout(parent::typed_node const& node) {
         }
     }
 
-    if (node.has_fused_primitives()) {
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        output_type = impl_param.get_fused_output_layout().data_type;
 
         // pooling doesn't support i32 data type
         // FIXME: Someday delete this, when pooling supports i32 output.
@@ -47,7 +47,7 @@ layout pooling_inst::calc_output_layout(parent::typed_node const& node) {
     }
 
     if (!desc->argmax.empty())
-        CLDNN_ERROR_NOT_EQUAL(node.id(),
+        CLDNN_ERROR_NOT_EQUAL(desc->id,
                               "Pooling mode",
                               static_cast<size_t>(desc->mode),
                               "should be max_with_argmax",
@@ -55,21 +55,21 @@ layout pooling_inst::calc_output_layout(parent::typed_node const& node) {
                               "Pooling mode should be set to max_with_argmax when argmax primitive is present.");
 
     if (desc->mode == pooling_mode::max_with_argmax) {
-        CLDNN_ERROR_NOT_EQUAL(node.id(),
+        CLDNN_ERROR_NOT_EQUAL(desc->id,
                               "Argmax primitive",
                               static_cast<size_t>(desc->argmax.empty()),
                               "should not be empty",
                               static_cast<size_t>(0),
                               "Argmax primitive not present despite max_with_argmax mode.");
 
-        auto argmax_layout = node.argmax().get_output_layout();
-        CLDNN_ERROR_NOT_EQUAL(node.id(),
+        auto argmax_layout = impl_param.input_layouts[1];
+        CLDNN_ERROR_NOT_EQUAL(desc->id,
                               "Argmax data type",
                               static_cast<size_t>(argmax_layout.data_type),
                               "expected to be fp32",
                               static_cast<size_t>(data_types::f32),
                               "Argmax data type is not fp32.");
-        CLDNN_ERROR_NOT_PROPER_FORMAT(node.id(),
+        CLDNN_ERROR_NOT_PROPER_FORMAT(desc->id,
                                       "Input_layout.format",
                                       input_layout.format.value,
                                       "argmax_layout.format",
@@ -92,25 +92,25 @@ layout pooling_inst::calc_output_layout(parent::typed_node const& node) {
     uint32_t kernel_x = window_size.size() >= 1 ? window_size[window_size.size() - 1] : 1;
 
     // TODO: Consider moving general parameter verification to arguments constructor.
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "stride spatial X",
                                    stride_x,
                                    "",
                                    0,
                                    "Stride spatial X must be positive (>= 1)");
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "stride spatial Y",
                                    stride_y,
                                    "",
                                    0,
                                    "Stride spatial Y must be positive (>= 1)");
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "window size spatial X",
                                    kernel_x,
                                    "",
                                    0,
                                    "Size X (of pooling window) must be positive (>= 1)");
-    CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+    CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                    "window size spatial Y",
                                    kernel_y,
                                    "",
@@ -118,13 +118,13 @@ layout pooling_inst::calc_output_layout(parent::typed_node const& node) {
                                    "Size Y (of pooling window) must be positive (>= 1)");
     if (input_layout.format.spatial_num() == 3) {
         // 3D
-        CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+        CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                        "stride spatial Z",
                                        stride_z,
                                        "",
                                        0,
                                        "Stride spatial Z must be positive (>= 1)");
-        CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+        CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                        "window size spatial Z",
                                        kernel_z,
                                        "",
@@ -133,19 +133,19 @@ layout pooling_inst::calc_output_layout(parent::typed_node const& node) {
     }
 
     if (desc->with_output_size) {
-        CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+        CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                        "User-defined size of output X",
                                        desc->output_size.spatial[0],
                                        "",
                                        0,
                                        "User-defined size of output layout (spatial X) must be positive (>= 1)");
-        CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+        CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                        "User-defined size of output Y",
                                        desc->output_size.spatial[1],
                                        "",
                                        0,
                                        "User-defined size of output layout (spatial Y) must be positive (>= 1)");
-        CLDNN_ERROR_LESS_OR_EQUAL_THAN(node.id(),
+        CLDNN_ERROR_LESS_OR_EQUAL_THAN(desc->id,
                                        "User-defined size of output Z",
                                        desc->output_size.spatial[2],
                                        "",

--- a/src/plugins/intel_gpu/src/graph/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/prior_box.cpp
@@ -355,14 +355,14 @@ void prior_box_node::calc_result() {
                                                                              *typed_desc());
 }
 
-layout prior_box_inst::calc_output_layout(prior_box_node const& node) {
-    auto desc = node.get_primitive();
-    auto input_layout = node.input().get_output_layout();
+layout prior_box_inst::calc_output_layout(prior_box_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<prior_box>();
+    auto input_layout = impl_param.input_layouts[0];
 
     const int layer_width = input_layout.spatial(0);
     const int layer_height = input_layout.spatial(1);
 
-    int num_priors = node.is_clustered() ?
+    int num_priors = desc->is_clustered() ?
         static_cast<int>(desc->widths.size()) :
         desc->scale_all_sizes
             ? static_cast<int>(desc->aspect_ratios.size()) * static_cast<int>(desc->min_sizes.size()) + static_cast<int>(desc->max_sizes.size())
@@ -388,8 +388,8 @@ layout prior_box_inst::calc_output_layout(prior_box_node const& node) {
     // Second feature stores the variance of each prior coordinate.
 
     auto output_data_type = input_layout.data_type == data_types::f16 ? data_types::f16 : data_types::f32;
-    if (node.get_primitive()->output_data_type)
-        output_data_type = *node.get_primitive()->output_data_type;
+    if (desc->output_data_type)
+        output_data_type = *desc->output_data_type;
     return {output_data_type, cldnn::format::bfyx, cldnn::tensor(1, 2, 1, layer_width * layer_height * num_priors * 4)};
 }
 

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -226,7 +226,7 @@ bool program_node::is_detached(bool whole_branch) {
 }
 
 layout program_node::calc_output_layout() const {
-    return type()->calc_output_layout(*this);
+    return type()->calc_output_layout(*this, *get_kernel_impl_params());
 }
 
 layout program_node::get_output_layout(bool invalidate_users_if_changed) {

--- a/src/plugins/intel_gpu/src/graph/proposal.cpp
+++ b/src/plugins/intel_gpu/src/graph/proposal.cpp
@@ -25,11 +25,11 @@ primitive_type_id proposal::type_id() {
     return &instance;
 }
 
-layout proposal_inst::calc_output_layout(proposal_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout proposal_inst::calc_output_layout(proposal_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for proposal_node!");
-    auto desc = node.get_primitive();
-    layout input_layout = node.get_dependency(cls_scores_index).get_output_layout();
+    auto desc = impl_param.typed_desc<proposal>();
+    layout input_layout = impl_param.input_layouts[cls_scores_index];
 
     return layout(input_layout.data_type,
                   format::bfyx,

--- a/src/plugins/intel_gpu/src/graph/pyramid_roi_align.cpp
+++ b/src/plugins/intel_gpu/src/graph/pyramid_roi_align.cpp
@@ -15,15 +15,15 @@ primitive_type_id pyramid_roi_align::type_id() {
     return &instance;
 }
 
-layout pyramid_roi_align_inst::calc_output_layout(pyramid_roi_align_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout pyramid_roi_align_inst::calc_output_layout(pyramid_roi_align_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for "
            "pyramid_roi_align node!");
 
-    auto desc = node.get_primitive();
+    auto desc = impl_param.typed_desc<pyramid_roi_align>();
 
-    auto boxes_layout = node.input().get_output_layout();
-    auto P2_layout = node.P2().get_output_layout();
+    auto boxes_layout = impl_param.input_layouts[0];
+    auto P2_layout = impl_param.input_layouts[1];
 
     int32_t output_b = boxes_layout.batch();
     int32_t output_f = P2_layout.feature();

--- a/src/plugins/intel_gpu/src/graph/quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/quantize.cpp
@@ -17,14 +17,14 @@ primitive_type_id quantize::type_id() {
     return &instance;
 }
 
-layout quantize_inst::calc_output_layout(quantize_node const& node) {
-    auto desc = node.get_primitive();
+layout quantize_inst::calc_output_layout(quantize_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<quantize>();
 
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     auto output_format = input_layout.format;
     auto out_dt = input_layout.data_type;
-    if (node.get_primitive()->output_data_type)
-        out_dt = *node.get_primitive()->output_data_type;
+    if (desc->output_data_type)
+        out_dt = *desc->output_data_type;
 
     if (out_dt == data_types::bin) {
         output_format = format::b_fs_yx_32fp;

--- a/src/plugins/intel_gpu/src/graph/random_uniform.cpp
+++ b/src/plugins/intel_gpu/src/graph/random_uniform.cpp
@@ -19,8 +19,8 @@ random_uniform_inst::typed_primitive_inst(network& network, random_uniform_node 
 : parent(network, node) {
 }
 
-layout random_uniform_inst::calc_output_layout(random_uniform_node const &node) {
-    auto primitive = node.get_primitive();
+layout random_uniform_inst::calc_output_layout(random_uniform_node const &node, kernel_impl_params const& impl_param) {
+    auto primitive = impl_param.typed_desc<random_uniform>();
     return {*primitive->output_data_type, primitive->output_format, primitive->output_shape};
 }
 

--- a/src/plugins/intel_gpu/src/graph/range.cpp
+++ b/src/plugins/intel_gpu/src/graph/range.cpp
@@ -21,8 +21,8 @@ primitive_type_id range::type_id() {
     return &instance;
 }
 
-layout range_inst::calc_output_layout(range_node const& node) {
-    return node.get_primitive()->output_layout;
+layout range_inst::calc_output_layout(range_node const& node, kernel_impl_params const& impl_param) {
+    return impl_param.typed_desc<range>()->output_layout;
 }
 
 std::string range_inst::to_string(range_node const& node) {

--- a/src/plugins/intel_gpu/src/graph/read_value.cpp
+++ b/src/plugins/intel_gpu/src/graph/read_value.cpp
@@ -20,8 +20,8 @@ read_value_inst::typed_primitive_inst(network& network, const read_value_node& n
     memory_state::variable{node.get_primitive()->variable_id} {
 }
 
-layout read_value_inst::calc_output_layout(const read_value_node& node) {
-    return node.get_primitive()->output_layout;
+layout read_value_inst::calc_output_layout(const read_value_node& node, kernel_impl_params const& impl_param) {
+    return impl_param.typed_desc<read_value>()->output_layout;
 }
 
 std::string read_value_inst::to_string(const read_value_node& node) {

--- a/src/plugins/intel_gpu/src/graph/reduce.cpp
+++ b/src/plugins/intel_gpu/src/graph/reduce.cpp
@@ -17,10 +17,10 @@ primitive_type_id reduce::type_id() {
     return &instance;
 }
 
-layout reduce_inst::calc_output_layout(reduce_node const& node) {
-    auto desc = node.get_primitive();
+layout reduce_inst::calc_output_layout(reduce_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<reduce>();
 
-    auto input_layout = node.input(0).get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     auto input_format = input_layout.format;
     auto format_dim = input_format.dimension();
     auto output_type = input_layout.data_type;
@@ -67,8 +67,8 @@ layout reduce_inst::calc_output_layout(reduce_node const& node) {
     if (desc->output_data_type)
         output_type = *desc->output_data_type;
 
-    if (node.has_fused_primitives())
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives())
+        output_type = impl_param.get_fused_output_layout().data_type;
 
     if (format_dim == 6)
         return layout{output_type, input_format, tensor(batch(in_dims[0]), feature(in_dims[1]), spatial(in_dims[2], in_dims[3], in_dims[4], in_dims[5]))};

--- a/src/plugins/intel_gpu/src/graph/region_yolo.cpp
+++ b/src/plugins/intel_gpu/src/graph/region_yolo.cpp
@@ -13,12 +13,12 @@ primitive_type_id region_yolo::type_id() {
     return &instance;
 }
 
-layout region_yolo_inst::calc_output_layout(region_yolo_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout region_yolo_inst::calc_output_layout(region_yolo_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for "
            "region_yolo_node!");
-    auto input_layout = node.input().get_output_layout();
-    auto desc = node.get_primitive();
+    auto input_layout = impl_param.input_layouts[0];
+    auto desc = impl_param.typed_desc<region_yolo>();
 
     if (desc->do_softmax) {
         return cldnn::layout(

--- a/src/plugins/intel_gpu/src/graph/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/reorder.cpp
@@ -20,13 +20,14 @@ primitive_type_id reorder::type_id() {
     return &instance;
 }
 
-layout reorder_inst::calc_output_layout(reorder_node const& node) {
-    auto input_layout = node.input().get_output_layout();
+layout reorder_inst::calc_output_layout(reorder_node const& node, kernel_impl_params const& impl_param) {
+    auto input_layout = impl_param.input_layouts[0];
     auto ifmt = input_layout.format;
 
-    auto odt = *node.get_primitive()->output_data_type;
-    auto ofmt = node.get_primitive()->output_format;
-    auto op = node.get_primitive()->output_padding;
+    auto desc = impl_param.typed_desc<reorder>();
+    auto odt = *desc->output_data_type;
+    auto ofmt = desc->output_format;
+    auto op = desc->output_padding;
 
     if (ofmt == format::any) {
         ofmt = ifmt;
@@ -38,12 +39,12 @@ layout reorder_inst::calc_output_layout(reorder_node const& node) {
         if (ofmt != ifmt)
             return layout(odt, ofmt, data_size, op);
 
-        CLDNN_ERROR_MESSAGE(node.id(), "No image_nv12 to image_nv12 reorder is supported");
+        CLDNN_ERROR_MESSAGE(desc->id, "No image_nv12 to image_nv12 reorder is supported");
     } else if (ofmt.is_winograd() && ifmt.is_winograd()) {
         if (ofmt == ifmt)
             return layout(odt, ofmt, input_layout.get_tensor(), op);
 
-        CLDNN_ERROR_MESSAGE(node.id(), "Reordering between winograd weights and data formats is unsupported");
+        CLDNN_ERROR_MESSAGE(desc->id, "Reordering between winograd weights and data formats is unsupported");
     } else if (ifmt == format::image_2d_rgba) {
         return layout(data_types::f16, format::bfyx, input_layout.get_tensor(), op);
     }
@@ -89,13 +90,13 @@ layout reorder_inst::calc_output_layout(reorder_node const& node) {
 
     // transformation of weights from standard to winograd
     if (ofmt == format::winograd_2x3_s1_weights || ofmt == format::winograd_2x3_s1_fused_weights) {
-        CLDNN_ERROR_NOT_EQUAL(node.id(),
+        CLDNN_ERROR_NOT_EQUAL(desc->id,
                               "input_layout.spatial(0)",
                               input_layout.spatial(0),
                               "expected value",
                               3,
                               "input for conversion to winograd_2x3_s1 weights format should have spatial size 3x3");
-        CLDNN_ERROR_NOT_EQUAL(node.id(),
+        CLDNN_ERROR_NOT_EQUAL(desc->id,
                               "input_layout.spatial(1)",
                               input_layout.spatial(1),
                               "expected value",
@@ -104,13 +105,13 @@ layout reorder_inst::calc_output_layout(reorder_node const& node) {
 
         return layout(odt, ofmt, tensor{input_layout.batch(), input_layout.feature(), 4, 3});
     } else if (ofmt == format::winograd_6x3_s1_fused_weights) {
-        CLDNN_ERROR_NOT_EQUAL(node.id(),
+        CLDNN_ERROR_NOT_EQUAL(desc->id,
                               "input_layout.spatial(0)",
                               input_layout.spatial(0),
                               "expected value",
                               3,
                               "input for conversion to winograd_2x3_s1 weights format should have spatial size 3x3");
-        CLDNN_ERROR_NOT_EQUAL(node.id(),
+        CLDNN_ERROR_NOT_EQUAL(desc->id,
                               "input_layout.spatial(1)",
                               input_layout.spatial(1),
                               "expected value",
@@ -147,7 +148,7 @@ layout reorder_inst::calc_output_layout(reorder_node const& node) {
     // transformation of weights from winograd to standard
     if (ifmt == format::winograd_2x3_s1_weights || ifmt == format::winograd_2x3_s1_fused_weights ||
         ifmt == format::winograd_6x3_s1_fused_weights) {
-        CLDNN_ERROR_MESSAGE(node.id(),
+        CLDNN_ERROR_MESSAGE(desc->id,
                             "Conversion of weights from winograd to standard domain is currently unsupported");
     }
 

--- a/src/plugins/intel_gpu/src/graph/reorg_yolo.cpp
+++ b/src/plugins/intel_gpu/src/graph/reorg_yolo.cpp
@@ -13,12 +13,12 @@ primitive_type_id reorg_yolo::type_id() {
     return &instance;
 }
 
-layout reorg_yolo_inst::calc_output_layout(reorg_yolo_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout reorg_yolo_inst::calc_output_layout(reorg_yolo_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for "
            "reorg_yolo_node!");
-    auto input_layout = node.input().get_output_layout();
-    auto desc = node.get_primitive();
+    auto input_layout = impl_param.input_layouts[0];
+    auto desc = impl_param.typed_desc<reorg_yolo>();
     auto stride = desc->stride;
 
     cldnn::layout layoutTemp = cldnn::layout(input_layout.data_type,

--- a/src/plugins/intel_gpu/src/graph/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/resample.cpp
@@ -15,23 +15,23 @@ primitive_type_id resample::type_id() {
     return &instance;
 }
 
-layout resample_inst::calc_output_layout(resample_node const& node) {
-    auto desc = node.get_primitive();
-    auto input_layout = node.input().get_output_layout();
+layout resample_inst::calc_output_layout(resample_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<resample>();
+    auto input_layout = impl_param.input_layouts[0];
 
     auto output_type = input_layout.data_type;
     if ((input_layout.data_type == data_types::i8 || input_layout.data_type == data_types::u8)
         && desc->operation_type != resample_type::nearest) {
         output_type = data_types::f32;
     }
-    if (node.has_fused_primitives()) {
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        output_type = impl_param.get_fused_output_layout().data_type;
     }
 
     auto result_sizes = desc->output_size;
 
-    CLDNN_ERROR_NOT_EQUAL(node.id(), "Input batch size", input_layout.batch(), "output batch size", result_sizes.batch[0], "");
-    CLDNN_ERROR_NOT_EQUAL(node.id(), "Input feature size", input_layout.feature(), "output feature size", result_sizes.feature[0], "");
+    CLDNN_ERROR_NOT_EQUAL(desc->id, "Input batch size", input_layout.batch(), "output batch size", result_sizes.batch[0], "");
+    CLDNN_ERROR_NOT_EQUAL(desc->id, "Input feature size", input_layout.feature(), "output feature size", result_sizes.feature[0], "");
 
     auto result = layout({output_type, input_layout.format, result_sizes});
     return result;

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -17,11 +17,12 @@ primitive_type_id reshape::type_id() {
     return &instance;
 }
 
-layout reshape_inst::calc_output_layout(reshape_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout reshape_inst::calc_output_layout(reshape_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for reshape_node!");
-    auto input_layout = node.input().get_non_padded_output_layout();
-    auto sizes = node.get_primitive()->output_shape.sizes();
+    auto input_layout = impl_param.get_non_padded_input_layout();
+    auto desc = impl_param.typed_desc<reshape>();
+    auto sizes = desc->output_shape.sizes();
     auto input_sizes = input_layout.get_tensor().sizes();
     size_t need_recalc = 0;
     uint32_t shape_count = 1;
@@ -29,7 +30,7 @@ layout reshape_inst::calc_output_layout(reshape_node const& node) {
     for (size_t i = 0; i < sizes.size(); i++) {
         if (sizes[i] == -1) {
             if (need_recalc) {
-                CLDNN_ERROR_MESSAGE(node.id(), "Only one dimension of the new shape can be -1");
+                CLDNN_ERROR_MESSAGE(desc->id, "Only one dimension of the new shape can be -1");
             }
             need_recalc = i;
             continue;

--- a/src/plugins/intel_gpu/src/graph/reverse.cpp
+++ b/src/plugins/intel_gpu/src/graph/reverse.cpp
@@ -14,8 +14,8 @@ primitive_type_id reverse::type_id() {
     return &instance;
 }
 
-layout reverse_inst::calc_output_layout(reverse_node const& node) {
-    return node.input(0).get_output_layout();
+layout reverse_inst::calc_output_layout(reverse_node const& node, kernel_impl_params const& impl_param) {
+    return impl_param.input_layouts[0];
 }
 
 std::string reverse_inst::to_string(reverse_node const& node) {

--- a/src/plugins/intel_gpu/src/graph/reverse_sequence.cpp
+++ b/src/plugins/intel_gpu/src/graph/reverse_sequence.cpp
@@ -15,10 +15,8 @@ primitive_type_id reverse_sequence::type_id() {
     return &instance;
 }
 
-layout reverse_sequence_inst::calc_output_layout(reverse_sequence_node const& node) {
-    auto desc = node.get_primitive();
-
-    auto input_layout = node.input(0).get_output_layout();
+layout reverse_sequence_inst::calc_output_layout(reverse_sequence_node const& node, kernel_impl_params const& impl_param) {
+    auto input_layout = impl_param.input_layouts[0];
     auto input_format = input_layout.format;
 
     return layout{input_layout.data_type, input_format, input_layout.get_tensor()};

--- a/src/plugins/intel_gpu/src/graph/roi_align.cpp
+++ b/src/plugins/intel_gpu/src/graph/roi_align.cpp
@@ -18,10 +18,10 @@ primitive_type_id roi_align::type_id() {
 roi_align_inst::typed_primitive_inst(network& network, roi_align_node const& node)
     : parent(network, node) {}
 
-layout roi_align_inst::calc_output_layout(roi_align_node const& node) {
-    auto primitive = node.get_primitive();
-    auto input_layout = node.input(0).get_output_layout();
-    auto rois_layout = node.input(1).get_output_layout();
+layout roi_align_inst::calc_output_layout(roi_align_node const& node, kernel_impl_params const& impl_param) {
+    auto primitive = impl_param.typed_desc<roi_align>();
+    auto input_layout = impl_param.input_layouts[0];
+    auto rois_layout = impl_param.input_layouts[1];
     auto num_rois = rois_layout.batch();
     auto num_channels = input_layout.feature();
     return layout(input_layout.data_type,

--- a/src/plugins/intel_gpu/src/graph/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/roi_pooling.cpp
@@ -14,12 +14,12 @@ primitive_type_id roi_pooling::type_id() {
     return &instance;
 }
 
-layout roi_pooling_inst::calc_output_layout(roi_pooling_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout roi_pooling_inst::calc_output_layout(roi_pooling_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for roi_pooling_node!");
-    auto desc = node.get_primitive();
-    layout data_layout = node.input().get_output_layout();
-    layout rois_layout = node.rois().get_output_layout();
+    auto desc = impl_param.typed_desc<roi_pooling>();
+    layout data_layout = impl_param.input_layouts[0];
+    layout rois_layout = impl_param.input_layouts[1];
     int num_rois = rois_layout.batch();
     int out_fm = desc->position_sensitive ? desc->output_dim : data_layout.feature();
 

--- a/src/plugins/intel_gpu/src/graph/roll.cpp
+++ b/src/plugins/intel_gpu/src/graph/roll.cpp
@@ -15,8 +15,8 @@ primitive_type_id roll::type_id() {
     return &instance;
 }
 
-layout roll_inst::calc_output_layout(const roll_node& node) {
-    return node.input().get_output_layout();
+layout roll_inst::calc_output_layout(const roll_node& node, kernel_impl_params const& impl_param) {
+    return impl_param.input_layouts[0];
 }
 
 std::string roll_inst::to_string(const roll_node& node) {

--- a/src/plugins/intel_gpu/src/graph/scale.cpp
+++ b/src/plugins/intel_gpu/src/graph/scale.cpp
@@ -14,10 +14,10 @@ primitive_type_id scale::type_id() {
     return &instance;
 }
 
-layout scale_inst::calc_output_layout(scale_node const& node) {
-    auto desc = node.get_primitive();
-    auto result = node.input().get_non_padded_output_layout();
-    auto scale_layout = node.scale_in().get_non_padded_output_layout();
+layout scale_inst::calc_output_layout(scale_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.desc;
+    auto result = impl_param.get_non_padded_input_layout();
+    auto scale_layout = impl_param.get_non_padded_input_layout(1);
 
     auto scale_x_size = scale_layout.spatial(0);
     auto scale_y_size = scale_layout.spatial(1);
@@ -28,25 +28,25 @@ layout scale_inst::calc_output_layout(scale_node const& node) {
     auto input_z_size = result.spatial(2);
 
     if ((result.data_type == data_types::u8 || result.data_type == data_types::i8 || result.data_type == data_types::i32) &&
-        (node.scale_in().get_non_padded_output_layout().data_type == data_types::f32 ||
-         node.scale_in().get_non_padded_output_layout().data_type == data_types::f16))
-        result.data_type = node.scale_in().get_non_padded_output_layout().data_type;
+        (scale_layout.data_type == data_types::f32 ||
+         scale_layout.data_type == data_types::f16))
+        result.data_type = scale_layout.data_type;
 
     if (desc->output_data_type)
         result.data_type = *desc->output_data_type;
 
-    if (node.has_fused_primitives()) {
-        result.data_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        result.data_type = impl_param.get_fused_output_layout().data_type;
     }
 
     if (scale_x_size != 1) {
-        CLDNN_ERROR_NOT_EQUAL(node.id(), "Scale x size", scale_x_size, "input x size", input_x_size, "");
+        CLDNN_ERROR_NOT_EQUAL(desc->id, "Scale x size", scale_x_size, "input x size", input_x_size, "");
     }
     if (scale_y_size != 1) {
-        CLDNN_ERROR_NOT_EQUAL(node.id(), "Scale y size", scale_y_size, "input y size", input_y_size, "");
+        CLDNN_ERROR_NOT_EQUAL(desc->id, "Scale y size", scale_y_size, "input y size", input_y_size, "");
     }
     if (scale_z_size != 1) {
-        CLDNN_ERROR_NOT_EQUAL(node.id(), "Scale z size", scale_z_size, "input z size", input_z_size, "");
+        CLDNN_ERROR_NOT_EQUAL(desc->id, "Scale z size", scale_z_size, "input z size", input_z_size, "");
     }
 
     return result;

--- a/src/plugins/intel_gpu/src/graph/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_elements_update.cpp
@@ -15,24 +15,24 @@ primitive_type_id scatter_elements_update::type_id() {
     return &instance;
 }
 
-layout scatter_elements_update_inst::calc_output_layout(scatter_elements_update_node const& node) {
-    auto desc = node.get_primitive();
+layout scatter_elements_update_inst::calc_output_layout(scatter_elements_update_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<scatter_elements_update>();
 
     const int32_t axis = desc->axis;
-    const size_t input_number_of_dims = node.input(0).get_output_layout().get_tensor().sizes().size();
+    const size_t input_number_of_dims = impl_param.input_layouts[0].get_tensor().sizes().size();
 
-    auto input_layout = node.input(0).get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
 
     auto output_shape = input_layout.get_tensor();
     auto input_format = input_layout.format;
     auto output_type = input_layout.data_type;
 
-    if (node.has_fused_primitives()) {
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        output_type = impl_param.get_fused_output_layout().data_type;
     }
 
     if (static_cast<size_t>(axis) < 0 || static_cast<size_t>(axis) >= input_number_of_dims)
-        CLDNN_ERROR_MESSAGE(node.id(), "Incorrect axis value for ScatterElementsUpdate: Axis must be positive and less than the input tensor dimension.");
+        CLDNN_ERROR_MESSAGE(desc->id, "Incorrect axis value for ScatterElementsUpdate: Axis must be positive and less than the input tensor dimension.");
 
     return layout{output_type, input_format, output_shape};
 }

--- a/src/plugins/intel_gpu/src/graph/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_nd_update.cpp
@@ -16,15 +16,15 @@ primitive_type_id scatter_nd_update::type_id() {
 }
 
 
-layout scatter_nd_update_inst::calc_output_layout(scatter_nd_update_node const& node) {
-    auto input_layout = node.input(0).get_output_layout();
+layout scatter_nd_update_inst::calc_output_layout(scatter_nd_update_node const& node, kernel_impl_params const& impl_param) {
+    auto input_layout = impl_param.input_layouts[0];
 
     auto output_shape = input_layout.get_tensor();
     auto input_format = input_layout.format;
     auto output_type = input_layout.data_type;
 
-    if (node.has_fused_primitives()) {
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        output_type = impl_param.get_fused_output_layout().data_type;
     }
 
     return layout{output_type, input_format, output_shape};

--- a/src/plugins/intel_gpu/src/graph/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_update.cpp
@@ -15,17 +15,17 @@ primitive_type_id scatter_update::type_id() {
     return &instance;
 }
 
-layout scatter_update_inst::calc_output_layout(scatter_update_node const& node) {
-    auto desc = node.get_primitive();
+layout scatter_update_inst::calc_output_layout(scatter_update_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<scatter_update>();
 
-    auto input_layout = node.input(0).get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
 
     auto output_shape = input_layout.get_tensor();
     auto input_format = input_layout.format;
     auto output_type = input_layout.data_type;
 
-    if (node.has_fused_primitives()) {
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        output_type = impl_param.get_fused_output_layout().data_type;
     }
 
     return layout{output_type, input_format, output_shape};

--- a/src/plugins/intel_gpu/src/graph/select.cpp
+++ b/src/plugins/intel_gpu/src/graph/select.cpp
@@ -15,16 +15,16 @@ primitive_type_id select::type_id() {
     return &instance;
 }
 
-layout select_inst::calc_output_layout(select_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout select_inst::calc_output_layout(select_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for select_node!");
 
-    auto in_layout = node.input(1).get_non_padded_output_layout();
+    auto in_layout = impl_param.get_non_padded_input_layout(1);
     auto output_size = in_layout.get_tensor();
 
-    if (node.get_primitive()->broadcast_type == "numpy") {
-        auto input1_size = node.input(1).get_output_layout().get_tensor();
-        auto input2_size = node.input(2).get_output_layout().get_tensor();
+    if (impl_param.typed_desc<select>()->broadcast_type == "numpy") {
+        auto input1_size = impl_param.input_layouts[1].get_tensor();
+        auto input2_size = impl_param.input_layouts[2].get_tensor();
         output_size = tensor::max(input1_size, input2_size);
     }
 

--- a/src/plugins/intel_gpu/src/graph/shape_of.cpp
+++ b/src/plugins/intel_gpu/src/graph/shape_of.cpp
@@ -15,16 +15,16 @@ primitive_type_id shape_of::type_id() {
     return &instance;
 }
 
-layout shape_of_inst::calc_output_layout(shape_of_node const& node) {
-    auto prim = node.get_primitive();
+layout shape_of_inst::calc_output_layout(shape_of_node const& node, kernel_impl_params const& impl_param) {
+    auto prim = impl_param.typed_desc<shape_of>();
 
     data_types dt = data_types::i32;
 
     if (prim->output_data_type)
         dt = *prim->output_data_type;
 
-    if (node.has_fused_primitives()) {
-        dt = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        dt = impl_param.get_fused_output_layout().data_type;
     }
 
     cldnn::tensor out_size{static_cast<tensor::value_type>(prim->output_rank), 1, 1, 1};

--- a/src/plugins/intel_gpu/src/graph/shuffle_channels.cpp
+++ b/src/plugins/intel_gpu/src/graph/shuffle_channels.cpp
@@ -15,10 +15,10 @@ primitive_type_id shuffle_channels::type_id() {
     return &instance;
 }
 
-layout shuffle_channels_inst::calc_output_layout(shuffle_channels_node const& node) {
-    auto desc = node.get_primitive();
+layout shuffle_channels_inst::calc_output_layout(shuffle_channels_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<shuffle_channels>();
 
-    auto input_layout = node.input(0).get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     auto input_format = input_layout.format;
 
     const int32_t number_of_dims = 4;
@@ -29,16 +29,16 @@ layout shuffle_channels_inst::calc_output_layout(shuffle_channels_node const& no
         axis += number_of_dims;
 
     if (axis < 0 || axis >= number_of_dims)
-        CLDNN_ERROR_MESSAGE(node.id(), "Incorrect axis value! Actual axis is" + std::to_string(group));
+        CLDNN_ERROR_MESSAGE(desc->id, "Incorrect axis value! Actual axis is" + std::to_string(group));
 
     if (group < 1)
         CLDNN_ERROR_MESSAGE(
-            node.id(),
+            desc->id,
             "Invalid group size value (should equal at least one). Actual block size is" + std::to_string(group));
 
     if (input_layout.get_tensor().sizes(format::bfyx)[axis] % group != 0)
         CLDNN_ERROR_MESSAGE(
-            node.id(),
+            desc->id,
             "Group parameter must evenly divide the channel dimension. Actual group size is " + std::to_string(group));
 
     return layout{input_layout.data_type, input_format, input_layout.get_tensor()};

--- a/src/plugins/intel_gpu/src/graph/slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/slice.cpp
@@ -17,9 +17,9 @@ primitive_type_id slice::type_id() {
 slice_inst::typed_primitive_inst(network& network, slice_node const& node)
     : parent(network, node) {}
 
-layout slice_inst::calc_output_layout(slice_node const& node) {
-    auto primitive = node.get_primitive();
-    auto input_layout = node.input(0).get_output_layout();
+layout slice_inst::calc_output_layout(slice_node const& node, kernel_impl_params const& impl_param) {
+    auto primitive = impl_param.typed_desc<slice>();
+    auto input_layout = impl_param.input_layouts[0];
     return {input_layout.data_type, input_layout.format, primitive->output_shape};
 }
 

--- a/src/plugins/intel_gpu/src/graph/softmax.cpp
+++ b/src/plugins/intel_gpu/src/graph/softmax.cpp
@@ -13,14 +13,14 @@ primitive_type_id softmax::type_id() {
     return &instance;
 }
 
-layout softmax_inst::calc_output_layout(softmax_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout softmax_inst::calc_output_layout(softmax_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for softmax_node!");
 
-    auto output_layout = node.input().get_output_layout();
+    auto output_layout = impl_param.input_layouts[0];
 
-    if (node.has_fused_primitives())
-        output_layout.data_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives())
+        output_layout.data_type = impl_param.get_fused_output_layout().data_type;
 
     return output_layout;
 }

--- a/src/plugins/intel_gpu/src/graph/space_to_batch.cpp
+++ b/src/plugins/intel_gpu/src/graph/space_to_batch.cpp
@@ -17,16 +17,16 @@ primitive_type_id cldnn::space_to_batch::type_id() {
     return &instance;
 }
 
-layout space_to_batch_inst::calc_output_layout(space_to_batch_node const& node) {
-    auto desc = node.get_primitive();
+layout space_to_batch_inst::calc_output_layout(space_to_batch_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<space_to_batch>();
 
-    auto input_layout = node.input(0).get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     auto input_format = input_layout.format;
 
     auto output_type = desc->output_data_type ? *desc->output_data_type : input_layout.data_type;
 
-    if (node.has_fused_primitives())
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives())
+        output_type = impl_param.get_fused_output_layout().data_type;
 
     const size_t spatial_num = format::spatial_num(input_format);
 
@@ -35,27 +35,27 @@ layout space_to_batch_inst::calc_output_layout(space_to_batch_node const& node) 
     const auto& pads_end = desc->pads_end;
 
     if (block_shape.batch[0] != 1)
-        CLDNN_ERROR_MESSAGE(node.id(),
+        CLDNN_ERROR_MESSAGE(desc->id,
             "block_shape[0] is expected to be 1. Actual block_shape[0] is " +
             std::to_string(block_shape.batch[0]));
 
     if (pads_begin.batch[0] != 0)
-        CLDNN_ERROR_MESSAGE(node.id(),
+        CLDNN_ERROR_MESSAGE(desc->id,
             "pads_begin[0] is expected to be 0. Actual pads_begin[0] is " +
             std::to_string(pads_begin.batch[0]));
 
     if (pads_end.batch[0] != 0)
-        CLDNN_ERROR_MESSAGE(node.id(),
+        CLDNN_ERROR_MESSAGE(desc->id,
             "pads_end[0] is expected to be 0. Actual pads_end[0] is " +
             std::to_string(pads_end.batch[0]));
 
     if ((input_layout.feature() + pads_begin.feature[0] + pads_end.feature[0]) % block_shape.feature[0] != 0)
-            CLDNN_ERROR_MESSAGE(node.id(),
+            CLDNN_ERROR_MESSAGE(desc->id,
                 "Input feature shape after padding must be divisible by block_shape");
 
     for (size_t i = 0; i < spatial_num; ++i)
         if ((input_layout.spatial(i) + pads_begin.spatial[i] + pads_end.spatial[i]) % block_shape.spatial[i] != 0)
-            CLDNN_ERROR_MESSAGE(node.id(),
+            CLDNN_ERROR_MESSAGE(desc->id,
                 "Input spatial shapes after padding must be divisible by block_shape");
 
     return layout{output_type, input_format, desc->out_size};

--- a/src/plugins/intel_gpu/src/graph/space_to_depth.cpp
+++ b/src/plugins/intel_gpu/src/graph/space_to_depth.cpp
@@ -15,32 +15,32 @@ primitive_type_id space_to_depth::type_id() {
     return &instance;
 }
 
-layout space_to_depth_inst::calc_output_layout(space_to_depth_node const& node) {
-    auto desc = node.get_primitive();
+layout space_to_depth_inst::calc_output_layout(space_to_depth_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<space_to_depth>();
 
-    auto input_layout = node.input(0).get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     auto input_format = input_layout.format;
 
     const size_t block_size = desc->block_size;
     auto depth_mode = desc->mode;
 
     auto output_type = input_layout.data_type;
-    if (node.has_fused_primitives()) {
-        output_type = node.get_fused_output_layout().data_type;
+    if (impl_param.has_fused_primitives()) {
+        output_type = impl_param.get_fused_output_layout().data_type;
     }
 
     if (depth_mode != space_to_depth::depth_first && depth_mode != space_to_depth::blocks_first)
-        CLDNN_ERROR_MESSAGE(node.id(),
+        CLDNN_ERROR_MESSAGE(desc->id,
                             "Invalid mode for spaceToDepth: must be \"blocks_first\" or \"depth_first\" only");
 
     if (block_size < 1)
-        CLDNN_ERROR_MESSAGE(node.id(),
+        CLDNN_ERROR_MESSAGE(desc->id,
                             "Invalid spaceToDepth block_size value (should be >= 1). Actual block size is" +
                                 std::to_string(block_size));
 
     if (input_layout.spatial(0) % block_size != 0 || input_layout.spatial(1) % block_size != 0)
         CLDNN_ERROR_MESSAGE(
-            node.id(),
+            desc->id,
             "Sizes of spatials x, y must be divisible by block size. Actual spatial sizes are " +
                 std::to_string(input_layout.spatial(0)) + ", " + std::to_string(input_layout.spatial(1)) +
                     " (x, y). Actual block size is " + std::to_string(block_size));
@@ -49,7 +49,7 @@ layout space_to_depth_inst::calc_output_layout(space_to_depth_node const& node) 
     if (input_layout.format.dimension() == 5) {
         if (input_layout.spatial(2) % block_size != 0)
         CLDNN_ERROR_MESSAGE(
-            node.id(),
+            desc->id,
             "Sizes of spatials z must be divisible by block size. Actual spatial sizes are " +
                 std::to_string(input_layout.spatial(2)) +
                     " (z). Block size is " + std::to_string(block_size));

--- a/src/plugins/intel_gpu/src/graph/split.cpp
+++ b/src/plugins/intel_gpu/src/graph/split.cpp
@@ -15,17 +15,18 @@ primitive_type_id split::type_id() {
     return &instance;
 }
 
-layout split_inst::calc_output_layout(split_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout split_inst::calc_output_layout(split_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for split_node!");
-    auto output_ids = node.get_primitive()->output_ids;
-    auto output_offsets = node.get_primitive()->output_offsets;
+    auto desc = impl_param.typed_desc<split>();
+    auto output_ids = desc->output_ids;
+    auto output_offsets = desc->output_offsets;
     auto param_num = output_ids.size();
-    auto input_sizes = node.get_dependency(0).get_non_padded_output_layout().get_tensor();
+    auto input_sizes = impl_param.get_non_padded_input_layout().get_tensor();
     tensor null_tensor { 0, 0, 0, 0 };
 
     // check if output_ids count equals output_offsets count
-    CLDNN_ERROR_NOT_EQUAL(node.id(),
+    CLDNN_ERROR_NOT_EQUAL(desc->id,
                           "Output_ids count",
                           param_num,
                           "output_offsets count",
@@ -35,7 +36,7 @@ layout split_inst::calc_output_layout(split_node const& node) {
     for (decltype(param_num) i = 0; i < param_num; i++) {
         if (i != param_num - 1)
             // check if output offset sizes is less than next output offset sizes
-            CLDNN_ERROR_TENSOR_SIZES_GREATER_THAN(node.id(),
+            CLDNN_ERROR_TENSOR_SIZES_GREATER_THAN(desc->id,
                                                   "output_offsets",
                                                   output_offsets[i],
                                                   "next output_offsets",
@@ -43,7 +44,7 @@ layout split_inst::calc_output_layout(split_node const& node) {
                                                   "Output_offsets tensor/ next input output_offsets tensor mismatch");
         else
             // check if output offset sizes matches output offsets sizes
-            CLDNN_ERROR_TENSOR_SIZES_GREATER_THAN(node.id(),
+            CLDNN_ERROR_TENSOR_SIZES_GREATER_THAN(desc->id,
                                                   "Output_offsets",
                                                   output_offsets[i],
                                                   "input sizes",
@@ -51,7 +52,7 @@ layout split_inst::calc_output_layout(split_node const& node) {
                                                   "Output_offsets tensor/ input tensor mismatch");
 
         // check if offsets do not extend input sizes and if match the output sizes
-        CLDNN_ERROR_TENSOR_SIZES_LESS_THAN(node.id(),
+        CLDNN_ERROR_TENSOR_SIZES_LESS_THAN(desc->id,
                                            "Output_offsets",
                                            output_offsets[i],
                                            "0 value",
@@ -59,7 +60,7 @@ layout split_inst::calc_output_layout(split_node const& node) {
                                            "Invalid output_offsets: dims cannot be less than 0");
     }
 
-    return node.input().get_non_padded_output_layout();
+    return impl_param.get_non_padded_input_layout();
 }
 
 std::string split_inst::to_string(split_node const& node) {

--- a/src/plugins/intel_gpu/src/graph/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/strided_slice.cpp
@@ -16,9 +16,9 @@ primitive_type_id strided_slice::type_id() {
     return &instance;
 }
 
-layout strided_slice_inst::calc_output_layout(strided_slice_node const& node) {
-    auto desc = node.get_primitive();
-    auto input_layout = node.input(0).get_output_layout();
+layout strided_slice_inst::calc_output_layout(strided_slice_node const& node, kernel_impl_params const& impl_param) {
+    auto desc = impl_param.typed_desc<strided_slice>();
+    auto input_layout = impl_param.input_layouts[0];
     auto output_format = format::get_default_format(desc->out_size.size());
     auto out_shape = desc->out_size;
     std::vector<tensor::value_type> dims_converted(out_shape.begin(), out_shape.end());

--- a/src/plugins/intel_gpu/src/graph/tile.cpp
+++ b/src/plugins/intel_gpu/src/graph/tile.cpp
@@ -15,12 +15,12 @@ primitive_type_id tile::type_id() {
     return &instance;
 }
 
-layout tile_inst::calc_output_layout(tile_node const& node) {
-    assert(static_cast<bool>(node.get_primitive()->output_data_type) == false &&
+layout tile_inst::calc_output_layout(tile_node const& node, kernel_impl_params const& impl_param) {
+    assert(static_cast<bool>(impl_param.desc->output_data_type) == false &&
            "Output data type forcing is not supported for tile_node!");
-    auto desc = node.get_primitive();
+    auto desc = impl_param.typed_desc<tile>();
 
-    auto input_layout = node.input().get_output_layout();
+    auto input_layout = impl_param.input_layouts[0];
     auto input_format = input_layout.format;
     return layout{input_layout.data_type, input_format, desc->out_shape};
 }


### PR DESCRIPTION
### Details:
 - This is baseline work for enabling dynamic shape for GPU plugin
 - For implementing dynamic shape, we need to be able to calculate output layout of primitive instance independent on the common program_node from each stream

### Tickets:
 - 80676
