### PR TITLE
[GPU] Disable TCs for OVClassHeteroExecutableNetworkGetMetricTest

### DIFF
--- a/src/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
@@ -93,5 +93,7 @@ std::vector<std::string> disabledTestPatterns() {
             R"(.*smoke_Auto_BehaviorTests.*InferDynamicNetwork/.*)",
             // Issue: CVS-86976
             R"(.*smoke_VirtualPlugin_BehaviorTests.*LoadedRemoteContext.*)",
+            // Issue: CVS-88667 - Need to verify hetero interoperability
+            R"(.*nightly_OVClassHeteroExecutableNetworlGetMetricTest.*SUPPORTED_(CONFIG_KEYS|METRICS).*)",
     };
 }


### PR DESCRIPTION
### Details:
 - Disable TCs(_SUPPORTED_CONFIG_KEYS/METRICS) for OVClassHeteroExecutableNetworkGetMetricTest same as GPU and GNA plugin
 - This is the same change with https://github.com/openvinotoolkit/openvino/pull/12433

### Tickets:
 - 88667
