### PR TITLE
U22 adoption in github actions

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -17,11 +17,11 @@ jobs:
           set -e
           # install doc dependencies
           sudo apt update
-          sudo apt --assume-yes install libusb-1.0-0-dev graphviz texlive
+          sudo apt --assume-yes install libusb-1.0-0-dev graphviz texlive liblua5.2-0
           cd docs
-          python -m pip install -r requirements.txt --user
+          python3 -m pip install -r requirements.txt --user
           cd openvino_sphinx_theme
-          python setup.py install --user
+          python3 setup.py install --user
           cd ../..
           # install doxyrest
           wget https://github.com/vovkos/doxyrest/releases/download/doxyrest-2.1.3/doxyrest-2.1.3-linux-amd64.tar.xz

--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   Build_Doc:
     if: github.repository == 'openvinotoolkit/openvino'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone OpenVINO
         uses: actions/checkout@v2
@@ -43,7 +43,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DENABLE_DOCS=ON -DENABLE_PYTHON=ON -DNGRAPH_PYTHON_BUILD_ENABLE=ON -DCMAKE_BUILD_TYPE=Release ..
+          cmake -DENABLE_DOCS=ON -DENABLE_PYTHON=ON -DCMAKE_BUILD_TYPE=Release ..
 
       - name: Build doc
         run: |

--- a/.github/workflows/check_pr_commits.yml
+++ b/.github/workflows/check_pr_commits.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   Checks:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone OpenVINO
         uses: actions/checkout@v2

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -3,16 +3,16 @@ on: [push, pull_request]
 
 jobs:
   clang-format:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Install clang-format
+      - name: Install clang-format-9
         run: |
           sudo apt update
-          sudo apt --assume-yes install clang-format-14
+          sudo apt --assume-yes install clang-format-9
 
       - name: Install dependencies
         run: |
@@ -73,7 +73,7 @@ jobs:
         working-directory: build
 
   NamingConventionCheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -82,8 +82,8 @@ jobs:
       - name: Install Clang dependency
         run: |
           sudo apt update
-          sudo apt --assume-yes remove clang-7 clang-8 clang-9 clang-10 clang-11
-          sudo apt --assume-yes install libclang-12-dev
+          sudo apt --assume-yes remove clang-7 clang-8 clang-9 clang-10 clang-11 clang-12 clang-13
+          sudo apt --assume-yes install libclang-14-dev
 
       - name: Install Python-based dependencies
         run: python3 -m pip install -r cmake/developer_package/ncc_naming_style/requirements_dev.txt

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -3,16 +3,16 @@ on: [push, pull_request]
 
 jobs:
   clang-format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Install clang-format-9
+      - name: Install clang-format
         run: |
           sudo apt update
-          sudo apt --assume-yes install clang-format-9
+          sudo apt --assume-yes install clang-format-14
 
       - name: Install dependencies
         run: |
@@ -48,7 +48,7 @@ jobs:
           path: build/code_style_diff.diff
 
   ShellCheck:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/files_size.yml
+++ b/.github/workflows/files_size.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   Check_Files_Size:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/mo.yml
+++ b/.github/workflows/mo.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Pylint-UT:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/py_checks.yml
+++ b/.github/workflows/py_checks.yml
@@ -12,7 +12,7 @@ on:
       - 'samples/python/**'
 jobs:
   linters:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Code checkout
         uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.10'
       - name: Install dependencies
         run: python -m pip install -r src/bindings/python/requirements_test.txt
       # samples code-style

--- a/cmake/developer_package/clang_format/clang_format.cmake
+++ b/cmake/developer_package/clang_format/clang_format.cmake
@@ -3,21 +3,9 @@
 #
 
 if(ENABLE_CLANG_FORMAT)
-    set(CLANG_FORMAT_FILENAME clang-format-9 clang-format)
+    set(CLANG_FORMAT_FILENAME clang-format)
     find_host_program(CLANG_FORMAT NAMES ${CLANG_FORMAT_FILENAME} PATHS ENV PATH)
