### PR TITLE
refine auto config and enable default config values

### DIFF
--- a/src/plugins/auto/plugin.hpp
+++ b/src/plugins/auto/plugin.hpp
@@ -14,6 +14,7 @@
 #include <cpp_interfaces/interface/ie_internal_plugin_config.hpp>
 #include "utils/log_util.hpp"
 #include "common.hpp"
+#include "utils/config.hpp"
 
 #ifdef  MULTIUNITTEST
 #define MOCKTESTMACRO virtual
@@ -65,9 +66,7 @@ private:
                                                                        InferenceEngine::CNNNetwork network,
                                                                        const std::map<std::string, std::string>& config,
                                                                        const std::string &networkPrecision = METRIC_VALUE(FP32));
-    static void CheckConfig(const std::map<std::string, std::string>& config,
-                            AutoScheduleContext::Ptr& context,
-                            std::map<std::string, std::string>& filterConfig);
+    PluginConfig _pluginConfig;
     std::vector<DeviceInformation> FilterDevice(const std::vector<DeviceInformation>& metaDevices,
                                                 const std::map<std::string, std::string>& config);
     std::vector<DeviceInformation> FilterDeviceByNetwork(const std::vector<DeviceInformation>& metaDevices,
@@ -76,7 +75,6 @@ private:
     static std::mutex _mtx;
     static std::map<unsigned int, std::list<std::string>> _priorityMap;
     std::string _LogTag;
-    static std::set<std::string> _availableDevices;
 };
 
 }  // namespace MultiDevicePlugin

