### PR TITLE
Porting Update to add climits for ULLONG_MAX to 2022.2 (#11958)

### DIFF
--- a/thirdparty/cnpy/cnpy.cpp
+++ b/thirdparty/cnpy/cnpy.cpp
@@ -7,6 +7,7 @@
 #include<cstdlib>
 #include<algorithm>
 #include<cstring>
+#include<climits>
 #include<iomanip>
 #include<stdint.h>
 #include<stdexcept>


### PR DESCRIPTION
Avoid GCC compiling issue ‘ULLONG_MAX’ was not declared in this scope

Co-authored-by: Ilya Lavrenov <ilya.lavrenov@intel.com>
Co-authored-by: Ilya Churaev <ilya.churaev@intel.com>

### Details:
 - *#include <climits>*

