### PR TITLE
Fixed CVS-89248

### DIFF
--- a/.ci/azure/linux_debian.yml
+++ b/.ci/azure/linux_debian.yml
@@ -22,7 +22,7 @@ resources:
     ref: master
 
 jobs:
-- job: Lin-Debian
+- job: Lin_Debian
   # About 150% of total time
   timeoutInMinutes: 120
 

--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -135,7 +135,7 @@ set(IE_EXTRA_MODULES "" CACHE STRING "Extra paths for extra modules to include i
 ie_dependent_option(ENABLE_TBB_RELEASE_ONLY "Only Release TBB libraries are linked to the Inference Engine binaries" ON "THREADING MATCHES TBB;LINUX" OFF)
 
 get_linux_name(LINUX_OS_NAME)
-if(LINUX_OS_NAME MATCHES "^Ubuntu [0-9]+\.[0-9]+$" AND NOT DEFINED ENV{TBBROOT})
+if(LINUX_OS_NAME MATCHES "^Ubuntu [0-9]+\.[0-9]+$")
     # Debian packages are enabled on Ubuntu systems
     # so, system TBB / pugixml can be tried for usage
     set(ENABLE_SYSTEM_LIBS_DEFAULT ON)
@@ -143,10 +143,15 @@ else()
     set(ENABLE_SYSTEM_LIBS_DEFAULT OFF)
 endif()
 
+set(ENABLE_SYSTEM_TBB_DEFAULT ${ENABLE_SYSTEM_LIBS_DEFAULT})
+if(DEFINED ENV{TBBROOT} OR DEFINED ENV{TBB_DIR} OR DEFINED TBB_DIR OR DEFINED TBBROOT)
+    set(ENABLE_SYSTEM_TBB_DEFAULT OFF)
+endif()
+
 # for static libraries case libpugixml.a must be compiled with -fPIC
 ie_dependent_option (ENABLE_SYSTEM_PUGIXML "use the system copy of pugixml" ${ENABLE_SYSTEM_LIBS_DEFAULT} "BUILD_SHARED_LIBS" OFF)
 
-ie_dependent_option (ENABLE_SYSTEM_TBB  "use the system version of TBB" ${ENABLE_SYSTEM_LIBS_DEFAULT} "THREADING MATCHES TBB;LINUX" OFF)
+ie_dependent_option (ENABLE_SYSTEM_TBB  "use the system version of TBB" ${ENABLE_SYSTEM_TBB_DEFAULT} "THREADING MATCHES TBB;LINUX" OFF)
 
 ie_option (ENABLE_DEBUG_CAPS "enable OpenVINO debug capabilities at runtime" OFF)
 

--- a/scripts/setupvars/setupvars.sh
+++ b/scripts/setupvars/setupvars.sh
@@ -61,6 +61,8 @@ if [ -e "$INSTALLDIR/runtime/3rdparty/tbb" ]; then
         export TBB_DIR=$INSTALLDIR/runtime/3rdparty/tbb/lib64/cmake/TBB
     elif [ -e "$INSTALLDIR/runtime/3rdparty/tbb/cmake" ]; then
         export TBB_DIR=$INSTALLDIR/runtime/3rdparty/tbb/cmake
+    else
+        echo "TBB_DIR directory is not defined automatically by setupvars.sh. Please, set it manually to point to TBBConfig.cmake"
     fi
 fi
 

--- a/src/cmake/install_tbb.cmake
+++ b/src/cmake/install_tbb.cmake
@@ -106,8 +106,16 @@ if(THREADING MATCHES "^(TBB|TBB_AUTO)$" AND
             message(FATAL_ERROR "Failed to deduce TBBROOT, please define env var TBBROOT")
         endif()
 
-        file(RELATIVE_PATH IE_TBB_DIR_INSTALL "${TBBROOT}" "${TBB_DIR}")
-        set(IE_TBB_DIR_INSTALL "${IE_TBBROOT_INSTALL}/${IE_TBB_DIR_INSTALL}")
+        if(TBB_DIR MATCHES "^${TBBROOT}.*")
+            file(RELATIVE_PATH IE_TBB_DIR_INSTALL "${TBBROOT}" "${TBB_DIR}")
+            set(IE_TBB_DIR_INSTALL "${IE_TBBROOT_INSTALL}/${IE_TBB_DIR_INSTALL}")
+        else()
+            # TBB_DIR is not a subdirectory of TBBROOT
+            # example: old TBB 2017 with no cmake support at all
+            # - TBBROOT point to actual root of TBB
+            # - TBB_DIR points to cmake/developer_package/tbb/<lnx|mac|win>
+            set(IE_TBB_DIR_INSTALL "${TBB_DIR}")
+        endif()
 
         install(DIRECTORY "${TBBROOT}/"
                 DESTINATION "${IE_TBBROOT_INSTALL}"

--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -22,6 +22,16 @@ file(GLOB_RECURSE HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.h
 
 addVersionDefines(${CMAKE_CURRENT_SOURCE_DIR}/src/plugin.cpp CI_BUILD_NUMBER)
 
+# WA for old TBBConfig.cmake like tbb2019_20180718oss
+# they don't check that imported target is already created
+if(TBB_FOUND AND TBB_VERSION VERSION_GREATER_EQUAL 2018 AND TBB_VERSION VERSION_LESS_EQUAL 2019.4)
+    set(Threading_cmake_included ON)
+    set(DNNL_CPU_THREADING_RUNTIME "${THREADING}")
+    function(find_package_tbb)
+        # dummy
+    endfunction()
+endif()
+
 add_subdirectory(thirdparty)
 
 # create plugin


### PR DESCRIPTION
### Details:
 - Don't set `ENABLE_SYSTEM_TBB_DEFAULT` to `ON` if a user has provided his variables.
 - Handle case with TBB 2017 with no cmake files
 - Added check before oneDNN to disable TBB finding, oneDNN can rely on OpenVINO TBB. Otherwise, we have issues that TBB target is defined multiple times

### Tickets:
 - CVS-89248
 - CVS-86372
