### PR TITLE
[GPU] Shared memory optimization for network::execute_impl() call

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -225,6 +225,7 @@ private:
     bool _reset_arguments;
 
     std::unordered_map<primitive_id, std::shared_ptr<primitive_inst>> _primitives;
+    std::vector<shared_mem_type> _in_out_shared_mem_types;
     std::vector<std::shared_ptr<primitive_inst>> _inputs;
     std::vector<std::shared_ptr<primitive_inst>> _outputs;
     std::list<std::shared_ptr<primitive_inst>> _exec_order;


### PR DESCRIPTION
### Details:
 This change allows to apply surfaces_lock only in really "surface scenario" and reduces infer request time preparing in other cases

