### PR TITLE
[CPU] default enable avx512 f32 brgconv

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -279,11 +279,6 @@ Convolution::Convolution(const std::shared_ptr<ngraph::Node>& op, const dnnl::en
         paddingR = groupConvolutionOp->get_pads_end();
         autoPadding = one_of(groupConvolutionOp->get_auto_pad(), ov::op::PadType::SAME_UPPER, ov::op::PadType::SAME_LOWER);
     }
-
-    // Due to performance issue, brgconv will only be enabled by default:
-    // 1, support avx512
-    // 2, static shape(dynamic shape may change weights layout if the input shape changes and cause performance issue: 86948)
-    shouldTryBrgconv = dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core) && !isDynamicNode();
 }
 
 bool Convolution::canBeExecutedInInt8() const {
@@ -375,22 +370,7 @@ void Convolution::getSupportedDescriptors() {
 
     withBiases = getOriginalInputsNumber() == 3;
 
-    // should remove after binary postops performance issue resolved
-    // heuristics: if it's int8 model and it has binary post ops we will not use brgconv
-    auto tryDisableBrgInt8 = [&]() {
-        if (shouldTryBrgconv && canBeExecutedInInt8()) {
-            dnnl::primitive_attr attrs;
-            setPostOps(attrs, MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), false);
-            const auto& ops = attrs.get_post_ops();
-            for (int i = 0; i < ops.len(); i++) {
-                if (ops.kind(i) == dnnl::primitive::kind::binary) {
-                    shouldTryBrgconv = false;
-                    break;
-                }
-            }
-        }
-    };
-    tryDisableBrgInt8();
+    initTryBrgconvFlag();
 
     if (!implPriorities.empty()) {
         isPrimitivesPriorityDefined = true;
@@ -732,13 +712,12 @@ void Convolution::initSupportedPrimitiveDescriptors() {
     if (!supportedPrimitiveDescriptors.empty())
         return;
 
-    // attr[0] - depthwise, quantize
-    // attr[1] - binary
-    dnnl::primitive_attr attrs[2];
+    pInitAttrs[0] = std::make_shared<dnnl::primitive_attr>();
     auto attrsNum = shouldTryBrgconv ? 2 : 1;
-    setPostOps(attrs[0], MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), true);
-    if (shouldTryBrgconv) {
-        setPostOps(attrs[1], MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), false);
+    setPostOps(*pInitAttrs[0], MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), true);
+    if (shouldTryBrgconv && !pInitAttrs[1]) {
+        pInitAttrs[1] = std::make_shared<dnnl::primitive_attr>();
+        setPostOps(*pInitAttrs[1], MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), false);
     }
 
     bool containJitImpl = false;
