### PR TITLE
Don't use system tbb for 2022.2

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -136,21 +136,7 @@ ie_dependent_option(ENABLE_TBB_RELEASE_ONLY "Only Release TBB libraries are link
 
 ie_dependent_option (ENABLE_SYSTEM_PUGIXML "use the system copy of pugixml" OFF "BUILD_SHARED_LIBS" OFF)
 
-get_linux_name(LINUX_OS_NAME)
-if(LINUX_OS_NAME MATCHES "^Ubuntu [0-9]+\.[0-9]+$")
-    # Debian packages are enabled on Ubuntu systems
-    # so, system TBB can be tried for usage
-    set(ENABLE_SYSTEM_LIBS_DEFAULT ON)
-else()
-    set(ENABLE_SYSTEM_LIBS_DEFAULT OFF)
-endif()
-
-set(ENABLE_SYSTEM_TBB_DEFAULT ${ENABLE_SYSTEM_LIBS_DEFAULT})
-if(DEFINED ENV{TBBROOT} OR DEFINED ENV{TBB_DIR} OR DEFINED TBB_DIR OR DEFINED TBBROOT)
-    set(ENABLE_SYSTEM_TBB_DEFAULT OFF)
-endif()
-
-ie_dependent_option (ENABLE_SYSTEM_TBB  "use the system version of TBB" ${ENABLE_SYSTEM_TBB_DEFAULT} "THREADING MATCHES TBB;LINUX" OFF)
+ie_dependent_option (ENABLE_SYSTEM_TBB  "use the system version of TBB" OFF "THREADING MATCHES TBB;LINUX" OFF)
 
 ie_option (ENABLE_DEBUG_CAPS "enable OpenVINO debug capabilities at runtime" OFF)
 


### PR DESCRIPTION
### Details:
 - Because it's targeted only for debian package support