### PR TITLE
Use static TBBBind if dynamic one is not found

### DIFF
--- a/cmake/developer_package/tbb/lnx/TBBConfig.cmake
+++ b/cmake/developer_package/tbb/lnx/TBBConfig.cmake
@@ -172,6 +172,10 @@ if (NOT _lib_exists AND TBB_FIND_REQUIRED AND TBB_FIND_REQUIRED_${_tbb_component
     message(FATAL_ERROR "Missed required Intel TBB component: ${_tbb_component}")
 endif()
 
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TBB
+    REQUIRED_VARS _lib_exists)
+
 unset(_tbb_x32_subdir)
 unset(_tbb_x64_subdir)
 unset(_tbb_arch_subdir)

--- a/cmake/developer_package/tbb/mac/TBBConfig.cmake
+++ b/cmake/developer_package/tbb/mac/TBBConfig.cmake
@@ -91,6 +91,10 @@ foreach (_tbb_component ${TBB_FIND_COMPONENTS})
     endif()
 endforeach()
 
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TBB
+    REQUIRED_VARS TBB_tbb_FOUND)
+
 unset(_tbb_x32_subdir)
 unset(_tbb_x64_subdir)
 unset(_tbb_arch_subdir)

--- a/cmake/developer_package/tbb/win/TBBConfig.cmake
+++ b/cmake/developer_package/tbb/win/TBBConfig.cmake
@@ -117,6 +117,10 @@ foreach (_tbb_component ${TBB_FIND_COMPONENTS})
     endif()
 endforeach()
 
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TBB
+    REQUIRED_VARS TBB_tbb_FOUND)
+
 unset(_tbb_x32_subdir)
 unset(_tbb_x64_subdir)
 unset(_tbb_arch_subdir)

--- a/src/cmake/ie_parallel.cmake
+++ b/src/cmake/ie_parallel.cmake
@@ -43,8 +43,9 @@ macro(ov_find_package_tbb)
             endforeach()
         endif()
 
-        if (NOT TBB_FOUND)
-            set(THREADING "SEQ" PARENT_SCOPE)
+        if(NOT TBB_FOUND)
+            set(THREADING "SEQ")
+            set(ENABLE_TBBBIND_2_5 OFF)
             message(WARNING "TBB was not found by the configured TBB_DIR/TBBROOT path.\
                              SEQ method will be used.")
         else()
@@ -62,11 +63,13 @@ function(set_ie_threading_interface_for TARGET_NAME)
 
         # set variables to parent scope to prevent multiple invocations of find_package(TBB)
         # at the same CMakeLists.txt; invocations in different directories are allowed
+        set(THREADING ${THREADING} PARENT_SCOPE)
         set(TBB_FOUND ${TBB_FOUND} PARENT_SCOPE)
         set(TBB_IMPORTED_TARGETS ${TBB_IMPORTED_TARGETS} PARENT_SCOPE)
         set(TBB_VERSION ${TBB_VERSION} PARENT_SCOPE)
         set(TBB_DIR ${TBB_DIR} PARENT_SCOPE)
         set(ENABLE_SYSTEM_TBB ${ENABLE_SYSTEM_TBB} PARENT_SCOPE)
+        set(ENABLE_TBBBIND_2_5 ${ENABLE_TBBBIND_2_5} PARENT_SCOPE)
     endif()
 
     get_target_property(target_type ${TARGET_NAME} TYPE)


### PR DESCRIPTION
### Details:
 - On U22 with oneTBB 2021.5 TBBBind is not present in debian packages, so we still need to use our prebuilt static tbbind 2.5
 - See https://github.com/oneapi-src/oneTBB/issues/879

### Tickets:
 - CVS-89825
