### PR TITLE
[GPU] fix Transpose issue for ConvertColor with FakeQuantize.

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/ops/transpose.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/transpose.cpp
@@ -45,8 +45,11 @@ static void CreateTransposeOp(Program& p, const std::shared_ptr<ngraph::op::v1::
     // Handle Transpose operation related to ConvertColor operation:
     // In case of ConvertColor operation we have NHWC (byxf) input format which should be converted to
     // NCHW (bfyx) by this Permute, so we replace Permute with Reorder (to bfyx) primitve
-    auto input = op->get_input_node_shared_ptr(0);
-    if (is_convert_color_type(input) && order == std::vector<uint16_t>{0, 3, 1, 2}) {
+    auto input = op->get_input_size() > 0 ? op->get_input_node_shared_ptr(0) : nullptr;
+    // Handle the case ConvertColor -> FakeQuantize -> Permute
+    auto input1 = input ? (input->get_input_size() > 0 ? input->get_input_node_shared_ptr(0) : nullptr) : nullptr;
+    if (((input && is_convert_color_type(input)) || (input1 && is_convert_color_type(input1)))
+            && order == std::vector<uint16_t>{0, 3, 1, 2}) {
         auto precision = input->get_element_type();
         p.AddPrimitive(cldnn::reorder(layerName,
                                       inputPrimitives[0],


### PR DESCRIPTION
### Details:
 - *Failed to compile yolo-v4-tf FP16-INT8 model on dGPU, error:*
   ```
   cldnn program build failed! could not create a descriptor for a dilated convolution forward propagation primitive
   ```
 - *There's FakeQuantize between Transpose and ConvertColor in FP16-INT8 model, it needs to trace back one more layer to find the ConvertColor*

### Tickets:
 - *89726*
