### PR TITLE
[MULTI]Fix the issue that QueryNetworkMultiThrows failed to pass

### DIFF
--- a/src/plugins/auto/plugin.cpp
+++ b/src/plugins/auto/plugin.cpp
@@ -471,7 +471,7 @@ IExecutableNetworkInternal::Ptr MultiDeviceInferencePlugin::LoadNetworkImpl(cons
         _LogTag = "AUTO";
         LOG_INFO_TAG("CUMULATIVE Call MULTI PERFORMACE_HINT set to THROUGHPUT");
     }
-    if (priorities == fullConfig.end() || priorities->second.empty()) {
+    if (priorities->second.empty()) {
         IE_THROW() << "KEY_MULTI_DEVICE_PRIORITIES key is not set for " << GetName() << " device";
     } else {  // for use case -d MULTI:xPU or -d AUTO:xPU
         metaDevices = ParseMetaDevices(priorities->second, fullConfig);
@@ -574,7 +574,7 @@ QueryNetworkResult MultiDeviceInferencePlugin::QueryNetwork(const CNNNetwork&   
     queryconfig.UpdateFromMap(config, GetName());
     auto fullConfig = queryconfig._keyConfigMap;
     auto priorities = fullConfig.find(MultiDeviceConfigParams::KEY_MULTI_DEVICE_PRIORITIES);
-    if (priorities == fullConfig.end()) {
+    if (priorities->second.empty()) {
         IE_THROW() << "KEY_MULTI_DEVICE_PRIORITIES key is not set for " << GetName() <<  " device";
     }
     auto metaDevices = ParseMetaDevices(priorities->second, fullConfig);
@@ -749,7 +749,7 @@ std::string MultiDeviceInferencePlugin::GetDeviceList(const std::map<std::string
     std::string allDevices;
     auto deviceList = GetCore()->GetAvailableDevices();
     auto deviceListConfig = config.find(MultiDeviceConfigParams::KEY_MULTI_DEVICE_PRIORITIES);
-    if (deviceListConfig == config.end() || deviceListConfig->second.empty()) {
+    if (deviceListConfig->second.empty()) {
         for (auto&& device : deviceList) {
             allDevices += device;
             allDevices += ((device == deviceList[deviceList.size()-1]) ? "" : ",");

--- a/src/tests/functional/plugin/shared/include/behavior/ov_plugin/core_integration.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_plugin/core_integration.hpp
@@ -596,7 +596,15 @@ TEST_P(OVClassNetworkTestP, QueryNetworkHeteroActualNoThrow) {
 
 TEST_P(OVClassNetworkTestP, QueryNetworkMultiThrows) {
     ov::Core ie = createCoreWithTemplate();
-    ASSERT_THROW(ie.query_model(actualNetwork, CommonTestUtils::DEVICE_MULTI), ov::Exception);
+    try {
+        ie.query_model(actualNetwork, CommonTestUtils::DEVICE_MULTI);
+    } catch (ov::Exception& error) {
+        EXPECT_PRED_FORMAT2(testing::IsSubstring,
+                            std::string("KEY_MULTI_DEVICE_PRIORITIES key is not set for"),
+                            error.what());
+    } catch (...) {
+        FAIL() << "query_model failed for unexpected reson.";
+    }
 }
 
 TEST(OVClassBasicTest, smoke_GetMetricSupportedMetricsHeteroNoThrow) {
@@ -940,6 +948,19 @@ using OVClassNetworkTestP = OVClassBaseTestP;
 TEST_P(OVClassNetworkTestP, LoadNetworkActualNoThrow) {
     ov::Core ie = createCoreWithTemplate();
     OV_ASSERT_NO_THROW(ie.compile_model(actualNetwork, target_device));
+}
+
+TEST_P(OVClassNetworkTestP, LoadNetworkMultiWithoutSettingDevicePrioritiesThrows) {
+    ov::Core ie = createCoreWithTemplate();
+    try {
+        ie.compile_model(actualNetwork, CommonTestUtils::DEVICE_MULTI);
+    } catch (ov::Exception& error) {
+        EXPECT_PRED_FORMAT2(testing::IsSubstring,
+                            std::string("KEY_MULTI_DEVICE_PRIORITIES key is not set for"),
+                            error.what());
+    } catch (...) {
+        FAIL() << "compile_model failed for unexpected reson.";
+    }
 }
 
 TEST_P(OVClassNetworkTestP, LoadNetworkActualHeteroDeviceNoThrow) {

--- a/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/plugin/core_integration.hpp
@@ -533,7 +533,15 @@ TEST_P(IEClassNetworkTestP, QueryNetworkHeteroActualNoThrow) {
 
 TEST_P(IEClassNetworkTestP, QueryNetworkMultiThrows) {
     InferenceEngine::Core  ie = BehaviorTestsUtils::createIECoreWithTemplate();
-    ASSERT_THROW(ie.QueryNetwork(actualCnnNetwork, CommonTestUtils::DEVICE_MULTI), InferenceEngine::Exception);
+    try {
+        ie.QueryNetwork(actualCnnNetwork, CommonTestUtils::DEVICE_MULTI);
+    } catch (InferenceEngine::Exception& error) {
+        EXPECT_PRED_FORMAT2(testing::IsSubstring,
+                            std::string("KEY_MULTI_DEVICE_PRIORITIES key is not set for"),
+                            error.what());
+    } catch (...) {
+        FAIL() << "QueryNetwork failed for unexpected reson.";
+    }
 }
 
 TEST(IEClassBasicTest, smoke_GetMetricSupportedMetricsHeteroNoThrow) {
@@ -922,6 +930,20 @@ TEST_P(IEClassNetworkTestP, LoadNetworkActualNoThrow) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
     InferenceEngine::Core  ie = BehaviorTestsUtils::createIECoreWithTemplate();
     ASSERT_NO_THROW(ie.LoadNetwork(actualCnnNetwork,  target_device));
+}
+
+TEST_P(IEClassNetworkTestP, LoadNetworkMultiWithoutSettingDevicePrioritiesThrows) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    InferenceEngine::Core ie = BehaviorTestsUtils::createIECoreWithTemplate();
+    try {
+        ie.LoadNetwork(actualCnnNetwork, CommonTestUtils::DEVICE_MULTI);
+    } catch (InferenceEngine::Exception& error) {
+        EXPECT_PRED_FORMAT2(testing::IsSubstring,
+                            std::string("KEY_MULTI_DEVICE_PRIORITIES key is not set for"),
+                            error.what());
+    } catch (...) {
+        FAIL() << "LoadNetowrk failed for unexpected reson.";
+    }
 }
 
 TEST_P(IEClassNetworkTestP, LoadNetworkActualHeteroDeviceNoThrow) {


### PR DESCRIPTION
Update the logic to check if device priorities is set through the value of device priorities instead of no found in the config map.

Signed-off-by: Wang, Yang <yang4.wang@intel.com>

### Details:
 - Update logic that checking if the value of device priorities is empty

### Tickets:
 - 84420
 - 89781