@@ -747,7 +726,7 @@ void Convolution::initSupportedPrimitiveDescriptors() {
         if (containJitImpl && isPossibleToSkipInitConfig(desc))
             continue;
         for (int i = 0; i < attrsNum; i++) {
-            auto &attr = attrs[i];
+            auto &attr = *pInitAttrs[i];
             addZeroPoints(attr);
             auto itpd = desc.createPrimitiveDescriptorIterator(getEngine(), attr);
             while (static_cast<bool>(itpd)) {
@@ -959,14 +938,7 @@ void Convolution::initDescriptor(const NodeConfig& config) {
     if (isStridedBlobsSupported) {
         createDescriptor({config.inConfs[0].getMemDesc()}, {config.outConfs[0].getMemDesc()});
     }
-    // attr[0] - depthwise, quantize
-    // attr[1] - binary
-    dnnl::primitive_attr attrs[2];
     auto attrsNum = shouldTryBrgconv ? 2 : 1;
-    setPostOps(attrs[0], MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), true);
-    if (shouldTryBrgconv) {
-        setPostOps(attrs[1], MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), false);
-    }
 
     auto rightConfig = selectedPD->getConfig();
     size_t selected_count = 0;
@@ -978,7 +950,7 @@ void Convolution::initDescriptor(const NodeConfig& config) {
         if (containJitImpl && isPossibleToSkipInitConfig(desc))
             continue;
         for (int n = 0; n < attrsNum; n++) {
-            auto &attr = attrs[n];
+            auto &attr = *pInitAttrs[n];
             addZeroPoints(attr);
             auto itpd = desc.createPrimitiveDescriptorIterator(getEngine(), attr);
             while (static_cast<bool>(itpd)) {
@@ -1568,6 +1540,35 @@ void Convolution::appendZeroPointsArgs() {
     }
     if (outputCompensationMemPtr != nullptr) {
         primArgs[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST] = outputCompensationMemPtr->GetPrimitive();
+    }
+}
+
+void Convolution::initTryBrgconvFlag() {
+    // Due to performance issue, brgconv will only be enabled by default:
+    // 1, static shape(dynamic shape may change weights layout if the input shape changes and cause performance issue: 86948)
+    // 2, support amx
+    // 3, int8 without binary postops when avx512
+    if (!isDynamicNode()) {
+        if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx)) {
+            shouldTryBrgconv = true;
+        } else if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
+            // should remove after binary postops performance issue resolved
+            // heuristics: if it's int8 model and it has binary post ops we will not use brgconv
+            if (canBeExecutedInInt8()) {
+                shouldTryBrgconv = true;
+                dnnl::primitive_attr attrs;
+                setPostOps(attrs, MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), false);
+                const auto& ops = attrs.get_post_ops();
+                for (int i = 0; i < ops.len(); i++) {
+                    if (ops.kind(i) == dnnl::primitive::kind::binary) {
+                        shouldTryBrgconv = false;
+                        break;
+                    }
+                }
+                if (shouldTryBrgconv)
+                    pInitAttrs[1] = std::make_shared<dnnl::primitive_attr>(std::move(attrs));
+            }
+        }
     }
 }
 

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -1547,15 +1547,15 @@ void Convolution::initTryBrgconvFlag() {
     // Due to performance issue, brgconv will only be enabled by default:
     // 1, static shape(dynamic shape may change weights layout if the input shape changes and cause performance issue: 86948)
     // 2, support amx
-    // 3, int8 without binary postops when avx512
+    // 3, support avx512 except int8 with binary postops
     if (!isDynamicNode()) {
         if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx)) {
             shouldTryBrgconv = true;
         } else if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
+            shouldTryBrgconv = true;
             // should remove after binary postops performance issue resolved
             // heuristics: if it's int8 model and it has binary post ops we will not use brgconv
             if (canBeExecutedInInt8()) {
-                shouldTryBrgconv = true;
                 dnnl::primitive_attr attrs;
                 setPostOps(attrs, MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), false);
                 const auto& ops = attrs.get_post_ops();

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -136,7 +136,7 @@ private:
     const size_t Y_AXIS = 1;
 
     bool isWino = false;
-    // if we have amx support and shape is static or user specified we will try brgconv
+    // if we have AVX512 support and shape is static or user specified we will try brgconv
     bool shouldTryBrgconv = false;
     AttrPtr pAttr;
     bool autoPadding = false;

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -102,6 +102,7 @@ private:
     MemoryPtr getOutputMemory() const;
 
     void appendZeroPointsArgs();
+    void initTryBrgconvFlag();
 
     bool withBiases;
     bool withSum;
@@ -136,8 +137,9 @@ private:
     const size_t Y_AXIS = 1;
 
     bool isWino = false;
-    // if we have AVX512 support and shape is static or user specified we will try brgconv
     bool shouldTryBrgconv = false;
+    // cache attr for later usage. [0] - depthwise, quantize, [1] - binary
+    AttrPtr pInitAttrs[2];
     AttrPtr pAttr;
     bool autoPadding = false;
     FusedSubgraphPtr subgraph;


### PR DESCRIPTION
### Details:
 - *default enable avx512 f32 brgconv due to it will get performance improvement on ICX*
 - *checkry-pick from #12406 #12619*

### Tickets:
 - *86301*
