### PR TITLE
[GPU] change OpenCL include header file name

### DIFF
--- a/src/inference/include/ie/gpu/gpu_ocl_wrapper.hpp
+++ b/src/inference/include/ie/gpu/gpu_ocl_wrapper.hpp
@@ -39,7 +39,7 @@
 #    pragma GCC system_header
 #endif
 
-#include <CL/cl2.hpp>
+#include <CL/opencl.hpp>
 
 #ifdef __GNUC__
 #    pragma GCC diagnostic pop

--- a/src/inference/include/openvino/runtime/intel_gpu/ocl/ocl_wrapper.hpp
+++ b/src/inference/include/openvino/runtime/intel_gpu/ocl/ocl_wrapper.hpp
@@ -41,7 +41,7 @@
 #    pragma GCC system_header
 #endif
 
-#include <CL/cl2.hpp>
+#include <CL/opencl.hpp>
 
 #ifdef __GNUC__
 #    pragma GCC diagnostic pop


### PR DESCRIPTION
### Details:
 - changed to include "opench.hpp" instead of "cl2.hpp"
 - This PR removes the below warning message
 `cl2.hpp has been renamed to opencl.hpp to make it clear that it supports all versions of OpenCL. Please include opencl.hpp directly.`