### PR TITLE
[TF FE] Correct Deconvolution for NCHW layout

### DIFF
--- a/src/frontends/tensorflow/src/op/conv_2d_backprop.cpp
+++ b/src/frontends/tensorflow/src/op/conv_2d_backprop.cpp
@@ -75,11 +75,17 @@ OutputVector translate_conv_2d_backprop_input_op(const NodeContext& node) {
     filter = make_transpose(filter, {3, 2, 0, 1});
     convert_nhwc_to_nchw(is_nhwc, out_backprop, ov::Rank(4));
 
-    // input_sizes is 1D tensor that contains a shape of output tensor and
-    // always in the form [batch, height, width, channels]
-    auto ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
-    auto ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{3});
+    // initially think that output shape defined for NCHW layout
+    auto ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{2});
+    auto ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{4});
     auto ss_strides = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
+
+    // change range of indices for spatial dimensions in case NHWC layout
+    if (is_nhwc) {
+        ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
+        ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{3});
+    }
+
     auto spatial_shape = make_shared<StridedSlice>(input_sizes,
                                                    ss_begin,
                                                    ss_end,

--- a/src/frontends/tensorflow/src/op/conv_2d_backprop.cpp
+++ b/src/frontends/tensorflow/src/op/conv_2d_backprop.cpp
@@ -75,17 +75,11 @@ OutputVector translate_conv_2d_backprop_input_op(const NodeContext& node) {
     filter = make_transpose(filter, {3, 2, 0, 1});
     convert_nhwc_to_nchw(is_nhwc, out_backprop, ov::Rank(4));
 
-    // initially think that output shape defined for NCHW layout
-    auto ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{2});
-    auto ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{-1});
+    // input_sizes is 1D tensor that contains a shape of output tensor and
+    // always in the form [batch, height, width, channels]
+    auto ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
+    auto ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{3});
     auto ss_strides = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
-
-    // change range of indices for spatial dimensions in case NHWC layout
-    if (is_nhwc) {
-        ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
-        ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{3});
-    }
-
     auto spatial_shape = make_shared<StridedSlice>(input_sizes,
                                                    ss_begin,
                                                    ss_end,

--- a/src/frontends/tensorflow/src/op/conv_3d_backprop.cpp
+++ b/src/frontends/tensorflow/src/op/conv_3d_backprop.cpp
@@ -77,11 +77,17 @@ OutputVector translate_conv_3d_backprop_input_v2_op(const NodeContext& node) {
     filter = make_transpose(filter, {4, 3, 0, 1, 2});
     convert_nhwc_to_nchw(is_nhwc, out_backprop, ov::Rank(5));
 
-    // input_sizes is 1D tensor that contains a shape of output tensor and
-    // always in the form [batch, depth, height, width, channels]
-    auto ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
-    auto ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{4});
+    // initially think that output shape defined for NCDHW layout
+    auto ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{2});
+    auto ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{5});
     auto ss_strides = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
+
+    // change range of indices for spatial dimensions in case NDHWC layout
+    if (is_nhwc) {
+        ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
+        ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{4});
+    }
+
     auto spatial_shape = make_shared<StridedSlice>(input_sizes,
                                                    ss_begin,
                                                    ss_end,

--- a/src/frontends/tensorflow/src/op/conv_3d_backprop.cpp
+++ b/src/frontends/tensorflow/src/op/conv_3d_backprop.cpp
@@ -77,17 +77,11 @@ OutputVector translate_conv_3d_backprop_input_v2_op(const NodeContext& node) {
     filter = make_transpose(filter, {4, 3, 0, 1, 2});
     convert_nhwc_to_nchw(is_nhwc, out_backprop, ov::Rank(5));
 
-    // initially think that output shape defined for NCDHW layout
-    auto ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{2});
-    auto ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{-1});
+    // input_sizes is 1D tensor that contains a shape of output tensor and
+    // always in the form [batch, depth, height, width, channels]
+    auto ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
+    auto ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{4});
     auto ss_strides = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
-
-    // change range of indices for spatial dimensions in case NDHWC layout
-    if (is_nhwc) {
-        ss_begin = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{1});
-        ss_end = make_shared<Constant>(element::i64, Shape{1}, std::vector<int64_t>{4});
-    }
-
     auto spatial_shape = make_shared<StridedSlice>(input_sizes,
                                                    ss_begin,
                                                    ss_end,


### PR DESCRIPTION
**Details:** With `end=-1` StridedSlice behaves unclear. It seems to include the latest element (slice) in case `end=-1` but it doesn't. The specification for StridedSlice has unclear items that were requested to resolve in ticket 90128

**Ticket:** 90101

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

