### PR TITLE
Models path adjustment in ONNX tests

### DIFF
--- a/cmake/test_model_zoo.cmake
+++ b/cmake/test_model_zoo.cmake
@@ -138,5 +138,5 @@ if(ENABLE_TESTS)
     install(DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_model_zoo"
             DESTINATION tests COMPONENT tests EXCLUDE_FROM_ALL)
 
-    set(TEST_MODEL_ZOO "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_model_zoo" CACHE PATH "Path to test model zoo")
+    set(TEST_MODEL_ZOO "./test_model_zoo" CACHE PATH "Path to test model zoo")
 endif()

--- a/cmake/test_model_zoo.cmake
+++ b/cmake/test_model_zoo.cmake
@@ -138,5 +138,5 @@ if(ENABLE_TESTS)
     install(DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_model_zoo"
             DESTINATION tests COMPONENT tests EXCLUDE_FROM_ALL)
 
-    set(TEST_MODEL_ZOO "./test_model_zoo" CACHE PATH "Path to test model zoo")
+    set(TEST_MODEL_ZOO "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_model_zoo" CACHE PATH "Path to test model zoo")
 endif()

--- a/src/frontends/tests/onnx/onnx_editor.cpp
+++ b/src/frontends/tests/onnx/onnx_editor.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <sstream>
 
+#include "common_test_utils/file_utils.hpp"
 #include "default_opset.hpp"
 #include "editor.hpp"
 #include "engines_util/test_case.hpp"
@@ -46,7 +47,9 @@ std::shared_ptr<op::v0::Parameter> find_input(const ParameterVector& inputs, con
 
 NGRAPH_TEST(onnx_editor, types__single_input_type_substitution) {
     // the original model contains 2 inputs with i64 data type and one f32 input
-    ONNXModelEditor editor{ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_abc.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/add_abc.onnx")};
 
     editor.set_input_types({{"A", element::i64}});
 
@@ -67,7 +70,9 @@ NGRAPH_TEST(onnx_editor, types__single_input_type_substitution) {
 
 NGRAPH_TEST(onnx_editor, types__all_inputs_type_substitution) {
     // the original model contains 2 inputs with i64 data type and one f32 input
-    ONNXModelEditor editor{ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_abc.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/add_abc.onnx")};
 
     editor.set_input_types({{"A", element::i8}, {"B", element::i8}, {"C", element::i8}});
 
@@ -86,37 +91,44 @@ NGRAPH_TEST(onnx_editor, types__all_inputs_type_substitution) {
 }
 
 NGRAPH_TEST(onnx_editor, types__missing_type_in_input_descriptor) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/invalid_input_no_type.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/invalid_input_no_type.onnx")};
 
     // input A doesn't have the "type" field in the model and so the data type cannot be modified
     EXPECT_THROW(editor.set_input_types({{"A", element::f32}}), ngraph::ngraph_error);
 }
 
 NGRAPH_TEST(onnx_editor, types__missing_tensor_type_in_input_descriptor) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/invalid_input_no_tensor_type.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/invalid_input_no_tensor_type.onnx")};
 
     // input A doesn't have the "tensor_type" field in the model
     EXPECT_THROW(editor.set_input_types({{"A", element::f32}}), ngraph::ngraph_error);
 }
 
 NGRAPH_TEST(onnx_editor, types__unsupported_data_type_passed) {
-    ONNXModelEditor editor{ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_abc.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/add_abc.onnx")};
 
     EXPECT_THROW(editor.set_input_types({{"A", element::dynamic}}), ngraph::ngraph_error);
 }
 
 NGRAPH_TEST(onnx_editor, types__incorrect_input_name_passed) {
-    ONNXModelEditor editor{ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_abc.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/add_abc.onnx")};
 
     EXPECT_THROW(editor.set_input_types({{"ShiaLaBeouf", element::i64}}), ngraph::ngraph_error);
 }
 
 NGRAPH_TEST(onnx_editor, types__elem_type_missing_in_input) {
     // the original model contains 2 inputs with i64 data type and one f32 input
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/elem_type_missing_in_input.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/elem_type_missing_in_input.onnx")};
 
     // the "elem_type" is missing in the model but it should be possible to set the type anyway
     EXPECT_NO_THROW(editor.set_input_types({{"A", element::i64}}));
@@ -135,8 +147,9 @@ NGRAPH_TEST(onnx_editor, types__elem_type_missing_in_input) {
 }
 
 NGRAPH_TEST(onnx_editor, shapes__modify_single_input) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/shapes__add_two_inputs.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/shapes__add_two_inputs.onnx")};
 
     const auto new_shape = PartialShape{1};
 
@@ -149,8 +162,9 @@ NGRAPH_TEST(onnx_editor, shapes__modify_single_input) {
 }
 
 NGRAPH_TEST(onnx_editor, shapes__modify_all_inputs) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/shapes__add_two_inputs.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/shapes__add_two_inputs.onnx")};
 
     const auto new_shape = PartialShape{1, 2, 3, 5, 8, 13};
 
@@ -165,8 +179,9 @@ NGRAPH_TEST(onnx_editor, shapes__modify_all_inputs) {
 }
 
 NGRAPH_TEST(onnx_editor, shapes__dynamic_rank_in_model) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/shapes__dynamic_rank_in_model.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/shapes__dynamic_rank_in_model.onnx")};
 
     // input A in the model doesn't have the "shape" field meaning it has dynamic rank
     // it should still be possible to set such input's shape to some custom value
@@ -180,8 +195,9 @@ NGRAPH_TEST(onnx_editor, shapes__dynamic_rank_in_model) {
 }
 
 NGRAPH_TEST(onnx_editor, shapes__set_dynamic_dimension) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/shapes__add_two_inputs.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/shapes__add_two_inputs.onnx")};
 
     const auto new_shape = PartialShape{Dimension::dynamic()};
 
@@ -194,8 +210,9 @@ NGRAPH_TEST(onnx_editor, shapes__set_dynamic_dimension) {
 }
 
 NGRAPH_TEST(onnx_editor, shapes__set_mixed_dimensions) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/shapes__add_two_inputs.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/shapes__add_two_inputs.onnx")};
 
     const auto new_shape_A = PartialShape{21, Dimension::dynamic()};
     const auto new_shape_B = PartialShape{Dimension::dynamic(), 37};
@@ -213,8 +230,9 @@ NGRAPH_TEST(onnx_editor, shapes__set_mixed_dimensions) {
 }
 
 NGRAPH_TEST(onnx_editor, shapes__set_scalar_inputs) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/shapes__add_two_inputs.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/shapes__add_two_inputs.onnx")};
 
     const auto new_shape = PartialShape{};
 
@@ -231,8 +249,9 @@ NGRAPH_TEST(onnx_editor, shapes__set_scalar_inputs) {
 }
 
 NGRAPH_TEST(onnx_editor, shapes__static_to_dynamic_rank_substitution) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/shapes__add_two_inputs.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/shapes__add_two_inputs.onnx")};
 
     const auto new_shape = PartialShape::dynamic();
 
@@ -247,13 +266,15 @@ NGRAPH_TEST(onnx_editor, shapes__static_to_dynamic_rank_substitution) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__linear_model_head_cut) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph__inception_head.onnx")};
 
     editor.extract_subgraph({{InputEdge(1, 0)}}, {});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/subgraph__linear_model_head_cut.onnx");
 
     const auto result = compare_onnx_models(editor.model_string(), ref_model);
@@ -262,14 +283,16 @@ NGRAPH_TEST(onnx_editor, subgraph__linear_model_head_cut) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__linear_model_head_cut_ins_and_outs) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph__inception_head.onnx")};
 
     editor.extract_subgraph({{InputEdge(1, 0)}}, {{OutputEdge(2, 0)}});
 
     // expected to behave the same way as subgraph__linear_model_head_cut
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/subgraph__linear_model_head_cut.onnx");
 
     const auto result = compare_onnx_models(editor.model_string(), ref_model);
@@ -278,13 +301,15 @@ NGRAPH_TEST(onnx_editor, subgraph__linear_model_head_cut_ins_and_outs) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__linear_model_deeper_head_cut) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph__inception_head.onnx")};
 
     editor.extract_subgraph({{InputEdge(2, 0)}}, {});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/subgraph__linear_model_deeper_head_cut.onnx");
 
     const auto result = compare_onnx_models(editor.model_string(), ref_model);
@@ -293,13 +318,15 @@ NGRAPH_TEST(onnx_editor, subgraph__linear_model_deeper_head_cut) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__linear_model_tail_cut) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph__inception_head.onnx")};
 
     editor.extract_subgraph({}, {{OutputEdge{1, 0}}});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/subgraph__linear_model_tail_cut.onnx");
 
     const auto result = compare_onnx_models(editor.model_string(), ref_model);
@@ -308,14 +335,16 @@ NGRAPH_TEST(onnx_editor, subgraph__linear_model_tail_cut) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__linear_model_tail_cut_ins_and_outs) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph__inception_head.onnx")};
 
     editor.extract_subgraph({{InputEdge{0, 0}}}, {{OutputEdge{1, 0}}});
 
     // expected to behave the same way as subgraph__linear_model_tail_cut
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/subgraph__linear_model_tail_cut.onnx");
 
     const auto result = compare_onnx_models(editor.model_string(), ref_model);
@@ -325,12 +354,14 @@ NGRAPH_TEST(onnx_editor, subgraph__linear_model_tail_cut_ins_and_outs) {
 
 NGRAPH_TEST(onnx_editor, subgraph__linear_model_with_initializer_tail_cut) {
     ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/subgraph__inception_head_with_initializer.onnx")};
 
     editor.extract_subgraph({}, {{OutputEdge{1, 0}}});
 
     const auto ref_model = ngraph::file_util::path_join(
+        CommonTestUtils::getExecutableDirectory(),
         SERIALIZED_ZOO,
         "onnx/model_editor/reference/subgraph__linear_model_with_initializer_tail_cut.onnx");
 
@@ -341,12 +372,14 @@ NGRAPH_TEST(onnx_editor, subgraph__linear_model_with_initializer_tail_cut) {
 
 NGRAPH_TEST(onnx_editor, subgraph__initializer_without_matching_input_tail_cut) {
     ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/subgraph__initializer_without_matching_input.onnx")};
 
     editor.extract_subgraph({}, {{OutputEdge{1, 0}}});
 
-    const auto ref_model = ngraph::file_util::path_join(SERIALIZED_ZOO,
+    const auto ref_model = ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
                                                         "onnx/model_editor/reference/"
                                                         "subgraph__initializer_without_matching_input_tail_cut.onnx");
 
@@ -356,13 +389,15 @@ NGRAPH_TEST(onnx_editor, subgraph__initializer_without_matching_input_tail_cut) 
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__linear_model_deeper_tail_cut) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph__inception_head.onnx")};
 
     editor.extract_subgraph({}, {{OutputEdge{0, 0}}});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/subgraph__linear_model_deeper_tail_cut.onnx");
 
     const auto result = compare_onnx_models(editor.model_string(), ref_model);
@@ -371,8 +406,9 @@ NGRAPH_TEST(onnx_editor, subgraph__linear_model_deeper_tail_cut) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__no_input_params) {
-    const auto model_path =
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx");
+    const auto model_path = ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                         SERIALIZED_ZOO,
+                                                         "onnx/model_editor/subgraph__inception_head.onnx");
 
     ONNXModelEditor editor{model_path};
 
@@ -385,13 +421,15 @@ NGRAPH_TEST(onnx_editor, subgraph__no_input_params) {
 
 NGRAPH_TEST(onnx_editor, subgraph__initializer_to_input_replacement) {
     ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/subgraph__inception_head_with_initializer.onnx")};
 
     editor.extract_subgraph({{InputEdge{0, 2}}}, {{OutputEdge{0, 0}}});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/subgraph__initializer_to_input_replacement.onnx");
 
     const auto result = compare_onnx_models(editor.model_string(), ref_model);
@@ -401,13 +439,15 @@ NGRAPH_TEST(onnx_editor, subgraph__initializer_to_input_replacement) {
 
 NGRAPH_TEST(onnx_editor, subgraph__initializer_to_input_replacement_2) {
     ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/subgraph__initializer_without_matching_input.onnx")};
 
     editor.extract_subgraph({{InputEdge{0, 2}}}, {{OutputEdge{0, 0}}});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/subgraph__initializer_to_input_replacement.onnx");
 
     const auto result = compare_onnx_models(editor.model_string(), ref_model);
@@ -416,13 +456,15 @@ NGRAPH_TEST(onnx_editor, subgraph__initializer_to_input_replacement_2) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__multiout_op_output_edge) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     editor.extract_subgraph({}, {{OutputEdge{5, 1}}});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/subgraph__multiout_op_output_edge.onnx");
 
     const auto result = compare_onnx_models(editor.model_string(), ref_model);
@@ -431,12 +473,14 @@ NGRAPH_TEST(onnx_editor, subgraph__multiout_op_output_edge) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__existing_inputs_and_outputs_based_extraction) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     editor.extract_subgraph({{InputEdge{1, 1}, InputEdge{2, 0}}}, {{OutputEdge{4, 0}}});
 
-    const auto ref_model = ngraph::file_util::path_join(SERIALIZED_ZOO,
+    const auto ref_model = ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
                                                         "onnx/model_editor/reference/"
                                                         "subgraph__existing_inputs_and_outputs_based_extraction.onnx");
 
@@ -446,12 +490,15 @@ NGRAPH_TEST(onnx_editor, subgraph__existing_inputs_and_outputs_based_extraction)
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__twice_input_edge_from_tensor_with_single_consumer) {
-    ONNXModelEditor editor{ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_ab.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/add_ab.onnx")};
 
     editor.extract_subgraph({InputEdge{1, 1}}, {});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/"
                                      "subgraph__twice_input_edge_from_tensor_with_single_consumer.onnx");
 
@@ -461,13 +508,15 @@ NGRAPH_TEST(onnx_editor, subgraph__twice_input_edge_from_tensor_with_single_cons
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__input_edge_from_tensor_with_multiple_consumers) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     editor.extract_subgraph({{InputEdge{1, 0}, InputEdge{6, 0}}}, {{OutputEdge{6, 0}, OutputEdge{4, 0}}});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/"
                                      "subgraph__input_edge_from_tensor_with_multiple_consumers.onnx");
 
@@ -477,13 +526,15 @@ NGRAPH_TEST(onnx_editor, subgraph__input_edge_from_tensor_with_multiple_consumer
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__input_edge_from_tensor_with_multiple_consumers_2) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     editor.extract_subgraph({{InputEdge{3, 0}, InputEdge{3, 1}}}, {{OutputEdge{3, 0}, OutputEdge{4, 0}}});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/"
                                      "subgraph__input_edge_from_tensor_with_multiple_consumers_2.onnx");
 
@@ -493,13 +544,15 @@ NGRAPH_TEST(onnx_editor, subgraph__input_edge_from_tensor_with_multiple_consumer
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__input_edge_from_tensor_with_multiple_consumers_3) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     editor.extract_subgraph({{InputEdge{3, 0}, InputEdge{6, 0}}}, {{OutputEdge{6, 0}, OutputEdge{5, 1}}});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/"
                                      "subgraph__input_edge_from_tensor_with_multiple_consumers_3.onnx");
 
@@ -509,13 +562,15 @@ NGRAPH_TEST(onnx_editor, subgraph__input_edge_from_tensor_with_multiple_consumer
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__input_edge_from_tensor_with_multiple_consumers_4) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     editor.extract_subgraph({{InputEdge{1, 0}, InputEdge{3, 0}}}, {});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/"
                                      "subgraph__input_edge_from_tensor_with_multiple_consumers_4.onnx");
 
@@ -525,14 +580,16 @@ NGRAPH_TEST(onnx_editor, subgraph__input_edge_from_tensor_with_multiple_consumer
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__input_edge_from_tensor_with_multiple_consumers_5) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     editor.extract_subgraph({InputEdge{3, 0}}, {{OutputEdge{6, 0}, OutputEdge{5, 1}}});
 
     // expected to behave the same way as the test above
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/"
                                      "subgraph__input_edge_from_tensor_with_multiple_consumers_5.onnx");
 
@@ -542,14 +599,16 @@ NGRAPH_TEST(onnx_editor, subgraph__input_edge_from_tensor_with_multiple_consumer
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__input_edge_from_tensor_with_multiple_consumers_custom_names) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     editor.extract_subgraph({{InputEdge{1, 0, "new_name_1"}, InputEdge{6, 0, "new_name_2"}}},
                             {{OutputEdge{6, 0}, OutputEdge{4, 0}}});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/"
                                      "subgraph__input_edge_from_tensor_with_multiple_consumers_custom_names.onnx");
 
@@ -559,12 +618,14 @@ NGRAPH_TEST(onnx_editor, subgraph__input_edge_from_tensor_with_multiple_consumer
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__multiple_consumers_of_graph_input_relu2) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests_2.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests_2.onnx")};
 
     editor.extract_subgraph({{InputEdge{4, 0}}}, {});
 
-    const auto ref_model = ngraph::file_util::path_join(SERIALIZED_ZOO,
+    const auto ref_model = ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
                                                         "onnx/model_editor/reference/"
                                                         "subgraph__multiple_consumers_of_graph_input_relu2.onnx");
 
@@ -574,12 +635,14 @@ NGRAPH_TEST(onnx_editor, subgraph__multiple_consumers_of_graph_input_relu2) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__multiple_consumers_of_graph_initializer) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests_2.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests_2.onnx")};
 
     editor.extract_subgraph({{InputEdge{2, 0}}}, {});
 
-    const auto ref_model = ngraph::file_util::path_join(SERIALIZED_ZOO,
+    const auto ref_model = ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
                                                         "onnx/model_editor/reference/"
                                                         "subgraph__multiple_consumers_of_graph_initializer.onnx");
 
@@ -589,13 +652,15 @@ NGRAPH_TEST(onnx_editor, subgraph__multiple_consumers_of_graph_initializer) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__multiple_consumers_of_graph_initializer_2) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests_2.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests_2.onnx")};
 
     editor.extract_subgraph({{InputEdge{2, 0}, InputEdge{3, 0}}}, {});
 
     // same as above
-    const auto ref_model = ngraph::file_util::path_join(SERIALIZED_ZOO,
+    const auto ref_model = ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
                                                         "onnx/model_editor/reference/"
                                                         "subgraph__multiple_consumers_of_graph_initializer.onnx");
 
@@ -605,13 +670,15 @@ NGRAPH_TEST(onnx_editor, subgraph__multiple_consumers_of_graph_initializer_2) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__multiple_consumers_of_graph_initializer_relu2_and_init) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests_2.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests_2.onnx")};
 
     editor.extract_subgraph({{InputEdge{5, 0}, InputEdge{3, 0}}}, {});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/"
                                      "subgraph__multiple_consumers_of_graph_initializer_relu2_and_init.onnx");
 
@@ -621,8 +688,9 @@ NGRAPH_TEST(onnx_editor, subgraph__multiple_consumers_of_graph_initializer_relu2
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__invalid_edge_idx) {
-    const auto model_path =
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx");
+    const auto model_path = ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                         SERIALIZED_ZOO,
+                                                         "onnx/model_editor/subgraph__inception_head.onnx");
 
     ONNXModelEditor editor{model_path};
     try {
@@ -635,8 +703,9 @@ NGRAPH_TEST(onnx_editor, subgraph__invalid_edge_idx) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__invalid_port_idx) {
-    const auto model_path =
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx");
+    const auto model_path = ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                         SERIALIZED_ZOO,
+                                                         "onnx/model_editor/subgraph__inception_head.onnx");
 
     ONNXModelEditor editor{model_path};
     try {
@@ -648,8 +717,9 @@ NGRAPH_TEST(onnx_editor, subgraph__invalid_port_idx) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__inputs_getter) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph__inception_head.onnx")};
 
     EXPECT_EQ(editor.model_inputs(), (std::vector<std::string>{"data_0", "conv1/7x7_s2_w_0", "conv1/7x7_s2_b_0"}));
 
@@ -659,8 +729,9 @@ NGRAPH_TEST(onnx_editor, subgraph__inputs_getter) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__custom_input_name_already_exist) {
-    const auto model_path =
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx");
+    const auto model_path = ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                         SERIALIZED_ZOO,
+                                                         "onnx/model_editor/subgraph__inception_head.onnx");
 
     ONNXModelEditor editor{model_path};
     try {
@@ -675,8 +746,9 @@ NGRAPH_TEST(onnx_editor, subgraph__custom_input_name_already_exist) {
 // HIGHT LEVEL API TESTS
 // INPUT EDGES TEST
 NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_output_name_and_input_name) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph__inception_head.onnx")};
 
     const InputEdge edge =
         editor.find_input_edge(EditorNode{EditorOutput{"conv1/7x7_s2_2"}}, EditorInput{"conv1/7x7_s2_1"});
@@ -689,8 +761,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_output_name_and_input_n
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_output_name_and_input_index) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph__inception_head.onnx")};
 
     const InputEdge edge = editor.find_input_edge(EditorNode{EditorOutput{"conv1/7x7_s2_2"}}, EditorInput{0});
     EXPECT_EQ(edge.m_node_idx, 1);
@@ -706,8 +779,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_output_name_and_input_i
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_node_name_and_input_name) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph__inception_head.onnx")};
 
     const InputEdge edge = editor.find_input_edge(EditorNode{"relu1"}, EditorInput{"conv1/7x7_s2_1"});
     EXPECT_EQ(edge.m_node_idx, 1);
@@ -719,8 +793,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_node_name_and_input_nam
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_node_name_and_input_index) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const InputEdge edge = editor.find_input_edge(EditorNode{"relu1_name"}, EditorInput{0});
     EXPECT_EQ(edge.m_node_idx, 0);
@@ -732,8 +807,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_node_name_and_input_ind
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_node_name_and_input_index_custom_name) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const InputEdge edge = editor.find_input_edge(EditorNode{"relu1_name"}, EditorInput{0, "custom_input_name_1"});
     EXPECT_EQ(edge.m_node_idx, 0);
@@ -747,8 +823,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_node_name_and_input_ind
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_node_index) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const InputEdge edge = editor.find_input_edge(EditorNode{0}, EditorInput{0, "custom_input_name_1"});
     EXPECT_EQ(edge.m_node_idx, 0);
@@ -768,8 +845,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_node_index) {
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_empty_node_name) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     try {
         editor.find_input_edge(EditorNode{""}, EditorInput{"conv1/7x7_s2_1"});
@@ -782,8 +860,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_empty_node_name) {
 
 // OUTPUT EDGES TEST
 NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_output_name) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const OutputEdge edge = editor.find_output_edge(EditorNode{EditorOutput{"mul2"}}, EditorOutput{"mul2"});
     EXPECT_EQ(edge.m_node_idx, 4);
@@ -804,8 +883,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_output_name) {
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_output_name_and_output_index) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const OutputEdge edge = editor.find_output_edge(EditorNode{EditorOutput{"add2"}}, EditorOutput{0});
     EXPECT_EQ(edge.m_node_idx, 3);
@@ -821,8 +901,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_output_name_and_output
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_node_name_and_output_name) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const OutputEdge edge = editor.find_output_edge(EditorNode{"relu1_name"}, EditorOutput{"relu1"});
     EXPECT_EQ(edge.m_node_idx, 0);
@@ -834,8 +915,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_node_name_and_output_n
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_node_name_and_output_index) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const OutputEdge edge = editor.find_output_edge(EditorNode{"relu1_name"}, EditorOutput{0});
     EXPECT_EQ(edge.m_node_idx, 0);
@@ -847,8 +929,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_node_name_and_output_i
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_node_index) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const OutputEdge edge = editor.find_output_edge(EditorNode{5}, EditorOutput{1});
     EXPECT_EQ(edge.m_node_idx, 5);
@@ -863,8 +946,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_node_index) {
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_edge_const_network) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests_2.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests_2.onnx")};
 
     const InputEdge edge = editor.find_input_edge(EditorNode{EditorOutput{"relu4"}}, EditorInput{0});
     EXPECT_EQ(edge.m_node_idx, 3);
@@ -880,8 +964,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_edge_const_network) {
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_edge_error_handling) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests_2.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests_2.onnx")};
 
     // node with given output name not found
     try {
@@ -936,8 +1021,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_edge_error_handling) {
 
 // Nodes with ambiguous node names tests
 NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_ambiguous_node_name_but_matched_input) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     InputEdge edge = editor.find_input_edge(EditorNode{"add_ambiguous_name"}, EditorInput{"in2"});
     EXPECT_EQ(edge.m_node_idx, 1);
@@ -949,8 +1035,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_ambiguous_node_name_but
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_ambiguous_node_name_and_not_matched_input) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     try {
         editor.find_input_edge(EditorNode{"add_ambiguous_name"}, EditorInput{"in3"});
@@ -972,8 +1059,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_ambiguous_node_name_and
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_ambiguous_node_name_and_input_index) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     try {
         editor.find_input_edge(EditorNode{"add_ambiguous_name"}, EditorInput{0});
@@ -986,8 +1074,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_input_edge_by_ambiguous_node_name_and
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_ambiguous_node_name_but_matched_output) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const OutputEdge edge = editor.find_output_edge(EditorNode{"add_ambiguous_name"}, EditorOutput{"add1"});
     EXPECT_EQ(edge.m_node_idx, 1);
@@ -999,8 +1088,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_ambiguous_node_name_bu
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_the_same_node_name_and_output_name) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests_2.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests_2.onnx")};
 
     const OutputEdge edge = editor.find_output_edge(EditorNode{"add1"}, EditorOutput{0});
     EXPECT_EQ(edge.m_node_idx, 0);
