### PR TITLE
[GPU] Shared memory optimization for network::execute_impl() call

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -205,6 +205,7 @@ private:
     bool _reset_arguments;
 
     std::unordered_map<primitive_id, std::shared_ptr<primitive_inst>> _primitives;
+    std::vector<shared_mem_type> _in_out_shared_mem_types;
     std::vector<std::shared_ptr<primitive_inst>> _inputs;
     std::vector<std::shared_ptr<primitive_inst>> _outputs;
     std::list<std::shared_ptr<primitive_inst>> _exec_order;

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -636,16 +636,28 @@ void network::execute_impl(const std::vector<event::ptr>& events) {
     GPU_DEBUG_IF(debug_config->verbose >= 1)
         GPU_DEBUG_COUT << "----------------------------------------------" << std::endl;
 
-    std::vector<memory::ptr> in_out_mem;
-    for (auto& inst : _inputs) {
-        in_out_mem.push_back(inst->output_memory_ptr());
-    }
+    std::unique_ptr<cldnn::surfaces_lock> surf_lock;
+    bool shared_mem_found = std::any_of(_in_out_shared_mem_types.begin(),
+                                        _in_out_shared_mem_types.end(),
+                                        [](const shared_mem_type& shared_mem_type) {
+                                            return shared_mem_type == shared_mem_type::shared_mem_vasurface ||
+                                                   shared_mem_type == shared_mem_type::shared_mem_dxbuffer;
+                                        });
 
-    for (auto& inst : _outputs) {
-        in_out_mem.push_back(inst->output_memory_ptr());
-    }
+    if (shared_mem_found) {
+        std::vector<memory::ptr> in_out_mem;
+        for (auto& inst : _inputs) {
+            if (inst->output_memory_ptr())
+                in_out_mem.push_back(inst->output_memory_ptr());
+        }
 
-    auto surf_lock = surfaces_lock::create(get_engine().type(), in_out_mem, get_stream());
+        for (auto& inst : _outputs) {
+            if (inst->output_memory_ptr())
+                in_out_mem.push_back(inst->output_memory_ptr());
+        }
+
+        surf_lock = surfaces_lock::create(get_engine().type(), in_out_mem, get_stream());
+    }
 
     set_arguments();
     for (auto& inst : _exec_order) {
@@ -869,9 +881,14 @@ void network::allocate_primitive_instance(program_node const& node) {
     }
 
     _primitives[node.id()] = inst;
-    if (node.is_input())
+    if (node.is_input()) {
+        if (inst->output_memory_ptr())
+            _in_out_shared_mem_types.push_back(inst->output_memory_ptr()->get_internal_params().mem_type);
         _inputs.push_back(inst);
+    }
     if (node.is_output()) {
+        if (inst->output_memory_ptr())
+            _in_out_shared_mem_types.push_back(inst->output_memory_ptr()->get_internal_params().mem_type);
         _outputs.push_back(inst);
         if (node.is_type<data>())
             _data_outputs.push_back(inst);


### PR DESCRIPTION
### Details:
 This change allows to apply surfaces_lock only in really "surface scenario" and reduces infer request time preparing in other cases

