### PR TITLE
GroupedGatherElimination short circuit

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
@@ -75,15 +75,15 @@ ngraph::pass::GroupedGatherElimination::GroupedGatherElimination() {
                 (curr->input_value(0) != next->input_value(0))) {
                 ++i;
                 continue;
-            }  
-            
-            // Scalar inputs are not supported by Concat and we don't want to throw an exception here. 
+            }
+
+            // Scalar inputs are not supported by Concat and we don't want to throw an exception here.
             // The transformation should not be applied instead.
             if (curr->input_value(1).get_partial_shape().same_scheme(Shape{}) ||
                 next->input_value(1).get_partial_shape().same_scheme(Shape{})) {
                 return false;
             }
-            
+
             // curr and next are the same type of gather which takes data from the same source
             auto joint_indices = ngraph::op::util::make_try_fold<opset1::Concat>(
                 OutputVector{curr->input_value(1), next->input_value(1)},

--- a/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
@@ -75,7 +75,16 @@ ngraph::pass::GroupedGatherElimination::GroupedGatherElimination() {
                 (curr->input_value(0) != next->input_value(0))) {
                 ++i;
                 continue;
-            }  // curr and next are the same type of gather which takes data from the same source
+            }  
+            
+            // Scalar inputs are not supported by Concat and we don't want to throw an exception here. 
+            // The transformation should not be applied instead.
+            if (curr->input_value(1).get_partial_shape().same_scheme(Shape{}) ||
+                next->input_value(1).get_partial_shape().same_scheme(Shape{})) {
+                return false;
+            }
+            
+            // curr and next are the same type of gather which takes data from the same source
             auto joint_indices = ngraph::op::util::make_try_fold<opset1::Concat>(
                 OutputVector{curr->input_value(1), next->input_value(1)},
                 0);


### PR DESCRIPTION
### Details:
 - The inputs containing gather indices might be scalars
 - The concatenation of scalars is not supported
 - An initial fix is to return false from the GroupedGatherElimination pass when such subgraph is found in a model
 - This situation could potentially be handled by using Reshape operators before they are passed to the Concat node but it should be done as a follow-up of this PR

### Tickets:
 - 88091
