### PR TITLE
[CPU] Removed contexts from Load/Store emitters

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/jit_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/jit_emitter.hpp
@@ -23,6 +23,11 @@ enum emitter_in_out_map {
     gpr_to_gpr,
 };
 
+// structure for storage of emitter parameters to hash in map
+struct emitter_params {
+    virtual size_t hash() const = 0;
+};
+
 struct emitter_context {
     virtual ~emitter_context() = default;
 };

--- a/src/plugins/intel_cpu/src/emitters/jit_load_store_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/jit_load_store_emitters.hpp
@@ -15,40 +15,37 @@ using namespace InferenceEngine;
 namespace ov {
 namespace intel_cpu {
 
-struct load_emitter_context : public emitter_context {
-    load_emitter_context() : src_prc_(Precision::FP32), dst_prc_(Precision::FP32), load_num_(8),
-    offset_byte_(0), is_fill_(false), fill_value_("zero") {}
+struct load_emitter_params : public emitter_params {
+    load_emitter_params(Precision src_prc, Precision dst_prc, int load_num, bool is_fill = false, std::string fill_value = "zero"):
+        src_prc_(src_prc), dst_prc_(dst_prc), load_num_(load_num), is_fill_(is_fill), fill_value_(fill_value) {}
 
-    load_emitter_context(Precision src_prc, Precision dst_prc, int load_num, int offset_byte = 0, bool is_fill = false, std::string fill_value = "zero"):
-    src_prc_(src_prc), dst_prc_(dst_prc), load_num_(load_num), offset_byte_(offset_byte), is_fill_(is_fill), fill_value_(fill_value) {}
+    size_t hash() const override;
 
-    int offset_byte_;
-    int load_num_;
     Precision src_prc_;
     Precision dst_prc_;
+    int load_num_;
     bool is_fill_;
     std::string fill_value_;
 };
 
-struct store_emitter_context : public emitter_context {
-    store_emitter_context() : src_prc_(Precision::FP32), dst_prc_(Precision::FP32),
-    store_num_(8), offset_byte_(0) {}
+struct store_emitter_params : public emitter_params {
+    store_emitter_params(Precision src_prc, Precision dst_prc, int store_num):
+        src_prc_(src_prc), dst_prc_(dst_prc), store_num_(store_num) {}
 
-    store_emitter_context(Precision src_prc, Precision dst_prc, int store_num, int offset_byte = 0)
-    : src_prc_(src_prc), dst_prc_(dst_prc), store_num_(store_num), offset_byte_(offset_byte) {}
+    size_t hash() const override;
 
-    int offset_byte_;
-    int store_num_;
     Precision src_prc_;
     Precision dst_prc_;
+    int store_num_;
 };
 
 class jit_load_emitter : public jit_emitter {
 public:
-    jit_load_emitter(dnnl::impl::cpu::x64::jit_generator *host, dnnl::impl::cpu::x64::cpu_isa_t host_isa,
-                    InferenceEngine::Precision exec_prc = InferenceEngine::Precision::FP32, emitter_in_out_map in_out_type = emitter_in_out_map::gpr_to_vec);
+    jit_load_emitter(dnnl::impl::cpu::x64::jit_generator *host, dnnl::impl::cpu::x64::cpu_isa_t host_isa, Precision src_prc, Precision dst_prc, int load_num,
+                     Precision exec_prc = Precision::FP32, bool is_fill = false, std::string fill_value = "zero",
+                     emitter_in_out_map in_out_type = emitter_in_out_map::gpr_to_vec);
     /**
-    * load_num values with src_prc precision are loaded from ptr[Reg64(in_idxs[0]) + offset_byte] address to Vmm[out_idxs[0]] as dst_prc.
+    * load_num values with src_prc precision are loaded from ptr[Reg64(in_idxs[0]) + offset_byte] address to Vmm[out_idxs[0]] as dst_prc, where offset_byte is in_idxs[1]
     * is_fill: when load_num can not fully fit in vector register, whether fill_value should be filled as default values.
     * fill_value: when load_num can not fully fit in vector register, what values should be filled as default values.
     *   currently support "zero", "int_one", "float_one", "int32_min", "float_min", "int32_max" and "float_max".
@@ -66,27 +63,23 @@ public:
     * dst_prc
     */
     void emit_impl(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
-                  const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs,
-                  const emitter_context *emit_context) const override;
+                   const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs,
+                   const emitter_context *emit_context) const override;
 
     size_t get_inputs_num() const override;
 
 private:
     template <dnnl::impl::cpu::x64::cpu_isa_t isa>
-    void emit_isa(const Xbyak::Reg64 &reg_src, int offset_byte, InferenceEngine::Precision src_prc,
-        const int out_vec_idx, InferenceEngine::Precision dst_prc, int load_num, bool is_fill = false, std::string fill_value = "zero") const;
+    void emit_isa(const Xbyak::Reg64 &reg_src,  const int out_vec_idx, const int offset) const;
 
     template <typename Vmm>
-    void load_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int offset, int load_size,
-        bool is_fill = false, std::string fill_value = "zero") const;
+    void load_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int offset, int load_size) const;
 
     template <typename Vmm>
-    void load_bytes_to_dword_extension(const Vmm &vmm, const Xbyak::Reg64 &reg, int offset, bool is_signed, int load_size,
-        bool is_fill = false, std::string fill_value = "zero") const;
+    void load_bytes_to_dword_extension(const Vmm &vmm, const Xbyak::Reg64 &reg, int offset, bool is_signed, int load_size) const;
 
     template <typename Vmm>
-    void load_words_to_dword_extension(const Vmm &vmm, const Xbyak::Reg64 &reg, int offset, bool is_bf16, bool is_signed, int load_size,
-        bool is_fill = false, std::string fill_value = "zero") const;
+    void load_words_to_dword_extension(const Vmm &vmm, const Xbyak::Reg64 &reg, int offset, bool is_bf16, bool is_signed, int load_size) const;
 
     template <typename Vmm>
     void fill_with_default(const Vmm &vmm, std::string fill_value, const int &load_num) const;
@@ -95,17 +88,23 @@ private:
 
     size_t aux_gprs_count() const override;
 
-    std::string name;
-    int v_len_elt;  // 4/8/16
+    std::string name_;
+    int v_len_elt_;  // 4/8/16
+    int load_num_;
+    int load_size_;
+    Precision src_prc_;
+    Precision dst_prc_;
+    bool is_fill_;
+    std::string fill_value_;
 };
 
 class jit_store_emitter : public jit_emitter {
 public:
-    jit_store_emitter(dnnl::impl::cpu::x64::jit_generator *host, dnnl::impl::cpu::x64::cpu_isa_t host_isa,
-                    InferenceEngine::Precision exec_prc = InferenceEngine::Precision::FP32, emitter_in_out_map in_out_type = emitter_in_out_map::vec_to_gpr);
+    jit_store_emitter(dnnl::impl::cpu::x64::jit_generator *host, dnnl::impl::cpu::x64::cpu_isa_t host_isa, Precision src_prc, Precision dst_prc, int store_num,
+                      Precision exec_prc = Precision::FP32, emitter_in_out_map in_out_type = emitter_in_out_map::vec_to_gpr);
 
     /**
-    * store_num values with src_prc in Vmm[in_vec_idx] is stored to ptr[reg_dst + offset_byte] address as dst_prc data.
+    * store_num values with src_prc in Vmm[in_vec_idx] is stored to ptr[reg_dst + offset_byte] address as dst_prc data, where offset_byte is in_idxs[1]
     * supported src_prc and dst_prc pairs are as below(x indicate for support):
     *       FP32  I32   I16   U16   I8    U8    BF16  --> src_prc
     * FP32   x     x
@@ -120,21 +119,20 @@ public:
     * note: FP32/I32-->BF16(x*) is supported only on at least avx512-core plateform
     */
     void emit_impl(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
-                  const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs,
-                  const emitter_context *emit_context) const override;
+                   const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs,
+                   const emitter_context *emit_context) const override;
 
     size_t get_inputs_num() const override;
 
     void emit_data() const override;
 
     std::shared_ptr<jit_emu_vcvtneps2bf16> get_emu_vcvtneps2bf16() const {
-        return emu_vcvtneps2bf16;
+        return emu_vcvtneps2bf16_;
     }
 
 private:
     template <dnnl::impl::cpu::x64::cpu_isa_t isa>
-    void emit_isa(const int in_vec_idx, InferenceEngine::Precision src_prc,
-        const Xbyak::Reg64 &reg_dst, int offset_byte, InferenceEngine::Precision dst_prc, int store_num) const;
+    void emit_isa(const int in_vec_idx,  const Xbyak::Reg64 &reg_dst, const int offset) const;
 
     template <typename Vmm>
     void store_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int offset, int store_size) const;
