### PR TITLE
[CPU] Remove extra inplace conflict check to avoid unnecessary reorders

### DIFF
--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -150,14 +150,6 @@ bool Edge::enforceReorder() {
         }
     }
 
-    if (in_place) {
-        int outNumber = getOutputNum();
-        if (inNumber >= 0 && inNumber < parentSPD->getConfig().outConfs.size() &&
-            parentSPD->getConfig().outConfs[inNumber].inPlace() >= 0 && outNumber >= 0 &&
-            outNumber < childSPD->getConfig().inConfs.size() && childSPD->getConfig().inConfs[outNumber].inPlace() >= 0)
-            canBeInPlaceConflicts = true;
-    }
-
     if (canBeInPlaceConflicts) {
         return true;
     }


### PR DESCRIPTION
### Details:
 - The situation when parent supports upstream inplace and child supports
downstream inplace is handled inside getBaseEdge()

### Tickets:
 - 87721