### PR TITLE
Add missing patchelf dependency on REHL8 for OV python wheel build

### DIFF
--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -110,6 +110,7 @@ elif [ -f /etc/redhat-release ]; then
             gcc \
             gcc-c++ \
             make \
+            patchelf \
             pkg-config \
             gflags-devel.i686 \
             zlib-devel.i686 \


### PR DESCRIPTION
**Root cause:** 
Missing patchelf dependency for REHL8 in install_build_dependencies.sh, will cause OpenVINO runtime wheel not build on RHEL8 even when -DENABLE_WHEEL=ON.

**Solutions:** 
Add patchelf dependency for REHL8 in install_build_dependencies.sh

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