@@ -148,9 +146,13 @@ private:
     size_t aux_gprs_count() const override;
     size_t aux_vecs_count() const override;
 
-    std::string name;
-    int v_len_elt;  // 4/8/16
-    std::shared_ptr<jit_emu_vcvtneps2bf16> emu_vcvtneps2bf16;
+    std::string name_;
+    int v_len_elt_;  // 4/8/16
+    int store_num_;
+    int store_size_;
+    Precision src_prc_;
+    Precision dst_prc_;
+    std::shared_ptr<jit_emu_vcvtneps2bf16> emu_vcvtneps2bf16_;
 };
 
 }   // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/roi_align.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.cpp
@@ -46,9 +46,6 @@ struct jit_uni_roi_align_kernel_f32 : public jit_uni_roi_align_kernel, public ji
     };
 
     void generate() override {
-        load_emitter.reset(new jit_load_emitter(this, isa));
-        store_emitter.reset(new jit_store_emitter(this, isa));
-
         this->preamble();
 
         uni_vpxor(vmm_zero, vmm_zero, vmm_zero);
@@ -65,8 +62,7 @@ struct jit_uni_roi_align_kernel_f32 : public jit_uni_roi_align_kernel, public ji
 
         this->postamble();
 
-        load_emitter->emit_data();
-        store_emitter->emit_data();
+        emit_emitters_data();
     }
 
 private:
@@ -107,10 +103,9 @@ private:
     // [1] for reg_dst
     Xmm xmm_args_pool = Xmm(15);
 
-    std::unique_ptr<jit_load_emitter> load_emitter = nullptr;
-    std::vector<size_t> load_pool_gpr_idxs;
+    std::unordered_map<size_t, std::unique_ptr<jit_emitter>> emitters;
 
-    std::unique_ptr<jit_store_emitter> store_emitter = nullptr;
+    std::vector<size_t> load_pool_gpr_idxs;
     std::vector<size_t> store_pool_gpr_idxs;
     std::vector<size_t> store_pool_vec_idxs;
 
@@ -157,6 +152,57 @@ private:
 
     reg64_t reg_params = abi_param1;
 
+    void emit_emitters_data() {
+        for (const auto& emitter : emitters) {
+            emitter.second->emit_data();
+        }
+    }
+
+    inline void load(Xbyak::Reg64 reg_src, Vmm vmm_src, const int elt_num, const int offset = 0) {
+        emit_load(reg_src, vmm_src, jcp_.data_prc, Precision::FP32, elt_num, offset);
+    }
+
+    inline void load_buffer(Xbyak::Reg64 reg_src, Vmm vmm_src, const int elt_num, const int offset = 0) {
+        emit_load(reg_src, vmm_src, Precision::FP32, Precision::FP32, elt_num, offset);
+    }
+
+    inline void load_idx(Xbyak::Reg64 reg_src, Vmm vmm_src, const int elt_num, const int offset = 0) {
+        emit_load(reg_src, vmm_src, Precision::I32, Precision::I32, elt_num, offset);
+    }
+
+    inline void store(Vmm vmm_dst, Xbyak::Reg64 reg_dst, const int elt_num, const int offset = 0) {
+        emit_store(vmm_dst, reg_dst, Precision::FP32, jcp_.data_prc, elt_num, offset);
+    }
+
+    inline void store_buffer(Vmm vmm_dst, Xbyak::Reg64 reg_dst, const int elt_num, const int offset = 0) {
+        emit_store(vmm_dst, reg_dst, Precision::FP32, Precision::FP32, elt_num, offset);
+    }
+
+    inline void emit_load(Xbyak::Reg64 reg_src, Vmm vmm_src, Precision src_prc, Precision dst_prc, const int elt_num, const int offset = 0) {
+        const auto seed = load_emitter_params(src_prc, dst_prc, elt_num).hash();
+        if (!emitters[seed]) {
+            emitters[seed].reset(new jit_load_emitter(this, isa, src_prc, dst_prc, elt_num));
+        }
+
+        emitters[seed]->emit_code({static_cast<size_t>(reg_src.getIdx()), static_cast<size_t>(offset)},
+                                  {static_cast<size_t>(vmm_src.getIdx())}, {}, {load_pool_gpr_idxs});
+    }
+
+    inline void emit_store(Vmm vmm_dst, Xbyak::Reg64 reg_dst, Precision src_prc, Precision dst_prc, const int elt_num, const int offset = 0) {
+        const auto seed = store_emitter_params(src_prc, dst_prc, elt_num).hash();
+        if (!emitters[seed]) {
+            emitters[seed].reset(new jit_store_emitter(this, isa, src_prc, dst_prc, elt_num));
+        }
+
+        // for cases when Store emitter need 2 aux vmm we can use vmm_dst as second aux vmm
+        std::vector<size_t> local_store_pool_vec_idxs = { static_cast<size_t>(vmm_dst.getIdx()) };
+        local_store_pool_vec_idxs.insert(local_store_pool_vec_idxs.begin(), store_pool_vec_idxs.begin(), store_pool_vec_idxs.end());
+
+        emitters[seed]->emit_code({static_cast<size_t>(vmm_dst.getIdx()), static_cast<size_t>(offset)},
+                                  {static_cast<size_t>(reg_dst.getIdx())},
+                                  {local_store_pool_vec_idxs}, {store_pool_gpr_idxs});
+    }
+
     void roi_align_cgather() {
         mov(reg_src_address, ptr[reg_params + GET_OFF(src)]);
         mov(reg_weights, ptr[reg_params + GET_OFF(weights)]);
@@ -179,23 +225,6 @@ private:
             mov(reg_src_stride, ptr[reg_params + GET_OFF(src_stride)]);
             imul(reg_src_stride, reg_src_stride, jcp_.data_size);
         }