--- a/src/plugins/auto/utils/config.hpp
+++ b/src/plugins/auto/utils/config.hpp
@@ -1,0 +1,172 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <ie_parameter.hpp>
+#include <ie_performance_hints.hpp>
+#include "log.hpp"
+#include <string>
+#include <map>
+#include <vector>
+
+namespace MultiDevicePlugin {
+using namespace InferenceEngine;
+
+struct PluginConfig {
+    PluginConfig():
+                _useProfiling(false),
+                _exclusiveAsyncRequests(false),
+                _disableAutoBatching(false),
+                _batchTimeout(0),
+                _devicePriority(""),
+                _modelPriority(0),
+                _deviceBindBuffer(false),
+                _logLevel("LOG_NONE") {
+        _perfHintsConfig.SetConfig(CONFIG_KEY(PERFORMANCE_HINT), CONFIG_VALUE(THROUGHPUT));
+        _perfHintsConfig.SetConfig(CONFIG_KEY(PERFORMANCE_HINT_NUM_REQUESTS), "0");
+        adjustKeyMapValues();
+    }
+
+    void UpdateFromMap(const std::map<std::string, std::string>& config, const std::string& pluginName, bool checkValid = true) {
+        const auto perf_hints_configs = PerfHintsConfig::SupportedKeys();
+        for (auto&& kvp : config) {
+            if (kvp.first == ov::enable_profiling) {
+                if (kvp.second == PluginConfigParams::YES) {
+                    _useProfiling = true;
+                } else if (kvp.second == PluginConfigParams::NO) {
+                    _useProfiling = false;
+                } else {
+                    IE_THROW() << "Unsupported config value: " << kvp.second
+                            << " for key: " << kvp.first;
+                }
+            } else if (kvp.first == PluginConfigParams::KEY_EXCLUSIVE_ASYNC_REQUESTS) {
+                if (kvp.second == PluginConfigParams::YES) _exclusiveAsyncRequests = true;
+                else if (kvp.second == PluginConfigParams::NO) _exclusiveAsyncRequests = false;
+                else
+                    IE_THROW() << "Unsupported config value: " << kvp.second
+                            << " for key: " << kvp.first;
+            } else if (kvp.first == ov::log::level.name()) {
+                _logLevel = kvp.second;
+                auto success = setLogLevel(_logLevel);
+                if (!success) {
+                    IE_THROW() << "Unsupported config value: " << kvp.second
+                                << " for key: " << kvp.first;
+                }
+            } else if (kvp.first == ov::hint::model_priority) {
+                if (kvp.second == "LOW" ||
+                    kvp.second == CONFIG_VALUE(MODEL_PRIORITY_LOW)) {
+                    _modelPriority = 2;
+                } else if (kvp.second == "MEDIUM" ||
+                    kvp.second == CONFIG_VALUE(MODEL_PRIORITY_MED)) {
+                    _modelPriority = 1;
+                } else if (kvp.second == "HIGH" ||
+                    kvp.second == CONFIG_VALUE(MODEL_PRIORITY_HIGH)) {
+                    _modelPriority = 0;
+                } else {
+                    IE_THROW() << "Unsupported config value: " << kvp.second
+                        << " for key: " << kvp.first;
+                }
+            } else if (kvp.first == ov::hint::allow_auto_batching) {
+                if (kvp.second == PluginConfigParams::NO) _disableAutoBatching = true;
+                else if (kvp.second == PluginConfigParams::YES) _disableAutoBatching = false;
+                else
+                    IE_THROW() << "Unsupported config value: " << kvp.second
+                            << " for key: " << kvp.first;
+            } else if (kvp.first == ov::auto_batch_timeout) {
+                try {
+                    auto _batchTimeout = std::stoi(kvp.second);
+                    if (_batchTimeout < 0) {
+                        IE_THROW() << "Unsupported config value: " << kvp.second
+                            << " for key: " << kvp.first;
+                    }
+                } catch (...) {
+                    IE_THROW() << "Unsupported config value: " << kvp.second
+                            << " for key: " << kvp.first;
+                }
+            } else if (kvp.first == ov::intel_auto::device_bind_buffer.name()) {
+                if (kvp.second == PluginConfigParams::YES) _deviceBindBuffer = true;
+                else if (kvp.second == PluginConfigParams::NO) _deviceBindBuffer = false;
+                else
+                    IE_THROW() << "Unsupported config value: " << kvp.second
+                            << " for key: " << kvp.first;
+            } else if (kvp.first == ov::device::priorities.name()) {
+                _devicePriority = kvp.second;
+            } else if (std::find(perf_hints_configs.begin(), perf_hints_configs.end(), kvp.first) != perf_hints_configs.end()) {
+                _perfHintsConfig.SetConfig(kvp.first, kvp.second);
+            } else if (_availableDevices.end() !=
+                   std::find(_availableDevices.begin(), _availableDevices.end(), kvp.first)) {
+                _passThroughConfig.emplace(kvp.first, kvp.second);
+            } else if (kvp.first.find("AUTO_") == 0) {
+                _passThroughConfig.emplace(kvp.first, kvp.second);
+            } else {
+                if (pluginName.find("AUTO") != std::string::npos || checkValid)
+                    IE_THROW(NotFound) << "Unsupported property " << kvp.first;
+                else
+                    _passThroughConfig.emplace(kvp.first, kvp.second);
+            }
+        }
+        if (!config.empty())
+            _keyConfigMap.clear();
+        adjustKeyMapValues();
+    }
+    void adjustKeyMapValues() {
+        if (_useProfiling) {
+            _keyConfigMap[PluginConfigParams::KEY_PERF_COUNT] = PluginConfigParams::YES;
+        } else {
+            _keyConfigMap[PluginConfigParams::KEY_PERF_COUNT] = PluginConfigParams::NO;
+        }
+        if (_exclusiveAsyncRequests)
+            _keyConfigMap[PluginConfigParams::KEY_EXCLUSIVE_ASYNC_REQUESTS] = PluginConfigParams::YES;
+        else
+            _keyConfigMap[PluginConfigParams::KEY_EXCLUSIVE_ASYNC_REQUESTS] = PluginConfigParams::NO;
+        {
+            std::string priority;
+            if (_modelPriority == 0)
+                priority = ov::util::to_string(ov::hint::Priority::HIGH);
+            else if (_modelPriority == 1)
+                priority = ov::util::to_string(ov::hint::Priority::MEDIUM);
+            else
+                priority = ov::util::to_string(ov::hint::Priority::LOW);
+            _keyConfigMap[ov::hint::model_priority.name()] = priority;
+        }
+        _keyConfigMap[PluginConfigParams::KEY_PERFORMANCE_HINT] = _perfHintsConfig.ovPerfHint;
+        _keyConfigMap[PluginConfigParams::KEY_PERFORMANCE_HINT_NUM_REQUESTS] = std::to_string(_perfHintsConfig.ovPerfHintNumRequests);
+
+        _keyConfigMap[ov::device::priorities.name()] = _devicePriority;
+
+        if (_disableAutoBatching)
+            _keyConfigMap[ov::hint::allow_auto_batching.name()] = PluginConfigParams::NO;
+        else
+            _keyConfigMap[ov::hint::allow_auto_batching.name()] = PluginConfigParams::YES;
+        if (_deviceBindBuffer)
+            _keyConfigMap[ov::intel_auto::device_bind_buffer.name()] = PluginConfigParams::YES;
+        else
+            _keyConfigMap[ov::intel_auto::device_bind_buffer.name()] = PluginConfigParams::NO;
+
+        _keyConfigMap[ov::auto_batch_timeout.name()] = _batchTimeout;
+
+        _keyConfigMap[ov::log::level.name()] = _logLevel;
+
+        // for 2nd properties or independent configs from multi
+        for (auto && kvp : _passThroughConfig) {
+            _keyConfigMap[kvp.first] = kvp.second;
+        }
+    }
+    static bool isNewApiProperty(std::string property);
+    bool _useProfiling;
+    bool _exclusiveAsyncRequests;
+    bool _disableAutoBatching;
+    uint _batchTimeout;
+    std::string _devicePriority;
+    int _modelPriority;
+    bool _deviceBindBuffer;
+    std::string _logLevel;
+    PerfHintsConfig  _perfHintsConfig;
+    std::map<std::string, std::string> _passThroughConfig;
+    std::map<std::string, std::string> _keyConfigMap;
+    const std::set<std::string> _availableDevices = {"CPU", "GPU", "GNA", "TEMPLATE", "MYRAID", "HDDL", "VPUX", "MULTI", "HETERO", "CUDA", "HPU_GOYA"};
+};
+} // namespace MultiDevicePlugin