@@ -1012,8 +1102,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_the_same_node_name_and
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_ambiguous_node_name_and_not_matched_output) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     try {
         editor.find_output_edge(EditorNode{"add_ambiguous_name"}, EditorOutput{"split2"});
@@ -1025,8 +1116,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_ambiguous_node_name_an
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_ambiguous_node_name_and_output_index) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     try {
         editor.find_output_edge(EditorNode{"add_ambiguous_name"}, EditorOutput{0});
@@ -1040,8 +1132,9 @@ NGRAPH_TEST(onnx_editor, editor_api_select_output_edge_by_ambiguous_node_name_an
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_use_edge_mapper_with_graph_cutter) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     // InputEdge{1, "in2"}
     const auto input_edge_1 = editor.find_input_edge(EditorNode(EditorOutput("add1")), EditorInput(1));
@@ -1052,7 +1145,8 @@ NGRAPH_TEST(onnx_editor, editor_api_use_edge_mapper_with_graph_cutter) {
     // OutputEdge{4, "mul2"}
     editor.extract_subgraph({input_edge_1, input_edge_2}, {output_edge});
 
-    const auto ref_model = ngraph::file_util::path_join(SERIALIZED_ZOO,
+    const auto ref_model = ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
                                                         "onnx/model_editor/reference/"
                                                         "subgraph__existing_inputs_and_outputs_based_extraction.onnx");
 
@@ -1075,8 +1169,9 @@ NGRAPH_TEST(onnx_editor, editor_api_use_edge_mapper_with_graph_cutter) {
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_use_edge_mapper_with_graph_cutter_custom_names) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const auto input_edge_1 = editor.find_input_edge(EditorNode{EditorOutput{"mul2"}}, EditorInput{1, "new_name_1"});
     const auto input_edge_2 =
@@ -1085,7 +1180,8 @@ NGRAPH_TEST(onnx_editor, editor_api_use_edge_mapper_with_graph_cutter_custom_nam
     editor.extract_subgraph({input_edge_1, input_edge_2}, {});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/"
                                      "subgraph__use_edge_mapper_with_graph_cutter_custom_names.onnx");
 
@@ -1095,8 +1191,9 @@ NGRAPH_TEST(onnx_editor, editor_api_use_edge_mapper_with_graph_cutter_custom_nam
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_find_output_consumers) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     std::vector<InputEdge> output_consumers = editor.find_output_consumers("relu1");
     EXPECT_EQ(output_consumers.size(), 3);
@@ -1121,15 +1218,18 @@ NGRAPH_TEST(onnx_editor, editor_api_find_output_consumers) {
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_find_output_consumers_empty_result) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const std::vector<InputEdge> output_consumers = editor.find_output_consumers("not_existed");
     EXPECT_EQ(output_consumers.size(), 0);
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_inputs_with_the_same_name) {
-    ONNXModelEditor editor{ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_ab.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/add_ab.onnx")};
 
     std::vector<InputEdge> output_consumers = editor.find_output_consumers("X");
     EXPECT_EQ(output_consumers[0].m_node_idx, 1);
@@ -1139,8 +1239,9 @@ NGRAPH_TEST(onnx_editor, editor_api_inputs_with_the_same_name) {
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_find_output_consumers_name) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests_3.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests_3.onnx")};
     const std::string output_name{"2891"};
 
     std::vector<InputEdge> output_consumers = editor.find_output_consumers(output_name);
@@ -1153,8 +1254,9 @@ NGRAPH_TEST(onnx_editor, editor_api_find_output_consumers_name) {
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_is_correct_and_unambiguous_node) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     bool is_correct_node = editor.is_correct_and_unambiguous_node(EditorNode{EditorOutput{"relu1"}});
     EXPECT_EQ(is_correct_node, true);
@@ -1185,8 +1287,9 @@ NGRAPH_TEST(onnx_editor, editor_api_is_correct_and_unambiguous_node) {
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_get_node_index) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     EXPECT_EQ(editor.get_node_index(EditorNode{2}), 2);
     EXPECT_EQ(editor.get_node_index(EditorNode{EditorOutput{"relu1"}}), 0);
@@ -1212,13 +1315,16 @@ NGRAPH_TEST(onnx_editor, editor_api_get_node_index) {
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_input_edge_from_tensor_with_single_consumer) {
-    ONNXModelEditor editor{ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_ab.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/add_ab.onnx")};
 
     const auto edge = editor.find_input_edge(EditorNode{EditorOutput{"Y"}}, EditorInput{1});
     editor.extract_subgraph({edge}, {});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/"
                                      "subgraph__twice_input_edge_from_tensor_with_single_consumer.onnx");
 
@@ -1228,7 +1334,9 @@ NGRAPH_TEST(onnx_editor, editor_api_input_edge_from_tensor_with_single_consumer)
 }
 
 NGRAPH_TEST(onnx_editor, editor_api_input_edge_from_tensor_with_single_consumer_ambiguous) {
-    ONNXModelEditor editor{ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_ab.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/add_ab.onnx")};
 
     try {
         editor.find_input_edge(EditorNode{EditorOutput{"Y"}}, EditorInput{"X"});
@@ -1239,7 +1347,9 @@ NGRAPH_TEST(onnx_editor, editor_api_input_edge_from_tensor_with_single_consumer_
 }
 
 NGRAPH_TEST(onnx_editor, values__append_one_initializer) {
-    onnx_editor::ONNXModelEditor editor{ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_1D.onnx")};
+    onnx_editor::ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                     SERIALIZED_ZOO,
+                                                                     "onnx/model_editor/add_1D.onnx")};
     std::map<std::string, std::shared_ptr<ngraph::op::Constant>> in_vals;
 
     in_vals.emplace("A", ngraph::op::Constant::create(element::i64, Shape{2}, {1, 2}));
@@ -1253,8 +1363,9 @@ NGRAPH_TEST(onnx_editor, values__append_one_initializer) {
 }
 
 NGRAPH_TEST(onnx_editor, values__append_two_initializers_to_invalid) {
-    onnx_editor::ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_1D_invalid.onnx")};
+    onnx_editor::ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                     SERIALIZED_ZOO,
+                                                                     "onnx/model_editor/add_1D_invalid.onnx")};
     std::map<std::string, std::shared_ptr<ngraph::op::Constant>> in_vals;
 
     in_vals.emplace("A", ngraph::op::Constant::create(element::i64, Shape{2}, {4, 2}));
@@ -1269,7 +1380,9 @@ NGRAPH_TEST(onnx_editor, values__append_two_initializers_to_invalid) {
 
 NGRAPH_TEST(onnx_editor, values__modify_one_initializer) {
     onnx_editor::ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_1D_with_initializers.onnx")};
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
+                                     "onnx/model_editor/add_1D_with_initializers.onnx")};
     std::map<std::string, std::shared_ptr<ngraph::op::Constant>> in_vals;
 
     in_vals.emplace("B", ngraph::op::Constant::create(element::i64, Shape{2}, {3, 4}));
@@ -1283,7 +1396,9 @@ NGRAPH_TEST(onnx_editor, values__modify_one_initializer) {
 
 NGRAPH_TEST(onnx_editor, values__modify_two_initializers) {
     onnx_editor::ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_1D_with_initializers.onnx")};
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
+                                     "onnx/model_editor/add_1D_with_initializers.onnx")};
     std::map<std::string, std::shared_ptr<ngraph::op::Constant>> in_vals;
 
     in_vals.emplace("A", ngraph::op::Constant::create(element::i64, Shape{2}, {3, 6}));
@@ -1298,7 +1413,9 @@ NGRAPH_TEST(onnx_editor, values__modify_two_initializers) {
 
 NGRAPH_TEST(onnx_editor, values__no_inputs_modify_two_initializers) {
     onnx_editor::ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_1D_with_initializers_only.onnx")};
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
+                                     "onnx/model_editor/add_1D_with_initializers_only.onnx")};
     std::map<std::string, std::shared_ptr<ngraph::op::Constant>> in_vals;
 
     in_vals.emplace("A", ngraph::op::Constant::create(element::i64, Shape{2}, {1, 2}));
@@ -1312,7 +1429,9 @@ NGRAPH_TEST(onnx_editor, values__no_inputs_modify_two_initializers) {
 }
 
 NGRAPH_TEST(onnx_editor, values__append_two_initializers_change_shape_type) {
-    onnx_editor::ONNXModelEditor editor{ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_1D.onnx")};
+    onnx_editor::ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                     SERIALIZED_ZOO,
+                                                                     "onnx/model_editor/add_1D.onnx")};
     std::map<std::string, std::shared_ptr<ngraph::op::Constant>> in_vals;
 
     in_vals.emplace("A", ngraph::op::Constant::create(element::i8, Shape{2, 1}, {-1, 1}));
@@ -1326,8 +1445,9 @@ NGRAPH_TEST(onnx_editor, values__append_two_initializers_change_shape_type) {
 }
 
 NGRAPH_TEST(onnx_editor, values__append_two_initializers_mixed_types) {
-    onnx_editor::ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/gather_elements_float_3D_axis_2.onnx")};
+    onnx_editor::ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                     SERIALIZED_ZOO,
+                                                                     "onnx/gather_elements_float_3D_axis_2.onnx")};
     std::map<std::string, std::shared_ptr<ngraph::op::Constant>> in_vals;
 
     in_vals.emplace("data", ngraph::op::Constant::create(element::i16, Shape{2, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8}));
@@ -1341,7 +1461,9 @@ NGRAPH_TEST(onnx_editor, values__append_two_initializers_mixed_types) {
 }
 
 NGRAPH_TEST(onnx_editor, read_model_from_stream) {
-    std::string path = ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/external_data/external_data.onnx");
+    std::string path = ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                    SERIALIZED_ZOO,
+                                                    "onnx/external_data/external_data.onnx");
     std::ifstream stream{path, std::ios::in | std::ios::binary};
     ASSERT_TRUE(stream.is_open());
     ONNXModelEditor editor{stream, path};
@@ -1356,15 +1478,17 @@ NGRAPH_TEST(onnx_editor, read_model_from_stream) {
 }
 
 NGRAPH_TEST(onnx_editor, combined__cut_and_replace_shape) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph__inception_head.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph__inception_head.onnx")};
 
     const auto new_shape = PartialShape({1, 64, 112, 112});
     editor.extract_subgraph({{InputEdge(1, 0)}}, {});
     editor.set_input_shapes({{"conv1/7x7_s2_1", new_shape}});
 
     const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO,
+        ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                     SERIALIZED_ZOO,
                                      "onnx/model_editor/reference/subgraph__linear_model_head_cut.onnx");
 
     const auto result = compare_onnx_models(editor.model_string(), ref_model);
@@ -1376,13 +1500,15 @@ NGRAPH_TEST(onnx_editor, combined__cut_and_replace_shape) {
 }
 
 NGRAPH_TEST(onnx_editor, cut_operator_with_no_schema) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/unknown_input_value_info.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/unknown_input_value_info.onnx")};
 
     editor.extract_subgraph({{InputEdge{1, 0}}}, {});
 
-    const auto ref_model =
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/reference/unknown_input_value_info.onnx");
+    const auto ref_model = ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/reference/unknown_input_value_info.onnx");
 
     const auto result = compare_onnx_models(editor.model_string(), ref_model);
 
@@ -1390,8 +1516,9 @@ NGRAPH_TEST(onnx_editor, cut_operator_with_no_schema) {
 }
 
 NGRAPH_TEST(onnx_editor, get_source_tensor_name) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     EXPECT_EQ(editor.get_source_tensor_name(InputEdge{0, 0}), "in1");
     EXPECT_EQ(editor.get_source_tensor_name(InputEdge{1, 0}), "relu1");
@@ -1404,8 +1531,9 @@ NGRAPH_TEST(onnx_editor, get_source_tensor_name) {
 }
 
 NGRAPH_TEST(onnx_editor, is_model_input) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     EXPECT_TRUE(editor.is_input(InputEdge{0, 0}));
     const auto edge1 = editor.find_input_edge(EditorOutput{"add1"}, 1);
@@ -1422,8 +1550,9 @@ NGRAPH_TEST(onnx_editor, is_model_input) {
 }
 
 NGRAPH_TEST(onnx_editor, get_target_tensor_name) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     EXPECT_EQ(editor.get_target_tensor_name(OutputEdge{0, 0}), "relu1");
     EXPECT_EQ(editor.get_target_tensor_name(OutputEdge{1, 0}), "add1");
@@ -1434,8 +1563,9 @@ NGRAPH_TEST(onnx_editor, get_target_tensor_name) {
 }
 
 NGRAPH_TEST(onnx_editor, is_model_output) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     EXPECT_TRUE(editor.is_output(OutputEdge{4, 0}));
     EXPECT_TRUE(editor.is_output(OutputEdge{5, 1}));
@@ -1450,31 +1580,36 @@ NGRAPH_TEST(onnx_editor, is_model_output) {
 }
 
 NGRAPH_TEST(onnx_editor, model_inputs) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const auto inputs = editor.model_inputs();
     EXPECT_TRUE(inputs == (std::vector<std::string>{"in1", "in2", "in3"}));  // in4 is initializer
 }
 
 NGRAPH_TEST(onnx_editor, model_inputs_with_non_input_initializers) {
-    ONNXModelEditor editor{ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/instance_norm_dynamic.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/instance_norm_dynamic.onnx")};
 
     const auto inputs = editor.model_inputs();
     EXPECT_TRUE(inputs == (std::vector<std::string>{"input"}));
 }
 
 NGRAPH_TEST(onnx_editor, model_output) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const auto outputs = editor.model_outputs();
     EXPECT_TRUE(outputs == (std::vector<std::string>{"mul1", "split2", "mul2"}));
 }
 
 NGRAPH_TEST(onnx_editor, get_tensor_shape) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     EXPECT_EQ(editor.get_tensor_shape("mul2"), (PartialShape{1, 1, 2, 2}));
     EXPECT_EQ(editor.get_tensor_shape("in1"), (PartialShape{2, 2}));
@@ -1491,8 +1626,9 @@ NGRAPH_TEST(onnx_editor, get_tensor_shape) {
 }
 
 NGRAPH_TEST(onnx_editor, get_tensor_shape_after_modification) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     EXPECT_EQ(editor.get_tensor_shape("in3"), (PartialShape{1, 1, 2, 2}));
     EXPECT_EQ(editor.get_tensor_shape("conv1"), (PartialShape{1, 1, 2, 2}));
@@ -1503,8 +1639,9 @@ NGRAPH_TEST(onnx_editor, get_tensor_shape_after_modification) {
 }
 
 NGRAPH_TEST(onnx_editor, is_correct_tensor_name) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     EXPECT_TRUE(editor.is_correct_tensor_name("in1"));
     EXPECT_TRUE(editor.is_correct_tensor_name("relu1"));
@@ -1518,8 +1655,9 @@ NGRAPH_TEST(onnx_editor, is_correct_tensor_name) {
 }
 
 NGRAPH_TEST(onnx_editor, get_input_ports) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const auto ports_1 = editor.get_input_ports(EditorNode{"relu1_name"});
     EXPECT_EQ(ports_1.size(), 1);
@@ -1550,8 +1688,9 @@ NGRAPH_TEST(onnx_editor, get_input_ports) {
     }
 }
 NGRAPH_TEST(onnx_editor, get_output_ports) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     const auto ports_1 = editor.get_output_ports(EditorNode{"relu1_name"});
     EXPECT_EQ(ports_1.size(), 1);
@@ -1583,7 +1722,9 @@ NGRAPH_TEST(onnx_editor, get_output_ports) {
 }
 
 NGRAPH_TEST(onnx_editor, add_output) {
-    ONNXModelEditor editor{ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/add_abc.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/add_abc.onnx")};
 
     editor.add_output({OutputEdge{0, 0}});
 
@@ -1592,8 +1733,9 @@ NGRAPH_TEST(onnx_editor, add_output) {
 }
 
 NGRAPH_TEST(onnx_editor, get_tensor_element_type) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     EXPECT_EQ(editor.get_input_type("in1"), (element::f32));
     EXPECT_EQ(editor.get_input_type("in2"), (element::f32));
@@ -1602,8 +1744,9 @@ NGRAPH_TEST(onnx_editor, get_tensor_element_type) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__cut_one_edge_and_merge_all_new_inputs) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     // InputEdge{1, "relu1"}
     const auto input_edge_1 = editor.find_input_edge(EditorNode(EditorOutput("add1")), EditorInput(0));
@@ -1611,6 +1754,7 @@ NGRAPH_TEST(onnx_editor, subgraph__cut_one_edge_and_merge_all_new_inputs) {
     editor.extract_subgraph({{input_edge_1}}, {}, true);
 
     const auto ref_model = ngraph::file_util::path_join(
+        CommonTestUtils::getExecutableDirectory(),
         SERIALIZED_ZOO,
         "onnx/model_editor/reference/subgraph__cut_one_edge_and_merge_all_new_inputs.onnx");
 
@@ -1622,6 +1766,7 @@ NGRAPH_TEST(onnx_editor, subgraph__cut_one_edge_and_merge_all_new_inputs) {
     editor.extract_subgraph({{input_edge_2}}, {}, true);
 
     const auto ref_model1 = ngraph::file_util::path_join(
+        CommonTestUtils::getExecutableDirectory(),
         SERIALIZED_ZOO,
         "onnx/model_editor/reference/subgraph__cut_one_another_edge_and_merge_all_new_inputs.onnx");
 
@@ -1631,8 +1776,9 @@ NGRAPH_TEST(onnx_editor, subgraph__cut_one_edge_and_merge_all_new_inputs) {
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__cut_two_edges_from_one_source_and_merge_all_new_inputs) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     // InputEdge{3, "relu1"}
     const auto input_edge_1 = editor.find_input_edge(EditorNode(EditorOutput("add2")), EditorInput(0));
@@ -1642,6 +1788,7 @@ NGRAPH_TEST(onnx_editor, subgraph__cut_two_edges_from_one_source_and_merge_all_n
     editor.extract_subgraph({{input_edge_1, input_edge_2}}, {}, true);
 
     const auto ref_model = ngraph::file_util::path_join(
+        CommonTestUtils::getExecutableDirectory(),
         SERIALIZED_ZOO,
         "onnx/model_editor/reference/subgraph__cut_two_edges_from_one_source_and_merge_all_new_inputs.onnx");
 
@@ -1651,8 +1798,9 @@ NGRAPH_TEST(onnx_editor, subgraph__cut_two_edges_from_one_source_and_merge_all_n
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__cut_two_edges_from_different_sources_and_merge_all_new_inputs) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     // InputEdge{3, "add1"}
     const auto input_edge_1 = editor.find_input_edge(EditorNode(EditorOutput("add2")), EditorInput(1));
@@ -1662,6 +1810,7 @@ NGRAPH_TEST(onnx_editor, subgraph__cut_two_edges_from_different_sources_and_merg
     editor.extract_subgraph({{input_edge_1, input_edge_2}}, {}, true);
 
     const auto ref_model = ngraph::file_util::path_join(
+        CommonTestUtils::getExecutableDirectory(),
         SERIALIZED_ZOO,
         "onnx/model_editor/reference/subgraph__cut_two_edges_from_different_sources_and_merge_all_new_inputs.onnx");
 
@@ -1671,8 +1820,9 @@ NGRAPH_TEST(onnx_editor, subgraph__cut_two_edges_from_different_sources_and_merg
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__cut_all_edges_from_one_source_and_merge_all_new_inputs) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     // InputEdge{3, "relu1"}
     const auto input_edge_1 = editor.find_input_edge(EditorNode(EditorOutput("add2")), EditorInput(0));
@@ -1684,6 +1834,7 @@ NGRAPH_TEST(onnx_editor, subgraph__cut_all_edges_from_one_source_and_merge_all_n
     editor.extract_subgraph({{input_edge_1, input_edge_2, input_edge_3}}, {}, true);
 
     const auto ref_model = ngraph::file_util::path_join(
+        CommonTestUtils::getExecutableDirectory(),
         SERIALIZED_ZOO,
         "onnx/model_editor/reference/subgraph__cut_all_edges_from_one_source_and_merge_all_new_inputs.onnx");
 
@@ -1693,8 +1844,9 @@ NGRAPH_TEST(onnx_editor, subgraph__cut_all_edges_from_one_source_and_merge_all_n
 }
 
 NGRAPH_TEST(onnx_editor, subgraph__cut_custom_edges_from_different_sources_and_merge_all_new_inputs) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/subgraph_extraction_tests.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/subgraph_extraction_tests.onnx")};
 
     // InputEdge{3, "relu1"}
     const auto input_edge_1 = editor.find_input_edge(EditorNode(EditorOutput("add2")), EditorInput(0));
@@ -1706,6 +1858,7 @@ NGRAPH_TEST(onnx_editor, subgraph__cut_custom_edges_from_different_sources_and_m
     editor.extract_subgraph({{input_edge_2, input_edge_1, input_edge_3}}, {}, true);
 
     const auto ref_model = ngraph::file_util::path_join(
+        CommonTestUtils::getExecutableDirectory(),
         SERIALIZED_ZOO,
         "onnx/model_editor/reference/subgraph__cut_custom_edges_from_different_sources_and_merge_all_new_inputs.onnx");
 
@@ -1715,8 +1868,9 @@ NGRAPH_TEST(onnx_editor, subgraph__cut_custom_edges_from_different_sources_and_m
 }
 
 NGRAPH_TEST(onnx_editor, onnx_shape_infer_exception) {
-    ONNXModelEditor editor{
-        ngraph::file_util::path_join(SERIALIZED_ZOO, "onnx/model_editor/onnx_shape_infer_exception.onnx")};
+    ONNXModelEditor editor{ngraph::file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                        SERIALIZED_ZOO,
+                                                        "onnx/model_editor/onnx_shape_infer_exception.onnx")};
 
     const auto input_edge = editor.find_input_edge(EditorNode(EditorOutput("input_ReduceMin")), EditorInput(0));
 

--- a/src/frontends/tests/onnx/onnx_import.in.cpp
+++ b/src/frontends/tests/onnx/onnx_import.in.cpp
@@ -23,6 +23,7 @@
 #define DEFAULT_DOUBLE_TOLERANCE_BITS ${BACKEND_NAME}_DOUBLE_TOLERANCE_BITS
 #endif
 // clang-format on
+#include "common_test_utils/file_utils.hpp"
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "default_opset.hpp"
 #include "engines_util/test_case.hpp"
@@ -53,7 +54,8 @@ using Outputs = std::vector<std::vector<float>>;
 
 // ############################################################################ CORE TESTS
 NGRAPH_TEST(${BACKEND_NAME}, onnx_test_test_case) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/add_abc.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/add_abc.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1});
@@ -64,7 +66,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_test_test_case) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_test_test_case_mutliple_inputs) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/add_abc.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/add_abc.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_multiple_inputs(Inputs{{1}, {2}, {3}});
@@ -73,8 +76,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_test_test_case_mutliple_inputs) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_output_names_check) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/split_equal_parts_default.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/split_equal_parts_default.onnx"));
 
     std::size_t size = function->get_output_size();
     for (std::size_t i{0}; i < size; ++i) {
@@ -84,7 +88,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_output_names_check) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_node_names_check) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/add_abc.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/add_abc.onnx"));
 
     // Filter out Add nodes from the function graph
     std::vector<std::shared_ptr<Node>> additions;
@@ -101,8 +106,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_node_names_check) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_duplicated_output_name) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/duplicated_output_name.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/duplicated_output_name.onnx"));
     EXPECT_EQ(function->get_output_size(), 2);
 
     auto test_case = test::TestCase(function, s_device);
@@ -113,8 +119,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_duplicated_output_name) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_duplicated_more_output_names) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/duplicated_more_output_names.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/duplicated_more_output_names.onnx"));
     EXPECT_EQ(function->get_output_size(), 4);
 
     auto test_case = test::TestCase(function, s_device);
@@ -127,7 +134,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_duplicated_more_output_names) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_binary_add_abc) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/add_abc.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/add_abc.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_multiple_inputs(Inputs{{1}, {2}, {3}});
@@ -136,7 +144,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_binary_add_abc) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_bool_const_op) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/bool_const_op.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/bool_const_op.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output(std::vector<bool>{1, 0, 0, 1});
@@ -144,7 +153,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_bool_const_op) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_bool_init_and) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/bool_init_and.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/bool_init_and.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output(std::vector<bool>{1});
@@ -152,7 +162,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_bool_init_and) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_bool_input_or) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/bool_input_or.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/bool_input_or.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<bool>{true, false, true, false});
@@ -162,7 +173,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_bool_input_or) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_bool_init_raw) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/bool_init_raw.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/bool_init_raw.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output(std::vector<bool>{true, false, true});
@@ -170,8 +182,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_bool_init_raw) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_add_abc_initializers) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/add_abc_initializers.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/add_abc_initializers.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1, 2, 3, 4});
@@ -190,7 +203,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_override_op) {
         return {std::make_shared<ngraph::op::v1::Subtract>(ng_inputs.at(0), ng_inputs.at(1))};
     });
 
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/override_op.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/override_op.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(std::vector<float>{0.f, 1.f, 2.f, 3.f});
@@ -204,7 +218,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_override_op) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_import_non_existing_file) {
     try {
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/i.dont.exist"));
+        onnx_import::import_onnx_model(
+            file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/i.dont.exist"));
     } catch (const std::runtime_error& exc) {
         // asserts that an exception was thrown and that the error message contains the file name
         std::string msg{exc.what()};
@@ -214,7 +229,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_import_non_existing_file) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_unsupported_op) {
     try {
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/unsupported_op.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/unsupported_op.onnx"));
         FAIL() << "Expected ngraph::ngraph_error";
     } catch (ngraph::ngraph_error const& err) {
         std::string what{err.what()};
@@ -232,7 +249,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_custom_op) {
         return {std::make_shared<ngraph::op::v1::Add>(ng_inputs.at(0), ng_inputs.at(1))};
     });
 
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/custom_operator.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/custom_operator.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.f, 2.f, 3.f, 4.f});
@@ -246,7 +264,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_custom_op_register_unregister) {
         return {std::make_shared<ngraph::op::v1::Add>(ng_inputs.at(0), ng_inputs.at(1))};
     });
 
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/custom_operator.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/custom_operator.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.f, 2.f, 3.f, 4.f});
@@ -255,8 +274,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_custom_op_register_unregister) {
 
     onnx_import::unregister_operator("AddQ", 1, "com.intel.ai");
     try {
-        auto function =
-            onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/custom_operator.onnx"));
+        auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                            SERIALIZED_ZOO,
+                                                                            "onnx/custom_operator.onnx"));
         FAIL() << "Expected ngraph::ngraph_error";
     } catch (ngraph::ngraph_error const& err) {
         std::string what{err.what()};
@@ -272,8 +292,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_custom_op_default_domain) {
         return {std::make_shared<ngraph::op::v1::Add>(ng_inputs.at(0), ng_inputs.at(1))};
     });
 
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/custom_operator_default_domain.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/custom_operator_default_domain.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.f, 2.f, 3.f, 4.f});
@@ -318,7 +339,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_missing_op_domain) {
 
     EXPECT_TRUE(onnx_import::is_operator_supported("CustomAdd", 1, "custom.op"));
 
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/missing_op_domain.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/missing_op_domain.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(std::vector<float>{0.f, 1.f, 2.f, 3.f});
@@ -342,12 +364,15 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_custom_op_in_supported_operators) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_unknown_domain) {
     // the importer should not throw when it encounters an unknown domain in the model
-    EXPECT_NO_THROW(onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/unknown_domain.onnx")));
+    EXPECT_NO_THROW(onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/unknown_domain.onnx")));
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_op_in_unknown_domain) {
     try {
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/unknown_domain_add.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/unknown_domain_add.onnx"));
 
         FAIL() << "The onnx_importer did not throw for unknown domain and op";
     } catch (const ngraph::ngraph_error& e) {
@@ -396,7 +421,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_missing_input) {
                                        return {result};
                                    });
 
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/missing_input.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/missing_input.onnx"));
 
     Inputs inputs{{1, 2, 3, 4}, {5, 6, 7, 8}};
 
@@ -408,8 +434,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_missing_input) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_initializer_wo_input) {
     // This test checks a model which has an initializer, but no input with the same name
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/initializer_wo_input.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/initializer_wo_input.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0, 1, 2, 3, 4, 5});
@@ -418,8 +445,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_initializer_wo_input) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_expand_function_dependency_to_created_subgraph) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/transformations/greater_or_equal.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/transformations/greater_or_equal.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{5}, {3.f, 5.f, 3.f, 3.f, 6.f});
@@ -429,8 +458,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_expand_function_dependency_to_created_subgraph
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_expand_function_greater_or_equal_inside_if) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/transformations/greater_or_equal_inside_if.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/transformations/greater_or_equal_inside_if.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -451,8 +482,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_expand_function_greater_or_equal_inside_if) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_expand_context_dependent_function) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/transformations/softmax_crossentropy_consumed.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/transformations/softmax_crossentropy_consumed.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{3, 5},
@@ -478,7 +511,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_expand_context_dependent_function) {
 
 // ############################################################################ OPERATOR TESTS
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_addmul_abc) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/addmul_abc.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/addmul_abc.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({9, 10, 11, 12});
@@ -489,8 +523,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_addmul_abc) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_argmin_no_keepdims) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/argmin_no_keepdims.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/argmin_no_keepdims.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({2, 1, 3, 10});
@@ -500,7 +535,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_argmin_no_keepdims) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_batch_norm_default) {
     // Batch Normalization with default parameters
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/batchnorm_default.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/batchnorm_default.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({-1.f, 0.f, 1.f, 2.f, 3.f, 4.f});  // data {1, 2, 1, 3}
@@ -515,7 +551,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_batch_norm_default) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_relu) {
     // Simple ReLU test
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/relu.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/relu.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({-1, -2, 0, 1, 2, 3});
@@ -525,7 +562,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_relu) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sum_opset1) {
     // Simple Sum test for opset1.
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/sum_opset1.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/sum_opset1.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({3.f, 0.f, 2.f});
@@ -537,7 +575,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sum_opset1) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sum) {
     // Simple Sum test for opset8.
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/sum.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/sum.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({3.f});
@@ -548,7 +587,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sum) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sum_one_input) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/sum_one_input.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/sum_one_input.onnx"));
 
     // input data shape (3, )
     auto test_case = test::TestCase(function, s_device);
