### PR TITLE
[GPU] Fix network loading time related to onednn engine creation

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/stream.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/stream.hpp
@@ -44,7 +44,7 @@ public:
     static queue_types detect_queue_type(engine_types engine_type, void* queue_handle);
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
-    virtual dnnl::stream& get_onednn_stream() = 0;
+    virtual dnnl::stream& get_onednn_stream() const = 0;
 #endif
 
 protected:

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.hpp
@@ -44,7 +44,8 @@ public:
     stream& get_program_stream() const override;
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
-    /// Returns onednn engine object which shares device and context with current engine
+    // Returns onednn engine object which shares device and context with current engine
+    // If onednn engine has not been created yet, it creates on-demand.
     dnnl::engine& get_onednn_engine() const override;
 #endif
 
@@ -57,7 +58,8 @@ private:
     std::unique_ptr<cl::UsmHelper> _usm_helper;
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
-    std::shared_ptr<dnnl::engine> _onednn_engine;
+    mutable std::mutex onednn_mutex;
+    mutable std::shared_ptr<dnnl::engine> _onednn_engine;
 #endif
 };
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
@@ -289,6 +289,7 @@ ocl_stream::ocl_stream(const ocl_engine &engine)
     queue_builder.set_supports_queue_families(queue_families_extension);
 
     _command_queue = queue_builder.build(context, device);
+
 #ifdef ENABLE_ONEDNN_FOR_GPU
     if (config.queue_type == queue_types::in_order) {
         auto onednn_engine = engine.get_onednn_engine();
@@ -317,9 +318,10 @@ ocl_stream::ocl_stream(const ocl_engine &engine, void *handle)
 }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
-dnnl::stream& ocl_stream::get_onednn_stream() {
+dnnl::stream& ocl_stream::get_onednn_stream() const {
     if (!_onednn_stream)
         throw std::runtime_error("[GPU] onednn stream is nullptr");
+
     return *_onednn_stream;
 }
 #endif

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.hpp
@@ -83,7 +83,7 @@ public:
     static queue_types detect_queue_type(void* queue_handle);
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
-    dnnl::stream& get_onednn_stream() override;
+    dnnl::stream& get_onednn_stream() const override;
 #endif
 
 private:


### PR DESCRIPTION
+ benchmark cache_dir option takes longer than cl_cache_dir env in loading network.
+ For clDNN execution, benchmark cache_dir created onednn_engine if just ONEDNN_ENABLE config is ON.
+ Creation of onednn_engine in ocl_engine is changed to on-demand.

Signed-off-by: Min, Byungil <byungil.min@intel.com>

### Details:
 - *item1*
 - *...*

### Tickets:
 - 87811
