### PR TITLE
Use OSX 11 pool for MacOSX

### DIFF
--- a/.ci/azure/mac.yml
+++ b/.ci/azure/mac.yml
@@ -27,7 +27,7 @@ jobs:
   timeoutInMinutes: 360
 
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-11'
 
   variables:
     system.debug: true


### PR DESCRIPTION
### Details:
 - 10.x is deprecated

### Tickets:
 - CVS-89140