@@ -558,7 +598,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sum_one_input) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_cum_sum_1d) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/cum_sum_1d.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/cum_sum_1d.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.f, 2.f, 3.f});
@@ -567,8 +608,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_cum_sum_1d) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_cum_sum_2d_axis_input) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/cum_sum_2d_axis_input.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/cum_sum_2d_axis_input.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.f, 2.f, 3.f, 4.f, 5.f, 6.f});
@@ -577,8 +619,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_cum_sum_2d_axis_input) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_cum_sum_2d_dynamic_axis_input) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/cum_sum_2d_dynamic_axis_input.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/cum_sum_2d_dynamic_axis_input.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.f, 2.f, 3.f, 4.f, 5.f, 6.f});
@@ -588,8 +631,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_cum_sum_2d_dynamic_axis_input) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_cum_sum_3d_exclusive_reverse) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/cum_sum_3d_exclusive_reverse.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/cum_sum_3d_exclusive_reverse.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.f,  2.f,  3.f,  4.f,  5.f,  6.f,  7.f,  8.f,  9.f,  10.f, 11.f, 12.f,
@@ -601,8 +645,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_cum_sum_3d_exclusive_reverse) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_min_two_inputs_opset1) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/min_two_inputs_opset1.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/min_two_inputs_opset1.onnx"));
 
     // input data shape (3, )
     auto test_case = test::TestCase(function, s_device);
@@ -613,7 +658,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_min_two_inputs_opset1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_min_two_inputs) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/min_two_inputs.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/min_two_inputs.onnx"));
 
     // input data shape (3, )
     auto test_case = test::TestCase(function, s_device);
@@ -624,7 +670,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_min_two_inputs) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_opset1) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/max_opset1.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/max_opset1.onnx"));
 
     // input data shape (3, )
     auto test_case = test::TestCase(function, s_device);
@@ -637,7 +684,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_opset1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/max.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/max.onnx"));
 
     // input data shape (3, )
     auto test_case = test::TestCase(function, s_device);
@@ -650,7 +698,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mean_opset1) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mean_opset1.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/mean_opset1.onnx"));
 
     // input data shape (3, )
     auto test_case = test::TestCase(function, s_device);
@@ -663,7 +712,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mean_opset1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mean) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mean.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/mean.onnx"));
 
     // input data shape (3, )
     auto test_case = test::TestCase(function, s_device);
@@ -676,7 +726,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mean) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gemm_abc) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gemm_abc.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/gemm_abc.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(
@@ -703,7 +754,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gemm_abc) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/matmul.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/matmul.onnx"));
 
     std::vector<std::vector<float>> inputs;
 
@@ -720,7 +772,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softmax_0D) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/softmax_0D.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/softmax_0D.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<float>({1.0});
@@ -728,7 +781,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softmax_0D) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softmax_1D) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/softmax_1D.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/softmax_1D.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({-1.0, 0.0, 1.0});
@@ -757,7 +811,8 @@ const std::vector<float> SOFTMAX_INPUT = {
 // clang-format on
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softmax_axis_0) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/softmax_axis_0.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/softmax_axis_0.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(SOFTMAX_INPUT);
@@ -785,7 +840,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softmax_axis_0) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softmax_axis_1) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/softmax_axis_1.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/softmax_axis_1.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(SOFTMAX_INPUT);
@@ -813,8 +869,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softmax_axis_1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softmax_axis_1_opset11) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/softmax_axis_1_opset11.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/softmax_axis_1_opset11.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(SOFTMAX_INPUT);
@@ -842,8 +899,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softmax_axis_1_opset11) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softmax_axis_negative_1_opset11) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/softmax_axis_negative_1_opset11.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/softmax_axis_negative_1_opset11.onnx"));
 
     auto test_case = test::TestCase(function);
     test_case.add_input<float>(SOFTMAX_INPUT);
@@ -871,8 +929,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softmax_axis_negative_1_opset11) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softmax_axis_negative_1_opset13) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/softmax_axis_negative_1_opset13.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/softmax_axis_negative_1_opset13.onnx"));
 
     auto test_case = test::TestCase(function);
     test_case.add_input<float>(SOFTMAX_INPUT);
@@ -900,7 +959,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softmax_axis_negative_1_opset13) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sub) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/sub.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/sub.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(test::NDArray<float, 3>({{{1, 2, 3}}}).get_vector());
@@ -916,7 +976,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sub) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_div) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/div.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/div.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(test::NDArray<float, 3>({{{1, 2, 3}}}).get_vector());
@@ -931,7 +992,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_div) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_add_bcast) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/add_bcast.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/add_bcast.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(test::NDArray<float, 3>({{{1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}},
@@ -954,8 +1016,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_add_bcast) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_nonmaxsuppression_center_point_box_format) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/nonmaxsuppression_center_point_box_format.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/nonmaxsuppression_center_point_box_format.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -972,8 +1036,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_nonmaxsuppression_center_point_box_forma
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_nonmaxsuppression_single_box) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/nonmaxsuppression_single_box.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/nonmaxsuppression_single_box.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -988,8 +1053,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_nonmaxsuppression_single_box) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_nonmaxsuppression_v9_single_box) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/nonmaxsuppression_v9_single_box.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/nonmaxsuppression_v9_single_box.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -1004,7 +1070,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_nonmaxsuppression_v9_single_box) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_log_sum) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_log_sum.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/reduce_log_sum.onnx"));
 
     // input data shape (1, 1, 4, 4)
     Inputs inputs{test::NDArray<float, 4>({{{{1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}}}}).get_vector()};
@@ -1019,8 +1086,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_log_sum) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_log_sum_exp) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_log_sum_exp.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/reduce_log_sum_exp.onnx"));
 
     // input data shape (1, 1, 4, 4)
     Inputs inputs{test::NDArray<float, 4>({{{{1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}}}}).get_vector()};
@@ -1035,7 +1103,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_log_sum_exp) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_l1) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_l1.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/reduce_l1.onnx"));
 
     // input data shape (1, 1, 4, 4)
     Inputs inputs{test::NDArray<float, 4>({{{{1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}}}}).get_vector()};
@@ -1050,7 +1119,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_l1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_l2) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_l2.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/reduce_l2.onnx"));
 
     // input data shape (1, 1, 4, 4)
     Inputs inputs{test::NDArray<float, 4>({{{{1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}}}}).get_vector()};
@@ -1065,7 +1135,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_l2) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_max) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_max.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/reduce_max.onnx"));
 
     // input data shape (1, 1, 4, 4)
     Inputs inputs{
@@ -1081,13 +1152,15 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_max) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_max_invalid_axes) {
-    EXPECT_THROW(
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_max_invalid_axes.onnx")),
-        ngraph::ngraph_error);
+    EXPECT_THROW(onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                     SERIALIZED_ZOO,
+                                                                     "onnx/reduce_max_invalid_axes.onnx")),
+                 ngraph::ngraph_error);
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_mean) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_mean.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/reduce_mean.onnx"));
 
     // input data shape (1, 1, 4, 4)
     Inputs inputs{test::NDArray<float, 4>({{{{1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}}}}).get_vector()};
@@ -1102,7 +1175,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_mean) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_min) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_min.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/reduce_min.onnx"));
 
     // input data shape (1, 1, 4, 4)
     Inputs inputs{
@@ -1118,7 +1192,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_min) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_prod) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_prod.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/reduce_prod.onnx"));
 
     // input data shape (1, 1, 4, 4)
     Inputs inputs{test::NDArray<float, 4>({{{{1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}}}}).get_vector()};
@@ -1133,7 +1208,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_prod) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_sum.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/reduce_sum.onnx"));
 
     // input data shape (1, 1, 4, 4)
     Inputs inputs{test::NDArray<float, 4>({{{{1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}}}}).get_vector()};
@@ -1148,8 +1224,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_dynamic_rank_input) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_sum_dynamic_rank_input.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/reduce_sum_dynamic_rank_input.onnx"));
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(
         Shape{1, 1, 4, 4},
@@ -1160,7 +1237,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_dynamic_rank_input) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_square) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_sum_square.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/reduce_sum_square.onnx"));
 
     // input data shape (1, 1, 4, 4)
     Inputs inputs{test::NDArray<float, 4>({{{{1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}, {1, 1, 1, 1}}}}).get_vector()};
@@ -1175,8 +1253,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_square) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_as_constant) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_sum_13_axes_as_constant.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/reduce_sum_13_axes_as_constant.onnx"));
 
     Inputs inputs{test::NDArray<float, 4>({{{{1.0f, 1.0f, 1.0f, 1.0f},
                                              {1.0f, 1.0f, 1.0f, 1.0f},
@@ -1193,8 +1272,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_as_constant) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_as_constant_single_axis) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_sum_13_axes_as_constant_single_axis.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/reduce_sum_13_axes_as_constant_single_axis.onnx"));
 
     Inputs inputs{test::NDArray<float, 3>({{{1, 2, 3}, {4, 5, 6}}, {{7, 8, 9}, {10, 11, 12}}}).get_vector()};
 
@@ -1207,8 +1288,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_as_constant_single_ax
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_as_constant_keepdims_off) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_sum_13_axes_as_constant_keepdims_off.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/reduce_sum_13_axes_as_constant_keepdims_off.onnx"));
 
     // input data shape (1, 1, 4, 4)
     Inputs inputs{test::NDArray<float, 4>({{{{1.0f, 1.0f, 1.0f, 1.0f},
@@ -1226,8 +1309,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_as_constant_keepdims_
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_as_input) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_sum_13_axes_as_input.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/reduce_sum_13_axes_as_input.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.0f, 2.0f, 3.0f, 4.0f});
@@ -1238,8 +1322,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_as_input) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_as_0_dim_input) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_sum_13_axes_as_0_dim_input.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/reduce_sum_13_axes_as_0_dim_input.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f});
@@ -1250,8 +1335,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_as_0_dim_input) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_input_dynamic) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_sum_13_input_dynamic.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/reduce_sum_13_input_dynamic.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<int64_t>({1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
@@ -1261,8 +1347,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_input_dynamic) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_empty) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_sum_13_axes_empty.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/reduce_sum_13_axes_empty.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(
@@ -1273,8 +1360,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_empty) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_empty_dynamic_rank_input) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_sum_13_axes_empty_dynamic_rank_input.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/reduce_sum_13_axes_empty_dynamic_rank_input.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(
@@ -1286,8 +1375,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_empty_dynamic_rank_in
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_empty_with_noop) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_sum_13_axes_empty_with_noop.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/reduce_sum_13_axes_empty_with_noop.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(
@@ -1300,8 +1391,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_empty_with_noop) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_empty_without_noop) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/reduce_sum_13_axes_empty_without_noop.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/reduce_sum_13_axes_empty_without_noop.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(
@@ -1312,8 +1405,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reduce_sum_13_axes_empty_without_noop) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize10_asymertic_last_dim) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/resize10_asymertic_last_dim.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/resize10_asymertic_last_dim.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     std::vector<float> input_data{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f};
@@ -1342,8 +1436,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize10_asymertic_last_dim) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize10_asymertic_dim_in_the_middle) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize10_asymertic_dim_in_the_middle.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize10_asymertic_dim_in_the_middle.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     std::vector<float> input_data{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f};
@@ -1375,8 +1471,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_empty_constant_as_input) {
     // this model contains a Constant node with an empty underlying tensor
     // this node is connected to the "roi" input of the Resize op but this input should be
     // ignored since the Resize coordinate_transformation_mode is set to asymmetric
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_empty_constant_as_input.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_empty_constant_as_input.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     std::vector<float> input_data{1.0f, 3.0f, 4.0f, 8.0f, 6.0f, 2.0f, 7.0f, 11.0f};
@@ -1393,8 +1491,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_empty_constant_as_input) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize10_down_scales_const_nearest) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize10_down_scales_const_nearest.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize10_down_scales_const_nearest.onnx"));
 
     // Input data shape (1, 1, 2, 4)
     // Input const scales values {1.0, 1.0, 0.6, 0.6}
@@ -1408,8 +1508,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize10_down_scales_const_nearest) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize10_up_scales_const_linear) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize10_up_scales_const_linear.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize10_up_scales_const_linear.onnx"));
 
     // Input data shape (1, 1, 2, 2)
     // Input const scales values {1.0, 1.0, 2.0, 2.0}
@@ -1425,8 +1527,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize10_up_scales_const_linear) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize10_up_scales_const_nearest) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize10_up_scales_const_nearest.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize10_up_scales_const_nearest.onnx"));
 
     // Input data shape (1, 1, 2, 2)
     // Input const scales values {1.0, 1.0, 2.0, 3.0}
@@ -1443,8 +1547,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize10_up_scales_const_nearest) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_down_scales_linear_asymmetric) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_down_scales_linear_asymmetric.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_down_scales_linear_asymmetric.onnx"));
 
     const Shape expected_output_shape{1, 1, 1, 2};
     auto test_case = test::TestCase(function, s_device);
@@ -1459,7 +1565,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_down_scales_linear_asymmetric) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_scales_nearest_asymmetric_floor_dynamic_sizes) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_scales_nearest_asymmetric_floor_dynamic_scales.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/resize11_scales_nearest_asymmetric_floor_dynamic_scales.onnx"));
 
     const Shape expected_output_shape{2, 1, 4, 1};
     auto test_case = test::TestCase(function, s_device);
@@ -1473,8 +1581,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_scales_nearest_asymmetric_floor_dynam
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_scales_linear_asymmetric) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_up_scales_linear_asymmetric.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_up_scales_linear_asymmetric.onnx"));
 
     const Shape expected_output_shape{2, 1, 4, 8};
     auto test_case = test::TestCase(function, s_device);
@@ -1492,8 +1602,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_scales_linear_asymmetric) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_scales_nearest_asymmetric_floor) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_scales_nearest_asymmetric_floor.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_scales_nearest_asymmetric_floor.onnx"));
 
     const Shape expected_output_shape{2, 1, 4, 1};
     auto test_case = test::TestCase(function, s_device);
@@ -1505,8 +1617,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_scales_nearest_asymmetric_floor) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_scales_cubic_align_corners) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_up_scales_cubic_align_corners.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_up_scales_cubic_align_corners.onnx"));
 
     const Shape expected_output_shape{1, 1, 8, 8};
     auto test_case = test::TestCase(function, s_device);
@@ -1545,8 +1659,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_scales_cubic_align_corners) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_scales_tf_half_pixel) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_up_scales_tf_half_pixel.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_up_scales_tf_half_pixel.onnx"));
 
     const Shape expected_output_shape{1, 1, 8, 8};
     auto test_case = test::TestCase(function, s_device);
@@ -1579,8 +1695,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_scales_tf_half_pixel) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_all_attributes_default) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_up_sizes_all_attributes_default.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_up_sizes_all_attributes_default.onnx"));
 
     const Shape expected_output_shape{1, 1, 7, 8};
     auto test_case = test::TestCase(function, s_device);
@@ -1596,8 +1714,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_all_attributes_default) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_sizes_nearest_asymmetric_floor) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_sizes_nearest_asymmetric_floor.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_sizes_nearest_asymmetric_floor.onnx"));
 
     const Shape expected_output_shape{2, 1, 4, 1};
     auto test_case = test::TestCase(function, s_device);
@@ -1609,8 +1729,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_sizes_nearest_asymmetric_floor) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_linear_asymmetric) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_up_sizes_linear_asymmetric.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_up_sizes_linear_asymmetric.onnx"));
 
     const Shape expected_output_shape{2, 1, 4, 8};
     auto test_case = test::TestCase(function, s_device);
@@ -1627,8 +1749,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_linear_asymmetric) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_down_sizes_cubic_half_pixel) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_down_sizes_cubic_half_pixel.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_down_sizes_cubic_half_pixel.onnx"));
 
     const Shape expected_output_shape{1, 1, 3, 3};
     auto test_case = test::TestCase(function, s_device);
@@ -1657,8 +1781,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_down_sizes_cubic_half_pixel) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_down_sizes_linear_pytorch_half_pixel) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_down_sizes_linear_pytorch_half_pixel.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_down_sizes_linear_pytorch_half_pixel.onnx"));
 
     const Shape expected_output_shape{1, 1, 3, 1};
     auto test_case = test::TestCase(function, s_device);
@@ -1685,8 +1811,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_down_sizes_linear_pytorch_half_pixel)
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_cubic_half_pixel) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_up_sizes_cubic_half_pixel.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_up_sizes_cubic_half_pixel.onnx"));
 
     const Shape expected_output_shape{1, 1, 9, 10};
     auto test_case = test::TestCase(function, s_device);
@@ -1726,7 +1854,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_cubic_half_pixel) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_cubic_half_pixel_dynamic_sizes) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_up_sizes_cubic_half_pixel_dynamic_sizes.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/resize11_up_sizes_cubic_half_pixel_dynamic_sizes.onnx"));
 
     const Shape expected_output_shape{1, 1, 9, 10};
     auto test_case = test::TestCase(function, s_device);
@@ -1767,7 +1897,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_cubic_half_pixel_dynamic_siz
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_nearest_round_prefer_floor_half_pixel) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_up_sizes_nearest_round_prefer_floor_half_pixel.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/resize11_up_sizes_nearest_round_prefer_floor_half_pixel.onnx"));
 
     const Shape expected_output_shape{1, 1, 7, 8};
     auto test_case = test::TestCase(function, s_device);
@@ -1784,7 +1916,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_nearest_round_prefer_floor_h
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_nearest_prefer_ceil_asymmetric) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_up_sizes_nearest_prefer_ceil_asymmetric.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/resize11_up_sizes_nearest_prefer_ceil_asymmetric.onnx"));
 
     const Shape expected_output_shape{1, 1, 8, 8};
     auto test_case = test::TestCase(function, s_device);
@@ -1818,8 +1952,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_nearest_prefer_ceil_asymmetr
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_nearest_ceil_half_pixel) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_up_sizes_nearest_ceil_half_pixel.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_up_sizes_nearest_ceil_half_pixel.onnx"));
 
     const Shape expected_output_shape{1, 1, 8, 8};
     auto test_case = test::TestCase(function, s_device);
@@ -1851,8 +1987,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_nearest_ceil_half_pixel) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_nearest_floor_align_corners) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_up_sizes_nearest_floor_align_corners.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_up_sizes_nearest_floor_align_corners.onnx"));
 
     const Shape expected_output_shape{1, 1, 8, 8};
     auto test_case = test::TestCase(function, s_device);
@@ -1883,8 +2021,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_up_sizes_nearest_floor_align_corners)
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_down_sizes_tf_half_pixel) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/resize11_down_sizes_tf_half_pixel.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/resize11_down_sizes_tf_half_pixel.onnx"));
 
     const Shape expected_output_shape{1, 1, 3, 2};
     auto test_case = test::TestCase(function, s_device);
@@ -1910,7 +2050,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_resize11_down_sizes_tf_half_pixel) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_shape) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/shape.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/shape.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(test::NDArray<float, 3>({{{1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}},
@@ -1925,7 +2066,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_elu) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/elu.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/elu.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(
@@ -1957,7 +2099,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_elu) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_leaky_relu) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/leaky_relu.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/leaky_relu.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(
@@ -1980,7 +2123,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_leaky_relu) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_prelu_nd) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/prelu.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/prelu.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(
@@ -2007,7 +2151,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_prelu_nd) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_prelu_batch_nd_elementwise) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/prelu_batch_nd.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/prelu_batch_nd.onnx"));
 
     Inputs inputs;
     // Shape{2, 3, 4, 5}
@@ -2042,7 +2187,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_prelu_batch_nd_elementwise) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_prelu_1d) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/prelu_1d.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/prelu_1d.onnx"));
 
     Inputs inputs;
     // Shape{2, 3, 4, 5}
@@ -2073,7 +2219,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_prelu_1d) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_prelu_C_1_1) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/prelu_c_1_1.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/prelu_c_1_1.onnx"));
 
     Inputs inputs;
     // Shape{2, 3, 4, 5}
@@ -2104,7 +2251,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_prelu_C_1_1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_selu) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/selu.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/selu.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(
@@ -2136,7 +2284,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_selu) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sigmoid) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/sigmoid.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/sigmoid.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(
@@ -2172,7 +2321,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sigmoid) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_tanh) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/tanh.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/tanh.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(
@@ -2204,7 +2354,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_tanh) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_thresholded_relu) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/thresholded_relu.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/thresholded_relu.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(
@@ -2226,7 +2377,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_thresholded_relu) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_vec_ten3d) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/matmul_vec_ten3d.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/matmul_vec_ten3d.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(std::vector<float>{0.f, 1.f});
@@ -2241,7 +2393,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_vec_ten3d) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softplus) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/softplus.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/softplus.onnx"));
 
     // -1.0f, 0, 1.0f, 10.f,                    normal input values for activation
     // 100.0f, -100.0f, 1000.0f, -1000.0f,      input values that leads to exp() overflow
@@ -2283,7 +2436,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softplus) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softplus_infinity) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/softplus.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/softplus.onnx"));
 
     std::vector<float> input(13, std::numeric_limits<float>::infinity());
     std::vector<float> expected_output(13, std::numeric_limits<float>::infinity());
@@ -2295,7 +2449,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softplus_infinity) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sum_opset8) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/sum_opset8.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/sum_opset8.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(std::vector<float>{1.0f, 2.0f, 3.0f});
@@ -2317,7 +2472,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sum_opset8) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_argmax_int32) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/argmax_int32.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/argmax_int32.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<std::int32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
@@ -2326,7 +2482,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_argmax_int32) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_argmin_int32) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/argmin_int32.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/argmin_int32.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<std::int32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
@@ -2335,7 +2492,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_argmin_int32) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_argmax_float) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/argmax_float.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/argmax_float.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({4, 0.1, 2, 3, -3, 1, -0.9, 0, 1, 2, 3, 0});
@@ -2344,7 +2502,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_argmax_float) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_argmin_float) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/argmin_float.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/argmin_float.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({4, 0.1, 2, 3, -3, 1, -0.9, 0, 1, 2, 3, 0});
@@ -2353,8 +2512,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_argmin_float) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_argmax_select_last_index) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/argmax_select_last_index.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/argmax_select_last_index.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{4, 3}, {1, 1, 1, 0.5, 3, 4, 0.5, 1, 1.1, 0, 3, 0});
@@ -2363,8 +2523,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_argmax_select_last_index) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_argmin_select_last_index) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/argmin_select_last_index.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/argmin_select_last_index.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{4, 3}, {1, 1, 1, 2, 3, 4, 2, 1, 1.1, 3, 3, 8});
@@ -2373,7 +2534,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_argmin_select_last_index) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_top_k) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/top_k.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/top_k.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
@@ -2383,7 +2545,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_top_k) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_top_k_opset_10) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/top_k_opset_10.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/top_k_opset_10.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
@@ -2395,8 +2558,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_top_k_opset_10) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_top_k_opset_10_const_k) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/top_k_opset_10_const_k.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/top_k_opset_10_const_k.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
@@ -2407,8 +2571,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_top_k_opset_10_const_k) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_top_k_opset_11_const_k_smallest) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/top_k_opset_11_const_k_smallest.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/top_k_opset_11_const_k_smallest.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0, 1, 2, 3, 4, 5, 6, 7, 11, 10, 9, 8});
@@ -2419,8 +2584,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_top_k_opset_11_const_k_smallest) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_top_k_opset_11_const_k_smallest_negative_axis) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/top_k_opset_11_const_k_smallest_negative_axis.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/top_k_opset_11_const_k_smallest_negative_axis.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0, 1, 2, 3, 4, 5, 6, 7, 11, 10, 9, 8});
@@ -2431,7 +2598,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_top_k_opset_11_const_k_smallest_negative_axis)
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_acosh) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/acosh.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/acosh.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{1, 3}, {1.0f, 2.5f, 4.3f});
@@ -2441,7 +2609,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_acosh) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_asinh) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/asinh.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/asinh.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{1, 3}, {-1.0f, 0.0f, 1.0f});
@@ -2451,7 +2620,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_asinh) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_atanh) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/atanh.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/atanh.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{1, 3}, {-0.9f, 0.0f, 0.9f});
@@ -2461,7 +2631,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_atanh) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sinh) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/sinh.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/sinh.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({-1.0f, 0.0f, 1.0f});
@@ -2470,7 +2641,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sinh) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_cosh) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/cosh.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/cosh.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({-1.0f, 0.0f, 1.0f});
@@ -2479,7 +2651,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_cosh) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sign) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/sign.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/sign.onnx"));
 
     Inputs inputs{std::vector<float>{-std::numeric_limits<float>::infinity(),
                                      -3.141592f,
@@ -2494,7 +2667,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sign) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_one_hot_with_axis) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/one_hot_axis.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/one_hot_axis.onnx"));
 
     Inputs inputs{{1.0, 9.0, 2.0, 4.0}, {1.0, 3.0}};
     std::vector<float> expected_output{{1.0, 1.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
@@ -2508,7 +2682,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_one_hot_with_axis) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_one_hot_without_axis) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/one_hot_no_axis.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/one_hot_no_axis.onnx"));
 
     std::vector<std::vector<std::int64_t>> inputs{{0, 7, 8}, {2, 5}};
     std::vector<std::int64_t> expected_output{5, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
@@ -2521,7 +2696,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_one_hot_without_axis) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_where) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/where.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/where.onnx"));
 
     // conditions tensor - 3x3x3
     auto condition =
@@ -2547,7 +2723,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_where) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_erf) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/erf.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/erf.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(test::NDArray<float, 2>{
@@ -2565,7 +2742,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_erf) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_erf_int32) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/erf_int32.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/erf_int32.onnx"));
 
     const std::vector<std::vector<int32_t>> inputs{
         {-std::numeric_limits<int32_t>::max(), -1, 0, 1, std::numeric_limits<int32_t>::max()}};
@@ -2579,8 +2757,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_erf_int32) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_shrink_float) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/shrink_float.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/shrink_float.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({-2.0f, -1.6f, -1.5f, -1.4f, -1.0f, 0.0f, 1.0f, 1.4f, 1.5f, 1.6f, 2.0f});
@@ -2591,7 +2769,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_shrink_float) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_shrink_int) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/shrink_int.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/shrink_int.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<int>({-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5});
@@ -2601,7 +2780,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_shrink_int) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lp_norm_p1) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lp_norm_p1.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/lp_norm_p1.onnx"));
 
     Shape data_shape{2, 3, 4};
     std::vector<float> data(shape_size(data_shape));
@@ -2619,7 +2799,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lp_norm_p1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lp_norm_p2) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lp_norm_p2.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/lp_norm_p2.onnx"));
 
     Shape data_shape{2, 3, 4};
     std::vector<float> data(shape_size(data_shape));
@@ -2637,8 +2818,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lp_norm_p2) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lp_norm_default) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lp_norm_default.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/lp_norm_default.onnx"));
 
     Shape data_shape{2, 3, 4};
     std::vector<float> data(shape_size(data_shape));
@@ -2656,8 +2837,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lp_norm_default) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lp_norm_default_dynamic) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lp_norm_default_dynamic.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/lp_norm_default_dynamic.onnx"));
 
     Shape data_shape{2, 3, 4};
     std::vector<float> data(shape_size(data_shape));
@@ -2675,8 +2857,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lp_norm_default_dynamic) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_instance_normalization) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/instance_norm.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/instance_norm.onnx"));
 
     Shape data_shape{1, 2, 3, 4};
     std::vector<float> data(shape_size(data_shape));