--- a/src/plugins/auto/utils/config.hpp
+++ b/src/plugins/auto/utils/config.hpp
@@ -20,17 +20,15 @@ struct PluginConfig {
                 _useProfiling(false),
                 _exclusiveAsyncRequests(false),
                 _disableAutoBatching(false),
-                _batchTimeout(0),
+                _batchTimeout("1000"),
                 _devicePriority(""),
                 _modelPriority(0),
                 _deviceBindBuffer(false),
                 _logLevel("LOG_NONE") {
-        _perfHintsConfig.SetConfig(CONFIG_KEY(PERFORMANCE_HINT), CONFIG_VALUE(THROUGHPUT));
-        _perfHintsConfig.SetConfig(CONFIG_KEY(PERFORMANCE_HINT_NUM_REQUESTS), "0");
         adjustKeyMapValues();
     }
 
-    void UpdateFromMap(const std::map<std::string, std::string>& config, const std::string& pluginName, bool checkValid = true) {
+    void UpdateFromMap(const std::map<std::string, std::string>& config, const std::string& pluginName, bool checkValid = false) {
         const auto perf_hints_configs = PerfHintsConfig::SupportedKeys();
         for (auto&& kvp : config) {
             if (kvp.first == ov::enable_profiling) {
@@ -77,11 +75,12 @@ struct PluginConfig {
                             << " for key: " << kvp.first;
             } else if (kvp.first == ov::auto_batch_timeout) {
                 try {
-                    auto _batchTimeout = std::stoi(kvp.second);
-                    if (_batchTimeout < 0) {
+                    auto batchTimeout = std::stoi(kvp.second);
+                    if (batchTimeout < 0) {
                         IE_THROW() << "Unsupported config value: " << kvp.second
                             << " for key: " << kvp.first;
                     }
+                    _batchTimeout = kvp.second;
                 } catch (...) {
                     IE_THROW() << "Unsupported config value: " << kvp.second
                             << " for key: " << kvp.first;
@@ -155,11 +154,10 @@ struct PluginConfig {
             _keyConfigMap[kvp.first] = kvp.second;
         }
     }
-    static bool isNewApiProperty(std::string property);
     bool _useProfiling;
     bool _exclusiveAsyncRequests;
     bool _disableAutoBatching;
-    uint _batchTimeout;
+    std::string _batchTimeout;
     std::string _devicePriority;
     int _modelPriority;
     bool _deviceBindBuffer;

--- a/src/tests/functional/plugin/cpu/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/src/tests/functional/plugin/cpu/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -20,7 +20,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVPropertiesTests,
         ::testing::Combine(
                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
                 ::testing::ValuesIn(cpu_properties)),
-        OVPropertiesDefaultTests::getTestCaseName);
+        OVPropertiesTests::getTestCaseName);
 
 const std::vector<ov::AnyMap> multi_Auto_properties = {
         {ov::device::priorities(CommonTestUtils::DEVICE_CPU), ov::hint::performance_mode(ov::hint::PerformanceMode::UNDEFINED)},
@@ -73,4 +73,19 @@ INSTANTIATE_TEST_SUITE_P(smoke_AutoMultiCompileModelBehaviorTests,
                                             ::testing::ValuesIn(auto_multi_plugin_properties),
                                             ::testing::ValuesIn(auto_multi_compileModel_properties)),
                          OVSetPropComplieModleGetPropTests::getTestCaseName);
+
+const std::vector<ov::AnyMap> default_properties = {
+        {ov::enable_profiling(false)},
+        {ov::log::level("LOG_NONE")},
+        {ov::hint::model_priority(ov::hint::Priority::HIGH)},
+        {ov::hint::allow_auto_batching(true)},
+        {ov::auto_batch_timeout("1000")},
+        {ov::intel_auto::device_bind_buffer(false)},
+        {ov::device::priorities("")}
+};
+INSTANTIATE_TEST_SUITE_P(smoke_AutoBehaviorTests, OVPropertiesDefaultTests,
+        ::testing::Combine(
+                ::testing::Values(CommonTestUtils::DEVICE_AUTO),
+                ::testing::ValuesIn(default_properties)),
+        OVPropertiesDefaultTests::getTestCaseName);
 } // namespace

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -20,7 +20,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVPropertiesTests,
         ::testing::Combine(
                 ::testing::Values(CommonTestUtils::DEVICE_GPU),
                 ::testing::ValuesIn(gpu_properties)),
-        OVPropertiesDefaultTests::getTestCaseName);
+        OVPropertiesTests::getTestCaseName);
 
 const std::vector<ov::AnyMap> auto_multi_properties = {
         {ov::device::priorities(CommonTestUtils::DEVICE_GPU), ov::hint::performance_mode(ov::hint::PerformanceMode::UNDEFINED)},

--- a/src/tests/unit/auto/auto_select_device_failed_test.cpp
+++ b/src/tests/unit/auto/auto_select_device_failed_test.cpp
@@ -203,7 +203,8 @@ TEST_P(AutoLoadFailedTest, LoadCNNetWork) {
                 break;
             case LATENCY:
                 devInfo = {deviceName, {{CONFIG_KEY(PERFORMANCE_HINT),
-                    InferenceEngine::PluginConfigParams::LATENCY}}, 2, ""};
+                    InferenceEngine::PluginConfigParams::LATENCY}, {CONFIG_KEY(ALLOW_AUTO_BATCHING), "YES"}, {CONFIG_KEY(AUTO_BATCH_TIMEOUT), "1000"}},
+                    2, ""};
                 break;
             case THROUGHPUT:
                 devInfo = {deviceName, {{CONFIG_KEY(PERFORMANCE_HINT),


### PR DESCRIPTION
Signed-off-by: fishbell <bell.song@intel.com>

### Details:
 - refine config
 - return default values for config and enable tests
 - support 2.0 API for getConfig

### Tickets:
 - 84420
