### PR TITLE
[CI] Bump GitHub workflows Ubuntu version

### DIFF
--- a/.github/workflows/py_checks.yml
+++ b/.github/workflows/py_checks.yml
@@ -12,7 +12,7 @@ on:
       - 'samples/python/**'
 jobs:
   linters:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Code checkout
         uses: actions/checkout@v2

--- a/.github/workflows/py_checks.yml
+++ b/.github/workflows/py_checks.yml
@@ -12,7 +12,7 @@ on:
       - 'samples/python/**'
 jobs:
   linters:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Code checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
### Details:
 - Due to [Ubuntu 18.04 deprecation on GitHub workflows](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/) it's being turned off every week as a warning. The OS needs to be upgraded to stop CI disruptions.

### Tickets:
 - ...
