### PR TITLE
Fix build with MSVC 141 (Visual Studio 2017)

### DIFF
--- a/samples/cpp/common/utils/include/samples/common.hpp
+++ b/samples/cpp/common/utils/include/samples/common.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cctype>
 #include <fstream>
 #include <functional>
 #include <iomanip>

--- a/src/common/util/include/openvino/util/common_util.hpp
+++ b/src/common/util/include/openvino/util/common_util.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cctype>
 #include <cstring>
 #include <sstream>
 #include <string>

--- a/src/frontends/ir/src/ir_deserializer.hpp
+++ b/src/frontends/ir/src/ir_deserializer.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cctype>
 #include <istream>
 #include <memory>
 #include <pugixml.hpp>

--- a/src/frontends/ir/src/rt_info_deserializer.hpp
+++ b/src/frontends/ir/src/rt_info_deserializer.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cctype>
 #include <istream>
 #include <memory>
 


### PR DESCRIPTION
This PR fixes broken MSVC 141 build (yeah, I know it's pretty outdated, but anyway) by adding missing STL header includes.