### PR TITLE
[releases/2022/2] openvino-dev uses opencv-python-headless as default

### DIFF
--- a/tools/benchmark_tool/requirements.txt
+++ b/tools/benchmark_tool/requirements.txt
@@ -1,4 +1,3 @@
 py-cpuinfo>=7.0.0
 numpy>=1.16.6,<1.20
 progress>=1.5
-opencv-python==4.5.*

--- a/tools/benchmark_tool/setup.py
+++ b/tools/benchmark_tool/setup.py
@@ -8,7 +8,9 @@ Use this script to create a wheel with OpenVINO™ Python* tools:
 
 $ python setup.py sdist bdist_wheel
 """
+import importlib
 import pkg_resources
+import warnings
 from setuptools import setup, find_packages
 
 with open('README.md', 'r', encoding='utf-8') as f:
@@ -21,6 +23,13 @@ with open('requirements.txt') as requirements_txt:
         in pkg_resources.parse_requirements(requirements_txt)
     ]
 
+try:
+    importlib.import_module('cv2')
+except ImportError as opencv_import_error:
+    warnings.warn(
+            "Problem with cv2 import: \n{}\n opencv-python-headless will be added to requirements".format(opencv_import_error)
+    )
+    reqs.append('opencv-python-headless==4.5.*')
 
 setup(
     name='benchmark_tool',


### PR DESCRIPTION
### Details:
 - *switch openvino-dev package on opencv-python-headless version by default due to problem to run tools in docker and server platforms without UI*

### Tickets:
 - *88523*