@@ -2697,8 +2879,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_instance_normalization) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_instance_normalization_dynamic) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/instance_norm_dynamic.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/instance_norm_dynamic.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     std::vector<float> input_data{1.f, 2.f, 3.f};
@@ -2709,7 +2892,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_instance_normalization_dynamic) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_eye_like) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/eye_like.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/eye_like.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{3, 4}, {5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f});
@@ -2719,8 +2903,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_eye_like) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reverse_sequence_0_batch_1) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/reverse_sequence_time_0_batch_1.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/reverse_sequence_time_0_batch_1.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({0.f, 4.f, 8.f, 12.f, 1.f, 5.f, 9.f, 13.f, 2.f, 6.f, 10.f, 14.f, 3.f, 7.f, 11.f, 15.f});
@@ -2733,8 +2919,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reverse_sequence_0_batch_1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reverse_sequence_1_batch_0) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/reverse_sequence_time_1_batch_0.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/reverse_sequence_time_1_batch_0.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f});
@@ -2747,30 +2935,36 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reverse_sequence_1_batch_0) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reverse_sequence_incorrect_batch_axis) {
-    EXPECT_THROW(onnx_import::import_onnx_model(
-                     file_util::path_join(SERIALIZED_ZOO, "onnx/reverse_sequence_incorrect_batch_axis.onnx")),
-                 ngraph_error)
+    EXPECT_THROW(
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/reverse_sequence_incorrect_batch_axis.onnx")),
+        ngraph_error)
         << "ReverseSequence batch_axis attribute can only equal 0 or 1. Value of '2' is not "
            "accepted.";
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reverse_sequence_incorrect_time_axis) {
-    EXPECT_THROW(onnx_import::import_onnx_model(
-                     file_util::path_join(SERIALIZED_ZOO, "onnx/reverse_sequence_incorrect_time_axis.onnx")),
+    EXPECT_THROW(onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                     SERIALIZED_ZOO,
+                                                                     "onnx/reverse_sequence_incorrect_time_axis.onnx")),
                  ngraph_error)
         << "ReverseSequence time_axis attribute can only equal 0 or 1. Value of '2' is not "
            "accepted.";
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reverse_sequence_time_and_batch_axis_equal) {
-    EXPECT_THROW(onnx_import::import_onnx_model(
-                     file_util::path_join(SERIALIZED_ZOO, "onnx/reverse_sequence_time_and_batch_axis_equal.onnx")),
-                 ngraph_error)
+    EXPECT_THROW(
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/reverse_sequence_time_and_batch_axis_equal.onnx")),
+        ngraph_error)
         << "ReverseSequence 'time_axis' and 'batch_axis' can't be equal.";
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_matmul_float_type) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/matmul_float.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/matmul_float.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(std::vector<float>{0, 1, 2, 3, 4, 5});
@@ -2781,7 +2975,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_matmul_float_type) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_sign) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mod_sign.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/mod_sign.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<int32_t>({-4, 7, 5, 4, -7, 8});
@@ -2792,8 +2987,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_sign) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_sign_i64) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mod_sign_i64.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/mod_sign_i64.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<int64_t>({-4, 7, 5, 4, -7, 8});
@@ -2804,8 +2999,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_sign_i64) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_sign_broadcast) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mod_sign_broadcast.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/mod_sign_broadcast.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<int32_t>({-8, 3, 4, 9, -17, 1});
@@ -2817,8 +3013,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_sign_broadcast) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_sign_f32) {
     try {
-        const auto function =
-            onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mod_sign_f32.onnx"));
+        const auto function = onnx_import::import_onnx_model(
+            file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/mod_sign_f32.onnx"));
         FAIL() << "Expected exception was not thrown";
     } catch (const ngraph::ngraph_error& e) {
         EXPECT_HAS_SUBSTRING(
@@ -2830,8 +3026,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_sign_f32) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_sign_fmod) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mod_sign_fmod.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/mod_sign_fmod.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<int32_t>({-8, 3, 4, 9, -17, 1});
@@ -2842,8 +3038,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_sign_fmod) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_sign_fmod_broadcast) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mod_sign_fmod_broadcast.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/mod_sign_fmod_broadcast.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<int32_t>({-8, 3, 4, 9, -17, 1});
@@ -2854,8 +3051,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_sign_fmod_broadcast) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_sign_fmod_f32) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mod_sign_fmod_f32.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/mod_sign_fmod_f32.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({-4.3, 7.2, 5.0, 4.3, -7.2, 8.0});
@@ -2868,7 +3065,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_sign_fmod_f32) {
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_incorrect_fmod) {
     try {
         const auto function =
-            onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mod_incorrect_fmod.onnx"));
+            onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                SERIALIZED_ZOO,
+                                                                "onnx/mod_incorrect_fmod.onnx"));
         FAIL() << "Expected exception was not thrown";
     } catch (const ngraph::ngraph_error& e) {
         EXPECT_HAS_SUBSTRING(e.what(), std::string("Unsupported value of 'fmod' attribute (should be: 0 or 1)"));
@@ -2879,7 +3078,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mod_incorrect_fmod) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_scatterND_param_i64_indices) {
     const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scatter_nd_param_i64_indices.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/scatter_nd_param_i64_indices.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f});
@@ -2892,7 +3093,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_scatterND_param_i64_indices) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_scatterND_const_i32_indices) {
     const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scatter_nd_const_i32_indices.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/scatter_nd_const_i32_indices.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f});
@@ -2903,8 +3106,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_scatterND_const_i32_indices) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_float_1D) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gather_float_1D.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/gather_float_1D.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     // clang-format off
@@ -2922,8 +3125,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_float_1D) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_int32_3D_axis_1) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gather_int32_3D_axis_1.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/gather_int32_3D_axis_1.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     // clang-format off
@@ -2954,8 +3158,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_int32_3D_axis_1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_int8_3D_axis_neg_1) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gather_int8_3D_axis_neg_1.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/gather_int8_3D_axis_neg_1.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     // clang-format off
@@ -2979,8 +3184,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_int8_3D_axis_neg_1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_float_2D_neg_indices) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gather_float_2D_axis_1.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/gather_float_2D_axis_1.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     // clang-format off
@@ -3007,8 +3213,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_float_2D_neg_indices) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_elements_float_1D) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gather_elements_float_1D.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/gather_elements_float_1D.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>(Shape{3}, {1, 2, 3});
@@ -3019,8 +3226,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_elements_float_1D) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_elements_int8_axis_1) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gather_elements_int8_axis_1.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/gather_elements_int8_axis_1.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<int8_t>(Shape{2, 2}, {1, 2, 3, 4});
@@ -3032,7 +3240,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_elements_int8_axis_1) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_elements_int32_axis_0) {
     const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gather_elements_int32_axis_0.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/gather_elements_int32_axis_0.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<int32_t>(Shape{3, 3}, {1, 2, 3, 4, 5, 6, 7, 8, 9});
@@ -3043,8 +3253,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_elements_int32_axis_0) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_elements_float_negative_axis) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/gather_elements_float_negative_axis.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/gather_elements_float_negative_axis.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>(Shape{2, 2}, {1, 2, 3, 4});
@@ -3055,8 +3267,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_elements_float_negative_axis) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_elements_float_3D_axis_2) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/gather_elements_float_3D_axis_2.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/gather_elements_float_3D_axis_2.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>(Shape{2, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8});
@@ -3067,8 +3281,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gather_elements_float_3D_axis_2) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gatherND_int32) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gatherND_int32.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/gatherND_int32.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<int32_t>({0, 1, 2, 3});
@@ -3079,8 +3293,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gatherND_int32) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gatherND_float) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gatherND_float.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/gatherND_float.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f});
@@ -3091,8 +3305,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_gatherND_float) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_pad_constant) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/pad_constant.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/pad_constant.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({1.f, 1.2f, 2.3f, 3.4f, 4.5f, 5.7f});
@@ -3103,8 +3317,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_pad_constant) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_pow_float32_float32) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/pow_float32_float32.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/pow_float32_float32.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({1.f, 2.f, 3.f, 4.f});  // base
@@ -3116,8 +3331,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_pow_float32_float32) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_pow_float32_int32) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/pow_float32_int32.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/pow_float32_int32.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({1.f, 2.f, 3.f, 4.f});  // base
@@ -3129,8 +3344,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_pow_float32_int32) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_pow_int32_float32) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/pow_int32_float32.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/pow_int32_float32.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<int>({1, 2, 3, 4});  // base
@@ -3142,7 +3357,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_pow_int32_float32) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reciprocal) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reciprocal.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/reciprocal.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({1.f, 2.f, 3.f, 4.f, 5.f, 6.f});
@@ -3152,7 +3368,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reciprocal) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_round) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/round.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/round.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({0.1f, 0.9f, 1.2f, 1.5f, 1.8f, 2.3f, 2.7f, -1.1f, -1.9f, -2.2f, -2.8f});
@@ -3162,8 +3379,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_round) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_round_half_nearest_even) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/round_half_nearest_even.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/round_half_nearest_even.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({0.5f, 2.5f, -1.5f, -2.5f});
@@ -3173,8 +3391,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_round_half_nearest_even) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_scatter10_import_only) {
-    const auto scatter_fn =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scatter_opset10.onnx"));
+    const auto scatter_fn = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/scatter_opset10.onnx"));
 
     const Shape data_shape{2, 2};
 
@@ -3186,7 +3404,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_scatter10_import_only) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_scatter_elements_import_only) {
     const auto scatter_fn =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scatter_elements_opset11.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/scatter_elements_opset11.onnx"));
 
     const Shape data_shape{1, 5};
 
@@ -3199,7 +3419,7 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_scatter_elements_import_only) {
 NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample6_nearest_infer) {
     // clang-format off
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/upsample6_nearest.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/upsample6_nearest.onnx"));
     // height_scale: 2.0
     // width_scale: 3.0
     // mode: nearest
@@ -3222,7 +3442,7 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample6_nearest_infer) {
 NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample6_bilinear_infer) {
     // clang-format off
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/upsample6_bilinear.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/upsample6_bilinear.onnx"));
     // height_scale: 2.0
     // width_scale: 3.0
     // mode: bilinear
@@ -3245,7 +3465,7 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample6_bilinear_infer) {
 NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample6_dynamic) {
     // clang-format off
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/upsample6_dynamic.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/upsample6_dynamic.onnx"));
     // height_scale: 1.5
     // width_scale: 2.5
     // mode: nearest
@@ -3267,8 +3487,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample6_dynamic) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample8_nearest_infer) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/upsample8_nearest.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/upsample8_nearest.onnx"));
 
     // Input data shape (1, 1, 2, 2)
     // Scales attribute values {1.0, 1.0, 2.0, 3.0}
@@ -3284,8 +3504,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample8_nearest_infer) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample8_linear_infer) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/upsample8_linear.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/upsample8_linear.onnx"));
 
     // Input data shape (1, 1, 2, 2)
     // Scales attribute values {1.0, 1.0, 2.0, 2.0}
@@ -3301,8 +3521,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample8_linear_infer) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample9_scales_const_nearest_infer) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/upsample9_scales_const_nearest.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/upsample9_scales_const_nearest.onnx"));
 
     // Input data shape (1, 1, 2, 2)
     // Input const scales values {1.0, 1.0, 2.0, 3.0}
@@ -3319,7 +3541,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample9_scales_const_nearest_infer) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample9_scales_const_linear_infer) {
     const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/upsample9_scales_const_linear.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/upsample9_scales_const_linear.onnx"));
 
     // Input data shape (1, 1, 2, 2)
     // Input const scales values {1.0, 1.0, 2.0, 2.0}
@@ -3335,8 +3559,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample9_scales_const_linear_infer) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_image_scaler) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/image_scaler.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/image_scaler.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.0, 2.0, 3.0, 4.0, 10.0, 20.0, 30.0, 40.0});
@@ -3345,8 +3569,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_image_scaler) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_size_op_single) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/size_op_single.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/size_op_single.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{2, 3}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
@@ -3355,8 +3579,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_size_op_single) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_size_op_graph_end) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/size_op_graph_end.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/size_op_graph_end.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.0, 2.0, 3.0, 4.0});
@@ -3365,8 +3589,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_size_op_graph_end) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_size_op_graph_middle) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/size_op_graph_middle.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/size_op_graph_middle.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.0, 2.0, 3.0, 4.0});
@@ -3376,7 +3601,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_size_op_graph_middle) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_size_op_on_input_graph_middle) {
     const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/size_op_on_input_graph_middle.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/size_op_on_input_graph_middle.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{1, 2, 4, 1, 3}, {0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
@@ -3391,8 +3618,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_empty_initializers_handling) {
     // int this test the "scales" input of the Resize operator is set to an empty initializer
     // this input should be ignored since the "sizes" optional input is provided
     // and the inference should use the data from the latter
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/empty_initializers_handling.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/empty_initializers_handling.onnx"));
 
     const Shape expected_output_shape{2, 1, 4, 8};
     auto test_case = test::TestCase(function, s_device);
@@ -3409,8 +3637,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_empty_initializers_handling) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_roi_align_f32) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/roi_align_f32.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/roi_align_f32.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.,  10., 11., 12., 13., 14.,
@@ -3447,7 +3675,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_roi_align_f32) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_roialign16_avg_out_half_pixel) {
     const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/roialign16_avg_out_half_pixel.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/roialign16_avg_out_half_pixel.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(
@@ -3485,8 +3715,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_roialign16_avg_out_half_pixel) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_roialign16_avg_half_pixel) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/roialign16_avg_half_pixel.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/roialign16_avg_half_pixel.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(
@@ -3524,8 +3755,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_roialign16_avg_half_pixel) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, quant_dequant_pattern) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/quant_dequant_pattern.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/quant_dequant_pattern.onnx"));
     auto test_case = test::TestCase(function, s_device);
     // scale == 3.0
     // zero point == 10
@@ -3536,8 +3768,9 @@ NGRAPH_TEST(${BACKEND_NAME}, quant_dequant_pattern) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, quant_dequant_pattern_axis) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/quant_dequant_pattern_axis.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/quant_dequant_pattern_axis.onnx"));
     auto test_case = test::TestCase(function, s_device);
     // axis = 1
     // scale == {2.0, 3.0, 4.0}
@@ -3549,7 +3782,8 @@ NGRAPH_TEST(${BACKEND_NAME}, quant_dequant_pattern_axis) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_logsoftmax_0D) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/softmax_0D.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/softmax_0D.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({3.141592});
@@ -3558,8 +3792,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_logsoftmax_0D) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_logsoftmax_1D) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/logsoftmax_1D.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/logsoftmax_1D.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({-1.0f, 0.0f, 1.0f});
@@ -3568,8 +3802,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_logsoftmax_1D) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_logsoftmax13_1D) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/logsoftmax13_1D.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/logsoftmax13_1D.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({-1.0f, 0.0f, 1.0f});
@@ -3578,8 +3812,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_logsoftmax13_1D) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_logsoftmax13_2D) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/logsoftmax13_2D.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/logsoftmax13_2D.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({0.0f, 1.0f, 2.0f, 3.0f, 10000, 10001, 10002, 10003});
@@ -3590,8 +3824,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_logsoftmax13_2D) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_logsoftmax13_2D_reshape) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/logsoftmax13_2D.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/logsoftmax13_2D.onnx"));
     InferenceEngine::CNNNetwork net(function);
     InferenceEngine::ICNNNetwork::InputShapes shapes = {};
     InferenceEngine::SizeVector shape = {1, 1, 4000};
@@ -3601,7 +3835,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_logsoftmax13_2D_reshape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_hard_sigmoid) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/hard_sigmoid.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/hard_sigmoid.onnx"));
 
     const auto inf = std::numeric_limits<float>::infinity();
     const auto neg_inf = -std::numeric_limits<float>::infinity();
@@ -3614,7 +3849,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_hard_sigmoid) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mul_v6) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mul_v6.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/mul_v6.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({1.0f, 2.0f, 3.0f});
@@ -3624,8 +3860,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mul_v6) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mul_v6_broadcast_axis_1) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mul_v6_broadcast_axis_1.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/mul_v6_broadcast_axis_1.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{1, 3, 2, 2};
@@ -3640,8 +3877,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mul_v6_broadcast_axis_1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mul_v6_broadcast_axes_1_2) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mul_v6_broadcast_axes_1_2.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/mul_v6_broadcast_axes_1_2.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{1, 3, 2, 2};
@@ -3654,8 +3892,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mul_v6_broadcast_axes_1_2) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mul_v6_broadcast_no_axis) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mul_v6_broadcast_no_axis.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/mul_v6_broadcast_no_axis.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{2, 2};
@@ -3668,7 +3907,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mul_v6_broadcast_no_axis) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mul_v7) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mul_v7.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/mul_v7.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({1.0f, 2.0f, 3.0f});
@@ -3678,8 +3918,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mul_v7) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mul_v7_broadcast) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mul_v7_broadcast.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/mul_v7_broadcast.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{1, 2, 3};
@@ -3692,8 +3932,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_mul_v7_broadcast) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_add_v6_broadcast_axis_1) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/add_v6_broadcast_axis_1.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/add_v6_broadcast_axis_1.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{1, 3, 2, 2};
@@ -3708,8 +3949,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_add_v6_broadcast_axis_1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_add_v6_broadcast_axes_1_2) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/add_v6_broadcast_axes_1_2.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/add_v6_broadcast_axes_1_2.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{1, 3, 2, 2};
@@ -3721,8 +3963,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_add_v6_broadcast_axes_1_2) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_add_v6_broadcast_no_axis) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/add_v6_broadcast_no_axis.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/add_v6_broadcast_no_axis.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{2, 2};
@@ -3735,7 +3978,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_add_v6_broadcast_no_axis) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_add_v7) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/add_v7.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/add_v7.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({1.0f, 2.0f, 3.0f});
@@ -3745,8 +3989,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_add_v7) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sub_v6_broadcast_axis_1) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/sub_v6_broadcast_axis_1.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/sub_v6_broadcast_axis_1.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{1, 3, 2, 2};
@@ -3760,8 +4005,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sub_v6_broadcast_axis_1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sub_v6_broadcast_axes_1_2) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/sub_v6_broadcast_axes_1_2.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/sub_v6_broadcast_axes_1_2.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{1, 3, 2, 2};
@@ -3774,8 +4020,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sub_v6_broadcast_axes_1_2) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sub_v6_broadcast_no_axis) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/sub_v6_broadcast_no_axis.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/sub_v6_broadcast_no_axis.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{2, 2};
@@ -3788,7 +4035,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sub_v6_broadcast_no_axis) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sub_v7) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/sub_v7.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/sub_v7.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({1.0f, 2.0f, 3.0f});
@@ -3798,8 +4046,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sub_v7) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sub_v7_broadcast) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/sub_v7_broadcast.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/sub_v7_broadcast.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{1, 2, 3};
@@ -3812,8 +4060,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_sub_v7_broadcast) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_div_v6_broadcast_axis_1) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/div_v6_broadcast_axis_1.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/div_v6_broadcast_axis_1.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{1, 3, 2, 2};
@@ -3828,8 +4077,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_div_v6_broadcast_axis_1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_div_v6_broadcast_axes_1_2) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/div_v6_broadcast_axes_1_2.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/div_v6_broadcast_axes_1_2.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{1, 3, 2, 2};
@@ -3843,8 +4093,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_div_v6_broadcast_axes_1_2) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_div_v6_broadcast_no_axis) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/div_v6_broadcast_no_axis.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/div_v6_broadcast_no_axis.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{2, 2};
@@ -3857,7 +4108,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_div_v6_broadcast_no_axis) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_div_v7) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/div_v7.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/div_v7.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     test_case.add_input<float>({1.0f, 2.0f, 3.0f});
@@ -3867,8 +4119,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_div_v7) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_div_v7_broadcast) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/div_v7_broadcast.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/div_v7_broadcast.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{1, 2, 3};
@@ -3881,8 +4133,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_div_v7_broadcast) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dangling_parameter) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dangling_parameter.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dangling_parameter.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -3892,8 +4145,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dangling_parameter) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_inbounds) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/test_clip_inbounds.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/test_clip_inbounds.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<int32_t> data{-1, 0, 1, -9999, 9999};
@@ -3903,8 +4157,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_inbounds) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_no_min_no_max) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/clip_no_min_no_max.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/clip_no_min_no_max.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<float> data{-1.6, -0.1, 10., 0., -10., 1.99, 2.015, 3.};
@@ -3916,8 +4171,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_no_min_no_max) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_no_min_no_max_inf) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/clip_no_min_no_max.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/clip_no_min_no_max.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<float> data{std::numeric_limits<float>::infinity(),
@@ -3945,8 +4201,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_no_min_no_max_inf) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_no_min_set_max) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/clip_no_min_set_max.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/clip_no_min_set_max.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<float> data{-1.6, -0.1, 10., 0., -10., 1.99, 2.015, 3.};
@@ -3961,8 +4218,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_no_min_set_max) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_set_min_no_max) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/clip_set_min_no_max.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/clip_set_min_no_max.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<float> data{-1.6, -0.1, 10., 0., -10., 1.99, 2.015, 3.};
@@ -3977,8 +4235,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_set_min_no_max) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_no_min_no_max_int64) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/clip_no_min_no_max_int64.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/clip_no_min_no_max_int64.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<int64_t> data{INT64_MAX, INT64_MIN, INT32_MAX, INT32_MIN, 0, -1, 1, 0};
@@ -3990,8 +4249,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_no_min_no_max_int64) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_no_min_set_max_int64) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/clip_no_min_set_max_int64.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/clip_no_min_set_max_int64.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<int64_t> data{INT64_MAX, INT64_MIN, INT32_MAX, INT32_MIN, 0, -1, 1, 0};
@@ -4006,8 +4266,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_no_min_set_max_int64) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_set_min_no_max_initializers) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/clip_set_min_no_max_initializers.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/clip_set_min_no_max_initializers.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<float> data{-1.6, -0.1, 10., 0., -10., 1.99, 2.015, 3.};
@@ -4020,8 +4281,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_set_min_no_max_initializers) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_set_min_set_max) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/clip_set_min_set_max.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/clip_set_min_set_max.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<float> data{-1.6, -0.1, 10., 0., -10., 1.99, 2.015, 3.};
@@ -4038,8 +4300,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_set_min_set_max) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_set_min_set_max_initializers) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/clip_set_min_set_max_initializers.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/clip_set_min_set_max_initializers.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<float> data{-1.6, -0.1, 10., 0., -10., 1.99, 2.015, 3.};
@@ -4052,7 +4315,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_clip_set_min_set_max_initializers) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_mvn_v6) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/mvn_v6.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/mvn_v6.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0.8439683,  0.5665144, 0.05836735, 0.02916367, 0.12964272, 0.5060197, 0.79538304,
@@ -4069,8 +4333,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_mvn_v6) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout1_no_training_no_return_mask) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dropout1_no_training_no_return_mask.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dropout1_no_training_no_return_mask.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<float> data(3 * 4 * 5, 2.0f);
@@ -4080,8 +4346,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout1_no_training_no_return_mask) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout1_no_training_return_mask) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dropout1_no_training_return_mask.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dropout1_no_training_return_mask.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<float> data(3 * 4 * 5, 2.0f);
@@ -4093,8 +4360,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout1_no_training_return_mask) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout7_no_return_mask) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dropout7_no_return_mask.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dropout7_no_return_mask.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<float> data(3 * 4 * 5, 2.0f);
@@ -4104,8 +4372,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout7_no_return_mask) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout12_no_training_no_return_mask) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dropout12_no_training_no_return_mask.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dropout12_no_training_no_return_mask.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<float> data(3 * 4 * 5, 2.0f);
@@ -4115,8 +4385,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout12_no_training_no_return_mask) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout12_no_training_return_mask) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dropout12_no_training_return_mask.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dropout12_no_training_return_mask.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<float> data(3 * 4 * 5, 2.0f);
@@ -4128,8 +4399,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout12_no_training_return_mask) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout12_no_traning_no_const_rato) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dropout12_no_traning_no_const_rato.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dropout12_no_traning_no_const_rato.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1, 2, 3, 4});
@@ -4141,8 +4414,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout12_no_traning_no_const_rato) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout12_training_mode) {
     try {
-        auto function =
-            onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dropout12_training_mode.onnx"));
+        auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                            SERIALIZED_ZOO,
+                                                                            "onnx/dropout12_training_mode.onnx"));
         FAIL() << "Expected exception was not thrown";
     } catch (const ngraph::ngraph_error& e) {
         EXPECT_HAS_SUBSTRING(e.what(), std::string("Training mode is not supported for Dropout op"));
@@ -4153,8 +4427,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout12_training_mode) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dropout12_not_const_training_mode) {
     try {
-        auto function = onnx_import::import_onnx_model(
-            file_util::path_join(SERIALIZED_ZOO, "onnx/dropout12_not_const_training_mode.onnx"));
+        auto function =
+            onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                SERIALIZED_ZOO,
+                                                                "onnx/dropout12_not_const_training_mode.onnx"));
         FAIL() << "Expected exception was not thrown";
     } catch (const ngraph::ngraph_error& e) {
         EXPECT_HAS_SUBSTRING(e.what(), std::string("Non-constant training_mode input is not supported."));
@@ -4167,8 +4443,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_multiple_slices_last_layer) {
     std::vector<float> data(1 * 30 * 320 * 320);
     std::fill(data.begin(), data.end(), 1);
 
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/multiple_slices_last_layer.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/multiple_slices_last_layer.onnx"));
     auto test_case = test::TestCase(function, s_device);
     std::vector<float> o1(1 * 320 * 320 * 21);
     std::fill(o1.begin(), o1.end(), 1);
@@ -4183,8 +4460,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_multiple_slices_last_layer) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_slice_const_axes_source) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/slice_const_axes_source.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/slice_const_axes_source.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(std::vector<float>{1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f});
@@ -4193,8 +4471,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_slice_const_axes_source) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_softmax_crossentropy_loss_mean) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/softmax_crossentropy_loss_mean.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/softmax_crossentropy_loss_mean.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0.54881352186203,
@@ -4218,8 +4497,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_softmax_crossentropy_loss_mean) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_negativelog_likelihood_loss) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/negativelog_likelihood_loss.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/negativelog_likelihood_loss.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({
@@ -4236,8 +4516,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_negativelog_likelihood_loss) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_fill_input_as_shape_default_value) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_fill_input_as_shape_default_value.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/constant_fill_input_as_shape_default_value.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<float>(Shape{1, 2, 3}, {0.f, 0.f, 0.f, 0.f, 0.f, 0.f});
@@ -4245,8 +4527,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_fill_input_as_shape_default_value) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_fill_input_as_shape_u8_type) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_fill_input_as_shape_u8_type.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/constant_fill_input_as_shape_u8_type.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<uint8_t>(Shape{3, 1, 2}, {3, 3, 3, 3, 3, 3});
@@ -4254,8 +4538,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_fill_input_as_shape_u8_type) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_fill_extra_shape) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/constant_fill_extra_shape.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_fill_extra_shape.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<float>(Shape{3, 1, 2, 2, 1}, std::vector<float>(12, 3.0f));
@@ -4263,8 +4548,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_fill_extra_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_fill_shape_attribute) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/constant_fill_shape_attribute.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_fill_shape_attribute.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<int32_t>(Shape{2, 3, 4}, std::vector<int32_t>(24, 5));
@@ -4272,8 +4558,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_fill_shape_attribute) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_float_tensor) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/constant_float_tensor.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_float_tensor.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<float>(Shape{2, 3}, {0.0f, 0.5f, 1.f, 1.5f, 2.f, 2.5f});
@@ -4281,8 +4568,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_float_tensor) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_bfloat_tensor) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/constant_bfloat_tensor.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_bfloat_tensor.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<bfloat16>(Shape{2, 3}, {0.f, 5.f, 10.f, 15.f, 20.f, 25.f});
@@ -4290,8 +4578,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_bfloat_tensor) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_float_scalar) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/constant_float_scalar.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_float_scalar.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<float>(Shape{}, {0.5f});
@@ -4299,8 +4588,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_float_scalar) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_float_array) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/constant_float_array.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_float_array.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<float>(Shape{3}, {0.5f, 1.f, 1.5f});
@@ -4308,8 +4598,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_float_array) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_integer_scalar) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/constant_integer_scalar.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_integer_scalar.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<std::int64_t>(Shape{}, {1});
@@ -4317,8 +4608,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_integer_scalar) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_integer_array) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/constant_integer_array.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_integer_array.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<std::int64_t>(Shape{3}, {0, 1, 2});
@@ -4326,8 +4618,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_integer_array) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_float_2x2) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_sparse_tensor.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<float>(Shape{2, 2}, {0.f, 5.f, 0.f, 0.f});
@@ -4335,8 +4628,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_float_2x2) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_float_3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_float_3x4.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_sparse_tensor_float_3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<float>(Shape{3, 4}, {1.f, 0.f, 0.f, 8.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 3.f, 0.f});
@@ -4345,7 +4639,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_float_3x4) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_float_3x4_linearized_indices) {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_float_3x4_linearized_indices.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/constant_sparse_tensor_float_3x4_linearized_indices.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<float>(Shape{3, 4}, {1.f, 0.f, 0.f, 8.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 3.f, 0.f});
@@ -4353,8 +4649,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_float_3x4_linearized_in
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_int32_3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_int32_3x4.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_sparse_tensor_int32_3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<int32_t>(Shape{3, 4}, {1, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3, 0});
@@ -4362,8 +4659,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_int32_3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_int64_3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_int64_3x4.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_sparse_tensor_int64_3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<int64_t>(Shape{3, 4}, {1, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3, 0});
@@ -4371,8 +4669,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_int64_3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_boolean_3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_boolean_3x4.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/constant_sparse_tensor_boolean_3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<bool>(Shape{3, 4}, {1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0});
@@ -4380,8 +4680,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_boolean_3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_float16_3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_float16_3x4.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/constant_sparse_tensor_float16_3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<ngraph::float16>(Shape{3, 4}, {1, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3, 0});
@@ -4389,8 +4691,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_float16_3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_double_3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_double_3x4.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_sparse_tensor_double_3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<double>(Shape{3, 4}, {1, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3, 0});
@@ -4398,8 +4701,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_double_3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_int8_3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_int8_3x4.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_sparse_tensor_int8_3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<int8_t>(Shape{3, 4}, {1, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3, 0});
@@ -4407,8 +4711,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_int8_3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_int16_3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_int16_3x4.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_sparse_tensor_int16_3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<int16_t>(Shape{3, 4}, {1, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3, 0});
@@ -4416,8 +4721,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_int16_3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_uint8_3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_uint8_3x4.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_sparse_tensor_uint8_3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<uint8_t>(Shape{3, 4}, {1, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3, 0});
@@ -4425,8 +4731,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_uint8_3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_uint16_3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_uint16_3x4.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_sparse_tensor_uint16_3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<uint16_t>(Shape{3, 4}, {1, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3, 0});
@@ -4434,8 +4741,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_uint16_3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_uint32_3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_uint32_3x4.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_sparse_tensor_uint32_3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<uint32_t>(Shape{3, 4}, {1, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3, 0});
@@ -4443,8 +4751,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_uint32_3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_uint64_3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_uint64_3x4.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_sparse_tensor_uint64_3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<uint64_t>(Shape{3, 4}, {1, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3, 0});
@@ -4452,8 +4761,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_uint64_3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_bfloat16_3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_bfloat16_3x4.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/constant_sparse_tensor_bfloat16_3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<ngraph::bfloat16>(Shape{3, 4}, {1, 0, 0, 8, 0, 0, 0, 0, 0, 0, 3, 0});
@@ -4461,8 +4772,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_bfloat16_3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_float_8x17) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_float_8x17.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_sparse_tensor_float_8x17.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<float>(
@@ -4478,8 +4790,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_float_8x17) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_float_2x3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_float_2x3x4.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/constant_sparse_tensor_float_2x3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<float>(Shape{2, 3, 4}, {1.f, 0.f, 0.f, 8.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 3.f, 0.f,
@@ -4488,8 +4802,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_float_2x3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_float_2x2x3x4) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/constant_sparse_tensor_float_2x2x3x4.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/constant_sparse_tensor_float_2x2x3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<float>(
@@ -4501,7 +4817,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_sparse_tensor_float_2x2x3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_einsum_sum) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/einsum_sum.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/einsum_sum.onnx"));
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{3, 4},
                                {1.764052345967664,
@@ -4521,8 +4838,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_einsum_sum) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_float16_tensor_as_int32) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/conv_fp16_W_as_int32.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/conv_fp16_W_as_int32.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // clang-format off
@@ -4543,7 +4861,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_float16_tensor_as_int32) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_pool_3d) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/max_pool_3d.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/max_pool_3d.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<int32_t>(Shape{1, 3, 3}, {-1, 0, 1, 20, -20, 10, 0, 2, 1});
@@ -4554,8 +4873,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_pool_3d) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_pool_4d_ceil_mode) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/max_pool_4d_ceil_mode.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/max_pool_4d_ceil_mode.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<int32_t>(Shape{1, 1, 4, 4}, gen_range<int32_t>(16, 1));
@@ -4566,8 +4886,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_pool_4d_ceil_mode) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_pool_4d_dilations) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/max_pool_4d_dilations.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/max_pool_4d_dilations.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<int32_t>(Shape{1, 1, 4, 4}, {9, 10, 11, 12, 1, 2, 3, 4, 16, 14, 15, 13, 5, 6, 8, 7});
@@ -4581,8 +4902,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_pool_4d_strides) {
     // kernel: 3x3
     // strides: 3, 3
     // explicit pads: 2, 2, 2, 2
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/max_pool_4d_strides.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/max_pool_4d_strides.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<int8_t>(Shape{1, 1, 5, 5}, gen_range<int8_t>(25, 1));
@@ -4596,8 +4918,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_pool_4d_ceil_strides) {
     // kernel: 3x3
     // strides: 2, 2
     // ceil_mode: 1
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/max_pool_4d_ceil_strides.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/max_pool_4d_ceil_strides.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(
@@ -4610,8 +4933,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_pool_4d_ceil_strides) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_random_uniform) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/random_uniform.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/random_uniform.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<float>(Shape{2, 2}, {43.45518, 48.67585, 42.227386, 40.86294});
@@ -4619,8 +4942,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_random_uniform) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_random_uniform_like) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/random_uniform_like.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/random_uniform_like.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{2, 2}, {41, 42, 43, 44});
@@ -4629,8 +4953,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_random_uniform_like) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_random_normal) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/random_normal.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/random_normal.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_expected_output<float>(Shape{2, 2}, {13.459274, 41.75028, -19.311913, 131.79282});
@@ -4638,8 +4962,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_random_normal) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_random_normal_like) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/random_normal_like.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/random_normal_like.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{2, 2}, {0, 0, 0, 0});
@@ -4649,7 +4974,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_random_normal_like) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_embedding_bag_packed_sum_2in) {
     const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/aten_embedding_sum_packed_2in.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/aten_embedding_sum_packed_2in.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{5, 2}, {-0.2, -0.6, -0.1, -0.4, -1.9, -1.8, -1., 1.5, 0.8, -0.7});
