### PR TITLE
[GNA] Fix issue with inference when input or output first dim is diff…

### DIFF
--- a/src/plugins/intel_gna/backend/dnn_components.cpp
+++ b/src/plugins/intel_gna/backend/dnn_components.cpp
@@ -10,7 +10,6 @@
 #include <iomanip>
 #include <caseless.hpp>
 #include <layers/gna_copy_layer.hpp>
-#include "backend/dnn_types.h"
 
 #include "dnn_components.hpp"
 
@@ -38,17 +37,40 @@ intel_dnn_component_t & DnnComponents::addComponent(const std::string layerName,
     return currentComponent;
 }
 
-intel_dnn_component_t * DnnComponents::findComponent(InferenceEngine::CNNLayerPtr __layer) {
-    auto component = std::find_if(begin(components),
-                                  end(components),
-                                  [&](storage_type ::value_type &comp) {
-                                      return comp.name == __layer->name;
-                                  });
-    // check for generic prev layer
+intel_dnn_component_t* DnnComponents::findComponent(InferenceEngine::CNNLayerPtr layer) {
+    if (layer) {
+        return findComponent(layer->name);
+    }
+
+    return nullptr;
+}
+
+intel_dnn_component_t* GNAPluginNS::backend::DnnComponents::findComponent(const std::string& layerName) {
+    auto component = std::find_if(begin(components), end(components), [&](const storage_type ::value_type& comp) {
+        return comp.name == layerName;
+    });
     if (component != components.end()) {
         return &component->dnnComponent;
     }
+    return nullptr;
+}
 
+const intel_dnn_component_t* GNAPluginNS::backend::DnnComponents::findComponent(
+    const InferenceEngine::CNNLayerPtr layer) const {
+    if (layer) {
+        return findComponent(layer->name);
+    }
+
+    return nullptr;
+}
+
+const intel_dnn_component_t* GNAPluginNS::backend::DnnComponents::findComponent(const std::string& layerName) const {
+    auto component = std::find_if(begin(components), end(components), [&](const storage_type ::value_type& comp) {
+        return comp.name == layerName;
+    });
+    if (component != components.end()) {
+        return &component->dnnComponent;
+    }
     return nullptr;
 }
 

--- a/src/plugins/intel_gna/backend/dnn_components.hpp
+++ b/src/plugins/intel_gna/backend/dnn_components.hpp
@@ -5,10 +5,14 @@
 #pragma once
 
 #include <list>
+#include <vector>
 #include <string>
 #include <utility>
 
 #include <ie_common.h>
+#include <legacy/ie_layers.h>
+#include "dnn_types.h"
+
 
 namespace GNAPluginNS {
 namespace backend {
@@ -40,6 +44,24 @@ struct DnnComponents {
      * @return
      */
     intel_dnn_component_t * findComponent(InferenceEngine::CNNLayerPtr layer);
+
+    /**
+     * @brief returns Pointer to corresponding dnn layer for topology layer name
+     * @return
+     */
+    intel_dnn_component_t* findComponent(const std::string& layerName);
+
+    /**
+     * @brief returns Pointer to const corresponding dnn layer for topology layer
+     * @return
+     */
+    const intel_dnn_component_t* findComponent(InferenceEngine::CNNLayerPtr layer) const;
+
+     /**
+     * @brief returns const Pointer to const corresponding dnn layer name for topology layer name
+     * @return
+     */
+    const intel_dnn_component_t* findComponent(const std::string& layerName) const;
 
     /**
      * @brief extract components in execution order

--- a/src/plugins/intel_gna/descriptions/gna_desc.hpp
+++ b/src/plugins/intel_gna/descriptions/gna_desc.hpp
@@ -129,7 +129,7 @@ public:
         if (key.empty()) {
             throw std::invalid_argument("The key cannot be empty");
         }
-        auto desc_it = std::find_if(infos_.begin(), infos_.end(), [&key](const T& desc){return desc.name == key;});
+        auto desc_it = find(key);
         if (desc_it == infos_.end()) {
             throw std::out_of_range("The key cannot be found");
         }
@@ -138,6 +138,22 @@ public:
 
     T& at(const std::string &key) {
       return const_cast<T&>( static_cast<const GnaNetworkInfo&>(*this).at(key) );
+    }
+
+    typename std::vector<T>::iterator end() {
+        return infos_.end();
+    }
+
+    typename std::vector<T>::const_iterator find(const std::string& key) const {
+        return std::find_if(infos_.cbegin(), infos_.cend(), [&key](const T& desc) {
+            return desc.name == key;
+        });
+    }
+
+    typename std::vector<T>::iterator find(const std::string& key) {
+        return std::find_if(infos_.begin(), infos_.end(), [&key](const T& desc) {
+            return desc.name == key;
+        });
     }
 
     T& operator[](const std::string &key) {

--- a/src/plugins/intel_gna/gna_plugin.hpp
+++ b/src/plugins/intel_gna/gna_plugin.hpp
@@ -157,7 +157,6 @@ protected:
      /**
       * QueryMetrics API
       */
-
      InferenceEngine::Parameter GetAvailableDevices() const;
 
  protected:

--- a/src/plugins/intel_gna/orientation_helper.cpp
+++ b/src/plugins/intel_gna/orientation_helper.cpp
@@ -1,0 +1,91 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "orientation_helper.hpp"
+
+#include <legacy/ie_layers.h>
+
+#include <gna_graph_tools.hpp>
+
+namespace GNAPluginNS {
+namespace helpers {
+
+void updateModelInputOrientationWithoutConvolution(const InferenceEngine::CNNLayer& inputLayer,
+                                                   const GNAPluginNS::backend::DnnComponents& components,
+                                                   GNAPluginNS::GnaInputs& inputs) {
+    // does not make sense to go further is there is no input to set
+    auto input = inputs.find(inputLayer.name);
+
+    if (input == inputs.end()) {
+        return;
+    }
+
+    auto doesntHaveGnaMapping = [=](InferenceEngine::CNNLayerPtr l) {
+        auto dnnLayer = components.findComponent(l);
+        return dnnLayer == nullptr;
+    };
+
+    auto nextLayers = InferenceEngine::CNNNetGetAllNextLayersSkipCertain(&inputLayer, -1, doesntHaveGnaMapping);
+    if (nextLayers.empty()) {
+        input->orientation = kDnnInterleavedOrientation;
+        return;
+    }
+
+    std::vector<intel_dnn_orientation_t> suggestedOrientations;
+
+    auto dims = input->dims;
+    auto raws = dims[0];
+    auto rest = InferenceEngine::details::product(std::next(std::begin(dims)), std::end(dims));
+    if (rest == 0) {
+        rest = 1;
+    }
+
+    for (auto& nextLayer : nextLayers) {
+        auto dnnLayer = components.findComponent(nextLayer);
+
+        if (!dnnLayer) {
+            THROW_GNA_LAYER_EXCEPTION(nextLayer) << " gna mapped layer search connection failed";
+        }
+
+        if (dnnLayer->operation != kDnnInterleaveOp && dnnLayer->operation != kDnnDeinterleaveOp && raws > 1 &&
+            rest > 1) {
+            suggestedOrientations.push_back(dnnLayer->orientation_in);
+        }
+    }
+
+    if (suggestedOrientations.empty()) {
+        input->orientation = kDnnNonInterleavedOrientation;
+        return;
+    }
+
+    if (std::adjacent_find(suggestedOrientations.begin(),
+                           suggestedOrientations.end(),
+                           std::not_equal_to<intel_dnn_orientation_t>()) != suggestedOrientations.end()) {
+        // unsupported case: orientations are different and they are important for these components
+        THROW_GNA_EXCEPTION << "Input layer[" << inputLayer.name
+                            << "] is used as input by multiple layers with different orientation!";
+    }
+
+    input->orientation = suggestedOrientations.front();
+    return;
+}
+
+void updateModelOutputOrientation(const std::string& outputName,
+                                  const std::string& cnnlayerName,
+                                  const GNAPluginNS::backend::DnnComponents& components,
+                                  GNAPluginNS::GnaOutputs& outputs) {
+    // if there is no output to set does not make sense to go further
+    auto output = outputs.find(outputName);
+    if (output == outputs.end()) {
+        return;
+    }
+
+    auto dnnLayer = components.findComponent(cnnlayerName);
+    if (dnnLayer && (dnnLayer->operation == kDnnInterleaveOp || dnnLayer->operation == kDnnDeinterleaveOp ||
+                     dnnLayer->num_rows_out == 1 || dnnLayer->num_columns_out == 1)) {
+        output->orientation = kDnnNonInterleavedOrientation;
+    }
+}
+}  // namespace helpers
+}  // namespace GNAPluginNS

--- a/src/plugins/intel_gna/orientation_helper.hpp
+++ b/src/plugins/intel_gna/orientation_helper.hpp
@@ -12,7 +12,8 @@
 #include "backend/dnn_components.hpp"
 #include "descriptions/gna_desc.hpp"
 
-namespace GNAPluginNS {
+namespace ov {
+namespace intela_gna {
 /**
  * @namespace helpers contains helpers tools for gna plugin.
  */
@@ -24,11 +25,11 @@ namespace helpers {
  *
  * @note Function check following parameters if:
  *  - there is at least one dnn input layer for given cnn layer
- *  - corespoding dnn layers operation are not kDnnInterleaveOp and not kDnnDeinterleaveOp
- *  - corespoding input layer first dimenions and product of rest of dimensions is greater than 1
+ *  - corresponding dnn layers operation are not kDnnInterleaveOp and not kDnnDeinterleaveOp
+ *  - corresponding input layer first dimenions and product of rest of dimensions is greater than 1
  *
  * If any of conditions is not met kDnnNonInterleavedOrientation is set.
- * If all of condtions above will be met kDnnInterleavedOrientation is set.
+ * If all of conditions above will be met kDnnInterleavedOrientation is set.
  *
  * @param inputLayer model input layer
  * @param components layers transformed to form consumable by GNA
@@ -45,10 +46,10 @@ void updateModelInputOrientationWithoutConvolution(const InferenceEngine::CNNLay
  * transposition for output data of output layer is needed.
  *
  * @note Function checks following parameters if:
- *  - corespoding dnn layer operation is kDnnInterleaveOp or kDnnDeinterleaveOp
- *  - corespoding dnn layer is present and columns and rows numbes are bigger than 1
+ *  - corresponding dnn layer operation is kDnnInterleaveOp or kDnnDeinterleaveOp
+ *  - corresponding dnn layer is present and columns and rows numbes are bigger than 1
  *
- * If any of condtion above will be not met orientation is set to kDnnNonInterleavedOrientation.
+ * If any of conditions above will be not met orientation is set to kDnnNonInterleavedOrientation.
  * If there is no corespnding dnn layer orientation is untouched.
  *
  * @param outputName name of the model output
@@ -63,4 +64,5 @@ void updateModelOutputOrientation(const std::string& outputName,
                                   GNAPluginNS::GnaOutputs& outputs);
 
 }  // namespace helpers
-}  // namespace GNAPluginNS
+}  // namespace intela_gna
+}  // namespace ov

--- a/src/plugins/intel_gna/orientation_helper.hpp
+++ b/src/plugins/intel_gna/orientation_helper.hpp
@@ -1,0 +1,66 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <legacy/ie_layers.h>
+
+#include <ie/ie_input_info.hpp>
+#include <string>
+
+#include "backend/dnn_components.hpp"
+#include "descriptions/gna_desc.hpp"
+
+namespace GNAPluginNS {
+/**
+ * @namespace helpers contains helpers tools for gna plugin.
+ */
+namespace helpers {
+
+/**
+ * @brief Update expected orientation for model input of given \p inputLayer. It is needed to recognize if extra
+ * transposition for input data of input layer is needed.
+ *
+ * @note Function check following parameters if:
+ *  - there is at least one dnn input layer for given cnn layer
+ *  - corespoding dnn layers operation are not kDnnInterleaveOp and not kDnnDeinterleaveOp
+ *  - corespoding input layer first dimenions and product of rest of dimensions is greater than 1
+ *
+ * If any of conditions is not met kDnnNonInterleavedOrientation is set.
+ * If all of condtions above will be met kDnnInterleavedOrientation is set.
+ *
+ * @param inputLayer model input layer
+ * @param components layers transformed to form consumable by GNA
+ * @param inputs of model
+ *
+ * @throws if orientations of input for multiple layers are different
+ */
+void updateModelInputOrientationWithoutConvolution(const InferenceEngine::CNNLayer& inputLayer,
+                                                   const GNAPluginNS::backend::DnnComponents& components,
+                                                   GNAPluginNS::GnaInputs& inputs);
+
+/**
+ * @brief Update expected orientation for model output of given \p outputName. It is needed to recognize if extra
+ * transposition for output data of output layer is needed.
+ *
+ * @note Function checks following parameters if:
+ *  - corespoding dnn layer operation is kDnnInterleaveOp or kDnnDeinterleaveOp
+ *  - corespoding dnn layer is present and columns and rows numbes are bigger than 1
+ *
+ * If any of condtion above will be not met orientation is set to kDnnNonInterleavedOrientation.
+ * If there is no corespnding dnn layer orientation is untouched.
+ *
+ * @param outputName name of the model output
+ * @param cnnLayerName name of coresponding model input layer
+ * @param components layers transformed to form consumable by GNA
+ * @param outputs outputs of model
+ *
+ */
+void updateModelOutputOrientation(const std::string& outputName,
+                                  const std::string& cnnlayerName,
+                                  const GNAPluginNS::backend::DnnComponents& components,
+                                  GNAPluginNS::GnaOutputs& outputs);
+
+}  // namespace helpers
+}  // namespace GNAPluginNS

--- a/src/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/permute_concat_permute.cpp
+++ b/src/tests/functional/plugin/gna/shared_tests_instances/subgraph_tests/permute_concat_permute.cpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "subgraph_tests/permute_concat_permute.hpp"
+
+#include <vector>
+
+using namespace SubgraphTestsDefinitions;
+
+namespace {
+std::vector<std::vector<std::vector<size_t>>> inputs{
+    {{32, 2}, {1, 0}, {1, 0}},
+    {{8, 2}, {1, 0}, {1, 0}},
+    {{1, 8}, {1, 0}, {1, 0}},
+};
+
+std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_permute_concat_permute,
+                         PermuteConcatPermute,
+                         ::testing::Combine(::testing::ValuesIn(inputs),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(CommonTestUtils::DEVICE_GNA)),
+                         PermuteConcatPermute::getTestCaseName);
+}  // namespace

--- a/src/tests/functional/plugin/gna/shared_tests_instances/transpose_add.cpp
+++ b/src/tests/functional/plugin/gna/shared_tests_instances/transpose_add.cpp
@@ -10,8 +10,9 @@ std::vector<std::vector<size_t>> input_shapes {
     {1, 4, 32},
     {1, 8, 8},
     {1, 7, 8},
-    {1, 40, 3}
-};
+    {1, 40, 3},
+    {32, 8},
+    {8, 2}};
 
 std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,

--- a/src/tests/functional/plugin/shared/include/subgraph_tests/permute_concat_permute.hpp
+++ b/src/tests/functional/plugin/shared/include/subgraph_tests/permute_concat_permute.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/subgraph/permute_concat_permute.hpp"
+
+namespace SubgraphTestsDefinitions {
+
+TEST_P(PermuteConcatPermute, CompareWithRefs) {
+    Run();
+}
+
+}  // namespace SubgraphTestsDefinitions

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/permute_concat_permute.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/permute_concat_permute.hpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "shared_test_classes/base/layer_test_utils.hpp"
+
+namespace SubgraphTestsDefinitions {
+typedef std::tuple<std::vector<std::vector<size_t>>,  // input shapes and permute shapes
+                   InferenceEngine::Precision,        // Network precision
+                   std::string                        // Device name
+                   >
+    PermuteConcatPermuteTuple;
+
+class PermuteConcatPermute : public testing::WithParamInterface<PermuteConcatPermuteTuple>,
+                             virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<PermuteConcatPermuteTuple>& obj);
+
+protected:
+    void SetUp() override;
+    InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo& inputInfo) const override;
+
+    int32_t range_{};
+    int32_t start_{1};
+    int32_t step_{1};
+};
+}  // namespace SubgraphTestsDefinitions