-
-        auto store = [&](Vmm vmm_dst, Xbyak::Reg64 reg_dst, int elt_num) {
-                    store_emitter->emit_code({static_cast<size_t>(vmm_dst.getIdx())}, {static_cast<size_t>(reg_dst.getIdx())},
-                    std::make_shared<store_emitter_context>(Precision::FP32, jcp_.data_prc, elt_num),
-                    {store_pool_vec_idxs}, {store_pool_gpr_idxs});
-        };
-
-        auto load_buf = [&](Xbyak::Reg64 reg_src, Vmm vmm_src, int elt_num) {
-                    load_emitter->emit_code({static_cast<size_t>(reg_src.getIdx())}, {static_cast<size_t>(vmm_src.getIdx())},
-                    std::make_shared<load_emitter_context>(Precision::FP32, Precision::FP32, elt_num),
-                    {}, {load_pool_gpr_idxs});
-        };
-        auto store_buf = [&](Vmm vmm_dst, Xbyak::Reg64 reg_dst, int elt_num) {
-                    store_emitter->emit_code({static_cast<size_t>(vmm_dst.getIdx())}, {static_cast<size_t>(reg_dst.getIdx())},
-                    std::make_shared<store_emitter_context>(Precision::FP32, Precision::FP32, elt_num),
-                    {store_pool_vec_idxs}, {store_pool_gpr_idxs});
-        };
 
         // out loop for samples in bin
         Xbyak::Label out_loop_label;
@@ -228,13 +257,13 @@ private:
                 generate_samples(v_step);
                 // now this sample value across channel reside in vmm_sample
                 // compute with other samples in vmm_buf
-                load_buf(reg_buf, vmm_buf, v_step);
+                load_buffer(reg_buf, vmm_buf, v_step);
                 if (jcp_.alg == Algorithm::ROIAlignAvg) {
                     uni_vaddps(vmm_buf, vmm_buf, vmm_sample);
                 } else {
                     uni_vmaxps(vmm_buf, vmm_buf, vmm_sample);
                 }
