### PR TITLE
n should be compared to size of each batch, not the whole tensor size

### DIFF
--- a/samples/cpp/common/utils/include/samples/classification_results.h
+++ b/samples/cpp/common/utils/include/samples/classification_results.h
@@ -61,7 +61,7 @@ private:
         size_t batchSize = shape[0];
         std::vector<unsigned> indexes(input.get_size() / batchSize);
 
-        n = static_cast<unsigned>(std::min<size_t>((size_t)n, input.get_size()));
+        n = static_cast<unsigned>(std::min<size_t>((size_t)n, input.get_size() / batchSize));
         output.resize(n * batchSize);
 
         for (size_t i = 0; i < batchSize; i++) {


### PR DESCRIPTION
### Details:

`n` is the top n results of each batch, so should be compared with the size of each batch, while not the total size `input.get_size()`
