### PR TITLE
remove test case LoadNetwork_SingleIECore

### DIFF
--- a/src/tests/functional/plugin/shared/include/behavior/plugin/core_threading.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/core_threading.hpp
@@ -333,20 +333,6 @@ TEST_P(CoreThreadingTestsWithIterations, smoke_LoadNetworkAccuracy) {
     }, numIterations, numThreads);
 }
 
-// tested function: single IECore ReadNetwork, SetConfig, LoadNetwork, AddExtension
-TEST_P(CoreThreadingTestsWithIterations, smoke_LoadNetwork_SingleIECore) {
-    std::atomic<unsigned int> counter{0u};
-    InferenceEngine::Core ie;
-
-    SetupNetworks();
-
-    runParallel([&] () {
-        auto value = counter++;
-        ie.SetConfig(config, deviceName);
-        (void)ie.LoadNetwork(networks[value % networks.size()], deviceName);
-    }, numIterations, numThreads);
-}
-
 // tested function: ReadNetwork, SetConfig, LoadNetwork, AddExtension
 TEST_P(CoreThreadingTestsWithIterations, smoke_LoadNetwork_MultipleIECores) {
     std::atomic<unsigned int> counter{0u};


### PR DESCRIPTION
### Details:
 - *remove test case smoke_LoadNetwork_SingleIECore from releases/2022/2*
 - *master PR  https://github.com/openvinotoolkit/openvino/pull/12557*

### Tickets:
 - *ticket-89440*