-                store_buf(vmm_buf, reg_buf, v_step);
+                store_buffer(vmm_buf, reg_buf, v_step);
 
                 if ((isa == cpu::x64::sse41) && (jcp_.layout == ROIAlignLayoutType::blk)) {
                     add(reg_src0, x_step * jcp_.data_size);
@@ -244,13 +273,13 @@ private:
                     add(reg_buf, x_step * sizeof(float));
 
                     generate_samples(x_step);
-                    load_buf(reg_buf, vmm_buf, x_step);
+                    load_buffer(reg_buf, vmm_buf, x_step);
                     if (jcp_.alg == Algorithm::ROIAlignAvg) {
                         uni_vaddps(vmm_buf, vmm_buf, vmm_sample);
                     } else {
                         uni_vmaxps(vmm_buf, vmm_buf, vmm_sample);
                     }
-                    store_buf(vmm_buf, reg_buf, x_step);
+                    store_buffer(vmm_buf, reg_buf, x_step);
 
                     sub(reg_src0, x_step * jcp_.data_size);
                     sub(reg_src1, x_step * jcp_.data_size);
@@ -280,13 +309,13 @@ private:
                 jl(in_loop_tail_end_label, T_NEAR);
 
                 generate_samples(tail_step);
-                load_buf(reg_buf, vmm_buf, tail_step);
+                load_buffer(reg_buf, vmm_buf, tail_step);
                 if (jcp_.alg == Algorithm::ROIAlignAvg) {
                     uni_vaddps(vmm_buf, vmm_buf, vmm_sample);
                 } else {
                     uni_vmaxps(vmm_buf, vmm_buf, vmm_sample);
                 }
-                store_buf(vmm_buf, reg_buf, tail_step);
+                store_buffer(vmm_buf, reg_buf, tail_step);
 
                 int tail_src_stride = tail_step * jcp_.data_size;
                 add(reg_src0, tail_src_stride);
@@ -333,7 +362,7 @@ private:
             cmp(reg_work_amount, v_step);
             jl(store_loop_main_end_label, T_NEAR);
 
-            load_buf(reg_buf, vmm_buf, v_step);
+            load_buffer(reg_buf, vmm_buf, v_step);
             if (jcp_.alg == Algorithm::ROIAlignAvg) {
                 uni_vmulps(vmm_buf, vmm_buf, vmm_scale);
             }
@@ -343,7 +372,7 @@ private:
                 add(reg_buf, x_step * sizeof(float));
                 add(reg_dst, x_step * jcp_.data_size);
 
-                load_buf(reg_buf, vmm_buf, x_step);
+                load_buffer(reg_buf, vmm_buf, x_step);
                 if (jcp_.alg == Algorithm::ROIAlignAvg) {
                     uni_vmulps(vmm_buf, vmm_buf, vmm_scale);
                 }
@@ -369,7 +398,7 @@ private:
             cmp(reg_work_amount, tail_step);
             jl(store_loop_tail_end_label, T_NEAR);
 
-            load_buf(reg_buf, vmm_buf, tail_step);
+            load_buffer(reg_buf, vmm_buf, tail_step);
             if (jcp_.alg == Algorithm::ROIAlignAvg) {
                 uni_vmulps(vmm_buf, vmm_buf, vmm_scale);
             }
@@ -402,12 +431,6 @@ private:
     }
 
     void generate_samples(int num) {
-        auto load = [&](Xbyak::Reg64 reg_src, Vmm vmm_src, int elt_num) {
-                    load_emitter->emit_code({static_cast<size_t>(reg_src.getIdx())}, {static_cast<size_t>(vmm_src.getIdx())},
-                    std::make_shared<load_emitter_context>(jcp_.data_prc, Precision::FP32, elt_num),
-                    {}, {load_pool_gpr_idxs});
-        };
-
         uni_vpxor(vmm_sample, vmm_sample, vmm_sample);
         load(reg_src0, vmm_src0, num);
         uni_vfmadd231ps(vmm_sample, vmm_src0, vmm_weights0);
@@ -431,12 +454,6 @@ private:
             mov(reg_tmp_64, ptr[reg_params + GET_OFF(scale)]);
             uni_vbroadcastss(vmm_scale, ptr[reg_tmp_64]);
         }
-
-        auto load_idx = [&](Xbyak::Reg64 reg_idx, Vmm vmm_idx, int elt_num) {
-                    load_emitter->emit_code({static_cast<size_t>(reg_idx.getIdx())}, {static_cast<size_t>(vmm_idx.getIdx())},
-                    std::make_shared<load_emitter_context>(Precision::I32, Precision::I32, elt_num),
-                    {}, {load_pool_gpr_idxs});
-        };
 
         Xbyak::Label main_loop_label;
         Xbyak::Label main_loop_end_label;

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
@@ -48,8 +48,9 @@ struct jit_uni_roi_pooling_kernel_f32 : public jit_uni_roi_pooling_kernel, publi
     };
 
     void generate() override {
-        load_emitter.reset(new jit_load_emitter(this, isa));
-        store_emitter.reset(new jit_store_emitter(this, isa));
+        load_emitter.reset(new jit_load_emitter(this, isa, jpp_.src_prc, Precision::FP32, step));
+        store_emitter.reset(new jit_store_emitter(this, isa, Precision::FP32, jpp_.dst_prc, step));
+        store_empty_roi_emitter.reset(new jit_store_emitter(this, isa, jpp_.src_prc, jpp_.dst_prc, step));
 
         this->preamble();
 
@@ -93,6 +94,7 @@ struct jit_uni_roi_pooling_kernel_f32 : public jit_uni_roi_pooling_kernel, publi
 
         load_emitter->emit_data();
         store_emitter->emit_data();
+        store_empty_roi_emitter->emit_data();
     }
 
 private:
@@ -114,6 +116,7 @@ private:
     std::vector<size_t> load_pool_gpr_idxs;
 
     std::unique_ptr<jit_store_emitter> store_emitter = nullptr;
+    std::unique_ptr<jit_store_emitter> store_empty_roi_emitter = nullptr;
     std::vector<size_t> store_pool_gpr_idxs;
     std::vector<size_t> store_pool_vec_idxs;
 
@@ -147,6 +150,12 @@ private:
     Xbyak::Reg64 reg_load_table = r15;
     Xbyak::Reg64 reg_load_store_mask = abi_param1;
 
+    std::vector<size_t> get_local_store_pool_vec_idxs(Vmm vmm) const {
+        std::vector<size_t> local_store_pool_vec_idxs = { static_cast<size_t>(vmm.getIdx()) };
+        local_store_pool_vec_idxs.insert(local_store_pool_vec_idxs.begin(), store_pool_vec_idxs.begin(), store_pool_vec_idxs.end());
+        return local_store_pool_vec_idxs;
+    }
+
     void roi_pool_max(int c_blocks) {
         Label h_loop_label;
         Label w_loop_label;
@@ -157,8 +166,7 @@ private:
         for (int i = 0; i < c_blocks; i++) {
             Vmm vmm_max = get_acc_reg(i);
 
-            load_emitter->emit_code({static_cast<size_t>(reg_input.getIdx())}, {static_cast<size_t>(vmm_max.getIdx())},
-                                    std::make_shared<load_emitter_context>(jpp_.src_prc, Precision::FP32, step, i * src_c_off),
+            load_emitter->emit_code({static_cast<size_t>(reg_input.getIdx()), static_cast<size_t>(i * src_c_off)}, {static_cast<size_t>(vmm_max.getIdx())},
                                     {}, load_pool_gpr_idxs);
         }
 
@@ -171,9 +179,8 @@ private:
                     Vmm vmm_max = get_acc_reg(i);
                     Vmm vmm_src = get_src_reg(i);
 
-                    load_emitter->emit_code({static_cast<size_t>(aux_reg_input1.getIdx())}, {static_cast<size_t>(vmm_src.getIdx())},
-                                            std::make_shared<load_emitter_context>(jpp_.src_prc, Precision::FP32, step, i * src_c_off),
-                                            {}, load_pool_gpr_idxs);
+                    load_emitter->emit_code({static_cast<size_t>(aux_reg_input1.getIdx()), static_cast<size_t>(i * src_c_off)},
+                                            {static_cast<size_t>(vmm_src.getIdx())}, {}, load_pool_gpr_idxs);
 
                     if (isa == cpu::x64::sse41) {
                         movups(vmm_mask, vmm_max);
@@ -206,9 +213,8 @@ private:
         for (int i = 0; i < c_blocks; i++) {
             Vmm vmm_dst = get_acc_reg(i);
 
-            store_emitter->emit_code({static_cast<size_t>(vmm_dst.getIdx())}, {static_cast<size_t>(reg_output.getIdx())},
-                                     std::make_shared<store_emitter_context>(Precision::FP32, jpp_.dst_prc, step, i * dst_c_off),
-                                     store_pool_vec_idxs, store_pool_gpr_idxs);
+            store_emitter->emit_code({static_cast<size_t>(vmm_dst.getIdx()), static_cast<size_t>(i * dst_c_off)}, {static_cast<size_t>(reg_output.getIdx())},
+                                     get_local_store_pool_vec_idxs(vmm_dst), store_pool_gpr_idxs);
         }
     }
 
@@ -225,27 +231,22 @@ private:
 
         for (int i = 0; i < c_blocks; i++) {
             const int src_c_off = i * jpp_.ih * jpp_.iw * jpp_.c_block * jpp_.src_prc.size();
-            const auto load_context = std::make_shared<load_emitter_context>(jpp_.src_prc, Precision::FP32, step, src_c_off);
 
             mov(aux_reg_input, reg_input);
 
-            load_emitter->emit_code({static_cast<size_t>(aux_reg_input.getIdx())}, {static_cast<size_t>(vmm_src00.getIdx())},
-                                    load_context,
+            load_emitter->emit_code({static_cast<size_t>(aux_reg_input.getIdx()), static_cast<size_t>(src_c_off)}, {static_cast<size_t>(vmm_src00.getIdx())},
                                     {}, load_pool_gpr_idxs);
             add(aux_reg_input, reg_xoff);
 
-            load_emitter->emit_code({static_cast<size_t>(aux_reg_input.getIdx())}, {static_cast<size_t>(vmm_src01.getIdx())},
-                                    load_context,
+            load_emitter->emit_code({static_cast<size_t>(aux_reg_input.getIdx()), static_cast<size_t>(src_c_off)}, {static_cast<size_t>(vmm_src01.getIdx())},
                                     {}, load_pool_gpr_idxs);
 
             add(aux_reg_input, reg_yoff);
-            load_emitter->emit_code({static_cast<size_t>(aux_reg_input.getIdx())}, {static_cast<size_t>(vmm_src11.getIdx())},
-                                    load_context,
+            load_emitter->emit_code({static_cast<size_t>(aux_reg_input.getIdx()), static_cast<size_t>(src_c_off)}, {static_cast<size_t>(vmm_src11.getIdx())},
                                     {}, load_pool_gpr_idxs);
             sub(aux_reg_input, reg_xoff);
 
-            load_emitter->emit_code({static_cast<size_t>(aux_reg_input.getIdx())}, {static_cast<size_t>(vmm_src10.getIdx())},
-                                    load_context,
+            load_emitter->emit_code({static_cast<size_t>(aux_reg_input.getIdx()), static_cast<size_t>(src_c_off)}, {static_cast<size_t>(vmm_src10.getIdx())},
                                     {}, load_pool_gpr_idxs);
 
             uni_vsubps(vmm_src01, vmm_src01, vmm_src00);
@@ -259,9 +260,8 @@ private:
 
             const int dst_c_off = i * jpp_.oh * jpp_.ow * jpp_.c_block * jpp_.dst_prc.size();
 
-            store_emitter->emit_code({static_cast<size_t>(vmm_src11.getIdx())}, {static_cast<size_t>(reg_output.getIdx())},
-                                     std::make_shared<store_emitter_context>(Precision::FP32, jpp_.dst_prc, step, dst_c_off),
-                                     store_pool_vec_idxs, store_pool_gpr_idxs);
+            store_emitter->emit_code({static_cast<size_t>(vmm_src11.getIdx()), static_cast<size_t>(dst_c_off)}, {static_cast<size_t>(reg_output.getIdx())},
+                                     get_local_store_pool_vec_idxs(vmm_src11), store_pool_gpr_idxs);
         }
     }
 
@@ -270,9 +270,8 @@ private:
 
         const int dst_c_off = jpp_.oh * jpp_.ow * jpp_.c_block * jpp_.dst_prc.size();
         for (int i = 0; i < c_blocks; i++) {
-            store_emitter->emit_code({static_cast<size_t>(vmm_zero.getIdx())}, {static_cast<size_t>(reg_output.getIdx())},
-                                     std::make_shared<store_emitter_context>(jpp_.src_prc, jpp_.dst_prc, step, i * dst_c_off),
-                                     store_pool_vec_idxs, store_pool_gpr_idxs);
+            store_empty_roi_emitter->emit_code({static_cast<size_t>(vmm_zero.getIdx()), static_cast<size_t>(i * dst_c_off)},
+                                               {static_cast<size_t>(reg_output.getIdx())}, store_pool_vec_idxs, store_pool_gpr_idxs);
         }
     }
 

--- a/src/plugins/intel_cpu/src/utils/jit_kernel.hpp
+++ b/src/plugins/intel_cpu/src/utils/jit_kernel.hpp
@@ -697,11 +697,8 @@ struct jit_kernel : public dnnl::impl::cpu::x64::jit_generator {
 private:
     reg_indices _free_x64regs;
     reg_indices _free_rmmregs;
-    bool _is_load_emitter_used = false;
-    bool _is_store_emitter_used = false;
-    jit_load_emitter _load_emitter;
-    jit_store_emitter _store_emitter;
     internal::consts_table _consts;
+    std::unordered_map<size_t, std::unique_ptr<jit_emitter>> _emitters;
 };
 
 template<typename T>
@@ -746,17 +743,18 @@ void jit_kernel::load(const variable<DstT[N]> & dst, const variable<SrcT> & src,
     const std::vector<size_t> pool_vec_idxs(_free_rmmregs.begin(), _free_rmmregs.end());
     const std::vector<size_t> pool_gpr_idxs(_free_x64regs.begin(), _free_x64regs.end());
 
-    _load_emitter.emit_code(
+    const auto src_prc = internal::type2precision<src_type>();
+    const auto dst_prc = internal::type2precision<dst_type>();
+
+    const auto key = load_emitter_params(src_prc, dst_prc, length).hash();
+    if (!_emitters[key]) {
+        _emitters[key].reset(new jit_load_emitter(this, internal::get_current_isa(), src_prc, dst_prc, length));
+    }
+    _emitters[key]->emit_code(
         { static_cast<size_t>(static_cast<const Xbyak::Operand&>(src).getIdx()) },
         { static_cast<size_t>(static_cast<const Xbyak::Operand&>(dst).getIdx()) },
-        std::make_shared<load_emitter_context>(
-            internal::type2precision<src_type>(),
-            internal::type2precision<dst_type>(),
-            static_cast<int>(length)),
         pool_vec_idxs,
         pool_gpr_idxs);
-
-    _is_load_emitter_used = true;
 }
 
 template<typename DstT, size_t N, typename SrcT>
@@ -788,17 +786,18 @@ void jit_kernel::store(const variable<DstT> & dst, const variable<SrcT[N]> & src
     const std::vector<size_t> pool_vec_idxs(_free_rmmregs.begin(), _free_rmmregs.end());
     const std::vector<size_t> pool_gpr_idxs(_free_x64regs.begin(), _free_x64regs.end());
 
-    _store_emitter.emit_code(
+    const auto src_prc = internal::type2precision<src_type>();
+    const auto dst_prc = internal::type2precision<dst_type>();
+
+    const auto key = store_emitter_params(src_prc, dst_prc, length).hash();
+    if (!_emitters[key]) {
+        _emitters[key].reset(new jit_store_emitter(this, internal::get_current_isa(), src_prc, dst_prc, length));
+    }
+    _emitters[key]->emit_code(
         { static_cast<size_t>(static_cast<const Xbyak::Operand&>(src).getIdx()) },
         { static_cast<size_t>(static_cast<const Xbyak::Operand&>(dst).getIdx()) },
-        std::make_shared<store_emitter_context>(
-            internal::type2precision<src_type>(),
-            internal::type2precision<dst_type>(),
-            static_cast<int>(length)),
         pool_vec_idxs,
         pool_gpr_idxs);
-
-    _is_store_emitter_used = true;
 }
 
 template<typename DstT, typename SrcT, size_t N>

--- a/src/tests/unit/cpu/jit_kernel_test.cpp
+++ b/src/tests/unit/cpu/jit_kernel_test.cpp
@@ -318,15 +318,30 @@ private:
 };
 
 TEST(JitKernel, variable_load_and_store) {
-    jit_variable_load_store_test_kernel<uint8_t, float> kernel;
-    if (mayiuse(cpu_isa_t::avx512_core)) {
-        kernel.test<16>();
+    {
+        jit_variable_load_store_test_kernel<uint8_t, float> kernel;
+        if (mayiuse(cpu_isa_t::avx512_core)) {
+            kernel.test<16>();
+        }
+        if (mayiuse(cpu_isa_t::avx2)) {
+            kernel.test<8>();
+        }
+        if (mayiuse(cpu_isa_t::sse41)) {
+            kernel.test<4>();
+        }
     }
-    if (mayiuse(cpu_isa_t::avx2)) {
-        kernel.test<8>();
-    }
-    if (mayiuse(cpu_isa_t::sse41)) {
-        kernel.test<4>();
+
+    {
+        jit_variable_load_store_test_kernel<int8_t, int8_t> kernel;
+        if (mayiuse(cpu_isa_t::avx512_core)) {
+            kernel.test<16>();
+        }
+        if (mayiuse(cpu_isa_t::avx2)) {
+            kernel.test<8>();
+        }
+        if (mayiuse(cpu_isa_t::sse41)) {
+            kernel.test<4>();
+        }
     }
 }
 


### PR DESCRIPTION
### Details:
 - *Removed contexts from Load/Store emitters. At the moment `Store` [pollutes](https://github.com/openvinotoolkit/openvino/blob/af05733a3a8ee249a6be23ae3862c4b49005115a/src/plugins/intel_cpu/src/emitters/jit_load_store_emitters.cpp#L587) `src_vmm` register in cases when src and dst precisions are different. So in the next stage in jit pipeline our `src_vmm` can be broken. To avoid additional `aux_vmm` in each store emitter this PR removes contexts to create exact emitter using ctor. Thus, count of aux registers is known it the moment emitter creation and this count is different for each case (at the moment in master `Store` and `Load` emitters have hardcoded count of aux regs*
 - *Updated `Interpolate`, `MVN`, `NMS`, `ROI Align`, `ROI Pooling`, `TopK`, `ColorConvert`*

### Tickets:
 - *89024*