@@ -4660,8 +4987,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_embedding_bag_packed_sum_2in) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_embedding_bag_packed_sum_3in_offsets_none) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/aten_embedding_sum_packed_3in_offset_none.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/aten_embedding_sum_packed_3in_offset_none.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{5, 2}, {-0.2, -0.6, -0.1, -0.4, -1.9, -1.8, -1., 1.5, 0.8, -0.7});
@@ -4673,7 +5002,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_embedding_bag_packed_sum_3in_offsets_none
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_embedding_bag_packed_sum_4in_per_sample_weights) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/aten_embedding_sum_packed_4in_per_sample_weights.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/aten_embedding_sum_packed_4in_per_sample_weights.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{5, 2}, {-0.2, -0.6, -0.1, -0.4, -1.9, -1.8, -1., 1.5, 0.8, -0.7});
@@ -4685,8 +5016,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_embedding_bag_packed_sum_4in_per_sample_w
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_embedding_bag_packed_sum_4in_two_none) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/aten_embedding_sum_packed_4in_two_none.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/aten_embedding_sum_packed_4in_two_none.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{5, 2}, {-0.2, -0.6, -0.1, -0.4, -1.9, -1.8, -1., 1.5, 0.8, -0.7});
@@ -4698,7 +5031,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_embedding_bag_packed_sum_4in_two_none) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_embedding_bag_offsets_sum_3in) {
     const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/aten_embedding_sum_offset_3in.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/aten_embedding_sum_offset_3in.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{5, 2}, {-0.2, -0.6, -0.1, -0.4, -1.9, -1.8, -1., 1.5, 0.8, -0.7});
@@ -4711,7 +5046,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_embedding_bag_offsets_sum_3in) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_embedding_bag_offsets_sum_4in) {
     const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/aten_embedding_sum_offset_4in.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/aten_embedding_sum_offset_4in.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{5, 2}, {-0.2, -0.6, -0.1, -0.4, -1.9, -1.8, -1., 1.5, 0.8, -0.7});
@@ -4724,8 +5061,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_embedding_bag_offsets_sum_4in) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_embedding_bag_many_node_outputs) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/aten_embedding_sum_many_outputs.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/aten_embedding_sum_many_outputs.onnx"));
 
     // 4 outputs in onnx Node (1 connected and 3 not connected)
     EXPECT_EQ(function->outputs().size(), 1);
@@ -4742,8 +5081,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_embedding_bag_many_node_outputs) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_unsupported_embedding_mode) {
     try {
-        const auto function = onnx_import::import_onnx_model(
-            file_util::path_join(SERIALIZED_ZOO, "onnx/aten_unsupported_embedding_mode.onnx"));
+        const auto function =
+            onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                SERIALIZED_ZOO,
+                                                                "onnx/aten_unsupported_embedding_mode.onnx"));
         FAIL() << "Expected exception was not thrown.";
     } catch (const ngraph::ngraph_error& e) {
         EXPECT_HAS_SUBSTRING(
@@ -4758,7 +5099,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_unsupported_embedding_mode) {
 NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_unsupported_operator) {
     try {
         const auto function =
-            onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/aten_unsupported_operator.onnx"));
+            onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                SERIALIZED_ZOO,
+                                                                "onnx/aten_unsupported_operator.onnx"));
         FAIL() << "Expected exception was not thrown.";
     } catch (const ngraph::ngraph_error& e) {
         EXPECT_HAS_SUBSTRING(
@@ -4771,8 +5114,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_aten_unsupported_operator) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_unsqueeze_ai_onnx_domain) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/unsqueeze_ai_onnx_domain.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/unsqueeze_ai_onnx_domain.onnx"));
 
     auto input = test::NDArray<float, 3>({{{1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}},
                                           {{1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}},
@@ -4792,8 +5136,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_unsqueeze_ai_onnx_domain) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_unsqueeze_default_domain) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/unsqueeze_default_domain.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/unsqueeze_default_domain.onnx"));
 
     auto input = test::NDArray<float, 3>({{{1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}},
                                           {{1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}},
@@ -4813,8 +5158,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_unsqueeze_default_domain) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_unsqueeze_default_domain_opset13) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/unsqueeze_default_domain_opset13.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/unsqueeze_default_domain_opset13.onnx"));
 
     auto input = test::NDArray<float, 3>({{{1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}},
                                           {{1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}},
@@ -4833,8 +5179,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_unsqueeze_default_domain_opset13) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_unsqueeze_ai_onnx_domain_opset13) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/unsqueeze_ai_onnx_domain_opset13.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/unsqueeze_ai_onnx_domain_opset13.onnx"));
 
     auto input = test::NDArray<float, 3>({{{1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}},
                                           {{1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}},
@@ -4853,8 +5200,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_unsqueeze_ai_onnx_domain_opset13) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_expand_failsafe_node) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/expand_failsafe_node.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/expand_failsafe_node.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const auto input_data = std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f};
@@ -4865,8 +5213,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_expand_failsafe_node) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_fib_like) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scan15_fib_like.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/scan15_fib_like.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{}, {0});
@@ -4880,8 +5228,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_fib_like) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_fib_like_out_rev) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scan15_fib_like_out_rev.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/scan15_fib_like_out_rev.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{}, {0});
@@ -4895,8 +5244,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_fib_like_out_rev) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_fib_like_input_rev) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scan15_fib_like_input_rev.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/scan15_fib_like_input_rev.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{}, {0});
@@ -4913,7 +5263,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_fib_like_input_rev) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_fib_like_input_out_rev) {
     const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scan15_fib_like_input_out_rev.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/scan15_fib_like_input_out_rev.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{}, {0});
@@ -4929,8 +5281,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_fib_like_input_out_rev) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_ND_mixed_ones) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scan15_ND_mixed.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/scan15_ND_mixed.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{1, 3, 2}, {0, 0, 0, 0, 0, 0});
@@ -4947,8 +5299,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_ND_mixed_ones) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_ND_mixed_vals) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scan15_ND_mixed.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/scan15_ND_mixed.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{1, 3, 2}, {0, 0, 0, 0, 0, 0});
@@ -4972,8 +5324,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_ND_mixed_vals) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_ND_mixed_vals_neg_axes) {
     // Negative indices for scan_input_axes and scan_output_axes attributes
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scan15_ND_mixed_neg_axes.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/scan15_ND_mixed_neg_axes.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{1, 3, 2}, {0, 0, 0, 0, 0, 0});
@@ -4996,8 +5349,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_ND_mixed_vals_neg_axes) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_dyn_rank_vals) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scan15_dyn_rank.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/scan15_dyn_rank.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{1, 3, 2}, {0, 0, 0, 0, 0, 0});
@@ -5023,7 +5376,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_dyn_rank_vals_neg_axes) {
     // Negative indices for scan_input_axes and scan_output_axes attributes
     try {
         const auto function =
-            onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scan15_dyn_rank_neg_axes.onnx"));
+            onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                SERIALIZED_ZOO,
+                                                                "onnx/scan15_dyn_rank_neg_axes.onnx"));
     } catch (const ngraph::ngraph_error& e) {
         EXPECT_HAS_SUBSTRING(e.what(), std::string("Rank must be static in order to normalize negative axis"));
     } catch (...) {
@@ -5032,8 +5387,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_dyn_rank_vals_neg_axes) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_ND_b4_input_rev_vals) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scan15_ND_b4_input_rev.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/scan15_ND_b4_input_rev.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{4, 3, 2}, std::vector<float>(24, 0));
@@ -5077,7 +5433,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_scan15_ND_b4_input_rev_vals) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_scan8_ND_b4_ones) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scan8_ND_b4.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/scan8_ND_b4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{4, 3, 2}, std::vector<float>(24, 0));
@@ -5101,8 +5458,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_scan8_ND_b4_ones) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_scan8_ND_b4_input_rev_vals) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scan8_ND_b4_input_rev.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/scan8_ND_b4_input_rev.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{4, 3, 2}, std::vector<float>(24, 0));
@@ -5149,7 +5507,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_scan8_ND_b4_seq_lens) {
     // ONNX Scan-8 can has optional `sequence_lens` input, the input was removed since ONNX Scan-9
     try {
         const auto function =
-            onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scan8_ND_b4_seq_lens.onnx"));
+            onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                SERIALIZED_ZOO,
+                                                                "onnx/scan8_ND_b4_seq_lens.onnx"));
     } catch (const ngraph::ngraph_error& e) {
         EXPECT_HAS_SUBSTRING(e.what(), std::string(" ONNX Scan-8 `sequence_lens` input is not supported. "));
     } catch (...) {
@@ -5158,7 +5518,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_scan8_ND_b4_seq_lens) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softsign) {
-    auto model = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/softsign.onnx"));
+    auto model = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/softsign.onnx"));
 
     Inputs inputs{std::vector<float>{1.0, 0.1, 20.0, 12.0, -12.0, -0.2, 0.5, 100.0, 0.0, -1.0}};
 
@@ -5172,7 +5533,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_softsign) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_grid_sample) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/grid_sample.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/grid_sample.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{1, 1, 4, 4}, gen_range<float>(16));
@@ -5197,8 +5559,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_grid_sample) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_concat_empty_init) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/concat_empty_init.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/concat_empty_init.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<int64_t>(Shape{2}, std::vector<int64_t>{1, 2});

--- a/src/frontends/tests/onnx/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/tests/onnx/onnx_import_com_microsoft.in.cpp
@@ -13,10 +13,11 @@
 #endif
 // clang-format on
 
-#include "onnx_import/onnx.hpp"
+#include "common_test_utils/file_utils.hpp"
 #include "default_opset.hpp"
 #include "engines_util/test_case.hpp"
 #include "engines_util/test_engines.hpp"
+#include "onnx_import/onnx.hpp"
 #include "util/test_control.hpp"
 
 NGRAPH_SUPPRESS_DEPRECATED_START
@@ -27,8 +28,9 @@ static std::string s_manifest = "${MANIFEST}";
 static std::string s_device = test::backend_name_to_device("${BACKEND_NAME}");
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_bias_gelu) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/bias_gelu.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/com.microsoft/bias_gelu.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0.5488135,
@@ -49,7 +51,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_bias_gelu) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_skip_layer_normalization_with_gamma_beta_bias) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/skip_layer_normalization_with_gamma_beta_bias.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/com.microsoft/skip_layer_normalization_with_gamma_beta_bias.onnx"));
 
     std::vector<float> input = {
         0.54881352, 0.71518934, 0.60276335, 0.54488319, 0.42365479, 0.64589411, 0.43758720, 0.89177299,
@@ -75,7 +79,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_skip_layer_normalization_with_gamma_beta
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_skip_layer_normalization_with_gamma_beta) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/skip_layer_normalization_with_gamma_beta.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/com.microsoft/skip_layer_normalization_with_gamma_beta.onnx"));
 
     std::vector<float> input = {
         0.54881352, 0.71518934, 0.60276335, 0.54488319, 0.42365479, 0.64589411, 0.43758720, 0.89177299,
@@ -101,7 +107,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_skip_layer_normalization_with_gamma_beta
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_skip_layer_normalization_with_gamma) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/skip_layer_normalization_with_gamma.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/com.microsoft/skip_layer_normalization_with_gamma.onnx"));
 
     std::vector<float> input = {
         0.54881352, 0.71518934, 0.60276335, 0.54488319, 0.42365479, 0.64589411, 0.43758720, 0.89177299,
@@ -127,7 +135,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_skip_layer_normalization_with_gamma) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_skip_layer_normalization_dynamic_shapes) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/skip_layer_normalization_dynamic_shapes.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/com.microsoft/skip_layer_normalization_dynamic_shapes.onnx"));
 
     std::vector<float> input = {
         0.54881352, 0.71518934, 0.60276335, 0.54488319, 0.42365479, 0.64589411, 0.43758720, 0.89177299,
@@ -174,8 +184,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_skip_layer_normalization_dynamic_shapes)
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_embed_layer_normalization) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/embed_layer_normalization.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/com.microsoft/embed_layer_normalization.onnx"));
 
     std::vector<int> input_ids = {
         8, 1, 5, 9, 8, 9, 4, 3, 0, 3, 5, 0, 2, 3, 8, 1, 3, 3, 3, 7, 0, 1, 9, 9,
@@ -206,7 +218,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_embed_layer_normalization) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_embed_layer_normalization_with_segment_embedding) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO,
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
                              "onnx/com.microsoft/embed_layer_normalization_with_segment_embedding.onnx"));
 
     std::vector<int> input_ids = {
@@ -249,7 +262,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_embed_layer_normalization_with_segment_e
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_embed_layer_normalization_with_segment_embedding_and_mask) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO,
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
                              "onnx/com.microsoft/embed_layer_normalization_with_segment_embedding_and_mask.onnx"));
 
     std::vector<int> input_ids = {
@@ -295,7 +309,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_embed_layer_normalization_with_segment_e
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_embed_layer_normalization_dynamic_shapes) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/embed_layer_normalization_dynamic_shapes.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/com.microsoft/embed_layer_normalization_dynamic_shapes.onnx"));
 
     std::vector<int> input_ids = {
         8, 1, 5, 9, 8, 9, 4, 3, 0, 3, 5, 0, 2, 3, 8, 1, 3, 3, 3, 7, 0, 1, 9, 9,
@@ -390,8 +406,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_embed_layer_normalization_dynamic_shapes
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/attention.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/com.microsoft/attention.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     std::vector<float> input = {
@@ -412,8 +429,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_qkv_hidden_sizes) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/attention_qkv_hidden_sizes.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/com.microsoft/attention_qkv_hidden_sizes.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     std::vector<float> input = {
@@ -438,8 +457,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_qkv_hidden_sizes) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_unidirectional) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/attention_unidirectional.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/com.microsoft/attention_unidirectional.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     std::vector<float> input = {
@@ -471,8 +492,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_unidirectional) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_mask_index_1) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/attention_mask_index_1.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/com.microsoft/attention_mask_index_1.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     std::vector<float> input = {
@@ -509,8 +532,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_mask_index_1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_mask_index_2) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/attention_mask_index_2.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/com.microsoft/attention_mask_index_2.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     std::vector<float> input = {
@@ -549,8 +574,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_mask_index_2) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_mask_index_3) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/attention_mask_index_3.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/com.microsoft/attention_mask_index_3.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     std::vector<float> input = {
@@ -593,8 +620,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_mask_index_3) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_mask_index_4) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/attention_mask_index_4.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/com.microsoft/attention_mask_index_4.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     std::vector<float> input = {
@@ -631,7 +660,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_mask_index_4) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_past) {
     const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/attention_past.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/com.microsoft/attention_past.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     std::vector<float> input = {
@@ -706,8 +737,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_past) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_extra_add) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/attention_extra_add.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/com.microsoft/attention_extra_add.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     std::vector<float> input = {
@@ -761,8 +794,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_extra_add) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_dynamic_shapes) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/attention_dynamic_shapes.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/com.microsoft/attention_dynamic_shapes.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     std::vector<float> input = {
@@ -857,8 +892,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_attention_dynamic_shapes) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_fusedgemm_abc) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/com.microsoft/fusedgemm.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/com.microsoft/fusedgemm.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     std::vector<float> inputA = {

--- a/src/frontends/tests/onnx/onnx_import_const_folding.in.cpp
+++ b/src/frontends/tests/onnx/onnx_import_const_folding.in.cpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 
+#include "common_test_utils/file_utils.hpp"
 #include "default_opset.hpp"
 #include "gtest/gtest.h"
 #include "ngraph/file_util.hpp"
@@ -51,32 +52,37 @@ void test_constant_folding(std::shared_ptr<ngraph::Function> ng_function,
 }  // namespace
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_const_folding_model_scatter_elements) {
-    const auto fn =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/scatter_elements_opset11.onnx"));
+    const auto fn = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/scatter_elements_opset11.onnx"));
 
     test_constant_folding<float>(fn, {1.0, 1.1, 3.0, 2.1, 5.0}, Shape{1, 5});
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_const_folding_model_non_zero_scalar) {
-    const auto fn = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/non_zero_scalar.onnx"));
+    const auto fn = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/non_zero_scalar.onnx"));
 
     test_constant_folding<int64_t>(fn, {0}, Shape{1, 1});
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_const_folding_model_non_zero_1d) {
-    const auto fn = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/non_zero_1d.onnx"));
+    const auto fn = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/non_zero_1d.onnx"));
 
     test_constant_folding<int64_t>(fn, {1, 2, 4}, Shape{1, 3});
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_const_folding_model_non_zero_1d_float) {
-    const auto fn = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/non_zero_1d_float.onnx"));
+    const auto fn = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/non_zero_1d_float.onnx"));
 
     test_constant_folding<int64_t>(fn, {0, 1, 3, 4, 5, 6, 7, 8, 9});
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_const_folding_model_non_zero_3d) {
-    const auto fn = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/non_zero_3d.onnx"));
+    const auto fn = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/non_zero_3d.onnx"));
 
     // Vertical slices are 3D indices of non-zero elements in the input tensor
     // {0, 0, 0, 1, 1, 2, 2}
@@ -86,7 +92,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_const_folding_model_non_zero_3d) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_const_folding_model_non_zero_2d_bool) {
-    const auto fn = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/non_zero_2d_bool.onnx"));
+    const auto fn = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/non_zero_2d_bool.onnx"));
 
     test_constant_folding<int64_t>(fn, {0, 1, 1, 0});
 }

--- a/src/frontends/tests/onnx/onnx_import_controlflow.in.cpp
+++ b/src/frontends/tests/onnx/onnx_import_controlflow.in.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "common_test_utils/file_utils.hpp"
 #include "default_opset.hpp"
 #include "engines_util/test_case.hpp"
 #include "engines_util/test_engines.hpp"
@@ -31,8 +32,9 @@ static std::string s_device = test::backend_name_to_device("${BACKEND_NAME}");
 //       cond = ...; // ignored
 //     }
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_add) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_add.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/controlflow/loop_2d_add.onnx"));
 
     // Shape inference tests
     const auto& parameters = function->get_parameters();
@@ -66,7 +68,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_add) {
 //     }
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_no_identity_termination_cond) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_add_no_identity_termination_cond.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/controlflow/loop_2d_add_no_identity_termination_cond.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // termination condition
@@ -80,8 +84,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_no_identity_termination_co
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_trip_count_max_int) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_add_trip_count_max_int.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/controlflow/loop_2d_add_trip_count_max_int.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // termination condition
@@ -96,7 +102,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_trip_count_max_int) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_no_identity_termination_cond_static_shapes) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO,
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
                              "onnx/controlflow/loop_2d_add_no_identity_termination_cond_static_shapes.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
@@ -113,7 +120,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_no_identity_termination_co
 // input ("", cond) // Note this is analogous to a while loop
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_no_identity_termination_cond_false) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_add_no_identity_termination_cond_false.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/controlflow/loop_2d_add_no_identity_termination_cond_false.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // a_init
@@ -131,7 +140,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_no_identity_termination_co
 //      }
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_const_no_identity_termination_cond) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_add_const_no_identity_termination_cond.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/controlflow/loop_2d_add_const_no_identity_termination_cond.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // a_init
@@ -144,7 +155,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_const_no_identity_terminat
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_const_no_identity_termination_cond_static_shapes) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO,
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
                              "onnx/controlflow/loop_2d_add_const_no_identity_termination_cond_static_shapes.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
@@ -163,7 +175,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_const_no_identity_terminat
 //      }
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_both_cond_and_trip_count_as_inputs) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_add_cond_and_trip_count_as_inputs.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/controlflow/loop_2d_add_cond_and_trip_count_as_inputs.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // trip count
@@ -182,7 +196,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_both_cond_and_trip_count_a
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_both_cond_and_trip_count_as_inputs_static_shapes) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO,
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
                              "onnx/controlflow/loop_2d_add_cond_and_trip_count_as_inputs_static_shapes.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
@@ -203,7 +218,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_both_cond_and_trip_count_a
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_initializer_from_parent_scope) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_add_initializer_from_parent_scope.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/controlflow/loop_2d_add_initializer_from_parent_scope.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -217,7 +234,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_initializer_from_parent_s
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_node_from_parent_scope) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_add_node_from_parent_scope.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/controlflow/loop_2d_add_node_from_parent_scope.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // a_init
@@ -230,7 +249,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_node_from_parent_scope) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_node_from_parent_scope_used_in_parent_and_in_body) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO,
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
                              "onnx/controlflow/loop_add_node_from_parent_scope_used_in_parent_and_in_body.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
@@ -248,7 +268,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_node_from_parent_scope_us
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_value_access_to_body_scope_exception) {
     try {
         const auto function = onnx_import::import_onnx_model(
-            file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_add_incorrect_access_body_scope.onnx"));
+            file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                 SERIALIZED_ZOO,
+                                 "onnx/controlflow/loop_2d_add_incorrect_access_body_scope.onnx"));
         FAIL() << "Incorrect access to body scope not detected";
     } catch (const ngraph_error& e) {
         // patent graph should have no access to subgraph (body Loop) scope
@@ -259,8 +281,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_value_access_to_body_scop
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_value_the_same_node_from_parent_and_subgraph) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_add_the_same_name.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/controlflow/loop_2d_add_the_same_name.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // a_init
@@ -273,7 +297,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_value_the_same_node_from_
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_input_from_parent_graph) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_add_input_from_parent_graph.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/controlflow/loop_2d_add_input_from_parent_graph.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // a_init
@@ -287,8 +313,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_input_from_parent_graph) 
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_the_proper_opset_in_subgraph) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_mul_opset1.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/controlflow/loop_2d_mul_opset1.onnx"));
 
     const auto parent_ops = function->get_ops();
     const auto loop_node_it = std::find_if(parent_ops.begin(), parent_ops.end(), [](const std::shared_ptr<Node>& op) {
@@ -306,7 +334,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_the_proper_opset_in_subgraph)
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_scalars) {
     const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_scalars_add.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/controlflow/loop_scalars_add.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // a_init
@@ -318,8 +348,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_scalars) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_add_const_cond) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_add_const_cond.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/controlflow/loop_2d_add_const_cond.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // a_init
@@ -331,8 +363,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_add_const_cond) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_trip_count_dynamic) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_add_trip_count_dynamic.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/controlflow/loop_2d_add_trip_count_dynamic.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // trip count
@@ -348,7 +382,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_trip_count_dynamic) {
 // ~~~~~~~~SUBGRAPH TYPES INFERENCE:~~~~~~~~
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_infer_types) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/onnx_controlflow_loop_2d_infer_types.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/controlflow/onnx_controlflow_loop_2d_infer_types.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // trip count
@@ -366,7 +402,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_infer_types) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_node_from_parent_scope_infer_types) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_add_node_from_parent_scope_infer_types.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/controlflow/loop_add_node_from_parent_scope_infer_types.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // a_init
@@ -383,8 +421,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_add_node_from_parent_scope_in
 // ~~~~~~~~ADDITIONAL TESTS:~~~~~~~~
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_concat_values) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_concat_values.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/controlflow/loop_concat_values.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // trip_count
@@ -408,7 +448,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_concat_values) {
 //       }
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_trip_count_and_cond_skipped_shape_inference) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_2d_add_trip_count_and_cond_skipped.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/controlflow/loop_2d_add_trip_count_and_cond_skipped.onnx"));
 
     const auto& results = function->get_results();
     EXPECT_EQ(results.size(), 2);