-    if(CLANG_FORMAT)
-        execute_process(COMMAND ${CLANG_FORMAT} ${CMAKE_CURRENT_SOURCE_DIR} ARGS --version OUTPUT_VARIABLE CLANG_VERSION)
-        if(NOT CLANG_VERSION OR CLANG_VERSION STREQUAL "")
-            message(WARNING "Supported clang-format version is 9!")
-            set(ENABLE_CLANG_FORMAT OFF)
-        else()
-            string(REGEX REPLACE "[^0-9]+([0-9]+)\\..*" "\\1" CLANG_FORMAT_MAJOR_VERSION ${CLANG_VERSION})
-            if(NOT ${CLANG_FORMAT_MAJOR_VERSION} EQUAL "9")
-                message(WARNING "Supported clang-format version is 9!")
-                set(ENABLE_CLANG_FORMAT OFF)
-            endif()
-        endif()
-    else()
+    if(NOT CLANG_FORMAT)
         message(WARNING "Supported clang-format version is not found!")
         set(ENABLE_CLANG_FORMAT OFF)
     endif()
@@ -88,6 +76,7 @@ function(add_clang_format_target TARGET_NAME)
             "[clang-format] ${source_file}"
             VERBATIM)
 
+        list(APPEND all_input_sources "${source_file}")
         list(APPEND all_output_files "${output_file}")
     endforeach()
 
@@ -108,7 +97,7 @@ function(add_clang_format_target TARGET_NAME)
         -D "EXCLUDE_PATTERNS=${CLANG_FORMAT_EXCLUDE_PATTERNS}"
         -P "${IEDevScripts_DIR}/clang_format/clang_format_fix.cmake"
         DEPENDS
-        "${CLANG_FORMAT_FOR_SOURCES}"
+        "${all_input_sources}"
         "${IEDevScripts_DIR}/clang_format/clang_format_fix.cmake"
         COMMENT
         "[clang-format] ${TARGET_NAME}_fix"

--- a/cmake/developer_package/ncc_naming_style/ncc_naming_style.cmake
+++ b/cmake/developer_package/ncc_naming_style/ncc_naming_style.cmake
@@ -9,6 +9,25 @@ endif()
 set(ncc_style_dir "${IEDevScripts_DIR}/ncc_naming_style")
 set(ncc_style_bin_dir "${CMAKE_CURRENT_BINARY_DIR}/ncc_naming_style")
 
+# find python3
+
+find_package(PythonInterp 3 QUIET)
+if(NOT PYTHONINTERP_FOUND)
+    message(WARNING "Python3 interpreter was not found (required for ncc naming style check)")
+    set(ENABLE_NCC_STYLE OFF)
+endif()
+
+if(PYTHON_VERSION_MINOR EQUAL 6)
+    set(clang_version 10)
+elseif(PYTHON_VERSION_MINOR EQUAL 8)
+    set(clang_version 12)
+elseif(PYTHON_VERSION_MINOR EQUAL 9)
+    set(clang_version 12)
+elseif(PYTHON_VERSION_MINOR EQUAL 10)
+    set(clang_version 14)
+endif()
+
+
 if(ENABLE_NCC_STYLE)
     # try to find_package(Clang QUIET)
     # ClangConfig.cmake contains bug that if libclang-XX-dev is not
@@ -16,17 +35,16 @@ if(ENABLE_NCC_STYLE)
     configure_file("${ncc_style_dir}/try_find_clang.cmake"
                    "${ncc_style_bin_dir}/source/CMakeLists.txt" COPYONLY)
     execute_process(
-        COMMAND
-            "${CMAKE_COMMAND}" -S "${ncc_style_bin_dir}/source"
-                               -B "${ncc_style_bin_dir}/build"
+        COMMAND "${CMAKE_COMMAND}" -S "${ncc_style_bin_dir}/source"
+                                   -B "${ncc_style_bin_dir}/build"
         RESULT_VARIABLE clang_find_result
         OUTPUT_VARIABLE output_var
         ERROR_VARIABLE error_var)
 
     if(NOT clang_find_result EQUAL "0")