--- a/src/tests/functional/shared_test_classes/src/subgraph/permute_concat_permute.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/permute_concat_permute.cpp
@@ -38,11 +38,11 @@ void PermuteConcatPermute::SetUp() {
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
-    auto input_param = std::make_shared<ngraph::opset1::Parameter>(ngPrc, ngraph::Shape{input_shape});
+    auto input_param = std::make_shared<ngraph::opset9::Parameter>(ngPrc, ngraph::Shape{input_shape});
     auto permute_params_1 =
-        ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{permute_1_param.size()}, permute_1_param);
+        ngraph::opset9::Constant::create(ngraph::element::i64, ngraph::Shape{permute_1_param.size()}, permute_1_param);
 
-    auto permute_1 = std::make_shared<ngraph::opset1::Transpose>(input_param, permute_params_1);
+    auto permute_1 = std::make_shared<ngraph::opset9::Transpose>(input_param, permute_params_1);
 
     auto const_input_shape_vec = std::vector<size_t>{1};
     const_input_shape_vec.insert(const_input_shape_vec.end(), input_shape.begin(), std::prev(input_shape.end()));
@@ -50,16 +50,16 @@ void PermuteConcatPermute::SetUp() {
     auto const_input_values_size = InferenceEngine::details::product(const_input_shape_vec);
     auto const_input_values = std::vector<size_t>(const_input_values_size, 0);
 
-    auto const_input_1 = ngraph::opset1::Constant::create(ngPrc, constinput_shape, const_input_values);
-    auto const_input_2 = ngraph::opset1::Constant::create(ngPrc, constinput_shape, const_input_values);
-    auto const_input_3 = ngraph::opset1::Constant::create(ngPrc, constinput_shape, const_input_values);
+    auto const_input_1 = ngraph::opset9::Constant::create(ngPrc, constinput_shape, const_input_values);
+    auto const_input_2 = ngraph::opset9::Constant::create(ngPrc, constinput_shape, const_input_values);
+    auto const_input_3 = ngraph::opset9::Constant::create(ngPrc, constinput_shape, const_input_values);
 
-    auto concat = std::make_shared<ngraph::opset1::Concat>(
+    auto concat = std::make_shared<ngraph::opset9::Concat>(
         ngraph::OutputVector{const_input_1, const_input_2, permute_1, const_input_3},
         0);
     auto permute_params_2 =
-        ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{permute_2_param.size()}, permute_2_param);
-    auto permute_2 = std::make_shared<ngraph::opset1::Transpose>(concat, permute_params_2);
+        ngraph::opset9::Constant::create(ngraph::element::i64, ngraph::Shape{permute_2_param.size()}, permute_2_param);
+    auto permute_2 = std::make_shared<ngraph::opset9::Transpose>(concat, permute_params_2);
 
     function =
         std::make_shared<ngraph::Function>(permute_2, ngraph::ParameterVector{input_param}, "permute_concat_permute");

--- a/src/tests/functional/shared_test_classes/src/subgraph/permute_concat_permute.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/permute_concat_permute.cpp
@@ -1,0 +1,72 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/subgraph/permute_concat_permute.hpp"
+
+#include <debug.h>
+
+#include <cstdlib>
+#include <ctime>
+#include <iterator>
+
+#include "ngraph_functions/builders.hpp"
+
+namespace SubgraphTestsDefinitions {
+std::string PermuteConcatPermute::getTestCaseName(const testing::TestParamInfo<PermuteConcatPermuteTuple>& obj) {
+    std::vector<std::vector<size_t>> input;
+    InferenceEngine::Precision netPrecision;
+    std::string targetName;
+    std::tie(input, netPrecision, targetName) = obj.param;
+    std::ostringstream results;
+
+    results << "IS=" << CommonTestUtils::vec2str(input[0]) << "_";
+    results << "netPRC=" << netPrecision.name() << "_";
+    results << "targetDevice=" << targetName << "_";
+    return results.str();
+}
+
+void PermuteConcatPermute::SetUp() {
+    std::srand(std::time(nullptr));
+
+    std::vector<std::vector<size_t>> inputs;
+    InferenceEngine::Precision netPrecision;
+    std::tie(inputs, netPrecision, targetDevice) = this->GetParam();
+    auto input_shape = inputs[0];
+    auto permute_1_param = inputs[1];
+    auto permute_2_param = inputs[2];
+
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+
+    auto input_param = std::make_shared<ngraph::opset1::Parameter>(ngPrc, ngraph::Shape{input_shape});
+    auto permute_params_1 =
+        ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{permute_1_param.size()}, permute_1_param);
+
+    auto permute_1 = std::make_shared<ngraph::opset1::Transpose>(input_param, permute_params_1);
+
+    auto const_input_shape_vec = std::vector<size_t>{1};
+    const_input_shape_vec.insert(const_input_shape_vec.end(), input_shape.begin(), std::prev(input_shape.end()));
+    const auto constinput_shape = ngraph::Shape{const_input_shape_vec};
+    auto const_input_values_size = InferenceEngine::details::product(const_input_shape_vec);
+    auto const_input_values = std::vector<size_t>(const_input_values_size, 0);
+
+    auto const_input_1 = ngraph::opset1::Constant::create(ngPrc, constinput_shape, const_input_values);
+    auto const_input_2 = ngraph::opset1::Constant::create(ngPrc, constinput_shape, const_input_values);
+    auto const_input_3 = ngraph::opset1::Constant::create(ngPrc, constinput_shape, const_input_values);
+
+    auto concat = std::make_shared<ngraph::opset1::Concat>(
+        ngraph::OutputVector{const_input_1, const_input_2, permute_1, const_input_3},
+        0);
+    auto permute_params_2 =
+        ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{permute_2_param.size()}, permute_2_param);
+    auto permute_2 = std::make_shared<ngraph::opset1::Transpose>(concat, permute_params_2);
+
+    function =
+        std::make_shared<ngraph::Function>(permute_2, ngraph::ParameterVector{input_param}, "permute_concat_permute");
+    range_ = InferenceEngine::details::product(input_shape);
+}
+
+InferenceEngine::Blob::Ptr PermuteConcatPermute::GenerateInput(const InferenceEngine::InputInfo& inputInfo) const {
+    return FuncTestUtils::createAndFillBlobConsistently(inputInfo.getTensorDesc(), range_, start_, step_);
+}
+}  // namespace SubgraphTestsDefinitions


### PR DESCRIPTION
Details:
* enforce init input layer and export output results to use
    kDnnNonInterleavedOrientation orientation if condition for
    inteleave not met.
* added functional regression tests for reproduction of issue

Tickets:
* 88521