### PR TITLE
[DO NOT MERGE, ONLY FOR TEST] Port TF FE changes from master for integration with OVTF (#12…

### DIFF
--- a/src/frontends/tensorflow/src/decoder_proto.cpp
+++ b/src/frontends/tensorflow/src/decoder_proto.cpp
@@ -67,8 +67,14 @@ ov::Any DecoderProto::get_attribute(const std::string& name) const {
         return ov::PartialShape(dims);
     }
 
-    case ::tensorflow::AttrValue::ValueCase::kType:
-        return TYPE_MAP().at(attrs[0].type());
+    case ::tensorflow::AttrValue::ValueCase::kType: {
+        if (TYPE_MAP().count(attrs[0].type())) {
+            return TYPE_MAP().at(attrs[0].type());
+        } else {
+            // for all unsupported types return undefined type
+            return ov::element::undefined;
+        }
+    }
 
     case ::tensorflow::AttrValue::ValueCase::kList: {
         const auto& list = attrs[0].list();

--- a/src/frontends/tensorflow/src/frontend.cpp
+++ b/src/frontends/tensorflow/src/frontend.cpp
@@ -122,6 +122,13 @@ void FrontEnd::translate_graph(const ov::frontend::InputModel::Ptr& model,
                                 producer_name + "', expected input port index: " + std::to_string(producer_port_idx) +
                                 '\n');
             }
+
+            // skip conditional edges that must be resolved before operation translation
+            // now we can meet them because we still work with TensorFlow protobuf
+            if (is_conditional_edge(producer_name)) {
+                continue;
+            }
+
             // TODO: re-implement the logic below once Place graph structure is implemented
             // Using Place graph structure (OpPlace, In/OutPortPlace places and their connections) can give
             // names of ports and operations that can be used for further check about existence in ng_op_map

--- a/src/frontends/tensorflow/src/input_model.cpp
+++ b/src/frontends/tensorflow/src/input_model.cpp
@@ -170,9 +170,10 @@ std::vector<std::shared_ptr<OpPlace>> InputModel::InputModelTFImpl::get_op_place
 }
 
 std::vector<std::shared_ptr<OpPlace>> InputModel::InputModelTFImpl::determine_cut_nodes() const {
-    std::queue<std::shared_ptr<DecoderBase>> decoders_queue;
-    std::unordered_set<std::string> visited;
-    std::vector<std::shared_ptr<OpPlace>> new_ops;
+    std::vector<std::shared_ptr<OpPlace>> topologically_sorted_ops;
+    std::stack<std::shared_ptr<OpPlace>> ops_to_do;
+    std::unordered_set<std::shared_ptr<OpPlace>> ops_done;
+
     for (const auto& output_place : m_outputs) {
         FRONT_END_GENERAL_CHECK(output_place->get_names().size() > 0, "TensorPlace must have at least one name.");
         auto output_place_name = output_place->get_names()[0];
@@ -180,72 +181,83 @@ std::vector<std::shared_ptr<OpPlace>> InputModel::InputModelTFImpl::determine_cu
         size_t port_idx;
         std::string port_type;
         tensorflow::extract_operation_name_and_port(output_place_name, operation_name, port_idx, port_type);
-        if (!visited.count(operation_name)) {
-            visited.insert(operation_name);
-            FRONT_END_GENERAL_CHECK(m_op_places_map.count(operation_name),
-                                    "Custom specified output is incorrect: " + output_place_name);
-            auto output_operation_place = m_op_places_map.at(operation_name);
-            FRONT_END_GENERAL_CHECK(output_operation_place,
-                                    "There is not operation place in the map: " + operation_name);
-            new_ops.push_back(output_operation_place);
-            decoders_queue.push(output_operation_place->get_decoder());
+        FRONT_END_GENERAL_CHECK(m_op_places_map.count(operation_name),
+                                "Custom specified output is incorrect: " + output_place_name);
+        auto output_operation_place = m_op_places_map.at(operation_name);
+        ops_to_do.push(output_operation_place);
+    }
+
+    // the traversing algorithm to compute topologically sorted nodes is taken from topological_sort in
+    // core/graph_util.hpp
+    while (ops_to_do.size() > 0) {
+        auto current_operation_place = ops_to_do.top();
+        auto current_operation_decoder = current_operation_place->get_decoder();
+        auto current_operation_name = current_operation_decoder->get_op_name();
+        if (ops_done.count(current_operation_place) == 0) {
+            bool can_add = true;
+            auto input_count = current_operation_decoder->get_input_size();
+            for (size_t input_port_idx = 0; input_port_idx < input_count; ++input_port_idx) {
+                std::string producer_name;
+                size_t producer_output_port_idx;
+                try {
+                    current_operation_decoder->get_input_node(input_port_idx, producer_name, producer_output_port_idx);
+                } catch (const std::exception& e) {
+                    FRONT_END_THROW("[ ERROR ] Exception happened when preparing input " +
+                                    std::to_string(input_port_idx) + " for op '" +
+                                    current_operation_decoder->get_op_name() + "', expected input name: '" +
+                                    producer_name +
+                                    "', expected input port index: " + std::to_string(producer_output_port_idx) + '\n');
+                }
+
+                // skip conditional edges for all operators
+                if (is_conditional_edge(producer_name)) {
+                    continue;
+                }
+
+                // is_input is a flag to leave producer operation node or not.
+                // this producing node is not left if consumer is pruned by its input port,
+                // the producer node is pruned by its output port or the producer becomes new input
+                // 1. check if the current node is pruned by its input port
+                bool is_input = false;
+                std::string input_port_name = std::to_string(input_port_idx) + ":" + current_operation_name;
+                if (m_tensor_places.find(input_port_name) != m_tensor_places.end()) {
+                    const auto& tensor_place = m_tensor_places[input_port_name];
+                    is_input |= tensor_place->is_input();
+                }
+
+                // 2. check if the producer node is pruned by its output port
+                std::string output_port_name = producer_name + ":" + std::to_string(producer_output_port_idx);
+                if (m_tensor_places.find(output_port_name) != m_tensor_places.end()) {
+                    const auto& tensor_place = m_tensor_places[output_port_name];
+                    is_input |= tensor_place->is_input();
+                }
+
+                // 3. check if the current node is an input
+                FRONT_END_GENERAL_CHECK(m_op_places_map.count(producer_name),
+                                        "There is no operation node with name: " + producer_name);
+                const auto& producer_operation_place = m_op_places_map.at(producer_name);
+                if (m_tensor_places.find(producer_name) != m_tensor_places.end()) {
+                    const auto& tensor_place = m_tensor_places[producer_name];
+                    is_input |= tensor_place->is_input();
+                }
+
+                if (!is_input && ops_done.count(producer_operation_place) == 0) {
+                    can_add = false;
+                    ops_to_do.push(producer_operation_place);
+                }
+            }
+
+            if (can_add) {
+                topologically_sorted_ops.push_back(current_operation_place);
+                ops_to_do.pop();
+                ops_done.insert(current_operation_place);
+            }
+        } else {
+            ops_to_do.pop();
         }
     }
-    while (!decoders_queue.empty()) {
-        auto operation_decoder = decoders_queue.front();
-        decoders_queue.pop();
-        auto current_operation_name = operation_decoder->get_op_name();
-        for (size_t input_port_idx = 0; input_port_idx < operation_decoder->get_input_size(); ++input_port_idx) {
-            std::string producer_name;
-            size_t producer_output_port_idx;
-            try {
-                operation_decoder->get_input_node(input_port_idx, producer_name, producer_output_port_idx);
-            } catch (const std::exception& e) {
-                FRONT_END_THROW("[ ERROR ] Exception happened when preparing input " + std::to_string(input_port_idx) +
-                                " for op '" + operation_decoder->get_op_name() + "', expected input name: '" +
-                                producer_name +
-                                "', expected input port index: " + std::to_string(producer_output_port_idx) + '\n');
-            }
 
-            // TODO: re-implement the logic below using Place graph structure (with OpPlace, In/OutPortPlace
-            // connections) and based on check if Place->is_input() decide to leave a node or not
-
-            // is_input is a flag to leave producer operation node or not.
-            // this producing node is not left if consumer is pruned by its input port,
-            // the producer node is pruned by its output port or the producer becomes new input
-            // 1. check if the current node is pruned by its input port
-            bool is_input = false;
-            std::string input_port_name = std::to_string(input_port_idx) + ":" + current_operation_name;
-            if (m_tensor_places.find(input_port_name) != m_tensor_places.end()) {
-                const auto& tensor_place = m_tensor_places[input_port_name];
-                is_input = is_input || (tensor_place->is_input() ? true : false);
-            }
-
-            // 2. check if the producer node is pruned by its output port
-            std::string output_port_name = producer_name + ":" + std::to_string(producer_output_port_idx);
-            if (m_tensor_places.find(output_port_name) != m_tensor_places.end()) {
-                const auto& tensor_place = m_tensor_places[output_port_name];
-                is_input = is_input || (tensor_place->is_input() ? true : false);
-            }
-
-            // 3. check if the current node is an input
-            FRONT_END_GENERAL_CHECK(m_op_places_map.count(producer_name),
-                                    "There is no operation node with name: " + producer_name);
-            const auto& producer_operation_place = m_op_places_map.at(producer_name);
-            if (m_tensor_places.find(producer_name) != m_tensor_places.end()) {
-                const auto& tensor_place = m_tensor_places[producer_name];
-                is_input |= (tensor_place->is_input() ? true : false);
-            }
-
-            if (!is_input && !visited.count(producer_name)) {
-                visited.insert(producer_name);
-                new_ops.push_back(producer_operation_place);
-                decoders_queue.push(producer_operation_place->get_decoder());
-            }
-        }
-    }
-    std::reverse(new_ops.begin(), new_ops.end());
-    return new_ops;
+    return topologically_sorted_ops;
 }
 
 InputModel::InputModelTFImpl::InputModelTFImpl(const GraphIterator::Ptr& graph_iterator,

--- a/src/frontends/tensorflow/src/op/avg_pool.cpp
+++ b/src/frontends/tensorflow/src/op/avg_pool.cpp
@@ -39,7 +39,7 @@ OutputVector translate_avg_pool_op(const NodeContext& node) {
     convert_nhwc_to_hw(is_nhwc, tf_strides, ng_strides);
     convert_nhwc_to_hw(is_nhwc, ng_input.get_shape(), ng_image_shape);
     convert_nhwc_to_hw(is_nhwc, tf_ksize, ng_kernel_shape);
-    convert_nhwc_to_nchw(node.get_name(), is_nhwc, ng_input);
+    convert_nhwc_to_nchw(is_nhwc, ng_input);
 
     CoordinateDiff padding_below;
     CoordinateDiff padding_above;
@@ -66,7 +66,7 @@ OutputVector translate_avg_pool_op(const NodeContext& node) {
                                          ov::op::RoundingType::FLOOR);
     auto res = res_node->output(0);
 
-    convert_nchw_to_nhwc(node.get_name(), is_nhwc, res);
+    convert_nchw_to_nhwc(is_nhwc, res);
     set_node_name(node.get_name(), res.get_node_shared_ptr());
     return {res};
 }

--- a/src/frontends/tensorflow/src/op/bias_add.cpp
+++ b/src/frontends/tensorflow/src/op/bias_add.cpp
@@ -14,36 +14,39 @@ namespace tensorflow {
 namespace op {
 
 OutputVector translate_bias_add_op(const NodeContext& node) {
-    Output<Node> ng_input = node.get_input(0), ng_bias = node.get_input(1);
+    auto value = node.get_input(0);
+    auto bias = node.get_input(1);
 
-    std::string tf_data_format = node.get_attribute<std::string>("data_format", "NHWC");
+    std::string data_format = node.get_attribute<std::string>("data_format", "NHWC");
 
     TENSORFLOW_OP_VALIDATION(node,
-                             tf_data_format == "NHWC" || tf_data_format == "NCHW",
-                             "BiasAdd data format is neither NHWC nor NCHW");
+                             data_format == "NHWC" || data_format == "NCHW",
+                             "BiasAdd data format is neither NHWC nor NCHW.");
 
-    auto ng_input_shape = ng_input.get_shape();
-    auto ng_bias_shape = ng_bias.get_shape();
-    TENSORFLOW_OP_VALIDATION(node, ng_bias_shape.size() == 1, "Bias argument to BiasAdd does not have one dimension");
+    auto value_shape = value.get_partial_shape();
+    auto bias_shape = bias.get_partial_shape();
+    TENSORFLOW_OP_VALIDATION(node, bias_shape.size() == 1, "Bias input of BiasAdd must have one dimension");
 
-    // We'll choose reshape over broadcast
-    // Reshape the bias to (1, C, 1, ...) if input is channels-first.
-    Output<Node> ng_bias_reshaped = ng_bias;
-    if (tf_data_format == "NCHW") {
-        auto channel_dim = ng_input_shape[1];
-        std::vector<int64_t> target_shape(ng_input_shape.size());
-        for (int64_t i = 0; i < ng_input_shape.size(); i++) {
-            if (i == 1) {
-                target_shape[i] = channel_dim;
-            } else {
-                target_shape[i] = 1;
+    Output<Node> bias_reshaped = bias;
+
+    // in case NCHW layout bias must be reshaped to have a shape (1, C, 1, ...)
+    // for further correct use of Add operation
+    if (data_format == "NCHW") {
+        TENSORFLOW_OP_VALIDATION(node,
+                                 value_shape.rank().is_static(),
+                                 "Value of dynamic rank for BiasAdd in NCHW layout is not supported.");
+        auto value_rank = value_shape.rank().get_length();
+        std::vector<int64_t> axes_unsqueeze;
+        for (size_t dim_ind = 0; dim_ind < value_rank; ++dim_ind) {
+            if (dim_ind != 1) {
+                axes_unsqueeze.push_back(dim_ind);
             }
         }
-        auto target_shape_node = make_shared<Constant>(element::i64, Shape{ng_input_shape.size()}, target_shape);
-        ng_bias_reshaped = make_shared<Reshape>(ng_bias, target_shape_node, false);
+        auto axes_unsqueeze_node = make_shared<Constant>(element::i64, Shape{axes_unsqueeze.size()}, axes_unsqueeze);
+        bias_reshaped = make_shared<Unsqueeze>(bias, axes_unsqueeze_node);
     }
 
-    auto res = make_shared<Add>(ng_input, ng_bias_reshaped);
+    auto res = make_shared<Add>(value, bias_reshaped);
     set_node_name(node.get_name(), res);
     return res->outputs();
 }

--- a/src/frontends/tensorflow/src/op/conv_2d.cpp
+++ b/src/frontends/tensorflow/src/op/conv_2d.cpp
@@ -4,6 +4,7 @@
 
 #include "op_table.hpp"
 #include "openvino/opsets/opset8.hpp"
+#include "utils.hpp"
 
 using namespace std;
 using namespace ov::opset8;
@@ -14,58 +15,7 @@ namespace tensorflow {
 namespace op {
 
 OutputVector translate_conv_2d_op(const NodeContext& node) {
-    auto ng_input = node.get_input(0), ng_filter = node.get_input(1);
-
-    auto tf_strides = node.get_attribute<std::vector<int64_t>>("strides");
-    auto tf_dilations = node.get_attribute<std::vector<int64_t>>("dilations");
-    auto tf_padding_type = node.get_attribute<std::string>("padding");
-    auto tf_data_format = node.get_attribute<std::string>("data_format");
-
-    TENSORFLOW_OP_VALIDATION(node,
-                             tf_data_format == "NHWC" || tf_data_format == "NCHW",
-                             "Conv2D data format is neither NHWC nor NCHW");
-
-    bool is_nhwc = (tf_data_format == "NHWC");
-
-    // TF Kernel Test Checks
-    // Strides in the batch and depth dimension is not supported
-    if (tf_strides[0] != 1 || tf_strides[is_nhwc ? 3 : 1] != 1) {
-        TENSORFLOW_OP_VALIDATION(node,
-                                 false,
-                                 "Strides in batch and depth dimensions is not supported: " + node.get_op_type());
-    }
-
-    Strides ng_strides(2);
-    Strides ng_dilations(2);
-    Shape ng_image_shape(2);
-    Shape ng_kernel_shape(2);
-
-    convert_nhwc_to_hw(is_nhwc, tf_strides, ng_strides);
-    convert_nhwc_to_hw(is_nhwc, ng_input.get_shape(), ng_image_shape);
-    convert_nhwc_to_hw(is_nhwc, tf_dilations, ng_dilations);
-    convert_nhwc_to_nchw(node.get_name(), is_nhwc, ng_input);
-
-    auto& ng_filter_shape = ng_filter.get_shape();
-    ng_kernel_shape[0] = ng_filter_shape[0];
-    ng_kernel_shape[1] = ng_filter_shape[1];
-    transpose<3, 2, 0, 1>(ng_filter);
-
-    CoordinateDiff ng_padding_below;
-    CoordinateDiff ng_padding_above;
-    make_padding(tf_padding_type,
-                 ng_image_shape,
-                 ng_kernel_shape,
-                 ng_strides,
-                 ng_dilations,
-                 ng_padding_below,
-                 ng_padding_above);
-
-    Output<Node> res =
-        make_shared<Convolution>(ng_input, ng_filter, ng_strides, ng_padding_below, ng_padding_above, ng_dilations);
-
-    convert_nchw_to_nhwc(node.get_name(), is_nhwc, res);
-    set_node_name(node.get_name(), res.get_node_shared_ptr());
-    return {res};
+    return translate_convolution_op(node, 2);
 }
 }  // namespace op
 }  // namespace tensorflow

--- a/src/frontends/tensorflow/src/op/conv_2d_backprop.cpp
+++ b/src/frontends/tensorflow/src/op/conv_2d_backprop.cpp
@@ -3,7 +3,9 @@
 //
 
 #include "op_table.hpp"
+#include "openvino/op/util/attr_types.hpp"
 #include "openvino/opsets/opset8.hpp"
+#include "utils.hpp"
 
 using namespace std;
 using namespace ov::opset8;
@@ -14,82 +16,100 @@ namespace tensorflow {
 namespace op {
 
 OutputVector translate_conv_2d_backprop_input_op(const NodeContext& node) {
-    auto ng_filter = node.get_input(1), ng_out_backprop = node.get_input(2);
+    TENSORFLOW_OP_VALIDATION(node, node.get_input_size() >= 3, "Conv2DBackpropInput must have at least three inputs.");
+    auto input_sizes = node.get_input(0);
+    auto filter = node.get_input(1);
+    auto out_backprop = node.get_input(2);
 
-    // TODO: refactor me to be less redundant with other convolution ops
+    // retrieve attributes for Conv2DBackpropInput
     auto tf_strides = node.get_attribute<std::vector<int64_t>>("strides");
-    auto tf_dilations = node.get_attribute<std::vector<int64_t>>("dilations");
     auto tf_padding_type = node.get_attribute<std::string>("padding");
-    auto tf_data_format = node.get_attribute<std::string>("data_format");
+    ov::op::PadType auto_pad = convert_tf_padding(node, tf_padding_type);
+
+    // retrieve optional attributes
+    auto tf_dilations = node.get_attribute<std::vector<int64_t>>("dilations", {1, 1, 1, 1});
+    auto tf_explicit_paddings = std::vector<int64_t>{};
+    if (auto_pad == ov::op::PadType::EXPLICIT) {
+        tf_explicit_paddings = node.get_attribute<std::vector<int64_t>>("explicit_paddings", {});
+    }
+    auto tf_data_format = node.get_attribute<std::string>("data_format", "NHWC");
 
     TENSORFLOW_OP_VALIDATION(node,
                              tf_data_format == "NHWC" || tf_data_format == "NCHW",
                              "Conv2DBackpropInput data format is neither NHWC nor NCHW");
-
-    std::vector<int64_t> tf_input_sizes;
-    get_const_input(node, 0, &tf_input_sizes);
-
-    if (std::any_of(tf_input_sizes.begin(), tf_input_sizes.end(), [](int32_t size) {
-            return size <= 0;
-        })) {
-        FRONT_END_THROW("Conv2DBackpropInput input sizes must be positive integers");
+    if (auto_pad == ov::op::PadType::EXPLICIT) {
+        TENSORFLOW_OP_VALIDATION(node,
+                                 tf_explicit_paddings.size() == 8,
+                                 "Conv2DBackpropInput expects 8 padding values for EXPLICIT padding mode.");
     }
-
     bool is_nhwc = (tf_data_format == "NHWC");
 
-    Strides ng_strides(2);
-    Strides ng_dilations(2);
-    Shape ng_image_shape(2);
-    Shape ng_kernel_shape(2);
-    Shape ng_batch_shape(4);
+    // prepare attributes for OpenVINO ConvolutionBackpropData
+    Strides strides(2);
+    Strides dilations(2);
+    convert_nhwc_to_hw(is_nhwc, tf_strides, strides);
+    convert_nhwc_to_hw(is_nhwc, tf_dilations, dilations);
 
-    convert_nhwc_to_hw(is_nhwc, tf_strides, ng_strides);
-    convert_nhwc_to_hw(is_nhwc, tf_dilations, ng_dilations);
-    convert_nhwc_to_hw(is_nhwc, tf_input_sizes, ng_image_shape);
-    convert_nhwc_to_nchw(node.get_name(), is_nhwc, ng_out_backprop);
-    if (is_nhwc) {
-        ng_batch_shape = {static_cast<unsigned long>(tf_input_sizes[0]),
-                          static_cast<unsigned long>(tf_input_sizes[3]),
-                          static_cast<unsigned long>(tf_input_sizes[1]),
-                          static_cast<unsigned long>(tf_input_sizes[2])};
-    } else {
-        ng_batch_shape = {static_cast<unsigned long>(tf_input_sizes[0]),
-                          static_cast<unsigned long>(tf_input_sizes[1]),
-                          static_cast<unsigned long>(tf_input_sizes[2]),
-                          static_cast<unsigned long>(tf_input_sizes[3])};
+    ov::CoordinateDiff pads_begin;
+    ov::CoordinateDiff pads_end;
+    if (auto_pad == ov::op::PadType::EXPLICIT) {
+        // prepare pads_begin and pads_end attributes for EXPLICIT padding mode
+        if (is_nhwc) {
+            // For NHWC layout, explicit paddings has the following form:
+            // [0, 0, pad_h1, pad_h2, pad_w1, pad_w2, 0, 0]
+            pads_begin.push_back(tf_explicit_paddings[2]);
+            pads_begin.push_back(tf_explicit_paddings[4]);
+            pads_end.push_back(tf_explicit_paddings[3]);
+            pads_end.push_back(tf_explicit_paddings[5]);
+        } else {
+            // For NCHW layout, explicit paddings has the following form:
+            // [0, 0, 0, 0, pad_h1, pad_h2, pad_w1, pad_w2]
+            pads_begin.push_back(tf_explicit_paddings[4]);
+            pads_begin.push_back(tf_explicit_paddings[6]);
+            pads_end.push_back(tf_explicit_paddings[5]);
+            pads_end.push_back(tf_explicit_paddings[7]);
+        }
     }
 
-    auto& ng_filter_shape = ng_filter.get_shape();
-    ng_kernel_shape[0] = ng_filter_shape[0];
-    ng_kernel_shape[1] = ng_filter_shape[1];
-    transpose<3, 2, 0, 1>(ng_filter);
+    // prepare inputs to ConvolutionBackpropData
+    filter = make_transpose(filter, {3, 2, 0, 1});
+    convert_nhwc_to_nchw(is_nhwc, out_backprop);
 
-    CoordinateDiff ng_padding_below;
-    CoordinateDiff ng_padding_above;
-    make_padding(tf_padding_type,
-                 ng_image_shape,
-                 ng_kernel_shape,
-                 ng_strides,
-                 ng_dilations,
-                 ng_padding_below,
-                 ng_padding_above);
+    // initially think that output shape defined for NCHW layout
+    auto ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{2});
+    auto ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{-1});
+    auto ss_strides = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
 
-    auto ng_output_shape = make_shared<Constant>(element::i64,
-                                                 Shape{ng_batch_shape.size() - 2},
-                                                 vector<size_t>(ng_batch_shape.begin() + 2, ng_batch_shape.end()));
+    // change range of indices for spatial dimensions in case NHWC layout
+    if (is_nhwc) {
+        ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
+        ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{3});
+    }
 
-    auto res_node = make_shared<ConvolutionBackpropData>(ng_out_backprop,
-                                                         ng_filter,
-                                                         ng_output_shape,
-                                                         ng_strides,
-                                                         ng_padding_below,
-                                                         ng_padding_above,
-                                                         ng_dilations);
-    auto res = res_node->output(0);
+    auto spatial_shape = make_shared<StridedSlice>(input_sizes,
+                                                   ss_begin,
+                                                   ss_end,
+                                                   ss_strides,
+                                                   std::vector<int64_t>{},
+                                                   std::vector<int64_t>{});
 
-    convert_nchw_to_nhwc(node.get_name(), is_nhwc, res);
-    set_node_name(node.get_name(), res.get_node_shared_ptr());
-    return {res};
+    auto conv_backprop = make_shared<ConvolutionBackpropData>(out_backprop,
+                                                              filter,
+                                                              spatial_shape,
+                                                              strides,
+                                                              pads_begin,
+                                                              pads_end,
+                                                              dilations,
+                                                              auto_pad);
+
+    // insert Transpose only if original Conv2DBackpropInput is in NHWC layout
+    auto conv_backprop_output = conv_backprop->output(0);
+    convert_nchw_to_nhwc(is_nhwc, conv_backprop_output);
+
+    // move the original name to new ConvolutionBackpropData if original layout is NCHW
+    // move the original name to Transpose if original layout is NHWC
+    set_node_name(node.get_name(), conv_backprop_output.get_node_shared_ptr());
+    return {conv_backprop_output};
 }
 }  // namespace op
 }  // namespace tensorflow

--- a/src/frontends/tensorflow/src/op/conv_3d.cpp
+++ b/src/frontends/tensorflow/src/op/conv_3d.cpp
@@ -15,61 +15,7 @@ namespace tensorflow {
 namespace op {
 
 OutputVector translate_conv_3d_op(const NodeContext& node) {
-    auto ng_input = node.get_input(0), ng_filter = node.get_input(1);
-
-    auto tf_strides = node.get_attribute<std::vector<int64_t>>("strides");
-    auto tf_dilations = node.get_attribute<std::vector<int64_t>>("dilations");
-    auto tf_padding_type = node.get_attribute<std::string>("padding");
-    auto tf_data_format = node.get_attribute<std::string>("data_format");
-
-    TENSORFLOW_OP_VALIDATION(node,
-                             tf_data_format == "NDHWC" || tf_data_format == "NCDHW",
-                             "Conv3D data format is neither NDHWC nor NCDHW");
-
-    bool is_ndhwc = (tf_data_format == "NDHWC");
-
-    // TODO: in 3D
-    // TF Kernel Test Checks
-    // // Strides in the batch and depth dimension is not supported
-    // if (tf_strides[0] != 1 || tf_strides[is_nhwc ? 3 : 1] != 1) {
-    //   return errors::InvalidArgument(
-    //       "Strides in batch and depth dimensions is not supported: ",
-    //       op->type_string());
-    // }
-
-    Strides ng_strides(3);
-    Strides ng_dilations(3);
-    Shape ng_image_shape(3);
-    Shape ng_kernel_shape(3);
-
-    convert_nhwc_to_hw(is_ndhwc, tf_strides, ng_strides);
-    convert_nhwc_to_hw(is_ndhwc, ng_input.get_shape(), ng_image_shape);
-    convert_nhwc_to_hw(is_ndhwc, tf_dilations, ng_dilations);
-    convert_nhwc_to_nchw(node.get_name(), is_ndhwc, ng_input);
-
-    auto& ng_filter_shape = ng_filter.get_shape();
-    ng_kernel_shape[0] = ng_filter_shape[0];
-    ng_kernel_shape[1] = ng_filter_shape[1];
-    ng_kernel_shape[2] = ng_filter_shape[2];
-    transpose_3d<4, 3, 0, 1, 2>(ng_filter);
-
-    CoordinateDiff ng_padding_below;
-    CoordinateDiff ng_padding_above;
-    make_padding(tf_padding_type,
-                 ng_image_shape,
-                 ng_kernel_shape,
-                 ng_strides,
-                 ng_dilations,
-                 ng_padding_below,
-                 ng_padding_above);
-
-    auto res_node =
-        make_shared<Convolution>(ng_input, ng_filter, ng_strides, ng_padding_below, ng_padding_above, ng_dilations);
-    auto res = res_node->output(0);
-
-    convert_nchw_to_nhwc(node.get_name(), is_ndhwc, res);
-    set_node_name(node.get_name(), res.get_node_shared_ptr());
-    return {res};
+    return translate_convolution_op(node, 3);
 }
 }  // namespace op
 }  // namespace tensorflow

--- a/src/frontends/tensorflow/src/op/conv_3d_backprop.cpp
+++ b/src/frontends/tensorflow/src/op/conv_3d_backprop.cpp
@@ -14,89 +14,104 @@ namespace tensorflow {
 namespace op {
 
 OutputVector translate_conv_3d_backprop_input_v2_op(const NodeContext& node) {
-    auto ng_filter = node.get_input(1);
-    auto ng_out_backprop = node.get_input(2);
+    TENSORFLOW_OP_VALIDATION(node, node.get_input_size() >= 3, "Conv3DBackpropInput must have at least three inputs.");
+    auto input_sizes = node.get_input(0);
+    auto filter = node.get_input(1);
+    auto out_backprop = node.get_input(2);
 
-    // TODO: refactor me to be less redundant with other convolution ops
+    // retrieve attributes for Conv3DBackpropInput
     auto tf_strides = node.get_attribute<std::vector<int64_t>>("strides");
-    auto tf_dilations = node.get_attribute<std::vector<int64_t>>("dilations");
     auto tf_padding_type = node.get_attribute<std::string>("padding");
-    auto tf_data_format = node.get_attribute<std::string>("data_format");
+    ov::op::PadType auto_pad = convert_tf_padding(node, tf_padding_type);
+
+    // retrieve optional attributes
+    auto tf_dilations = node.get_attribute<std::vector<int64_t>>("dilations", {1, 1, 1, 1, 1});
+    auto tf_explicit_paddings = std::vector<int64_t>{};
+    if (auto_pad == ov::op::PadType::EXPLICIT) {
+        tf_explicit_paddings = node.get_attribute<std::vector<int64_t>>("explicit_paddings", {});
+    }
+    auto tf_data_format = node.get_attribute<std::string>("data_format", "NDHWC");
 
     TENSORFLOW_OP_VALIDATION(node,
                              tf_data_format == "NDHWC" || tf_data_format == "NCDHW",
-                             "Conv3DBackpropInputV2 data format is neither NDHWC nor NCDHW. "
-                             "Provided data format: ",
-                             tf_data_format);
+                             "Conv3DBackpropInput data format is neither NDHWC nor NCDHW");
+    if (auto_pad == ov::op::PadType::EXPLICIT) {
+        TENSORFLOW_OP_VALIDATION(node,
+                                 tf_explicit_paddings.size() == 10,
+                                 "Conv3DBackpropInput expects 10 padding values for EXPLICIT padding mode.");
+    }
+    bool is_nhwc = (tf_data_format == "NDHWC");
 
-    std::vector<int64_t> tf_input_sizes;
-    get_const_input(node, 0, &tf_input_sizes);
+    // prepare attributes for OpenVINO ConvolutionBackpropData
+    Strides strides(3);
+    Strides dilations(3);
+    convert_nhwc_to_hw(is_nhwc, tf_strides, strides);
+    convert_nhwc_to_hw(is_nhwc, tf_dilations, dilations);
 
-    if (std::any_of(tf_input_sizes.begin(), tf_input_sizes.end(), [](int32_t size) {
-            return size <= 0;
-        })) {
-        FRONT_END_THROW("Conv3DBackpropInputV2 input sizes must be positive integers");
+    ov::CoordinateDiff pads_begin;
+    ov::CoordinateDiff pads_end;
+    if (auto_pad == ov::op::PadType::EXPLICIT) {
+        // prepare pads_begin and pads_end attributes for EXPLICIT padding mode
+        if (is_nhwc) {
+            // For NDHWC layout, explicit paddings has the following form:
+            // [0, 0, pad_d1, pad_d2, pad_h1, pad_h2, pad_w1, pad_w2, 0, 0]
+            pads_begin.push_back(tf_explicit_paddings[2]);
+            pads_begin.push_back(tf_explicit_paddings[4]);
+            pads_begin.push_back(tf_explicit_paddings[6]);
+            pads_end.push_back(tf_explicit_paddings[3]);
+            pads_end.push_back(tf_explicit_paddings[5]);
+            pads_end.push_back(tf_explicit_paddings[7]);
+        } else {
+            // For NCDHW layout, explicit paddings has the following form:
+            // [0, 0, 0, 0, pad_d1, pad_d2, pad_h1, pad_h2, pad_w1, pad_w2]
+            pads_begin.push_back(tf_explicit_paddings[4]);
+            pads_begin.push_back(tf_explicit_paddings[6]);
+            pads_begin.push_back(tf_explicit_paddings[8]);
+            pads_end.push_back(tf_explicit_paddings[5]);
+            pads_end.push_back(tf_explicit_paddings[7]);
+            pads_end.push_back(tf_explicit_paddings[9]);
+        }
     }
 
-    bool is_ndhwc = (tf_data_format == "NDHWC");
+    // prepare inputs to ConvolutionBackpropData
+    filter = make_transpose(filter, {4, 3, 0, 1, 2});
+    convert_nhwc_to_nchw(is_nhwc, out_backprop);
 
-    ov::Strides ng_strides(3);
-    ov::Strides ng_dilations(3);
-    ov::Shape ng_image_shape(3);
-    ov::Shape ng_kernel_shape(3);
-    ov::Shape ng_batch_shape(5);
+    // initially think that output shape defined for NCDHW layout
+    auto ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{2});
+    auto ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{-1});
+    auto ss_strides = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
 
-    convert_nhwc_to_hw(is_ndhwc, tf_strides, ng_strides);
-    convert_nhwc_to_hw(is_ndhwc, tf_dilations, ng_dilations);
-    convert_nhwc_to_hw(is_ndhwc, tf_input_sizes, ng_image_shape);
-    convert_nhwc_to_nchw(node.get_name(), is_ndhwc, ng_out_backprop);
-    if (is_ndhwc) {
-        ng_batch_shape = {static_cast<unsigned long>(tf_input_sizes[0]),
-                          static_cast<unsigned long>(tf_input_sizes[4]),
-                          static_cast<unsigned long>(tf_input_sizes[1]),
-                          static_cast<unsigned long>(tf_input_sizes[2]),
-                          static_cast<unsigned long>(tf_input_sizes[3])};
-    } else {
-        ng_batch_shape = {static_cast<unsigned long>(tf_input_sizes[0]),
-                          static_cast<unsigned long>(tf_input_sizes[1]),
-                          static_cast<unsigned long>(tf_input_sizes[2]),
-                          static_cast<unsigned long>(tf_input_sizes[3]),
-                          static_cast<unsigned long>(tf_input_sizes[4])};
+    // change range of indices for spatial dimensions in case NDHWC layout
+    if (is_nhwc) {
+        ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
+        ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{4});
     }
 
-    auto& ng_filter_shape = ng_filter.get_shape();
-    ng_kernel_shape[0] = ng_filter_shape[0];
-    ng_kernel_shape[1] = ng_filter_shape[1];
-    ng_kernel_shape[2] = ng_filter_shape[2];
-    transpose_3d<4, 3, 0, 1, 2>(ng_filter);
+    auto spatial_shape = make_shared<StridedSlice>(input_sizes,
+                                                   ss_begin,
+                                                   ss_end,
+                                                   ss_strides,
+                                                   std::vector<int64_t>{},
+                                                   std::vector<int64_t>{});
 
-    ov::CoordinateDiff ng_padding_below;
-    ov::CoordinateDiff ng_padding_above;
+    auto conv_backprop = make_shared<ConvolutionBackpropData>(out_backprop,
+                                                              filter,
+                                                              spatial_shape,
+                                                              strides,
+                                                              pads_begin,
+                                                              pads_end,
+                                                              dilations,
+                                                              auto_pad);
 
-    make_padding(tf_padding_type,
-                 ng_image_shape,
-                 ng_kernel_shape,
-                 ng_strides,
-                 ng_dilations,
-                 ng_padding_below,
-                 ng_padding_above);
+    // insert Transpose only if original Conv3DBackpropInput is in NDHWC layout
+    auto conv_backprop_output = conv_backprop->output(0);
+    convert_nchw_to_nhwc(is_nhwc, conv_backprop_output);
 
-    auto ng_output_shape = make_shared<Constant>(element::i64,
-                                                 Shape{ng_batch_shape.size() - 2},
-                                                 vector<size_t>(ng_batch_shape.begin() + 2, ng_batch_shape.end()));
-
-    auto res_node = make_shared<ConvolutionBackpropData>(ng_out_backprop,
-                                                         ng_filter,
-                                                         ng_output_shape,
-                                                         ng_strides,
-                                                         ng_padding_below,
-                                                         ng_padding_above,
-                                                         ng_dilations);
-    auto res = res_node->output(0);
-
-    convert_nchw_to_nhwc(node.get_name(), is_ndhwc, res);
-    set_node_name(node.get_name(), res.get_node_shared_ptr());
-    return {res};
+    // move the original name to new ConvolutionBackpropData if original layout is NCHW
+    // move the original name to Transpose if original layout is NHWC
+    set_node_name(node.get_name(), conv_backprop_output.get_node_shared_ptr());
+    return {conv_backprop_output};
 }
 }  // namespace op
 }  // namespace tensorflow

--- a/src/frontends/tensorflow/src/op/crop_and_resize.cpp
+++ b/src/frontends/tensorflow/src/op/crop_and_resize.cpp
@@ -123,10 +123,10 @@ OutputVector translate_crop_and_resize_op(const NodeContext& node) {
                 interpolate_attrs.mode = Interpolate::InterpolateMode::NEAREST;
             }
 
-            transpose<0, 3, 1, 2>(ng_crop);
+            ng_crop = make_transpose(ng_crop, {0, 3, 1, 2});
             auto ng_output =
                 make_shared<Interpolate>(ng_crop, ng_size, ng_scales, ng_axes, interpolate_attrs)->output(0);
-            transpose<0, 2, 3, 1>(ng_output);
+            ng_output = make_transpose(ng_output, {0, 2, 3, 1});
             ng_crop_outputs.at(i) = ng_output;
         }
 

--- a/src/frontends/tensorflow/src/op/depth_to_space.cpp
+++ b/src/frontends/tensorflow/src/op/depth_to_space.cpp
@@ -27,10 +27,10 @@ OutputVector translate_depth_to_space_op(const NodeContext& node) {
 
     bool is_nhwc = (tf_data_format == "NHWC");
 
-    convert_nhwc_to_nchw(node.get_name(), is_nhwc, ng_input);
+    convert_nhwc_to_nchw(is_nhwc, ng_input);
     auto ng_mode = DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST;
     Output<Node> res = make_shared<DepthToSpace>(ng_input, ng_mode, block_size)->output(0);
-    convert_nchw_to_nhwc(node.get_name(), is_nhwc, res);
+    convert_nchw_to_nhwc(is_nhwc, res);
     set_node_name(node.get_name(), res.get_node_shared_ptr());
     return {res};
 }

--- a/src/frontends/tensorflow/src/op/depthwise_conv_2d.cpp
+++ b/src/frontends/tensorflow/src/op/depthwise_conv_2d.cpp
@@ -36,7 +36,7 @@ OutputVector translate_depthwise_conv_2d_native_op(const NodeContext& node) {
     convert_nhwc_to_hw(is_nhwc, ng_input.get_shape(), ng_image_shape);
     convert_nhwc_to_hw(is_nhwc, tf_strides, ng_strides);
     convert_nhwc_to_hw(is_nhwc, tf_dilations, ng_dilations);
-    convert_nhwc_to_nchw(node.get_name(), is_nhwc, ng_input);
+    convert_nhwc_to_nchw(is_nhwc, ng_input);
 
     auto& ng_filter_shape = ng_filter.get_shape();
     ng_kernel_shape[0] = ng_filter_shape[0];
@@ -71,7 +71,7 @@ OutputVector translate_depthwise_conv_2d_native_op(const NodeContext& node) {
                                                       ng_dilations);
     auto ng_conv = ng_conv_node->output(0);
 
-    convert_nchw_to_nhwc(node.get_name(), is_nhwc, ng_conv);
+    convert_nchw_to_nhwc(is_nhwc, ng_conv);
     set_node_name(node.get_name(), ng_conv.get_node_shared_ptr());
     return {ng_conv};
 }

--- a/src/frontends/tensorflow/src/op/fake_quant_min_max_vars.cpp
+++ b/src/frontends/tensorflow/src/op/fake_quant_min_max_vars.cpp
@@ -51,11 +51,13 @@ OutputVector translate_fake_quant_op(const NodeContext& node) {
     auto max_adj = make_shared<Add>(maximum, adjustment);
 
     auto ng_input_shape = ng_input.get_shape();
-    if (ng_input_shape.size() == 4)
-        transpose<0, 3, 1, 2>(ng_input);
+    if (ng_input_shape.size() == 4) {
+        ng_input = make_transpose(ng_input, {0, 3, 1, 2});
+    }
     auto res = make_shared<FakeQuantize>(ng_input, min_adj, max_adj, min_adj, max_adj, levels)->output(0);
-    if (ng_input_shape.size() == 4)
-        transpose<0, 2, 3, 1>(res);
+    if (ng_input_shape.size() == 4) {
+        res = make_transpose(res, {0, 2, 3, 1});
+    }
 
     set_node_name(node.get_name(), res.get_node_shared_ptr());
     return {res};

--- a/src/frontends/tensorflow/src/op/fused_batch_norm.cpp
+++ b/src/frontends/tensorflow/src/op/fused_batch_norm.cpp
@@ -34,11 +34,11 @@ OutputVector translate_fused_batch_norm_op(const NodeContext& node) {
 
     OPENVINO_DEBUG << "epsilon: " << tf_epsilon;
 
-    convert_nhwc_to_nchw(node.get_name(), is_nhwc, ng_input);
+    convert_nhwc_to_nchw(is_nhwc, ng_input);
 
     auto ng_batch_norm =
         make_shared<BatchNormInference>(ng_input, ng_scale, ng_offset, ng_mean, ng_variance, tf_epsilon)->output(0);
-    convert_nchw_to_nhwc(node.get_name(), is_nhwc, ng_batch_norm);
+    convert_nchw_to_nhwc(is_nhwc, ng_batch_norm);
 
     // TODO: Why are there so many? Is it correct?
     OutputVector result = {ng_batch_norm, ng_mean, ng_variance, ng_mean, ng_variance};

--- a/src/frontends/tensorflow/src/op/interpolate.cpp
+++ b/src/frontends/tensorflow/src/op/interpolate.cpp
@@ -36,9 +36,9 @@ ov::OutputVector translate_interpolate_op(const NodeContext& node) {
     auto ng_scales = make_shared<Divide>(ng_sizes, ng_spatial_shape);
     auto ng_axes = make_shared<Constant>(element::i32, Shape{2}, std::vector<int>({2, 3}));
 
-    transpose<0, 3, 1, 2>(input);
+    input = make_transpose(input, {0, 3, 1, 2});
     auto res = make_shared<Interpolate>(input, input_sizes, ng_scales, ng_axes, interpolate_attrs)->output(0);
-    transpose<0, 2, 3, 1>(res);
+    res = make_transpose(res, {0, 2, 3, 1});
     set_node_name(node.get_name(), res.get_node_shared_ptr());
     return {res};
 }

--- a/src/frontends/tensorflow/src/op/linspace.cpp
+++ b/src/frontends/tensorflow/src/op/linspace.cpp
@@ -1,0 +1,82 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "op_table.hpp"
+#include "openvino/opsets/opset8.hpp"
+
+using namespace std;
+using namespace ov::opset8;
+
+namespace ov {
+namespace frontend {
+namespace tensorflow {
+namespace op {
+OutputVector translate_linspace_op(const NodeContext& node) {
+    /* LinSpace operation can be expressed in the following form:
+     * 1) Compute deltas by which each element will be increased in each slice
+     * through new dimension as delta = (stop - start) / (num - 1)
+     * 2) Generate a range of numbers by which times delta will be added to start to
+     * compute new elements in each slide as range = [0, 1, ..., num - 1]
+     * 3) Unsqueeze start and delta by new axis. And unsqueeze range by axes except given axis
+     * 4) Compute the result of the operation as result = start + delta * range
+     */
+    auto num_inputs = node.get_input_size();
+    auto start = node.get_input(0);
+    auto stop = node.get_input(1);
+    auto num = node.get_input(2);
+
+    TENSORFLOW_OP_VALIDATION(node, start.get_partial_shape().rank().is_static(), "Input rank must be static.");
+    int64_t start_rank = start.get_partial_shape().rank().get_length();
+
+    // retrieve axis from Constant node and compute a range of axes except given axis
+    // for unsqueezing start and delta tensors
+    std::vector<int64_t> axis;
+    std::vector<int64_t> except_axis_range;
+    if (num_inputs > 3 && start_rank > 0) {
+        get_const_input(node, 3, &axis);
+        TENSORFLOW_OP_VALIDATION(node, axis.size() == 1, "Axis must be a scalar for LinSpace operation.");
+        axis[0] = axis[0] >= 0 ? axis[0] : start_rank + 1 + axis[0];
+        for (int64_t dim_ind = 0; dim_ind < start_rank + 1; ++dim_ind) {
+            if (dim_ind != axis[0]) {
+                except_axis_range.push_back(dim_ind);
+            }
+        }
+    }
+
+    TENSORFLOW_OP_VALIDATION(node,
+                             axis.empty() && start_rank == 0 || axis.size() == 1 && start_rank > 0,
+                             "Axis must be used only if input for LinSpace operation is ND tensor.");
+
+    auto one = make_shared<Constant>(num.get_element_type(), Shape{}, 1);
+    auto num_minus_1 = make_shared<ConvertLike>(make_shared<Subtract>(num, one), start);
+    auto delta = make_shared<Divide>(make_shared<Subtract>(stop, start), num_minus_1);
+
+    auto zero = make_shared<Constant>(num.get_element_type(), Shape{}, 0);
+    auto range_0_num_minus_1 =
+        make_shared<ConvertLike>(make_shared<Range>(zero, num, one, num.get_element_type()), start);
+
+    // convert a case with scalar inputs
+    if (axis.empty() && start_rank == 0) {
+        auto delta_mul_range = make_shared<Multiply>(delta, range_0_num_minus_1);
+        auto result = make_shared<Add>(start, delta_mul_range);
+        set_node_name(node.get_name(), result);
+        return result->outputs();
+    }
+
+    auto const_axis = make_shared<Constant>(element::i64, Shape{axis.size()}, axis);
+    auto const_except_axis = make_shared<Constant>(element::i64, Shape{except_axis_range.size()}, except_axis_range);
+
+    auto unsqueeze_start = make_shared<Unsqueeze>(start, const_axis);
+    auto unsqueeze_delta = make_shared<Unsqueeze>(delta, const_axis);
+    auto unsqueeze_range = make_shared<Unsqueeze>(range_0_num_minus_1, const_except_axis);
+
+    auto delta_mul_range = make_shared<Multiply>(unsqueeze_delta, unsqueeze_range);
+    auto result = make_shared<Add>(unsqueeze_start, delta_mul_range);
+    set_node_name(node.get_name(), result);
+    return result->outputs();
+}
+}  // namespace op
+}  // namespace tensorflow
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/tensorflow/src/op/matmul.cpp
+++ b/src/frontends/tensorflow/src/op/matmul.cpp
@@ -23,6 +23,18 @@ OutputVector translate_mat_mul_op(const NodeContext& node) {
     set_node_name(node.get_name(), res);
     return res->outputs();
 }
+
+OutputVector translate_batch_mat_mul_op(const NodeContext& node) {
+    auto x = node.get_input(0);
+    auto y = node.get_input(1);
+
+    auto adj_x = node.get_attribute<bool>("adj_x", false);
+    auto adj_y = node.get_attribute<bool>("adj_y", false);
+
+    auto result = make_shared<MatMul>(x, y, adj_x, adj_y);
+    set_node_name(node.get_name(), result);
+    return result->outputs();
+}
 }  // namespace op
 }  // namespace tensorflow
 }  // namespace frontend

--- a/src/frontends/tensorflow/src/op/max_pool.cpp
+++ b/src/frontends/tensorflow/src/op/max_pool.cpp
@@ -3,7 +3,8 @@
 //
 
 #include "op_table.hpp"
-#include "openvino/opsets/opset7.hpp"
+#include "openvino/opsets/opset8.hpp"
+#include "utils.hpp"
 
 using namespace std;
 using namespace ov;
@@ -14,56 +15,103 @@ namespace frontend {
 namespace tensorflow {
 namespace op {
 
-OutputVector translate_max_pool_op(const NodeContext& node) {
-    auto ng_input = node.get_input(0);
+OutputVector translate_max_pool_util(const NodeContext& node,
+                                     size_t spatial_dims_num,
+                                     const std::vector<int64_t>& tf_kernel_sizes,
+                                     const std::vector<int64_t>& tf_strides) {
+    TENSORFLOW_OP_VALIDATION(node, node.get_input_size() > 0, "MaxPool operation must have at least one input.");
+    TENSORFLOW_OP_VALIDATION(node,
+                             spatial_dims_num == 2 || spatial_dims_num == 3,
+                             "Only MaxPool2D and MaxPool3D are supported.");
+    auto input = node.get_input(0);
 
-    auto tf_strides = node.get_attribute<std::vector<int64_t>>("strides");
-    auto tf_ksize = node.get_attribute<std::vector<int64_t>>("ksize");
     auto tf_padding_type = node.get_attribute<std::string>("padding");
-    auto tf_data_format = node.get_attribute<std::string>("data_format");
+    ov::op::PadType auto_pad = convert_tf_padding(node, tf_padding_type);
+    auto tf_data_format = node.get_attribute<std::string>("data_format", spatial_dims_num == 2 ? "NHWC" : "NDHWC");
 
-    bool is_nhwc = (tf_data_format == "NHWC") || (tf_data_format == "NDHWC");
-
-    int N = 2;
-    if (node.get_op_type() == "MaxPool3D") {
-        N = 3;
+    auto tf_explicit_paddings = std::vector<int64_t>{};
+    if (auto_pad == ov::op::PadType::EXPLICIT) {
+        tf_explicit_paddings = node.get_attribute<std::vector<int64_t>>("explicit_paddings", {});
     }
-    Strides ng_strides(N);
-    Shape ng_image_shape(N);
-    Shape ng_kernel_shape(N);
-    Shape ng_dilations(N, 1);
 
-    convert_nhwc_to_hw(is_nhwc, tf_strides, ng_strides);
-    convert_nhwc_to_hw(is_nhwc, ng_input.get_shape(), ng_image_shape);
-    convert_nhwc_to_hw(is_nhwc, tf_ksize, ng_kernel_shape);
-    convert_nhwc_to_nchw(node.get_name(), is_nhwc, ng_input);
+    bool is_nhwc = true;
+    if (spatial_dims_num == 2) {
+        TENSORFLOW_OP_VALIDATION(node,
+                                 tf_data_format == "NHWC" || tf_data_format == "NCHW",
+                                 "MaxPool2D or MaxPoolV2 data format is neither NHWC nor NCHW");
+        is_nhwc = (tf_data_format == "NHWC");
+    } else {
+        TENSORFLOW_OP_VALIDATION(node,
+                                 tf_data_format == "NDHWC" || tf_data_format == "NCDHW",
+                                 "MaxPool3D data format is neither NDHWC nor NCDHW");
+        is_nhwc = (tf_data_format == "NDHWC");
+    }
 
-    CoordinateDiff padding_below;
-    CoordinateDiff padding_above;
-    make_padding(tf_padding_type,
-                 ng_image_shape,
-                 ng_kernel_shape,
-                 ng_strides,
-                 ng_dilations,
-                 padding_below,
-                 padding_above);
+    // prepare attributes for OpenVINO MaxPool operation
+    ov::Strides strides(spatial_dims_num);
+    ov::Strides dilations = (spatial_dims_num == 2 ? ov::Strides({1, 1}) : ov::Strides({1, 1, 1}));
+    ov::Shape kernel_sizes(spatial_dims_num);
+    ov::frontend::tensorflow::convert_nhwc_to_hw(is_nhwc, tf_strides, strides);
+    ov::frontend::tensorflow::convert_nhwc_to_hw(is_nhwc, tf_kernel_sizes, kernel_sizes);
 
-    // TODO: remove this once OV supports negative padding
-    // (CoordinateDiff) for MaxPool
-    Shape ng_padding_below(padding_below.begin(), padding_below.end());
-    Shape ng_padding_above(padding_above.begin(), padding_above.end());
+    ov::CoordinateDiff pads_begin;
+    ov::CoordinateDiff pads_end;
+    if (auto_pad == ov::op::PadType::EXPLICIT) {
+        fill_explicit_pads_vectors(node, is_nhwc, spatial_dims_num, tf_explicit_paddings, pads_begin, pads_end);
+    }
 
-    auto res_node = make_shared<ov::opset7::MaxPool>(ng_input,
-                                                     ng_strides,
-                                                     ng_padding_below,
-                                                     ng_padding_above,
-                                                     ng_kernel_shape,
-                                                     ov::op::RoundingType::FLOOR);
-    auto res = res_node->output(0);
+    // prepare input to MaxPool
+    convert_nhwc_to_nchw(is_nhwc, input);
 
-    convert_nchw_to_nhwc(node.get_name(), is_nhwc, res);
-    set_node_name(node.get_name(), res.get_node_shared_ptr());
-    return {res};
+    auto max_pool_node = std::make_shared<ov::opset8::MaxPool>(input,
+                                                               strides,
+                                                               dilations,
+                                                               ov::Shape(pads_begin.begin(), pads_begin.end()),
+                                                               ov::Shape(pads_end.begin(), pads_end.end()),
+                                                               kernel_sizes,
+                                                               ov::op::RoundingType::FLOOR,
+                                                               auto_pad);
+    auto max_pool = max_pool_node->output(0);
+    ov::frontend::tensorflow::convert_nchw_to_nhwc(is_nhwc, max_pool);
+    ov::frontend::tensorflow::set_node_name(node.get_name(), max_pool.get_node_shared_ptr());
+    return {max_pool};
+}
+
+OutputVector translate_max_pool(const NodeContext& node, size_t spatial_dims_num) {
+    // MaxPool2D and MaxPool3D have ksize and strides as attributes
+    // retrieve attributes
+    auto strides = node.get_attribute<std::vector<int64_t>>("strides");
+    auto kernel_sizes = node.get_attribute<std::vector<int64_t>>("ksize");
+    return translate_max_pool_util(node, spatial_dims_num, kernel_sizes, strides);
+}
+
+OutputVector translate_max_pool_v2(const NodeContext& node) {
+    // MaxPoolV2 has ksize and strides as input parameters
+    TENSORFLOW_OP_VALIDATION(node, node.get_input_size() > 2, "MaxPoolV2 operation must have at least three inputs.");
+    auto ksize = node.get_input(1);
+    auto strides = node.get_input(2);
+
+    auto ksize_constant = get_constant_from_source(ksize);
+    TENSORFLOW_OP_VALIDATION(node, ksize_constant, "MaxPoolV2 is supported only with constant ksize.");
+    auto strides_constant = get_constant_from_source(strides);
+    TENSORFLOW_OP_VALIDATION(node, ksize_constant, "MaxPoolV2 is supported only with constant strides.");
+
+    auto ksize_vector = ksize_constant->cast_vector<int64_t>();
+    auto strides_vector = strides_constant->cast_vector<int64_t>();
+
+    return translate_max_pool_util(node, 2, ksize_vector, strides_vector);
+}
+
+OutputVector translate_max_pool_op(const NodeContext& node) {
+    if (node.get_op_type() == "MaxPool") {
+        return translate_max_pool(node, 2);
+    } else if (node.get_op_type() == "MaxPoolV2") {
+        return translate_max_pool_v2(node);
+    } else if (node.get_op_type() == "MaxPool3D") {
+        return translate_max_pool(node, 3);
+    } else {
+        TENSORFLOW_OP_VALIDATION(node, false, "Only MaxPool2D, MaxPoolV2 and MaxPool3D are supported.");
+    }
 }
 
 }  // namespace op

--- a/src/frontends/tensorflow/src/op/slice.cpp
+++ b/src/frontends/tensorflow/src/op/slice.cpp
@@ -18,11 +18,26 @@ OutputVector translate_slice_op(const NodeContext& node) {
     auto start = node.get_input(1);
     auto size = node.get_input(2);
 
-    auto stop = make_shared<Add>(start, size);
+    // compute stop values in case non-negative sizes
+    auto stop_pos = make_shared<Add>(start, size);
 
-    auto one = make_shared<Constant>(element::i64, Shape{1}, 1);
-    auto shape = make_shared<ShapeOf>(start);
-    auto step = make_shared<Broadcast>(one, shape);
+    // compute stop values in case negative sizes
+    // since TensorFlow supports only -1 among negative sizes
+    // assign stop values to the data shape
+    auto input_shape = make_shared<ShapeOf>(input);
+    auto stop_neg = make_shared<ConvertLike>(input_shape, size);
+
+    // select the correct stop value based on a sign of size value
+    auto zeros = make_shared<Constant>(size.get_element_type(), Shape{}, 0);
+    auto negative_sizes_mask = make_shared<Less>(size, zeros);
+    // TODO: investigate if we can simplify and replace Select with FloorMod operation
+    // like FloorMod(size, input_shape)
+    auto stop = make_shared<Select>(negative_sizes_mask, stop_neg, stop_pos);
+
+    // broadcast step value
+    auto start_shape = make_shared<ShapeOf>(start);
+    auto one = make_shared<Constant>(start.get_element_type(), Shape{}, 1);
+    auto step = make_shared<Broadcast>(one, start_shape);
 
     auto res = make_shared<Slice>(input, start, stop, step);
     set_node_name(node.get_name(), res);

--- a/src/frontends/tensorflow/src/op/space_to_depth.cpp
+++ b/src/frontends/tensorflow/src/op/space_to_depth.cpp
@@ -22,10 +22,10 @@ OutputVector translate_space_to_depth_op(const NodeContext& node) {
     TENSORFLOW_OP_VALIDATION(node, data_format == "NHWC" || data_format == "NCHW", "Unsupported data format.");
 
     bool is_nhwc = (data_format == "NHWC");
-    convert_nhwc_to_nchw(node.get_name(), is_nhwc, input);
+    convert_nhwc_to_nchw(is_nhwc, input);
     auto ng_mode = SpaceToDepth::SpaceToDepthMode::BLOCKS_FIRST;
     auto res = make_shared<SpaceToDepth>(input, ng_mode, block_size)->output(0);
-    convert_nchw_to_nhwc(node.get_name(), is_nhwc, res);
+    convert_nchw_to_nhwc(is_nhwc, res);
     set_node_name(node.get_name(), res.get_node_shared_ptr());
     return {res};
 }

--- a/src/frontends/tensorflow/src/op/strided_slice.cpp
+++ b/src/frontends/tensorflow/src/op/strided_slice.cpp
@@ -15,28 +15,24 @@ namespace op {
 
 OutputVector translate_strided_slice_op(const NodeContext& node) {
     auto input = node.get_input(0);
-    auto rank = input.get_partial_shape().rank();
     auto begin = node.get_input(1);
     auto end = node.get_input(2);
     auto strides = node.get_input(3);
 
-    auto begin_mask = node.get_attribute<int64_t>("begin_mask");
-    auto end_mask = node.get_attribute<int64_t>("end_mask");
-    auto new_axis_mask = node.get_attribute<int64_t>("new_axis_mask");
-    auto ellipsis_mask = node.get_attribute<int64_t>("ellipsis_mask");
-    auto shrink_axis_mask = node.get_attribute<int64_t>("shrink_axis_mask");
+    auto begin_mask = node.get_attribute<int64_t>("begin_mask", 0);
+    auto end_mask = node.get_attribute<int64_t>("end_mask", 0);
+    auto new_axis_mask = node.get_attribute<int64_t>("new_axis_mask", 0);
+    auto ellipsis_mask = node.get_attribute<int64_t>("ellipsis_mask", 0);
+    auto shrink_axis_mask = node.get_attribute<int64_t>("shrink_axis_mask", 0);
 
-    auto mask_to_vec = [](int64_t mask, const ov::Rank& rank) {
+    auto mask_to_vector = [](int64_t mask) {
         auto length = sizeof(mask) * CHAR_BIT;
-        if (rank.is_static() && rank.get_length() < length) {
-            length = rank.get_length();
-        }
         vector<int64_t> vec(length, 0);
         if (mask == 0) {
             return vec;
         }
         for (auto i = 0; i < length; ++i) {
-            if (static_cast<unsigned char>(mask >> i & 0x01) == 1) {
+            if (static_cast<unsigned char>(mask >> i & 0x1) == 1) {
                 vec[i] = 1;
             }
         }
@@ -47,11 +43,11 @@ OutputVector translate_strided_slice_op(const NodeContext& node) {
                                          begin,
                                          end,
                                          strides,
-                                         mask_to_vec(begin_mask, rank),
-                                         mask_to_vec(end_mask, rank),
-                                         mask_to_vec(new_axis_mask, rank),
-                                         mask_to_vec(shrink_axis_mask, rank),
-                                         mask_to_vec(ellipsis_mask, rank));
+                                         mask_to_vector(begin_mask),
+                                         mask_to_vector(end_mask),
+                                         mask_to_vector(new_axis_mask),
+                                         mask_to_vector(shrink_axis_mask),
+                                         mask_to_vector(ellipsis_mask));
     set_node_name(node.get_name(), res);
     return res->outputs();
 }

--- a/src/frontends/tensorflow/src/op_table.cpp
+++ b/src/frontends/tensorflow/src/op_table.cpp
@@ -25,8 +25,9 @@ OP_CONVERTER(translate_add_n_op);
 OP_CONVERTER(translate_arg_max_op);
 OP_CONVERTER(translate_arg_min_op);
 OP_CONVERTER(translate_avg_pool_op);
-OP_CONVERTER(translate_bias_add_op);
+OP_CONVERTER(translate_batch_mat_mul_op);
 OP_CONVERTER(translate_batch_nd_and_space_nd_op);
+OP_CONVERTER(translate_bias_add_op);
 OP_CONVERTER(translate_cast_op);
 OP_CONVERTER(translate_concat_op);
 OP_CONVERTER(translate_const_op);
@@ -51,6 +52,7 @@ OP_CONVERTER(translate_identity_op);
 OP_CONVERTER(translate_interpolate_op);
 OP_CONVERTER(translate_is_finite_op);
 OP_CONVERTER(translate_l2_loss_op);
+OP_CONVERTER(translate_linspace_op);
 OP_CONVERTER(translate_leaky_relu_op);
 OP_CONVERTER(translate_log_softmax_op);
 OP_CONVERTER(translate_log_1p_op);
@@ -160,6 +162,8 @@ const std::map<std::string, CreatorFunction> get_supported_ops() {
         {"ArgMin", translate_arg_min_op},
         {"AvgPool", translate_avg_pool_op},
         {"AvgPool3D", translate_avg_pool_op},
+        {"BatchMatMul", translate_batch_mat_mul_op},
+        {"BatchMatMulV2", translate_batch_mat_mul_op},
         {"BatchToSpaceND", translate_batch_nd_and_space_nd_op},
         {"BiasAdd", translate_bias_add_op},
         {"Cast", translate_cast_op},
@@ -190,11 +194,13 @@ const std::map<std::string, CreatorFunction> get_supported_ops() {
         {"IsFinite", translate_is_finite_op},
         {"L2Loss", translate_l2_loss_op},
         {"LeakyRelu", translate_leaky_relu_op},
+        {"LinSpace", translate_linspace_op},
         {"LogSoftmax", translate_log_softmax_op},
         {"Log1p", translate_log_1p_op},
         {"LRN", translate_lrn_op},
         {"MatMul", translate_mat_mul_op},
         {"MaxPool", translate_max_pool_op},
+        {"MaxPoolV2", translate_max_pool_op},
         {"MaxPool3D", translate_max_pool_op},
         {"MirrorPad", translate_pad_op},
         {"NonMaxSuppression", translate_non_max_suppression_op},
@@ -234,6 +240,7 @@ const std::map<std::string, CreatorFunction> get_supported_ops() {
         {"SpaceToDepth", translate_space_to_depth_op},
         {"Split", translate_split_op},
         {"SplitV", translate_split_v_op},
+        {"StopGradient", translate_identity_op},
         {"Sqrt", translate_sqrt_op},
         {"Square", translate_square_op},
         {"Squeeze", translate_squeeze_op},

--- a/src/frontends/tensorflow/src/openvino_conversions.cpp
+++ b/src/frontends/tensorflow/src/openvino_conversions.cpp
@@ -10,26 +10,37 @@ namespace ov {
 namespace frontend {
 namespace tensorflow {
 
-void convert_nhwc_to_nchw(const std::string& op_name, bool need_convert, ov::Output<ov::Node>& node) {
+void convert_nhwc_to_nchw(bool need_convert, ov::Output<ov::Node>& node) {
     if (need_convert) {
-        auto rank = node.get_shape().size();
+        OPENVINO_ASSERT(node.get_partial_shape().rank().is_static(),
+                        "The input rank must be static to convert to the first channel format.");
+        auto rank = node.get_partial_shape().rank().get_length();
         if (rank == 4) {
-            transpose<0, 3, 1, 2>(node);
+            node = make_transpose(node, {0, 3, 1, 2});
         } else if (rank == 5) {
-            transpose_3d<0, 4, 1, 2, 3>(node);
+            node = make_transpose(node, {0, 4, 1, 2, 3});
         }
     }
 }
 
-void convert_nchw_to_nhwc(const std::string& op_name, bool need_convert, ov::Output<ov::Node>& node) {
+void convert_nchw_to_nhwc(bool need_convert, ov::Output<ov::Node>& node) {
     if (need_convert) {
-        auto rank = node.get_shape().size();
+        OPENVINO_ASSERT(node.get_partial_shape().rank().is_static(),
+                        "The input rank must be static to convert to the last channel format.");
+        auto rank = node.get_partial_shape().rank().get_length();
         if (rank == 4) {
-            transpose<0, 2, 3, 1>(node);
+            node = make_transpose(node, {0, 2, 3, 1});
         } else if (rank == 5) {
-            transpose_3d<0, 2, 3, 4, 1>(node);
+            node = make_transpose(node, {0, 2, 3, 4, 1});
         }
     }
+}
+
+std::shared_ptr<ov::opset8::Transpose> make_transpose(const ov::Output<ov::Node>& arg,
+                                                      const ov::AxisVector& input_order) {
+    auto order = std::make_shared<ov::opset8::Constant>(element::i64, Shape{input_order.size()}, input_order);
+    auto transpose = std::make_shared<ov::opset8::Transpose>(arg, order);
+    return transpose;
 }
 
 }  // namespace tensorflow

--- a/src/frontends/tensorflow/src/openvino_conversions.hpp
+++ b/src/frontends/tensorflow/src/openvino_conversions.hpp
@@ -16,36 +16,8 @@ namespace tensorflow {
 
 using ::tensorflow::DataType;
 
-template <size_t a, size_t b, size_t c, size_t d>
-void transpose(ov::Output<ov::Node>& node) {
-    static_assert(a < 4 && b < 4 && c < 4 && d < 4, "Number of dimensions cannot exceed 4");
-    static_assert(a != b && a != c && a != d && b != c && b != d && c != d, "Dimensions indices cannot be equal");
-    ov::Shape transpose_order{a, b, c, d};
-    auto input_order =
-        std::make_shared<ov::opset8::Constant>(ov::element::u64, ov::Shape{transpose_order.size()}, transpose_order);
-    node = std::make_shared<ov::opset8::Transpose>(node, input_order);
-}
-
-template <size_t a, size_t b, size_t c, size_t d>
-void transpose(std::shared_ptr<ov::Node>& node) {
-    transpose<a, b, c, d>(node->get_default_output());
-}
-
-template <size_t a, size_t b, size_t c, size_t d, size_t e>
-void transpose_3d(ov::Output<ov::Node>& node) {
-    static_assert(a < 5 && b < 5 && c < 5 && d < 5 && e < 5, "Number of dimensions cannot exceed 5");
-    static_assert(a != b && a != c && a != d && a != e && b != c && b != d && b != e && c != d && c != e && d != e,
-                  "Dimensions indices cannot be equal");
-    ov::Shape transpose_order{a, b, c, d, e};
-    auto input_order =
-        std::make_shared<ov::opset8::Constant>(ov::element::u64, ov::Shape{transpose_order.size()}, transpose_order);
-    node = std::make_shared<ov::opset8::Transpose>(node, input_order);
-}
-
-template <size_t a, size_t b, size_t c, size_t d, size_t e>
-void transpose_3d(std::shared_ptr<ov::Node>& node) {
-    transpose_3d<a, b, c, d, e>(node->get_default_output());
-}
+std::shared_ptr<ov::opset8::Transpose> make_transpose(const ov::Output<ov::Node>& arg,
+                                                      const ov::AxisVector& input_order);
 
 namespace detail {
 template <typename T>
@@ -71,9 +43,9 @@ void convert_nchw_to_hw(const std::vector<T>& src, std::vector<size_t>& dst) {
 }
 }  // namespace detail
 
-void convert_nhwc_to_nchw(const std::string& op_name, bool need_convert, ov::Output<ov::Node>& ng_input);
+void convert_nhwc_to_nchw(bool need_convert, ov::Output<ov::Node>& node);
 
-void convert_nchw_to_nhwc(const std::string& op_name, bool need_convert, ov::Output<ov::Node>& ng_node);
+void convert_nchw_to_nhwc(bool need_convert, ov::Output<ov::Node>& node);
 
 template <typename T>
 void convert_nhwc_to_hw(bool is_nhwc, const std::vector<T>& src, std::vector<size_t>& dst) {

--- a/src/frontends/tensorflow/src/pass/transpose_sinking.cpp
+++ b/src/frontends/tensorflow/src/pass/transpose_sinking.cpp
@@ -8,10 +8,12 @@
 #include "openvino/opsets/opset8.hpp"
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/util/common_util.hpp"
+#include "openvino_conversions.hpp"
 #include "utils.hpp"
 
 using namespace std;
 using namespace ov;
+using namespace ov::frontend::tensorflow;
 using namespace opset8;
 
 using TransposeMap = unordered_map<string, shared_ptr<Transpose>>;
@@ -56,15 +58,8 @@ static string describe(shared_ptr<Node> node) {
     return ss.str();
 }
 
-static shared_ptr<Transpose> make_transpose(const Output<Node>& arg, const AxisVector& input_order) {
-    auto order = std::make_shared<Constant>(element::u64, Shape{input_order.size()}, input_order);
-    auto transpose = make_shared<Transpose>(arg, order);
-    OPENVINO_DEBUG << "Make Transpose " << describe<Transpose>(transpose);
-    return transpose;
-}
-
 static shared_ptr<Reshape> make_reshape(const Output<Node>& arg, const AxisVector& input_order) {
-    auto order = std::make_shared<Constant>(element::u64, Shape{input_order.size()}, input_order);
+    auto order = std::make_shared<Constant>(element::i64, Shape{input_order.size()}, input_order);
     auto transpose = make_shared<Reshape>(arg, order, false);
     OPENVINO_DEBUG << "Make Reshape " << describe<Reshape>(transpose);
     return transpose;
@@ -132,7 +127,7 @@ static void mark_transpose_for_deletion(const shared_ptr<Node>& transpose,
 
 static shared_ptr<Transpose> create_default_transpose(const Output<Node>& n) {
     auto default_order = get_default_order(n.get_shape().size());
-    auto order = std::make_shared<Constant>(element::u64, Shape{default_order.size()}, default_order);
+    auto order = std::make_shared<Constant>(element::i64, Shape{default_order.size()}, default_order);
     return make_shared<Transpose>(n, order);
 }
 
@@ -160,7 +155,6 @@ static void convert_binary_to_default_order(const shared_ptr<Node>& binary,
         left_shape.insert(left_shape.begin(), perm_to_def.size() - left_shape.size(), 1);
 
         auto new_shape = apply_permutation(left_shape, perm_to_def);
-
         new_node = make_reshape(left, new_shape);
     } else if (left_shape.size() == perm_to_def.size()) {
         new_node = make_transpose(left, perm_to_def);

--- a/src/frontends/tensorflow/src/utils.cpp
+++ b/src/frontends/tensorflow/src/utils.cpp
@@ -4,6 +4,10 @@
 
 #include "utils.hpp"
 
+#include "openvino/opsets/opset8.hpp"
+
+using namespace ov::opset8;
+
 void ov::frontend::tensorflow::tf_shape_to_ov_shape(const ::tensorflow::TensorShapeProto& tf_shape,
                                                     ov::PartialShape* ng_shape) {
     std::vector<ov::Dimension> dims;
@@ -26,4 +30,157 @@ void ov::frontend::tensorflow::set_node_name(const std::string& node_name, const
 
 void ov::frontend::tensorflow::set_out_name(const std::string& out_name, const ov::Output<ov::Node>& output) {
     output.get_tensor().add_names({out_name});
+}
+
+ov::op::PadType ov::frontend::tensorflow::convert_tf_padding(const ov::frontend::tensorflow::NodeContext& node,
+                                                             const std::string& tf_padding) {
+    auto op_type = node.get_op_type();
+
+    TENSORFLOW_OP_VALIDATION(node,
+                             op_type == "Conv2D" || op_type == "Conv2DBackpropInput" || op_type == "Conv3D" ||
+                                 op_type == "Conv3DBackpropInputV2" || op_type == "MaxPool" || op_type == "MaxPoolV2" ||
+                                 op_type == "MaxPool3D",
+                             "The convert_conv_tf_padding routine supports only convolutional operations.");
+    TENSORFLOW_OP_VALIDATION(
+        node,
+        tf_padding == "VALID" || tf_padding == "SAME" || tf_padding == "EXPLICIT",
+        "The deconvolutional operation must have one of the padding type: VALID, SAME, and EXPLICIT.");
+
+    if (tf_padding == "VALID") {
+        return ov::op::PadType::VALID;
+    }
+    if (op_type == "Conv2DBackpropInput" || op_type == "Conv3DBackpropInputV2") {
+        if (tf_padding == "SAME") {
+            // According to the formulas for calculating auto_pad values of the
+            // ConvBackpropData layer in the Operation specification,
+            // the SAME_LOWER value matches to the SAME value in TensorFlow
+            return ov::op::PadType::SAME_LOWER;
+        }
+    } else if (op_type == "Conv2D" || op_type == "Conv3D" || op_type == "MaxPool" || op_type == "MaxPoolV2" ||
+               op_type == "MaxPool3D") {
+        if (tf_padding == "SAME") {
+            // According to the formulas for calculating auto_pad values of the
+            // Conv layer in the Operation specification,
+            // the SAME_UPPER value matches to the SAME value in TensorFlow
+            return ov::op::PadType::SAME_UPPER;
+        }
+    }
+
+    return ov::op::PadType::EXPLICIT;
+}
+
+void ov::frontend::tensorflow::fill_explicit_pads_vectors(const ov::frontend::tensorflow::NodeContext& node,
+                                                          bool is_nhwc,
+                                                          size_t spatial_dims_num,
+                                                          const std::vector<int64_t>& tf_explicit_paddings,
+                                                          ov::CoordinateDiff& pads_begin,
+                                                          ov::CoordinateDiff& pads_end) {
+    auto fullfill_pads = [&](ov::CoordinateDiff& pads, const std::vector<int64_t>& indexes) {
+        pads.resize(indexes.size());
+        for (int i = 0; i < indexes.size(); ++i) {
+            pads[i] = tf_explicit_paddings[indexes[i]];
+        }
+    };
+
+    if (spatial_dims_num == 2) {
+        TENSORFLOW_OP_VALIDATION(node,
+                                 tf_explicit_paddings.size() == 8,
+                                 "Conv2D expects 8 padding values for EXPLICIT padding mode.");
+        // prepare pads_begin and pads_end attributes for EXPLICIT padding mode
+        if (is_nhwc) {
+            // For NHWC layout, explicit paddings has the following form:
+            // [0, 0, pad_h1, pad_h2, pad_w1, pad_w2, 0, 0]
+            fullfill_pads(pads_begin, {2, 4});
+            fullfill_pads(pads_end, {3, 5});
+        } else {
+            // For NCHW layout, explicit paddings has the following form:
+            // [0, 0, 0, 0, pad_h1, pad_h2, pad_w1, pad_w2]
+            fullfill_pads(pads_begin, {4, 6});
+            fullfill_pads(pads_end, {5, 7});
+        }
+    } else {
+        TENSORFLOW_OP_VALIDATION(node,
+                                 tf_explicit_paddings.size() == 10,
+                                 "Conv3D expects 10 padding values for EXPLICIT padding mode.");
+        // prepare pads_begin and pads_end attributes for EXPLICIT padding mode
+        if (is_nhwc) {
+            // For NDHWC layout, explicit paddings has the following form:
+            // [0, 0, pad_d1, pad_d2, pad_h1, pad_h2, pad_w1, pad_w2, 0, 0]
+            fullfill_pads(pads_begin, {2, 4, 6});
+            fullfill_pads(pads_end, {3, 5, 7});
+        } else {
+            // For NCDHW layout, explicit paddings has the following form:
+            // [0, 0, 0, 0, pad_d1, pad_d2, pad_h1, pad_h2, pad_w1, pad_w2]
+            fullfill_pads(pads_begin, {4, 6, 8});
+            fullfill_pads(pads_end, {5, 7, 9});
+        }
+    }
+}
+
+ov::OutputVector ov::frontend::tensorflow::translate_convolution_op(const ov::frontend::tensorflow::NodeContext& node,
+                                                                    size_t spatial_dims_num) {
+    TENSORFLOW_OP_VALIDATION(node,
+                             spatial_dims_num == 2 || spatial_dims_num == 3,
+                             "Conv2D or Conv3D are supported only.");
+    TENSORFLOW_OP_VALIDATION(node, node.get_input_size() >= 2, "Convolution must have at least two inputs.");
+    auto input = node.get_input(0);
+    auto filter = node.get_input(1);
+
+    // retrieve attributes for Conv2D
+    auto tf_strides = node.get_attribute<std::vector<int64_t>>("strides");
+    auto tf_padding_type = node.get_attribute<std::string>("padding");
+    ov::op::PadType auto_pad = convert_tf_padding(node, tf_padding_type);
+
+    // retrieve optional attributes
+    auto tf_data_format = node.get_attribute<std::string>("data_format", spatial_dims_num == 2 ? "NHWC" : "NDHWC");
+    auto tf_explicit_paddings = std::vector<int64_t>{};
+    if (auto_pad == ov::op::PadType::EXPLICIT) {
+        tf_explicit_paddings = node.get_attribute<std::vector<int64_t>>("explicit_paddings", {});
+    }
+    std::vector<int64_t> dilation_2d = {1, 1, 1, 1};
+    std::vector<int64_t> dilation_3d = {1, 1, 1, 1, 1};
+    auto tf_dilations =
+        node.get_attribute<std::vector<int64_t>>("dilations", spatial_dims_num == 2 ? dilation_2d : dilation_3d);
+
+    bool is_nhwc = true;
+    if (spatial_dims_num == 2) {
+        TENSORFLOW_OP_VALIDATION(node,
+                                 tf_data_format == "NHWC" || tf_data_format == "NCHW",
+                                 "Conv2D data format is neither NHWC nor NCHW");
+        is_nhwc = (tf_data_format == "NHWC");
+    } else {
+        TENSORFLOW_OP_VALIDATION(node,
+                                 tf_data_format == "NDHWC" || tf_data_format == "NCDHW",
+                                 "Conv3D data format is neither NDHWC nor NCDHW");
+        is_nhwc = (tf_data_format == "NDHWC");
+    }
+
+    // prepare attributes for OpenVINO Convolution operation
+    ov::Strides strides(spatial_dims_num);
+    ov::Strides dilations(spatial_dims_num);
+    ov::frontend::tensorflow::convert_nhwc_to_hw(is_nhwc, tf_strides, strides);
+    ov::frontend::tensorflow::convert_nhwc_to_hw(is_nhwc, tf_dilations, dilations);
+
+    ov::CoordinateDiff pads_begin;
+    ov::CoordinateDiff pads_end;
+    if (auto_pad == ov::op::PadType::EXPLICIT) {
+        fill_explicit_pads_vectors(node, is_nhwc, spatial_dims_num, tf_explicit_paddings, pads_begin, pads_end);
+    }
+
+    // prepare inputs to Convolution
+    ov::frontend::tensorflow::convert_nhwc_to_nchw(is_nhwc, input);
+    ov::AxisVector permutation_2d = {3, 2, 0, 1};
+    ov::AxisVector permutation_3d = {4, 3, 0, 1, 2};
+    filter = ov::frontend::tensorflow::make_transpose(filter, spatial_dims_num == 2 ? permutation_2d : permutation_3d);
+
+    ov::Output<ov::Node> conv =
+        std::make_shared<Convolution>(input, filter, strides, pads_begin, pads_end, dilations, auto_pad);
+
+    ov::frontend::tensorflow::convert_nchw_to_nhwc(is_nhwc, conv);
+    ov::frontend::tensorflow::set_node_name(node.get_name(), conv.get_node_shared_ptr());
+    return {conv};
+}
+
+bool ov::frontend::tensorflow::is_conditional_edge(const std::string& input_tensor_name) {
+    return input_tensor_name.length() > 0 && input_tensor_name[0] == '^';
 }

--- a/src/frontends/tensorflow/src/utils.hpp
+++ b/src/frontends/tensorflow/src/utils.hpp
@@ -41,6 +41,8 @@ void set_out_name(const std::string& out_name, const Output<Node>& output);
 
 void set_node_name(const std::string& node_name, const std::shared_ptr<Node>& node);
 
+bool is_conditional_edge(const std::string& input_tensor_name);
+
 static bool vec_str_cmp(const std::vector<std::string>& a, const std::vector<std::string>& b) {
     return a == b;
 }
@@ -196,6 +198,17 @@ void make_const_op(const NodeContext& node, element::Type et, ov::Output<ov::Nod
     values_from_const_node<T, VecT>(node, &ng_shape, &const_values);
     ng_node = std::make_shared<ov::opset8::Constant>(et, ng_shape, const_values);
 };
+
+ov::op::PadType convert_tf_padding(const NodeContext& node, const std::string& tf_padding);
+
+ov::OutputVector translate_convolution_op(const NodeContext& node, size_t spatial_dims_num);
+
+void fill_explicit_pads_vectors(const NodeContext& node,
+                                bool is_nhwc,
+                                size_t spatial_dims_num,
+                                const std::vector<int64_t>& tf_explicit_paddings,
+                                ov::CoordinateDiff& pads_begin,
+                                ov::CoordinateDiff& pads_end);
 }  // namespace tensorflow
 }  // namespace frontend
 }  // namespace ov

--- a/tests/layer_tests/tensorflow_tests/test_tf_StridedSlice.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_StridedSlice.py
@@ -96,6 +96,9 @@ class TestStridedSlice(CommonTFLayerTest):
         dict(input_shape=[1, 5, 5, 3], begin=[0, 0, 0, 0], end=[1, 5, 5, 3], strides=[1, 1, 1, 1],
              begin_mask=0,
              end_mask=0, ellipsis_mask=0, new_axis_mask=2, shrink_axis_mask=0),
+        dict(input_shape=[16, 4, 64], begin=[0, 0, 0, 0], end=[0, 0, 0, 0], strides=[1, 1, 1, 1],
+             begin_mask=19,
+             end_mask=19, ellipsis_mask=0, new_axis_mask=12, shrink_axis_mask=0),
     ]
 
     @pytest.mark.parametrize('params', test_unsqueeze_data)


### PR DESCRIPTION
…575)

* [TF FE] Handle optional attributes for Convolutional operations (#12230)

* [TF FE] Handle optional attributes for Convolutional operations

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Apply code-style rules

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* [TF FE] Implement LinSpace and BatchMatMul translators (#12271)

* [TF FE] Implement LinSpace and BatchMatMul translators

It helps to convert STN model (from e2e testing) using TensorFlow frontend

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Fix BatchMatMul translator

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Fix LinSpace operation translator

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Apply code-review feedback

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Apply code-style rules

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Apply code style rules

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* [TF FE] Fix conversion of NetVLAD model (#12328)

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* [TF FE] Implement translators for TensorFlow ConvBackpropInput operations (#12356)

* [TF FE] Implement ConvBackPropInput translators

Now the translators supports dynamic input_sizes attribute and different padding modes
including EXPLICIT mode

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Fix clang-style issue

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Fix code-style issue

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Fix code-style issue

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Apply code-review feedback and fix build issues

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Apply code-review feedback: check for input size

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Fix retrieving explicit_padding attribute

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Fix code style

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* [TF FE] Fix StridedSlice translator for new_axis vector size longer input rank (#12442)

* [TF FE] Fix StridedSlice translator for new_axis vector longer input rank

Currently, new_axis vector is cut by input rank that is correct and leads to the loss of new axes.

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Use int64 type in mask_to_vector function

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* [TF FE] Refactor translators for Conv2d and Conv3d (#12444)

It allows to convert CNN-Transformer model. Padding was previously incorrect.

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* [TF FE] Implement conversion for Attention OCR model (#12428)

* [TF FE] Implement conversion for Attention OCR model

The following scope of work is done to make Attention OCR convertable:
1. Refactored translators for BiasAdd, Slice, and ArgMax operations. Add translation for StopGradient operation.
2. The previous traversing algorithm to compute topological sorted nodes list was incorrect. Now it is implemented based on topologically_sorted function from core/graph_util.hpp.
3. The unsupported data types are now preliminary converted to undefined type for the purpose of to have them cut off.

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* [TF FE] Refactor MaxPool operation translator for xj_feature model (#12485)

* [TF FE] Refactor MaxPool operation translator for xj_feature model

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

* Correct MaxPoolV2 since it has three inputs

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