@@ -423,8 +465,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_2d_trip_count_and_cond_skippe
 
 // infinitive loop execution
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_infinite) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_infinite.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/controlflow/loop_infinite.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // trip_count
@@ -445,7 +488,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_infinite) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_no_variadic_inputs_and_outputs) {
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_no_variadic_inputs_and_outputs.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/controlflow/loop_no_variadic_inputs_and_outputs.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // trip_count
@@ -459,8 +504,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_no_variadic_inputs_and_output
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_controlflow_loop_power) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/loop_pow.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/controlflow/loop_pow.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // trip_count
@@ -483,8 +529,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_if_branches_with_same_inputs) {
          mul(x, y)
        }
     */
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/if_branches_with_same_inputs.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/controlflow/if_branches_with_same_inputs.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     std::vector<float> x(40, 2);
@@ -521,8 +569,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_if_branches_with_different_inputs) {
          abs(y)
        }
     */
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/if_branches_with_different_inputs.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/controlflow/if_branches_with_different_inputs.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     std::vector<float> x(40, 2);
@@ -559,8 +609,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_if_branches_without_inputs) {
          return const tensor {0, 5, 10, 15, 20, 25, 20}
        }
     */
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/if_branches_without_inputs.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/controlflow/if_branches_without_inputs.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -587,8 +639,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_if_inside_if) {
          sub(x, y)
        }
     */
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/if_inside_if.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/controlflow/if_inside_if.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -641,8 +694,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_if_branches_with_multiple_outputs) {
          transpose(part1), transpose(part2), transpose(part3)
        }
     */
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/if_branches_with_multiple_outputs.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/controlflow/if_branches_with_multiple_outputs.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -680,8 +735,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_if_inside_loop) {
                 a = a * b
         }
     */
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/if_inside_loop.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/controlflow/if_inside_loop.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // a_init
@@ -705,7 +761,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_if_with_only_indentity_in_else_branch) {
        output = add(input, if_output)
     */
     const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/if_with_only_indentity_in_else_branch.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/controlflow/if_with_only_indentity_in_else_branch.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -727,7 +785,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_if_dynamic_inputs) {
        }
     */
     const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/if_dynamic_inputs.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/controlflow/if_dynamic_inputs.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     std::vector<float> x(40, 2);
@@ -756,8 +816,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_if_dynamic_inputs) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_if_negative_missing_branches) {
     try {
-        const auto function = onnx_import::import_onnx_model(
-            file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/if_missing_then_branch.onnx"));
+        const auto function =
+            onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                SERIALIZED_ZOO,
+                                                                "onnx/controlflow/if_missing_then_branch.onnx"));
         FAIL() << "Model import succeed, but it shouldn't";
     } catch (const ngraph_error& e) {
         EXPECT_HAS_SUBSTRING(e.what(), std::string("Missing 'then_branch' attribute"));
@@ -766,8 +828,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_if_negative_missing_branches) {
     }
 
     try {
-        const auto function = onnx_import::import_onnx_model(
-            file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/if_missing_else_branch.onnx"));
+        const auto function =
+            onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                SERIALIZED_ZOO,
+                                                                "onnx/controlflow/if_missing_else_branch.onnx"));
         FAIL() << "Model import succeed, but it shouldn't";
     } catch (const ngraph_error& e) {
         EXPECT_HAS_SUBSTRING(e.what(), std::string("Missing 'else_branch' attribute"));
@@ -779,7 +843,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_if_negative_missing_branches) {
 NGRAPH_TEST(${BACKEND_NAME}, onnx_if_negative_mismatch_between_branches_output) {
     try {
         const auto function = onnx_import::import_onnx_model(
-            file_util::path_join(SERIALIZED_ZOO, "onnx/controlflow/if_negative_mismatch_between_branches_output.onnx"));
+            file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                 SERIALIZED_ZOO,
+                                 "onnx/controlflow/if_negative_mismatch_between_branches_output.onnx"));
         FAIL() << "Model import succeed, but it shouldn't";
     } catch (const ngraph_error& e) {
         EXPECT_HAS_SUBSTRING(e.what(),

--- a/src/frontends/tests/onnx/onnx_import_convpool.in.cpp
+++ b/src/frontends/tests/onnx/onnx_import_convpool.in.cpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include "common_test_utils/file_utils.hpp"
 #include "engines_util/test_case.hpp"
 #include "engines_util/test_engines.hpp"
 #include "gtest/gtest.h"
@@ -36,8 +37,9 @@ using Outputs = std::vector<std::vector<float>>;
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv2d_strides_padding) {
     // Convolution with strides=2 and padding=1
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/conv_with_strides_padding.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/conv_with_strides_padding.onnx"));
 
     Inputs inputs;
     // data (1, 1, 7, 5) input tensor
@@ -67,8 +69,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv2d_strides_padding) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv2d_strides_no_padding) {
     // Convolution with strides=2 and padding=1
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/conv_with_strides_no_padding.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/conv_with_strides_no_padding.onnx"));
 
     Inputs inputs;
     // data (1, 1, 7, 5) input tensor
@@ -95,8 +98,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv2d_strides_no_padding) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv2d_strides_assymetric_padding) {
     // Convolution with strides=2 and padding=1
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/conv_with_strides_and_asymmetric_padding.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/conv_with_strides_and_asymmetric_padding.onnx"));
 
     Inputs inputs;
     // data (1, 1, 7, 5) input tensor
@@ -123,8 +128,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv2d_strides_assymetric_padding) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv2d_dilation_assymetric_pads_strides) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/conv2d_dilation_assym_pads_strides.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/conv2d_dilation_assym_pads_strides.onnx"));
 
     //   "",                           // auto_pad
     //   vector<int64_t>{1, 1},        // dilations
@@ -161,7 +168,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv2d_dilation_assymetric_pads_strides)
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv3d_bias) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/conv3d_bias.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/conv3d_bias.onnx"));
 
     // "",                                 // auto_pad
     // vector<int64_t>{2, 2, 2},           // dilations
@@ -264,8 +272,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv3d_bias) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv_transpose_w_groups) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/conv_transpose_w_groups.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/conv_transpose_w_groups.onnx"));
 
     Inputs inputs;
     inputs.emplace_back(
@@ -284,7 +293,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv_transpose_w_groups) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_average_pool_2d) {
     // Pooling with strides=2 and no padding
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/average_pool_2d.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/average_pool_2d.onnx"));
 
     // input data shape (1, 1, 4, 4)
     Inputs inputs;
@@ -304,8 +314,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_average_pool_2d) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_average_pool_2d_pads) {
     // Pooling with strides=2 and padding=1
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/average_pool_2d_pads.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/average_pool_2d_pads.onnx"));
 
     // input data shape (1, 1, 4, 4)
     Inputs inputs;
@@ -325,8 +336,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_average_pool_2d_pads) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_average_pool_empty_auto_pad) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/average_pool_empty_auto_pad.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/average_pool_empty_auto_pad.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f});
@@ -337,8 +349,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_average_pool_empty_auto_pad) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_pool_empty_auto_pad) {
-    const auto model =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/max_pool_empty_auto_pad.onnx"));
+    const auto model = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                           SERIALIZED_ZOO,
+                                                                           "onnx/max_pool_empty_auto_pad.onnx"));
 
     for (const auto& op : model->get_ops()) {
         if (const auto max_pool = std::dynamic_pointer_cast<op::v8::MaxPool>(op)) {
@@ -352,7 +365,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_pool_empty_auto_pad) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_pool_2d_pads) {
     // Pooling with strides=2 and padding=1
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/max_pool_2d_pads.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/max_pool_2d_pads.onnx"));
 
     // input data shape (1, 1, 4, 4)
     Inputs inputs;
@@ -372,7 +386,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_pool_2d_pads) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_global_lp_pool_p0) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/global_lp_pool_p0.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/global_lp_pool_p0.onnx"));
 
     std::vector<std::int64_t> input{1, 0, -4, 0, 2, 1, -6, 1, 0, 0, 0, 0, -7, 1, -1, 0, -1, 8, 0, 10, 9, 0, 0, 5};
 
@@ -385,7 +400,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_global_lp_pool_p0) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_global_lp_pool_p1) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/global_lp_pool_p1.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/global_lp_pool_p1.onnx"));
 
     Inputs inputs{std::vector<float>(2 * 3 * 4)};
     std::iota(std::begin(inputs.front()), std::end(inputs.front()), 0.f);
@@ -399,7 +415,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_global_lp_pool_p1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_global_lp_pool_p2) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/global_lp_pool_p2.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/global_lp_pool_p2.onnx"));
 
     Inputs inputs{std::vector<float>(2 * 3 * 4)};
     std::iota(std::begin(inputs.front()), std::end(inputs.front()), 0.f);
@@ -413,7 +430,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_global_lp_pool_p2) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_global_lp_pool_p3) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/global_lp_pool_p3.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/global_lp_pool_p3.onnx"));
 
     Inputs inputs{std::vector<float>(2 * 3 * 4)};
     std::iota(std::begin(inputs.front()), std::end(inputs.front()), 0.f);
@@ -427,21 +445,31 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_global_lp_pool_p3) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_convtranspose_output_shape) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/convtranspose_output_shape.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/convtranspose_output_shape.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
-    test_case.add_input_from_file<float>(TEST_FILES, "onnx/convtranspose_output_shape/x.bin");
-    test_case.add_input_from_file<float>(TEST_FILES, "onnx/convtranspose_output_shape/w.bin");
-    test_case.add_expected_output_from_file<float>({1, 2, 10, 8}, TEST_FILES, "onnx/convtranspose_output_shape/y.bin");
+    test_case.add_input_from_file<float>(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                              TEST_FILES,
+                                                              "onnx/convtranspose_output_shape/x.bin"));
+    test_case.add_input_from_file<float>(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                              TEST_FILES,
+                                                              "onnx/convtranspose_output_shape/w.bin"));
+    test_case.add_expected_output_from_file<float>({1, 2, 10, 8},
+                                                   file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        TEST_FILES,
+                                                                        "onnx/convtranspose_output_shape/y.bin"));
 
     test_case.run();
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_convtranspose_output_shape_auto_pads_same_upper) {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/convtranspose_output_shape_auto_pads_same_upper.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/convtranspose_output_shape_auto_pads_same_upper.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -466,7 +494,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_convtranspose_output_shape_auto_pads_sam
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_convtranspose_output_shape_auto_pads_same_lower) {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/convtranspose_output_shape_auto_pads_same_lower.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/convtranspose_output_shape_auto_pads_same_lower.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -490,8 +520,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_convtranspose_output_shape_auto_pads_sam
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_convtranspose_groups_w_pads) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/convtranspose_groups_w_pads.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/convtranspose_groups_w_pads.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -542,8 +573,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_convtranspose_groups_w_pads) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_convtranspose_groups_pads_bias) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/convtranspose_groups_pads_bias.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/convtranspose_groups_pads_bias.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 

--- a/src/frontends/tests/onnx/onnx_import_deprecated.in.cpp
+++ b/src/frontends/tests/onnx/onnx_import_deprecated.in.cpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include "common_test_utils/file_utils.hpp"
 #include "engines_util/test_case.hpp"
 #include "engines_util/test_engines.hpp"
 #include "gtest/gtest.h"
@@ -31,7 +32,8 @@ static std::string s_manifest = "${MANIFEST}";
 static std::string s_device = test::backend_name_to_device("${BACKEND_NAME}");
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_affine) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/affine.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/affine.onnx"));
 
     // input/output shape (1, 3)
     auto input = test::NDArray<float, 2>{{{0.f, 1.f, 2.f}}}.get_vector();
@@ -44,7 +46,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_affine) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_crop) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/crop.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/crop.onnx"));
 
     // input shape (1, 1, 4, 4)
     auto input = test::NDArray<float, 4>({{{{19.f, 20.f, 21.f, 22.f},
@@ -63,7 +66,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_crop) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_crop_with_scale) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/crop_with_scale.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/crop_with_scale.onnx"));
 
     // input shape (1, 1, 4, 4)
     auto input = test::NDArray<float, 4>({{{{19.f, 20.f, 21.f, 22.f},

--- a/src/frontends/tests/onnx/onnx_import_dyn_shapes.in.cpp
+++ b/src/frontends/tests/onnx/onnx_import_dyn_shapes.in.cpp
@@ -15,12 +15,13 @@
 #include <iterator>
 #include <numeric>
 
+#include "common_test_utils/file_utils.hpp"
 #include "default_opset.hpp"
+#include "engines_util/test_case.hpp"
+#include "engines_util/test_engines.hpp"
 #include "gtest/gtest.h"
 #include "ngraph/file_util.hpp"
 #include "onnx_import/onnx.hpp"
-#include "engines_util/test_engines.hpp"
-#include "engines_util/test_case.hpp"
 #include "util/test_control.hpp"
 #include "util/test_tools.hpp"
 #include "util/type_prop.hpp"
@@ -36,8 +37,9 @@ static std::string s_device = test::backend_name_to_device("${BACKEND_NAME}");
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_onnx_dynamic_dims_to_ngraph_dynamic_dims) {
     // the model represents a linear function A * x + B
     // where all 3 operands are model inputs (no initializers)
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/ab_plus_c.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/dynamic_shapes/ab_plus_c.onnx"));
 
     const auto& graph_inputs = function->get_parameters();
     EXPECT_EQ(graph_inputs.size(), 3);
@@ -69,8 +71,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_onnx_dynamic_dims_to_ngraph_dynamic
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_ab_plus_c_inference) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/ab_plus_c.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/dynamic_shapes/ab_plus_c.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -107,8 +110,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_ab_plus_c_inference) {
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_scalar_initializers_shape_check) {
     // initializers defined witout the "dims" field should produce Constants with an empty Shape
     // initializers with "dims: 0" should be have the same way (Shape{} not Shape{0})
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/scalar_initializers.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/scalar_initializers.onnx"));
 
     for (auto ng_node : function->get_ordered_ops()) {
         if (as_type_ptr<default_opset::Constant>(ng_node)) {
@@ -119,8 +124,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_scalar_initializers_shape_check) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_dynamic_rank_input_check) {
     // the model contains a single Add operation that takes a fully dynamic input and a scalar
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/a_plus_b_dyn_rank.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/a_plus_b_dyn_rank.onnx"));
 
     const auto& graph_inputs = function->get_parameters();
     ASSERT_EQ(graph_inputs.size(), 2);
@@ -142,8 +149,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_dynamic_rank_input_check) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_dynamic_rank_input_inference) {
     // the model contains a single Add operation that takes a fully dynamic input and a scalar
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/a_plus_b_dyn_rank.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/a_plus_b_dyn_rank.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -169,8 +178,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_dynamic_rank_input_inference) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_acosh_1_3) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/acosh_dyn_shape.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dynamic_shapes/acosh_dyn_shape.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{1, 3}, {1.0f, 2.5f, 4.3f});
@@ -180,8 +190,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_acosh_1_3) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_acosh_3_2) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/acosh_dyn_shape.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dynamic_shapes/acosh_dyn_shape.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{3, 2}, {1.0f, 2.5f, 4.3f, 1.0f, 2.5f, 4.3f});
@@ -191,8 +202,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_acosh_3_2) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_asinh_1_3) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/asinh_dyn_shape.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dynamic_shapes/asinh_dyn_shape.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{1, 3}, {-1.5f, 0.0f, 1.5f});
@@ -202,8 +214,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_asinh_1_3) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_asinh_3_2) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/asinh_dyn_shape.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dynamic_shapes/asinh_dyn_shape.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{3, 2}, {-1.5f, 0.0f, 1.5f, -1.5f, 0.0f, 1.5f});
@@ -213,8 +226,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_asinh_3_2) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_atanh_1_3) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/atanh_dyn_shape.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dynamic_shapes/atanh_dyn_shape.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{1, 3}, {-0.9f, 0.0f, 0.9f});
@@ -224,8 +238,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_atanh_1_3) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_atanh_3_2) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/atanh_dyn_shape.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dynamic_shapes/atanh_dyn_shape.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{3, 2}, {-0.9f, 0.0f, 0.9f, -0.9f, 0.0f, 0.9f});
@@ -236,8 +251,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_atanh_3_2) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_conv_with_dynamic_batch) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/conv_with_dynamic_batch.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/conv_with_dynamic_batch.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -258,8 +275,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_conv_with_dynamic_batch) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_conv_with_dynamic_bias) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/conv_with_dynamic_bias.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/conv_with_dynamic_bias.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -280,8 +299,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_conv_with_dynamic_bias) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_avg_pool_dyn_shape) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/average_pool_2d_dyn.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/average_pool_2d_dyn.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -299,8 +320,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_avg_pool_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_max_pool_dyn_shape) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/max_pool_2d_dyn.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/max_pool_2d_dyn.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -318,8 +341,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_max_pool_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_max_pool_with_indices_output) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/max_pool_with_indices_output.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/max_pool_with_indices_output.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -340,8 +365,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_max_pool_with_indices_output) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_global_avg_pool_dyn_shape) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/global_average_pool_dyn.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/global_average_pool_dyn.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -359,8 +386,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_global_avg_pool_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_global_max_pool_dyn_shape) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/global_max_pool_dyn.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/global_max_pool_dyn.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -378,8 +407,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_global_max_pool_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_arg_max_dyn_shape) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/argmax_dyn.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/dynamic_shapes/argmax_dyn.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -397,8 +427,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_arg_max_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_arg_min_no_keep_dims_dyn_shape) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/argmin_no_keep_dims_dyn.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/argmin_no_keep_dims_dyn.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -416,8 +448,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_arg_min_no_keep_dims_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_constant_of_shape_float_zeros) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/constant_of_shape_float_zeros.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/constant_of_shape_float_zeros.onnx"));
 
     std::vector<float> expected_values(24, 0);
 
@@ -430,8 +464,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_constant_of_shape_float_zeros) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_constant_of_shape_int_ones) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/constant_of_shape_int_ones.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/constant_of_shape_int_ones.onnx"));
 
     std::vector<int32_t> expected_values(6, 1);
 
@@ -444,8 +480,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_constant_of_shape_int_ones) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_expand_1_dyn_shape) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/expand_dyn.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/dynamic_shapes/expand_dyn.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -461,8 +498,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_expand_1_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_expand_2_dyn_shape) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/expand_dyn.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/dynamic_shapes/expand_dyn.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -477,8 +515,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_expand_2_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_expand_3_dyn_shape) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/expand_dyn.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/dynamic_shapes/expand_dyn.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -492,8 +531,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_expand_3_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_expand_4_dyn_shape) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/expand_dyn.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/dynamic_shapes/expand_dyn.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -507,8 +547,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_expand_4_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_expand_5_dyn_shape) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/expand_dyn.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/dynamic_shapes/expand_dyn.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -523,8 +564,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_expand_5_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_expand_6_dyn_shape) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/expand_dyn.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/dynamic_shapes/expand_dyn.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -539,8 +581,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_expand_6_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_expand_uint16_dyn_shape) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/expand_uint16_dyn.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/expand_uint16_dyn.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -554,7 +598,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_expand_uint16_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_tile) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/tile.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/tile.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<std::int16_t>({0, 1, 2, 3, 4, 5});  // input
@@ -564,7 +609,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_tile) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_tile_static) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/tile_static.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/tile_static.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<std::int16_t>({0, 1, 2, 3, 4, 5});  // input
@@ -574,8 +620,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_tile_static) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_convtranspose_dyn_data) {
-    auto ct_fn =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/convtranspose_dyn_data.onnx"));
+    auto ct_fn = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                     SERIALIZED_ZOO,
+                                                                     "onnx/convtranspose_dyn_data.onnx"));
 
     auto test_case = test::TestCase(ct_fn);
 
@@ -615,8 +662,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_convtranspose_dyn_data) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_convtranspose_dyn_filters) {
-    auto ct_fn =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/convtranspose_dyn_filters.onnx"));
+    auto ct_fn = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                     SERIALIZED_ZOO,
+                                                                     "onnx/convtranspose_dyn_filters.onnx"));
 
     auto test_case = test::TestCase(ct_fn);
 
@@ -656,8 +704,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_convtranspose_dyn_filters) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_transpose) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/transpose.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/dynamic_shapes/transpose.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     Shape shape{2, 2, 4, 3};
@@ -688,8 +737,10 @@ Shape get_flattened_shape(const Shape& in_shape, size_t axis) {
 }  // namespace
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_flatten_axis_0) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/flatten_dyn_shape_axis0.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/flatten_dyn_shape_axis0.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     const size_t RANKS_TO_TEST = 4;
@@ -713,8 +764,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_flatten_axis_0) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_flatten_axis) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/flatten_dyn_shape_axis.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/flatten_dyn_shape_axis.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     const size_t RANKS_TO_TEST = 4;
@@ -738,8 +791,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_flatten_axis) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_flatten_neg_axis) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/flatten_dyn_shape_neg_axis.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/flatten_dyn_shape_neg_axis.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     const size_t RANKS_TO_TEST = 4;
@@ -763,7 +818,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_flatten_neg_axis) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_flatten) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/flatten.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/flatten.onnx"));
 
     std::vector<float> data{1, 2, 3, 4, 5, 6, 7, 8};
     auto test_case = test::TestCase(function, s_device);
@@ -774,8 +830,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_flatten) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_global_lp_dynamic_hw) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/global_lp_pool_dynamic_hw.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/global_lp_pool_dynamic_hw.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<int64_t>(Shape{1, 2, 3, 4},
@@ -786,8 +843,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_model_global_lp_dynamic_hw) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_2d_input) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_2d_input.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dynamic_shapes/slice_2d_input.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8});
@@ -799,8 +857,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_2d_input) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_default_steps) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_default_steps.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/slice_default_steps.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1, 2, 3, 4, 5, 6, 7, 8});
@@ -812,7 +872,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_default_steps) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_slice_2d_default_steps_dyn_begin_end) {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_2d_default_steps_dyn_begin_end.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/dynamic_shapes/slice_2d_default_steps_dyn_begin_end.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1, 2, 3, 4});
@@ -823,8 +885,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_slice_2d_default_steps_dyn
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_clamp_neg_ends) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_default_steps.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/slice_default_steps.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8});
@@ -835,8 +899,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_clamp_neg_ends) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_3d_input) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_3d_input.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dynamic_shapes/slice_3d_input.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -852,8 +917,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_3d_input) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_3d_input_neg_axes) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_3d_input_neg_axes.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/slice_3d_input_neg_axes.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -869,8 +936,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_3d_input_neg_axes) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_3d_input_12_axes) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_3d_input_12_axes.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/slice_3d_input_12_axes.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -885,8 +954,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_3d_input_12_axes) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_3d_input_20_axes) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_3d_input_20_axes.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/slice_3d_input_20_axes.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -902,8 +973,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_3d_input_20_axes) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_4d_input_23_axes) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_4d_input_23_axes.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/slice_4d_input_23_axes.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -919,7 +992,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_4d_input_23_axes) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_4d_input_0231_axes_ends_max) {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_4d_input_0231_axes_ends_max.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/dynamic_shapes/slice_4d_input_0231_axes_ends_max.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -937,8 +1012,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_4d_input_0231_axes_ends_ma
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_4d_input_2103_axes_ends_max) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_4d_input_2103_axes.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/slice_4d_input_2103_axes.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -958,7 +1035,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_4d_input_2103_axes_ends_ma
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_4d_input_23_axes_21_steps) {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_4d_input_23_axes_21_steps.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/dynamic_shapes/slice_4d_input_23_axes_21_steps.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -973,8 +1052,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_4d_input_23_axes_21_steps)
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_default_axes) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_default_axes.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dynamic_shapes/slice_default_axes.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -988,8 +1068,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_default_axes) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_the_same_output_same) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_2d_the_same_out_shape.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/slice_2d_the_same_out_shape.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
@@ -999,7 +1081,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_10_the_same_output_same) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_model_hardmax) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/hardmax.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/hardmax.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(
@@ -1029,7 +1112,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_model_hardmax) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_model_softmax_axis_2) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/softmax_axis_2.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/softmax_axis_2.onnx"));
 
     const std::vector<float> input = {
         2.75793882,  -0.50841322, 0.82013929,  -0.62409912, -0.96136118, 0.21004745,  1.38337255,
@@ -1065,7 +1149,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_model_softmax_axis_2) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_range_positive_step) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/range.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/range.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -1078,7 +1163,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_range_positive_step) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_range_negative_step) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/range.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/range.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -1091,8 +1177,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_range_negative_step) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_instance_normalization_dyn_shape) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/instance_norm_dyn_shape.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/instance_norm_dyn_shape.onnx"));
 
     Shape data_shape{1, 2, 3, 4};
     std::vector<float> data(shape_size(data_shape));
@@ -1112,8 +1200,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_instance_normalization_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_instance_normalization_dyn_shape2) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/instance_norm_dyn_shape2.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/instance_norm_dyn_shape2.onnx"));
 
     Shape data_shape{1, 2, 3, 4};
     std::vector<float> data(shape_size(data_shape));
@@ -1135,7 +1225,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_instance_normalization_dyn_shape2) {
 // NGRAPH_TEST(${BACKEND_NAME}, onnx_upsample9_scales_input_nearest_infer)
 // {
 //     const auto function = onnx_import::import_onnx_model(
-//         file_util::path_join(SERIALIZED_ZOO, "onnx/upsample9_scales_input_nearest.onnx"));
+//         file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO,
+//         "onnx/upsample9_scales_input_nearest.onnx"));
 //
 //     // Input data shape (1, 1, 2, 2)
 //     // mode: nearest
@@ -1151,8 +1242,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_instance_normalization_dyn_shape2) {
 // }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_1_2d_input) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_2d_input_opset1.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/slice_2d_input_opset1.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8});
@@ -1161,8 +1254,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_1_2d_input) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_1_clamp_neg_ends) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_2d_clamp_neg_ends_opset1.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/slice_2d_clamp_neg_ends_opset1.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8});
@@ -1172,7 +1267,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_1_clamp_neg_ends) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_1_3d_input_21_axes_ends_max) {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/slice_3d_input_21_axes_ends_max_opset1.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/dynamic_shapes/slice_3d_input_21_axes_ends_max_opset1.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -1187,7 +1284,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_slice_1_3d_input_21_axes_ends_max) 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_reduce_max_dynamic_input_rank_negative_axis) {
     // the ReduceMax node has a fully dynamic input and the reduction axis is -1
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/reduce_max_dynamic_input_rank_negative_axis.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/dynamic_shapes/reduce_max_dynamic_input_rank_negative_axis.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{2, 4}, std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8});
@@ -1196,8 +1295,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_dyn_shapes_reduce_max_dynamic_input_rank_negat
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_size_dyn_op) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/size_op_dyn.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/dynamic_shapes/size_op_dyn.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{2, 3}, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
@@ -1207,7 +1307,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_size_dyn_op) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_pool_dyn_rank_without_default_attrs) {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/max_pool_dyn_rank_without_default_attrs.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/dynamic_shapes/max_pool_dyn_rank_without_default_attrs.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -1220,8 +1322,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_max_pool_dyn_rank_without_default_attrs)
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_dynamic_input) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/depth_to_space.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dynamic_shapes/depth_to_space.onnx"));
 
     std::vector<float> input(32);
     std::iota(input.begin(), input.end(), 0);
