### PR TITLE
Install only required TBB libraries

### DIFF
--- a/src/cmake/install_tbb.cmake
+++ b/src/cmake/install_tbb.cmake
@@ -61,6 +61,10 @@ if(THREADING MATCHES "^(TBB|TBB_AUTO)$" AND
     endif()
 
     if(ENABLE_SYSTEM_TBB)
+        # TODO: what's about tbbbind for cases U22 with >= TBB 20221
+        # it seems that oneTBB from U22 distro does not contains tbbbind library
+        # message(FATAL_ERROR "TBB_IMPORTED_TARGETS - ${TBB_IMPORTED_TARGETS}")
+
         # for system libraries we still need to install TBB libraries
         # so, need to take locations of actual libraries and install them
         foreach(tbb_lib IN LISTS TBB_IMPORTED_TARGETS)
@@ -68,14 +72,13 @@ if(THREADING MATCHES "^(TBB|TBB_AUTO)$" AND
             # depending on the TBB, tbb_loc can be in form:
             # - libtbb.so.x.y
             # - libtbb.so.x
-            # - libtbb.so
             # We need to install such files
             get_filename_component(name_we "${tbb_loc}" NAME_WE)
             get_filename_component(dir "${tbb_loc}" DIRECTORY)
             # grab all tbb files matching pattern
             file(GLOB tbb_files "${dir}/${name_we}.*")
             foreach(tbb_file IN LISTS tbb_files)
-                if(tbb_file MATCHES "^.*\.${CMAKE_SHARED_LIBRARY_SUFFIX}(\.[0-9]+)*$")
+                if(tbb_file MATCHES "^.*\.${CMAKE_SHARED_LIBRARY_SUFFIX}(\.[0-9]+)+$")
                     # since the setup.py for pip installs tbb component
                     # explicitly, it's OK to put EXCLUDE_FROM_ALL to such component
                     # to ignore from IRC / apt / yum distribution;
@@ -117,9 +120,19 @@ if(THREADING MATCHES "^(TBB|TBB_AUTO)$" AND
             set(IE_TBB_DIR_INSTALL "${TBB_DIR}")
         endif()
 
-        install(DIRECTORY "${TBBROOT}/"
-                DESTINATION "${IE_TBBROOT_INSTALL}"
-                COMPONENT tbb)
+        # try to select proper library directory
+        get_target_property(_tbb_lib_location TBB::tbb IMPORTED_LOCATION_RELEASE)
+        get_filename_component(_tbb_libs_dir "${_tbb_lib_location}" DIRECTORY)
+        file(RELATIVE_PATH tbb_libs_dir "${TBBROOT}" "${_tbb_libs_dir}")
+
+        # install only meaningful directories
+        foreach(dir include ${tbb_libs_dir} cmake lib/cmake)
+            if(EXISTS "${TBBROOT}/${dir}")
+                install(DIRECTORY "${TBBROOT}/${dir}/"
+                        DESTINATION "${IE_TBBROOT_INSTALL}/${dir}"
+                        COMPONENT tbb)
+            endif()
+        endforeach()
     elseif(tbb_downloaded)
         set(IE_TBB_DIR_INSTALL "runtime/3rdparty/tbb/")
 


### PR DESCRIPTION
### Details:
 - In old TBB packages there are a lot of libraries for several archs, compilers:
 ```c++
ilyal@wanglei-nuc:~/Documents/Programming/build/openvino-release/tbb2017_20170807oss$ tree -L 2 lib/
lib/
├── ia32
│   ├── gcc4.1
│   ├── gcc4.4
│   └── gcc4.7
├── intel64
│   ├── gcc4.1
│   ├── gcc4.4
│   └── gcc4.7
└── mic
    ├── libtbb_debug.so
    ├── libtbb_debug.so.2
    ├── libtbbmalloc_debug.so
    ├── libtbbmalloc_debug.so.2
    ├── libtbbmalloc_proxy_debug.so
    ├── libtbbmalloc_proxy_debug.so.2
    ├── libtbbmalloc_proxy.so
    ├── libtbbmalloc_proxy.so.2
    ├── libtbbmalloc.so
    ├── libtbbmalloc.so.2
    ├── libtbb_preview_debug.so
    ├── libtbb_preview_debug.so.2
    ├── libtbb_preview.so
    ├── libtbb_preview.so.2
    ├── libtbb.so
    └── libtbb.so.2
```
So, let's install only required ones.