### PR TITLE
Auto Batch: if plugin is disabled during cmake

### DIFF
--- a/src/inference/src/ie_core.cpp
+++ b/src/inference/src/ie_core.cpp
@@ -580,6 +580,12 @@ public:
             // as the result is being checked by the user
             strictly_check_dims = false;
         } else {
+            // check if Auto-Batch plugin registered
+            try {
+                GetCPPPluginByName("BATCH");
+            } catch (...) {
+                return;
+            }
             // check whether the Auto-Batching is disabled explicitly
             const auto& batch_mode = config.find(ov::hint::allow_auto_batching.name());
             if (batch_mode != config.end()) {


### PR DESCRIPTION
# This is not yet approved to be merged to 2022.1.1 despite green status

### Details:
 - *Auto-batch fix: if plugin if disabled during cmake*

### Tickets:
 - *88449*
