### PR TITLE
[GPU] Fix Interpolate missed axes values alignment with scales

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
@@ -43,7 +43,7 @@ static void CreateInterpolateOp(Program& p, const std::shared_ptr<ngraph::op::v4
         ov::normalize_axes(op.get(), inputRank, axes);
     } else {
         for (size_t i = 0; i < inputRank; ++i) {
-            ov::normalize_axis(op.get(), i, inputRank);
+            axes.push_back(ov::normalize_axis(op.get(), i, inputRank));
         }
     }
 

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/interpolate.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/interpolate.cpp
@@ -78,6 +78,8 @@ const std::vector<std::vector<int64_t>> defaultAxes = {
     {0, 1, 2, 3}
 };
 
+const std::vector<std::vector<int64_t>> emptyAxes = {{}};
+
 const std::vector<std::vector<float>> defaultScales = {
     {1.f, 1.f, 2.f, 2.f}
 };
@@ -96,6 +98,18 @@ const auto interpolateCasesWithoutNearest = ::testing::Combine(
         ::testing::ValuesIn(defaultAxes),
         ::testing::ValuesIn(defaultScales));
 
+const auto interpolateCasesWithoutNearestEmptyAxes = ::testing::Combine(
+        ::testing::ValuesIn(modesWithoutNearest),
+        ::testing::ValuesIn(shapeCalculationMode),
+        ::testing::ValuesIn(coordinateTransformModes),
+        ::testing::ValuesIn(defaultNearestMode),
+        ::testing::ValuesIn(antialias),
+        ::testing::ValuesIn(pads),
+        ::testing::ValuesIn(pads),
+        ::testing::ValuesIn(cubeCoefs),
+        ::testing::ValuesIn(emptyAxes),
+        ::testing::ValuesIn(defaultScales));
+
 const auto interpolateCasesNearesMode = ::testing::Combine(
         ::testing::ValuesIn(nearestMode),
         ::testing::ValuesIn(shapeCalculationMode),
@@ -110,6 +124,19 @@ const auto interpolateCasesNearesMode = ::testing::Combine(
 
 INSTANTIATE_TEST_SUITE_P(smoke_Interpolate_Basic, InterpolateLayerTest, ::testing::Combine(
         interpolateCasesWithoutNearest,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::ValuesIn(inShapes),
+        ::testing::ValuesIn(targetShapes),
+        ::testing::Values(CommonTestUtils::DEVICE_GPU),
+        ::testing::Values(additional_config)),
+    InterpolateLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Interpolate_BasicEmptyAxes, InterpolateLayerTest, ::testing::Combine(
+        interpolateCasesWithoutNearestEmptyAxes,
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
         ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),

--- a/src/tests/functional/shared_test_classes/src/single_layer/interpolate.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/interpolate.cpp
@@ -81,16 +81,25 @@ void InterpolateLayerTest::SetUp() {
     auto scales_const = ngraph::opset3::Constant(ngraph::element::Type_t::f32, {scales.size()}, scales);
     auto scalesInput = std::make_shared<ngraph::opset3::Constant>(scales_const);
 
-    auto axesConst = ngraph::opset3::Constant(ngraph::element::Type_t::i64, {axes.size()}, axes);
-    auto axesInput = std::make_shared<ngraph::opset3::Constant>(axesConst);
-
     ngraph::op::v4::Interpolate::InterpolateAttrs interpolateAttributes{mode, shapeCalcMode, padBegin,
         padEnd, coordinateTransformMode, nearestMode, antialias, cubeCoef};
-    auto interpolate = std::make_shared<ngraph::op::v4::Interpolate>(params[0],
-                                                                     sizesInput,
-                                                                     scalesInput,
-                                                                     axesInput,
-                                                                     interpolateAttributes);
+
+    std::shared_ptr<ngraph::op::v4::Interpolate> interpolate;
+    if (axes.empty()) {
+        interpolate = std::make_shared<ngraph::op::v4::Interpolate>(params[0],
+                                                                    sizesInput,
+                                                                    scalesInput,
+                                                                    interpolateAttributes);
+    } else {
+        auto axesConst = ngraph::opset3::Constant(ngraph::element::Type_t::i64, {axes.size()}, axes);
+        auto axesInput = std::make_shared<ngraph::opset3::Constant>(axesConst);
+
+        interpolate = std::make_shared<ngraph::op::v4::Interpolate>(params[0],
+                                                                    sizesInput,
+                                                                    scalesInput,
+                                                                    axesInput,
+                                                                    interpolateAttributes);
+    }
     const ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(interpolate)};
     function = std::make_shared<ngraph::Function>(results, params, "interpolate");
 }


### PR DESCRIPTION
### Details:
This PR fixes missed alignment between axes and scales in Interpolate operation in case of empty Axes input

### Tickets:
 - 89673
