### PR TITLE
Convolution shape inference

### DIFF
--- a/src/core/include/openvino/op/convolution.hpp
+++ b/src/core/include/openvino/op/convolution.hpp
@@ -78,8 +78,12 @@ public:
     const CoordinateDiff& get_pads_end() const {
         return m_pads_end;
     }
-    void set_adding_above(const CoordinateDiff& pads_end) {
+    void set_pads_end(const CoordinateDiff& pads_end) {
         m_pads_end = pads_end;
+    }
+    OPENVINO_DEPRECATED("This method is deprecated and will be removed soon. Please use set_pads_end instead.")
+    void set_adding_above(const CoordinateDiff& pads_end) {
+        set_pads_end(pads_end);
     }
     /// \return The pad type for convolution.
     const PadType& get_auto_pad() const {
@@ -110,8 +114,7 @@ private:
                                          const int64_t& num_non_spatial_filter_dims);
 
     template <class ConvType>
-    friend void update_and_validate_attributes(ConvType* op);
-
+    friend void update_and_validate_attributes(ConvType* op, int64_t num_spatial);
     template <class ConvType, class ShapeType>
     friend bool resolve_auto_pad_for_shape(const ConvType* op,
                                            CoordinateDiff& pads_begin,
@@ -290,10 +293,9 @@ private:
                                          const int64_t& num_non_spatial_filter_dims);
 
     template <class ConvType>
-    friend void update_and_validate_attributes(ConvType* op);
-
+    friend void update_and_validate_attributes(ConvType* op, int64_t num_spatial);
     template <class ConvType>
-    friend void update_and_validate_attributes_back_prop(ConvType* op);
+    friend void update_and_validate_attributes_back_prop(ConvType* op, int64_t num_spatial);
 
     template <class ConvType, class ShapeType>
     friend bool resolve_auto_pad_for_shape_back_prop(const ConvType* op,

--- a/src/core/include/openvino/op/group_conv.hpp
+++ b/src/core/include/openvino/op/group_conv.hpp
@@ -75,8 +75,12 @@ public:
     const CoordinateDiff& get_pads_end() const {
         return m_pads_end;
     }
-    void set_adding_above(const CoordinateDiff& pads_end) {
+    void set_pads_end(const CoordinateDiff& pads_end) {
         m_pads_end = pads_end;
+    }
+    OPENVINO_DEPRECATED("This method is deprecated and will be removed soon. Please use set_pads_end instead.")
+    void set_adding_above(const CoordinateDiff& pads_end) {
+        set_pads_end(pads_end);
     }
     /// \return The pad type for convolution.
     const PadType& get_auto_pad() const {
@@ -107,8 +111,7 @@ private:
                                          const int64_t& num_non_spatial_filter_dims);
 
     template <class ConvType>
-    friend void update_and_validate_attributes(ConvType* op);
-
+    friend void update_and_validate_attributes(ConvType* op, int64_t num_spatial);
     template <class ConvType, class ShapeType>
     friend bool resolve_auto_pad_for_shape(const ConvType* op,
                                            CoordinateDiff& pads_begin,
@@ -316,10 +319,10 @@ private:
                                          const int64_t& num_non_spatial_filter_dims);
 
     template <class ConvType>
-    friend void update_and_validate_attributes(ConvType* op);
+    friend void update_and_validate_attributes(ConvType* op, int64_t num_spatial);
 
     template <class ConvType>
-    friend void update_and_validate_attributes_back_prop(ConvType* op);
+    friend void update_and_validate_attributes_back_prop(ConvType* op, int64_t num_spatial);
 
     template <class ConvType, class ShapeType>
     friend bool resolve_auto_pad_for_shape_back_prop(const ConvType* op,

--- a/src/core/shape_inference/CMakeLists.txt
+++ b/src/core/shape_inference/CMakeLists.txt
@@ -22,6 +22,8 @@ target_include_directories(${TARGET_NAME} PUBLIC
     $<BUILD_INTERFACE:${SHAPE_INFER_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${OV_CORE_INCLUDE_PATH}>)
 
+add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME})
+
 if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(${TARGET_NAME} PUBLIC OPENVINO_STATIC_LIBRARY)
 endif()

--- a/src/core/shape_inference/include/broadcast_shape_inference.hpp
+++ b/src/core/shape_inference/include/broadcast_shape_inference.hpp
@@ -165,7 +165,6 @@ void broadcase_base_shape_infer(
     const std::vector<T>& input_shapes,
     std::vector<T>& output_shapes,
     const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
-
     // shape node should produce a one dimensional shape.
     auto broadcast_shape_rank = input_shapes[1].rank();
     NODE_VALIDATION_CHECK(op,

--- a/src/core/shape_inference/include/convolution_shape_inference.hpp
+++ b/src/core/shape_inference/include/convolution_shape_inference.hpp
@@ -5,13 +5,14 @@
 
 #include <openvino/op/convolution.hpp>
 #include <openvino/op/group_conv.hpp>
+
 #include "utils.hpp"
 
 namespace ov {
 namespace op {
 namespace v1 {
 
-template<class ConvType>
+template <class ConvType>
 int64_t calculate_num_spatial(const ConvType* op,
                               const PartialShape& input_shape,
                               const PartialShape& filters_shape,
@@ -19,41 +20,57 @@ int64_t calculate_num_spatial(const ConvType* op,
                               const int64_t& num_non_spatial_filter_dims) {
     int64_t num_spatial = op->m_num_spatial;
     if (num_spatial == -1) {
-        const auto &input_rank = input_shape.rank();
-        const auto &filters_rank = filters_shape.rank();
+        const auto& input_rank = input_shape.rank();
+        const auto& filters_rank = filters_shape.rank();
 
         if (input_rank.is_static())
             num_spatial = input_rank.get_length() - num_non_spatial_data_dims;
         if (filters_rank.is_static())
             num_spatial = filters_rank.get_length() - num_non_spatial_filter_dims;
 
-        if (const auto &size = op->m_dilations.size()) {
-            NODE_VALIDATION_CHECK(op, num_spatial == -1 || num_spatial == static_cast<int64_t>(size),
+        if (const auto& size = op->m_dilations.size()) {
+            NODE_VALIDATION_CHECK(op,
+                                  num_spatial == -1 || num_spatial == size,
                                   "Dilations should be defined for all and only spatial dimensions.");
             num_spatial = static_cast<int64_t>(size);
         }
-        if (const auto &size = op->m_strides.size()) {
-            NODE_VALIDATION_CHECK(op, num_spatial == -1 || num_spatial == static_cast<int64_t>(size),
+        if (const auto& size = op->m_strides.size()) {
+            NODE_VALIDATION_CHECK(op,
+                                  num_spatial == -1 || num_spatial == size,
                                   "Strides should be defined for all and only spatial dimensions.");
             num_spatial = static_cast<int64_t>(size);
         }
-        if (const auto &size = op->m_pads_begin.size()) {
-            NODE_VALIDATION_CHECK(op, num_spatial == -1 || num_spatial == static_cast<int64_t>(size),
+        if (const auto& size = op->m_pads_begin.size()) {
+            NODE_VALIDATION_CHECK(op,
+                                  num_spatial == -1 || num_spatial == size,
                                   "Pads begin should be defined for all and only spatial dimensions.");
             num_spatial = static_cast<int64_t>(size);
         }
-        if (const auto &size = op->m_pads_end.size()) {
-            NODE_VALIDATION_CHECK(op, num_spatial == -1 || num_spatial == static_cast<int64_t>(size),
-                                  "Pads begin should be defined for all and only spatial dimensions.");
+        if (const auto& size = op->m_pads_end.size()) {
+            NODE_VALIDATION_CHECK(op,
+                                  num_spatial == -1 || num_spatial == size,
+                                  "Pads end should be defined for all and only spatial dimensions.");
             num_spatial = static_cast<int64_t>(size);
         }
     }
     return num_spatial;
 }
 
-template<class ConvType>
-void update_and_validate_attributes(ConvType* op) {
-    const auto& num_spatial = op->m_num_spatial;
+template <class ConvType, class ShapeType>
+int64_t calculate_num_spatial(const ConvType* op,
+                              const ShapeType& input_shape,
+                              const ShapeType& filters_shape,
+                              const int64_t& num_non_spatial_data_dims,
+                              const int64_t& num_non_spatial_filter_dims) {
+    return calculate_num_spatial(op,
+                                 input_shape.to_partial_shape(),
+                                 filters_shape.to_partial_shape(),
+                                 num_non_spatial_data_dims,
+                                 num_non_spatial_filter_dims);
+}
+
+template <class ConvType>
+void update_and_validate_attributes(ConvType* op, int64_t num_spatial) {
     if (num_spatial != -1) {
         auto& strides = op->m_strides;
         auto& dilations = op->m_dilations;
@@ -78,12 +95,12 @@ void update_and_validate_attributes(ConvType* op) {
                               "Dilations should be defined for all and only spatial dimensions..");
         NODE_VALIDATION_CHECK(op,
                               static_cast<int64_t>(pad_begin.size()) == num_spatial &&
-                              static_cast<int64_t>(pad_end.size()) == num_spatial,
+                                  static_cast<int64_t>(pad_end.size()) == num_spatial,
                               "Pads should be defined for all and only spatial dimensions..");
         NODE_VALIDATION_CHECK(op,
                               std::all_of(dilations.begin(),
                                           dilations.end(),
-                                          [](const size_t &i) {
+                                          [](const size_t& i) {
                                               return i > 0;
                                           }),
                               "Filter dilation (",
@@ -92,12 +109,14 @@ void update_and_validate_attributes(ConvType* op) {
         NODE_VALIDATION_CHECK(op,
                               std::all_of(strides.begin(),
                                           strides.end(),
-                                          [](const size_t &i) {
+                                          [](const size_t& i) {
                                               return i > 0;
                                           }),
                               "Filter strides (",
                               strides,
                               ") has zero dimension.");
+    } else if (op->m_num_spatial != -1) {
+        update_and_validate_attributes(op, op->m_num_spatial);
     }
 }
 
@@ -108,16 +127,16 @@ inline bool dynamic_check(const int64_t& num_spatial) {
     return true;
 }
 
-template<>
+template <>
 inline bool dynamic_check<PartialShape>(const int64_t& num_spatial) {
     return num_spatial != -1;
 }
 
-template<class ConvType, class ShapeType>
+template <class ConvType, class ShapeType>
 bool resolve_auto_pad_for_shape(const ConvType* op,
                                 CoordinateDiff& pads_begin,
                                 CoordinateDiff& pads_end,
-                                const std::vector<ShapeType> &input_shapes,
+                                const std::vector<ShapeType>& input_shapes,
                                 const int64_t& num_non_spatial_data_dims,
                                 const int64_t& num_non_spatial_filter_dims) {
     const auto& auto_pad = op->m_auto_pad;
@@ -127,12 +146,17 @@ bool resolve_auto_pad_for_shape(const ConvType* op,
         return true;
     }
 
-    auto& num_spatial = op->m_num_spatial;
-    if (!dynamic_check<ShapeType>(num_spatial))
-        return false;
-
     auto input_shape = input_shapes[0];
     auto filters_shape = input_shapes[1];
+
+    const auto num_spatial = op->m_num_spatial != -1 ? op->m_num_spatial
+                                                     : calculate_num_spatial(op,
+                                                                             input_shape,
+                                                                             filters_shape,
+                                                                             num_non_spatial_data_dims,
+                                                                             num_non_spatial_filter_dims);
+    if (!dynamic_check<ShapeType>(num_spatial))
+        return false;
 
     if (input_shape.rank().is_dynamic())
         input_shape.resize(num_spatial + num_non_spatial_data_dims);
@@ -177,37 +201,62 @@ bool resolve_auto_pad_for_shape(const ConvType* op,
     return status;
 }
 
+template <class DimType>
+void divide_ceil(const DimType& dividend, const typename DimType::value_type& divisor, DimType& quotient) {
+    OPENVINO_ASSERT(divisor >= 0, "divisor must be greater than 0");
+    if (dividend.get_max_length() == -1) {
+        quotient = -1;
+    } else {
+        auto lb = ceil(1. * dividend.get_min_length() / divisor);
+        auto ub = ceil(1. * dividend.get_max_length() / divisor);
+        quotient = DimType(lb, ub);
+    }
+}
 
-template<class ConvType, class ShapeType>
-void calculate_output_spatial_dims_for_convolution(
-        const ConvType* op,
-        const ShapeType& input_shape,
-        const ShapeType& filters_shape,
-        ShapeType& output_shape,
-        const int64_t& num_spatial,
-        const Strides& strides,
-        const Strides& dilations,
-        const CoordinateDiff& pads_begin,
-        const CoordinateDiff& pads_end,
-        const int64_t& num_non_spatial_data_dims,
-        const int64_t& num_non_spatial_filter_dims) {
+template <class DimType>
+void divide_floor(const DimType& dividend, const typename DimType::value_type& divisor, DimType& quotient) {
+    OPENVINO_ASSERT(divisor >= 0, "divisor must be greater than 0");
+    if (dividend.get_max_length() == -1) {
+        quotient = -1;
+    } else {
+        auto lb = floor(1. * dividend.get_min_length() / divisor);
+        auto ub = floor(1. * dividend.get_max_length() / divisor);
+        quotient = DimType(lb, ub);
+    }
+}
 
+template <class ConvType, class ShapeType>
+void calculate_output_spatial_dims_for_convolution(const ConvType* op,
+                                                   const ShapeType& input_shape,
+                                                   const ShapeType& filters_shape,
+                                                   ShapeType& output_shape,
+                                                   const int64_t& num_spatial,
+                                                   const Strides& strides,
+                                                   const Strides& dilations,
+                                                   const CoordinateDiff& pads_begin,
+                                                   const CoordinateDiff& pads_end,
+                                                   const int64_t& num_non_spatial_data_dims,
+                                                   const int64_t& num_non_spatial_filter_dims) {
+    bool auto_pad = op->get_auto_pad() == op::PadType::SAME_UPPER || op->get_auto_pad() == op::PadType::SAME_LOWER;
     for (int64_t i = 0; i < num_spatial; ++i) {
-        const auto& input_dim = input_shape[i + num_non_spatial_data_dims];
+        auto input_dim = input_shape[i + num_non_spatial_data_dims];
+        if (auto_pad) {
+            divide_ceil(input_dim, strides[i], output_shape[i + num_non_spatial_data_dims]);
+            continue;
+        }
         const auto& filters_dim = filters_shape[i + num_non_spatial_filter_dims];
+        const auto& window_dilated_dim = (filters_dim - 1) * dilations[i] + 1;
+        const auto& data_padded_dilated_dim = input_dim + pads_begin[i] + pads_end[i];
         if (input_dim.is_static() && filters_dim.is_static()) {
-            const int64_t& window_dilated_dim = (filters_dim.get_length() - 1) * dilations[i] + 1;
             NODE_VALIDATION_CHECK(op,
-                                  window_dilated_dim > 0,
+                                  window_dilated_dim.get_length() > 0,
                                   "Window after dilation has dimension less than 1 (dim: ",
                                   window_dilated_dim,
                                   ") at axis ",
                                   i,
                                   ".");
-
-            const int64_t& data_padded_dilated_dim = input_dim.get_length() + pads_begin[i] + pads_end[i];
             NODE_VALIDATION_CHECK(op,
-                                  window_dilated_dim <= data_padded_dilated_dim,
+                                  window_dilated_dim.get_length() <= data_padded_dilated_dim.get_length(),
                                   "Window after dilation has dimension (dim: ",
                                   window_dilated_dim,
                                   ") larger than the data shape after padding (dim: ",
@@ -215,23 +264,32 @@ void calculate_output_spatial_dims_for_convolution(
                                   ") at axis ",
                                   i,
                                   ".");
-            output_shape[i + num_non_spatial_data_dims] = (data_padded_dilated_dim - window_dilated_dim) / strides[i] + 1;
         }
+        divide_floor(data_padded_dilated_dim - window_dilated_dim,
+                     strides[i],
+                     output_shape[i + num_non_spatial_data_dims]);
+        output_shape[i + num_non_spatial_data_dims] += 1;
     }
 }
 
-
-template<class T>
+template <class T>
 void shape_infer(const Convolution* op,
                  const CoordinateDiff& pads_begin,
                  const CoordinateDiff& pads_end,
-                 const std::vector<T> &input_shapes,
-                 std::vector<T> &output_shapes) {
+                 const std::vector<T>& input_shapes,
+                 std::vector<T>& output_shapes) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 2 && output_shapes.size() == 1);
+    constexpr size_t num_non_spatial_data_dims = 2, num_non_spatial_filter_dims = 2;
     auto input_shape = input_shapes[0], filters_shape = input_shapes[1];
 
-    const auto& num_spatial = op->m_num_spatial;
-    NODE_VALIDATION_CHECK(op, num_spatial != -1,
+    const auto num_spatial = op->m_num_spatial != -1 ? op->m_num_spatial
+                                                     : calculate_num_spatial(op,
+                                                                             input_shape,
+                                                                             filters_shape,
+                                                                             num_non_spatial_data_dims,
+                                                                             num_non_spatial_filter_dims);
+    NODE_VALIDATION_CHECK(op,
+                          num_spatial != -1,
                           "Convolution shape_infer should be provided with correct num_spatial attribute");
 
     if (input_shape.rank().is_dynamic())
@@ -239,67 +297,82 @@ void shape_infer(const Convolution* op,
     if (filters_shape.rank().is_dynamic())
         filters_shape.resize(num_spatial + 2);
 
-    NODE_VALIDATION_CHECK(op,
-                          (static_cast<int64_t>(input_shape.size()) == (num_spatial + 2)) &&
-                          (static_cast<int64_t>(filters_shape.size()) == (num_spatial + 2)),
-                          "Data batch and filters rank do not match (data batch shape: ",
-                          input_shape,
-                          ", filters shape: ",
-                          filters_shape,
-                          ").");
+    NODE_VALIDATION_CHECK(
+        op,
+        (static_cast<int64_t>(input_shape.size()) == (num_spatial + num_non_spatial_data_dims)) &&
+            (static_cast<int64_t>(filters_shape.size()) == (num_spatial + num_non_spatial_filter_dims)),
+        "Data batch and filters rank do not match (data batch shape: ",
+        input_shape,
+        ", filters shape: ",
+        filters_shape,
+        ").");
 
     // ranks are originally static or aligned with num_spatial, attributes assumed to be valid
     auto& output_shape = output_shapes[0];
-    output_shape.resize(num_spatial + 2);
+    output_shape.resize(num_spatial + num_non_spatial_data_dims);
     output_shape[0] = input_shape[0];
     output_shape[1] = filters_shape[0];
 
-    NODE_VALIDATION_CHECK(
-            op,
-            input_shape[1].compatible(filters_shape[1]),
-            "Data batch channel count (",
-            input_shape[1],
-            ") does not match filter input ",
-            "channel count (",
-            filters_shape[1],
-            ").");
+    NODE_VALIDATION_CHECK(op,
+                          input_shape[1].compatible(filters_shape[1]),
+                          "Data batch channel count (",
+                          input_shape[1],
+                          ") does not match filter input ",
+                          "channel count (",
+                          filters_shape[1],
+                          ").");
 
-    calculate_output_spatial_dims_for_convolution(
-        op, input_shape, filters_shape, output_shape,
-        num_spatial, op->m_strides, op->m_dilations, pads_begin, pads_end, 2, 2
-    );
+    calculate_output_spatial_dims_for_convolution(op,
+                                                  input_shape,
+                                                  filters_shape,
+                                                  output_shape,
+                                                  num_spatial,
+                                                  op->m_strides,
+                                                  op->m_dilations,
+                                                  pads_begin,
+                                                  pads_end,
+                                                  num_non_spatial_data_dims,
+                                                  num_non_spatial_filter_dims);
 }
 
-template<class T>
+template <class T>
 void shape_infer(const GroupConvolution* op,
                  const CoordinateDiff& pads_begin,
                  const CoordinateDiff& pads_end,
-                 const std::vector<T> &input_shapes,
-                 std::vector<T> &output_shapes) {
+                 const std::vector<T>& input_shapes,
+                 std::vector<T>& output_shapes) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 2 && output_shapes.size() == 1);
     auto input_shape = input_shapes[0], filters_shape = input_shapes[1];
+    constexpr size_t num_non_spatial_data_dims = 2, num_non_spatial_filter_dims = 3;
 
-    const auto& num_spatial = op->m_num_spatial;
-    NODE_VALIDATION_CHECK(op, num_spatial != -1,
+    const auto num_spatial = op->m_num_spatial != -1 ? op->m_num_spatial
+                                                     : calculate_num_spatial(op,
+                                                                             input_shape,
+                                                                             filters_shape,
+                                                                             num_non_spatial_data_dims,
+                                                                             num_non_spatial_filter_dims);
+    NODE_VALIDATION_CHECK(op,
+                          num_spatial != -1,
                           "GroupConvolution shape_infer should be provided with correct num_spatial attribute");
 
     if (input_shape.rank().is_dynamic())
-        input_shape.resize(num_spatial + 2);
+        input_shape.resize(num_spatial + num_non_spatial_data_dims);
     if (filters_shape.rank().is_dynamic())
-        filters_shape.resize(num_spatial + 3);
+        filters_shape.resize(num_spatial + num_non_spatial_filter_dims);
 
-    NODE_VALIDATION_CHECK(op,
-                          (static_cast<int64_t>(input_shape.size()) == (num_spatial + 2)) &&
-                          (static_cast<int64_t>(filters_shape.size()) == (num_spatial + 3)),
-                          "Data batch and filters rank do not match (data batch shape: ",
-                          input_shape,
-                          ", filters shape: ",
-                          filters_shape,
-                          ").");
+    NODE_VALIDATION_CHECK(
+        op,
+        (static_cast<int64_t>(input_shape.size()) == (num_spatial + num_non_spatial_data_dims)) &&
+            (static_cast<int64_t>(filters_shape.size()) == (num_spatial + num_non_spatial_filter_dims)),
+        "Data batch and filters rank do not match (data batch shape: ",
+        input_shape,
+        ", filters shape: ",
+        filters_shape,
+        ").");
 
     // ranks are originally static or aligned with num_spatial, attributes assumed to be valid
     auto& output_shape = output_shapes[0];
-    output_shape.resize(num_spatial + 2);
+    output_shape.resize(num_spatial + num_non_spatial_data_dims);
     output_shape[0] = input_shape[0];
 
     auto groups = filters_shape[0];
@@ -316,28 +389,33 @@ void shape_infer(const GroupConvolution* op,
     if (input_shape[1].is_static()) {
         // GROUPS and C_IN consistency checks
         if (groups.is_static() && filters_shape[2].is_static()) {
-            NODE_VALIDATION_CHECK(
-                op,
-                input_shape[1].get_length() / groups.get_length() == filters_shape[2].get_length(),
-                "Input channels dimension of data batch has incompatible value "
-                "with filter shape.");
+            NODE_VALIDATION_CHECK(op,
+                                  input_shape[1].get_length() / groups.get_length() == filters_shape[2].get_length(),
+                                  "Input channels dimension of data batch has incompatible value "
+                                  "with filter shape.");
         } else if (groups.is_static()) {
-            NODE_VALIDATION_CHECK(
-                    op,
-                    input_shape[1].get_length() % groups.get_length() == 0,
-                    "Input channels dimension of data batch not a multiple of group size.");
+            NODE_VALIDATION_CHECK(op,
+                                  input_shape[1].get_length() % groups.get_length() == 0,
+                                  "Input channels dimension of data batch not a multiple of group size.");
         }
     }
 
     output_shape[1] = groups * filters_shape[1];
 
-    calculate_output_spatial_dims_for_convolution(
-        op, input_shape, filters_shape, output_shape,
-        num_spatial, op->m_strides, op->m_dilations, pads_begin, pads_end, 2, 3
-    );
+    calculate_output_spatial_dims_for_convolution(op,
+                                                  input_shape,
+                                                  filters_shape,
+                                                  output_shape,
+                                                  num_spatial,
+                                                  op->m_strides,
+                                                  op->m_dilations,
+                                                  pads_begin,
+                                                  pads_end,
+                                                  num_non_spatial_data_dims,
+                                                  num_non_spatial_filter_dims);
 }
 
-template<class ConvType>
+template <class ConvType>
 int64_t calculate_num_spatial(const ConvType* op,
                               const PartialShape& input_shape,
                               const PartialShape& filters_shape,
@@ -346,16 +424,23 @@ int64_t calculate_num_spatial(const ConvType* op,
                               const int64_t& num_non_spatial_filter_dims) {
     auto num_spatial = op->m_num_spatial;
     if (num_spatial == -1) {
-        num_spatial = calculate_num_spatial(
-            op, input_shape, filters_shape, num_non_spatial_data_dims, num_non_spatial_filter_dims);
-        if (const auto &size = op->m_output_padding.size()) {
-            NODE_VALIDATION_CHECK(op, num_spatial == -1 || num_spatial == static_cast<int64_t>(size),
+        num_spatial = calculate_num_spatial(op,
+                                            input_shape,
+                                            filters_shape,
+                                            num_non_spatial_data_dims,
+                                            num_non_spatial_filter_dims);
+        if (const auto& size = op->m_output_padding.size()) {
+            NODE_VALIDATION_CHECK(op,
+                                  num_spatial == -1 || num_spatial == size,
                                   "Output padding should be defined for all and only spatial dimensions.");
             num_spatial = static_cast<int64_t>(size);
         }
         if (output_shapes_shape.is_static()) {
-            NODE_VALIDATION_CHECK(op, output_shapes_shape.size() == 1, "Input delivering output shape must have rank 1");
-            NODE_VALIDATION_CHECK(op, num_spatial == -1 || num_spatial == output_shapes_shape[0].get_length(),
+            NODE_VALIDATION_CHECK(op,
+                                  output_shapes_shape.size() == 1,
+                                  "Input delivering output shape must have rank 1");
+            NODE_VALIDATION_CHECK(op,
+                                  num_spatial == -1 || num_spatial == output_shapes_shape[0].get_length(),
                                   "Output shape should be specified only and for all spatial dimensions.");
             num_spatial = static_cast<int64_t>(output_shapes_shape[0].get_length());
         }
@@ -363,11 +448,25 @@ int64_t calculate_num_spatial(const ConvType* op,
     return num_spatial;
 }
 
-template<class ConvType>
-void update_and_validate_attributes_back_prop(ConvType* op) {
-    const auto& num_spatial = op->m_num_spatial;
+template <class ConvType, class ShapeType>
+int64_t calculate_num_spatial(const ConvType* op,
+                              const ShapeType& input_shape,
+                              const ShapeType& filters_shape,
+                              const ShapeType& output_shapes_shape,
+                              const int64_t& num_non_spatial_data_dims,
+                              const int64_t& num_non_spatial_filter_dims) {
+    return calculate_num_spatial(op,
+                                 input_shape.to_partial_shape(),
+                                 filters_shape.to_partial_shape(),
+                                 output_shapes_shape.to_partial_shape(),
+                                 num_non_spatial_data_dims,
+                                 num_non_spatial_filter_dims);
+}
+
+template <class ConvType>
+void update_and_validate_attributes_back_prop(ConvType* op, int64_t num_spatial) {
     if (num_spatial != -1) {
-        update_and_validate_attributes(op);
+        update_and_validate_attributes(op, num_spatial);
         auto& output_padding = op->m_output_padding;
         if (output_padding.empty())
             output_padding = CoordinateDiff(num_spatial, 0);
@@ -375,18 +474,19 @@ void update_and_validate_attributes_back_prop(ConvType* op) {
                               static_cast<int64_t>(output_padding.size()) == num_spatial,
                               "Output padding should be defined for all and only "
                               "spatial dimensions..");
+    } else if (op->m_num_spatial != -1) {
+        update_and_validate_attributes_back_prop(op, op->m_num_spatial);
     }
 }
 
-
-template<class ConvType, class ShapeType>
+template <class ConvType, class ShapeType>
 bool resolve_auto_pad_for_shape_back_prop(const ConvType* op,
-                                CoordinateDiff& pads_begin,
-                                CoordinateDiff& pads_end,
-                                const std::vector<ShapeType> &input_shapes,
-                                ShapeType& output_spatial_shape,
-                                const int64_t& num_non_spatial_data_dims,
-                                const int64_t& num_non_spatial_filter_dims) {
+                                          CoordinateDiff& pads_begin,
+                                          CoordinateDiff& pads_end,
+                                          const std::vector<ShapeType>& input_shapes,
+                                          ShapeType& output_spatial_shape,
+                                          const int64_t& num_non_spatial_data_dims,
+                                          const int64_t& num_non_spatial_filter_dims) {
     const auto& auto_pad = op->m_auto_pad;
     if (auto_pad != PadType::SAME_UPPER && auto_pad != PadType::SAME_LOWER) {
         pads_begin = op->m_pads_begin;
@@ -428,8 +528,10 @@ bool resolve_auto_pad_for_shape_back_prop(const ConvType* op,
         if (data_dim.is_static() && filter_dim.is_static() && output_dim.is_static()) {
             const auto& strides = op->m_strides[i];
             const auto& dilations = op->m_dilations[i];
-            int total_padding = std::max<int>(
-                    strides * (data_dim.get_length() - 1) + dilations * (filter_dim.get_length() - 1) + 1 - output_dim.get_length() + output_padding, 0);
+            int total_padding =
+                std::max<int>(strides * (data_dim.get_length() - 1) + dilations * (filter_dim.get_length() - 1) + 1 -
+                                  output_dim.get_length() + output_padding,
+                              0);
             if (auto_pad != op::PadType::SAME_UPPER) {
                 pads_begin[i] = total_padding / 2;
                 pads_end[i] = total_padding - pads_begin[i];
@@ -444,26 +546,6 @@ bool resolve_auto_pad_for_shape_back_prop(const ConvType* op,
     return status;
 }
 
-
-
-template<class ConvType, class ShapeType>
-void calculate_output_spatial_dims_for_convolution_back_prop_data(
-        const ConvType* op,
-        const ShapeType& input_shape,
-        const ShapeType& filters_shape,
-        const ShapeType& output_rank,
-        ShapeType& output_shape,
-        const int64_t& num_spatial,
-        const Strides& strides,
-        const Strides& dilations,
-        const CoordinateDiff& pads_begin,
-        const CoordinateDiff& pads_end,
-        const CoordinateDiff& output_padding,
-        const int64_t& num_non_spatial_data_dims,
-        const int64_t& num_non_spatial_filter_dims) {
-
-}
-
 template <class T>
 void shape_infer(const ConvolutionBackpropData* op,
                  const CoordinateDiff& pads_begin,
@@ -471,56 +553,75 @@ void shape_infer(const ConvolutionBackpropData* op,
                  const T& output_shape_from_input,
                  const std::vector<T>& input_shapes,
                  std::vector<T>& output_shapes) {
+    constexpr size_t num_non_spatial_data_dims = 2, num_non_spatial_filter_dims = 2;
     size_t input_size = input_shapes.size();
     NODE_VALIDATION_CHECK(op, (input_size == 2 || input_size == 3) && output_shapes.size() == 1);
     auto input_shape = input_shapes[0], filters_shape = input_shapes[1];
 
-    const auto& num_spatial = op->m_num_spatial;
-    NODE_VALIDATION_CHECK(op, num_spatial != -1,
+    const auto num_spatial = op->m_num_spatial != -1
+                                 ? op->m_num_spatial
+                                 : input_size == 3 ? calculate_num_spatial(op,
+                                                                           input_shape,
+                                                                           filters_shape,
+                                                                           input_shapes[2],
+                                                                           num_non_spatial_data_dims,
+                                                                           num_non_spatial_filter_dims)
+                                                   : calculate_num_spatial(op,
+                                                                           input_shape,
+                                                                           filters_shape,
+                                                                           num_non_spatial_data_dims,
+                                                                           num_non_spatial_filter_dims);
+
+    NODE_VALIDATION_CHECK(op,
+                          num_spatial != -1,
                           "ConvolutionBackpropData shape_infer should be provided with correct num_spatial attribute");
 
-    NODE_VALIDATION_CHECK(op, num_spatial == 1 || num_spatial == 2 || num_spatial == 3,
+    NODE_VALIDATION_CHECK(op,
+                          num_spatial == 1 || num_spatial == 2 || num_spatial == 3,
                           "Data and filters inputs must have rank 3, 4 or 5");
 
     if (input_shape.rank().is_dynamic())
-        input_shape.resize(num_spatial + 2);
+        input_shape.resize(num_spatial + num_non_spatial_data_dims);
     if (filters_shape.rank().is_dynamic())
-        filters_shape.resize(num_spatial + 2);
+        filters_shape.resize(num_spatial + num_non_spatial_filter_dims);
 
-    NODE_VALIDATION_CHECK(op,
-                          (static_cast<int64_t>(input_shape.size()) == (num_spatial + 2)) &&
-                          (static_cast<int64_t>(filters_shape.size()) == (num_spatial + 2)),
-                          "Data and filters rank do not match (data batch shape: ",
-                          input_shape,
-                          ", filters shape: ",
-                          filters_shape,
-                          ").");
+    NODE_VALIDATION_CHECK(
+        op,
+        (static_cast<int64_t>(input_shape.size()) == (num_spatial + num_non_spatial_data_dims)) &&
+            (static_cast<int64_t>(filters_shape.size()) == (num_spatial + num_non_spatial_filter_dims)),
+        "Data and filters rank do not match (data batch shape: ",
+        input_shape,
+        ", filters shape: ",
+        filters_shape,
+        ").");
 
     // ranks are originally static or aligned with num_spatial, attributes assumed to be valid
     auto& output_shape = output_shapes[0];
-    output_shape.resize(num_spatial + 2);
+    output_shape.resize(num_spatial + num_non_spatial_data_dims);
     output_shape[0] = input_shape[0];
     output_shape[1] = filters_shape[1];
 
-    NODE_VALIDATION_CHECK(op, input_shape[1].compatible(filters_shape[0]),
+    NODE_VALIDATION_CHECK(op,
+                          input_shape[1].compatible(filters_shape[0]),
                           "Input channels dimension of data and filters inputs must be equal");
 
     if (input_size == 3) {
         if (output_shape_from_input.rank().is_static()) {
-            NODE_VALIDATION_CHECK(op, output_shape_from_input.size() == num_spatial,
+            NODE_VALIDATION_CHECK(op,
+                                  output_shape_from_input.size() == num_spatial,
                                   "Output shape should be specified only and for all spatial dimensions.");
             for (int64_t i = 0; i < num_spatial; ++i)
-                output_shape[i + 2] = output_shape_from_input[i];
+                output_shape[i + num_non_spatial_data_dims] = output_shape_from_input[i];
         }
     } else {
         const auto& strides = op->m_strides;
         const auto& dilations = op->m_dilations;
         const auto& output_padding = op->m_output_padding;
         for (int64_t i = 0; i < num_spatial; ++i) {
-            if (filters_shape[i + 2].is_static() && input_shape[i + 2].is_static())
-                output_shape[i + 2] = strides[i] * (input_shape[i + 2].get_length() - 1) +
-                  dilations[i] * (filters_shape[i + 2].get_length() - 1) + 1 - pads_begin[i] - pads_end[i] +
-                  output_padding[i];
+            const auto &data_idx = i + num_non_spatial_data_dims, filter_idx = i + num_non_spatial_filter_dims;
+            output_shape[data_idx] = (input_shape[data_idx] - 1) * strides[i] +
+                                     (filters_shape[filter_idx] - 1) * dilations[i] + 1 - pads_begin[i] - pads_end[i] +
+                                     output_padding[i];
         }
     }
 }
@@ -532,34 +633,52 @@ void shape_infer(const GroupConvolutionBackpropData* op,
                  const T& output_shape_from_input,
                  const std::vector<T>& input_shapes,
                  std::vector<T>& output_shapes) {
+    constexpr size_t num_non_spatial_data_dims = 2, num_non_spatial_filter_dims = 3;
     size_t input_size = input_shapes.size();
     NODE_VALIDATION_CHECK(op, (input_size == 2 || input_size == 3) && output_shapes.size() == 1);
     auto input_shape = input_shapes[0], filters_shape = input_shapes[1];
 
-    const auto& num_spatial = op->m_num_spatial;
-    NODE_VALIDATION_CHECK(op, num_spatial != -1,
-                          "GroupConvolutionBackpropData shape_infer should be provided with correct num_spatial attribute");
+    const auto num_spatial = op->m_num_spatial != -1
+                                 ? op->m_num_spatial
+                                 : input_size == 3 ? calculate_num_spatial(op,
+                                                                           input_shape,
+                                                                           filters_shape,
+                                                                           input_shapes[2],
+                                                                           num_non_spatial_data_dims,
+                                                                           num_non_spatial_filter_dims)
+                                                   : calculate_num_spatial(op,
+                                                                           input_shape,
+                                                                           filters_shape,
+                                                                           num_non_spatial_data_dims,
+                                                                           num_non_spatial_filter_dims);
 
-    NODE_VALIDATION_CHECK(op, num_spatial == 1 || num_spatial == 2 || num_spatial == 3,
+    NODE_VALIDATION_CHECK(
+        op,
+        num_spatial != -1,
+        "GroupConvolutionBackpropData shape_infer should be provided with correct num_spatial attribute");
+
+    NODE_VALIDATION_CHECK(op,
+                          num_spatial == 1 || num_spatial == 2 || num_spatial == 3,
                           "Data and filters inputs must have rank 3, 4 or 5");
 
     if (input_shape.rank().is_dynamic())
-        input_shape.resize(num_spatial + 2);
+        input_shape.resize(num_spatial + num_non_spatial_data_dims);
     if (filters_shape.rank().is_dynamic())
-        filters_shape.resize(num_spatial + 3);
+        filters_shape.resize(num_spatial + num_non_spatial_filter_dims);
 
-    NODE_VALIDATION_CHECK(op,
-                          (static_cast<int64_t>(input_shape.size()) == (num_spatial + 2)) &&
-                          (static_cast<int64_t>(filters_shape.size()) == (num_spatial + 3)),
-                          "Data and filters rank do not match (data batch shape: ",
-                          input_shape,
-                          ", filters shape: ",
-                          filters_shape,
-                          ").");
+    NODE_VALIDATION_CHECK(
+        op,
+        (static_cast<int64_t>(input_shape.size()) == (num_spatial + num_non_spatial_data_dims)) &&
+            (static_cast<int64_t>(filters_shape.size()) == (num_spatial + num_non_spatial_filter_dims)),
+        "Data and filters rank do not match (data batch shape: ",
+        input_shape,
+        ", filters shape: ",
+        filters_shape,
+        ").");
 
     // ranks are originally static or aligned with num_spatial, attributes assumed to be valid
     auto& output_shape = output_shapes[0];
-    output_shape.resize(num_spatial + 2);
+    output_shape.resize(num_spatial + num_non_spatial_data_dims);
     output_shape[0] = input_shape[0];
 
     auto groups = filters_shape[0];
@@ -576,16 +695,14 @@ void shape_infer(const GroupConvolutionBackpropData* op,
     if (input_shape[1].is_static()) {
         // GROUPS and C_IN consistency checks
         if (groups.is_static() && filters_shape[1].is_static()) {
-            NODE_VALIDATION_CHECK(
-                    op,
-                    input_shape[1].get_length() / groups.get_length() == filters_shape[1].get_length(),
-                    "Input channels dimension of data batch has incompatible value "
-                    "with filter shape.");
+            NODE_VALIDATION_CHECK(op,
+                                  input_shape[1].get_length() / groups.get_length() == filters_shape[1].get_length(),
+                                  "Input channels dimension of data batch has incompatible value "
+                                  "with filter shape.");
         } else if (groups.is_static()) {
-            NODE_VALIDATION_CHECK(
-                    op,
-                    input_shape[1].get_length() % groups.get_length() == 0,
-                    "Input channels dimension of data batch not a multiple of group size.");
+            NODE_VALIDATION_CHECK(op,
+                                  input_shape[1].get_length() % groups.get_length() == 0,
+                                  "Input channels dimension of data batch not a multiple of group size.");
         }
     }
 
@@ -593,24 +710,25 @@ void shape_infer(const GroupConvolutionBackpropData* op,
 
     if (input_size == 3) {
         if (output_shape_from_input.rank().is_static()) {
-            NODE_VALIDATION_CHECK(op, output_shape_from_input.size() == num_spatial,
+            NODE_VALIDATION_CHECK(op,
+                                  output_shape_from_input.size() == num_spatial,
                                   "Output shape should be specified only and for all spatial dimensions.");
             for (int64_t i = 0; i < num_spatial; ++i)
-                output_shape[i + 2] = output_shape_from_input[i];
+                output_shape[i + num_non_spatial_data_dims] = output_shape_from_input[i];
         }
     } else {
         const auto& strides = op->m_strides;
         const auto& dilations = op->m_dilations;
         const auto& output_padding = op->m_output_padding;
         for (int64_t i = 0; i < num_spatial; ++i) {
-            if (filters_shape[i + 3].is_static() && input_shape[i + 2].is_static())
-                output_shape[i + 2] = strides[i] * (input_shape[i + 2].get_length() - 1) +
-                  dilations[i] * (filters_shape[i + 3].get_length() - 1) + 1 - pads_begin[i] - pads_end[i] +
-                  output_padding[i];
+            const auto &data_idx = i + num_non_spatial_data_dims, filter_idx = i + num_non_spatial_filter_dims;
+            output_shape[data_idx] = (input_shape[data_idx] - 1) * strides[i] +
+                                     (filters_shape[filter_idx] - 1) * dilations[i] + 1 - pads_begin[i] - pads_end[i] +
+                                     output_padding[i];
         }
     }
 }
 
-}
-}
-}
+}  // namespace v1
+}  // namespace op
+}  // namespace ov

--- a/src/core/shape_inference/include/depth_to_space_shape_inference.hpp
+++ b/src/core/shape_inference/include/depth_to_space_shape_inference.hpp
@@ -28,7 +28,7 @@ void shape_infer(const ov::op::v0::DepthToSpace* op,
 
     if (data_rank.is_static()) {
         NODE_VALIDATION_CHECK(op,
-                               data_shape.size() >= 3,
+                              data_shape.size() >= 3,
                               "The input tensor with rank lower than 3 is not supported (input rank: ",
                               data_shape.size(),
                               ")");

--- a/src/core/shape_inference/include/eye_shape_inference.hpp
+++ b/src/core/shape_inference/include/eye_shape_inference.hpp
@@ -4,13 +4,14 @@
 #pragma once
 #include <openvino/core/validation_util.hpp>
 #include <openvino/opsets/opset9.hpp>
+
 #include "utils.hpp"
 
 namespace ov {
 namespace op {
 namespace util {
 
-template<class T>
+template <class T>
 void check_1D_or_scalar_shape(const ov::op::v9::Eye* op, const T& input_shape, const std::string name) {
     if (input_shape.is_static()) {
         const auto& num_rows_rank = input_shape.rank().get_length();
@@ -24,11 +25,12 @@ void check_1D_or_scalar_shape(const ov::op::v9::Eye* op, const T& input_shape, c
     }
 }
 
-
 }  // namespace util
 
-template<class T>
-void shape_infer(const ov::op::v9::Eye* op, const std::vector<T> &input_shapes, std::vector<T> &output_shapes,
+template <class T>
+void shape_infer(const ov::op::v9::Eye* op,
+                 const std::vector<T>& input_shapes,
+                 std::vector<T>& output_shapes,
                  const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == op->get_input_size() && output_shapes.size() == 1);
     // output_shape = dims_batch_shape + dims_matrix

--- a/src/core/shape_inference/include/fake_quantize.hpp
+++ b/src/core/shape_inference/include/fake_quantize.hpp
@@ -4,12 +4,13 @@
 #pragma once
 
 #include <openvino/op/fake_quantize.hpp>
+
 #include "utils.hpp"
 
 template <class T>
 void shape_infer(const ov::op::v0::FakeQuantize* op,
-                 const std::vector<T> &input_shapes,
-                 std::vector<T> &output_shapes) {
+                 const std::vector<T>& input_shapes,
+                 std::vector<T>& output_shapes) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 5 && output_shapes.size() == 1);
 
     T data_pshape = input_shapes[0];
@@ -17,15 +18,12 @@ void shape_infer(const ov::op::v0::FakeQuantize* op,
 
     for (size_t i = 1; i <= 4; ++i) {
         if (auto_broadcast.m_type == ov::op::AutoBroadcastType::NONE) {
-            NODE_VALIDATION_CHECK(op,
-                                  T::merge_into(data_pshape, input_shapes[i]),
-                                  "Argument shapes are inconsistent.");
+            NODE_VALIDATION_CHECK(op, T::merge_into(data_pshape, input_shapes[i]), "Argument shapes are inconsistent.");
         } else if (auto_broadcast.m_type == ov::op::AutoBroadcastType::NUMPY ||
                    auto_broadcast.m_type == ov::op::AutoBroadcastType::PDPD) {
-            NODE_VALIDATION_CHECK(
-                    op,
-                    T::broadcast_merge_into(data_pshape, input_shapes[i], auto_broadcast),
-                    "Argument shapes are inconsistent.");
+            NODE_VALIDATION_CHECK(op,
+                                  T::broadcast_merge_into(data_pshape, input_shapes[i], auto_broadcast),
+                                  "Argument shapes are inconsistent.");
         } else {
             NODE_VALIDATION_CHECK(op, false, "Unsupported auto broadcast specification");
         }

--- a/src/core/shape_inference/include/generate_proposals_shape_inference.hpp
+++ b/src/core/shape_inference/include/generate_proposals_shape_inference.hpp
@@ -11,9 +11,7 @@ namespace op {
 
 namespace v9 {
 template <class T>
-void shape_infer(const GenerateProposals* op,
-                 const std::vector<T>& input_shapes,
-                 std::vector<T>& output_shapes) {
+void shape_infer(const GenerateProposals* op, const std::vector<T>& input_shapes, std::vector<T>& output_shapes) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 4 && output_shapes.size() == 3);
 
     const auto& im_info_shape = input_shapes[0];
@@ -62,7 +60,7 @@ void shape_infer(const GenerateProposals* op,
                               "equal. Got: ",
                               deltas_shape[0],
                               scores_shape[0]);
-        
+
         NODE_VALIDATION_CHECK(op,
                               deltas_shape[1].compatible(scores_shape[1] * 4),
                               "Anchor number for inputs 'input_deltas' and 'input_scores' should be "
@@ -86,11 +84,11 @@ void shape_infer(const GenerateProposals* op,
 
         if (im_info_shape_rank.is_static()) {
             NODE_VALIDATION_CHECK(op,
-                                deltas_shape[0].compatible(im_info_shape[0]),
-                                "Batch for inputs 'im_info' and 'input_deltas' should be "
-                                "equal. Got: ",
-                                deltas_shape[0],
-                                im_info_shape[0]);
+                                  deltas_shape[0].compatible(im_info_shape[0]),
+                                  "Batch for inputs 'im_info' and 'input_deltas' should be "
+                                  "equal. Got: ",
+                                  deltas_shape[0],
+                                  im_info_shape[0]);
         }
     }
 

--- a/src/core/shape_inference/include/irdft_shape_inference.hpp
+++ b/src/core/shape_inference/include/irdft_shape_inference.hpp
@@ -13,9 +13,9 @@ namespace op {
 namespace util {
 template <class T>
 void irdft_shape_infer(const ov::op::v9::IRDFT* op,
-                      const std::vector<T>& input_shapes,
-                      std::vector<T>& output_shapes,
-                      const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
+                       const std::vector<T>& input_shapes,
+                       std::vector<T>& output_shapes,
+                       const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
     using DimType = typename std::iterator_traits<typename T::iterator>::value_type;
     NODE_VALIDATION_CHECK(op, (input_shapes.size() == 2 || input_shapes.size() == 3) && output_shapes.size() == 1);
 
@@ -25,7 +25,11 @@ void irdft_shape_infer(const ov::op::v9::IRDFT* op,
     std::vector<int64_t> axes;
     bool axes_are_known = get_data_as_int64<T>(1, op, axes, constant_data);
 
-    rfft_common_validation::shape_validation(op, input_shapes, axes, axes_are_known, rfft_common_validation::RFFTKind::Inverse);
+    rfft_common_validation::shape_validation(op,
+                                             input_shapes,
+                                             axes,
+                                             axes_are_known,
+                                             rfft_common_validation::RFFTKind::Inverse);
 
     if (input_shape.rank().is_dynamic()) {
         output_shape = ov::PartialShape::dynamic();

--- a/src/core/shape_inference/include/matmul_shape_inference.hpp
+++ b/src/core/shape_inference/include/matmul_shape_inference.hpp
@@ -10,10 +10,8 @@
 namespace ov {
 namespace op {
 namespace v0 {
-template<class T>
-void shape_infer(const ov::op::v0::MatMul *op,
-                 const std::vector<T> &input_shapes,
-                 std::vector<T> &output_shapes) {
+template <class T>
+void shape_infer(const ov::op::v0::MatMul* op, const std::vector<T>& input_shapes, std::vector<T>& output_shapes) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 2 && output_shapes.size() == 1);
 
     auto arg0_shape = input_shapes[0], arg1_shape = input_shapes[1];
@@ -64,7 +62,8 @@ void shape_infer(const ov::op::v0::MatMul *op,
     auto merged_dimension = DimType();
     auto arg0_col_dim = arg0_shape_tmp[arg0_rank - 1];
     auto arg1_row_dim = arg1_shape_tmp[arg1_rank - 2];
-    NODE_VALIDATION_CHECK(op, DimType::merge(merged_dimension, arg0_col_dim, arg1_row_dim) || arg0_col_dim.is_dynamic() ||
+    NODE_VALIDATION_CHECK(op,
+                          DimType::merge(merged_dimension, arg0_col_dim, arg1_row_dim) || arg0_col_dim.is_dynamic() ||
                               arg1_row_dim.is_dynamic(),
                           "Incompatible MatMul matrix dimension. ",
                           "First input dimension=",
@@ -90,7 +89,8 @@ void shape_infer(const ov::op::v0::MatMul *op,
     // Broadcast all batches (last two dimensions represent matrix),
     // expand dim with value 1 to bigger dim if dimensions are not equal.
     for (size_t i = 0; i < max_rank - 2; ++i) {
-        NODE_VALIDATION_CHECK(op, DimType::broadcast_merge(output_shape[i], arg0_shape_tmp[i], arg1_shape_tmp[i]) ||
+        NODE_VALIDATION_CHECK(op,
+                              DimType::broadcast_merge(output_shape[i], arg0_shape_tmp[i], arg1_shape_tmp[i]) ||
                                   arg0_shape_tmp[i].is_dynamic() || arg1_shape_tmp[i].is_dynamic(),
                               "Incompatible MatMul batch dimension. ",
                               "Can't merge first input dimension=",
@@ -118,6 +118,6 @@ void shape_infer(const ov::op::v0::MatMul *op,
     }
     output_shapes[0] = output_shape;
 }
-}
-}
-}
+}  // namespace v0
+}  // namespace op
+}  // namespace ov

--- a/src/core/shape_inference/include/multiclass_nms_shape_inference.hpp
+++ b/src/core/shape_inference/include/multiclass_nms_shape_inference.hpp
@@ -4,10 +4,9 @@
 
 #pragma once
 
-#include <vector>
-
 #include <openvino/op/multiclass_nms.hpp>
 #include <openvino/op/util/multiclass_nms_base.hpp>
+#include <vector>
 
 namespace ov {
 namespace op {
@@ -19,8 +18,7 @@ void shape_infer(const ov::op::util::MulticlassNmsBase* op,
                  std::vector<T>& output_shapes,
                  bool static_output = false,
                  bool ignore_bg_class = false) {
-    NODE_VALIDATION_CHECK(op, (input_shapes.size() == 2 || input_shapes.size() == 3)
-                    && output_shapes.size() == 3);
+    NODE_VALIDATION_CHECK(op, (input_shapes.size() == 2 || input_shapes.size() == 3) && output_shapes.size() == 3);
 
     const auto& boxes_ps = input_shapes[0];
     const auto& scores_ps = input_shapes[1];
@@ -54,11 +52,10 @@ void shape_infer(const ov::op::util::MulticlassNmsBase* op,
                           boxes_ps[2]);
 
     if (ov::is_type<ov::op::v8::MulticlassNms>(op)) {
-        NODE_VALIDATION_CHECK(
-            op,
-            scores_ps.rank().is_static() && scores_ps.rank().get_length() == 3,
-            "Expected a 3D tensor for the 'scores' input. Got: ",
-            scores_ps);
+        NODE_VALIDATION_CHECK(op,
+                              scores_ps.rank().is_static() && scores_ps.rank().get_length() == 3,
+                              "Expected a 3D tensor for the 'scores' input. Got: ",
+                              scores_ps);
     } else {
         NODE_VALIDATION_CHECK(
             op,

--- a/src/core/shape_inference/include/nms_shape_inference.hpp
+++ b/src/core/shape_inference/include/nms_shape_inference.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include <vector>
-#include <openvino/op/non_max_suppression.hpp>
 #include <ngraph/validation_util.hpp>
+#include <openvino/op/non_max_suppression.hpp>
+#include <vector>
 
 using namespace ngraph;
 
@@ -15,9 +15,7 @@ namespace op {
 namespace v9 {
 
 template <class T>
-void shape_infer(const NonMaxSuppression* op,
-                 const std::vector<T>& input_shapes,
-                 std::vector<T>& output_shapes) {
+void shape_infer(const NonMaxSuppression* op, const std::vector<T>& input_shapes, std::vector<T>& output_shapes) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 2 && output_shapes.size() == 3);
 
     const auto& boxes_ps = input_shapes[0];
@@ -25,38 +23,38 @@ void shape_infer(const NonMaxSuppression* op,
 
     if (!boxes_ps.is_dynamic() && !scores_ps.is_dynamic()) {
         NODE_VALIDATION_CHECK(op,
-                            boxes_ps.rank().is_static() && boxes_ps.rank().get_length() == 3,
-                            "Expected a 3D tensor for the 'boxes' input. Got: ",
-                            boxes_ps);
+                              boxes_ps.rank().is_static() && boxes_ps.rank().get_length() == 3,
+                              "Expected a 3D tensor for the 'boxes' input. Got: ",
+                              boxes_ps);
 
         NODE_VALIDATION_CHECK(op,
-                            scores_ps.rank().is_static() && scores_ps.rank().get_length() == 3,
-                            "Expected a 3D tensor for the 'scores' input. Got: ",
-                            scores_ps);
+                              scores_ps.rank().is_static() && scores_ps.rank().get_length() == 3,
+                              "Expected a 3D tensor for the 'scores' input. Got: ",
+                              scores_ps);
 
         const auto num_batches_boxes = boxes_ps[0];
         const auto num_batches_scores = scores_ps[0];
         NODE_VALIDATION_CHECK(op,
-                            num_batches_boxes.same_scheme(num_batches_scores),
-                            "The first dimension of both 'boxes' and 'scores' must match. Boxes: ",
-                            num_batches_boxes,
-                            "; Scores: ",
-                            num_batches_scores);
+                              num_batches_boxes.same_scheme(num_batches_scores),
+                              "The first dimension of both 'boxes' and 'scores' must match. Boxes: ",
+                              num_batches_boxes,
+                              "; Scores: ",
+                              num_batches_scores);
 
         const auto num_boxes_boxes = boxes_ps[1];
         const auto num_boxes_scores = scores_ps[2];
         NODE_VALIDATION_CHECK(op,
-                            num_boxes_boxes.same_scheme(num_boxes_scores),
-                            "'boxes' and 'scores' input shapes must match at the second and third "
-                            "dimension respectively. Boxes: ",
-                            num_boxes_boxes,
-                            "; Scores: ",
-                            num_boxes_scores);
+                              num_boxes_boxes.same_scheme(num_boxes_scores),
+                              "'boxes' and 'scores' input shapes must match at the second and third "
+                              "dimension respectively. Boxes: ",
+                              num_boxes_boxes,
+                              "; Scores: ",
+                              num_boxes_scores);
 
         NODE_VALIDATION_CHECK(op,
-                            boxes_ps[2].is_static() && boxes_ps[2].get_length() == 4u,
-                            "The last dimension of the 'boxes' input must be equal to 4. Got:",
-                            boxes_ps[2]);
+                              boxes_ps[2].is_static() && boxes_ps[2].get_length() == 4u,
+                              "The last dimension of the 'boxes' input must be equal to 4. Got:",
+                              boxes_ps[2]);
     }
 
     // NonMaxSuppression produces triplets

--- a/src/core/shape_inference/include/rdft_shape_inference.hpp
+++ b/src/core/shape_inference/include/rdft_shape_inference.hpp
@@ -38,7 +38,11 @@ void rdft_shape_infer(const ov::op::v9::RDFT* op,
     std::vector<int64_t> axes;
     bool axes_are_known = get_data_as_int64<T>(1, op, axes, constant_data);
 
-    rfft_common_validation::shape_validation(op, input_shapes, axes, axes_are_known, rfft_common_validation::RFFTKind::Forward);
+    rfft_common_validation::shape_validation(op,
+                                             input_shapes,
+                                             axes,
+                                             axes_are_known,
+                                             rfft_common_validation::RFFTKind::Forward);
 
     if (input_shape.rank().is_dynamic()) {
         output_shape = ov::PartialShape::dynamic();

--- a/src/core/shape_inference/include/read_value_shape_inference.hpp
+++ b/src/core/shape_inference/include/read_value_shape_inference.hpp
@@ -3,12 +3,15 @@
 //
 #pragma once
 #include <openvino/op/read_value.hpp>
+
 #include "utils.hpp"
 namespace ov {
 namespace op {
 
 template <class OpType, class ShapeType>
-void read_value_shape_infer(const OpType* op, const std::vector<ShapeType>& input_shapes, std::vector<ShapeType>& output_shapes) {
+void read_value_shape_infer(const OpType* op,
+                            const std::vector<ShapeType>& input_shapes,
+                            std::vector<ShapeType>& output_shapes) {
     copy_shape_infer(op, input_shapes, output_shapes);
 }
 

--- a/src/core/shape_inference/include/reduce_shape_inference.hpp
+++ b/src/core/shape_inference/include/reduce_shape_inference.hpp
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #pragma once
+#include <openvino/core/validation_util.hpp>
 #include <openvino/op/util/arithmetic_reductions_keep_dims.hpp>
 #include <openvino/op/util/logical_reduction_keep_dims.hpp>
-#include <openvino/core/validation_util.hpp>
 #include <openvino/opsets/opset1.hpp>
+
 #include "utils.hpp"
 
 template <class T>
@@ -14,12 +15,17 @@ inline void dynamic_inference(const T& input_shape, T& output_shape, bool keep_d
 }
 
 template <>
-inline void dynamic_inference<ov::PartialShape>(const ov::PartialShape& input_shape, ov::PartialShape& output_shape, bool keep_dims) {
+inline void dynamic_inference<ov::PartialShape>(const ov::PartialShape& input_shape,
+                                                ov::PartialShape& output_shape,
+                                                bool keep_dims) {
     output_shape = keep_dims ? ov::PartialShape::dynamic(input_shape.rank()) : ov::PartialShape::dynamic();
 }
 
-template<class T>
-void reduce_shape_infer(const ov::op::util::ReductionBase* op, bool keep_dims, const T& input_shape, T& output_shape,
+template <class T>
+void reduce_shape_infer(const ov::op::util::ReductionBase* op,
+                        bool keep_dims,
+                        const T& input_shape,
+                        T& output_shape,
                         const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
     const auto& data_rank = input_shape.rank();
     std::vector<int64_t> axes_val;
@@ -28,8 +34,7 @@ void reduce_shape_infer(const ov::op::util::ReductionBase* op, bool keep_dims, c
     if (data_rank.is_static() && axes_are_known) {
         ov::normalize_axes(op, data_rank.get_length(), axes_val);
 
-        if (keep_dims)
-        {
+        if (keep_dims) {
             output_shape = input_shape;
             for (const auto& axis : axes_val)
                 output_shape[axis] = 1;
@@ -43,15 +48,19 @@ void reduce_shape_infer(const ov::op::util::ReductionBase* op, bool keep_dims, c
     }
 }
 
-template<class T>
-void shape_infer(const ov::op::util::ArithmeticReductionKeepDims* op, const std::vector<T> &input_shapes, std::vector<T> &output_shapes,
+template <class T>
+void shape_infer(const ov::op::util::ArithmeticReductionKeepDims* op,
+                 const std::vector<T>& input_shapes,
+                 std::vector<T>& output_shapes,
                  const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 2 && output_shapes.size() == 1);
     reduce_shape_infer(op, op->get_keep_dims(), input_shapes[0], output_shapes[0], constant_data);
 }
 
-template<class T>
-void shape_infer(const ov::op::util::LogicalReductionKeepDims* op, const std::vector<T> &input_shapes, std::vector<T> &output_shapes,
+template <class T>
+void shape_infer(const ov::op::util::LogicalReductionKeepDims* op,
+                 const std::vector<T>& input_shapes,
+                 std::vector<T>& output_shapes,
                  const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 2 && output_shapes.size() == 1);
     reduce_shape_infer(op, op->get_keep_dims(), input_shapes[0], output_shapes[0], constant_data);

--- a/src/core/shape_inference/include/reorg_yolo_shape_inference.hpp
+++ b/src/core/shape_inference/include/reorg_yolo_shape_inference.hpp
@@ -17,7 +17,7 @@ void shape_infer(const ReorgYolo* op, const std::vector<T>& input_shapes, std::v
     NODE_VALIDATION_CHECK(op, (input_shapes.size() == 1) && output_shapes.size() == 1);
     const auto& input_shape = input_shapes[0];
     auto& output_shape = output_shapes[0];
-    const auto & strides = op->get_strides();
+    const auto& strides = op->get_strides();
     if (input_shape.rank().is_static()) {
         NODE_VALIDATION_CHECK(op, input_shape.size() == 4, "[N, C, H, W] input shape is required.");
 

--- a/src/core/shape_inference/include/reverse_sequence_shape_inference.hpp
+++ b/src/core/shape_inference/include/reverse_sequence_shape_inference.hpp
@@ -31,17 +31,18 @@ void shape_infer(const ReverseSequence* op, const std::vector<T>& input_shapes, 
     output_pshape = data_pshape;
     if (data_rank.is_static() && seq_lengths_rank.is_static()) {
         DimType merged_sequence_length;
-        NODE_VALIDATION_CHECK(op,
-                              DimType::merge(merged_sequence_length, data_pshape[op->m_normalized_batch_axis], seq_lengths_pshape[0]),
-                              "Sequence lengths input size (",
-                              seq_lengths_pshape[0],
-                              ") is not equal to batch axis dimension of data input (",
-                              data_pshape[op->m_normalized_batch_axis],
-                              ") (argument shape: ",
-                              data_pshape,
-                              ", sequence indices shape: ",
-                              seq_lengths_pshape,
-                              ").");
+        NODE_VALIDATION_CHECK(
+            op,
+            DimType::merge(merged_sequence_length, data_pshape[op->m_normalized_batch_axis], seq_lengths_pshape[0]),
+            "Sequence lengths input size (",
+            seq_lengths_pshape[0],
+            ") is not equal to batch axis dimension of data input (",
+            data_pshape[op->m_normalized_batch_axis],
+            ") (argument shape: ",
+            data_pshape,
+            ", sequence indices shape: ",
+            seq_lengths_pshape,
+            ").");
         output_pshape[op->m_normalized_batch_axis] = merged_sequence_length;
     }
 }

--- a/src/core/shape_inference/include/rfft_common_validation.hpp
+++ b/src/core/shape_inference/include/rfft_common_validation.hpp
@@ -108,9 +108,7 @@ void validate_axes(const ov::op::util::FFTBase* op,
 }
 
 template <class T>
-void validate_signal_size(const ov::op::util::FFTBase* op,
-                          const T& axes_shape,
-                          const T& signal_size_shape) {
+void validate_signal_size(const ov::op::util::FFTBase* op, const T& axes_shape, const T& signal_size_shape) {
     NODE_VALIDATION_CHECK(op,
                           signal_size_shape.rank().compatible(1),
                           "(I)RDFT op signal size input must be 1D tensor. Got signal: ",
@@ -149,7 +147,7 @@ void shape_validation(const ov::op::util::FFTBase* op,
         validate_signal_size(op, axes_shape, signal_size_shape);
     }
 }
-}  // rfft_common_validation
+}  // namespace rfft_common_validation
 }  // namespace util
 }  // namespace op
 }  // namespace ov

--- a/src/core/shape_inference/include/shape_nodes.hpp
+++ b/src/core/shape_inference/include/shape_nodes.hpp
@@ -2,15 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #pragma once
+#include <openvino/core/validation_util.hpp>
 #include <openvino/op/util/arithmetic_reductions_keep_dims.hpp>
 #include <openvino/op/util/logical_reduction_keep_dims.hpp>
-#include <openvino/core/validation_util.hpp>
 #include <openvino/opsets/opset1.hpp>
 #include <openvino/opsets/opset3.hpp>
+
 #include "utils.hpp"
 
-template<class T>
-void shape_infer(const ov::opset1::Reshape* op, const std::vector<T> &input_shapes, std::vector<T> &output_shapes,
+template <class T>
+void shape_infer(const ov::opset1::Reshape* op,
+                 const std::vector<T>& input_shapes,
+                 std::vector<T>& output_shapes,
                  const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 2 && output_shapes.size() == 1);
     std::vector<int64_t> output_pattern;
@@ -26,9 +29,7 @@ void shape_infer(const ov::opset1::Reshape* op, const std::vector<T> &input_shap
     if (output_rank == 0 && output_shape.size() != 0) {
         output_pattern.clear();
         OPENVINO_ASSERT(output_pattern.size() == 1);
-        NODE_VALIDATION_CHECK(op,
-                              output_pattern[0] == 1,
-                              "The value of scalar shape pattern should be equal to 1!");
+        NODE_VALIDATION_CHECK(op, output_pattern[0] == 1, "The value of scalar shape pattern should be equal to 1!");
     }
 
     auto special_zero = op->get_special_zero();
@@ -36,8 +37,10 @@ void shape_infer(const ov::opset1::Reshape* op, const std::vector<T> &input_shap
     size_t output_product(1);
     int64_t minus_one_idx = -1;
     for (size_t i = 0; i < output_pattern.size(); ++i) {
-        if (output_pattern[i] == -1) { // resolving everything except -1
-            NODE_VALIDATION_CHECK(op, minus_one_idx == -1, "More than one element of output shape pattern has value of -1");
+        if (output_pattern[i] == -1) {  // resolving everything except -1
+            NODE_VALIDATION_CHECK(op,
+                                  minus_one_idx == -1,
+                                  "More than one element of output shape pattern has value of -1");
             minus_one_idx = static_cast<int64_t>(i);
             continue;
         }
@@ -93,8 +96,10 @@ void shape_infer(const ov::opset1::Reshape* op, const std::vector<T> &input_shap
                           input_shape);
 }
 
-template<class T>
-void shape_infer(const ov::opset1::Squeeze* op, const std::vector<T> &input_shapes, std::vector<T> &output_shapes,
+template <class T>
+void shape_infer(const ov::opset1::Squeeze* op,
+                 const std::vector<T>& input_shapes,
+                 std::vector<T>& output_shapes,
                  const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 2 && output_shapes.size() == 1);
     std::vector<int64_t> axes;
@@ -112,14 +117,17 @@ void shape_infer(const ov::opset1::Squeeze* op, const std::vector<T> &input_shap
         if (std::find(axes.begin(), axes.end(), idx) == axes.end()) {
             output_shape.push_back(input_shape[idx]);
         } else {
-            NODE_VALIDATION_CHECK(op, input_shape[idx] == 1, "provided axis value is invalid. Only axes of size 1 may be removed.");
+            NODE_VALIDATION_CHECK(op,
+                                  input_shape[idx] == 1,
+                                  "provided axis value is invalid. Only axes of size 1 may be removed.");
         }
     }
 }
 
-template<class T>
+template <class T>
 void shape_infer(const ov::opset1::Unsqueeze* op,
-                 const std::vector<T> &input_shapes, std::vector<T> &output_shapes,
+                 const std::vector<T>& input_shapes,
+                 std::vector<T>& output_shapes,
                  const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 2 && output_shapes.size() == 1);
     std::vector<int64_t> axes;
@@ -153,11 +161,8 @@ inline void dynamic_shape<ov::PartialShape>(ov::PartialShape& output_shape) {
     output_shape = ov::PartialShape::dynamic();
 }
 
-
-
-
-template<class T>
-void shape_of_shape_infer(const T &input_shape, T &output_shape) {
+template <class T>
+void shape_of_shape_infer(const T& input_shape, T& output_shape) {
     if (input_shape.rank().is_static()) {
         const auto& rank = input_shape.size();
         if (rank) {
@@ -171,17 +176,14 @@ void shape_of_shape_infer(const T &input_shape, T &output_shape) {
     }
 }
 
-
-template<class T>
-void shape_infer(const ov::opset1::ShapeOf* op,
-                 const std::vector<T> &input_shapes, std::vector<T> &output_shapes) {
+template <class T>
+void shape_infer(const ov::opset1::ShapeOf* op, const std::vector<T>& input_shapes, std::vector<T>& output_shapes) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 1 && output_shapes.size() == 1);
     shape_of_shape_infer(input_shapes[0], output_shapes[0]);
 }
 
-template<class T>
-void shape_infer(const ov::opset3::ShapeOf* op,
-                 const std::vector<T> &input_shapes, std::vector<T> &output_shapes) {
+template <class T>
+void shape_infer(const ov::opset3::ShapeOf* op, const std::vector<T>& input_shapes, std::vector<T>& output_shapes) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 1 && output_shapes.size() == 1);
     shape_of_shape_infer(input_shapes[0], output_shapes[0]);
 }

--- a/src/core/shape_inference/include/space_to_depth_shape_inference.hpp
+++ b/src/core/shape_inference/include/space_to_depth_shape_inference.hpp
@@ -32,7 +32,7 @@ void shape_infer(const ov::op::v0::SpaceToDepth* op,
                               ")");
 
         const auto& block_size = op->get_block_size();
-        NODE_VALIDATION_CHECK(op, block_size > 0, "The block size must begreater then 0 ", block_size);
+        NODE_VALIDATION_CHECK(op, block_size > 0, "The block size must be greater then 0 ", block_size);
         const ValType multiplier = std::pow(block_size, data_shape.size() - 2);
 
         auto& out_shape = output_shapes[0];

--- a/src/core/shape_inference/include/split_shape_inference.hpp
+++ b/src/core/shape_inference/include/split_shape_inference.hpp
@@ -32,7 +32,7 @@ void shape_infer(const Split* op,
     const auto data_rank = data_ps.rank();
 
     std::vector<int64_t> axes_values;
-    const auto & num_splits = op->get_num_splits();
+    const auto& num_splits = op->get_num_splits();
     if (get_data_as_int64<T>(1, op, axes_values, constant_data) && data_rank.is_static()) {
         NODE_VALIDATION_CHECK(op,
                               axes_values.size() == 1,

--- a/src/core/shape_inference/include/tile_shape_inference.hpp
+++ b/src/core/shape_inference/include/tile_shape_inference.hpp
@@ -22,28 +22,27 @@ void shape_infer(const Tile* op,
     std::vector<int64_t> axes_val;
     NODE_VALIDATION_CHECK(op, repeats_shape.rank().compatible(1), "PartialShape of repeats must be of rank 1");
 
-    //Get repeats
+    // Get repeats
     bool axes_are_known = get_data_as_int64<T>(1, op, axes_val, constant_data);
     const auto arg_rank = arg_shape.rank();
     if (arg_rank.is_static() && (axes_are_known || repeats_shape[0].is_static())) {
-        //try to specify rank
+        // try to specify rank
         int64_t data_rank = arg_shape.size();
         int64_t repeats_rank = axes_are_known ? axes_val.size() : repeats_shape[0].get_length();
         auto output_rank = std::max(data_rank, repeats_rank);
         output_shape.resize(output_rank);
-        //if have constant axes, compute new axes
+        // if have constant axes, compute new axes
         if (axes_are_known) {
             auto remain_arg = output_rank - data_rank;
             auto remain_axes = output_rank - repeats_rank;
             for (int64_t i = 0; i < output_rank; i++) {
                 auto data_tmp = i < remain_arg ? DimType(1) : arg_shape[i - (remain_arg)];
-                auto repeat_tmp =
-                    i < remain_axes ? DimType(1) : axes_val[i - remain_axes];
+                auto repeat_tmp = i < remain_axes ? DimType(1) : axes_val[i - remain_axes];
                 output_shape[i] = data_tmp * repeat_tmp;
             }
         }
     } else {
-        //can't deduce shape, set default value
+        // can't deduce shape, set default value
         output_shape = PartialShape::dynamic();
     }
 }

--- a/src/core/shape_inference/include/utils.hpp
+++ b/src/core/shape_inference/include/utils.hpp
@@ -3,35 +3,39 @@
 //
 #pragma once
 
-#include <openvino/opsets/opset1.hpp>
 #include <openvino/core/validation_util.hpp>
-
+#include <openvino/opsets/opset1.hpp>
 
 template <class OpType, class T>
 void copy_shape_infer(const OpType* op, const std::vector<T>& input_shapes, std::vector<T>& output_shapes) {
-    NODE_VALIDATION_CHECK(op, input_shapes.size() == 1 && output_shapes.size() == 1,
+    NODE_VALIDATION_CHECK(op,
+                          input_shapes.size() == 1 && output_shapes.size() == 1,
                           "Incorrect number of input/output shapes");
     output_shapes[0] = input_shapes[0];
 }
 
 template <class OpType, class T>
-void first_input_passthrough_infer(const OpType* op, const std::vector<T>& input_shapes, std::vector<T>& output_shapes) {
-    NODE_VALIDATION_CHECK(op, output_shapes.size() == 1 && input_shapes.size() >= 1,
+void first_input_passthrough_infer(const OpType* op,
+                                   const std::vector<T>& input_shapes,
+                                   std::vector<T>& output_shapes) {
+    NODE_VALIDATION_CHECK(op,
+                          output_shapes.size() == 1 && input_shapes.size() >= 1,
                           "Incorrect number of input and output shapes");
     output_shapes[0] = input_shapes[0];
 }
 
 template <class OpType, class T>
 void eltwise_shape_infer(const OpType* op, const std::vector<T>& input_shapes, std::vector<T>& output_shapes) {
-    NODE_VALIDATION_CHECK(op, input_shapes.size() == 2 && output_shapes.size() == 1,
+    NODE_VALIDATION_CHECK(op,
+                          input_shapes.size() == 2 && output_shapes.size() == 1,
                           "Incorrect number of input/output shapes");
     T output_shape = input_shapes[0];
     ov::op::AutoBroadcastSpec autob = op->get_autob();
     if (autob.m_type == ov::op::AutoBroadcastType::NONE) {
-        NODE_VALIDATION_CHECK(op, T::merge_into(output_shape, input_shapes[1]),
-                              "Argument shapes are inconsistent.");
+        NODE_VALIDATION_CHECK(op, T::merge_into(output_shape, input_shapes[1]), "Argument shapes are inconsistent.");
     } else if (autob.m_type == ov::op::AutoBroadcastType::NUMPY || autob.m_type == ov::op::AutoBroadcastType::PDPD) {
-        NODE_VALIDATION_CHECK(op, T::broadcast_merge_into(output_shape, input_shapes[1], autob),
+        NODE_VALIDATION_CHECK(op,
+                              T::broadcast_merge_into(output_shape, input_shapes[1], autob),
                               "Argument shapes are inconsistent.");
     } else {
         NODE_VALIDATION_CHECK(op, false, "Unsupported auto broadcast specification");
@@ -39,11 +43,12 @@ void eltwise_shape_infer(const OpType* op, const std::vector<T>& input_shapes, s
     output_shapes[0] = output_shape;
 }
 
-
 template <class T>
 inline bool get_data_as_int64(
-        size_t idx, const ov::Node* op, std::vector<int64_t>& axes_value,
-        const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
+    size_t idx,
+    const ov::Node* op,
+    std::vector<int64_t>& axes_value,
+    const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
     if (constant_data.count(idx)) {
         axes_value = ov::opset1::Constant(constant_data.at(idx)).cast_vector<int64_t>();
     } else {
@@ -56,8 +61,10 @@ inline bool get_data_as_int64(
 
 template <>
 inline bool get_data_as_int64<ov::PartialShape>(
-        size_t idx, const ov::Node* op, std::vector<int64_t>& axes_value,
-        const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data) {
+    size_t idx,
+    const ov::Node* op,
+    std::vector<int64_t>& axes_value,
+    const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data) {
     if (constant_data.count(idx)) {
         axes_value = ov::opset1::Constant(constant_data.at(idx)).cast_vector<int64_t>();
     } else if (const auto& constant = ov::get_constant_from_source(op->input_value(idx))) {
@@ -70,8 +77,10 @@ inline bool get_data_as_int64<ov::PartialShape>(
 
 template <class T>
 inline bool get_data_as_float(
-        size_t idx, const ov::Node* op, std::vector<float>& axes_value,
-        const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
+    size_t idx,
+    const ov::Node* op,
+    std::vector<float>& axes_value,
+    const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
     if (constant_data.count(idx)) {
         axes_value = ov::opset1::Constant(constant_data.at(idx)).cast_vector<float>();
     } else {
@@ -84,8 +93,10 @@ inline bool get_data_as_float(
 
 template <>
 inline bool get_data_as_float<ov::PartialShape>(
-        size_t idx, const ov::Node* op, std::vector<float>& axes_value,
-        const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data) {
+    size_t idx,
+    const ov::Node* op,
+    std::vector<float>& axes_value,
+    const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data) {
     if (constant_data.count(idx)) {
         axes_value = ov::opset1::Constant(constant_data.at(idx)).cast_vector<float>();
     } else if (const auto& constant = ov::get_constant_from_source(op->input_value(idx))) {
@@ -98,8 +109,10 @@ inline bool get_data_as_float<ov::PartialShape>(
 
 template <class T>
 inline bool get_data_as_shape(
-        size_t idx, const ov::Node* op, T& shape,
-        const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
+    size_t idx,
+    const ov::Node* op,
+    T& shape,
+    const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data = {}) {
     if (constant_data.count(idx)) {
         shape = T(ov::opset1::Constant(constant_data.at(idx)).cast_vector<size_t>());
     } else {
@@ -112,8 +125,10 @@ inline bool get_data_as_shape(
 
 template <>
 inline bool get_data_as_shape<ov::PartialShape>(
-        size_t idx, const ov::Node* op, ov::PartialShape& shape,
-        const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data) {
+    size_t idx,
+    const ov::Node* op,
+    ov::PartialShape& shape,
+    const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data) {
     if (constant_data.count(idx)) {
         shape = ov::PartialShape(ov::opset1::Constant(constant_data.at(idx)).cast_vector<int64_t>());
         return true;

--- a/src/core/src/dimension.cpp
+++ b/src/core/src/dimension.cpp
@@ -5,6 +5,7 @@
 #include "ngraph/dimension.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <limits>
 #include <sstream>
@@ -51,11 +52,13 @@ Dimension Dimension::operator-(const Dimension& dim) const {
 
 Dimension Dimension::operator/(const value_type divisor) const {
     OPENVINO_ASSERT(divisor >= 0, "divisor must be greater than 0");
-
+    if (divisor == 1)
+        return *this;
     if (m_dimension.get_max_val() == Interval::s_max && m_dimension.get_min_val() == 0)
         return Dimension::dynamic();
-
-    return Dimension((m_dimension.get_min_val() + divisor - 1) / divisor, m_dimension.get_max_val() / divisor);
+    const auto& lower_bound = ceil(static_cast<double>(m_dimension.get_min_val()) / divisor);
+    const auto& upper_bound = floor(static_cast<double>(m_dimension.get_max_val()) / divisor);
+    return Dimension(lower_bound, upper_bound);
 }
 
 Dimension Dimension::operator*(const Dimension& dim) const {

--- a/src/core/src/op/convolution.cpp
+++ b/src/core/src/op/convolution.cpp
@@ -68,7 +68,7 @@ void op::v1::Convolution::validate_and_infer_types() {
     auto& filter_shape = get_input_partial_shape(1);
 
     m_num_spatial = calculate_num_spatial(this, data_shape, filter_shape, 2, 2);
-    update_and_validate_attributes(this);
+    update_and_validate_attributes(this, m_num_spatial);
 
     std::vector<ov::PartialShape> input_shapes = {data_shape, filter_shape};
     std::vector<ov::PartialShape> output_shapes = {ov::PartialShape::dynamic()};
@@ -245,7 +245,7 @@ void op::v1::ConvolutionBackpropData::validate_and_infer_types() {
 
     auto& output_shapes_shape = output_shape_input_present ? get_input_partial_shape(2) : PartialShape::dynamic();
     m_num_spatial = calculate_num_spatial(this, data_shape, filter_shape, output_shapes_shape, 2, 2);
-    update_and_validate_attributes_back_prop(this);
+    update_and_validate_attributes_back_prop(this, m_num_spatial);
 
     std::vector<ov::PartialShape> input_shapes = {data_shape, filter_shape};
     if (output_shape_input_present)

--- a/src/core/src/op/group_conv.cpp
+++ b/src/core/src/op/group_conv.cpp
@@ -88,7 +88,7 @@ void op::v1::GroupConvolution::validate_and_infer_types() {
     auto& filter_shape = get_input_partial_shape(1);
 
     m_num_spatial = calculate_num_spatial(this, data_shape, filter_shape, 2, 3);
-    update_and_validate_attributes(this);
+    update_and_validate_attributes(this, m_num_spatial);
 
     std::vector<ov::PartialShape> input_shapes = {data_shape, filter_shape};
     std::vector<ov::PartialShape> output_shapes = {ov::PartialShape::dynamic()};
@@ -301,7 +301,7 @@ void op::v1::GroupConvolutionBackpropData::validate_and_infer_types() {
     auto& output_shapes_shape = output_shape_input_present ? get_input_partial_shape(2) : PartialShape::dynamic();
 
     m_num_spatial = calculate_num_spatial(this, data_shape, filter_shape, output_shapes_shape, 2, 3);
-    update_and_validate_attributes_back_prop(this);
+    update_and_validate_attributes_back_prop(this, m_num_spatial);
 
     std::vector<ov::PartialShape> input_shapes = {data_shape, filter_shape};
     if (output_shape_input_present)

--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -725,12 +725,12 @@ void auto_pad_resolving(ov::Node* node) {
     if (auto op = as_type<opset1::Convolution>(node)) {
         if (pad_agnostic_types.count(op->get_auto_pad())) {
             op->set_pads_begin(CoordinateDiff(op->get_pads_begin().size(), 0));
-            op->set_adding_above(CoordinateDiff(op->get_pads_end().size(), 0));
+            op->set_pads_end(CoordinateDiff(op->get_pads_end().size(), 0));
         }
     } else if (auto op = as_type<opset1::GroupConvolution>(node)) {
         if (pad_agnostic_types.count(op->get_auto_pad())) {
             op->set_pads_begin(CoordinateDiff(op->get_pads_begin().size(), 0));
-            op->set_adding_above(CoordinateDiff(op->get_pads_end().size(), 0));
+            op->set_pads_end(CoordinateDiff(op->get_pads_end().size(), 0));
         }
     } else if (auto op = as_type<opset1::ConvolutionBackpropData>(node)) {
         if (pad_agnostic_types.count(op->get_auto_pad())) {

--- a/src/core/tests/dimension.cpp
+++ b/src/core/tests/dimension.cpp
@@ -53,3 +53,17 @@ TEST(dimension, broadcast_merge_static_0_12_and_1_15) {
     EXPECT_TRUE(success);
     EXPECT_EQ(result, Dimension(0, 15));
 }
+
+TEST(dimension, division_of_static_dims_twenty_three_div_three_eq_seven) {
+    Dimension twenty_three(23);
+    Dimension::value_type three(3);
+    Dimension empty(8, 7);
+    EXPECT_EQ(empty, twenty_three / three);
+}
+
+TEST(dimension, division_of_static_dims) {
+    Dimension seven(7);
+    Dimension::value_type four(4);
+    Dimension empty(2, 1);
+    EXPECT_EQ(seven / four, empty);
+}

--- a/src/plugins/intel_cpu/src/utils/shape_inference/static_dimension.cpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/static_dimension.cpp
@@ -14,6 +14,12 @@ std::ostream& operator<<(std::ostream& str, const StaticDimension& dimension) {
 StaticDimension::StaticDimension(value_type dimension)
         : m_dimension(dimension) {}
 
+StaticDimension::StaticDimension(value_type ldimension, value_type udimension)
+        : m_dimension(ldimension) {
+    OPENVINO_ASSERT(ldimension == udimension,
+                    "Can not create StaticDimension out of [", ldimension, ", ", udimension, "]");
+}
+
 bool StaticDimension::operator==(const StaticDimension& dim) const {
     return m_dimension == dim.m_dimension;
 }

--- a/src/plugins/intel_cpu/src/utils/shape_inference/static_dimension.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/static_dimension.hpp
@@ -27,6 +27,11 @@ public:
     /// \param dimension Value of the dimension.
     StaticDimension(value_type dimension);
 
+    /// \brief Construct a static dimension.
+    /// \param ldimension Value of the dimension (must be equal to udimension)
+    /// \param udimension Value of the dimension (must be equal to ldimension)
+    StaticDimension(value_type ldimension, value_type udimension);
+
     /// \brief Construct a zero dimension
     StaticDimension() = default;
 


### PR DESCRIPTION
### Details: 
 - Precise spatial shape inference for dynamic shapes
  - Deprecated set_adding_above method and given alternative set_pads_end
  - Enabled shape inference for default-constructed Convultions (private field `num_spatials` is no more required to call shape_infer)
  - Test adjusted for dynamic spatial shapes calculation
  - Style check enabled for shape_inference lib -- sorry for the mess

### Tickets:
 - *82949, 82963*
