### PR TITLE
Fixed NameError: name 'ARCH' is not defined on Raspberry Pi (#12421)

### DIFF
--- a/src/bindings/python/wheel/setup.py
+++ b/src/bindings/python/wheel/setup.py
@@ -34,7 +34,7 @@ if machine == "x86_64" or machine == "AMD64":
     ARCH = "intel64"
 elif machine == "X86":
     ARCH = "ia32"
-elif machine == "arm":
+elif machine == "arm" or machine == "armv7l":
     ARCH = "arm"
 elif machine == "aarch64":
     ARCH = "arm64"


### PR DESCRIPTION
### Details:
When building wheel on Raspberry Pi the "ARCH" variable was not defined because the architecture of Pi is 'armv7l'