-        message(WARNING "Please, install clang-[N] libclang-[N]-dev package (required for ncc naming style check)")
-        message(WARNING "find_package(Clang) output: ${output_var}")
-        message(WARNING "find_package(Clang) error: ${error_var}")
+        message(WARNING "Please, install `apt-get install clang-${clang_version} libclang-${clang_version}-dev` package (required for ncc naming style check)")
+        message(TRACE "find_package(Clang) output: ${output_var}")
+        message(TRACE "find_package(Clang) error: ${error_var}")
         set(ENABLE_NCC_STYLE OFF)
     endif()
 endif()
@@ -39,17 +57,9 @@ if(ENABLE_NCC_STYLE)
         get_target_property(libclang_location libclang LOCATION)
         message(STATUS "Found libclang: ${libclang_location}")
     else()
-        message(WARNING "libclang is not found (required for ncc naming style check)")
+        message(WARNING "libclang-${clang_version} is not found (required for ncc naming style check)")
         set(ENABLE_NCC_STYLE OFF)
     endif()
-endif()
-
-# find python3
-
-find_package(PythonInterp 3 QUIET)
-if(NOT PYTHONINTERP_FOUND)
-    message(WARNING "Python3 interpreter was not found (required for ncc naming style check)")
-    set(ENABLE_NCC_STYLE OFF)
 endif()
 
 # check python requirements_dev.txt

--- a/cmake/developer_package/ncc_naming_style/requirements_dev.txt
+++ b/cmake/developer_package/ncc_naming_style/requirements_dev.txt
@@ -1,2 +1,5 @@
-clang==11.0
+clang==10.0.1; python_version == '3.6'
+clang==12.0.1; python_version == '3.8'
+clang==12.0.1; python_version == '3.9'
+clang==14.0; python_version == '3.10'
 pyyaml

--- a/cmake/developer_package/shellcheck/shellcheck.cmake
+++ b/cmake/developer_package/shellcheck/shellcheck.cmake
@@ -6,6 +6,17 @@ include(CMakeParseArguments)
 
 find_host_program(shellcheck_PROGRAM NAMES shellcheck DOC "Path to shellcheck tool")
 
+if(shellcheck_PROGRAM)
+    execute_process(COMMAND "${shellcheck_PROGRAM}" --version
+        RESULT_VARIABLE shellcheck_EXIT_CODE
+        OUTPUT_VARIABLE shellcheck_VERSION_STRING)
+    if(shellcheck_EXIT_CODE EQUAL 0)
+        if(shellcheck_VERSION_STRING MATCHES "version: ([0-9]+)\.([0-9]+).([0-9]+)")
+            set(shellcheck_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}" CACHE STRING "shellcheck version")
+        endif()
+    endif()
+endif()
+
 function(ie_shellcheck_process)
     if(NOT shellcheck_PROGRAM)
         message(WARNING "shellcheck tool is not found")
@@ -33,7 +44,7 @@ function(ie_shellcheck_process)
         set(output_file "${output_file}.txt")
         get_filename_component(script_name "${script}" NAME)
 
