### PR TITLE
Changed update date in MO message.

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/get_ov_update_message.py
+++ b/tools/mo/openvino/tools/mo/utils/get_ov_update_message.py
@@ -8,10 +8,10 @@ msg_fmt = 'Check for a new version of Intel(R) Distribution of OpenVINO(TM) tool
 
 
 def get_ov_update_message():
-    expected_update_date = datetime.date(year=2022, month=10, day=31)
+    expected_update_date = datetime.date(year=2023, month=2, day=1)
     current_date = datetime.date.today()
 
-    link = 'https://software.intel.com/content/www/us/en/develop/tools/openvino-toolkit/download.html?cid=other&source=prod&campid=ww_2022_bu_IOTG_OpenVINO-2022-2&content=upg_all&medium=organic'
+    link = 'https://software.intel.com/content/www/us/en/develop/tools/openvino-toolkit/download.html?cid=other&source=prod&campid=ww_2023_bu_IOTG_OpenVINO-2022-2&content=upg_all&medium=organic'
 
     return msg_fmt.format(link) if current_date >= expected_update_date else None
 


### PR DESCRIPTION
Root cause analysis: update date was too early, which may cause unexpected showing of update message.

Solution: Move update date in MO message to 1.02.22

Ticket: CVS 88686, CVS 89383


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A
* [x]  Transformation preserves tensor names - N/A


Validation:
* [x]  Unit tests - N/A
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check - N/A

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A
