### PR TITLE
Interpolate I8 nearest planar

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/jit_load_store_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/jit_load_store_emitters.cpp
@@ -77,6 +77,18 @@ size_t jit_load_emitter::aux_gprs_count() const {
     return count;
 }
 
+/**
+ * @brief Removes offset value from in_idxs and then calls parent's function
+ */
+void jit_load_emitter::emitter_preamble(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
+                                   const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs) const {
+    std::vector<size_t> in_idxs_clean = in_idxs;
+    if (in_idxs.size() == 2) {
+        in_idxs_clean.pop_back();
+    }
+    jit_emitter::emitter_preamble(in_idxs_clean, out_idxs, pool_vec_idxs, pool_gpr_idxs);
+}
+
 void jit_load_emitter::emit_impl(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
                                  const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs,
                                  const emitter_context *emit_context) const {
@@ -618,6 +630,18 @@ void jit_store_emitter::emit_data() const {
     jit_emitter::emit_data();
     if (uni_vcvtneps2bf16_)
         uni_vcvtneps2bf16_->emit_data();
+}
+
+/**
+ * @brief Removes offset value from in_idxs and then calls parent's function
+ */
+void jit_store_emitter::emitter_preamble(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
+                                   const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs) const {
+    std::vector<size_t> in_idxs_clean = in_idxs;
+    if (in_idxs.size() == 2) {
+        in_idxs_clean.pop_back();
+    }
+    jit_emitter::emitter_preamble(in_idxs_clean, out_idxs, pool_vec_idxs, pool_gpr_idxs);
 }
 
 void jit_store_emitter::emit_impl(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,

--- a/src/plugins/intel_cpu/src/emitters/jit_load_store_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/jit_load_store_emitters.hpp
@@ -74,6 +74,10 @@ public:
 
     size_t get_inputs_num() const override;
 
+protected:
+    void emitter_preamble(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
+                          const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs) const override;
+
 private:
     template <dnnl::impl::cpu::x64::cpu_isa_t isa>
     void emit_isa(const Xbyak::Reg64 &reg_src,  const int out_vec_idx, const int offset) const;
@@ -136,6 +140,10 @@ public:
     std::shared_ptr<jit_uni_vcvtneps2bf16> get_uni_vcvtneps2bf16() const {
         return uni_vcvtneps2bf16_;
     }
+
+protected:
+    void emitter_preamble(const std::vector<size_t> &in_idxs, const std::vector<size_t> &out_idxs,
+                          const std::vector<size_t> &pool_vec_idxs, const std::vector<size_t> &pool_gpr_idxs) const override;
 
 private:
     template <dnnl::impl::cpu::x64::cpu_isa_t isa>

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -47,10 +47,10 @@ namespace intel_cpu {
 namespace node {
 
 template <cpu_isa_t isa>
-struct jit_uni_interpolate_kernel_f32 : public jit_uni_interpolate_kernel, public jit_generator {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_interpolate_kernel_f32)
+struct jit_uni_interpolate_kernel_f32_i8 : public jit_uni_interpolate_kernel, public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_interpolate_kernel_f32_i8)
 
-    explicit jit_uni_interpolate_kernel_f32(jit_interpolate_config_params jcp, const dnnl_primitive_attr &attr)
+    explicit jit_uni_interpolate_kernel_f32_i8(jit_interpolate_config_params jcp, const dnnl_primitive_attr &attr)
     : jit_uni_interpolate_kernel(jcp, attr), jit_generator(jit_name()) {}
 
     void create_ker() override {
@@ -297,6 +297,12 @@ private:
     }
 
     void nn_planar() {
+        const bool is_i8 = jcp_.src_prc == InferenceEngine::Precision::I8
+                           && jcp_.dst_prc == InferenceEngine::Precision::I8;
+
+        if (is_i8 && attr_.post_ops_.len() != 0) {
+            IE_THROW() << "Interpolate I8 doesn't support fusing";
+        }
         Xbyak::Reg64 reg_index_h = reg_src_aux1;
         Xbyak::Reg64 reg_index_w = reg_src_aux2;
         mov(reg_index_h, reg_index);
@@ -310,6 +316,7 @@ private:
 
         Xbyak::Reg64 reg_work_amount_oh = rdi;
         mov(reg_work_amount_oh, jcp_.OH);
+
         L(out_loop_label);
         {
             // outloop status
@@ -328,6 +335,8 @@ private:
             // reset index_w, index_w * dataSize done when built to avoid redundent compute
             mov(reg_index, reg_index_w);
 
+            int step = vlen / (is_i8 ? sizeof(int8_t) : sizeof(float));
+
             Xbyak::Label nn_loop_label;
             Xbyak::Label nn_loop_end_label;
             Xbyak::Label nn_tail_loop_label;
@@ -335,45 +344,54 @@ private:
 
             L(nn_loop_label);   // inner loop
             {
-                cmp(reg_work_amount, vector_step);
+                cmp(reg_work_amount, step);
                 jl(nn_loop_end_label, T_NEAR);
+                if (is_i8) {
+                    gather_i8_i32_indices_store(reg_dst, reg_src_h, reg_index, step);
+                } else {
+                    uni_vmovdqu(vmm_index, ptr[reg_index]);
+                    uni_vpcmpeqd(vmm_mask, vmm_mask, vmm_mask);
+                    vgatherdps(vmm_val, ptr[reg_src_h + vmm_index], vmm_mask);
+                    if (attr_.post_ops_.len() != 0)
+                        apply_post_ops(jcp_.dst_prc, 1);
+                    store(vmm_val, reg_dst, step);
+                }
 
-                uni_vmovdqu(vmm_index, ptr[reg_index]);
-                uni_vpcmpeqd(vmm_mask, vmm_mask, vmm_mask);
-                vgatherdps(vmm_val, ptr[reg_src_h + vmm_index], vmm_mask);
-                if (attr_.post_ops_.len() != 0)
-                    apply_post_ops(jcp_.dst_prc, 1);
-                store(vmm_val, reg_dst, vector_step);
-
-                add(reg_dst, vector_step * jcp_.dst_data_size);
-                add(reg_index, vector_step * jcp_.indices_size);
-                sub(reg_work_amount, vector_step);
+                add(reg_dst, step * jcp_.dst_data_size);
+                add(reg_index, step * jcp_.indices_size);
+                sub(reg_work_amount, step);
 
                 jmp(nn_loop_label, T_NEAR);
             }
             L(nn_loop_end_label);
 
-            L(nn_tail_loop_label);
-            {
-                cmp(reg_work_amount, 1);
-                jl(nn_tail_loop_end_label, T_NEAR);
+            if (is_i8) {
+                    const int tail_count = jcp_.OW % step;
+                    gather_i8_i32_indices_store(reg_dst, reg_src_h, reg_index, tail_count);
+                    add(reg_dst, tail_count * jcp_.dst_data_size);
+                    add(reg_index, tail_count * jcp_.indices_size);
+            } else {
+                L(nn_tail_loop_label);
+                {
+                    cmp(reg_work_amount, 1);
+                    jl(nn_tail_loop_end_label, T_NEAR);
 
-                mov(reg_src_aux, reg_src_h);
-                mov(reg_index_offset, dword[reg_index]);
-                add(reg_src_aux, reg_index_offset);
+                    mov(reg_src_aux, reg_src_h);
+                    mov(reg_index_offset, dword[reg_index]);
+                    add(reg_src_aux, reg_index_offset);
 
-                load(reg_src_aux, vmm_val, scalar_step);
-                if (attr_.post_ops_.len() != 0)
-                    apply_post_ops(jcp_.dst_prc, 1);
-                store(vmm_val, reg_dst, scalar_step);
+                    load(reg_src_aux, vmm_val, scalar_step);
+                    if (attr_.post_ops_.len() != 0)
+                        apply_post_ops(jcp_.dst_prc, 1);
+                    store(vmm_val, reg_dst, scalar_step);
+                    }
+                    add(reg_dst, scalar_step * jcp_.dst_data_size);
+                    add(reg_index, scalar_step * jcp_.indices_size);
+                    sub(reg_work_amount, scalar_step);
 
-                add(reg_dst, scalar_step * jcp_.dst_data_size);
-                add(reg_index, scalar_step * jcp_.indices_size);
-                sub(reg_work_amount, scalar_step);
-
-                jmp(nn_tail_loop_label, T_NEAR);
-            }
-            L(nn_tail_loop_end_label);    // inner loop end
+                    jmp(nn_tail_loop_label, T_NEAR);
+                }
+                L(nn_tail_loop_end_label);    // inner loop end
 
             //increment index_h to next row
             add(reg_index_h, jcp_.indices_size);
@@ -1318,6 +1336,25 @@ private:
         }
     }
 
+    /**
+     * @brief Emulates vgatherdpd/vgatherdps instruction for byte-sized data with 32-bit indices.
+     * Mask is considered with all bits set.
+     *
+     * @param dest_addr Register with the start destination address
+     * @param source_addr Register with the start source address
+     * @param ind_addr Register with the start index address
+     * @param is_scalar Flag to perform scalar operation instead of vector
+     * @return none.
+     */
+    inline void gather_i8_i32_indices_store(const Xbyak::Reg64 &dest_addr, const Xbyak::Reg64 &source_addr,
+                                            const Xbyak::Reg64 &ind_addr, int gather_num) {
+        for (size_t i = 0; i < gather_num; ++i) {
+            mov(reg_tmp_64.cvt32(), ptr[ind_addr + i * sizeof(int32_t)]);
+            mov(reg_tmp_64.cvt8(), ptr[source_addr + reg_tmp_64]);
+            mov(ptr[dest_addr + i], reg_tmp_64.cvt8());
+        }
+    }
+
     // is_broadcast for broadcasting param for depth_wise and quantize(channel-sensitive post-ops), for fusion with plain layout.
     void apply_post_ops(Precision dst_prc, bool is_broadcast) {
         const auto &p = attr_.post_ops_;
@@ -1784,29 +1821,32 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
     const auto &dataMinDims = getInputShapeAtPort(DATA_ID).getMinDims();
     bool isBlkApplied = getInputShapeAtPort(DATA_ID).getRank() > 1 && dataMinDims[1] != Shape::UNDEFINED_DIM && dataMinDims[1] > 1;
 
+    impl_desc_type impl_type;
+    if (mayiuse(cpu::x64::avx512_core)) {
+        impl_type = impl_desc_type::jit_avx512;
+    } else if (mayiuse(cpu::x64::avx2)) {
+        impl_type = impl_desc_type::jit_avx2;
+    } else if (mayiuse(cpu::x64::sse41)) {
+        impl_type = impl_desc_type::jit_sse42;
+    } else {
+        impl_type = impl_desc_type::ref;
+    }
+
     if (!mayiuse(cpu::x64::sse41) || interpAttrs.mode == InterpolateMode::linear) {
-        pushDesc(LayoutType::ncsp, ref);
+        pushDesc(LayoutType::ncsp, impl_type);
     } else {
         // blk and by_channel JIT kernel on sse41 or above machine
         if (getInputShapeAtPort(DATA_ID).getRank() == 4 || (getInputShapeAtPort(DATA_ID).getRank() == 5 && interpAttrs.mode != InterpolateMode::cubic)) {
-            if (mayiuse(cpu::x64::avx512_core)) {
-                pushDesc(LayoutType::nspc, jit_avx512);
-                if (isBlkApplied)
-                    pushDesc(LayoutType::nCsp16c, jit_avx512);
-            } else if (mayiuse(cpu::x64::avx2)) {
-                pushDesc(LayoutType::nspc, jit_avx2);
-                if (isBlkApplied)
-                    pushDesc(LayoutType::nCsp8c, jit_avx2);
-            } else {
-                pushDesc(LayoutType::nspc, jit_sse42);
-                if (isBlkApplied)
-                    pushDesc(LayoutType::nCsp8c, jit_sse42);
+            pushDesc(LayoutType::nspc, impl_type);
+            if (isBlkApplied) {
+                pushDesc((mayiuse(cpu::x64::avx512_core)) ? LayoutType::nCsp16c : LayoutType::nCsp8c, impl_type);
             }
         }
-
         // planar for 1.ref on machine without sse41(if no sse41, canFuse() is false). 2.JIT kernel for f32 && avx2(gather).(with fuse)
-        if (mayiuse(cpu::x64::avx2) && inputPrecision == Precision::FP32) {
-            pushDesc(LayoutType::ncsp, jit_avx2);
+        const bool allowAvx2NcspFp32 = mayiuse(cpu::x64::avx2) && inputPrecision == Precision::FP32;
+        const bool allowAvx2NcspI8 = inputPrecision == Precision::I8 && outputPrecision == Precision::I8;
+        if (allowAvx2NcspFp32 || allowAvx2NcspI8) {
+            pushDesc(LayoutType::ncsp, impl_type);
         }
     }
 }
@@ -1902,10 +1942,14 @@ void Interpolate::prepareParams() {
 
     auto buildExecutor = [&](const InterpolateKey& key) -> std::shared_ptr<InterpolateExecutor> {
         std::shared_ptr<InterpolateExecutor> executor;
-        if ((key.nodeAttrs.mode == InterpolateMode::nearest || key.nodeAttrs.mode == InterpolateMode::linear_onnx ||
-            key.nodeAttrs.mode == InterpolateMode::cubic) &&
-            ((key.nodeAttrs.layout != InterpolateLayoutType::planar && mayiuse(cpu::x64::sse41)) ||
-                (mayiuse(cpu::x64::avx2) && key.nodeAttrs.inPrc == Precision::FP32))) {
+        const bool isPlanar = key.nodeAttrs.layout == InterpolateLayoutType::planar;
+        const bool allowNearestPlanarI8 = isPlanar && key.nodeAttrs.inPrc == Precision::I8 && key.nodeAttrs.outPrc == Precision::I8;
+        if ((key.nodeAttrs.mode == InterpolateMode::nearest ||
+             key.nodeAttrs.mode == InterpolateMode::linear_onnx ||
+             key.nodeAttrs.mode == InterpolateMode::cubic) &&
+            ((!isPlanar && mayiuse(cpu::x64::sse41)) ||
+             (mayiuse(cpu::x64::avx2) && key.nodeAttrs.inPrc == Precision::FP32) ||
+             allowNearestPlanarI8)) {
             executor = std::make_shared<InterpolateJitExecutor>(key.nodeAttrs,
                                                                key.srcDims,
                                                                key.dstDims,
@@ -3145,17 +3189,28 @@ Interpolate::InterpolateJitExecutor::InterpolateJitExecutor(const InterpolateAtt
     jcp.ID = srcDimPad5d[2];
     jcp.spatial_dim_size = getSpatialDimsNum(srcDims.size());
     jcp.layout = interpAttrs.layout;
+
+    const bool allowFp32 = interpAttrs.inPrc == InferenceEngine::Precision::FP32;
+    const bool allowI8 = interpAttrs.inPrc == InferenceEngine::Precision::I8 &&
+                         interpAttrs.outPrc == InferenceEngine::Precision::I8;
     if (jcp.layout != InterpolateLayoutType::planar) {
         if (mayiuse(cpu::x64::avx512_core)) {
-            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32<cpu::x64::avx512_core>(jcp, *attr.get()));
+            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32_i8<cpu::x64::avx512_core>(jcp, *attr.get()));
         } else if (mayiuse(cpu::x64::avx2)) {
-            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32<cpu::x64::avx2>(jcp, *attr.get()));
+            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32_i8<cpu::x64::avx2>(jcp, *attr.get()));
         } else if (mayiuse(cpu::x64::sse41)) {
-            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32<cpu::x64::sse41>(jcp, *attr.get()));
+            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32_i8<cpu::x64::sse41>(jcp, *attr.get()));
         }
-    } else if (mayiuse(cpu::x64::avx2) && interpAttrs.inPrc == InferenceEngine::Precision::FP32) {
-        // gather ISA(for planar JIT kernel) for avx2 and fp32
-        interpolateKernel.reset(new jit_uni_interpolate_kernel_f32<cpu::x64::avx2>(jcp, *attr.get()));
+    } else if (mayiuse(cpu::x64::avx2) && allowFp32) {
+        interpolateKernel.reset(new jit_uni_interpolate_kernel_f32_i8<cpu::x64::avx2>(jcp, *attr.get()));
+    } else if (allowI8) {
+        if (mayiuse(cpu::x64::avx512_core)) {
+            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32_i8<cpu::x64::avx512_core>(jcp, *attr.get()));
+        } else if (mayiuse(cpu::x64::avx2)) {
+            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32_i8<cpu::x64::avx2>(jcp, *attr.get()));
+        } else if (mayiuse(cpu::x64::sse41)) {
+           interpolateKernel.reset(new jit_uni_interpolate_kernel_f32_i8<cpu::x64::sse41>(jcp, *attr.get()));
+        }
     } else {
         IE_THROW() << "Can't create InterpolateJitExecutor";
     }
@@ -3253,7 +3308,11 @@ size_t Interpolate::getSpatialDimsNum(const Dim rank) {
 }
 
 bool Interpolate::canFuse(const NodePtr& node) const {
-    if (!mayiuse(cpu::x64::sse41) || interpAttrs.mode == InterpolateMode::linear) {
+    const bool is_i8_nearest_planar = interpAttrs.mode == InterpolateMode::nearest &&
+               interpAttrs.layout == InterpolateLayoutType::planar &&
+               interpAttrs.inPrc == InferenceEngine::Precision::I8 &&
+               interpAttrs.outPrc == InferenceEngine::Precision::I8;
+    if (!mayiuse(cpu::x64::sse41) || is_i8_nearest_planar || interpAttrs.mode == InterpolateMode::linear) {
         return false;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -1723,6 +1723,13 @@ Interpolate::Interpolate(const std::shared_ptr<ngraph::Node>& op, const dnnl::en
                 axes[i] = i;
             }
         }
+
+        const auto rtInfo = interp->get_rt_info();
+        const auto it = rtInfo.find("enforceAllSupportedLayouts");
+        if (it != rtInfo.end()) {
+            enforceAllSupportedLayouts = it->second.as<bool>();
+        }
+
     } else {
         IE_THROW(NotImplemented) << errorMessage;
     }
@@ -1846,8 +1853,8 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
                               dataMinDims[1] == 1;
 
     const bool isPlanarApplied = allowPlanarFp32 || allowPlanarI8OrU8;
-    const bool isBlkApplied = !isOneChannel;
-    const bool isChannelFirstApplied = !isOneChannel || !isPlanarApplied;
+    const bool isBlkApplied = !isOneChannel || enforceAllSupportedLayouts;
+    const bool isChannelFirstApplied = !isOneChannel || !isPlanarApplied || enforceAllSupportedLayouts;
 
     if (implType == impl_desc_type::ref || interpAttrs.mode == InterpolateMode::linear) {
         pushDesc(LayoutType::ncsp, implType);

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -1854,14 +1854,14 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
 
     const bool isPlanarApplied = allowPlanarFp32 || allowPlanarI8OrU8;
     const bool isBlkApplied = !isOneChannel || enforceAllSupportedLayouts;
-    const bool isChannelFirstApplied = !isOneChannel || !isPlanarApplied || enforceAllSupportedLayouts;
+    const bool isByChannelApplied = !isOneChannel || !isPlanarApplied || enforceAllSupportedLayouts;
 
     if (implType == impl_desc_type::ref || interpAttrs.mode == InterpolateMode::linear) {
         pushDesc(LayoutType::ncsp, implType);
     } else {
         // blk and by_channel JIT kernel on sse41 or above machine
         if (getInputShapeAtPort(DATA_ID).getRank() == 4 || (getInputShapeAtPort(DATA_ID).getRank() == 5 && interpAttrs.mode != InterpolateMode::cubic)) {
-            if (isChannelFirstApplied) {
+            if (isByChannelApplied) {
                 pushDesc(LayoutType::nspc, implType);
             }
             if (isBlkApplied) {
@@ -1869,6 +1869,9 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
             }
         }
         if (isPlanarApplied) {
+            if (allowPlanarFp32) {
+                implType = impl_desc_type::jit_avx2;
+            }
             pushDesc(LayoutType::ncsp, implType);
         }
     }

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -297,13 +297,17 @@ private:
     }
 
     void nn_planar() {
-        const bool is_i8_or_u8 =
-            (jcp_.src_prc == InferenceEngine::Precision::I8 && jcp_.dst_prc == InferenceEngine::Precision::I8)
-            || (jcp_.src_prc == InferenceEngine::Precision::U8 && jcp_.dst_prc == InferenceEngine::Precision::U8);
-
-        if (is_i8_or_u8 && attr_.post_ops_.len() != 0) {
-            IE_THROW() << "Interpolate I8 doesn't support fusing";
+        const Precision prc = jcp_.src_prc;
+        const bool can_copy = attr_.post_ops_.len() == 0 && prc == jcp_.dst_prc;
+        const bool native_gather_available = prc == Precision::FP32 &&
+                                             (isa == cpu::x64::avx2 || isa == cpu::x64::avx512_core);
+        int step;
+        if (prc == Precision::I8 || prc == Precision::U8) {
+            step = vlen / sizeof(int8_t);
+        } else {
+            step = vlen / sizeof(float);
         }
+
         Xbyak::Reg64 reg_index_h = reg_src_aux1;
         Xbyak::Reg64 reg_index_w = reg_src_aux2;
         mov(reg_index_h, reg_index);
@@ -336,8 +340,6 @@ private:
             // reset index_w, index_w * dataSize done when built to avoid redundent compute
             mov(reg_index, reg_index_w);
 
-            int step = vlen / (is_i8_or_u8 ? sizeof(int8_t) : sizeof(float));
-
             Xbyak::Label nn_loop_label;
             Xbyak::Label nn_loop_end_label;
             Xbyak::Label nn_tail_loop_label;
@@ -347,17 +349,17 @@ private:
             {
                 cmp(reg_work_amount, step);
                 jl(nn_loop_end_label, T_NEAR);
-                if (is_i8_or_u8) {
-                    gather_i8_i32_indices_store(reg_dst, reg_src_h, reg_index, step);
+
+                if (can_copy && !native_gather_available) {
+                    gather_i32_indices_store(reg_dst, reg_src_h, reg_index, prc, step);
                 } else {
                     uni_vmovdqu(vmm_index, ptr[reg_index]);
-                    uni_vpcmpeqd(vmm_mask, vmm_mask, vmm_mask);
-                    vgatherdps(vmm_val, ptr[reg_src_h + vmm_index], vmm_mask);
-                    if (attr_.post_ops_.len() != 0)
+                    gather_i32_indices(vmm_val, reg_src_h, 0, vmm_index, 1, prc, false, false);
+                    if (attr_.post_ops_.len() != 0) {
                         apply_post_ops(jcp_.dst_prc, 1);
+                    }
                     store(vmm_val, reg_dst, step);
                 }
-
                 add(reg_dst, step * jcp_.dst_data_size);
                 add(reg_index, step * jcp_.indices_size);
                 sub(reg_work_amount, step);
@@ -366,11 +368,11 @@ private:
             }
             L(nn_loop_end_label);
 
-            if (is_i8_or_u8) {
-                    const int tail_count = jcp_.OW % step;
-                    gather_i8_i32_indices_store(reg_dst, reg_src_h, reg_index, tail_count);
-                    add(reg_dst, tail_count * jcp_.dst_data_size);
-                    add(reg_index, tail_count * jcp_.indices_size);
+            if (can_copy) {
+                const int tail_count = jcp_.OW % step;
+                gather_i32_indices_store(reg_dst, reg_src_h, reg_index, prc, tail_count);
+                add(reg_dst, tail_count * jcp_.dst_data_size);
+                add(reg_index, tail_count * jcp_.indices_size);
             } else {
                 L(nn_tail_loop_label);
                 {
@@ -382,10 +384,11 @@ private:
                     add(reg_src_aux, reg_index_offset);
 
                     load(reg_src_aux, vmm_val, scalar_step);
-                    if (attr_.post_ops_.len() != 0)
+                    if (attr_.post_ops_.len() != 0) {
                         apply_post_ops(jcp_.dst_prc, 1);
-                    store(vmm_val, reg_dst, scalar_step);
                     }
+                    store(vmm_val, reg_dst, scalar_step);
+
                     add(reg_dst, scalar_step * jcp_.dst_data_size);
                     add(reg_index, scalar_step * jcp_.indices_size);
                     sub(reg_work_amount, scalar_step);
@@ -393,7 +396,7 @@ private:
                     jmp(nn_tail_loop_label, T_NEAR);
                 }
                 L(nn_tail_loop_end_label);    // inner loop end
-
+            }
             //increment index_h to next row
             add(reg_index_h, jcp_.indices_size);
 
@@ -1294,11 +1297,15 @@ private:
 
     // always gather to Vmm, compute with Vmm, store with Xmm if scalar_step
     inline void gather_i32_indices(Vmm vmm_src, const Xbyak::Reg64 &base, int offset, Vmm vmm_indices, int scale,
-                                Precision src_prc, bool is_scalar) {
+                                   Precision src_prc, bool is_scalar, bool is_cubic = true) {
         Xbyak::Address table_idx = ptr[base + offset + vmm_indices * scale];
         if ((isa == cpu::x64::avx512_core) && !is_scalar) {
-            // [0-15] bit of int to mask
-            kmovw(k_mask, cubic_planar_table_val(3));
+            if (is_cubic) {
+                // [0-15] bit of int to mask
+                kmovw(k_mask, cubic_planar_table_val(3));
+            } else {
+                kxnord(k_mask, k_mask, k_mask);
+            }
             if (src_prc == Precision::FP32) {
                 vgatherdps(vmm_src | k_mask, table_idx);  // dword index, packed single data
             } else if (src_prc == Precision::I32) {
@@ -1347,12 +1354,20 @@ private:
      * @param is_scalar Flag to perform scalar operation instead of vector
      * @return none.
      */
-    inline void gather_i8_i32_indices_store(const Xbyak::Reg64 &dest_addr, const Xbyak::Reg64 &source_addr,
-                                            const Xbyak::Reg64 &ind_addr, int gather_num) {
+    inline void gather_i32_indices_store(const Xbyak::Reg64 &dest_addr, const Xbyak::Reg64 &source_addr,
+                                         const Xbyak::Reg64 &ind_addr, Precision prc, int gather_num) {
         for (size_t i = 0; i < gather_num; ++i) {
-            mov(reg_tmp_64.cvt32(), ptr[ind_addr + i * sizeof(int32_t)]);
-            mov(reg_tmp_64.cvt8(), ptr[source_addr + reg_tmp_64]);
-            mov(ptr[dest_addr + i], reg_tmp_64.cvt8());
+            if (prc == Precision::FP32) {
+                mov(reg_tmp_64.cvt32(), ptr[ind_addr + i * sizeof(int32_t)]);
+                mov(reg_tmp_64.cvt32(), ptr[source_addr + reg_tmp_64]);
+                mov(ptr[dest_addr + i * prc.size()], reg_tmp_64.cvt32());
+            } else if (prc == Precision::I8 || prc == Precision::U8) {
+                mov(reg_tmp_64.cvt32(), ptr[ind_addr + i * sizeof(int32_t)]);
+                mov(reg_tmp_64.cvt8(), ptr[source_addr + reg_tmp_64]);
+                mov(ptr[dest_addr + i], reg_tmp_64.cvt8());
+            } else {
+                IE_THROW() << "Unsupported precision";
+            }
         }
     }
 
@@ -1841,7 +1856,8 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
     // 1. for ref on machine without sse41 (if no sse41, canFuse() is false)
     // 2. JIT kernel for f32 && avx2(gather) (with fuse)
     // 3. JIT kernel for i8/u8 with sse41 or above (without fusing)
-    const bool allowPlanarFp32 = mayiuse(cpu::x64::avx2) && inputPrecision == Precision::FP32;
+    const bool allowPlanarFp32 = inputPrecision == Precision::FP32 && (mayiuse(cpu::x64::avx2) ||
+                                                                       interpAttrs.mode == InterpolateMode::nearest);
     const bool allowPlanarI8OrU8 = fusedWith.empty() &&
                                    interpAttrs.mode == InterpolateMode::nearest &&
                                    ((inputPrecision == Precision::I8 && outputPrecision == Precision::I8) ||
@@ -1968,16 +1984,19 @@ void Interpolate::prepareParams() {
 
     auto buildExecutor = [&](const InterpolateKey& key) -> std::shared_ptr<InterpolateExecutor> {
         std::shared_ptr<InterpolateExecutor> executor;
+        const bool isNearest = key.nodeAttrs.mode == InterpolateMode::nearest;
         const bool isPlanar = key.nodeAttrs.layout == InterpolateLayoutType::planar;
         const bool isI8OrU8 = (key.nodeAttrs.inPrc == Precision::I8 && key.nodeAttrs.outPrc == Precision::I8) ||
                               (key.nodeAttrs.inPrc == Precision::U8 && key.nodeAttrs.outPrc == Precision::U8);
-        const bool allowNearestPlanarforI8OrU8 = isPlanar && isI8OrU8;
+        const bool allowNearestPlanarForI8OrU8 = isNearest && isPlanar && isI8OrU8;
+        const bool allowPlanarForFP32 = key.nodeAttrs.inPrc == Precision::FP32 && (mayiuse(cpu::x64::avx2) ||
+                                                                                   (isNearest && isPlanar));
         if ((key.nodeAttrs.mode == InterpolateMode::nearest ||
              key.nodeAttrs.mode == InterpolateMode::linear_onnx ||
              key.nodeAttrs.mode == InterpolateMode::cubic) &&
             ((!isPlanar && mayiuse(cpu::x64::sse41)) ||
-            (mayiuse(cpu::x64::avx2) && key.nodeAttrs.inPrc == Precision::FP32) ||
-            allowNearestPlanarforI8OrU8)) {
+             allowPlanarForFP32 ||
+             allowNearestPlanarForI8OrU8)) {
             executor = std::make_shared<InterpolateJitExecutor>(key.nodeAttrs,
                                                                key.srcDims,
                                                                key.dstDims,
@@ -3218,8 +3237,9 @@ Interpolate::InterpolateJitExecutor::InterpolateJitExecutor(const InterpolateAtt
     jcp.spatial_dim_size = getSpatialDimsNum(srcDims.size());
     jcp.layout = interpAttrs.layout;
 
-    const bool allowFp32 = interpAttrs.inPrc == InferenceEngine::Precision::FP32;
+    const bool isNearest = jcp.mode == InterpolateMode::nearest;
     const bool allowI8OrU8 = attr.get()->post_ops_.len() == 0 &&
+                             isNearest &&
                              ((interpAttrs.inPrc == InferenceEngine::Precision::I8 &&
                                interpAttrs.outPrc == InferenceEngine::Precision::I8) ||
                               (interpAttrs.inPrc == InferenceEngine::Precision::U8 &&
@@ -3233,8 +3253,14 @@ Interpolate::InterpolateJitExecutor::InterpolateJitExecutor(const InterpolateAtt
         } else if (mayiuse(cpu::x64::sse41)) {
             interpolateKernel.reset(new jit_uni_interpolate_kernel_t<cpu::x64::sse41>(jcp, *attr.get()));
         }
-    } else if (mayiuse(cpu::x64::avx2) && allowFp32) {
-        interpolateKernel.reset(new jit_uni_interpolate_kernel_t<cpu::x64::avx2>(jcp, *attr.get()));
+    } else if (interpAttrs.inPrc == InferenceEngine::Precision::FP32) {
+        if (mayiuse(cpu::x64::avx512_core) && isNearest) {
+            interpolateKernel.reset(new jit_uni_interpolate_kernel_t<cpu::x64::avx512_core>(jcp, *attr.get()));
+        } else if (mayiuse(cpu::x64::avx2)) {
+            interpolateKernel.reset(new jit_uni_interpolate_kernel_t<cpu::x64::avx2>(jcp, *attr.get()));
+        } else if (mayiuse(cpu::x64::sse41) && isNearest) {
+            interpolateKernel.reset(new jit_uni_interpolate_kernel_t<cpu::x64::sse41>(jcp, *attr.get()));
+        }
     } else {
         IE_THROW() << "Can't create InterpolateJitExecutor";
     }
@@ -3332,7 +3358,7 @@ size_t Interpolate::getSpatialDimsNum(const Dim rank) {
 }
 
 bool Interpolate::canFuse(const NodePtr& node) const {
-    if (!mayiuse(cpu::x64::sse41) || interpAttrs.mode == InterpolateMode::linear) {
+    if (interpAttrs.mode == InterpolateMode::linear) {
         return false;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -47,10 +47,10 @@ namespace intel_cpu {
 namespace node {
 
 template <cpu_isa_t isa>
-struct jit_uni_interpolate_kernel_f32_i8 : public jit_uni_interpolate_kernel, public jit_generator {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_interpolate_kernel_f32_i8)
+struct jit_uni_interpolate_kernel_t : public jit_uni_interpolate_kernel, public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_interpolate_kernel_t)
 
-    explicit jit_uni_interpolate_kernel_f32_i8(jit_interpolate_config_params jcp, const dnnl_primitive_attr &attr)
+    explicit jit_uni_interpolate_kernel_t(jit_interpolate_config_params jcp, const dnnl_primitive_attr &attr)
     : jit_uni_interpolate_kernel(jcp, attr), jit_generator(jit_name()) {}
 
     void create_ker() override {
@@ -297,10 +297,11 @@ private:
     }
 
     void nn_planar() {
-        const bool is_i8 = jcp_.src_prc == InferenceEngine::Precision::I8
-                           && jcp_.dst_prc == InferenceEngine::Precision::I8;
+        const bool is_i8_or_u8 =
+            (jcp_.src_prc == InferenceEngine::Precision::I8 && jcp_.dst_prc == InferenceEngine::Precision::I8)
+            || (jcp_.src_prc == InferenceEngine::Precision::U8 && jcp_.dst_prc == InferenceEngine::Precision::U8);
 
-        if (is_i8 && attr_.post_ops_.len() != 0) {
+        if (is_i8_or_u8 && attr_.post_ops_.len() != 0) {
             IE_THROW() << "Interpolate I8 doesn't support fusing";
         }
         Xbyak::Reg64 reg_index_h = reg_src_aux1;
@@ -335,7 +336,7 @@ private:
             // reset index_w, index_w * dataSize done when built to avoid redundent compute
             mov(reg_index, reg_index_w);
 
-            int step = vlen / (is_i8 ? sizeof(int8_t) : sizeof(float));
+            int step = vlen / (is_i8_or_u8 ? sizeof(int8_t) : sizeof(float));
 
             Xbyak::Label nn_loop_label;
             Xbyak::Label nn_loop_end_label;
@@ -346,7 +347,7 @@ private:
             {
                 cmp(reg_work_amount, step);
                 jl(nn_loop_end_label, T_NEAR);
-                if (is_i8) {
+                if (is_i8_or_u8) {
                     gather_i8_i32_indices_store(reg_dst, reg_src_h, reg_index, step);
                 } else {
                     uni_vmovdqu(vmm_index, ptr[reg_index]);
@@ -365,7 +366,7 @@ private:
             }
             L(nn_loop_end_label);
 
-            if (is_i8) {
+            if (is_i8_or_u8) {
                     const int tail_count = jcp_.OW % step;
                     gather_i8_i32_indices_store(reg_dst, reg_src_h, reg_index, tail_count);
                     add(reg_dst, tail_count * jcp_.dst_data_size);
@@ -1818,35 +1819,50 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
         supportedPrimitiveDescriptors.push_back({config, implDetail});
     };
 
-    const auto &dataMinDims = getInputShapeAtPort(DATA_ID).getMinDims();
-    bool isBlkApplied = getInputShapeAtPort(DATA_ID).getRank() > 1 && dataMinDims[1] != Shape::UNDEFINED_DIM && dataMinDims[1] > 1;
-
-    impl_desc_type impl_type;
+    impl_desc_type implType;
     if (mayiuse(cpu::x64::avx512_core)) {
-        impl_type = impl_desc_type::jit_avx512;
+        implType = impl_desc_type::jit_avx512;
     } else if (mayiuse(cpu::x64::avx2)) {
-        impl_type = impl_desc_type::jit_avx2;
+        implType = impl_desc_type::jit_avx2;
     } else if (mayiuse(cpu::x64::sse41)) {
-        impl_type = impl_desc_type::jit_sse42;
+        implType = impl_desc_type::jit_sse42;
     } else {
-        impl_type = impl_desc_type::ref;
+        implType = impl_desc_type::ref;
     }
 
-    if (!mayiuse(cpu::x64::sse41) || interpAttrs.mode == InterpolateMode::linear) {
-        pushDesc(LayoutType::ncsp, impl_type);
+    // planar layout supported:
+    // 1. for ref on machine without sse41 (if no sse41, canFuse() is false)
+    // 2. JIT kernel for f32 && avx2(gather) (with fuse)
+    // 3. JIT kernel for i8/u8 with sse41 or above (without fusing)
+    const bool allowPlanarFp32 = mayiuse(cpu::x64::avx2) && inputPrecision == Precision::FP32;
+    const bool allowPlanarI8OrU8 = fusedWith.empty() &&
+                                   interpAttrs.mode == InterpolateMode::nearest &&
+                                   ((inputPrecision == Precision::I8 && outputPrecision == Precision::I8) ||
+                                    (inputPrecision == Precision::U8 && outputPrecision == Precision::U8));
+
+    const auto &dataMinDims = getInputShapeAtPort(DATA_ID).getMinDims();
+    const bool isOneChannel = getInputShapeAtPort(DATA_ID).getRank() > 1 &&
+                              dataMinDims[1] != Shape::UNDEFINED_DIM &&
+                              dataMinDims[1] == 1;
+
+    const bool isPlanarApplied = allowPlanarFp32 || allowPlanarI8OrU8;
+    const bool isBlkApplied = !isOneChannel;
+    const bool isChannelFirstApplied = !isOneChannel || !isPlanarApplied;
+
+    if (implType == impl_desc_type::ref || interpAttrs.mode == InterpolateMode::linear) {
+        pushDesc(LayoutType::ncsp, implType);
     } else {
         // blk and by_channel JIT kernel on sse41 or above machine
         if (getInputShapeAtPort(DATA_ID).getRank() == 4 || (getInputShapeAtPort(DATA_ID).getRank() == 5 && interpAttrs.mode != InterpolateMode::cubic)) {
-            pushDesc(LayoutType::nspc, impl_type);
+            if (isChannelFirstApplied) {
+                pushDesc(LayoutType::nspc, implType);
+            }
             if (isBlkApplied) {
-                pushDesc((mayiuse(cpu::x64::avx512_core)) ? LayoutType::nCsp16c : LayoutType::nCsp8c, impl_type);
+                pushDesc(implType == impl_desc_type::jit_avx512 ? LayoutType::nCsp16c : LayoutType::nCsp8c, implType);
             }
         }
-        // planar for 1.ref on machine without sse41(if no sse41, canFuse() is false). 2.JIT kernel for f32 && avx2(gather).(with fuse)
-        const bool allowAvx2NcspFp32 = mayiuse(cpu::x64::avx2) && inputPrecision == Precision::FP32;
-        const bool allowAvx2NcspI8 = inputPrecision == Precision::I8 && outputPrecision == Precision::I8;
-        if (allowAvx2NcspFp32 || allowAvx2NcspI8) {
-            pushDesc(LayoutType::ncsp, impl_type);
+        if (isPlanarApplied) {
+            pushDesc(LayoutType::ncsp, implType);
         }
     }
 }
@@ -1943,13 +1959,15 @@ void Interpolate::prepareParams() {
     auto buildExecutor = [&](const InterpolateKey& key) -> std::shared_ptr<InterpolateExecutor> {
         std::shared_ptr<InterpolateExecutor> executor;
         const bool isPlanar = key.nodeAttrs.layout == InterpolateLayoutType::planar;
-        const bool allowNearestPlanarI8 = isPlanar && key.nodeAttrs.inPrc == Precision::I8 && key.nodeAttrs.outPrc == Precision::I8;
+        const bool isI8OrU8 = (key.nodeAttrs.inPrc == Precision::I8 && key.nodeAttrs.outPrc == Precision::I8) ||
+                              (key.nodeAttrs.inPrc == Precision::U8 && key.nodeAttrs.outPrc == Precision::U8);
+        const bool allowNearestPlanarforI8OrU8 = isPlanar && isI8OrU8;
         if ((key.nodeAttrs.mode == InterpolateMode::nearest ||
              key.nodeAttrs.mode == InterpolateMode::linear_onnx ||
              key.nodeAttrs.mode == InterpolateMode::cubic) &&
             ((!isPlanar && mayiuse(cpu::x64::sse41)) ||
-             (mayiuse(cpu::x64::avx2) && key.nodeAttrs.inPrc == Precision::FP32) ||
-             allowNearestPlanarI8)) {
+            (mayiuse(cpu::x64::avx2) && key.nodeAttrs.inPrc == Precision::FP32) ||
+            allowNearestPlanarforI8OrU8)) {
             executor = std::make_shared<InterpolateJitExecutor>(key.nodeAttrs,
                                                                key.srcDims,
                                                                key.dstDims,
@@ -3191,26 +3209,22 @@ Interpolate::InterpolateJitExecutor::InterpolateJitExecutor(const InterpolateAtt
     jcp.layout = interpAttrs.layout;
 
     const bool allowFp32 = interpAttrs.inPrc == InferenceEngine::Precision::FP32;
-    const bool allowI8 = interpAttrs.inPrc == InferenceEngine::Precision::I8 &&
-                         interpAttrs.outPrc == InferenceEngine::Precision::I8;
-    if (jcp.layout != InterpolateLayoutType::planar) {
+    const bool allowI8OrU8 = attr.get()->post_ops_.len() == 0 &&
+                             ((interpAttrs.inPrc == InferenceEngine::Precision::I8 &&
+                               interpAttrs.outPrc == InferenceEngine::Precision::I8) ||
+                              (interpAttrs.inPrc == InferenceEngine::Precision::U8 &&
+                               interpAttrs.outPrc == InferenceEngine::Precision::U8));
+
+    if (jcp.layout != InterpolateLayoutType::planar || allowI8OrU8) {
         if (mayiuse(cpu::x64::avx512_core)) {
-            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32_i8<cpu::x64::avx512_core>(jcp, *attr.get()));
+            interpolateKernel.reset(new jit_uni_interpolate_kernel_t<cpu::x64::avx512_core>(jcp, *attr.get()));
         } else if (mayiuse(cpu::x64::avx2)) {
-            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32_i8<cpu::x64::avx2>(jcp, *attr.get()));
+            interpolateKernel.reset(new jit_uni_interpolate_kernel_t<cpu::x64::avx2>(jcp, *attr.get()));
         } else if (mayiuse(cpu::x64::sse41)) {
-            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32_i8<cpu::x64::sse41>(jcp, *attr.get()));
+            interpolateKernel.reset(new jit_uni_interpolate_kernel_t<cpu::x64::sse41>(jcp, *attr.get()));
         }
     } else if (mayiuse(cpu::x64::avx2) && allowFp32) {
-        interpolateKernel.reset(new jit_uni_interpolate_kernel_f32_i8<cpu::x64::avx2>(jcp, *attr.get()));
-    } else if (allowI8) {
-        if (mayiuse(cpu::x64::avx512_core)) {
-            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32_i8<cpu::x64::avx512_core>(jcp, *attr.get()));
-        } else if (mayiuse(cpu::x64::avx2)) {
-            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32_i8<cpu::x64::avx2>(jcp, *attr.get()));
-        } else if (mayiuse(cpu::x64::sse41)) {
-           interpolateKernel.reset(new jit_uni_interpolate_kernel_f32_i8<cpu::x64::sse41>(jcp, *attr.get()));
-        }
+        interpolateKernel.reset(new jit_uni_interpolate_kernel_t<cpu::x64::avx2>(jcp, *attr.get()));
     } else {
         IE_THROW() << "Can't create InterpolateJitExecutor";
     }
@@ -3308,11 +3322,7 @@ size_t Interpolate::getSpatialDimsNum(const Dim rank) {
 }
 
 bool Interpolate::canFuse(const NodePtr& node) const {
-    const bool is_i8_nearest_planar = interpAttrs.mode == InterpolateMode::nearest &&
-               interpAttrs.layout == InterpolateLayoutType::planar &&
-               interpAttrs.inPrc == InferenceEngine::Precision::I8 &&
-               interpAttrs.outPrc == InferenceEngine::Precision::I8;
-    if (!mayiuse(cpu::x64::sse41) || is_i8_nearest_planar || interpAttrs.mode == InterpolateMode::linear) {
+    if (!mayiuse(cpu::x64::sse41) || interpAttrs.mode == InterpolateMode::linear) {
         return false;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/interpolate.h
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.h
@@ -258,6 +258,8 @@ private:
     VectorDims lastOutputDims;
 
     std::string errorPrefix;
+
+    bool enforceAllSupportedLayouts = false;
 };
 
 }   // namespace node

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/interpolate.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/interpolate.cpp
@@ -254,6 +254,9 @@ protected:
 
         function = makeNgraphFunction(ngPrc, params, interpolate, "InterpolateCPU");
 
+        // To be able to run CPU tests on all shapes real thresholds should be ignored
+        interpolate->get_rt_info().insert({"enforceAllSupportedLayouts", true});
+
         if (selectedType.empty()) {
             selectedType = getPrimitiveType();
         }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/interpolate.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/interpolate.cpp
@@ -301,6 +301,10 @@ std::vector<CPUSpecificParams> filterCPUInfoForDeviceNearestExtFP32() {
     std::vector<CPUSpecificParams> resCPUParams{filterCPUInfoForDevice()};
     if (InferenceEngine::with_cpu_x86_avx512f()) {
         resCPUParams.push_back(CPUSpecificParams{{nchw, x, x, x}, {nchw}, {"jit_avx2"}, "jit_avx2"});
+    } else if (InferenceEngine::with_cpu_x86_avx2()) {
+        return resCPUParams;
+    } else if (InferenceEngine::with_cpu_x86_sse42()) {
+        resCPUParams.push_back(CPUSpecificParams{{nchw, x, x, x}, {nchw}, {"jit_sse42"}, "jit_sse42"});
     }
     return resCPUParams;
 }
@@ -889,6 +893,10 @@ std::vector<CPUSpecificParams> filterCPUInfoForDevice5DNearestExtFP32() {
     std::vector<CPUSpecificParams> resCPUParams{filterCPUInfoForDevice5D()};
     if (InferenceEngine::with_cpu_x86_avx512f()) {
         resCPUParams.push_back(CPUSpecificParams{{ncdhw, x, x, x}, {ncdhw}, {"jit_avx2"}, "jit_avx2"});
+    } else if (InferenceEngine::with_cpu_x86_avx2()) {
+        return resCPUParams;
+    } else if (InferenceEngine::with_cpu_x86_sse42()) {
+        resCPUParams.push_back(CPUSpecificParams{{ncdhw, x, x, x}, {ncdhw}, {"jit_sse42"}, "jit_sse42"});
     }
     return resCPUParams;
 }

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/interpolate.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/interpolate.cpp
@@ -258,6 +258,11 @@ protected:
             selectedType = getPrimitiveType();
         }
         selectedType = makeSelectedTypeStr(selectedType, ngPrc);
+
+        const auto selLength = selectedType.length();
+        if (selLength > 1 && selectedType[selLength - 2] == 'U' && selectedType[selLength - 1] == '8') {
+            selectedType[selLength - 2] = 'I';
+        }
     }
 };
 


### PR DESCRIPTION
### Details:
 - update for Interpolate nearest planar kernel to support int8/uint8 precision without fusing and type conversion; is enabled for AVX2 and SSE41 instruction sets.
 - update for Interpolate nearest planar kernel to support fp32 precision with fusing and type conversion; is enabled for SSE41 instruction set
 - new Interpolate CPU function tests which cover these kernels

### Tickets:
 - [CVS-55387]
