### PR TITLE
[GPU] Enable cldnn covert nv12 input to gray format to support one ch…

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reorder.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reorder.hpp
@@ -24,6 +24,13 @@ enum class reorder_mean_mode {
     div,       // val/mean
 };
 
+/// @brief channel operation modes
+enum class channel_mode {
+    none,      // none
+    one,       // 1
+    three,     // 3
+};
+
 /// @brief Changes how data is ordered in memory. Value type is not changed & all information is preserved.
 /// @details Corresponding values are bitwise equal before/after reorder.
 /// Also merged with subtraction layer, which can subtract, multiply or divide values based on mean_mode value, while doing reordering.
@@ -46,7 +53,9 @@ struct reorder : public primitive_base<reorder> {
           output_format(output_layout.format),
           mean(""),
           subtract_per_feature(values_to_subtract),
-          mean_mode(mode) {}
+          mean_mode(mode) {
+              output_channels = channel_mode::three;
+          }
 
     /// @brief Constructs reorder primitive which takes mean subtract values from another primitive.
     /// @param id This primitive id.
@@ -63,7 +72,9 @@ struct reorder : public primitive_base<reorder> {
           output_format(output_layout.format),
           mean(mean),
           subtract_per_feature(0),
-          mean_mode(mode) {}
+          mean_mode(mode) {
+              output_channels = channel_mode::three;
+          }
 
     /// @brief Constructs reorder primitive with directly provided mean subtract values.
     /// @param id This primitive id.
@@ -82,7 +93,9 @@ struct reorder : public primitive_base<reorder> {
           output_format(output_format),
           mean(""),
           subtract_per_feature(values_to_subtract),
-          mean_mode(mode) {}
+          mean_mode(mode) {
+              output_channels = channel_mode::three;
+          }
 
     /// @brief Constructs reorder primitive which takes mean subtract values from another primitive.
     /// @param id This primitive id.
@@ -101,7 +114,9 @@ struct reorder : public primitive_base<reorder> {
           output_format(output_format),
           mean(mean),
           subtract_per_feature(0),
-          mean_mode(mode) {}
+          mean_mode(mode) {
+              output_channels = channel_mode::three;
+          }
 
     /// @brief Constructs reorder primitive with two inputs and directly provided mean subtract values.
     /// @param id This primitive id.
@@ -120,7 +135,9 @@ struct reorder : public primitive_base<reorder> {
           output_format(output_layout.format),
           mean(""),
           subtract_per_feature(values_to_subtract),
-          mean_mode(mode) {}
+          mean_mode(mode) {
+              output_channels = channel_mode::three;
+          }
 
     /// @brief Constructs reorder primitive with two inputs, which takes mean subtract values from another primitive.
     /// @param id This primitive id.
@@ -138,7 +155,9 @@ struct reorder : public primitive_base<reorder> {
         : primitive_base(id, { input, input2 }, ext_prim_id, output_layout.data_padding, optional_data_type{ output_layout.data_type }),
         output_format(output_layout.format),
         mean(mean),
-        mean_mode(mode) {}
+        mean_mode(mode) {
+            output_channels = channel_mode::three;
+        }
 
     /// @brief Requested memory format.
     format output_format;
@@ -148,6 +167,8 @@ struct reorder : public primitive_base<reorder> {
     std::vector<float> subtract_per_feature;
     /// @brief Mode of mean execution
     reorder_mean_mode mean_mode;
+    /// @brief Mode of output channels
+    channel_mode output_channels;
 
 protected:
     std::vector<std::reference_wrapper<const primitive_id>> get_dependencies() const override {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -403,6 +403,13 @@ void insert_reorders_in_dir(program& p, const std::map<program_node*, format::ty
         auto reorder = reorder_pair.first;
 
         if (reorder) {
+            if (node->is_type<cldnn::reorder>()) {
+                auto reorder_prim = node->as<cldnn::reorder>().get_primitive();
+                if (reorder_prim->output_channels == cldnn::channel_mode::one && in_layout.format.value == cldnn::format::nv12) {
+                    reorder->output_channels = cldnn::channel_mode::one;
+                }
+            }
+
             auto& reorder_node = p.get_or_create(reorder);
             p.add_intermediate(reorder_node,
                                *travel_direction_wrapper<dir>::second(node, next),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
@@ -100,6 +100,9 @@ public:
 
         reorder_params.winograd = impl_param->input_layouts[0].format.is_winograd() || output_layout.format.is_winograd();
 
+        if (output_layout.feature() == 1 && arg.get_org_primitive_id().find("_cldnn_input_preprocess") != std::string::npos)
+            reorder_params.output_one_channel = true;
+
         auto& kernel_selector = kernel_selector::reorder_kernel_selector::Instance();
         auto best_kernels = kernel_selector.GetBestKernels(reorder_params, reorder_optional_params);
 

--- a/src/plugins/intel_gpu/src/graph/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/reorder.cpp
@@ -34,7 +34,10 @@ layout reorder_inst::calc_output_layout(reorder_node const& node, kernel_impl_pa
     }
 
     if (ifmt.is_nv12()) {
-        auto data_size = tensor{ input_layout.batch(), input_layout.feature() * 3,
+        auto output_feature = input_layout.feature() * 3;
+        if(node.get_primitive()->output_channels == channel_mode::one)
+            output_feature = 1;
+        auto data_size = tensor{ input_layout.batch(), output_feature,
                                  input_layout.spatial(0), input_layout.spatial(1) };
         if (ofmt != ifmt)
             return layout(odt, ofmt, data_size, op);

--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/reorder/reorder_biplanar_nv12.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/reorder/reorder_biplanar_nv12.cpp
@@ -24,6 +24,8 @@ ParamsKey reorder_biplanar_nv12::GetSupportedKey() const {
 JitConstants reorder_biplanar_nv12::GetJitConstants(const reorder_params& params) const {
     auto jit = ReorderKernelBase::GetJitConstants(params);
     jit.Merge(GetTensorFriendlyWorkGroupsJit(params.inputs[0]));
+    if(params.output_one_channel)
+        jit.AddConstant(MakeJitConstant("OUTPUT_ONE_CHANNEL", 1));
     return jit;
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/reorder/reorder_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/reorder/reorder_kernel_base.h
@@ -25,6 +25,7 @@ struct reorder_params : public base_params {
     uint32_t winograd_nr_tiles_x;
     bool winograd = false;
     bool has_padded_output = false;
+    bool output_one_channel = false;
 
     ParamsKey GetParamsKey() const override {
         auto k = base_params::GetParamsKey();

--- a/src/plugins/intel_gpu/src/kernel_selector/core/cl_kernels/reorder_biplanar_nv12.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/cl_kernels/reorder_biplanar_nv12.cl
@@ -69,6 +69,13 @@ KERNEL(reorder_biplanar_nv12)(
 #endif
 
     float4 Y = read_imagef(input, (int2)(x, y));
+#if defined OUTPUT_ONE_CHANNEL
+    float gray = Y.x;
+
+    uint8 ov = RESHAPE_DIMS(INPUT0, OUTPUT, b, 0, w, z, y, x);
+    uint output_idx = FUNC_CALL(get_output_index)(ov[1], ov[2], ov[3], ov[4], ov[5], ov[6]);
+    output[output_idx] = ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_TYPE(gray), NL_M, NL_N);
+#else
     float4 UV = read_imagef(input_uv, (int2)(x / 2, y / 2));
 
     float Ycomponent = mad(Y.x, 296.82f, -18.624f);
@@ -106,5 +113,6 @@ KERNEL(reorder_biplanar_nv12)(
     output_idx = FUNC_CALL(get_output_index)(ov[1], ov[2], ov[3], ov[4], ov[5], ov[6]);
     output[output_idx] = ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_TYPE(B), NL_M, NL_N);
 
+#endif
 
     }

--- a/src/plugins/intel_gpu/src/plugin/ops/parameter.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/parameter.cpp
@@ -257,23 +257,29 @@ static void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::
                 switch (preProcess.getMeanVariant()) {
                 case NONE:
                 case MEAN_VALUE: {
-                    p.AddPrimitive(cldnn::reorder(preprocessPrimID,
-                                                  y_name,
-                                                  uv_name,
-                                                  networkInputLayout,
-                                                  meanValues,
-                                                  cldnn::reorder_mean_mode::subtract,
-                                                  inputInfo->name()));
+                    auto preprocessPrim = cldnn::reorder(preprocessPrimID,
+                                              y_name,
+                                              uv_name,
+                                              networkInputLayout,
+                                              meanValues,
+                                              cldnn::reorder_mean_mode::subtract,
+                                              inputInfo->name());
+                    if(inputDims[1] == 1)
+                        preprocessPrim.output_channels = cldnn::channel_mode::one;
+                    p.AddPrimitive(preprocessPrim);
                     break;
                 }
                 case MEAN_IMAGE: {
-                    p.AddPrimitive(cldnn::reorder(preprocessPrimID,
-                                                  y_name,
-                                                  uv_name,
-                                                  networkInputLayout,
-                                                  meanBlobID,
-                                                  cldnn::reorder_mean_mode::subtract,
-                                                  inputInfo->name()));
+                    auto preprocessPrim = cldnn::reorder(preprocessPrimID,
+                                              y_name,
+                                              uv_name,
+                                              networkInputLayout,
+                                              meanBlobID,
+                                              cldnn::reorder_mean_mode::subtract,
+                                              inputInfo->name());
+                    if(inputDims[1] == 1)
+                        preprocessPrim.output_channels = cldnn::channel_mode::one;
+                    p.AddPrimitive(preprocessPrim);
                     break;
                 }
                 default: IE_THROW(Unexpected) << "Invalid mean variant in input " + inputName;


### PR DESCRIPTION
…annel input models to uses vaapi-surface-sharing on dlstreamer

Signed-off-by: Wei Tang <wei1.tang@intel.com>
Co-authored-by: Chen Kurt <kurt.chen@intel.com>

### Details:
 - *dlstreamer use vaapi-surface-sharing and give NV12 input to openvino, openvino will use reorder_biplanar_nv12.cl*
 - *reorder_biplanar_nv12.cl don't support one channel*

### Tickets:
 - 88454