@@ -1237,8 +1340,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_dynamic_input) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_space_to_depth_dynamic_input) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/space_to_depth.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dynamic_shapes/space_to_depth.onnx"));
 
     std::vector<float> input(32);
     std::iota(input.begin(), input.end(), 0);
@@ -1255,8 +1359,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_space_to_depth_dynamic_input) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_eye_like_dyn_shape) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/eye_like_dyn_shape.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/eye_like_dyn_shape.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{3, 4}, {5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f});
@@ -1266,8 +1372,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_eye_like_dyn_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_eye_like_dyn_rank) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/eye_like_dyn_rank.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/eye_like_dyn_rank.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{3, 4}, {5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f, 5.f});

--- a/src/frontends/tests/onnx/onnx_import_exceptions.cpp
+++ b/src/frontends/tests/onnx/onnx_import_exceptions.cpp
@@ -4,6 +4,7 @@
 
 #include <exception>
 
+#include "common_test_utils/file_utils.hpp"
 #include "exceptions.hpp"
 #include "gtest/gtest.h"
 #include "ngraph/file_util.hpp"
@@ -16,14 +17,17 @@ NGRAPH_SUPPRESS_DEPRECATED_START
 using namespace ngraph;
 
 TEST(onnx_importer, exception_throws_ngraph_error) {
-    EXPECT_THROW(
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space_bad_blocksize.onnx")),
-        ngraph_error);
+    EXPECT_THROW(onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                     SERIALIZED_ZOO,
+                                                                     "onnx/depth_to_space_bad_blocksize.onnx")),
+                 ngraph_error);
 }
 
 TEST(onnx_importer, exception_msg_ngraph_error) {
     try {
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space_bad_blocksize.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/depth_to_space_bad_blocksize.onnx"));
         // Should have thrown, so fail if it didn't
         FAIL() << "ONNX Importer did not detected incorrect model!";
     } catch (const ngraph_error& e) {
@@ -35,7 +39,9 @@ TEST(onnx_importer, exception_msg_ngraph_error) {
 
 TEST(onnx_importer, exception_msg_onnx_node_validation_failure) {
     try {
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/instance_norm_bad_scale_type.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/instance_norm_bad_scale_type.onnx"));
         // Should have thrown, so fail if it didn't
         FAIL() << "ONNX Importer did not detected incorrect model!";
     } catch (const ::ngraph::onnx_import::error::OnnxNodeValidationFailure& e) {
@@ -54,7 +60,9 @@ TEST(onnx_importer, exception_msg_onnx_node_validation_failure) {
 // This test should throw a std error because of attempt to access shape from dynamic tensor.
 TEST(onnx_importer, exception_msg_std_err_wrapped) {
     try {
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/eye_like_wrong_shape.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/eye_like_wrong_shape.onnx"));
         // Should have thrown, so fail if it didn't
         FAIL() << "ONNX Importer did not detected incorrect model!";
     } catch (const std::exception& e) {

--- a/src/frontends/tests/onnx/onnx_import_external_data.in.cpp
+++ b/src/frontends/tests/onnx/onnx_import_external_data.in.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "common_test_utils/file_utils.hpp"
 #include "default_opset.hpp"
 #include "engines_util/test_case.hpp"
 #include "engines_util/test_engines.hpp"
@@ -23,8 +24,9 @@ static std::string s_manifest = "${MANIFEST}";
 static std::string s_device = test::backend_name_to_device("${BACKEND_NAME}");
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_external_data) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/external_data/external_data.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/external_data/external_data.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.f, 2.f, 3.f, 4.f});
@@ -34,7 +36,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_external_data) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_external_data_from_stream) {
-    std::string path = file_util::path_join(SERIALIZED_ZOO, "onnx/external_data/external_data.onnx");
+    std::string path = file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                            SERIALIZED_ZOO,
+                                            "onnx/external_data/external_data.onnx");
     std::ifstream stream{path, std::ios::in | std::ios::binary};
     ASSERT_TRUE(stream.is_open());
     const auto function = onnx_import::import_onnx_model(stream, path);
@@ -49,8 +53,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_external_data_from_stream) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_external_data_optional_fields) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/external_data/external_data_optional_fields.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/external_data/external_data_optional_fields.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.f, 2.f, 3.f, 4.f});
@@ -60,8 +66,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_external_data_optional_fields) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_external_data_in_different_paths) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/external_data/external_data_different_paths.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/external_data/external_data_different_paths.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // first input: {3.f}, second: {1.f, 2.f, 5.f} read from external files
@@ -73,7 +81,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_external_data_in_different_paths) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_external_two_tensors_data_in_the_same_file) {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO,
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
                              "onnx/external_data/external_data_two_tensors_data_in_the_same_file.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
@@ -87,7 +96,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_external_two_tensors_data_in_the_same_file) {
 NGRAPH_TEST(${BACKEND_NAME}, onnx_external_invalid_external_data_exception) {
     try {
         auto function = onnx_import::import_onnx_model(
-            file_util::path_join(SERIALIZED_ZOO, "onnx/external_data/external_data_file_not_found.onnx"));
+            file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                 SERIALIZED_ZOO,
+                                 "onnx/external_data/external_data_file_not_found.onnx"));
         FAIL() << "Incorrect path to external data not detected";
     } catch (const ngraph_error& error) {
         EXPECT_PRED_FORMAT2(testing::IsSubstring,
@@ -101,7 +112,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_external_invalid_external_data_exception) {
 NGRAPH_TEST(${BACKEND_NAME}, onnx_external_invalid_up_dir_path) {
     try {
         auto function = onnx_import::import_onnx_model(
-            file_util::path_join(SERIALIZED_ZOO, "onnx/external_data/inner_scope/external_data_file_in_up_dir.onnx"));
+            file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                 SERIALIZED_ZOO,
+                                 "onnx/external_data/inner_scope/external_data_file_in_up_dir.onnx"));
         FAIL() << "Incorrect path to external data not detected";
     } catch (const ngraph_error& error) {
         EXPECT_PRED_FORMAT2(testing::IsSubstring,
@@ -114,8 +127,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_external_invalid_up_dir_path) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_external_data_sanitize_path) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/external_data/external_data_sanitize_test.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/external_data/external_data_sanitize_test.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1.f, 2.f, 3.f, 4.f});

--- a/src/frontends/tests/onnx/onnx_import_org_openvino.in.cpp
+++ b/src/frontends/tests/onnx/onnx_import_org_openvino.in.cpp
@@ -22,20 +22,21 @@
 #endif
 // clang-format on
 
-#include "onnx_import/core/null_node.hpp"
+#include "common_test_utils/file_utils.hpp"
+#include "default_opset.hpp"
+#include "engines_util/test_case.hpp"
+#include "engines_util/test_engines.hpp"
 #include "gtest/gtest.h"
+#include "ngraph/ngraph.hpp"
+#include "ngraph/pass/constant_folding.hpp"
+#include "ngraph/pass/manager.hpp"
+#include "onnx_import/core/null_node.hpp"
 #include "onnx_import/onnx.hpp"
 #include "onnx_import/onnx_utils.hpp"
-#include "default_opset.hpp"
-#include "ngraph/ngraph.hpp"
-#include "ngraph/pass/manager.hpp"
-#include "ngraph/pass/constant_folding.hpp"
 #include "util/all_close.hpp"
 #include "util/all_close_f.hpp"
 #include "util/ndarray.hpp"
-#include "engines_util/test_case.hpp"
 #include "util/test_control.hpp"
-#include "engines_util/test_engines.hpp"
 #include "util/test_tools.hpp"
 #include "util/type_prop.hpp"
 
@@ -50,7 +51,8 @@ using Inputs = std::vector<std::vector<float>>;
 using Outputs = std::vector<std::vector<float>>;
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_prior_box) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/prior_box.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/prior_box.onnx"));
     auto test_case = test::TestCase(function, s_device);
     std::vector<float> A(3 * 2 * 2);
     std::vector<float> B(3 * 6 * 6);
@@ -71,8 +73,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_prior_box) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_priorbox_clustered) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/priorbox_clustered.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/priorbox_clustered.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     std::vector<float> A{15.0};
@@ -88,8 +91,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_priorbox_clustered) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_priorbox_clustered_most_attrs_default) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/priorbox_clustered_most_attrs_default.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/priorbox_clustered_most_attrs_default.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     std::vector<float> A(1 * 1 * 2 * 1);
@@ -120,8 +125,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_priorbox_clustered_most_attrs_default) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_priorbox_clustered_first_input_bad_shape) {
     try {
-        auto function = onnx_import::import_onnx_model(
-            file_util::path_join(SERIALIZED_ZOO, "onnx/priorbox_clustered_first_input_bad_shape.onnx"));
+        auto function =
+            onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                SERIALIZED_ZOO,
+                                                                "onnx/priorbox_clustered_first_input_bad_shape.onnx"));
         FAIL() << "Expected exception was not thrown";
     } catch (const ngraph::ngraph_error& e) {
         EXPECT_HAS_SUBSTRING(e.what(), std::string("Only 4D inputs are supported. First input rank: 5 (should be 4)"));
@@ -132,8 +139,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_priorbox_clustered_first_input_bad_shape) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_priorbox_clustered_second_input_bad_shape) {
     try {
-        auto function = onnx_import::import_onnx_model(
-            file_util::path_join(SERIALIZED_ZOO, "onnx/priorbox_clustered_second_input_bad_shape.onnx"));
+        auto function =
+            onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                SERIALIZED_ZOO,
+                                                                "onnx/priorbox_clustered_second_input_bad_shape.onnx"));
         FAIL() << "Expected exception was not thrown";
     } catch (const ngraph::ngraph_error& e) {
         EXPECT_HAS_SUBSTRING(e.what(), std::string("Only 4D inputs are supported. Second input rank: 5 (should be 4)"));
@@ -143,8 +152,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_priorbox_clustered_second_input_bad_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_detection_output) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/detection_output.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/detection_output.onnx"));
     auto test_case = test::TestCase(function, s_device);
 
     auto gen_vector = [](size_t size, float min, float max) -> std::vector<float> {
@@ -175,7 +184,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_detection_output) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_group_norm) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/group_norm.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/group_norm.onnx"));
     auto test_case = test::TestCase(function, s_device);
     Shape shape{2, 8, 2, 2};
     int size = shape_size(shape);
@@ -198,8 +208,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_group_norm) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_group_norm_5d) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/group_norm_5d.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/group_norm_5d.onnx"));
     auto test_case = test::TestCase(function, s_device);
     Shape shape{2, 8, 1, 2, 1};
     int size = shape_size(shape);
@@ -218,7 +228,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_group_norm_5d) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_normalize) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/normalize.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/normalize.onnx"));
     auto test_case = test::TestCase(function, s_device);
     std::vector<float> data(12);
     std::iota(data.begin(), data.end(), 1);
@@ -242,7 +253,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_normalize) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_swish_with_beta) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/swish_with_beta.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/swish_with_beta.onnx"));
 
     const Shape expected_output_shape{3};
     auto test_case = test::TestCase(function, s_device);
@@ -254,8 +266,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_swish_with_beta) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_swish_without_beta) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/swish_without_beta.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/swish_without_beta.onnx"));
 
     const Shape expected_output_shape{3};
     auto test_case = test::TestCase(function, s_device);
@@ -268,7 +281,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_swish_without_beta) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_experimental_detectron_detection_output) {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/org.openvinotoolkit/experimental_detectron/detection_output.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/org.openvinotoolkit/experimental_detectron/detection_output.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // rois
@@ -306,7 +321,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_experimental_detectron_detection_output)
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_experimental_detectron_detection_output_most_attrs_default) {
     auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO,
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
                                                             "onnx/org.openvinotoolkit/experimental_detectron/"
                                                             "detection_output_most_attrs_default.onnx"));
 
@@ -348,7 +364,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_experimental_detectron_detection_output_
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_experimental_detectron_generate_proposals_single_image) {
     auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO,
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
                                                             "onnx/org.openvinotoolkit/experimental_detectron/"
                                                             "generate_proposals_single_image.onnx"));
 
@@ -397,7 +414,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_experimental_detectron_generate_proposal
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_experimental_detectron_group_norm) {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/org.openvinotoolkit/experimental_detectron/group_norm.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/org.openvinotoolkit/experimental_detectron/group_norm.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     Shape shape{2, 8, 2, 2};
@@ -422,7 +441,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_experimental_detectron_group_norm) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_experimental_detectron_prior_grid_generator) {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO,
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
                              "onnx/org.openvinotoolkit/experimental_detectron/prior_grid_generator.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
@@ -448,7 +468,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_experimental_detectron_prior_grid_genera
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_experimental_detectron_roi_feature_extractor) {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO,
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
                              "onnx/org.openvinotoolkit/experimental_detectron/roi_feature_extractor.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
@@ -506,7 +527,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_experimental_detectron_roi_feature_extra
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_experimental_detectron_topk_rios) {
     auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/org.openvinotoolkit/experimental_detectron/topk_rios.onnx"));
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                             SERIALIZED_ZOO,
+                             "onnx/org.openvinotoolkit/experimental_detectron/topk_rios.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -518,8 +541,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_experimental_detectron_topk_rios) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_deformable_conv_2d) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/org.openvinotoolkit/deformable_conv_2d.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/org.openvinotoolkit/deformable_conv_2d.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 

--- a/src/frontends/tests/onnx/onnx_import_quant.in.cpp
+++ b/src/frontends/tests/onnx/onnx_import_quant.in.cpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include "common_test_utils/file_utils.hpp"
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "engines_util/test_case.hpp"
 #include "engines_util/test_engines.hpp"
@@ -35,8 +36,9 @@ using Inputs = std::vector<std::vector<float>>;
 using Outputs = std::vector<std::vector<float>>;
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear_const_scale_const_zero_p) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/quantize_linear_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/quantize_linear_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<float>{32.25f, 48.34f, 50.f, 83.f});
@@ -46,7 +48,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear_const_scale_const_zero_p
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/quantize_linear.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/quantize_linear.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<float>{32.25f, 48.34f, 50.f, 83.f});
@@ -57,8 +60,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear_zero_point) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/quantize_linear_zero_point.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/quantize_linear_zero_point.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<float>{0.f, 2.f, 3.f, 1000.f, -254.f, -1000.f});  // x
@@ -70,8 +74,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear_zero_point) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear_axis_zero) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/quantize_linear_axis_zero.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/quantize_linear_axis_zero.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<float>{0.f, 2.f, 3.f, 1000.f, 0.f, 2.f, 3.f, 1000.f, 0.f, 2.f, 3.f, 1000.f});  // x
@@ -87,8 +92,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear_axis_zero) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear_axis_negative) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/quantize_linear_axis_negative.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/quantize_linear_axis_negative.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<float>{0.f, 2.f, 3.f, 1000.f, 0.f, 2.f, 3.f, 1000.f, 0.f, 2.f, 3.f, 1000.f});  // x
@@ -104,7 +110,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear_axis_negative) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dequant_lin.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/dequant_lin.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<std::uint8_t>{19, 210, 21, 10});
@@ -114,8 +121,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_scale_and_zero_point) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dequantize_linear_scalar_scale_and_zero_point.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dequantize_linear_scalar_scale_and_zero_point.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<std::uint8_t>{19, 210, 21, 10});  // x
@@ -127,8 +136,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_scale_and_zero_
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_scale) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dequantize_linear_scalar_scale.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dequantize_linear_scalar_scale.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<std::uint8_t>{19, 210, 21, 10});  // x
@@ -140,8 +150,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_scale) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_inputs) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dequantize_linear_scalar_inputs.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dequantize_linear_scalar_inputs.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<std::uint8_t>{19});  // x
@@ -153,8 +164,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_inputs) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_zero_point) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dequantize_linear_scalar_zero_point.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dequantize_linear_scalar_zero_point.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<std::uint8_t>{19, 210, 21, 10});  // x
@@ -166,8 +179,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_zero_point) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_zero_scale_uint8) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dequantize_linear_0.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dequantize_linear_0.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<uint8_t>{0, 3, 128, 255});  // x
@@ -179,8 +193,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_zero_scale_uint
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_zero_scale_int8) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dequantize_linear_1.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dequantize_linear_1.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -193,8 +208,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_zero_scale_int8
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_1d_zero_scale_uint8) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dequantize_linear_2.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dequantize_linear_2.onnx"));
 
     auto test_case = ngraph::test::TestCase(function, s_device);
 
@@ -209,8 +225,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_1d_zero_scale_uint8) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_1d_zero_scale_int8) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dequantize_linear_3.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dequantize_linear_3.onnx"));
 
     auto test_case = ngraph::test::TestCase(function, s_device);
 
@@ -225,8 +242,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_1d_zero_scale_int8) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_1d_zero_scale_int8_4d) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dequantize_linear_4.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dequantize_linear_4.onnx"));
 
     auto test_case = ngraph::test::TestCase(function, s_device);
 
@@ -247,8 +265,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_1d_zero_scale_int8_4d)
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_1d_zero_scale_uint8_negative_axis) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/dequantize_linear_5.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dequantize_linear_5.onnx"));
 
     auto test_case = ngraph::test::TestCase(function, s_device);
 
@@ -263,8 +282,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_1d_zero_scale_uint8_ne
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dynamic_quantize_linear) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/quantization/dynamic_quantize_linear.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/quantization/dynamic_quantize_linear.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0.f, 2.f, -3.f, -2.5f, 1.34f, 0.5f});
@@ -275,8 +296,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dynamic_quantize_linear) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dynamic_quantize_linear_255) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/quantization/dynamic_quantize_linear.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/quantization/dynamic_quantize_linear.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({-1.f, -2.1f, -1.3f, -2.5f, -3.34f, -4.f});
@@ -287,8 +310,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dynamic_quantize_linear_255) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dynamic_quantize_linear_3x4) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/quantization/dynamic_quantize_linear_3x4.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/quantization/dynamic_quantize_linear_3x4.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -308,7 +333,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_dynamic_quantize_linear_3x4) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quant_conv_linear) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/quant_conv_lin.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/quant_conv_lin.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -338,11 +364,13 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quant_conv_linear) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quant_conv_linear_2d) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/qlinear_conv_2d.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/qlinear_conv_2d.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
-    test_case.add_input_from_file<uint8_t>(TEST_FILES, "onnx/qlinearconv2d/x.bin");
+    test_case.add_input_from_file<uint8_t>(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), TEST_FILES, "onnx/qlinearconv2d/x.bin"));
     test_case.add_input(std::vector<float>{0.00369204697199166f});  // x_scale
     test_case.add_input(std::vector<uint8_t>{132});                 // x_zero_point
     test_case.add_input(std::vector<uint8_t>{0});                   // w
@@ -351,12 +379,14 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quant_conv_linear_2d) {
     test_case.add_input(std::vector<float>{0.00162681262008846f});  // y_scale
     test_case.add_input(std::vector<uint8_t>{123});                 // y_zero_point
 
-    test_case.add_expected_output_from_file<uint8_t>({1, 1, 7, 7}, TEST_FILES, "onnx/qlinearconv2d/y.bin");
+    test_case.add_expected_output_from_file<uint8_t>({1, 1, 7, 7}, 
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), TEST_FILES, "onnx/qlinearconv2d/y.bin"));
     test_case.run();
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quant_conv_linear_3d) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/qlinear_conv_3d.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/qlinear_conv_3d.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -414,8 +444,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quant_conv_linear_3d) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quant_conv_linear_onnx_example) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/quantization/quant_conv_linear_onnx_example.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/quantization/quant_conv_linear_onnx_example.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -448,7 +480,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quant_conv_linear_onnx_example) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_qlinear_matmul_2d) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/qlinear_matmul.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/qlinear_matmul.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -466,7 +499,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_qlinear_matmul_2d) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_2d_simple_zero_point) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/matmul_integer.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/matmul_integer.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -491,8 +525,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_2d_simple_zero_point) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_int8) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/matmul_integer_int8.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/matmul_integer_int8.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -514,8 +549,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_int8) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_vectorized_zero_point) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/matmul_integer_vectorized_zero_point.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/matmul_integer_vectorized_zero_point.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -542,8 +579,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_vectorized_zero_point) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_no_zero_point) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/matmul_integer_no_zero_point.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/matmul_integer_no_zero_point.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -568,8 +606,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_no_zero_point) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_2d_x_3d) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/matmul_integer_2d_x_3d.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/matmul_integer_2d_x_3d.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -598,8 +637,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_2d_x_3d) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_3d_x_2d) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/matmul_integer_3d_x_2d.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/matmul_integer_3d_x_2d.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -627,7 +667,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_3d_x_2d) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_3d) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/matmul_integer_3d.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/matmul_integer_3d.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -661,7 +702,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_3d) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_4d) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/matmul_integer_4d.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/matmul_integer_4d.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -699,7 +741,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_4d) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_4d_zero_point) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/matmul_integer_4d.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/matmul_integer_4d.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -736,8 +779,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_4d_zero_point) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_matrix_zero_point) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/matmul_integer_matrix_zero_point.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/matmul_integer_matrix_zero_point.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -776,7 +820,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_matmul_integer_matrix_zero_point) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_qlinear_matmul_3d) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/qlinear_matmul_3d.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/qlinear_matmul_3d.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -797,7 +842,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_qlinear_matmul_3d) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv_integer_simple_zero_point) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/conv_integer.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/conv_integer.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -818,8 +864,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv_integer_simple_zero_point) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv_integer_scalar_zp) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/conv_integer_scalar_zp.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/conv_integer_scalar_zp.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -839,7 +886,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv_integer_scalar_zp) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv_integer_int8) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/conv_integer_int8.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/conv_integer_int8.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -860,8 +908,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv_integer_int8) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv_integer_no_zero_point) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/conv_integer_no_zero_point.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/conv_integer_no_zero_point.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -880,8 +929,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv_integer_no_zero_point) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv_integer_vector_w_zero_point) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/conv_integer_vector_w_zero_point.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/conv_integer_vector_w_zero_point.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -924,8 +974,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv_integer_vector_w_zero_point) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv_integer_overload) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/conv_integer_overload.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/conv_integer_overload.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -946,8 +997,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_conv_integer_overload) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_fake_quantize_import_only) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/quantization/fake_quantize_const_inputs.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/quantization/fake_quantize_const_inputs.onnx"));
 
     const Shape expected_output_shape{1, 2, 3, 4};
     EXPECT_EQ(function->get_output_size(), 1);
@@ -957,8 +1010,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_fake_quantize_import_only) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_fake_quantize_const_inputs_infer) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/quantization/fake_quantize_const_inputs.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/quantization/fake_quantize_const_inputs.onnx"));
 
     const Shape data_shape{1, 2, 3, 4};
     const auto n_elements = shape_size(data_shape);
@@ -975,8 +1030,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_fake_quantize_const_inputs_infer) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_fake_quantize_nonconst_inputs_infer) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/quantization/fake_quantize_nonconst_inputs.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/quantization/fake_quantize_nonconst_inputs.onnx"));
 
     const Shape data_shape{1, 2, 3, 4};
     const size_t n_elements = shape_size(data_shape);
@@ -1002,8 +1059,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_fake_quantize_nonconst_inputs_infer) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear_opset10) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/quantize_linear_opset10.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/quantize_linear_opset10.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<float>{32.25f, 48.34f, 50.f, 83.f});
@@ -1015,8 +1073,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear_opset10) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear_opsets_10_and_13_axis0) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/quantize_linear_opsets_10_and_13_axis0.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/quantize_linear_opsets_10_and_13_axis0.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<float>{32.25f, 48.34f, 50.f, 83.f});
@@ -1028,8 +1088,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear_opsets_10_and_13_axis0) 
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_quantize_linear_opsets_10_and_13_axis1) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/quantize_linear_opsets_10_and_13_axis1.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/quantize_linear_opsets_10_and_13_axis1.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(std::vector<float>{32.25f, 48.34f, 50.f, 83.f});

--- a/src/frontends/tests/onnx/onnx_import_reshape.in.cpp
+++ b/src/frontends/tests/onnx/onnx_import_reshape.in.cpp
@@ -12,6 +12,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include "common_test_utils/file_utils.hpp"
 #include "engines_util/execute_tools.hpp"
 #include "engines_util/test_case.hpp"
 #include "engines_util/test_engines.hpp"
@@ -35,8 +36,9 @@ using Inputs = std::vector<std::vector<float>>;
 using Outputs = std::vector<std::vector<float>>;
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reshape_reduced_dims) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reshape_reduced_dims.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/reshape_reduced_dims.onnx"));
 
     // input data shape (2, 3, 4)
     auto input = test::NDArray<float, 3>({{{0, 1, 2, 3}, {4, 5, 6, 7}, {8, 9, 10, 11}},
@@ -55,8 +57,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reshape_reduced_dims) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reshape_reordered_dims) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reshape_reordered_dims.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/reshape_reordered_dims.onnx"));
 
     // input data shape (2, 3, 4)
     auto input = test::NDArray<float, 3>({{{0, 1, 2, 3}, {4, 5, 6, 7}, {8, 9, 10, 11}},
@@ -77,8 +80,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reshape_reordered_dims) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reshape_extended_dims) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reshape_extended_dims.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/reshape_extended_dims.onnx"));
 
     // input data shape (2, 3, 4)
     auto input = test::NDArray<float, 3>({{{0, 1, 2, 3}, {4, 5, 6, 7}, {8, 9, 10, 11}},
@@ -98,8 +102,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reshape_extended_dims) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reshape_single_dim) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reshape_single_dim.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/reshape_single_dim.onnx"));
 
     // input data shape (2, 3, 4)
     auto input = test::NDArray<float, 3>({{{0, 1, 2, 3}, {4, 5, 6, 7}, {8, 9, 10, 11}},
@@ -119,8 +124,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reshape_single_dim) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reshape_negative_dim) {
     // the model contains the target shape in the initializers: [2, -1, 2]
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reshape_negative_dim.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/reshape_negative_dim.onnx"));
 
     // 2x3x4
     auto input = test::NDArray<float, 3>({{{0.5488135, 0.71518934, 0.60276335, 0.5448832},
@@ -155,8 +161,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reshape_negative_dim) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reshape_negative_with_zero_dim) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/reshape_negative_with_zero_dims.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/reshape_negative_with_zero_dims.onnx"));
 
     // input data shape (2, 3, 4)
     auto input = test::NDArray<float, 3>({{{0, 1, 2, 3}, {4, 5, 6, 7}, {8, 9, 10, 11}},
@@ -175,8 +182,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reshape_negative_with_zero_dim) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reshape_output_shape_as_input) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/reshape_output_shape_as_input.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/reshape_output_shape_as_input.onnx"));
 
     // input data shape (2, 3, 4)
     auto input = test::NDArray<float, 3>({{{0, 1, 2, 3}, {4, 5, 6, 7}, {8, 9, 10, 11}},
@@ -195,7 +203,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_reshape_output_shape_as_input) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/depth_to_space.onnx"));
 
     std::vector<float> input(32);
     std::iota(input.begin(), input.end(), 0);
@@ -211,7 +220,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_v1) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space_v1.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/depth_to_space_v1.onnx"));
 
     std::vector<float> input(32);
     std::iota(input.begin(), input.end(), 0);
@@ -227,8 +237,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_v1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_crd) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space_crd.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/depth_to_space_crd.onnx"));
 
     std::vector<float> input(32);
     std::iota(input.begin(), input.end(), 0);
@@ -246,21 +257,25 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_crd) {
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_bad_blocksize) {
     // This model fails to import since the depth channel length must be a multiple of the
     // `blocksize` attribute value.
-    EXPECT_THROW(
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space_bad_blocksize.onnx")),
-        std::runtime_error);
+    EXPECT_THROW(onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                     SERIALIZED_ZOO,
+                                                                     "onnx/depth_to_space_bad_blocksize.onnx")),
+                 std::runtime_error);
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_no_blocksize) {
     // This model fails to import since it lacks of required parameter `blocksize`.
-    EXPECT_THROW(
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space_no_blocksize.onnx")),
-        std::runtime_error);
+    EXPECT_THROW(onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                     SERIALIZED_ZOO,
+                                                                     "onnx/depth_to_space_no_blocksize.onnx")),
+                 std::runtime_error);
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_bad_mode) {
     try {
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space_bad_mode.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/depth_to_space_bad_mode.onnx"));
         FAIL() << "The onnx_importer did not throw for unknown mode to DepthToSpace op";
     } catch (const ngraph::ngraph_error& e) {
         std::string msg{e.what()};
@@ -272,8 +287,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_bad_mode) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_bad_input_shape) {
     try {
-        onnx_import::import_onnx_model(
-            file_util::path_join(SERIALIZED_ZOO, "onnx/depth_to_space_bad_input_shape.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/depth_to_space_bad_input_shape.onnx"));
         FAIL() << "The onnx_importer did not throw for invalid input shape to DepthToSpace op";
     } catch (const ngraph::ngraph_error& e) {
         std::string msg{e.what()};
@@ -284,7 +300,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_depth_to_space_bad_input_shape) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_space_to_depth) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/space_to_depth.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/space_to_depth.onnx"));
 
     std::vector<float> input(32);
     std::iota(input.begin(), input.end(), 0);
