### PR TITLE
Backport of #12713 "MO uses the same version of protobuf like other packages"

### DIFF
--- a/src/core/tests/frontend/paddle/requirements_dev.txt
+++ b/src/core/tests/frontend/paddle/requirements_dev.txt
@@ -3,4 +3,4 @@ paddlepaddle==2.1.0
 gast==0.3.3
 numpy~=1.19.2
 six~=1.15.0
-protobuf<4.0.0
+protobuf>=3.18.1,<4.0.0

--- a/src/core/tests/models/onnx/onnx_prototxt_converter_requirements.txt
+++ b/src/core/tests/models/onnx/onnx_prototxt_converter_requirements.txt
@@ -1,3 +1,3 @@
 docopt
-protobuf
+protobuf>=3.18.1,<4.0.0
 onnx

--- a/src/core/tests/requirements_test_onnx.txt
+++ b/src/core/tests/requirements_test_onnx.txt
@@ -1,4 +1,4 @@
 # ONNX - generate test models
 docopt~=0.6.2
 onnx~=1.11.0
-protobuf~=3.18
+protobuf>=3.18.1,<4.0.0

--- a/tools/mo/requirements.txt
+++ b/tools/mo/requirements.txt
@@ -4,7 +4,7 @@ mxnet~=1.2.0; sys_platform == 'win32'
 mxnet~=1.7.0.post2; sys_platform != 'win32'
 networkx~=2.5; python_version <= "3.6"
 networkx<2.8.1; python_version > "3.6"
-protobuf~=3.18.1
+protobuf>=3.18.1,<4.0.0
 onnx>=1.8.1,<1.12
 defusedxml>=0.7.1
 urllib3>=1.26.4

--- a/tools/mo/requirements.txt
+++ b/tools/mo/requirements.txt
@@ -4,7 +4,7 @@ mxnet~=1.2.0; sys_platform == 'win32'
 mxnet~=1.7.0.post2; sys_platform != 'win32'
 networkx~=2.5; python_version <= "3.6"
 networkx<2.8.1; python_version > "3.6"
-protobuf>=3.15.6
+protobuf~=3.18.1
 onnx>=1.8.1,<1.12
 defusedxml>=0.7.1
 urllib3>=1.26.4

--- a/tools/mo/requirements_caffe.txt
+++ b/tools/mo/requirements_caffe.txt
@@ -1,7 +1,7 @@
 networkx~=2.5; python_version <= "3.6"
 networkx<2.8.1; python_version > "3.6"
 numpy>=1.16.6,<=1.23.1
-protobuf>=3.15.6
+protobuf~=3.18.1
 defusedxml>=0.7.1
 requests>=2.25.1
 fastjsonschema~=2.15.1

--- a/tools/mo/requirements_caffe.txt
+++ b/tools/mo/requirements_caffe.txt
@@ -1,7 +1,7 @@
 networkx~=2.5; python_version <= "3.6"
 networkx<2.8.1; python_version > "3.6"
 numpy>=1.16.6,<=1.23.1
-protobuf~=3.18.1
+protobuf>=3.18.1,<4.0.0
 defusedxml>=0.7.1
 requests>=2.25.1
 fastjsonschema~=2.15.1

--- a/tools/mo/requirements_onnx.txt
+++ b/tools/mo/requirements_onnx.txt
@@ -5,3 +5,4 @@ numpy>=1.16.6,<=1.23.1
 defusedxml>=0.7.1
 requests>=2.25.1
 fastjsonschema~=2.15.1
+protobuf>=3.18.1,<4.0.0


### PR DESCRIPTION
- Backport of #12713 
- target branch: releases/2022/2