### PR TITLE
Changed update date in MO message.

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/get_ov_update_message.py
+++ b/tools/mo/openvino/tools/mo/utils/get_ov_update_message.py
@@ -8,7 +8,7 @@ msg_fmt = 'Check for a new version of Intel(R) Distribution of OpenVINO(TM) tool
 
 
 def get_ov_update_message():
-    expected_update_date = datetime.date(year=2023, month=2, day=31)
+    expected_update_date = datetime.date(year=2023, month=2, day=1)
     current_date = datetime.date.today()
 
     link = 'https://software.intel.com/content/www/us/en/develop/tools/openvino-toolkit/download.html?cid=other&source=prod&campid=ww_2022_bu_IOTG_OpenVINO-2022-2&content=upg_all&medium=organic'

--- a/tools/mo/openvino/tools/mo/utils/get_ov_update_message.py
+++ b/tools/mo/openvino/tools/mo/utils/get_ov_update_message.py
@@ -8,7 +8,7 @@ msg_fmt = 'Check for a new version of Intel(R) Distribution of OpenVINO(TM) tool
 
 
 def get_ov_update_message():
-    expected_update_date = datetime.date(year=2022, month=10, day=31)
+    expected_update_date = datetime.date(year=2023, month=2, day=31)
     current_date = datetime.date.today()
 
     link = 'https://software.intel.com/content/www/us/en/develop/tools/openvino-toolkit/download.html?cid=other&source=prod&campid=ww_2022_bu_IOTG_OpenVINO-2022-2&content=upg_all&medium=organic'


### PR DESCRIPTION
Root cause analysis: update date was too early, which may cause unexpected showing of update message.

Solution: Move update date in MO message to 1.02.22

Ticket: CVS 88686


Code:
* [ ]  Comments
* [ ]  Code style (PEP8)
* [ ]  Transformation generates reshape-able IR - N/A
* [ ]  Transformation preserves original framework node names - N/A
* [ ]  Transformation preserves tensor names - N/A


Validation:
* [ ]  Unit tests - N/A
* [ ]  Framework operation tests - N/A
* [ ]  Transformation tests - N/A
* [ ]  Model Optimizer IR Reader check - N/A

Documentation:
* [ ]  Supported frameworks operations list - N/A
* [ ]  Guide on how to convert the **public** model - N/A
* [ ]  User guide update - N/A