@@ -302,8 +319,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_space_to_depth) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_space_to_depth_invalid_input_shape) {
     try {
-        onnx_import::import_onnx_model(
-            file_util::path_join(SERIALIZED_ZOO, "onnx/space_to_depth_invalid_input_shape.onnx"));
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/space_to_depth_invalid_input_shape.onnx"));
         FAIL() << "Expected ngraph_error exception, but no exception was thrown";
     } catch (const ngraph::ngraph_error& e) {
         std::string msg{e.what()};
@@ -317,20 +335,23 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_space_to_depth_invalid_input_shape) {
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_space_to_depth_bad_blocksize) {
     // This model fails to import since the depth channel length must be a multiple of the
     // `blocksize` attribute value.
-    EXPECT_THROW(
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/space_to_depth_bad_blocksize.onnx")),
-        std::runtime_error);
+    EXPECT_THROW(onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                     SERIALIZED_ZOO,
+                                                                     "onnx/space_to_depth_bad_blocksize.onnx")),
+                 std::runtime_error);
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_space_to_depth_no_blocksize) {
     // This model fails to import since it lacks of required `blocksize` attribute.
-    EXPECT_THROW(
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/space_to_depth_no_blocksize.onnx")),
-        std::runtime_error);
+    EXPECT_THROW(onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                     SERIALIZED_ZOO,
+                                                                     "onnx/space_to_depth_no_blocksize.onnx")),
+                 std::runtime_error);
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_squeeze) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/squeeze.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/squeeze.onnx"));
 
     // {1, 4, 1, 1, 2}
     auto input = test::NDArray<float, 5>({{{{{1.0f, 2.0f}}}, {{{3.0f, 4.0f}}}, {{{5.0f, 6.0f}}}, {{{7.0f, 8.0f}}}}})
@@ -347,8 +368,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_squeeze) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_squeeze_opset13_no_axes) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/squeeze_opset13_no_axes.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/squeeze_opset13_no_axes.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     const std::vector<float> data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
@@ -358,7 +380,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_squeeze_opset13_no_axes) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_unsqueeze) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/unsqueeze.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/unsqueeze.onnx"));
 
     auto input = test::NDArray<float, 3>({{{1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}},
                                           {{1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}},
@@ -378,8 +401,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_unsqueeze) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_unsqueeze_negative_axes) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/unsqueeze_negative_axes.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/unsqueeze_negative_axes.onnx"));
 
     auto input = test::NDArray<float, 4>({{{{-1.8427763f, -1.0467733f, 0.50550157f, 1.4897262f, 0.33057404f}},
                                            {{1.9244908f, -0.3804572f, 0.76275414f, -0.8183123f, 0.93889356f}},
@@ -399,7 +423,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_unsqueeze_negative_axes) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_concat) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/concat.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/concat.onnx"));
 
     Inputs inputs;
 
@@ -415,8 +440,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_concat) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_concat_negative_axis) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/concat_negative_axis.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/concat_negative_axis.onnx"));
 
     Inputs inputs;
 
@@ -432,8 +458,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_concat_negative_axis) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_split_equal_parts_default) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/split_equal_parts_default.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/split_equal_parts_default.onnx"));
 
     Inputs inputs{{1, 2, 3, 4, 5, 6}};
     Outputs expected_outputs{{1, 2}, {3, 4}, {5, 6}};
@@ -448,8 +475,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_split_equal_parts_default) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_split_equal_parts_2d) {
     // Split into 2 equal parts along axis=1
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/split_equal_parts_2d.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/split_equal_parts_2d.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
@@ -460,8 +488,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_split_equal_parts_2d) {
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_split_variable_parts_2d) {
     // Split into variable parts {2, 4} along axis=1
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/split_variable_parts_2d.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/split_variable_parts_2d.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
@@ -471,8 +500,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_split_variable_parts_2d) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_expand_static_shape) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/expand_static_shape.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/expand_static_shape.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     // input data shape (3,1)

--- a/src/frontends/tests/onnx/onnx_import_rnn.in.cpp
+++ b/src/frontends/tests/onnx/onnx_import_rnn.in.cpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include "common_test_utils/file_utils.hpp"
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "engines_util/test_case.hpp"
 #include "engines_util/test_engines.hpp"
@@ -33,8 +34,9 @@ static std::string s_device = test::backend_name_to_device("${BACKEND_NAME}");
 
 // ONNX LSTM tests (implemented by nGraph LSTMCell and LSTMSequence)
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_fwd_default_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lstm_fwd_default_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/lstm_fwd_default_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0.68172926, 1.1405563, -0.03931177, -0.03759607});  // X
@@ -48,8 +50,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_fwd_default_const) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_reverse_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lstm_reverse_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/lstm_reverse_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0.68172926, 1.1405563, -0.03931177, -0.03759607});  // X
@@ -63,7 +66,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_reverse_const) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_bidir_const) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lstm_bidir_const.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/lstm_bidir_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0.68172926, 1.1405563, -0.03931177, -0.03759607});  // X
@@ -86,8 +90,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_bidir_const) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_fwd_with_clip_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lstm_fwd_clip_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/lstm_fwd_clip_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0.68172926, 1.1405563, -0.03931177, -0.03759607});  // X
@@ -101,8 +106,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_fwd_with_clip_const) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_fwd_mixed_seq_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lstm_fwd_mixed_seq_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/lstm_fwd_mixed_seq_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0.68172926, 1.1405563, -0.03931177, -0.03759607});  // X
@@ -131,8 +137,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_fwd_mixed_seq_const) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_reverse_mixed_seq_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lstm_reverse_mixed_seq_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/lstm_reverse_mixed_seq_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({0.68172926, 1.1405563, -0.03931177, -0.03759607});  // X
@@ -161,8 +168,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_reverse_mixed_seq_const) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_bidir_mixed_seq_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lstm_bidir_mixed_seq_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/lstm_bidir_mixed_seq_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(
@@ -208,8 +216,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_bidir_mixed_seq_const) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_fwd_with_clip_peepholes) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lstm_fwd_with_clip_peepholes.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/lstm_fwd_with_clip_peepholes.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({-0.455351, -0.276391, -0.185934, -0.269585});  // X
@@ -275,8 +284,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_fwd_with_clip_peepholes) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_fwd_mixed_seq) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lstm_fwd_mixed_seq.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/lstm_fwd_mixed_seq.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     int hidden_size{3};
@@ -312,8 +322,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_fwd_mixed_seq) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_fwd_hardsigmoid_activation) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/lstm_fwd_hardsigmoid_activation.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/lstm_fwd_hardsigmoid_activation.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -366,8 +377,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_fwd_hardsigmoid_activation) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_fwd_large_batch_no_clip) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lstm_fwd_large_batch_no_clip.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/lstm_fwd_large_batch_no_clip.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -407,8 +419,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_fwd_large_batch_no_clip) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_bdir_short_input_seq_peepholes) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lstm_bdir_short_input_seq.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/lstm_bdir_short_input_seq.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -452,8 +465,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_bdir_short_input_seq_peepholes) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_mixed_seq_reverse) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/lstm_mixed_seq_reverse.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/lstm_mixed_seq_reverse.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -494,8 +508,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_mixed_seq_reverse) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_import_only_lstm_dynamic_batch_seq_all_inputs) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/lstm_dyn_batch_seq.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/dynamic_shapes/lstm_dyn_batch_seq.onnx"));
 
     auto batch_size = Dimension::dynamic();
     auto seq_length = Dimension::dynamic();
@@ -514,8 +529,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_import_only_lstm_dynamic_batch_seq_all_i
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_import_only_lstm_dynamic_batch_seq_3_inputs) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/lstm_dyn_batch_seq_3_inputs.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/lstm_dyn_batch_seq_3_inputs.onnx"));
 
     auto batch_size = Dimension::dynamic();
     auto seq_length = Dimension::dynamic();
@@ -534,8 +551,10 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_import_only_lstm_dynamic_batch_seq_3_inp
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_lstm_dynamic_batch_size_and_seq_len) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/lstm_dynamic_batch_size_and_seq_len.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/lstm_dynamic_batch_size_and_seq_len.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>({1, 2, 3, 4, 5, 6});
@@ -648,8 +667,9 @@ protected:
 };
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_defaults_fwd_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gru_defaults_fwd_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/gru_defaults_fwd_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(in_X);
@@ -691,7 +711,8 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_defaults_fwd_const)
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_defaults_fwd) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gru_defaults_fwd.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/gru_defaults_fwd.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -737,8 +758,10 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_defaults_fwd) {
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_activations_const) {
     // activations: relu, sigmoid
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/gru_fwd_activations_relu_sigmoid_const.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/gru_fwd_activations_relu_sigmoid_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(in_X);
@@ -777,8 +800,10 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_activations_con
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_activations_relu_hardsigmoid) {
     // activations: relu, hardsigmoid
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/gru_fwd_activations_relu_hardsigmoid.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/gru_fwd_activations_relu_hardsigmoid.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -822,8 +847,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_activations_rel
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_mixed_seq_len) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gru_fwd_mixed_seq_len.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/gru_fwd_mixed_seq_len.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -871,8 +897,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_mixed_seq_len) 
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_mixed_seq_len_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gru_fwd_mixed_seq_len_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/gru_fwd_mixed_seq_len_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -911,8 +938,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_mixed_seq_len_c
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_reverse_mixed_seq_len_const) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/gru_reverse_mixed_seq_len_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/gru_reverse_mixed_seq_len_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -951,8 +979,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_reverse_mixed_seq_l
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_bidir_mixed_seq_len_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gru_bidir_mixed_seq_len_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/gru_bidir_mixed_seq_len_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -989,7 +1018,8 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_bidir_mixed_seq_len
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_rev_clip) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gru_rev_clip.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/gru_rev_clip.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -1034,8 +1064,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_rev_clip) {
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_rev_clip_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gru_rev_clip_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/gru_rev_clip_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(in_X);
@@ -1077,7 +1108,8 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_rev_clip_const) {
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_reverse_const) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gru_reverse_const.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/gru_reverse_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(in_X);
@@ -1119,7 +1151,8 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_reverse_const) {
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_reverse) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gru_reverse.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/gru_reverse.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -1164,8 +1197,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_reverse) {
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_bias_initial_h_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gru_fwd_bias_initial_h_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/gru_fwd_bias_initial_h_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(in_X);
@@ -1207,8 +1241,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_bias_initial_h_
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_bias_initial_h) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gru_fwd_bias_initial_h.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/gru_fwd_bias_initial_h.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -1255,8 +1290,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_bias_initial_h)
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_bidirectional_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gru_bidirectional_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/gru_bidirectional_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(in_X);
@@ -1297,7 +1333,8 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_bidirectional_const
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_bidirectional) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gru_bidirectional.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/gru_bidirectional.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -1341,8 +1378,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_bidirectional) {
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_linear_before_reset_const) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/gru_fwd_linear_before_reset_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/gru_fwd_linear_before_reset_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(in_X);
@@ -1384,8 +1422,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_linear_before_r
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_linear_before_reset) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gru_fwd_linear_before_reset.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/gru_fwd_linear_before_reset.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -1431,8 +1470,10 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_fwd_linear_before_r
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_defaults_fwd_const_dynamic) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/gru_defaults_fwd_const_dynamic.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/gru_defaults_fwd_const_dynamic.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{4, 3, 2}, in_X);
@@ -1474,8 +1515,10 @@ NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_gru_defaults_fwd_const_
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, GRUSequenceOp, onnx_model_import_only_gru_defaults_fwd_const_dynamic) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/gru_defaults_fwd_const_dynamic.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/gru_defaults_fwd_const_dynamic.onnx"));
 
     auto batch_size = Dimension::dynamic();
     auto seq_length = Dimension::dynamic();
@@ -1574,8 +1617,9 @@ protected:
 };
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_defaults_fwd_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_defaults_fwd_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/rnn_defaults_fwd_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(in_X);
@@ -1617,7 +1661,8 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_defaults_fwd_const)
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_defaults_fwd) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_defaults_fwd.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/rnn_defaults_fwd.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -1662,8 +1707,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_defaults_fwd) {
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_fwd_activations_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_fwd_activations_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/rnn_fwd_activations_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -1705,8 +1751,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_fwd_activations_con
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_fwd_activations) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_fwd_activations.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/rnn_fwd_activations.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -1750,8 +1797,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_fwd_activations) {
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_fwd_mixed_seq_len_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_fwd_mixed_seq_len_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/rnn_fwd_mixed_seq_len_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(in_X);
@@ -1793,8 +1841,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_fwd_mixed_seq_len_c
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_fwd_mixed_seq_len) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_fwd_mixed_seq_len.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/rnn_fwd_mixed_seq_len.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -1842,8 +1891,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_fwd_mixed_seq_len) 
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_reverse_mixed_seq_len_const) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_reverse_mixed_seq_len_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/rnn_reverse_mixed_seq_len_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(in_X);
@@ -1881,8 +1931,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_reverse_mixed_seq_l
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_bidir_mixed_seq_len_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_bidir_mixed_seq_len_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/rnn_bidir_mixed_seq_len_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(in_X);
@@ -1921,8 +1972,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_bidir_mixed_seq_len
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_rev_clip_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_rev_clip_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/rnn_rev_clip_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(in_X);
@@ -1964,7 +2016,8 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_rev_clip_const) {
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_rev_clip) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_rev_clip.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/rnn_rev_clip.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -2009,7 +2062,8 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_rev_clip) {
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_reverse_const) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_reverse_const.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/rnn_reverse_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(in_X);
@@ -2051,7 +2105,8 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_reverse_const) {
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_reverse) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_reverse.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/rnn_reverse.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -2096,8 +2151,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_reverse) {
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_fwd_bias_initial_h_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_fwd_bias_initial_h_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/rnn_fwd_bias_initial_h_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(in_X);
@@ -2139,8 +2195,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_fwd_bias_initial_h_
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_fwd_bias_initial_h) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_fwd_bias_initial_h.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/rnn_fwd_bias_initial_h.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -2187,7 +2244,8 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_fwd_bias_initial_h)
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_bidirectional) {
-    auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_bidirectional.onnx"));
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/rnn_bidirectional.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -2232,8 +2290,9 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_bidirectional) {
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_bidirectional_const) {
-    auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/rnn_bidirectional_const.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/rnn_bidirectional_const.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
 
@@ -2276,8 +2335,10 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_bidirectional_const
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_defaults_fwd_const_dynamic) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/rnn_defaults_fwd_const_dynamic.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/rnn_defaults_fwd_const_dynamic.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input<float>(Shape{4, 3, 2}, in_X);
@@ -2319,8 +2380,10 @@ NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_rnn_defaults_fwd_const_
 }
 
 NGRAPH_TEST_F(${BACKEND_NAME}, RNNSequenceOp, onnx_model_import_only_rnn_defaults_fwd_const_dynamic) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/dynamic_shapes/rnn_defaults_fwd_const_dynamic.onnx"));
+    auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/dynamic_shapes/rnn_defaults_fwd_const_dynamic.onnx"));
 
     auto batch_size = Dimension::dynamic();
     auto seq_length = Dimension::dynamic();

--- a/src/frontends/tests/onnx/onnx_import_with_editor.in.cpp
+++ b/src/frontends/tests/onnx/onnx_import_with_editor.in.cpp
@@ -11,12 +11,13 @@
 #endif
 // clang-format on
 
-#include "gtest/gtest.h"
+#include "common_test_utils/file_utils.hpp"
 #include "editor.hpp"
-#include "ngraph/ngraph.hpp"
 #include "engines_util/test_case.hpp"
-#include "util/test_control.hpp"
 #include "engines_util/test_engines.hpp"
+#include "gtest/gtest.h"
+#include "ngraph/ngraph.hpp"
+#include "util/test_control.hpp"
 
 using namespace ngraph;
 OPENVINO_SUPPRESS_DEPRECATED_START
@@ -26,7 +27,8 @@ static std::string s_device = test::backend_name_to_device("${BACKEND_NAME}");
 
 // ############################################################################ CORE TESTS
 NGRAPH_TEST(${BACKEND_NAME}, onnx_compress_axis_0) {
-    ov::onnx_editor::ONNXModelEditor editor{file_util::path_join(SERIALIZED_ZOO, "onnx/compress_0.onnx")};
+    ov::onnx_editor::ONNXModelEditor editor{
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/compress_0.onnx")};
 
     std::map<std::string, std::shared_ptr<ngraph::op::Constant>> in_vals;
 
@@ -42,7 +44,8 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_compress_axis_0) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_compress_axis_1) {
-    ov::onnx_editor::ONNXModelEditor editor{file_util::path_join(SERIALIZED_ZOO, "onnx/compress_1.onnx")};
+    ov::onnx_editor::ONNXModelEditor editor{
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/compress_1.onnx")};
 
     std::map<std::string, std::shared_ptr<ngraph::op::Constant>> in_vals;
 
@@ -58,7 +61,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_compress_axis_1) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_compress_default_axis) {
-    ov::onnx_editor::ONNXModelEditor editor{file_util::path_join(SERIALIZED_ZOO, "onnx/compress_default_axis.onnx")};
+    ov::onnx_editor::ONNXModelEditor editor{file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                 SERIALIZED_ZOO,
+                                                                 "onnx/compress_default_axis.onnx")};
 
     std::map<std::string, std::shared_ptr<ngraph::op::Constant>> in_vals;
 
@@ -74,7 +79,9 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_compress_default_axis) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, onnx_compress_negative_axis) {
-    ov::onnx_editor::ONNXModelEditor editor{file_util::path_join(SERIALIZED_ZOO, "onnx/compress_negative_axis.onnx")};
+    ov::onnx_editor::ONNXModelEditor editor{file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                 SERIALIZED_ZOO,
+                                                                 "onnx/compress_negative_axis.onnx")};
 
     std::map<std::string, std::shared_ptr<ngraph::op::Constant>> in_vals;
 

--- a/src/frontends/tests/onnx/onnx_tensor_names.cpp
+++ b/src/frontends/tests/onnx/onnx_tensor_names.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "common_test_utils/file_utils.hpp"
 #include "engines_util/test_case.hpp"
 #include "gtest/gtest.h"
 #include "ngraph/ngraph.hpp"
@@ -50,8 +51,8 @@ std::shared_ptr<OpType> find_by_friendly_name(const std::vector<DerivedFromNode>
 }
 
 NGRAPH_TEST(onnx_tensor_names, simple_model) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/tensor_names.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/tensor_names.onnx"));
 
     const auto ops = function->get_ordered_ops();
     EXPECT_TRUE(matching_node_found_in_graph<op::Parameter>(ops, "identity_on_input", {"input", "identity_on_input"}));
@@ -63,7 +64,8 @@ NGRAPH_TEST(onnx_tensor_names, simple_model) {
 }
 
 NGRAPH_TEST(onnx_tensor_names, node_multiple_outputs) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/top_k.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/top_k.onnx"));
 
     const auto ops = function->get_ordered_ops();
     EXPECT_TRUE(matching_node_found_in_graph<op::Parameter>(ops, "x", {"x"}));
@@ -76,8 +78,9 @@ NGRAPH_TEST(onnx_tensor_names, node_multiple_outputs) {
 }
 
 NGRAPH_TEST(onnx_tensor_names, subgraph_with_multiple_nodes) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/max_pool_transposed.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/max_pool_transposed.onnx"));
 
     // after the import the 2 Result objects are connected to 2 distinct nodes (MaxPool & Transpose)
     // the original MaxPool operator in the model doesn't have its name set
@@ -93,8 +96,8 @@ NGRAPH_TEST(onnx_tensor_names, subgraph_with_multiple_nodes) {
 }
 
 NGRAPH_TEST(onnx_tensor_names, simple_multiout_operator) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/max_pool_simple.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/max_pool_simple.onnx"));
 
     const auto ops = function->get_ordered_ops();
 
@@ -109,8 +112,9 @@ NGRAPH_TEST(onnx_tensor_names, simple_multiout_operator) {
 }
 
 NGRAPH_TEST(onnx_tensor_names, simple_multiout_named_operator) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/max_pool_simple_named.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/max_pool_simple_named.onnx"));
 
     const auto ops = function->get_ordered_ops();
 
@@ -125,8 +129,9 @@ NGRAPH_TEST(onnx_tensor_names, simple_multiout_named_operator) {
 }
 
 NGRAPH_TEST(onnx_tensor_names, subgraph_with_multiple_nodes_named) {
-    const auto function =
-        onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/max_pool_transposed_named.onnx"));
+    const auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                              SERIALIZED_ZOO,
+                                                                              "onnx/max_pool_transposed_named.onnx"));
 
     const auto ops = function->get_ordered_ops();
 
@@ -140,8 +145,10 @@ NGRAPH_TEST(onnx_tensor_names, subgraph_with_multiple_nodes_named) {
 }
 
 NGRAPH_TEST(onnx_tensor_names, subgraph_conv_with_bias) {
-    const auto function = onnx_import::import_onnx_model(
-        file_util::path_join(SERIALIZED_ZOO, "onnx/conv_with_strides_padding_bias.onnx"));
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/conv_with_strides_padding_bias.onnx"));
 
     const auto ops = function->get_ordered_ops();
 
@@ -154,7 +161,8 @@ NGRAPH_TEST(onnx_tensor_names, subgraph_conv_with_bias) {
 }
 
 NGRAPH_TEST(onnx_tensor_names, subgraph_gemm_with_bias) {
-    const auto function = onnx_import::import_onnx_model(file_util::path_join(SERIALIZED_ZOO, "onnx/gemm_abc.onnx"));
+    const auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/gemm_abc.onnx"));
 
     const auto ops = function->get_ordered_ops();
 

--- a/src/frontends/tests/onnx/onnx_test_utils.in.cpp
+++ b/src/frontends/tests/onnx/onnx_test_utils.in.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <sstream>
 
+#include "common_test_utils/file_utils.hpp"
 #include "default_opset.hpp"
 #include "editor.hpp"
 #include "engines_util/test_case.hpp"
@@ -32,7 +33,8 @@ TYPED_TEST_P(ElemTypesTests, onnx_test_add_abc_set_precission) {
     using DataType = TypeParam;
     const element::Type ng_type = element::from<DataType>();
 
-    ov::onnx_editor::ONNXModelEditor editor{file_util::path_join(SERIALIZED_ZOO, "onnx/add_abc_3d.onnx")};
+    ov::onnx_editor::ONNXModelEditor editor{
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/add_abc_3d.onnx")};
 
     editor.set_input_types({{"A", ng_type}, {"B", ng_type}, {"C", ng_type}});
 
@@ -49,8 +51,9 @@ TYPED_TEST_P(ElemTypesTests, onnx_test_split_multioutput_set_precission) {
     using DataType = TypeParam;
     const element::Type ng_type = element::from<DataType>();
 
-    ov::onnx_editor::ONNXModelEditor editor{
-        file_util::path_join(SERIALIZED_ZOO, "onnx/split_equal_parts_default.onnx")};
+    ov::onnx_editor::ONNXModelEditor editor{file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                 SERIALIZED_ZOO,
+                                                                 "onnx/split_equal_parts_default.onnx")};
 
     editor.set_input_types({{"input", ng_type}});
 
@@ -70,7 +73,8 @@ typedef ::testing::Types<int8_t, int16_t, int32_t, uint8_t, float> ElemTypes;
 INSTANTIATE_TYPED_TEST_SUITE_P(${BACKEND_NAME}, ElemTypesTests, ElemTypes);
 
 NGRAPH_TEST(${BACKEND_NAME}, add_abc_from_ir) {
-    const auto ir_xml = file_util::path_join(SERIALIZED_ZOO, "ir/add_abc.xml");
+    const auto ir_xml =
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "ir/add_abc.xml");
     const auto function = test::function_from_ir(ir_xml);
 
     auto test_case = test::TestCase(function, s_device);
@@ -83,8 +87,10 @@ NGRAPH_TEST(${BACKEND_NAME}, add_abc_from_ir) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, add_abc_from_ir_with_bin_path) {
-    const auto ir_xml = file_util::path_join(SERIALIZED_ZOO, "ir/add_abc.xml");
-    const auto ir_bin = file_util::path_join(SERIALIZED_ZOO, "ir/weights/add_abc.bin");
+    const auto ir_xml =
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "ir/add_abc.xml");
+    const auto ir_bin =
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "ir/weights/add_abc.bin");
     const auto function = test::function_from_ir(ir_xml, ir_bin);
 
     auto test_case = test::TestCase(function, s_device);

--- a/src/frontends/tests/onnx/onnx_transformations.cpp
+++ b/src/frontends/tests/onnx/onnx_transformations.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "common_test_utils/file_utils.hpp"
 #include "editor.hpp"
 #include "gtest/gtest.h"
 #include "ngraph/file_util.hpp"
@@ -62,10 +63,13 @@ bool after_func_expand_name_comp(std::string lhs, std::string rhs) {
 }  // namespace
 
 NGRAPH_TEST(onnx_transformations, expand_function_greater_or_equal) {
-    ONNXModelEditor editor{file_util::path_join(SERIALIZED_ZOO, "onnx/transformations/greater_or_equal.onnx")};
+    ONNXModelEditor editor{file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                SERIALIZED_ZOO,
+                                                "onnx/transformations/greater_or_equal.onnx")};
     editor.decode();  // onnx transformations are applied
 
-    const auto ref_model = file_util::path_join(SERIALIZED_ZOO,
+    const auto ref_model = file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                SERIALIZED_ZOO,
                                                 "onnx/transformations/reference/"
                                                 "greater_or_equal_expanded.onnx");
 
@@ -75,11 +79,13 @@ NGRAPH_TEST(onnx_transformations, expand_function_greater_or_equal) {
 
 // Disabled, ticket: #81976
 NGRAPH_TEST(onnx_transformations, DISABLED_expand_function_softmax_crossentropy) {
-    ONNXModelEditor editor{
-        file_util::path_join(SERIALIZED_ZOO, "onnx/transformations/softmax_crossentropy_consumed.onnx")};
+    ONNXModelEditor editor{file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                SERIALIZED_ZOO,
+                                                "onnx/transformations/softmax_crossentropy_consumed.onnx")};
     editor.decode();  // onnx transformations are applied
 
-    const auto ref_model = file_util::path_join(SERIALIZED_ZOO,
+    const auto ref_model = file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                SERIALIZED_ZOO,
                                                 "onnx/transformations/reference/"
                                                 "softmax_crossentropy_consumed_expanded.onnx");
 


### PR DESCRIPTION
### Details:
 - ONNX tests modified to use another path to the models
 - This change lets the test binaries operating on various models be executed outside of the bin/intel64/Debug (or Release) directory

### Tickets:
 - 88917