-        add_custom_command(OUTPUT ${output_file} 
+        add_custom_command(OUTPUT ${output_file}
                            COMMAND ${CMAKE_COMMAND}
                              -D IE_SHELLCHECK_PROGRAM=${shellcheck_PROGRAM}
                              -D IE_SHELL_SCRIPT=${script}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -21,7 +21,7 @@ py==1.10.0
 pydata-sphinx-theme==0.7.2
 Pygments==2.8.1
 pyparsing==2.4.7
-pytest==6.2.3
+pytest==6.2.5
 pytest-html==3.1.1
 pytest-metadata==1.11.0
 pytz==2021.1

--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -24,9 +24,9 @@ if [ -f /etc/lsb-release ]; then
     # Ubuntu
     host_cpu=$(uname -m)
     if [ "$host_cpu" = "x86_64" ]; then
-        x86_64_specific_packages="gcc-multilib g++-multilib"
+        x86_64_specific_packages=(gcc-multilib g++-multilib)
     else
-        x86_64_specific_packages=""
+        x86_64_specific_packages=()
     fi
 
     sudo -E apt update
@@ -40,7 +40,7 @@ if [ -f /etc/lsb-release ]; then
             ca-certificates \
             git \
             git-lfs \
-            "$x86_64_specific_packages" \
+            "${x86_64_specific_packages[@]}" \
             libgtk2.0-dev \
             unzip \
             shellcheck \

--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -40,7 +40,7 @@ if [ -f /etc/lsb-release ]; then
             ca-certificates \
             git \
             git-lfs \
-            $x86_64_specific_packages \
+            "$x86_64_specific_packages" \
             libgtk2.0-dev \
             unzip \
             shellcheck \

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -6,21 +6,30 @@
 # Shellcheck
 #
 
+set(shellcheck_skip_list
+    "${OpenVINO_SOURCE_DIR}/bin"
+    "${OpenVINO_SOURCE_DIR}/build"
+    "${OpenVINO_SOURCE_DIR}/thirdparty"
+    "${OpenVINO_SOURCE_DIR}/src/plugins/intel_cpu/thirdparty"
+    "${OpenVINO_SOURCE_DIR}/src/plugins/intel_gpu/thirdparty"
+    "${OpenVINO_SOURCE_DIR}/src/bindings/python/thirdparty/pybind11"
+    "${OpenVINO_SOURCE_DIR}/tools/pot/thirdparty"
+    "${TEMP}")
+
+# TODO fix and enable back
+list(APPEND shellcheck_skip_list
+    "${OpenVINO_SOURCE_DIR}/scripts/install_dependencies/install_NEO_OCL_driver.sh"
+    "${OpenVINO_SOURCE_DIR}/scripts/install_dependencies/install_openvino_dependencies.sh"
+    "${OpenVINO_SOURCE_DIR}/src/bindings/python/tests/test_onnx/model_zoo_preprocess.sh"
+    "${OpenVINO_SOURCE_DIR}/src/bindings/python/tests_compatibility/test_onnx/model_zoo_preprocess.sh")
+
+if(shellcheck_VERSION VERSION_GREATER_EQUAL 0.7.0)
+    list(APPEND shellcheck_skip_list
+        "${OpenVINO_SOURCE_DIR}/scripts/setupvars/setupvars.sh")
+endif()
+
 ie_shellcheck_process(DIRECTORY "${OpenVINO_SOURCE_DIR}"
-                      SKIP "${OpenVINO_SOURCE_DIR}/bin"
-                           "${OpenVINO_SOURCE_DIR}/build"
-                           "${OpenVINO_SOURCE_DIR}/thirdparty"
-                           "${OpenVINO_SOURCE_DIR}/src/plugins/intel_cpu/thirdparty"
-                           "${OpenVINO_SOURCE_DIR}/src/plugins/intel_gpu/thirdparty"
-                           "${OpenVINO_SOURCE_DIR}/src/bindings/python/thirdparty/pybind11"
-                           "${OpenVINO_SOURCE_DIR}/tools/pot/thirdparty"
-                           "${TEMP}"
-                           # TODO fix and enable back:
-                           "${OpenVINO_SOURCE_DIR}/scripts/install_dependencies/install_NEO_OCL_driver.sh"
-                           "${OpenVINO_SOURCE_DIR}/scripts/install_dependencies/install_openvino_dependencies.sh"
-                           "${OpenVINO_SOURCE_DIR}/src/bindings/python/tests/test_onnx/model_zoo_preprocess.sh"
-                           "${OpenVINO_SOURCE_DIR}/src/bindings/python/tests_compatibility/test_onnx/model_zoo_preprocess.sh"
-                           )
+                      SKIP ${shellcheck_skip_list})
 
 #
 # cpack

--- a/src/tests/functional/plugin/myriad/run_tests_myriad_multistick.sh
+++ b/src/tests/functional/plugin/myriad/run_tests_myriad_multistick.sh
@@ -18,6 +18,7 @@ if [[ -n "$2" ]]; then
 else
     # Windows default
     if [[ -f "${TEST_DIR}/${APP_NAME}" ]]; then
+        # shellcheck disable=SC2269
         TEST_DIR=${TEST_DIR}
     # Search for Release or Debug config
     elif [[ -f "${TEST_DIR}/Release/${APP_NAME}" ]]; then


### PR DESCRIPTION
### Details:
 - Used U22 for all github actions except clang-format 
 - Improved suggestions for users of NCC - what clang package versions need to be installed on the system depending on default python version on Ubuntu
 - Added support of multiple shellcheck versions and fixed several issues in bash scripts