### PR TITLE
[TF FE] Fix StridedSlice translator for new_axis vector size longer input rank

### DIFF
--- a/src/frontends/tensorflow/src/op/strided_slice.cpp
+++ b/src/frontends/tensorflow/src/op/strided_slice.cpp
@@ -25,7 +25,7 @@ OutputVector translate_strided_slice_op(const NodeContext& node) {
     auto ellipsis_mask = node.get_attribute<int64_t>("ellipsis_mask", 0);
     auto shrink_axis_mask = node.get_attribute<int64_t>("shrink_axis_mask", 0);
 
-    auto mask_to_vector = [](int mask) {
+    auto mask_to_vector = [](int64_t mask) {
         auto length = sizeof(mask) * CHAR_BIT;
         vector<int64_t> vec(length, 0);
         if (mask == 0) {

--- a/src/frontends/tensorflow/src/op/strided_slice.cpp
+++ b/src/frontends/tensorflow/src/op/strided_slice.cpp
@@ -15,28 +15,24 @@ namespace op {
 
 OutputVector translate_strided_slice_op(const NodeContext& node) {
     auto input = node.get_input(0);
-    auto rank = input.get_partial_shape().rank();
     auto begin = node.get_input(1);
     auto end = node.get_input(2);
     auto strides = node.get_input(3);
 
-    auto begin_mask = node.get_attribute<int64_t>("begin_mask");
-    auto end_mask = node.get_attribute<int64_t>("end_mask");
-    auto new_axis_mask = node.get_attribute<int64_t>("new_axis_mask");
-    auto ellipsis_mask = node.get_attribute<int64_t>("ellipsis_mask");
-    auto shrink_axis_mask = node.get_attribute<int64_t>("shrink_axis_mask");
+    auto begin_mask = node.get_attribute<int64_t>("begin_mask", 0);
+    auto end_mask = node.get_attribute<int64_t>("end_mask", 0);
+    auto new_axis_mask = node.get_attribute<int64_t>("new_axis_mask", 0);
+    auto ellipsis_mask = node.get_attribute<int64_t>("ellipsis_mask", 0);
+    auto shrink_axis_mask = node.get_attribute<int64_t>("shrink_axis_mask", 0);
 
-    auto mask_to_vec = [](int64_t mask, const ov::Rank& rank) {
+    auto mask_to_vector = [](int mask) {
         auto length = sizeof(mask) * CHAR_BIT;
-        if (rank.is_static() && rank.get_length() < length) {
-            length = rank.get_length();
-        }
         vector<int64_t> vec(length, 0);
         if (mask == 0) {
             return vec;
         }
         for (auto i = 0; i < length; ++i) {
-            if (static_cast<unsigned char>(mask >> i & 0x01) == 1) {
+            if (static_cast<unsigned char>(mask >> i & 0x1) == 1) {
                 vec[i] = 1;
             }
         }
@@ -47,11 +43,11 @@ OutputVector translate_strided_slice_op(const NodeContext& node) {
                                          begin,
                                          end,
                                          strides,
-                                         mask_to_vec(begin_mask, rank),
-                                         mask_to_vec(end_mask, rank),
-                                         mask_to_vec(new_axis_mask, rank),
-                                         mask_to_vec(shrink_axis_mask, rank),
-                                         mask_to_vec(ellipsis_mask, rank));
+                                         mask_to_vector(begin_mask),
+                                         mask_to_vector(end_mask),
+                                         mask_to_vector(new_axis_mask),
+                                         mask_to_vector(shrink_axis_mask),
+                                         mask_to_vector(ellipsis_mask));
     set_node_name(node.get_name(), res);
     return res->outputs();
 }

--- a/tests/layer_tests/tensorflow_tests/test_tf_StridedSlice.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_StridedSlice.py
@@ -96,6 +96,9 @@ class TestStridedSlice(CommonTFLayerTest):
         dict(input_shape=[1, 5, 5, 3], begin=[0, 0, 0, 0], end=[1, 5, 5, 3], strides=[1, 1, 1, 1],
              begin_mask=0,
              end_mask=0, ellipsis_mask=0, new_axis_mask=2, shrink_axis_mask=0),
+        dict(input_shape=[16, 4, 64], begin=[0, 0, 0, 0], end=[0, 0, 0, 0], strides=[1, 1, 1, 1],
+             begin_mask=19,
+             end_mask=19, ellipsis_mask=0, new_axis_mask=12, shrink_axis_mask=0),
     ]
 
     @pytest.mark.parametrize('params', test_unsqueeze_data)


### PR DESCRIPTION
**Details:** Currently, new_axis vector is cut by input rank that is incorrect and leads to the loss of new axes.

**Ticket:** 88982

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
