### PR TITLE
[GPU] Improved AddPrimitive function of the Program

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/program.hpp
@@ -131,12 +131,7 @@ public:
                          std::map<std::string, std::pair<int64_t, int64_t>>& batch_dim);
 
     // Profiling utils
-    void InitProfileInfo(const std::string& layerName,
-                         const std::string& layerType,
-                         bool isCPU = false,
-                         InferenceEngine::InferenceEngineProfileInfo::LayerStatus status
-                         = InferenceEngine::InferenceEngineProfileInfo::EXECUTED,
-                         std::string parentId = "");
+    void init_profile_info(const cldnn::primitive& prim);
 
     // Graph construction helpers
     std::vector<cldnn::primitive_id> GetInputPrimitiveIDs(const std::shared_ptr<ngraph::Node>& op) const;
@@ -204,6 +199,12 @@ void CreateElementwiseOp(Program& p, const std::shared_ptr<ngraph::Node>& node, 
 bool IsNodeOnConstPath(const std::shared_ptr<ngraph::Node>& node);
 
 void validate_inputs_count(const std::shared_ptr<ngraph::Node>& op, std::vector<size_t> possible_inputs_count);
+
+inline bool ends_with(const std::string& value, const std::string& suffix) {
+    if (suffix.size() > value.size())
+        return false;
+    return std::equal(suffix.rbegin(), suffix.rend(), value.rbegin());
+}
 
 }  // namespace intel_gpu
 }  // namespace ov

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/program.hpp
@@ -44,6 +44,13 @@ void __register ## _ ## op_name ## _ ## op_version() {                          
 namespace ov {
 namespace intel_gpu {
 
+template<class T>
+struct is_smart_pointer : std::false_type {};
+template<class T>
+struct is_smart_pointer<std::shared_ptr<T>> : std::true_type {};
+template<class T>
+struct is_smart_pointer<std::shared_ptr<const T>> : std::true_type {};
+
 std::string layer_type_lower(const ngraph::Node* op);
 std::string layer_type_name_ID(const ngraph::Node* op);
 std::string layer_type_lower(const std::shared_ptr<ngraph::Node>& op);
@@ -93,11 +100,11 @@ public:
     static const cldnn::primitive_id m_preCustomLayerTag;
     static const cldnn::primitive_id m_postCustomLayerTag;
 
-    std::map<std::string, cldnn::primitive_id> primitiveIDs;
+    std::map<std::string, cldnn::primitive_id> primitive_ids;
     std::map<std::string, std::vector<cldnn::primitive_id>> prevPrimitiveIDs;
     std::map<cldnn::primitive_id, std::pair<std::string, PerfCounter>> perfMap;
 
-    std::vector<cldnn::primitive_id> profilingIDs;
+    std::vector<cldnn::primitive_id> profiling_ids;
 
     std::map<std::string, InferenceEngine::SizeVector> outputDims;
     std::map<std::string, cldnn::layout> inputLayouts;
@@ -130,15 +137,8 @@ public:
                          InferenceEngine::InferenceEngineProfileInfo::LayerStatus status
                          = InferenceEngine::InferenceEngineProfileInfo::EXECUTED,
                          std::string parentId = "");
-    void AddPrimitiveToProfiler(cldnn::primitive_id id, const std::shared_ptr<ngraph::Node>& op,
-                                cldnn::primitive_id customOutputId = "");
-    void AddPrimitiveToProfiler(const std::shared_ptr<ngraph::Node>& op,
-                                cldnn::primitive_id customOutputId = "");
-    void AddInnerPrimitiveToProfiler(cldnn::primitive_id id, cldnn::primitive_id parentId,
-                                     const std::shared_ptr<ngraph::Node>& op);
 
     // Graph construction helpers
-    void ValidateInputs(const std::shared_ptr<ngraph::Node>& op, std::vector<size_t> validInputsCount);
     std::vector<cldnn::primitive_id> GetInputPrimitiveIDs(const std::shared_ptr<ngraph::Node>& op) const;
 
     using factory_t = std::function<void(Program&, const std::shared_ptr<ngraph::Node>&)>;
@@ -152,14 +152,12 @@ public:
             Program::factories_map.insert({OpType::get_type_info_static(), func});
     }
 
-    template<typename PType>
-    void AddPrimitive(const PType& prim) {
-        if (m_topology == nullptr) {
-            IE_THROW() << "m_topology object was not created in ov::runtime::intel_gpu::Program";
-        }
-
-        m_topology->add(prim);
+    template<typename PType, typename = typename std::enable_if<!is_smart_pointer<PType>::value>::type>
+    void add_primitive(const ngraph::Node& op, PType prim, std::vector<std::string> aliases = {}) {
+        add_primitive(op, std::static_pointer_cast<cldnn::primitive>(std::make_shared<PType>(prim)), aliases);
     }
+
+    void add_primitive(const ngraph::Node& op, std::shared_ptr<cldnn::primitive> prim, std::vector<std::string> aliases = {});
 
     std::shared_ptr<cldnn::topology> GetTopology() const { return m_topology; }
 
@@ -204,6 +202,8 @@ void CreateUnaryEltwiseOp(Program& p, const std::shared_ptr<ngraph::Node>& node,
 void CreateElementwiseOp(Program& p, const std::shared_ptr<ngraph::Node>& node, cldnn::eltwise_mode mode);
 
 bool IsNodeOnConstPath(const std::shared_ptr<ngraph::Node>& node);
+
+void validate_inputs_count(const std::shared_ptr<ngraph::Node>& op, std::vector<size_t> possible_inputs_count);
 
 }  // namespace intel_gpu
 }  // namespace ov

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/activation.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/activation.hpp
@@ -90,9 +90,8 @@ struct activation : public primitive_base<activation> {
                const primitive_id& input,
                activation_func activation_function,
                activation_additional_params additional_params = {0.f, 0.f},
-               const primitive_id& ext_prim_id = "",
                const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           activation_function(activation_function),
           additional_params(additional_params),
           additional_params_input("") {}
@@ -107,9 +106,8 @@ struct activation : public primitive_base<activation> {
                const primitive_id& input,
                const primitive_id& additional_params_input,
                activation_func activation_function,
-               const primitive_id& ext_prim_id = "",
                const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           activation_function(activation_function),
           additional_params({0, 0}),
           additional_params_input(additional_params_input) {}

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/adaptive_pooling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/adaptive_pooling.hpp
@@ -22,9 +22,8 @@ struct adaptive_pooling : public primitive_base<adaptive_pooling> {
     /// @param output_size Output data size of the primitive
     adaptive_pooling(const primitive_id &id,
                      const primitive_id &input,
-                     tensor output_size,
-                     const primitive_id &ext_prim_id = "")
-            : primitive_base(id, {input}, ext_prim_id),
+                     tensor output_size)
+            : primitive_base(id, {input}),
               mode{adaptive_pooling_mode::average},
               output_size{output_size} {}
 
@@ -39,9 +38,8 @@ struct adaptive_pooling : public primitive_base<adaptive_pooling> {
                      const primitive_id &input,
                      tensor output_size,
                      const primitive_id &indices_output,
-                     data_types index_element_type,
-                     const primitive_id &ext_prim_id = "")
-            : primitive_base(id, {input, indices_output}, ext_prim_id),
+                     data_types index_element_type)
+            : primitive_base(id, {input, indices_output}),
               mode{adaptive_pooling_mode::max},
               output_size{output_size},
               indices_output{indices_output},

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/arg_max_min.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/arg_max_min.hpp
@@ -40,10 +40,9 @@ struct arg_max_min : public primitive_base<arg_max_min> {
                 int64_t axis,
                 ov::op::TopKSortType sort = ov::op::TopKSortType::SORT_VALUES,
                 bool values_first = false,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding(),
                 data_types output_data_type = data_types::f32)
-        : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type {output_data_type}),
+        : primitive_base(id, {input}, output_padding, optional_data_type {output_data_type}),
           mode(mode),
           top_k(top_k),
           axis(axis),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/assign.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/assign.hpp
@@ -30,7 +30,7 @@ struct assign : public primitive_base<assign> {
                const std::vector<primitive_id>& inputs,
                const std::string& variable_id,
                const layout& output_layout)
-                : primitive_base(id, inputs, "", {}, optional_data_type{output_layout.data_type}),
+                : primitive_base(id, inputs, {}, optional_data_type{output_layout.data_type}),
                   variable_id{variable_id},
                   output_layout{output_layout} {}
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/average_unpooling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/average_unpooling.hpp
@@ -32,9 +32,8 @@ struct average_unpooling : public primitive_base<average_unpooling> {
         const tensor output_size,
         const tensor& size,
         const tensor& stride,
-        const primitive_id& ext_prim_id = "",
         const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), stride(stride), size(size), output_size(output_size) {}
+        : primitive_base(id, {input}, output_padding), stride(stride), size(size), output_size(output_size) {}
 
     /// @brief Defines shift in output buffer.
     tensor stride;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/batch_to_space.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/batch_to_space.hpp
@@ -59,9 +59,8 @@ struct batch_to_space : public primitive_base<batch_to_space> {
                    const tensor& crops_begin,
                    const tensor& crops_end,
                    const tensor& out_size,
-                   const primitive_id& ext_prim_id = "",
                    const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           block_shape(block_shape),
           crops_begin(crops_begin),
           crops_end(crops_end),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/binary_convolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/binary_convolution.hpp
@@ -45,9 +45,8 @@ struct binary_convolution : public primitive_base<binary_convolution> {
                        int groups = 1,
                        float pad_value = 0.0f,
                        data_types calc_precision = data_types::f32,
-                       const primitive_id& ext_prim_id = "",
                        const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type {calc_precision}),
+        : primitive_base(id, {input}, output_padding, optional_data_type {calc_precision}),
           pad(pad),
           stride(stride),
           dilation(dilation),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/border.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/border.hpp
@@ -49,9 +49,8 @@ struct border : public primitive_base<border> {
            const ov::CoordinateDiff& pads_end = {0, 0, 0, 0},
            const ov::op::PadMode pad_mode = ov::op::PadMode::CONSTANT,
            const float pad_value = 0.0f,
-           const primitive_id& ext_prim_id = "",
            const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pads_begin(pads_begin),
           pads_end(pads_end),
           pad_mode(pad_mode),
@@ -64,9 +63,8 @@ struct border : public primitive_base<border> {
            const primitive_id& pads_end_id,
            const ov::op::PadMode pad_mode = ov::op::PadMode::CONSTANT,
            const float pad_value = 0.0f,
-           const primitive_id& ext_prim_id = "",
            const padding& output_padding = padding())
-        : primitive_base(id, {input, pads_begin_id, pads_end_id}, ext_prim_id, output_padding),
+        : primitive_base(id, {input, pads_begin_id, pads_end_id}, output_padding),
           pads_begin({}),
           pads_end({}),
           pad_mode(pad_mode),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/broadcast.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/broadcast.hpp
@@ -77,9 +77,8 @@ struct broadcast : public primitive_base<broadcast> {
               const primitive_id& input,
               const tensor& broadcast_sizes,
               const std::vector<uint16_t>& broadcast_axes = {},
-              const primitive_id& ext_prim_id = "",
               const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           broadcast_sizes(broadcast_sizes),
           broadcast_axes(broadcast_axes) {}
 
@@ -103,9 +102,8 @@ struct broadcast : public primitive_base<broadcast> {
               const ov::Shape& target_shape,
               const ngraph::AxisSet& axes_mapping,
               const ov::op::BroadcastModeSpec& broadcast_spec = ov::op::BroadcastType::EXPLICIT,
-              const primitive_id& ext_prim_id = "",
               const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           target_shape(target_shape),
           axes_mapping(axes_mapping),
           broadcast_mode(broadcast_spec),
@@ -118,9 +116,8 @@ struct broadcast : public primitive_base<broadcast> {
           const primitive_id& target_shape_id,
           const ngraph::AxisSet& axes_mapping,
           const ov::op::BroadcastModeSpec& broadcast_spec = ov::op::BroadcastType::EXPLICIT,
-          const primitive_id& ext_prim_id = "",
           const padding& output_padding = padding())
-    : primitive_base(id, {input, target_shape_id}, ext_prim_id, output_padding),
+    : primitive_base(id, {input, target_shape_id}, output_padding),
       target_shape({}),
       axes_mapping(axes_mapping),
       broadcast_mode(broadcast_spec),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/bucketize.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/bucketize.hpp
@@ -26,9 +26,8 @@ struct bucketize : primitive_base<bucketize> {
               const std::vector<primitive_id>& inputs,
               data_types output_type = data_types::i64,
               bool with_right_bound = true,
-              const primitive_id& ext_prim_id = {},
               const padding& output_padding = {})
-        : primitive_base(id, inputs, ext_prim_id, output_padding, optional_data_type(output_type)),
+        : primitive_base(id, inputs, output_padding, optional_data_type(output_type)),
           with_right_bound(with_right_bound) {}
 
     bool with_right_bound;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/concatenation.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/concatenation.hpp
@@ -47,9 +47,8 @@ struct concatenation : public primitive_base<concatenation> {
         const primitive_id& id,
         const std::vector<primitive_id>& input,
         const int64_t axis,
-        const primitive_id& ext_prim_id = "",
         const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), axis(axis) {}
+        : primitive_base(id, {input}, output_padding), axis(axis) {}
 
     /// @li Constructs concatenation primitive.
     /// @param id This primitive id.
@@ -61,9 +60,8 @@ struct concatenation : public primitive_base<concatenation> {
         const std::vector<primitive_id>& input,
         const int64_t axis,
         const data_types output_dt,
-        const primitive_id& ext_prim_id = "",
         const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type{output_dt}), axis(axis) {}
+        : primitive_base(id, {input}, output_padding, optional_data_type{output_dt}), axis(axis) {}
 
     /// @brief Dimension along which concatenation should take place
     int64_t axis;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/condition.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/condition.hpp
@@ -47,9 +47,8 @@ struct condition : public primitive_base<condition> {
               const primitive_id& compare_data,
               const cond_functions& func,
               const tensor& offset = {0, 0, 0, 0, 0},
-              const primitive_id& ext_prim_id = "",
               const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           topology_true(topology_true),
           topology_false(topology_false),
           compare_data(compare_data),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/convert_color.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/convert_color.hpp
@@ -45,9 +45,8 @@ struct convert_color : public primitive_base<convert_color> {
                   const color_format output_color_format,
                   const memory_type mem_type,
                   const layout& output_layout,
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base(id, inputs, ext_prim_id, output_padding),
+        : primitive_base(id, inputs, output_padding),
           input_color_format(input_color_format),
           output_color_format(output_color_format),
           mem_type(mem_type),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/convolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/convolution.hpp
@@ -55,9 +55,8 @@ struct convolution : public primitive_base<convolution> {
                 tensor output_size,
                 data_types output_type,
                 bool grouped_weights_shape,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-            : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type{output_type}),
+            : primitive_base(id, {input}, output_padding, optional_data_type{output_type}),
               pad(pad),
               stride(stride),
               dilation(dilation),
@@ -105,9 +104,8 @@ struct convolution : public primitive_base<convolution> {
                 ov::Strides dilation,
                 tensor output_size,
                 bool grouped_weights_shape,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-            : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type{output_data_type}),
+            : primitive_base(id, {input}, output_padding, optional_data_type{output_data_type}),
               pad(pad),
               stride(stride),
               dilation(dilation),
@@ -162,9 +160,8 @@ struct convolution : public primitive_base<convolution> {
                 ov::Strides dilation,
                 tensor output_size,
                 bool grouped_weights_shape,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-            : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type{output_data_type}),
+            : primitive_base(id, {input}, output_padding, optional_data_type{output_data_type}),
               pad(pad),
               stride(stride),
               dilation(dilation),
@@ -208,9 +205,8 @@ struct convolution : public primitive_base<convolution> {
                 ov::Strides stride = {1, 1},
                 ov::CoordinateDiff pad = {0, 0},
                 ov::Strides dilation = {1, 1},
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           dilation(dilation),
@@ -253,9 +249,8 @@ struct convolution : public primitive_base<convolution> {
                 ov::Strides dilation,
                 ov::CoordinateDiff padding_above,
                 ov::CoordinateDiff padding_below,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           dilation(dilation),
@@ -300,9 +295,8 @@ struct convolution : public primitive_base<convolution> {
                 ov::Strides dilation,
                 ov::CoordinateDiff padding_above,
                 ov::CoordinateDiff padding_below,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           dilation(dilation),
@@ -345,9 +339,8 @@ struct convolution : public primitive_base<convolution> {
                 ov::CoordinateDiff pad = {0, 0},
                 ov::Strides dilation = {1, 1},
                 bool grouped_weights_shape = false,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           dilation(dilation),
@@ -388,9 +381,8 @@ struct convolution : public primitive_base<convolution> {
                 ov::CoordinateDiff pad = {0, 0},
                 ov::Strides dilation = {1, 1},
                 bool grouped_weights_shape = false,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           dilation(dilation),
@@ -429,9 +421,8 @@ struct convolution : public primitive_base<convolution> {
                 ov::Strides dilation,
                 ov::CoordinateDiff padding_above,
                 ov::CoordinateDiff padding_below,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           dilation(dilation),
@@ -472,9 +463,8 @@ struct convolution : public primitive_base<convolution> {
                 ov::Strides dilation,
                 ov::CoordinateDiff padding_above,
                 ov::CoordinateDiff padding_below,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           dilation(dilation),
@@ -513,9 +503,8 @@ struct convolution : public primitive_base<convolution> {
                 ov::Strides dilation = {1, 1},
                 tensor output_size = {0, 0, 0, 0},
                 bool grouped_weights_shape = false,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           dilation(dilation),
@@ -555,9 +544,8 @@ struct convolution : public primitive_base<convolution> {
                 ov::CoordinateDiff pad,
                 ov::Strides dilation,
                 tensor output_size,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           dilation(dilation),
@@ -598,9 +586,8 @@ struct convolution : public primitive_base<convolution> {
                 ov::CoordinateDiff pad,
                 ov::Strides dilation,
                 tensor output_size,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           dilation(dilation),
@@ -647,9 +634,8 @@ struct convolution : public primitive_base<convolution> {
                 ov::Strides dilation,
                 tensor output_size,
                 bool bilinear_interpolation_pad = false,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-    : primitive_base(id, inputs, ext_prim_id, output_padding),
+    : primitive_base(id, inputs, output_padding),
       pad(pad),
       stride(stride),
       dilation(dilation),
@@ -697,7 +683,6 @@ struct convolution : public primitive_base<convolution> {
                                                ov::Strides stride = {1, 1},
                                                ov::CoordinateDiff pad = {0, 0},
                                                ov::Strides dilation = {1, 1},
-                                               const primitive_id& ext_prim_id = "",
                                                const padding& output_padding = padding()) {
         return convolution(id,
                            input,
@@ -707,7 +692,6 @@ struct convolution : public primitive_base<convolution> {
                            pad,
                            dilation,
                            output_size,
-                           ext_prim_id,
                            output_padding);
     }
 
@@ -733,7 +717,6 @@ struct convolution : public primitive_base<convolution> {
                                                ov::Strides stride = {1, 1},
                                                ov::CoordinateDiff pad = {0, 0},
                                                ov::Strides dilation = {1, 1},
-                                               const primitive_id& ext_prim_id = "",
                                                const padding& output_padding = padding()) {
         return convolution(id,
                            input,
@@ -742,7 +725,6 @@ struct convolution : public primitive_base<convolution> {
                            pad,
                            dilation,
                            output_size,
-                           ext_prim_id,
                            output_padding);
     }
 
@@ -816,9 +798,8 @@ struct deformable_interp : public primitive_base<deformable_interp> {
                       tensor output_size,
                       tensor kernel_size,
                       bool bilinear_interpolation_pad,
-                      const primitive_id& ext_prim_id = "",
                       const padding& output_padding = padding())
-    : primitive_base(id, inputs, ext_prim_id, output_padding),
+    : primitive_base(id, inputs, output_padding),
       pad(pad),
       stride(stride),
       dilation(dilation),
@@ -865,9 +846,8 @@ struct deformable_conv : public primitive_base<deformable_conv> {
                     const std::vector<primitive_id>& biases,
                     uint32_t groups,
                     tensor output_size,
-                    const primitive_id& ext_prim_id = "",
                     const padding& output_padding = padding())
-    : primitive_base(id, {input}, ext_prim_id, output_padding),
+    : primitive_base(id, {input}, output_padding),
       output_size(output_size),
       groups(groups),
       weights(weights),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/crop.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/crop.hpp
@@ -51,9 +51,8 @@ struct crop : public primitive_base<crop> {
          const primitive_id& input,
          const tensor& reference_input,
          const tensor& offsets,
-         const primitive_id& ext_prim_id = "",
          const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), reference_input(reference_input), offsets(offsets) {}
+        : primitive_base(id, {input}, output_padding), reference_input(reference_input), offsets(offsets) {}
 
     /// @brief Constructs crop primitive (borders variant).
     ///
@@ -72,9 +71,8 @@ struct crop : public primitive_base<crop> {
          const tensor& lt_borders,
          const tensor& rb_borders,
          const crop_borders_t,
-         const primitive_id& ext_prim_id = "",
          const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), reference_input(rb_borders.negate()), offsets(lt_borders) {}
+        : primitive_base(id, {input}, output_padding), reference_input(rb_borders.negate()), offsets(lt_borders) {}
 
     /// @brief Constructs crop primitive (symmetric borders variant).
     ///
@@ -90,9 +88,8 @@ struct crop : public primitive_base<crop> {
          const primitive_id& input,
          const tensor& xy_borders,
          const crop_borders_t,
-         const primitive_id& ext_prim_id = "",
          const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), reference_input(xy_borders.negate()), offsets(xy_borders) {}
+        : primitive_base(id, {input}, output_padding), reference_input(xy_borders.negate()), offsets(xy_borders) {}
 
     /// @brief Reference input tensor with the required dimensions.
     tensor reference_input;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/ctc_greedy_decoder.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/ctc_greedy_decoder.hpp
@@ -28,9 +28,8 @@ struct ctc_greedy_decoder : public primitive_base<ctc_greedy_decoder> {
                        const uint32_t blank_index,
                        const bool ctc_merge_repeated,
                        const tensor output_tensor,
-                       const primitive_id& ext_prim_id = "",
                        const padding& output_padding = padding())
-        : primitive_base(id, input, ext_prim_id, output_padding)
+        : primitive_base(id, input, output_padding)
         , blank_index(blank_index)
         , ctc_merge_repeated(ctc_merge_repeated)
         , output_tensor(output_tensor) {}

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/cum_sum.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/cum_sum.hpp
@@ -28,9 +28,8 @@ struct cum_sum : public primitive_base<cum_sum> {
             const int64_t axis = 0,
             const bool exclusive = false,
             const bool reverse = false,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), axis(axis), exclusive(exclusive), reverse(reverse)
+        : primitive_base(id, {input}, output_padding), axis(axis), exclusive(exclusive), reverse(reverse)
     {}
 
     /// @brief Scalar axis.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/custom_gpu_primitive.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/custom_gpu_primitive.hpp
@@ -56,9 +56,8 @@ struct custom_gpu_primitive : public primitive_base<custom_gpu_primitive> {
                          const std::string& build_options,
                          const layout& output_layout,
                          const std::vector<size_t>& gws = {},
-                         const std::vector<size_t>& lws = {},
-                         const primitive_id& ext_prim_id = "")
-        : primitive_base(id, {input}, ext_prim_id, output_layout.data_padding),
+                         const std::vector<size_t>& lws = {})
+        : primitive_base(id, {input}, output_layout.data_padding),
           kernel_entry_point(kernel_entry_point),
           kernel_arguments(kernel_arguments),
           build_options(build_options),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -26,8 +26,8 @@ struct data : public primitive_base<data> {
     /// @param id This primitive id.
     /// @param mem @ref memory object which contains data.
     /// @note If memory is attached by memory::attach(), the attached buffer should be valid till network build.
-    data(const primitive_id& id, memory::ptr mem, const primitive_id& ext_prim_id = "")
-        : primitive_base(id, {}, ext_prim_id, padding()), mem(mem) {}
+    data(const primitive_id& id, memory::ptr mem)
+        : primitive_base(id, {}, padding()), mem(mem) {}
 
     /// @brief @ref memory object which contains data.
     /// @note If memory is attached by memory::attach(), the attached buffer should be valid till network build.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/deconvolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/deconvolution.hpp
@@ -39,9 +39,8 @@ struct deconvolution : public primitive_base<deconvolution> {
                   const std::vector<primitive_id>& bias,
                   ov::Strides stride = {1, 1},
                   ov::CoordinateDiff pad = {0, 0},
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           with_output_size(false),
@@ -66,9 +65,8 @@ struct deconvolution : public primitive_base<deconvolution> {
                   uint32_t groups,
                   ov::Strides stride = {1, 1},
                   ov::CoordinateDiff pad = {0, 0},
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           with_output_size(false),
@@ -90,9 +88,8 @@ struct deconvolution : public primitive_base<deconvolution> {
                   const std::vector<primitive_id>& weights,
                   ov::Strides stride = {1, 1},
                   ov::CoordinateDiff pad = {0, 0},
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           with_output_size(false),
@@ -116,9 +113,8 @@ struct deconvolution : public primitive_base<deconvolution> {
                   uint32_t groups,
                   ov::Strides stride = {1, 1},
                   ov::CoordinateDiff pad = {0, 0},
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           with_output_size(false),
@@ -144,9 +140,8 @@ struct deconvolution : public primitive_base<deconvolution> {
                   ov::Strides stride,
                   ov::CoordinateDiff pad,
                   tensor output_size,
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           with_output_size(true),
@@ -176,9 +171,8 @@ struct deconvolution : public primitive_base<deconvolution> {
                   ov::CoordinateDiff pad,
                   tensor output_size,
                   bool grouped_weights_shape,
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           with_output_size(true),
@@ -203,9 +197,8 @@ struct deconvolution : public primitive_base<deconvolution> {
                   ov::Strides stride,
                   ov::CoordinateDiff pad,
                   tensor output_size,
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           pad(pad),
           stride(stride),
           with_output_size(true),
@@ -233,7 +226,6 @@ struct deconvolution : public primitive_base<deconvolution> {
                                                  tensor output_size,
                                                  ov::Strides stride = {1, 1},
                                                  ov::CoordinateDiff pad = {0, 0},
-                                                 const primitive_id& ext_prim_id = "",
                                                  const padding& output_padding = padding()) {
         return deconvolution(id,
                              input,
@@ -242,7 +234,6 @@ struct deconvolution : public primitive_base<deconvolution> {
                              stride,
                              pad,
                              output_size,
-                             ext_prim_id,
                              output_padding);
     }
 
@@ -262,7 +253,6 @@ struct deconvolution : public primitive_base<deconvolution> {
                                                  tensor output_size,
                                                  ov::Strides stride = {1, 1},
                                                  ov::CoordinateDiff pad = {0, 0},
-                                                 const primitive_id& ext_prim_id = "",
                                                  const padding& output_padding = padding())     {
         return deconvolution(id,
                              input,
@@ -270,7 +260,6 @@ struct deconvolution : public primitive_base<deconvolution> {
                              stride,
                              pad,
                              output_size,
-                             ext_prim_id,
                              output_padding);
     }
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/depth_to_space.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/depth_to_space.hpp
@@ -36,9 +36,8 @@ struct depth_to_space : public primitive_base<depth_to_space> {
                    const primitive_id& input,
                    const size_t block_size,
                    const depth_to_space_mode mode,
-                   const primitive_id& ext_prim_id = "",
                    const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding)
+        : primitive_base(id, {input}, output_padding)
         , block_size(block_size)
         , mode(mode) {}
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/detection_output.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/detection_output.hpp
@@ -65,9 +65,8 @@ struct detection_output : public primitive_base<detection_output> {
                      const bool decrease_label_id = false,
                      const bool clip_before_nms = false,
                      const bool clip_after_nms = false,
-                     const primitive_id& ext_prim_id = "",
                      const padding& output_padding = padding())
-        : primitive_base(id, {input_location, input_confidence, input_prior_box}, ext_prim_id, output_padding),
+        : primitive_base(id, {input_location, input_confidence, input_prior_box}, output_padding),
           num_classes(num_classes),
           keep_top_k(keep_top_k),
           share_location(share_location),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/dft.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/dft.hpp
@@ -37,9 +37,8 @@ struct dft : public primitive_base<dft> {
         std::vector<int64_t>&& axes,
         const ov::Shape& output_shape,
         dft_kind kind,
-        const primitive_id& ext_prim_id = {},
         const padding& output_padding = {})
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           axes(std::move(axes)),
           output_shape(output_shape),
           kind(kind) {}

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/eltwise.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/eltwise.hpp
@@ -78,9 +78,8 @@ struct eltwise : public primitive_base<eltwise> {
             const primitive_id& input,
             const primitive_id& input2,
             eltwise_mode mode,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input, input2}, ext_prim_id, output_padding),
+        : primitive_base(id, {input, input2}, output_padding),
           mode(mode),
           coefficients(std::vector<float>(0)),
           stride(std::vector<tensor>(0)) {}
@@ -98,9 +97,8 @@ struct eltwise : public primitive_base<eltwise> {
             const primitive_id& input2,
             std::vector<tensor> stride,
             eltwise_mode mode,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input, input2}, ext_prim_id, output_padding),
+        : primitive_base(id, {input, input2}, output_padding),
           mode(mode),
           coefficients(std::vector<float>(0)),
           stride(stride) {}
@@ -114,9 +112,8 @@ struct eltwise : public primitive_base<eltwise> {
             const std::vector<primitive_id>& inputs,
             eltwise_mode mode,
             data_types data_type,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, inputs, ext_prim_id, output_padding, optional_data_type{data_type}),
+        : primitive_base(id, inputs, output_padding, optional_data_type{data_type}),
           mode(mode),
           coefficients(std::vector<float>(0)),
           stride(std::vector<tensor>(0)) {}
@@ -128,9 +125,8 @@ struct eltwise : public primitive_base<eltwise> {
     eltwise(const primitive_id& id,
             const std::vector<primitive_id>& inputs,
             eltwise_mode mode,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, inputs, ext_prim_id, output_padding),
+        : primitive_base(id, inputs, output_padding),
           mode(mode),
           coefficients(std::vector<float>(0)),
           stride(std::vector<tensor>(0)) {}
@@ -145,9 +141,8 @@ struct eltwise : public primitive_base<eltwise> {
             eltwise_mode mode,
             const std::vector<float>& coefficients,
             data_types data_type,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, inputs, ext_prim_id, output_padding, optional_data_type{data_type}),
+        : primitive_base(id, inputs, output_padding, optional_data_type{data_type}),
           mode(mode),
           coefficients(coefficients),
           stride(std::vector<tensor>(0)) {

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/embedding_bag.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/embedding_bag.hpp
@@ -36,9 +36,8 @@ struct embedding_bag : public primitive_base<embedding_bag> {
                   const embedding_bag_type& type,
                   const tensor& output_shape,
                   const int32_t default_index = -1,
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base(id, inputs, ext_prim_id, output_padding), type(type), output_shape(output_shape), default_index(default_index) {}
+        : primitive_base(id, inputs, output_padding), type(type), output_shape(output_shape), default_index(default_index) {}
 
     /// @brief Type of EmbeddingBag operation
     embedding_bag_type type;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_detection_output.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_detection_output.hpp
@@ -52,11 +52,9 @@ struct experimental_detectron_detection_output : public primitive_base<experimen
                                             bool class_agnostic_box_regression,
                                             float max_delta_log_wh,
                                             std::vector<float> deltas_weights,
-                                            const primitive_id& ext_prim_id = "",
                                             const padding& output_padding = {})
         : primitive_base{id,
                          {input_rois, input_deltas, input_scores, input_im_info, output_classes, output_scores},
-                         ext_prim_id,
                          output_padding},
           output_classes{output_classes},
           output_scores{output_scores},

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_generate_proposals_single_image.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_generate_proposals_single_image.hpp
@@ -41,9 +41,8 @@ struct experimental_detectron_generate_proposals_single_image
            float nms_threshold,
            int64_t pre_nms_count,
            int64_t post_nms_count,
-           const primitive_id& ext_prim_id = "",
            const padding& output_padding = {}) :
-            primitive_base{id, {input_im_info, input_anchors, input_deltas, input_scores, output_roi_scores}, ext_prim_id, output_padding},
+            primitive_base{id, {input_im_info, input_anchors, input_deltas, input_scores, output_roi_scores}, output_padding},
             output_roi_scores{output_roi_scores},
             min_size{min_size},
             nms_threshold{nms_threshold},

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_prior_grid_generator.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_prior_grid_generator.hpp
@@ -30,9 +30,8 @@ struct experimental_detectron_prior_grid_generator
                                                 uint64_t featmap_height,
                                                 uint64_t featmap_width,
                                                 uint64_t image_height,
-                                                uint64_t image_width,
-                                                const primitive_id& ext_prim_id = {})
-        : primitive_base{id, input, ext_prim_id},
+                                                uint64_t image_width)
+        : primitive_base{id, input},
           flatten{flatten},
           h{h},
           w{w},

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_roi_feature_extractor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_roi_feature_extractor.hpp
@@ -32,9 +32,8 @@ struct experimental_detectron_roi_feature_extractor : public primitive_base<expe
                                                  const std::vector<int64_t>& pyramid_scales,
                                                  int sampling_ratio,
                                                  bool aligned,
-                                                 const primitive_id& ext_prim_id = "",
                                                  const padding& output_padding = padding()) :
-            primitive_base(id, inputs, ext_prim_id, output_padding),
+            primitive_base(id, inputs, output_padding),
             output_dim(output_dim),
             pooled_height(output_dim),
             pooled_width(output_dim),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_topk_rois.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_topk_rois.hpp
@@ -31,7 +31,7 @@ struct experimental_detectron_topk_rois : public primitive_base<experimental_det
     experimental_detectron_topk_rois(const primitive_id &id, const std::vector<primitive_id> &inputs,
                                      const size_t max_rois,
                                      const padding &output_padding = padding())
-            : primitive_base(id, inputs, "", output_padding),
+            : primitive_base(id, inputs, output_padding),
               max_rois(max_rois) {}
 
     /// maximal numbers of output ROIs.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/extract_image_patches.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/extract_image_patches.hpp
@@ -43,9 +43,8 @@ struct extract_image_patches : public primitive_base<extract_image_patches> {
                           const std::vector<unsigned int>& rates,
                           const std::string& auto_pad,
                           const tensor& output_shape,
-                          const primitive_id& ext_prim_id = "",
                           const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           sizes(sizes),
           strides(strides),
           rates(rates),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
@@ -49,10 +49,9 @@ struct fully_connected : public primitive_base<fully_connected> {
                     const primitive_id& input,
                     const primitive_id& weights,
                     const primitive_id& bias = "",
-                    const primitive_id& ext_prim_id = "",
                     const padding& output_padding = padding(),
                     const size_t input_size = 2)
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           weights(weights),
           bias(bias),
           input_size(input_size)
@@ -68,10 +67,9 @@ struct fully_connected : public primitive_base<fully_connected> {
                     const primitive_id& weights,
                     const primitive_id& bias,
                     const data_types data_type,
-                    const primitive_id& ext_prim_id = "",
                     const padding& output_padding = padding(),
                     const size_t input_size = 2)
-        : primitive_base(id, { input }, ext_prim_id, output_padding, optional_data_type{data_type}),
+        : primitive_base(id, { input }, output_padding, optional_data_type{data_type}),
           weights(weights),
           bias(bias),
           input_size(input_size)

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gather.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gather.hpp
@@ -36,9 +36,8 @@ struct gather : public primitive_base<gather> {
            const ov::Shape& output_shape,
            const int64_t batch_dim = 0,
            const bool support_neg_ind = false,
-           const primitive_id& ext_prim_id = "",
            const padding& output_padding = padding())
-        : primitive_base(id, {dict, idx}, ext_prim_id, output_padding)
+        : primitive_base(id, {dict, idx}, output_padding)
         , axis(axis)
         , output_shape(output_shape)
         , batch_dim(batch_dim)

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gather_elements.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gather_elements.hpp
@@ -32,17 +32,15 @@ struct gather_elements : public primitive_base<gather_elements> {
                     const format& output_format,
                     const tensor& output_shape,
                     const int64_t axis,
-                    const primitive_id& ext_prim_id = "",
                     const padding& output_padding = padding())
-        : primitive_base(id, {data, indices}, ext_prim_id, output_padding), output_format(output_format), output_shape(output_shape), axis(axis) {}
+        : primitive_base(id, {data, indices}, output_padding), output_format(output_format), output_shape(output_shape), axis(axis) {}
 
     gather_elements(const primitive_id& id,
                     const primitive_id& data,
                     const primitive_id& indices,
                     const int64_t axis,
-                    const primitive_id& ext_prim_id = "",
                     const padding& output_padding = padding())
-        : primitive_base(id, {data, indices}, ext_prim_id, output_padding), output_format({}), output_shape({}), axis(axis) {}
+        : primitive_base(id, {data, indices}, output_padding), output_format({}), output_shape({}), axis(axis) {}
 
     /// @brief Gather Elements output format
     format output_format;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gather_nd.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gather_nd.hpp
@@ -37,9 +37,8 @@ struct gather_nd : public primitive_base<gather_nd> {
               const uint8_t indices_rank,
               const uint8_t batch_dims = 0,
               const bool batch_merged_output = true,
-              const primitive_id& ext_prim_id = "",
               const padding& output_padding = padding())
-        : primitive_base(id, {data, indices}, ext_prim_id, output_padding),
+        : primitive_base(id, {data, indices}, output_padding),
                          input_rank(input_rank),
                          indices_rank(indices_rank),
                          batch_dims(batch_dims),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gather_tree.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gather_tree.hpp
@@ -35,9 +35,8 @@ struct gather_tree : public primitive_base<gather_tree> {
                     const primitive_id& parent_input,
                     const primitive_id& max_seq_len_input,
                     const primitive_id& end_token,
-                    const primitive_id& ext_prim_id = "",
                     const padding& output_padding = padding())
-            : primitive_base(id, { step_input, parent_input, max_seq_len_input, end_token }, ext_prim_id, output_padding) {}
+            : primitive_base(id, { step_input, parent_input, max_seq_len_input, end_token }, output_padding) {}
 };
     /// @}
     /// @}

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gemm.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gemm.hpp
@@ -46,9 +46,8 @@ struct gemm : public primitive_base<gemm> {
          const bool transpose_input1 = false,
          const float alpha = 1.0f,
          const float beta = 0.0f,
-         const primitive_id& ext_prim_id = "",
          const padding& output_padding = padding())
-        : primitive_base(id, inputs, ext_prim_id, output_padding, optional_data_type{ data_type }),
+        : primitive_base(id, inputs, output_padding, optional_data_type{ data_type }),
           transpose_input0(transpose_input0),
           transpose_input1(transpose_input1),
           alpha(alpha),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/grn.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/grn.hpp
@@ -26,9 +26,8 @@ struct grn : public primitive_base<grn> {
         const primitive_id& input,
         const float bias,
         const data_types data_type,
-        const primitive_id& ext_prim_id = "",
         const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type{ data_type }),
+        : primitive_base(id, {input}, output_padding, optional_data_type{ data_type }),
         bias(bias)
     {}
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/input_layout.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/input_layout.hpp
@@ -28,8 +28,8 @@ struct input_layout : public primitive_base<input_layout> {
     /// @brief Constructs input layout primitive.
     /// @param id This primitive id.
     /// @param layout Defines layout for the data will be passed to network.
-    input_layout(const primitive_id& id, const layout& layout, const primitive_id& ext_prim_id = "")
-        : primitive_base(id, {}, ext_prim_id, layout.data_padding), layout(layout) {}
+    input_layout(const primitive_id& id, const layout& layout)
+        : primitive_base(id, {}, layout.data_padding), layout(layout) {}
 
     /// @brief Defines layout for the data will be passed to network.
     mutable cldnn::layout layout;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
@@ -130,9 +130,8 @@ struct loop : public primitive_base<loop> {
          int64_t max_iteration = -1,
          const primitive_id& current_iteration_id = primitive_id(),
          const primitive_id& condition_id = primitive_id(),
-         const primitive_id& ext_prim_id = "",
          const padding& output_padding = padding())
-            : primitive_base(id, inputs, ext_prim_id, output_padding),
+            : primitive_base(id, inputs, output_padding),
               body(body),
               trip_count_id(trip_count_id),
               initial_execution_id(initial_condition_id),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/lrn.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/lrn.hpp
@@ -48,9 +48,8 @@ struct lrn : public primitive_base<lrn> {
         float alpha,
         float beta,
         lrn_norm_region lrn_norm_region,
-        const primitive_id& ext_prim_id = "",
         const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           size(size),
           k(k),
           alpha(alpha),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm.hpp
@@ -85,9 +85,8 @@ struct lstm : public primitive_base<lstm> {
          const std::vector<activation_additional_params> activation_params = {},
          const lstm_output_selection output_selection = lstm_output_selection::sequence,
          const lstm_weights_order offset_order = lstm_weights_order::iofz,
-         const primitive_id& ext_prim_id = "",
          const padding& output_padding = padding())
-        : primitive_base(id, input, ext_prim_id, output_padding),
+        : primitive_base(id, input, output_padding),
           weights(weights),
           recurrent(recurrent),
           bias(bias),
@@ -167,9 +166,8 @@ struct lstm_gemm : public primitive_base<lstm_gemm> {
               const primitive_id& bias = "",
               const primitive_id& hidden = "",
               const uint32_t direction = 0,
-              const primitive_id& ext_prim_id = "",
               const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           weights(weights),
           recurrent(recurrent),
           bias(bias),
@@ -224,9 +222,8 @@ struct lstm_elt : public primitive_base<lstm_elt> {
              const std::vector<activation_additional_params> activation_params = {},
              const lstm_weights_order offset_order = lstm_weights_order::iofz,
              const uint32_t direction = 0,
-             const primitive_id& ext_prim_id = "",
              const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           cell(cell),
           clip(clip),
           input_forget(input_forget),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm_dynamic.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm_dynamic.hpp
@@ -52,9 +52,8 @@ struct lstm_dynamic : public primitive_base<lstm_dynamic> {
                  const primitive_id& initial_cell = "",
                  const float clip = 0.0f,
                  const bool input_forget = 0,
-                 const primitive_id& ext_prim_id = "",
                  const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           dyn_length(dyn_length),
           weights(weights),
           recurrent(recurrent),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm_dynamic_input.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm_dynamic_input.hpp
@@ -39,9 +39,8 @@ struct lstm_dynamic_input : public primitive_base<lstm_dynamic_input> {
                        const primitive_id& dyn_length,
                        const primitive_id& weights,
                        const primitive_id& bias = "",
-                       const primitive_id& ext_prim_id = "",
                        const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), dyn_length(dyn_length), weights(weights), bias(bias) {}
+        : primitive_base(id, {input}, output_padding), dyn_length(dyn_length), weights(weights), bias(bias) {}
 
     /// @brief Primitive id containing the dynamic sequence lengths.
     primitive_id dyn_length;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm_dynamic_timeloop.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm_dynamic_timeloop.hpp
@@ -47,9 +47,8 @@ struct lstm_dynamic_timeloop
                           const primitive_id& initial_cell = "",
                           const float clip = 0.0f,
                           const bool input_forget = 0,
-                          const primitive_id& ext_prim_id = "",
                           const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           dyn_length(dyn_length),
           recurrent(recurrent),
           last_hidden_state(last_hidden_state),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/max_unpooling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/max_unpooling.hpp
@@ -35,9 +35,8 @@ struct max_unpooling : public primitive_base<max_unpooling> {
                   const tensor& size,
                   const tensor& stride,
                   const tensor& pad = {0, 0, 0, 0},
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           argmax(argmax),
           pad(pad),
           stride(stride),
@@ -54,9 +53,8 @@ struct max_unpooling : public primitive_base<max_unpooling> {
                   const primitive_id& input,
                   const primitive_id& argmax,
                   tensor output_size,
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           argmax(argmax),
           with_output_size(true),
           output_size(output_size) {}

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/mutable_data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/mutable_data.hpp
@@ -33,9 +33,8 @@ struct mutable_data : public primitive_base<mutable_data> {
     /// @note If memory is attached by memory::attach(), the attached buffer should be valid till network build.
     mutable_data(const primitive_id& id,
                  memory::ptr mem,
-                 const primitive_id& ext_prim_id = "",
                  filler_type fill_type = filler_type::no_fill)
-        : primitive_base(id, {}, ext_prim_id, padding()), mem(mem), fill_type(fill_type) {}
+        : primitive_base(id, {}, padding()), mem(mem), fill_type(fill_type) {}
 
     /// @brief Constructs mutable_data primitive with inputs.
     /// @param id This primitive id.
@@ -46,9 +45,8 @@ struct mutable_data : public primitive_base<mutable_data> {
     mutable_data(const primitive_id& id,
                  const std::vector<primitive_id>& input,
                  memory::ptr mem,
-                 const primitive_id& ext_prim_id = "",
                  filler_type fill_type = filler_type::no_fill)
-        : primitive_base(id, {input}, ext_prim_id, padding()), mem(mem), fill_type(fill_type) {}
+        : primitive_base(id, {input}, padding()), mem(mem), fill_type(fill_type) {}
 
     /// @brief @ref memory object which contains data.
     /// @note If memory is attached by memory::attach(), the attached buffer should be valid till network build.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/mvn.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/mvn.hpp
@@ -32,9 +32,8 @@ struct mvn : public primitive_base<mvn> {
         const float epsilon,
         const bool eps_inside_sqrt,
         const bool across_channels = false,
-        const primitive_id& ext_prim_id = "",
         const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           normalize_variance(normalize_variance),
           epsilon(epsilon),
           eps_inside_sqrt(eps_inside_sqrt),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/non_max_suppression.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/non_max_suppression.hpp
@@ -47,9 +47,8 @@ struct non_max_suppression : public primitive_base<non_max_suppression> {
                         const primitive_id& score_threshold = primitive_id(),
                         const primitive_id& soft_nms_sigma = primitive_id(),
                         const primitive_id& second_output = primitive_id(),
-                        const primitive_id& third_output = primitive_id(),
-                        const primitive_id& ext_prim_id = "")
-        : primitive_base(id, {boxes_positions, boxes_score}, ext_prim_id)
+                        const primitive_id& third_output = primitive_id())
+        : primitive_base(id, {boxes_positions, boxes_score})
         , selected_indices_num(selected_indices_num)
         , center_point_box(center_point_box)
         , sort_result_descending(sort_result_descending)

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/non_zero.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/non_zero.hpp
@@ -16,9 +16,8 @@ struct count_nonzero : public primitive_base<count_nonzero> {
     /// @param data Input data primitive id.
     count_nonzero(const primitive_id& id,
                   const primitive_id& data,
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base(id, {data}, ext_prim_id, output_padding) {}
+        : primitive_base(id, {data}, output_padding) {}
 };
 
 struct gather_nonzero : public primitive_base<gather_nonzero> {
@@ -31,9 +30,8 @@ struct gather_nonzero : public primitive_base<gather_nonzero> {
     gather_nonzero(const primitive_id& id,
                    const primitive_id& data,
                    const primitive_id& output_shape,
-                   const primitive_id& ext_prim_id = "",
                    const padding& output_padding = padding())
-        : primitive_base(id, {data, output_shape}, ext_prim_id, output_padding) {}
+        : primitive_base(id, {data, output_shape}, output_padding) {}
 };
 
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/normalize.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/normalize.hpp
@@ -47,9 +47,8 @@ struct normalize : public primitive_base<normalize> {
               const primitive_id& scale_input,
               const bool across_spatial = true,
               const float epsilon = 1e-10f,
-              const primitive_id& ext_prim_id = "",
               const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           scale_input(scale_input),
           across_spatial(across_spatial),
           epsilon(epsilon) {}

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/one_hot.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/one_hot.hpp
@@ -53,9 +53,8 @@ struct one_hot : public primitive_base<one_hot> {
             const int64_t& depth,
             const float& on_value = 1.0f,
             const float& off_value = 0.0f,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding)
+        : primitive_base(id, {input}, output_padding)
         , shape(shape)
         , one_hot_axis(one_hot_axis)
         , depth(depth)
@@ -77,9 +76,8 @@ struct one_hot : public primitive_base<one_hot> {
             const int64_t& depth,
             const float& on_value = 1.0f,
             const float& off_value = 0.0f,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type{output_dt})
+        : primitive_base(id, {input}, output_padding, optional_data_type{output_dt})
         , shape(shape)
         , one_hot_axis(one_hot_axis)
         , depth(depth)

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/permute.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/permute.hpp
@@ -33,9 +33,8 @@ struct permute : public primitive_base<permute> {
     permute(const primitive_id& id,
             const primitive_id& input,
             const std::vector<uint16_t>& permute_order = {},
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), permute_order(permute_order) { }
+        : primitive_base(id, {input}, output_padding), permute_order(permute_order) { }
 
     /// @brief Array of permuted output order in bfyx format.
     std::vector<uint16_t> permute_order;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/pooling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/pooling.hpp
@@ -52,9 +52,8 @@ struct pooling : public primitive_base<pooling> {
             const ov::Shape& size,
             const ov::Strides& stride,
             const ov::Shape& pad = {0, 0},
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           argmax(""),
           mode(static_cast<pooling_mode>(mode)),
           global_pooling(false),
@@ -66,7 +65,6 @@ struct pooling : public primitive_base<pooling> {
 
     /// @brief Constructs pooling primitive with argmax.
     /// @param id This primitive id.
-    /// @param ext_prim_id
     /// @param input Input primitive id.
     /// @param argmax Primitive id which contains indices of each max pooling region.
     /// Indices must be in flattened bfyx format with no padding. Needs to be fp32 data type.
@@ -81,9 +79,8 @@ struct pooling : public primitive_base<pooling> {
             const ov::Shape& size,
             const ov::Strides& stride,
             const ov::Shape& pad = {0, 0},
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           argmax(argmax),
           mode(static_cast<pooling_mode>(mode)),
           global_pooling(false),
@@ -109,9 +106,8 @@ struct pooling : public primitive_base<pooling> {
             const ov::Shape& pad,
             tensor output_size,
             const data_types output_data_type,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type{output_data_type}),
+        : primitive_base(id, {input}, output_padding, optional_data_type{output_data_type}),
           argmax(""),
           mode(static_cast<pooling_mode>(mode)),
           global_pooling(false),
@@ -140,9 +136,8 @@ struct pooling : public primitive_base<pooling> {
             const ov::Strides& stride,
             const ov::Shape& pad,
             tensor output_size,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           argmax(argmax),
           mode(static_cast<pooling_mode>(mode)),
           global_pooling(false),
@@ -160,9 +155,8 @@ struct pooling : public primitive_base<pooling> {
     pooling(const primitive_id& id,
             const primitive_id& input,
             pooling_mode mode,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           argmax(""),
           mode(static_cast<pooling_mode>(mode)),
           global_pooling(true),
@@ -196,9 +190,8 @@ struct pooling : public primitive_base<pooling> {
             data_types index_element_type,
             tensor output_size,
             const data_types output_data_type,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-            : primitive_base(id, {input, indices_output}, ext_prim_id, output_padding, optional_data_type{output_data_type}),
+            : primitive_base(id, {input, indices_output}, output_padding, optional_data_type{output_data_type}),
               argmax(""),
               indices_output(indices_output),
               mode(pooling_mode::max),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/primitive.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/primitive.hpp
@@ -39,12 +39,10 @@ public:
     primitive(const primitive_type_id& type,
               const primitive_id& id,
               const std::vector<primitive_id>& input,
-              const primitive_id& ext_prim_id = "",
               const padding& output_padding = padding(),
               const optional_data_type output_data_type = optional_data_type())
         : type(type),
           id(id),
-          ext_prim_id(ext_prim_id),
           output_padding(output_padding),
           output_data_type(output_data_type),
           input(input) {}
@@ -82,9 +80,6 @@ public:
     /// @brief Primitive's id.
     const primitive_id id;
 
-    /// @brief Primitive's external id.
-    const primitive_id ext_prim_id;
-
     /// @brief Name of original ov operation.
     std::string origin_op_name;
 
@@ -116,10 +111,9 @@ class primitive_base : public primitive {
 protected:
     explicit primitive_base(const primitive_id& id,
                             const std::vector<primitive_id>& input,
-                            const primitive_id& ext_prim_id = "",
                             const padding& output_padding = padding(),
                             optional_data_type output_data_type = optional_data_type())
-        : primitive(PType::type_id(), id, input, ext_prim_id, output_padding, output_data_type) {}
+        : primitive(PType::type_id(), id, input, output_padding, output_data_type) {}
 };
 
 struct primitive_info {

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/primitive.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/primitive.hpp
@@ -85,6 +85,12 @@ public:
     /// @brief Primitive's external id.
     const primitive_id ext_prim_id;
 
+    /// @brief Name of original ov operation.
+    std::string origin_op_name;
+
+    /// @brief Type name of original ov operation.
+    std::string origin_op_type_name;
+
     /// @brief Requested output padding.
     padding output_padding;
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/prior_box.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/prior_box.hpp
@@ -55,9 +55,8 @@ struct prior_box : public primitive_base<prior_box> {
               const std::vector<float>& fixed_ratio = {},
               const std::vector<float>& fixed_size = {},
               const std::vector<float>& density = {},
-              const primitive_id& ext_prim_id = "",
               const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           img_size(img_size),
           min_sizes(min_sizes),
           max_sizes(max_sizes),
@@ -114,9 +113,8 @@ struct prior_box : public primitive_base<prior_box> {
               const std::vector<float>& widths,
               const std::vector<float>& heights,
               data_types output_dt,
-              const primitive_id& ext_prim_id = "",
               const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type{output_dt}),
+        : primitive_base(id, {input}, output_padding, optional_data_type{output_dt}),
           img_size(img_size),
           flip(false),
           clip(clip),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/proposal.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/proposal.hpp
@@ -33,9 +33,8 @@ struct proposal : public primitive_base<proposal> {
              int post_nms_topn,
              const std::vector<float>& ratios_param,
              const std::vector<float>& scales_param,
-             const primitive_id& ext_prim_id = "",
              const padding& output_padding = padding())
-        : primitive_base(id, {cls_scores, bbox_pred, image_info}, ext_prim_id, output_padding),
+        : primitive_base(id, {cls_scores, bbox_pred, image_info}, output_padding),
           max_proposals(max_proposals),
           iou_threshold(iou_threshold),
           base_bbox_size(16),
@@ -81,9 +80,8 @@ struct proposal : public primitive_base<proposal> {
              bool round_ratios,
              bool shift_anchors,
              bool normalize,
-             const primitive_id& ext_prim_id = "",
              const padding& output_padding = padding())
-        : primitive_base(id, {cls_scores, bbox_pred, image_info}, ext_prim_id, output_padding),
+        : primitive_base(id, {cls_scores, bbox_pred, image_info}, output_padding),
           max_proposals(max_proposals),
           iou_threshold(iou_threshold),
           base_bbox_size(base_bbox_size),
@@ -130,9 +128,8 @@ struct proposal : public primitive_base<proposal> {
              bool round_ratios,
              bool shift_anchors,
              bool normalize,
-             const primitive_id& ext_prim_id = "",
              const padding& output_padding = padding())
-            : primitive_base(id, {cls_scores, bbox_pred, image_info, second_output}, ext_prim_id, output_padding),
+            : primitive_base(id, {cls_scores, bbox_pred, image_info, second_output}, output_padding),
               max_proposals(max_proposals),
               iou_threshold(iou_threshold),
               base_bbox_size(base_bbox_size),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/pyramid_roi_align.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/pyramid_roi_align.hpp
@@ -50,11 +50,9 @@ struct pyramid_roi_align : public primitive_base<pyramid_roi_align> {
                       int sampling_ratio,
                       std::vector<int> pyramid_scales,
                       int pyramid_starting_level,
-                      const primitive_id& ext_prim_id = "",
                       const padding &output_padding = padding())
         : primitive_base(id,
                          { rois, P2, P3, P4, P5 },
-                         ext_prim_id,
                          output_padding)
         , output_size(output_size)
         , sampling_ratio(sampling_ratio)

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/quantize.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/quantize.hpp
@@ -31,9 +31,8 @@ struct quantize : public primitive_base<quantize> {
              const primitive_id& output_high,
              const int levels,
              const data_types output_data_type,
-             const primitive_id& ext_prim_id = "",
              const padding& output_padding = padding())
-        : primitive_base(id, {input, input_low, input_high, output_low, output_high}, ext_prim_id, output_padding, optional_data_type{output_data_type})
+        : primitive_base(id, {input, input_low, input_high, output_low, output_high}, output_padding, optional_data_type{output_data_type})
         , levels(levels) {}
 
     /// @brief levels The number of quantization levels.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/random_uniform.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/random_uniform.hpp
@@ -36,7 +36,7 @@ struct random_uniform : public primitive_base<random_uniform> {
                    const uint64_t op_seed, const tensor output_shape,
                    const format output_format,
                    const padding &output_padding = padding())
-            : primitive_base(id, inputs, "", output_padding,
+            : primitive_base(id, inputs, output_padding,
                              optional_data_type{data_type}),
               global_seed(global_seed),
               op_seed(op_seed),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/range.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/range.hpp
@@ -10,9 +10,8 @@ namespace cldnn {
 struct range: public primitive_base<range> {
     CLDNN_DECLARE_PRIMITIVE(range)
 
-    range(const primitive_id &id, const std::vector<primitive_id> &input, const layout &output_layout,
-          const primitive_id &ext_prim_id = { }) :
-        primitive_base { id, input, ext_prim_id, output_layout.data_padding }, output_layout { output_layout } {
+    range(const primitive_id &id, const std::vector<primitive_id> &input, const layout &output_layout) :
+        primitive_base { id, input, output_layout.data_padding }, output_layout { output_layout } {
     }
     layout output_layout;
 };

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/read_value.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/read_value.hpp
@@ -30,7 +30,7 @@ struct read_value : public primitive_base<read_value> {
                const std::vector<primitive_id>& inputs,
                const std::string& variable_id,
                const layout& output_layout)
-            : primitive_base(id, inputs, "", {}, optional_data_type{output_layout.data_type}),
+            : primitive_base(id, inputs, {}, optional_data_type{output_layout.data_type}),
               variable_id{variable_id},
               output_layout{output_layout} {}
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reduce.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reduce.hpp
@@ -58,9 +58,8 @@ struct reduce : public primitive_base<reduce> {
            const reduce_mode mode,
            const std::vector<int64_t> axes,
            const bool keep_dims,
-           const primitive_id& ext_prim_id = "",
            const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), mode(mode), axes(axes), keep_dims(keep_dims) {}
+        : primitive_base(id, {input}, output_padding), mode(mode), axes(axes), keep_dims(keep_dims) {}
 
     /// @brief Reduce operation type
     reduce_mode mode;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/region_yolo.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/region_yolo.hpp
@@ -32,9 +32,8 @@ struct region_yolo : public primitive_base<region_yolo> {
                 const uint32_t num,
                 const uint32_t mask_size = 0,
                 const bool do_softmax = true,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           coords(coords),
           classes(classes),
           num(num),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reorder.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reorder.hpp
@@ -40,9 +40,8 @@ struct reorder : public primitive_base<reorder> {
             const primitive_id& input,
             const layout& output_layout,
             const std::vector<float>& values_to_subtract = {},
-            const reorder_mean_mode mode = reorder_mean_mode::subtract,
-            const primitive_id& ext_prim_id = "")
-        : primitive_base(id, {input}, ext_prim_id, output_layout.data_padding, optional_data_type {output_layout.data_type}),
+            const reorder_mean_mode mode = reorder_mean_mode::subtract)
+        : primitive_base(id, {input}, output_layout.data_padding, optional_data_type {output_layout.data_type}),
           output_format(output_layout.format),
           mean(""),
           subtract_per_feature(values_to_subtract),
@@ -57,9 +56,8 @@ struct reorder : public primitive_base<reorder> {
             const primitive_id& input,
             const layout& output_layout,
             primitive_id const& mean,
-            const reorder_mean_mode mode = reorder_mean_mode::subtract,
-            const primitive_id& ext_prim_id = "")
-        : primitive_base(id, {input}, ext_prim_id, output_layout.data_padding, optional_data_type {output_layout.data_type}),
+            const reorder_mean_mode mode = reorder_mean_mode::subtract)
+        : primitive_base(id, {input}, output_layout.data_padding, optional_data_type {output_layout.data_type}),
           output_format(output_layout.format),
           mean(mean),
           subtract_per_feature(0),
@@ -76,9 +74,8 @@ struct reorder : public primitive_base<reorder> {
             data_types output_data_type,
             const std::vector<float>& values_to_subtract = {},
             const reorder_mean_mode mode = reorder_mean_mode::subtract,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type{output_data_type}),
+        : primitive_base(id, {input}, output_padding, optional_data_type{output_data_type}),
           output_format(output_format),
           mean(""),
           subtract_per_feature(values_to_subtract),
@@ -95,9 +92,8 @@ struct reorder : public primitive_base<reorder> {
             data_types output_data_type,
             primitive_id const& mean,
             const reorder_mean_mode mode = reorder_mean_mode::subtract,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type {output_data_type}),
+        : primitive_base(id, {input}, output_padding, optional_data_type {output_data_type}),
           output_format(output_format),
           mean(mean),
           subtract_per_feature(0),
@@ -114,9 +110,8 @@ struct reorder : public primitive_base<reorder> {
             const primitive_id& input2,
             const layout& output_layout,
             const std::vector<float>& values_to_subtract = {},
-            const reorder_mean_mode mode = reorder_mean_mode::subtract,
-            const primitive_id& ext_prim_id = "")
-        : primitive_base(id, { input, input2 }, ext_prim_id, output_layout.data_padding, optional_data_type { output_layout.data_type }),
+            const reorder_mean_mode mode = reorder_mean_mode::subtract)
+        : primitive_base(id, { input, input2 }, output_layout.data_padding, optional_data_type { output_layout.data_type }),
           output_format(output_layout.format),
           mean(""),
           subtract_per_feature(values_to_subtract),
@@ -133,9 +128,8 @@ struct reorder : public primitive_base<reorder> {
             const primitive_id& input2,
             const layout& output_layout,
             primitive_id const& mean,
-            const reorder_mean_mode mode = reorder_mean_mode::subtract,
-            const primitive_id& ext_prim_id = "")
-        : primitive_base(id, { input, input2 }, ext_prim_id, output_layout.data_padding, optional_data_type{ output_layout.data_type }),
+            const reorder_mean_mode mode = reorder_mean_mode::subtract)
+        : primitive_base(id, { input, input2 }, output_layout.data_padding, optional_data_type{ output_layout.data_type }),
         output_format(output_layout.format),
         mean(mean),
         mean_mode(mode) {}

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reorg_yolo.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reorg_yolo.hpp
@@ -28,9 +28,8 @@ struct reorg_yolo : public primitive_base<reorg_yolo> {
     reorg_yolo(const primitive_id& id,
                const primitive_id& input,
                const uint32_t stride,
-               const primitive_id& ext_prim_id = "",
                const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), stride(stride) {}
+        : primitive_base(id, {input}, output_padding), stride(stride) {}
 
     /// @brief Defines a scope of a reorg yolo normalization
     /// @details

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
@@ -35,9 +35,8 @@ struct resample : public primitive_base<resample> {
              tensor output_size,
              uint32_t num_filter,
              InterpolateOp::InterpolateMode operation_type = InterpolateOp::InterpolateMode::NEAREST,
-             const primitive_id& ext_prim_id = "",
              const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           output_size(output_size),
           num_filter(num_filter),
           output_pattern({}),
@@ -72,9 +71,8 @@ struct resample : public primitive_base<resample> {
              InterpolateOp::ShapeCalcMode shape_calc_mode = InterpolateOp::ShapeCalcMode::SIZES,
              InterpolateOp::CoordinateTransformMode ctm = InterpolateOp::CoordinateTransformMode::HALF_PIXEL,
              InterpolateOp::NearestMode nm = InterpolateOp::NearestMode::ROUND_PREFER_FLOOR,
-             const primitive_id& ext_prim_id = "",
              const padding& output_padding = padding())
-        : primitive_base(id, {input, pattern_id}, ext_prim_id, output_padding),
+        : primitive_base(id, {input, pattern_id}, output_padding),
           output_size(tensor()),
           num_filter(0),
           output_pattern({}),
@@ -106,9 +104,8 @@ struct resample : public primitive_base<resample> {
              InterpolateOp::ShapeCalcMode shape_calc_mode = InterpolateOp::ShapeCalcMode::SIZES,
              InterpolateOp::CoordinateTransformMode ctm = InterpolateOp::CoordinateTransformMode::HALF_PIXEL,
              InterpolateOp::NearestMode nm = InterpolateOp::NearestMode::ROUND_PREFER_FLOOR,
-             const primitive_id& ext_prim_id = "",
              const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           output_size(tensor()),
           num_filter(0),
           output_pattern(output_pattern),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reshape.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reshape.hpp
@@ -32,9 +32,8 @@ struct reshape : public primitive_base<reshape> {
     reshape(const primitive_id& id,
             const primitive_id& input,
             const tensor& output_shape,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding)
+        : primitive_base(id, {input}, output_padding)
         , output_shape(output_shape)
         , output_pattern({})
         , output_partial_shape({}) {}
@@ -45,9 +44,8 @@ struct reshape : public primitive_base<reshape> {
             const primitive_id& pattern_id,
             bool special_zero,
             const ov::PartialShape& output_partial_shape,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input, pattern_id}, ext_prim_id, output_padding)
+        : primitive_base(id, {input, pattern_id}, output_padding)
         , output_shape(tensor())
         , special_zero(special_zero)
         , output_pattern({})
@@ -59,9 +57,8 @@ struct reshape : public primitive_base<reshape> {
             bool special_zero,
             const std::vector<int64_t>& output_pattern,
             const ov::PartialShape& output_partial_shape,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding)
+        : primitive_base(id, {input}, output_padding)
         , output_shape(tensor())
         , special_zero(special_zero)
         , output_pattern(output_pattern)

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reverse.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reverse.hpp
@@ -23,9 +23,8 @@ struct reverse : public primitive_base<reverse> {
             const primitive_id& input,
             const primitive_id& axes,
             const reverse_mode mode,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base{id, {input, axes}, ext_prim_id, output_padding},
+        : primitive_base{id, {input, axes}, output_padding},
           mode{mode} {}
 
     reverse_mode mode{reverse_mode::index};

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/reverse_sequence.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/reverse_sequence.hpp
@@ -31,9 +31,8 @@ struct reverse_sequence : public primitive_base<reverse_sequence> {
                      const primitive_id& seq_lengths,
                      const int32_t seq_axis,
                      const int32_t batch_axis = 0,
-                     const primitive_id& ext_prim_id = "",
                      const padding& output_padding = padding())
-        : primitive_base(id, {input, seq_lengths}, ext_prim_id, output_padding), seq_axis(seq_axis), batch_axis(batch_axis) {
+        : primitive_base(id, {input, seq_lengths}, output_padding), seq_axis(seq_axis), batch_axis(batch_axis) {
         const int32_t number_of_dims = 4;
 
         int32_t batch_a = batch_axis;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/roi_align.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/roi_align.hpp
@@ -42,9 +42,8 @@ struct roi_align : public primitive_base<roi_align> {
               float spatial_scale,
               PoolingMode pooling_mode,
               AlignedMode aligned_mode,
-              const primitive_id& ext_prim_id = "",
               const padding& output_padding = padding())
-        : primitive_base(id, inputs, ext_prim_id, output_padding),
+        : primitive_base(id, inputs, output_padding),
           pooled_h{pooled_h},
           pooled_w{pooled_w},
           sampling_ratio{sampling_ratio},

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/roi_pooling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/roi_pooling.hpp
@@ -30,9 +30,8 @@ struct roi_pooling : public primitive_base<roi_pooling> {
                 int output_dim = 0,
                 int spatial_bins_x = 1,
                 int spatial_bins_y = 1,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-        : primitive_base(id, {input_data, input_rois}, ext_prim_id, output_padding),
+        : primitive_base(id, {input_data, input_rois}, output_padding),
           mode(mode),
           position_sensitive(position_sensitive),
           pooled_width(pooled_width),
@@ -60,9 +59,8 @@ struct roi_pooling : public primitive_base<roi_pooling> {
                 int output_dim = 0,
                 int spatial_bins_x = 1,
                 int spatial_bins_y = 1,
-                const primitive_id& ext_prim_id = "",
                 const padding& output_padding = padding())
-        : primitive_base(id, {inputs}, ext_prim_id, output_padding),
+        : primitive_base(id, {inputs}, output_padding),
           mode(mode),
           position_sensitive(position_sensitive),
           pooled_width(pooled_width),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/roll.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/roll.hpp
@@ -26,9 +26,8 @@ struct roll : primitive_base<roll> {
     roll(const primitive_id& id,
          const primitive_id& input,
          const tensor& shift,
-         const primitive_id& ext_prim_id = {},
          const padding& output_padding = {})
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           shift(shift) {}
 
     /// @brief Tensor which specifies the number of places by which the elements are shifted.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/scale.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/scale.hpp
@@ -40,9 +40,8 @@ struct scale : public primitive_base<scale> {
           const primitive_id& scale_input,  // should be bfyx or yxfb, where each dimension can be 1, if all dimensions
                                             // are 1 then this is scalar
           const optional_data_type& output_dt = {},
-          const primitive_id& ext_prim_id = "",
           const padding& output_padding = padding())
-        : primitive_base(id, {input, scale_input}, ext_prim_id, output_padding, output_dt), bias("") {}
+        : primitive_base(id, {input, scale_input}, output_padding, output_dt), bias("") {}
 
     /// @brief Constructs scale primitive with optional adding bias.
     /// @param id This primitive id.
@@ -55,9 +54,8 @@ struct scale : public primitive_base<scale> {
                                             // are 1 then this is scalar
           const primitive_id& bias,  // should be same size as scale_input
           const optional_data_type& output_dt = {},
-          const primitive_id& ext_prim_id = "",
           const padding& output_padding = padding())
-        : primitive_base(id, {input, scale_input}, ext_prim_id, output_padding, output_dt), bias(bias) {}
+        : primitive_base(id, {input, scale_input}, output_padding, output_dt), bias(bias) {}
 
     /// @brief Primitive id containing bias data.
     primitive_id bias;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/scatter_elements_update.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/scatter_elements_update.hpp
@@ -30,9 +30,8 @@ struct scatter_elements_update : public primitive_base<scatter_elements_update> 
                             const primitive_id& idx,
                             const primitive_id& idupd,
                             const int64_t axis,
-                            const primitive_id& ext_prim_id = "",
                             const padding& output_padding = padding())
-        : primitive_base(id, {data, idx, idupd}, ext_prim_id, output_padding), axis(axis) {}
+        : primitive_base(id, {data, idx, idupd}, output_padding), axis(axis) {}
 
     /// @brief ScatterElementsUpdate axis
     int64_t axis;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/scatter_nd_update.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/scatter_nd_update.hpp
@@ -30,9 +30,8 @@ struct scatter_nd_update : public primitive_base<scatter_nd_update> {
                       const primitive_id& idx,
                       const primitive_id& idupd,
                       const size_t indices_rank,
-                      const primitive_id& ext_prim_id = "",
                       const padding& output_padding = padding())
-        : primitive_base(id, {data, idx, idupd}, ext_prim_id, output_padding), indices_rank(indices_rank) {}
+        : primitive_base(id, {data, idx, idupd}, output_padding), indices_rank(indices_rank) {}
 
     /// @brief ScatterNDUpdate indices_rank
     size_t indices_rank;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/scatter_update.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/scatter_update.hpp
@@ -39,9 +39,8 @@ struct scatter_update : public primitive_base<scatter_update> {
                    const primitive_id& idx,
                    const primitive_id& idupd,
                    const int64_t axis,
-                   const primitive_id& ext_prim_id = "",
                    const padding& output_padding = padding())
-        : primitive_base(id, {dict, idx, idupd}, ext_prim_id, output_padding), axis(axis) {}
+        : primitive_base(id, {dict, idx, idupd}, output_padding), axis(axis) {}
 
     /// @brief ScatterUpdate axis
     int64_t axis;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/select.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/select.hpp
@@ -40,10 +40,9 @@ struct select : public primitive_base<select> {
            const primitive_id& mask,
            const primitive_id& input,
            const primitive_id& input2,
-           const primitive_id& ext_prim_id = "",
            const padding& output_padding = padding(),
            const std::string& broadcast_type = "numpy")
-        : primitive_base(id, {mask, input, input2}, ext_prim_id, output_padding),
+        : primitive_base(id, {mask, input, input2}, output_padding),
           broadcast_type(broadcast_type) {}
 
     /// @brief String which determines broadcast type.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/shape_of.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/shape_of.hpp
@@ -27,9 +27,8 @@ struct shape_of : public primitive_base<shape_of> {
              const primitive_id& input,
              size_t output_rank,
              const data_types output_data_type,
-             const primitive_id& ext_prim_id = "",
              const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding, optional_data_type{output_data_type})
+        : primitive_base(id, {input}, output_padding, optional_data_type{output_data_type})
         , output_rank(output_rank) {}
 
     size_t output_rank;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/shuffle_channels.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/shuffle_channels.hpp
@@ -29,9 +29,8 @@ struct shuffle_channels : public primitive_base<shuffle_channels> {
                      const primitive_id& input,
                      const int32_t group,
                      const int32_t axis = 1,
-                     const primitive_id& ext_prim_id = "",
                      const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), group(group), axis(axis) {}
+        : primitive_base(id, {input}, output_padding), group(group), axis(axis) {}
 
     /// @brief The number of groups to split the channel dimension. This number must evenly divide the channel dimension size.
     int32_t group;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/slice.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/slice.hpp
@@ -23,9 +23,8 @@ struct slice : public primitive_base<slice> {
     slice(const primitive_id& id,
                   const std::vector<primitive_id>& inputs,
                   const tensor output_shape,
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base{id, inputs, ext_prim_id, output_padding},
+        : primitive_base{id, inputs, output_padding},
           output_shape {output_shape}
     {}
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/softmax.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/softmax.hpp
@@ -32,9 +32,8 @@ struct softmax : public primitive_base<softmax> {
     softmax(const primitive_id& id,
             const primitive_id& input,
             const int64_t dimension = 1,
-            const primitive_id& ext_prim_id = "",
             const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), dimension(dimension) {}
+        : primitive_base(id, {input}, output_padding), dimension(dimension) {}
 
     /// @brief Defines a scope of a single softmax normalization.
     /// @details

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/space_to_batch.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/space_to_batch.hpp
@@ -56,9 +56,8 @@ struct space_to_batch : public primitive_base<space_to_batch> {
                    const tensor& pads_begin,
                    const tensor& pads_end,
                    const tensor& out_size,
-                   const primitive_id& ext_prim_id = "",
                    const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           block_shape(block_shape),
           pads_begin(pads_begin),
           pads_end(pads_end),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/space_to_depth.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/space_to_depth.hpp
@@ -63,9 +63,8 @@ struct space_to_depth : public primitive_base<space_to_depth> {
                    const primitive_id& input,
                    depth_mode mode,
                    const size_t block_size = 1,
-                   const primitive_id& ext_prim_id = "",
                    const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), mode(mode), block_size(block_size) {}
+        : primitive_base(id, {input}, output_padding), mode(mode), block_size(block_size) {}
 
     /// @brief Depth mode.
     depth_mode mode;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/split.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/split.hpp
@@ -46,9 +46,8 @@ struct split : public primitive_base<split> {
     split(const primitive_id& id,
           const primitive_id& input,
           const std::vector<std::pair<primitive_id, tensor> >& output_ids_offsets,
-          const primitive_id& ext_prim_id = "",
           const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           output_offsets(extract_tensor_vector(output_ids_offsets)),
           output_ids(extract_primitive_vector(output_ids_offsets)) {}
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/strided_slice.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/strided_slice.hpp
@@ -44,9 +44,8 @@ struct strided_slice : public primitive_base<strided_slice> {
                   const std::vector<int64_t>& shrink_axis_mask,
                   const std::vector<int64_t>& ellipsis_mask,
                   const ov::Shape out_size,
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base(id, {input, begin_id, end_id, strides_id}, ext_prim_id, output_padding),
+        : primitive_base(id, {input, begin_id, end_id, strides_id}, output_padding),
           begin_mask(begin_mask),
           end_mask(end_mask),
           new_axis_mask(new_axis_mask),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/tile.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/tile.hpp
@@ -25,18 +25,16 @@ struct tile : public primitive_base<tile> {
     tile(const primitive_id& id,
          const primitive_id& input,
          const std::vector<int64_t> repeats,
-         const primitive_id& ext_prim_id = "",
          const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding),
+        : primitive_base(id, {input}, output_padding),
           repeats(repeats) {}
 
     // @brief Constructs tile primitive with dynamic input.
     tile(const primitive_id& id,
          const primitive_id& input,
          const primitive_id& repeats_id,
-         const primitive_id& ext_prim_id = "",
          const padding& output_padding = padding())
-        : primitive_base(id, {input, repeats_id}, ext_prim_id, output_padding),
+        : primitive_base(id, {input, repeats_id}, output_padding),
           repeats({}) {}
 
     /// @brief A per-dimension replication factor

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/graph_initializations.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/graph_initializations.cpp
@@ -343,7 +343,6 @@ void graph_initializations::handle_dynamic_lstm_node(program& p, lstm_dynamic_no
                                              dyn_length_id,
                                              weights_id,
                                              bias_id,
-                                             "",
                                              node.get_primitive()->output_padding);
     auto& lstm_dynamic_input_node = p.get_or_create(lstm_dynamic_input_primitive);
     p.add_connection(node.input(), lstm_dynamic_input_node);  // connect real input to dlstm_input
@@ -370,7 +369,6 @@ void graph_initializations::handle_dynamic_lstm_node(program& p, lstm_dynamic_no
                                                 init_cell_id,
                                                 node.clip(),
                                                 node.input_forget(),
-                                                "",
                                                 lstm_dynamic_input_primitive->output_padding);
     auto& lstm_dynamic_timeloop_node = p.get_or_create(lstm_dynamic_timeloop_primitive);
     p.add_connection(lstm_dynamic_input_node, lstm_dynamic_timeloop_node);  // connect dlstm_input to dlstm_timeloop

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/pre_replace_deconv.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/pre_replace_deconv.cpp
@@ -118,7 +118,6 @@ void pre_replace_deconv::run(program& p) {
                                                               pad,
                                                               dilation,
                                                               grouped_weights_shape,
-                                                              "",
                                                               output_padding);
                 } else {
                     tensor output_size(0);
@@ -133,7 +132,6 @@ void pre_replace_deconv::run(program& p) {
                                                                   dilation,
                                                                   output_size,
                                                                   grouped_weights_shape,
-                                                                  "",
                                                                   output_padding);
                     } else {
                         conv_prim = std::make_shared<convolution>(deconv_node_id,
@@ -145,7 +143,6 @@ void pre_replace_deconv::run(program& p) {
                                                                   dilation,
                                                                   output_size,
                                                                   grouped_weights_shape,
-                                                                  "",
                                                                   output_padding);
                     }
                 }
@@ -283,7 +280,6 @@ void pre_replace_deconv::run(program& p) {
                                                                pad,
                                                                dilation,
                                                                grouped_weights_shape,
-                                                               "",
                                                                output_padding);
                 program_node& created_node = p.get_or_create(conv_prim);
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -517,7 +517,6 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
                                                                        desc->weights,
                                                                        bias_name,
                                                                        fc.get_output_layout().data_type,
-                                                                       desc->ext_prim_id,
                                                                        desc->output_padding,
                                                                        desc->input_size);
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
@@ -703,7 +703,6 @@ void prepare_quantization::prepare_asymmetric_quantization(program &p, convoluti
                 old_conv_prim->dilation,
                 output_size,
                 old_conv_prim->grouped_weights_shape,
-                "",
                 old_conv_prim->output_padding);
 
     auto& new_conv_node = p.get_or_create(new_conv_prim);

--- a/src/plugins/intel_gpu/src/graph/include/generic_layer.hpp
+++ b/src/plugins/intel_gpu/src/graph/include/generic_layer.hpp
@@ -35,9 +35,8 @@ struct generic_layer : public primitive_base<generic_layer> {
                   const primitive_id& input,
                   const layout& output_layout,
                   const kernel_selector::generic_kernel_params& generic_params,
-                  const primitive_id& ext_prim_id = "",
                   const padding& output_padding = padding())
-        : primitive_base(id, {input}, ext_prim_id, output_padding), output_layout(output_layout), generic_params(generic_params) {}
+        : primitive_base(id, {input}, output_padding), output_layout(output_layout), generic_params(generic_params) {}
 
     /// @brief Requested memory layout.
     layout output_layout;

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -87,7 +87,6 @@ public:
     primitive_type_id type() const { return _node.type(); }
     primitive_id id() const { return _node.id(); }
     primitive_id org_id() const { return _node.get_org_primitive_id(); }
-    const primitive_id& get_ext_prim_id() const { return _node.get_ext_prim_id(); }
     bool can_be_optimized() const { return _node.can_be_optimized(); }
     std::shared_ptr<const primitive> desc() const { return _node.get_primitive(); }
     program_node const& get_node() const { return _node; }

--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -149,8 +149,6 @@ public:
         return params;
     }
 
-    const primitive_id& get_ext_prim_id() const { return desc->ext_prim_id; }
-
     template <class PType>
     bool is_type() const {
         static_assert(

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -796,7 +796,7 @@ const program::graph_optimizer_info& network::get_optimizer_passes_info() const 
 std::map<primitive_id, primitive_id> network::get_ext_id_mapping() const {
     std::map<primitive_id, primitive_id> result;
     for (auto& prim : _primitives) {
-        result.emplace(prim.first, prim.second->get_ext_prim_id());
+        result.emplace(prim.first, prim.second->get_node().get_primitive()->origin_op_name);
     }
     for (auto& opt_id : _program->get_optimized_out()) {
         std::string ext_id = opt_id;

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -950,7 +950,8 @@ void program::replace(program_node& old_node, program_node& new_node) {
     new_node.constant = old_node.constant;
     new_node.data_flow = old_node.data_flow;
     new_node.user_mark = old_node.user_mark;
-    const_cast<primitive_id&>(new_node.desc->ext_prim_id) = old_node.desc->ext_prim_id;
+    const_cast<std::string&>(new_node.desc->origin_op_name) = old_node.desc->origin_op_name;
+    const_cast<std::string&>(new_node.desc->origin_op_type_name) = old_node.desc->origin_op_type_name;
 
     processing_order.insert(&old_node, &new_node);
     if (processing_order.get_processing_iterator(old_node) != processing_order.end())

--- a/src/plugins/intel_gpu/src/plugin/graph.cpp
+++ b/src/plugins/intel_gpu/src/plugin/graph.cpp
@@ -65,9 +65,9 @@ Graph::Graph(std::shared_ptr<Graph> graph, uint16_t stream_id)
 
 void Graph::UpdateLayersMaps() {
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "Graph::UpdateLayersMaps");
-    primitiveIDs = m_program->primitiveIDs;
+    primitiveIDs = m_program->primitive_ids;
     prevPrimitiveIDs = m_program->prevPrimitiveIDs;
-    profilingIDs = m_program->profilingIDs;
+    profilingIDs = m_program->profiling_ids;
     perfMap = m_program->perfMap;
     outputDims = m_program->outputDims;
 }

--- a/src/plugins/intel_gpu/src/plugin/graph.cpp
+++ b/src/plugins/intel_gpu/src/plugin/graph.cpp
@@ -572,9 +572,19 @@ std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> Graph::GetPer
     auto extIdMap = GetNetwork()->get_ext_id_mapping();
 
     auto getUpperCaseName = [](std::string name) {
-        if (name.length() > 0)
-            name[0] = toupper(name[0]);
-        return name;
+        std::vector<char> res;
+        bool convert_next_to_upper = true;
+        for (size_t i = 0; i < name.length(); i++) {
+            char c = convert_next_to_upper ? toupper(name[i]) : name[i];
+            if (c == '_') {
+                convert_next_to_upper = true;
+            } else {
+                convert_next_to_upper = false;
+                res.push_back(c);
+            }
+        }
+
+        return std::string(res.begin(), res.end());
     };
 
     auto getClearName = [](std::string name) {
@@ -587,11 +597,10 @@ std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> Graph::GetPer
     auto getFromProfiling = [&](std::string primId) -> bool {
         auto perfIter = perfMap.find(primId);
 
-        if (perfIter == perfMap.end())  return false;
-
-        const auto& layerName = perfIter->second.first;
-        if (layerName.length() == 0)  // no layer directly associated
+        if (perfIter == perfMap.end())
             return false;
+
+        auto layerName = getClearName(perfIter->second.first);
 
         const auto& perfCounter = perfIter->second.second;
 

--- a/src/plugins/intel_gpu/src/plugin/ops/adaptive_pooling.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/adaptive_pooling.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateAdaptiveAvgPoolOp(Program& p, const std::shared_ptr<ngraph::op::v8::AdaptiveAvgPool>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
 
     const auto input_primitives = p.GetInputPrimitiveIDs(op);
     const auto layer_name = layer_type_name_ID(op);
@@ -24,15 +24,12 @@ static void CreateAdaptiveAvgPoolOp(Program& p, const std::shared_ptr<ngraph::op
                                            input_primitives[0],
                                            tensor_from_dims(op->get_output_shape(0)),
                                            op_friendly_name};
-    p.AddPrimitive(poolPrim);
-    p.AddPrimitiveToProfiler(poolPrim, op);
+    p.add_primitive(*op, poolPrim);
 }
 
 static void CreateAdaptiveMaxPoolOp(Program& p, const std::shared_ptr<ngraph::op::v8::AdaptiveMaxPool>& op) {
-    p.ValidateInputs(op, {2});
-    if (op->get_output_size() != 2) {
-        IE_THROW() << "AdaptiveMaxPool requires 2 outputs";
-    }
+    validate_inputs_count(op, {2});
+    OPENVINO_ASSERT(op->get_output_size() == 2, "[GPU] AdaptiveMaxPool requires 2 outputs");
 
     auto input_primitives = p.GetInputPrimitiveIDs(op);
     const auto layer_type_name = layer_type_name_ID(op);
@@ -48,8 +45,7 @@ static void CreateAdaptiveMaxPoolOp(Program& p, const std::shared_ptr<ngraph::op
 
     const cldnn::primitive_id indices_id_w = layer_type_name + "_md_write";
     const cldnn::mutable_data indices_mutable_prim_w{indices_id_w, indices_memory, op_friendly_name};
-    p.primitiveIDs[indices_id_w] = indices_id_w;
-    p.AddPrimitive(indices_mutable_prim_w);
+    p.add_primitive(*op, indices_mutable_prim_w);
 
     input_primitives.push_back(indices_id_w);
 
@@ -59,14 +55,11 @@ static void CreateAdaptiveMaxPoolOp(Program& p, const std::shared_ptr<ngraph::op
                                            input_primitives.back(),
                                            DataTypeFromPrecision(op->get_index_element_type()),
                                            op_friendly_name};
-    p.AddPrimitive(poolPrim);
+    p.add_primitive(*op, poolPrim);
 
     const cldnn::primitive_id indices_id_r = layer_type_name + ".1";
     const cldnn::mutable_data indices_mutable_prim_r{indices_id_r, {layer_name}, indices_memory, op_friendly_name};
-    p.primitiveIDs[indices_id_r] = indices_id_r;
-    p.AddPrimitive(indices_mutable_prim_r);
-
-    p.AddPrimitiveToProfiler(poolPrim, op);
+    p.add_primitive(*op, indices_mutable_prim_r);
 }
 
 REGISTER_FACTORY_IMPL(v8, AdaptiveAvgPool);

--- a/src/plugins/intel_gpu/src/plugin/ops/adaptive_pooling.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/adaptive_pooling.cpp
@@ -18,12 +18,10 @@ static void CreateAdaptiveAvgPoolOp(Program& p, const std::shared_ptr<ngraph::op
 
     const auto input_primitives = p.GetInputPrimitiveIDs(op);
     const auto layer_name = layer_type_name_ID(op);
-    const auto op_friendly_name = op->get_friendly_name();
 
     const cldnn::adaptive_pooling poolPrim{layer_name,
                                            input_primitives[0],
-                                           tensor_from_dims(op->get_output_shape(0)),
-                                           op_friendly_name};
+                                           tensor_from_dims(op->get_output_shape(0))};
     p.add_primitive(*op, poolPrim);
 }
 
@@ -33,8 +31,7 @@ static void CreateAdaptiveMaxPoolOp(Program& p, const std::shared_ptr<ngraph::op
 
     auto input_primitives = p.GetInputPrimitiveIDs(op);
     const auto layer_type_name = layer_type_name_ID(op);
-    const auto layer_name = layer_type_name + ".0";
-    const auto op_friendly_name = op->get_friendly_name();
+    const auto layer_name = layer_type_name + ".out0";
 
     const auto indices_precision = op->get_output_element_type(1);
     const auto indices_shape = op->get_output_shape(1);
@@ -44,7 +41,7 @@ static void CreateAdaptiveMaxPoolOp(Program& p, const std::shared_ptr<ngraph::op
     const auto indices_memory = p.GetEngine().allocate_memory(indices_layout);
 
     const cldnn::primitive_id indices_id_w = layer_type_name + "_md_write";
-    const cldnn::mutable_data indices_mutable_prim_w{indices_id_w, indices_memory, op_friendly_name};
+    const cldnn::mutable_data indices_mutable_prim_w{indices_id_w, indices_memory};
     p.add_primitive(*op, indices_mutable_prim_w);
 
     input_primitives.push_back(indices_id_w);
@@ -53,12 +50,11 @@ static void CreateAdaptiveMaxPoolOp(Program& p, const std::shared_ptr<ngraph::op
                                            input_primitives[0],
                                            tensor_from_dims(op->get_output_shape(0)),
                                            input_primitives.back(),
-                                           DataTypeFromPrecision(op->get_index_element_type()),
-                                           op_friendly_name};
+                                           DataTypeFromPrecision(op->get_index_element_type())};
     p.add_primitive(*op, poolPrim);
 
-    const cldnn::primitive_id indices_id_r = layer_type_name + ".1";
-    const cldnn::mutable_data indices_mutable_prim_r{indices_id_r, {layer_name}, indices_memory, op_friendly_name};
+    const cldnn::primitive_id indices_id_r = layer_type_name + ".out1";
+    const cldnn::mutable_data indices_mutable_prim_r{indices_id_r, {layer_name}, indices_memory};
     p.add_primitive(*op, indices_mutable_prim_r);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/batch_to_space.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/batch_to_space.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateBatchToSpaceOp(Program& p, const std::shared_ptr<ngraph::op::v1::BatchToSpace>& op) {
-    p.ValidateInputs(op, {4});
+    validate_inputs_count(op, {4});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -46,8 +46,7 @@ static void CreateBatchToSpaceOp(Program& p, const std::shared_ptr<ngraph::op::v
                                                   out_size,
                                                   op->get_friendly_name());
 
-    p.AddPrimitive(batchToSpacePrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, batchToSpacePrim);
 }
 
 REGISTER_FACTORY_IMPL(v1, BatchToSpace);

--- a/src/plugins/intel_gpu/src/plugin/ops/batch_to_space.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/batch_to_space.cpp
@@ -43,8 +43,7 @@ static void CreateBatchToSpaceOp(Program& p, const std::shared_ptr<ngraph::op::v
                                                   inputs[0], // block_shape
                                                   inputs[1], // crops_begin
                                                   inputs[2], // crops_end
-                                                  out_size,
-                                                  op->get_friendly_name());
+                                                  out_size);
 
     p.add_primitive(*op, batchToSpacePrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/broadcast.cpp
@@ -38,8 +38,7 @@ static void CreateCommonBroadcastOp(Program& p, const std::shared_ptr<ngraph::No
                                               targetFormat,
                                               targetDatatype,
                                               std::vector<float>(),
-                                              cldnn::reorder_mean_mode::subtract,
-                                              op->get_friendly_name());
+                                              cldnn::reorder_mean_mode::subtract);
             p.add_primitive(*op, reorderPrim);
 
             inputPrimitive = reorderName;
@@ -72,7 +71,7 @@ static void CreateCommonBroadcastOp(Program& p, const std::shared_ptr<ngraph::No
 
         auto targetShape = tensor_from_dims(inputShape);
 
-        auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitive, targetShape, op->get_friendly_name());
+        auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitive, targetShape);
         p.add_primitive(*op, reshapePrim);
 
         inputPrimitive = reshapeName;
@@ -97,8 +96,7 @@ static void CreateCommonBroadcastOp(Program& p, const std::shared_ptr<ngraph::No
                                           inputPrimitive,
                                           outputShape,
                                           axis_mapping,
-                                          mode,
-                                          op->get_friendly_name());
+                                          mode);
 
     p.add_primitive(*op, broadcastPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/broadcast.cpp
@@ -40,8 +40,7 @@ static void CreateCommonBroadcastOp(Program& p, const std::shared_ptr<ngraph::No
                                               std::vector<float>(),
                                               cldnn::reorder_mean_mode::subtract,
                                               op->get_friendly_name());
-            p.AddPrimitive(reorderPrim);
-            p.AddInnerPrimitiveToProfiler(reorderName, layerName, op);
+            p.add_primitive(*op, reorderPrim);
 
             inputPrimitive = reorderName;
         }
@@ -74,8 +73,7 @@ static void CreateCommonBroadcastOp(Program& p, const std::shared_ptr<ngraph::No
         auto targetShape = tensor_from_dims(inputShape);
 
         auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitive, targetShape, op->get_friendly_name());
-        p.AddPrimitive(reshapePrim);
-        p.AddInnerPrimitiveToProfiler(reshapeName, layerName, op);
+        p.add_primitive(*op, reshapePrim);
 
         inputPrimitive = reshapeName;
     }
@@ -102,12 +100,11 @@ static void CreateCommonBroadcastOp(Program& p, const std::shared_ptr<ngraph::No
                                           mode,
                                           op->get_friendly_name());
 
-    p.AddPrimitive(broadcastPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, broadcastPrim);
 }
 
 static void CreateBroadcastOp(Program& p, const std::shared_ptr<ngraph::op::v1::Broadcast>& op) {
-    p.ValidateInputs(op, {2, 3});
+    validate_inputs_count(op, {2, 3});
     if (op->get_broadcast_spec().m_type == ngraph::op::AutoBroadcastType::NONE && op->get_input_size() == 3) {
         auto axis_mapping_node = std::dynamic_pointer_cast<ngraph::op::v0::Constant>(op->get_input_node_shared_ptr(2));
         if (!axis_mapping_node)
@@ -122,7 +119,7 @@ static void CreateBroadcastOp(Program& p, const std::shared_ptr<ngraph::op::v1::
 }
 
 static void CreateBroadcastOp(Program& p, const std::shared_ptr<ngraph::op::v3::Broadcast>& op) {
-    p.ValidateInputs(op, {2, 3});
+    validate_inputs_count(op, {2, 3});
     ngraph::AxisSet axis_mapping;
     if (op->get_input_size() == 3) {
         auto axis_mapping_node = std::dynamic_pointer_cast<ngraph::op::v0::Constant>(op->get_input_node_shared_ptr(2));

--- a/src/plugins/intel_gpu/src/plugin/ops/bucketize.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/bucketize.cpp
@@ -20,8 +20,7 @@ void CreateBucketizeOp(Program& p, const std::shared_ptr<ngraph::op::v3::Bucketi
     const cldnn::bucketize bucketize_prim(layer_type_name_ID(op),
                                           p.GetInputPrimitiveIDs(op),
                                           DataTypeFromPrecision(op->get_output_type()),
-                                          op->get_with_right_bound(),
-                                          op->get_friendly_name());
+                                          op->get_with_right_bound());
     p.add_primitive(*op, bucketize_prim);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/bucketize.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/bucketize.cpp
@@ -15,15 +15,14 @@ namespace intel_gpu {
 namespace {
 
 void CreateBucketizeOp(Program& p, const std::shared_ptr<ngraph::op::v3::Bucketize>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
 
     const cldnn::bucketize bucketize_prim(layer_type_name_ID(op),
                                           p.GetInputPrimitiveIDs(op),
                                           DataTypeFromPrecision(op->get_output_type()),
                                           op->get_with_right_bound(),
                                           op->get_friendly_name());
-    p.AddPrimitive(bucketize_prim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, bucketize_prim);
 }
 
 }  // namespace

--- a/src/plugins/intel_gpu/src/plugin/ops/concat.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/concat.cpp
@@ -26,8 +26,7 @@ static void CreateConcatOp(Program& p, const std::shared_ptr<ngraph::op::v0::Con
         DataTypeFromPrecision(op->get_output_element_type(0)),
         op->get_friendly_name());
 
-    p.AddPrimitive(concatPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, concatPrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, Concat);

--- a/src/plugins/intel_gpu/src/plugin/ops/concat.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/concat.cpp
@@ -23,8 +23,7 @@ static void CreateConcatOp(Program& p, const std::shared_ptr<ngraph::op::v0::Con
         layerName,
         inputPrimitives,
         axis,
-        DataTypeFromPrecision(op->get_output_element_type(0)),
-        op->get_friendly_name());
+        DataTypeFromPrecision(op->get_output_element_type(0)));
 
     p.add_primitive(*op, concatPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
@@ -228,7 +228,7 @@ void createClDnnConstant(Program& p, const ngraph::Shape& constDims, const std::
         } else {
             std::memcpy(&buf[0], &data[0], bufSize);
         }
-        p.add_primitive(*op, cldnn::data(initialconstPrimID, mem, op->get_friendly_name()));
+        p.add_primitive(*op, cldnn::data(initialconstPrimID, mem));
         p.blobMemCache[std::make_pair(data, newDims)] = initialconstPrimID;
         constPrimID = initialconstPrimID;
     }

--- a/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
@@ -191,6 +191,8 @@ void createClDnnConstant(Program& p, const ngraph::Shape& constDims, const std::
 
     if (bufIter != p.blobMemCache.end()) {
         constPrimID = bufIter->second;
+        p.primitive_ids[initialconstPrimID] = constPrimID;
+        p.profiling_ids.push_back(initialconstPrimID);
     } else {
         GPU_DEBUG_GET_INSTANCE(debug_config);
         GPU_DEBUG_IF(debug_config->verbose >= 2) {
@@ -226,12 +228,10 @@ void createClDnnConstant(Program& p, const ngraph::Shape& constDims, const std::
         } else {
             std::memcpy(&buf[0], &data[0], bufSize);
         }
-        p.AddPrimitive(cldnn::data(initialconstPrimID, mem, op->get_friendly_name()));
+        p.add_primitive(*op, cldnn::data(initialconstPrimID, mem, op->get_friendly_name()));
         p.blobMemCache[std::make_pair(data, newDims)] = initialconstPrimID;
         constPrimID = initialconstPrimID;
     }
-
-    p.AddPrimitiveToProfiler(op, constPrimID);
 }
 
 REGISTER_FACTORY_IMPL(v0, Constant);

--- a/src/plugins/intel_gpu/src/plugin/ops/convert.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/convert.cpp
@@ -25,8 +25,7 @@ static void CreateConvertLikeOp(Program& p, const std::shared_ptr<ngraph::op::v1
                                       cldnn::format::any,
                                       outDataType,
                                       std::vector<float>(),
-                                      cldnn::reorder_mean_mode::subtract,
-                                      op->get_friendly_name());
+                                      cldnn::reorder_mean_mode::subtract);
     p.add_primitive(*op, reorderPrim);
 }
 
@@ -42,8 +41,7 @@ static void CreateConvertOp(Program& p, const std::shared_ptr<ngraph::op::v0::Co
                                       cldnn::format::any,
                                       outDataType,
                                       std::vector<float>(),
-                                      cldnn::reorder_mean_mode::subtract,
-                                      op->get_friendly_name());
+                                      cldnn::reorder_mean_mode::subtract);
 
     p.add_primitive(*op, reorderPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/convert.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/convert.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateConvertLikeOp(Program& p, const std::shared_ptr<ngraph::op::v1::ConvertLike>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -27,12 +27,11 @@ static void CreateConvertLikeOp(Program& p, const std::shared_ptr<ngraph::op::v1
                                       std::vector<float>(),
                                       cldnn::reorder_mean_mode::subtract,
                                       op->get_friendly_name());
-    p.AddPrimitive(reorderPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, reorderPrim);
 }
 
 static void CreateConvertOp(Program& p, const std::shared_ptr<ngraph::op::v0::Convert>& op) {
-    p.ValidateInputs(op, {1});
+    validate_inputs_count(op, {1});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -46,8 +45,7 @@ static void CreateConvertOp(Program& p, const std::shared_ptr<ngraph::op::v0::Co
                                       cldnn::reorder_mean_mode::subtract,
                                       op->get_friendly_name());
 
-    p.AddPrimitive(reorderPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, reorderPrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, Convert);

--- a/src/plugins/intel_gpu/src/plugin/ops/convert_color.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/convert_color.cpp
@@ -44,44 +44,43 @@ static void CreateCommonConvertColorOp(Program& p, const std::shared_ptr<ngraph:
             new_shape.batch[0] = 1;
             out_layout.set_tensor(new_shape);
 
-            p.AddPrimitive(cldnn::convert_color(batched_prim_id,
-                                                batchedInputPrimitives,
-                                                from_color,
-                                                to_color,
-                                                memory_type,
-                                                out_layout,
-                                                op->get_friendly_name()));
+            p.add_primitive(*op, cldnn::convert_color(batched_prim_id,
+                                                      batchedInputPrimitives,
+                                                      from_color,
+                                                      to_color,
+                                                      memory_type,
+                                                      out_layout,
+                                                      op->get_friendly_name()));
         }
-        p.AddPrimitive(cldnn::concatenation(layerName, convert_color_names, 0, op->get_friendly_name()));
+        p.add_primitive(*op, cldnn::concatenation(layerName, convert_color_names, 0, op->get_friendly_name()));
     } else {
-        p.AddPrimitive(cldnn::convert_color(layerName,
-                                            inputPrimitives,
-                                            from_color,
-                                            to_color,
-                                            memory_type,
-                                            out_layout,
-                                            op->get_friendly_name()));
+        p.add_primitive(*op, cldnn::convert_color(layerName,
+                                                  inputPrimitives,
+                                                  from_color,
+                                                  to_color,
+                                                  memory_type,
+                                                  out_layout,
+                                                  op->get_friendly_name()));
     }
-    p.AddPrimitiveToProfiler(op);
 }
 
 static void CreateNV12toRGBOp(Program& p, const std::shared_ptr<ngraph::op::v8::NV12toRGB>& op) {
-    p.ValidateInputs(op, {1, 2});
+    validate_inputs_count(op, {1, 2});
     CreateCommonConvertColorOp(p, op, cldnn::convert_color::color_format::NV12, cldnn::convert_color::color_format::RGB);
 }
 
 static void CreateNV12toBGROp(Program& p, const std::shared_ptr<ngraph::op::v8::NV12toBGR>& op) {
-    p.ValidateInputs(op, {1, 2});
+    validate_inputs_count(op, {1, 2});
     CreateCommonConvertColorOp(p, op, cldnn::convert_color::color_format::NV12, cldnn::convert_color::color_format::BGR);
 }
 
 static void CreateI420toRGBOp(Program& p, const std::shared_ptr<ngraph::op::v8::I420toRGB>& op) {
-    p.ValidateInputs(op, {1, 3});
+    validate_inputs_count(op, {1, 3});
     CreateCommonConvertColorOp(p, op, cldnn::convert_color::color_format::I420, cldnn::convert_color::color_format::RGB);
 }
 
 static void CreateI420toBGROp(Program& p, const std::shared_ptr<ngraph::op::v8::I420toBGR>& op) {
-    p.ValidateInputs(op, {1, 3});
+    validate_inputs_count(op, {1, 3});
     CreateCommonConvertColorOp(p, op, cldnn::convert_color::color_format::I420, cldnn::convert_color::color_format::BGR);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/convert_color.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/convert_color.cpp
@@ -49,18 +49,16 @@ static void CreateCommonConvertColorOp(Program& p, const std::shared_ptr<ngraph:
                                                       from_color,
                                                       to_color,
                                                       memory_type,
-                                                      out_layout,
-                                                      op->get_friendly_name()));
+                                                      out_layout));
         }
-        p.add_primitive(*op, cldnn::concatenation(layerName, convert_color_names, 0, op->get_friendly_name()));
+        p.add_primitive(*op, cldnn::concatenation(layerName, convert_color_names, 0));
     } else {
         p.add_primitive(*op, cldnn::convert_color(layerName,
                                                   inputPrimitives,
                                                   from_color,
                                                   to_color,
                                                   memory_type,
-                                                  out_layout,
-                                                  op->get_friendly_name()));
+                                                  out_layout));
     }
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/convolution.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/convolution.cpp
@@ -53,8 +53,7 @@ static void CreateGroupConvolutionOp(Program& p, const std::shared_ptr<ngraph::o
                                        dilations,
                                        tensor_from_dims(outDims),
                                        DataTypeFromPrecision(outPrecision),
-                                       weights_have_group_dim,
-                                       op->get_friendly_name());
+                                       weights_have_group_dim);
 
     p.add_primitive(*op, convPrim);
 }
@@ -89,8 +88,7 @@ static void CreateConvolutionOp(Program& p, const std::shared_ptr<ngraph::op::v1
                                        dilations,
                                        tensor_from_dims(outDims),
                                        DataTypeFromPrecision(outPrecision),
-                                       weights_have_group_dim,
-                                       op->get_friendly_name());
+                                       weights_have_group_dim);
 
     p.add_primitive(*op, convPrim);
 }
@@ -124,8 +122,7 @@ static void CreateConvolutionBackpropDataOp(Program& p, const std::shared_ptr<ng
         std::swap(permute_order[1], permute_order[0]);
         auto permutePrim = cldnn::permute(permuteName,
                                           weightsName,
-                                          permute_order,
-                                          op->get_friendly_name());
+                                          permute_order);
 
         p.add_primitive(*op, permutePrim);
 
@@ -150,8 +147,7 @@ static void CreateConvolutionBackpropDataOp(Program& p, const std::shared_ptr<ng
                                            strides,
                                            pads_begin,
                                            tensor_from_dims(op->get_output_tensor(0).get_shape()),
-                                           weights_have_group_dim,
-                                           op->get_friendly_name());
+                                           weights_have_group_dim);
 
     p.add_primitive(*op, deconvPrim);
 }
@@ -186,8 +182,7 @@ static void CreateGroupConvolutionBackpropDataOp(Program& p, const std::shared_p
         std::swap(permute_order[2], permute_order[1]);
         auto permutePrim = cldnn::permute(permuteName,
                                           weightsName,
-                                          permute_order,
-                                          op->get_friendly_name());
+                                          permute_order);
 
         p.add_primitive(*op, permutePrim);
 
@@ -212,8 +207,7 @@ static void CreateGroupConvolutionBackpropDataOp(Program& p, const std::shared_p
                                            strides,
                                            pads_begin,
                                            tensor_from_dims(op->get_output_tensor(0).get_shape()),
-                                           weights_have_group_dim,
-                                           op->get_friendly_name());
+                                           weights_have_group_dim);
 
     p.add_primitive(*op, deconvPrim);
 }
@@ -262,16 +256,14 @@ static void DeformableConvolutionImpl(Program& p,
                                                           dilations,
                                                           tensor_from_dims(outDims),
                                                           kernel,
-                                                          bilinearInterpolationPad,
-                                                          op->get_friendly_name());
+                                                          bilinearInterpolationPad);
         p.add_primitive(*op, defConvPrimInterp);
         auto defConvPrim = cldnn::deformable_conv(defConvLayerNameConv,
                                                   defConvLayerNameInterp,
                                                   weights,
                                                   {},
                                                   groups,
-                                                  tensor_from_dims(outDims),
-                                                  op->get_friendly_name());
+                                                  tensor_from_dims(outDims));
         p.add_primitive(*op, defConvPrim);
     } else {
         auto convPrim = cldnn::convolution(layerName,
@@ -284,8 +276,7 @@ static void DeformableConvolutionImpl(Program& p,
                                            padding,
                                            dilations,
                                            tensor_from_dims(outDims),
-                                           bilinearInterpolationPad,
-                                           op->get_friendly_name());
+                                           bilinearInterpolationPad);
 
         p.add_primitive(*op, convPrim);
     }
@@ -354,8 +345,7 @@ static void CreateBinaryConvolutionOp(Program& p, const std::shared_ptr<ngraph::
                                               tensor_from_dims(outDims),
                                               1,
                                               op->get_pad_value(),
-                                              calc_precision,
-                                              op->get_friendly_name());
+                                              calc_precision);
 
     p.add_primitive(*op, convPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/convolution.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/convolution.cpp
@@ -23,7 +23,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateGroupConvolutionOp(Program& p, const std::shared_ptr<ngraph::op::v1::GroupConvolution>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputs = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -56,12 +56,11 @@ static void CreateGroupConvolutionOp(Program& p, const std::shared_ptr<ngraph::o
                                        weights_have_group_dim,
                                        op->get_friendly_name());
 
-    p.AddPrimitive(convPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, convPrim);
 }
 
 static void CreateConvolutionOp(Program& p, const std::shared_ptr<ngraph::op::v1::Convolution>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputs = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -93,13 +92,12 @@ static void CreateConvolutionOp(Program& p, const std::shared_ptr<ngraph::op::v1
                                        weights_have_group_dim,
                                        op->get_friendly_name());
 
-    p.AddPrimitive(convPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, convPrim);
 }
 
 static void CreateConvolutionBackpropDataOp(Program& p, const std::shared_ptr<ngraph::op::v1::ConvolutionBackpropData>& op) {
     // 3rd input is an optional output shape
-    p.ValidateInputs(op, {2, 3});
+    validate_inputs_count(op, {2, 3});
     auto inputs = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -129,8 +127,7 @@ static void CreateConvolutionBackpropDataOp(Program& p, const std::shared_ptr<ng
                                           permute_order,
                                           op->get_friendly_name());
 
-        p.AddPrimitive(permutePrim);
-        p.AddInnerPrimitiveToProfiler(permuteName, layerName, op);
+        p.add_primitive(*op, permutePrim);
 
         weightsName = permuteName;
     }
@@ -156,12 +153,11 @@ static void CreateConvolutionBackpropDataOp(Program& p, const std::shared_ptr<ng
                                            weights_have_group_dim,
                                            op->get_friendly_name());
 
-    p.AddPrimitive(deconvPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, deconvPrim);
 }
 
 static void CreateGroupConvolutionBackpropDataOp(Program& p, const std::shared_ptr<ngraph::op::v1::GroupConvolutionBackpropData>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputs = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -193,8 +189,7 @@ static void CreateGroupConvolutionBackpropDataOp(Program& p, const std::shared_p
                                           permute_order,
                                           op->get_friendly_name());
 
-        p.AddPrimitive(permutePrim);
-        p.AddInnerPrimitiveToProfiler(permuteName, layerName, op);
+        p.add_primitive(*op, permutePrim);
 
         weightsName = permuteName;
     }
@@ -220,8 +215,7 @@ static void CreateGroupConvolutionBackpropDataOp(Program& p, const std::shared_p
                                            weights_have_group_dim,
                                            op->get_friendly_name());
 
-    p.AddPrimitive(deconvPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, deconvPrim);
 }
 
 static void DeformableConvolutionImpl(Program& p,
@@ -270,8 +264,7 @@ static void DeformableConvolutionImpl(Program& p,
                                                           kernel,
                                                           bilinearInterpolationPad,
                                                           op->get_friendly_name());
-        p.AddPrimitive(defConvPrimInterp);
-        p.AddInnerPrimitiveToProfiler(defConvLayerNameInterp, defConvLayerNameConv, op);
+        p.add_primitive(*op, defConvPrimInterp);
         auto defConvPrim = cldnn::deformable_conv(defConvLayerNameConv,
                                                   defConvLayerNameInterp,
                                                   weights,
@@ -279,8 +272,7 @@ static void DeformableConvolutionImpl(Program& p,
                                                   groups,
                                                   tensor_from_dims(outDims),
                                                   op->get_friendly_name());
-        p.AddPrimitive(defConvPrim);
-        p.AddPrimitiveToProfiler(defConvLayerNameConv, op);
+        p.add_primitive(*op, defConvPrim);
     } else {
         auto convPrim = cldnn::convolution(layerName,
                                            inputs,
@@ -295,13 +287,12 @@ static void DeformableConvolutionImpl(Program& p,
                                            bilinearInterpolationPad,
                                            op->get_friendly_name());
 
-        p.AddPrimitive(convPrim);
-        p.AddPrimitiveToProfiler(op);
+        p.add_primitive(*op, convPrim);
     }
 }
 
 static void CreateDeformableConvolutionOp(Program& p, const std::shared_ptr<ngraph::op::v1::DeformableConvolution>& op) {
-    p.ValidateInputs(op, {3});
+    validate_inputs_count(op, {3});
     auto strides = op->get_strides();
     auto pads_begin = op->get_pads_begin();
     auto dilations = op->get_dilations();
@@ -315,7 +306,7 @@ static void CreateDeformableConvolutionOp(Program& p, const std::shared_ptr<ngra
 }
 
 static void CreateDeformableConvolutionOp(Program& p, const std::shared_ptr<ngraph::op::v8::DeformableConvolution>& op) {
-    p.ValidateInputs(op, {3, 4});
+    validate_inputs_count(op, {3, 4});
     auto strides = op->get_strides();
     auto pads_begin = op->get_pads_begin();
     auto dilations = op->get_dilations();
@@ -336,7 +327,7 @@ static void CreateDeformableConvolutionOp(Program& p, const std::shared_ptr<ngra
 }
 
 static void CreateBinaryConvolutionOp(Program& p, const std::shared_ptr<ngraph::op::v1::BinaryConvolution>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputs = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -366,8 +357,7 @@ static void CreateBinaryConvolutionOp(Program& p, const std::shared_ptr<ngraph::
                                               calc_precision,
                                               op->get_friendly_name());
 
-    p.AddPrimitive(convPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, convPrim);
 }
 
 REGISTER_FACTORY_IMPL(v1, GroupConvolution);

--- a/src/plugins/intel_gpu/src/plugin/ops/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/ctc_greedy_decoder.cpp
@@ -37,8 +37,7 @@ static void CreateCommonCTCGreedyDecoderOp(Program& p, const std::shared_ptr<ngr
                                                  targetFormat,
                                                  cldnn::data_types::i32,
                                                  std::vector<float>(),
-                                                 cldnn::reorder_mean_mode::subtract,
-                                                 op->get_friendly_name());
+                                                 cldnn::reorder_mean_mode::subtract);
             p.add_primitive(*op, preprocessPrim);
             reorderedInputs[portIndex] = (reorderPrimName);
         } else {
@@ -82,20 +81,18 @@ static void CreateCommonCTCGreedyDecoderOp(Program& p, const std::shared_ptr<ngr
 
         cldnn::primitive_id ctc_gd_mutable_id_w = layer_type_name_ID(op) + "_md_write";
         auto ctc_gd_mutable_prim = cldnn::mutable_data(ctc_gd_mutable_id_w,
-                                                       shared_memory[0],
-                                                       op->get_friendly_name());
+                                                       shared_memory[0]);
         p.add_primitive(*op, ctc_gd_mutable_prim);
         reorderedInputs.push_back(ctc_gd_mutable_id_w);
     }
 
-    auto CTCGreedyDecoderLayerName = num_output == 2 ? layer_type_name_ID(op) + ".0" : layer_type_name_ID(op);
+    auto CTCGreedyDecoderLayerName = num_output == 2 ? layer_type_name_ID(op) + ".out0" : layer_type_name_ID(op);
     auto primitive = cldnn::ctc_greedy_decoder(
                 CTCGreedyDecoderLayerName,
                 reorderedInputs,
                 blank_index,
                 ctc_merge_repeated,
-                tensor_from_dims(op->get_output_shape(0)),
-                op->get_friendly_name());
+                tensor_from_dims(op->get_output_shape(0)));
 
     // GPU primitive supports only i32 as output data type
     primitive.output_data_type = DataTypeFromPrecision(ngraph::element::i32);
@@ -107,11 +104,10 @@ static void CreateCommonCTCGreedyDecoderOp(Program& p, const std::shared_ptr<ngr
     p.add_primitive(*op, primitive);
 
     if (num_output == 2) {
-        cldnn::primitive_id ctc_gd_mutable_id_r = layer_type_name_ID(op) + ".1";
+        cldnn::primitive_id ctc_gd_mutable_id_r = layer_type_name_ID(op) + ".out1";
         auto ctc_gd_mutable_prim_r = cldnn::mutable_data(ctc_gd_mutable_id_r,
                                                          { CTCGreedyDecoderLayerName },
-                                                         shared_memory[0],
-                                                         op->get_friendly_name());
+                                                         shared_memory[0]);
         p.add_primitive(*op, ctc_gd_mutable_prim_r);
     }
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/cum_sum.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/cum_sum.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateCumSumOp(Program& p, const std::shared_ptr<ngraph::op::v0::CumSum>& op) {
-    p.ValidateInputs(op, {1, 2});
+    validate_inputs_count(op, {1, 2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -38,8 +38,7 @@ static void CreateCumSumOp(Program& p, const std::shared_ptr<ngraph::op::v0::Cum
                                     reverse,
                                     op->get_friendly_name());
 
-    p.AddPrimitive(primitive);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, primitive);
 }
 
 REGISTER_FACTORY_IMPL(v0, CumSum);

--- a/src/plugins/intel_gpu/src/plugin/ops/cum_sum.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/cum_sum.cpp
@@ -35,8 +35,7 @@ static void CreateCumSumOp(Program& p, const std::shared_ptr<ngraph::op::v0::Cum
                                     inputPrimitives[0],
                                     axis,
                                     exclusive,
-                                    reverse,
-                                    op->get_friendly_name());
+                                    reverse);
 
     p.add_primitive(*op, primitive);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/custom.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/custom.cpp
@@ -151,8 +151,7 @@ void CreateCustomOp(Program& p, const std::shared_ptr<ngraph::Node>& op, CustomL
                         cldnn::reorder_mean_mode::subtract,
                         op->get_friendly_name());
 
-                    p.AddPrimitive(preprocessPrim);
-                    p.AddInnerPrimitiveToProfiler(reorderPrimName, layer_type_name_ID(op), op);
+                    p.add_primitive(*op, preprocessPrim);
                     reorderedInputs[param.portIndex] = (reorderPrimName);
                 } else {
                     reorderedInputs[param.portIndex] = inputPrimitives[param.portIndex];
@@ -240,20 +239,16 @@ void CreateCustomOp(Program& p, const std::shared_ptr<ngraph::Node>& op, CustomL
     if (outputLayout.format != cldnn::format::any) {
         // Handle output reorder
         auto reorderPrimName = genericLayerName + Program::m_postCustomLayerTag;
-        p.AddPrimitive(
-            cldnn::reorder(reorderPrimName,
-                           genericLayerName,
-                           cldnn::format::get_default_format(op->get_output_shape(0).size()),
-                           customPrim.output_layout.data_type,
-                           std::vector<float>(),
-                           cldnn::reorder_mean_mode::subtract,
-                           op->get_friendly_name()));
+        p.add_primitive(*op, cldnn::reorder(reorderPrimName,
+                                            genericLayerName,
+                                            cldnn::format::get_default_format(op->get_output_shape(0).size()),
+                                            customPrim.output_layout.data_type,
+                                            std::vector<float>(),
+                                            cldnn::reorder_mean_mode::subtract,
+                                            op->get_friendly_name()));
         prevLayerName = reorderPrimName;
-        p.AddInnerPrimitiveToProfiler(reorderPrimName, layer_type_name_ID(op), op);
     }
-    p.AddPrimitive(customPrim);
-    p.AddPrimitiveToProfiler(genericLayerName, op);
-    p.primitiveIDs[genericLayerName] = prevLayerName;
+    p.add_primitive(*op, customPrim);
 }
 
 }  // namespace intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/ops/custom.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/custom.cpp
@@ -148,8 +148,7 @@ void CreateCustomOp(Program& p, const std::shared_ptr<ngraph::Node>& op, CustomL
                         param.format,
                         DataTypeFromPrecision(op->get_input_element_type(param.portIndex)),
                         std::vector<float>(),
-                        cldnn::reorder_mean_mode::subtract,
-                        op->get_friendly_name());
+                        cldnn::reorder_mean_mode::subtract);
 
                     p.add_primitive(*op, preprocessPrim);
                     reorderedInputs[param.portIndex] = (reorderPrimName);
@@ -232,8 +231,7 @@ void CreateCustomOp(Program& p, const std::shared_ptr<ngraph::Node>& op, CustomL
                                                   customLayer->CompilerOptions(),
                                                   outputLayout,
                                                   gws,
-                                                  lws,
-                                                  op->get_friendly_name());
+                                                  lws);
 
     auto prevLayerName = genericLayerName;
     if (outputLayout.format != cldnn::format::any) {
@@ -244,8 +242,7 @@ void CreateCustomOp(Program& p, const std::shared_ptr<ngraph::Node>& op, CustomL
                                             cldnn::format::get_default_format(op->get_output_shape(0).size()),
                                             customPrim.output_layout.data_type,
                                             std::vector<float>(),
-                                            cldnn::reorder_mean_mode::subtract,
-                                            op->get_friendly_name()));
+                                            cldnn::reorder_mean_mode::subtract));
         prevLayerName = reorderPrimName;
     }
     p.add_primitive(*op, customPrim);

--- a/src/plugins/intel_gpu/src/plugin/ops/depth_to_space.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/depth_to_space.cpp
@@ -34,8 +34,7 @@ static void CreateDepthToSpaceOp(Program& p, const std::shared_ptr<ngraph::op::v
     auto depthToSpacePrim = cldnn::depth_to_space(layerName,
                                                   inputPrimitives[0],
                                                   blockSize,
-                                                  mode,
-                                                  op->get_friendly_name());
+                                                  mode);
 
     p.add_primitive(*op, depthToSpacePrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/depth_to_space.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/depth_to_space.cpp
@@ -24,7 +24,7 @@ static cldnn::depth_to_space_mode GetDepthMode(ngraph::op::v0::DepthToSpace::Dep
 }
 
 static void CreateDepthToSpaceOp(Program& p, const std::shared_ptr<ngraph::op::v0::DepthToSpace>& op) {
-    p.ValidateInputs(op, {1});
+    validate_inputs_count(op, {1});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -37,8 +37,7 @@ static void CreateDepthToSpaceOp(Program& p, const std::shared_ptr<ngraph::op::v
                                                   mode,
                                                   op->get_friendly_name());
 
-    p.AddPrimitive(depthToSpacePrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, depthToSpacePrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, DepthToSpace);

--- a/src/plugins/intel_gpu/src/plugin/ops/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/detection_output.cpp
@@ -28,7 +28,7 @@ static cldnn::prior_box_code_type PriorBoxCodeFromString(const std::string& str)
 }
 
 static void CreateDetectionOutputOp(Program& p, const std::shared_ptr<ngraph::op::v0::DetectionOutput>& op) {
-    p.ValidateInputs(op, {3});
+    validate_inputs_count(op, {3});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -79,8 +79,7 @@ static void CreateDetectionOutputOp(Program& p, const std::shared_ptr<ngraph::op
                                                  clip_after_nms,
                                                  op->get_friendly_name());
 
-    p.AddPrimitive(detectionPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, detectionPrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, DetectionOutput);

--- a/src/plugins/intel_gpu/src/plugin/ops/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/detection_output.cpp
@@ -76,8 +76,7 @@ static void CreateDetectionOutputOp(Program& p, const std::shared_ptr<ngraph::op
                                                  input_height,
                                                  decrease_label_id,
                                                  clip_before_nms,
-                                                 clip_after_nms,
-                                                 op->get_friendly_name());
+                                                 clip_after_nms);
 
     p.add_primitive(*op, detectionPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/dft.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/dft.cpp
@@ -29,7 +29,7 @@ void createDft(Program& p, const std::shared_ptr<ngraph::Node>& op, cldnn::dft_k
     const uint8_t data_rank = out_shape.size();
     ov::normalize_axes(op.get(), data_rank - 1, axes);
 
-    const cldnn::dft prim(layer_name, inputs.front(), std::move(axes), out_shape, kind, op_friendly_name);
+    const cldnn::dft prim(layer_name, inputs.front(), std::move(axes), out_shape, kind);
 
     p.add_primitive(*op, prim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/dft.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/dft.cpp
@@ -14,7 +14,7 @@ namespace intel_gpu {
 namespace {
 
 void createDft(Program& p, const std::shared_ptr<ngraph::Node>& op, cldnn::dft_kind kind) {
-    p.ValidateInputs(op, {2, 3});
+    validate_inputs_count(op, {2, 3});
 
     const auto inputs = p.GetInputPrimitiveIDs(op);
     const auto layer_name = layer_type_name_ID(op);
@@ -31,8 +31,7 @@ void createDft(Program& p, const std::shared_ptr<ngraph::Node>& op, cldnn::dft_k
 
     const cldnn::dft prim(layer_name, inputs.front(), std::move(axes), out_shape, kind, op_friendly_name);
 
-    p.AddPrimitive(prim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, prim);
 }
 
 void CreateDFTOp(Program& p, const std::shared_ptr<ngraph::op::v7::DFT>& op) {

--- a/src/plugins/intel_gpu/src/plugin/ops/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/eltwise.cpp
@@ -55,9 +55,7 @@ void CreateElementwiseOp(Program& p, const std::shared_ptr<ngraph::Node>& op, cl
                                                   cldnn::reorder_mean_mode::subtract,
                                                   op->get_friendly_name());
 
-                p.AddPrimitive(reorderPrim);
-                p.AddInnerPrimitiveToProfiler(reorderName, layerName, op);
-
+                p.add_primitive(*op, reorderPrim);
                 inputPrimitives[i] = reorderName;
             }
 
@@ -69,8 +67,7 @@ void CreateElementwiseOp(Program& p, const std::shared_ptr<ngraph::Node>& op, cl
             auto targetShape = tensor_from_dims(inputShape);
 
             auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape, op->get_friendly_name());
-            p.AddPrimitive(reshapePrim);
-            p.AddInnerPrimitiveToProfiler(reshapeName, layerName, op);
+            p.add_primitive(*op, reshapePrim);
 
             inputPrimitives[i] = reshapeName;
         }
@@ -84,8 +81,7 @@ void CreateElementwiseOp(Program& p, const std::shared_ptr<ngraph::Node>& op, cl
                                       out_dt,
                                       op->get_friendly_name());
 
-    p.AddPrimitive(eltwisePrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, eltwisePrim);
 }
 
 static void CreateAddOp(Program& p, const std::shared_ptr<ngraph::op::v1::Add>& op) {
@@ -153,7 +149,7 @@ static void CreateLogicalXorOp(Program& p, const std::shared_ptr<ngraph::op::v1:
 }
 
 static void CreatePowerOp(Program& p, const std::shared_ptr<ngraph::op::v1::Power>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto power_node = std::dynamic_pointer_cast<ngraph::op::v0::Constant>(op->get_input_node_shared_ptr(1));
     if (power_node) {
         if (ngraph::shape_size(power_node->get_output_shape(0)) == 1) {

--- a/src/plugins/intel_gpu/src/plugin/ops/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/eltwise.cpp
@@ -52,8 +52,7 @@ void CreateElementwiseOp(Program& p, const std::shared_ptr<ngraph::Node>& op, cl
                                                   targetFormat,
                                                   targetDatatype,
                                                   std::vector<float>(),
-                                                  cldnn::reorder_mean_mode::subtract,
-                                                  op->get_friendly_name());
+                                                  cldnn::reorder_mean_mode::subtract);
 
                 p.add_primitive(*op, reorderPrim);
                 inputPrimitives[i] = reorderName;
@@ -66,7 +65,7 @@ void CreateElementwiseOp(Program& p, const std::shared_ptr<ngraph::Node>& op, cl
 
             auto targetShape = tensor_from_dims(inputShape);
 
-            auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape, op->get_friendly_name());
+            auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape);
             p.add_primitive(*op, reshapePrim);
 
             inputPrimitives[i] = reshapeName;
@@ -78,8 +77,7 @@ void CreateElementwiseOp(Program& p, const std::shared_ptr<ngraph::Node>& op, cl
                                       inputPrimitives,
                                       mode,
                                       {},
-                                      out_dt,
-                                      op->get_friendly_name());
+                                      out_dt);
 
     p.add_primitive(*op, eltwisePrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/embedding_bag.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/embedding_bag.cpp
@@ -52,8 +52,7 @@ static void CreateEmbeddingBagOffsetsSumOp(Program& p, const std::shared_ptr<ngr
                                                  targetFormat,
                                                  cldnn::data_types::i32,
                                                  std::vector<float>(),
-                                                 cldnn::reorder_mean_mode::subtract,
-                                                 op->get_friendly_name());
+                                                 cldnn::reorder_mean_mode::subtract);
             p.add_primitive(*op, preprocessPrim);
             reorderedInputs[portIndex] = (reorderPrimName);
         } else {
@@ -65,8 +64,7 @@ static void CreateEmbeddingBagOffsetsSumOp(Program& p, const std::shared_ptr<ngr
                                                  reorderedInputs,
                                                  cldnn::embedding_bag::offsets_sum,
                                                  tensor_from_dims(op->get_output_shape(0)),
-                                                 defaultIndex,
-                                                 op->get_friendly_name());
+                                                 defaultIndex);
 
     p.add_primitive(*op, embeddingBagPrim);
 }
@@ -91,8 +89,7 @@ static void CreateEmbeddingBagPackedSumOp(Program& p, const std::shared_ptr<ngra
                                                  targetFormat,
                                                  cldnn::data_types::i32,
                                                  std::vector<float>(),
-                                                 cldnn::reorder_mean_mode::subtract,
-                                                 op->get_friendly_name());
+                                                 cldnn::reorder_mean_mode::subtract);
             p.add_primitive(*op, preprocessPrim);
             reorderedInputs[portIndex] = (reorderPrimName);
         } else {
@@ -104,8 +101,7 @@ static void CreateEmbeddingBagPackedSumOp(Program& p, const std::shared_ptr<ngra
                                                  reorderedInputs,
                                                  cldnn::embedding_bag::packed_sum,
                                                  tensor_from_dims(op->get_output_shape(0)),
-                                                 -1,
-                                                 op->get_friendly_name());
+                                                 -1);
 
     p.add_primitive(*op, embeddingBagPrim);
 }
@@ -148,8 +144,7 @@ static void CreateEmbeddingSegmentsSumOp(Program& p, const std::shared_ptr<ngrap
                                                  targetFormat,
                                                  cldnn::data_types::i32,
                                                  std::vector<float>(),
-                                                 cldnn::reorder_mean_mode::subtract,
-                                                 op->get_friendly_name());
+                                                 cldnn::reorder_mean_mode::subtract);
             p.add_primitive(*op, preprocessPrim);
             reorderedInputs[portIndex] = (reorderPrimName);
         } else {
@@ -161,8 +156,7 @@ static void CreateEmbeddingSegmentsSumOp(Program& p, const std::shared_ptr<ngrap
                                                  reorderedInputs,
                                                  cldnn::embedding_bag::segments_sum,
                                                  tensor_from_dims(op->get_output_shape(0)),
-                                                 defaultIndex,
-                                                 op->get_friendly_name());
+                                                 defaultIndex);
 
     p.add_primitive(*op, embeddingBagPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/embedding_bag.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/embedding_bag.cpp
@@ -18,7 +18,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateEmbeddingBagOffsetsSumOp(Program& p, const std::shared_ptr<ngraph::op::v3::EmbeddingBagOffsetsSum>& op) {
-    p.ValidateInputs(op, {3, 4, 5});
+    validate_inputs_count(op, {3, 4, 5});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -54,8 +54,7 @@ static void CreateEmbeddingBagOffsetsSumOp(Program& p, const std::shared_ptr<ngr
                                                  std::vector<float>(),
                                                  cldnn::reorder_mean_mode::subtract,
                                                  op->get_friendly_name());
-            p.AddPrimitive(preprocessPrim);
-            p.AddInnerPrimitiveToProfiler(reorderPrimName, layer_type_name_ID(op), op);
+            p.add_primitive(*op, preprocessPrim);
             reorderedInputs[portIndex] = (reorderPrimName);
         } else {
             reorderedInputs[portIndex] = inputPrimitives[portIndex];
@@ -69,12 +68,11 @@ static void CreateEmbeddingBagOffsetsSumOp(Program& p, const std::shared_ptr<ngr
                                                  defaultIndex,
                                                  op->get_friendly_name());
 
-    p.AddPrimitive(embeddingBagPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, embeddingBagPrim);
 }
 
 static void CreateEmbeddingBagPackedSumOp(Program& p, const std::shared_ptr<ngraph::op::v3::EmbeddingBagPackedSum>& op) {
-    p.ValidateInputs(op, {2, 3});
+    validate_inputs_count(op, {2, 3});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -95,8 +93,7 @@ static void CreateEmbeddingBagPackedSumOp(Program& p, const std::shared_ptr<ngra
                                                  std::vector<float>(),
                                                  cldnn::reorder_mean_mode::subtract,
                                                  op->get_friendly_name());
-            p.AddPrimitive(preprocessPrim);
-            p.AddInnerPrimitiveToProfiler(reorderPrimName, layer_type_name_ID(op), op);
+            p.add_primitive(*op, preprocessPrim);
             reorderedInputs[portIndex] = (reorderPrimName);
         } else {
             reorderedInputs[portIndex] = inputPrimitives[portIndex];
@@ -110,12 +107,11 @@ static void CreateEmbeddingBagPackedSumOp(Program& p, const std::shared_ptr<ngra
                                                  -1,
                                                  op->get_friendly_name());
 
-    p.AddPrimitive(embeddingBagPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, embeddingBagPrim);
 }
 
 static void CreateEmbeddingSegmentsSumOp(Program& p, const std::shared_ptr<ngraph::op::v3::EmbeddingSegmentsSum>& op) {
-    p.ValidateInputs(op, {4, 5, 6});
+    validate_inputs_count(op, {4, 5, 6});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -154,8 +150,7 @@ static void CreateEmbeddingSegmentsSumOp(Program& p, const std::shared_ptr<ngrap
                                                  std::vector<float>(),
                                                  cldnn::reorder_mean_mode::subtract,
                                                  op->get_friendly_name());
-            p.AddPrimitive(preprocessPrim);
-            p.AddInnerPrimitiveToProfiler(reorderPrimName, layer_type_name_ID(op), op);
+            p.add_primitive(*op, preprocessPrim);
             reorderedInputs[portIndex] = (reorderPrimName);
         } else {
             reorderedInputs[portIndex] = inputPrimitives[portIndex];
@@ -169,8 +164,7 @@ static void CreateEmbeddingSegmentsSumOp(Program& p, const std::shared_ptr<ngrap
                                                  defaultIndex,
                                                  op->get_friendly_name());
 
-    p.AddPrimitive(embeddingBagPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, embeddingBagPrim);
 }
 
 REGISTER_FACTORY_IMPL(v3, EmbeddingBagOffsetsSum);

--- a/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_detection_output.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_detection_output.cpp
@@ -15,7 +15,7 @@ namespace intel_gpu {
 static void CreateExperimentalDetectronDetectionOutputOp(
     Program& p,
     const std::shared_ptr<ngraph::op::v6::ExperimentalDetectronDetectionOutput>& op) {
-    p.ValidateInputs(op, {4});
+    validate_inputs_count(op, {4});
 
     if (op->get_output_size() != 3) {
         IE_THROW() << "ExperimentalDetectronDetectionOutput requires 3 outputs";
@@ -39,8 +39,7 @@ static void CreateExperimentalDetectronDetectionOutputOp(
 
     const auto mutable_id_w1 = layer_type_name + "_md_write.1";
     const cldnn::mutable_data mutable_prim_w{mutable_id_w1, shared_memory1, op_friendly_name};
-    p.primitiveIDs[mutable_id_w1] = mutable_id_w1;
-    p.AddPrimitive(mutable_prim_w);
+    p.add_primitive(*op, mutable_prim_w);
     inputs.push_back(mutable_id_w1);
 
     const auto mutable_precision2 = op->get_output_element_type(2);
@@ -52,8 +51,7 @@ static void CreateExperimentalDetectronDetectionOutputOp(
 
     const auto mutable_id_w2 = layer_type_name + "_md_write.2";
     const cldnn::mutable_data mutable_prim_w2{mutable_id_w2, shared_memory2, op_friendly_name};
-    p.primitiveIDs[mutable_id_w2] = mutable_id_w2;
-    p.AddPrimitive(mutable_prim_w2);
+    p.add_primitive(*op, mutable_prim_w2);
     inputs.push_back(mutable_id_w2);
 
     const auto expectedPrimInputCount = 4 + 2; // 4 operation inputs plus 2 input-outputs
@@ -78,19 +76,15 @@ static void CreateExperimentalDetectronDetectionOutputOp(
                                                               attrs.deltas_weights,
                                                               op_friendly_name};
 
-    p.AddPrimitive(prim);
+    p.add_primitive(*op, prim);
 
     const auto mutable_id_r1 = layer_type_name + ".1";
     const cldnn::mutable_data mutable_prim_r1{mutable_id_r1, {layer_name}, shared_memory1, op_friendly_name};
-    p.primitiveIDs[mutable_id_r1] = mutable_id_r1;
-    p.AddPrimitive(mutable_prim_r1);
+    p.add_primitive(*op, mutable_prim_r1);
 
     const auto mutable_id_r2 = layer_type_name + ".2";
     const cldnn::mutable_data mutable_prim_r2{mutable_id_r2, {layer_name}, shared_memory2, op_friendly_name};
-    p.primitiveIDs[mutable_id_r2] = mutable_id_r2;
-    p.AddPrimitive(mutable_prim_r2);
-
-    p.AddPrimitiveToProfiler(prim, op);
+    p.add_primitive(*op, mutable_prim_r2);
 }
 
 REGISTER_FACTORY_IMPL(v6, ExperimentalDetectronDetectionOutput);

--- a/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_detection_output.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_detection_output.cpp
@@ -25,10 +25,8 @@ static void CreateExperimentalDetectronDetectionOutputOp(
 
     const auto& attrs = op->get_attrs();
 
-    const auto op_friendly_name = op->get_friendly_name();
-
     const auto layer_type_name = layer_type_name_ID(op);
-    const auto layer_name = layer_type_name + ".0";
+    const auto layer_name = layer_type_name + ".out0";
 
     const auto mutable_precision1 = op->get_output_element_type(1);
     const auto output_shape1 = op->get_output_shape(1);
@@ -38,7 +36,7 @@ static void CreateExperimentalDetectronDetectionOutputOp(
     cldnn::memory::ptr shared_memory1{p.GetEngine().allocate_memory(mutable_layout1)};
 
     const auto mutable_id_w1 = layer_type_name + "_md_write.1";
-    const cldnn::mutable_data mutable_prim_w{mutable_id_w1, shared_memory1, op_friendly_name};
+    const cldnn::mutable_data mutable_prim_w{mutable_id_w1, shared_memory1};
     p.add_primitive(*op, mutable_prim_w);
     inputs.push_back(mutable_id_w1);
 
@@ -50,7 +48,7 @@ static void CreateExperimentalDetectronDetectionOutputOp(
     cldnn::memory::ptr shared_memory2{p.GetEngine().allocate_memory(mutable_layout2)};
 
     const auto mutable_id_w2 = layer_type_name + "_md_write.2";
-    const cldnn::mutable_data mutable_prim_w2{mutable_id_w2, shared_memory2, op_friendly_name};
+    const cldnn::mutable_data mutable_prim_w2{mutable_id_w2, shared_memory2};
     p.add_primitive(*op, mutable_prim_w2);
     inputs.push_back(mutable_id_w2);
 
@@ -73,17 +71,16 @@ static void CreateExperimentalDetectronDetectionOutputOp(
                                                               static_cast<int>(attrs.max_detections_per_image),
                                                               attrs.class_agnostic_box_regression,
                                                               attrs.max_delta_log_wh,
-                                                              attrs.deltas_weights,
-                                                              op_friendly_name};
+                                                              attrs.deltas_weights};
 
     p.add_primitive(*op, prim);
 
-    const auto mutable_id_r1 = layer_type_name + ".1";
-    const cldnn::mutable_data mutable_prim_r1{mutable_id_r1, {layer_name}, shared_memory1, op_friendly_name};
+    const auto mutable_id_r1 = layer_type_name + ".out1";
+    const cldnn::mutable_data mutable_prim_r1{mutable_id_r1, {layer_name}, shared_memory1};
     p.add_primitive(*op, mutable_prim_r1);
 
-    const auto mutable_id_r2 = layer_type_name + ".2";
-    const cldnn::mutable_data mutable_prim_r2{mutable_id_r2, {layer_name}, shared_memory2, op_friendly_name};
+    const auto mutable_id_r2 = layer_type_name + ".out2";
+    const cldnn::mutable_data mutable_prim_r2{mutable_id_r2, {layer_name}, shared_memory2};
     p.add_primitive(*op, mutable_prim_r2);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_generate_proposals_single_image.cpp
@@ -25,10 +25,8 @@ static void CreateExperimentalDetectronGenerateProposalsSingleImageOp(
 
     const auto& attrs = op->get_attrs();
 
-    const auto op_friendly_name = op->get_friendly_name();
-
     const auto layer_type_name = layer_type_name_ID(op);
-    const auto layer_name = layer_type_name + ".0";
+    const auto layer_name = layer_type_name + ".out0";
 
     const auto mutable_precision = op->get_output_element_type(1);
     const auto output_shape = op->get_output_shape(1);
@@ -38,19 +36,18 @@ static void CreateExperimentalDetectronGenerateProposalsSingleImageOp(
     cldnn::memory::ptr shared_memory{p.GetEngine().allocate_memory(mutable_layout)};
 
     const auto mutable_id_w = layer_type_name + "_md_write";
-    const cldnn::mutable_data mutable_prim_w{mutable_id_w, shared_memory, op_friendly_name};
+    const cldnn::mutable_data mutable_prim_w{mutable_id_w, shared_memory};
     p.add_primitive(*op, mutable_prim_w);
     inputs.push_back(mutable_id_w);
 
     const cldnn::experimental_detectron_generate_proposals_single_image prim{layer_name,
                              inputs[0], inputs[1], inputs[2], inputs[3], inputs.back(),
-                             attrs.min_size, attrs.nms_threshold, attrs.pre_nms_count, attrs.post_nms_count,
-                             op_friendly_name};
+                             attrs.min_size, attrs.nms_threshold, attrs.pre_nms_count, attrs.post_nms_count};
 
     p.add_primitive(*op, prim);
 
-    const auto mutable_id_r = layer_type_name + ".1";
-    const cldnn::mutable_data mutable_prim_r{mutable_id_r, {layer_name}, shared_memory, op_friendly_name};
+    const auto mutable_id_r = layer_type_name + ".out1";
+    const cldnn::mutable_data mutable_prim_r{mutable_id_r, {layer_name}, shared_memory};
     p.add_primitive(*op, mutable_prim_r);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_generate_proposals_single_image.cpp
@@ -16,7 +16,7 @@ namespace intel_gpu {
 static void CreateExperimentalDetectronGenerateProposalsSingleImageOp(
         Program& p,
         const std::shared_ptr<ngraph::op::v6::ExperimentalDetectronGenerateProposalsSingleImage>& op) {
-    p.ValidateInputs(op, {4});
+    validate_inputs_count(op, {4});
     if (op->get_output_size() != 2) {
         IE_THROW() << "ExperimentalDetectronGenerateProposalsSingleImage requires 2 outputs";
     }
@@ -39,8 +39,7 @@ static void CreateExperimentalDetectronGenerateProposalsSingleImageOp(
 
     const auto mutable_id_w = layer_type_name + "_md_write";
     const cldnn::mutable_data mutable_prim_w{mutable_id_w, shared_memory, op_friendly_name};
-    p.primitiveIDs[mutable_id_w] = mutable_id_w;
-    p.AddPrimitive(mutable_prim_w);
+    p.add_primitive(*op, mutable_prim_w);
     inputs.push_back(mutable_id_w);
 
     const cldnn::experimental_detectron_generate_proposals_single_image prim{layer_name,
@@ -48,14 +47,11 @@ static void CreateExperimentalDetectronGenerateProposalsSingleImageOp(
                              attrs.min_size, attrs.nms_threshold, attrs.pre_nms_count, attrs.post_nms_count,
                              op_friendly_name};
 
-    p.AddPrimitive(prim);
+    p.add_primitive(*op, prim);
 
     const auto mutable_id_r = layer_type_name + ".1";
     const cldnn::mutable_data mutable_prim_r{mutable_id_r, {layer_name}, shared_memory, op_friendly_name};
-    p.primitiveIDs[mutable_id_r] = mutable_id_r;
-    p.AddPrimitive(mutable_prim_r);
-
-    p.AddPrimitiveToProfiler(prim, op);
+    p.add_primitive(*op, mutable_prim_r);
 }
 
 REGISTER_FACTORY_IMPL(v6, ExperimentalDetectronGenerateProposalsSingleImage);

--- a/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_prior_grid_generator.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_prior_grid_generator.cpp
@@ -39,8 +39,7 @@ static void CreateExperimentalDetectronPriorGridGeneratorOp(
                                                             featmap_shape[2],
                                                             featmap_shape[3],
                                                             image_shape[2],
-                                                            image_shape[3],
-                                                            op->get_friendly_name()};
+                                                            image_shape[3]};
     p.add_primitive(*op, prim);
 }
 }  // namespace

--- a/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_prior_grid_generator.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_prior_grid_generator.cpp
@@ -20,7 +20,7 @@ cldnn::tensor mkTensor(const ov::Shape& shape) {
 static void CreateExperimentalDetectronPriorGridGeneratorOp(
     Program& p,
     const std::shared_ptr<ngraph::op::v6::ExperimentalDetectronPriorGridGenerator>& op) {
-    p.ValidateInputs(op, {3});
+    validate_inputs_count(op, {3});
     cldnn::tensor outTensor = mkTensor(op->get_output_shape(0));
     auto outDataType = DataTypeFromPrecision(op->get_output_element_type(0));
     cldnn::layout outLayout{outDataType, cldnn::format::bfyx, outTensor};
@@ -41,8 +41,7 @@ static void CreateExperimentalDetectronPriorGridGeneratorOp(
                                                             image_shape[2],
                                                             image_shape[3],
                                                             op->get_friendly_name()};
-    p.AddPrimitive(prim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, prim);
 }
 }  // namespace
 

--- a/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_roi_feature_extractor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_roi_feature_extractor.cpp
@@ -28,8 +28,7 @@ static void CreateExperimentalDetectronROIFeatureExtractorOp(Program& p, const s
     cldnn::mutable_data experimenta_detectron_mutable_prim(experimental_detectron_mutable_id_w,
                                                            shared_memory,
                                                            op->get_friendly_name());
-    p.primitiveIDs[experimental_detectron_mutable_id_w] = experimental_detectron_mutable_id_w;
-    p.AddPrimitive(experimenta_detectron_mutable_prim);
+    p.add_primitive(*op, experimenta_detectron_mutable_prim);
     inputPrimitives.push_back(experimental_detectron_mutable_id_w);
 
     const ov::op::v6::ExperimentalDetectronROIFeatureExtractor::Attributes& operation_attributes = op->get_attrs();
@@ -40,17 +39,14 @@ static void CreateExperimentalDetectronROIFeatureExtractorOp(Program& p, const s
                                                                                   operation_attributes.pyramid_scales,
                                                                                   operation_attributes.sampling_ratio,
                                                                                   operation_attributes.aligned);
-    p.AddPrimitive(experimentalDetectronPrim);
+    p.add_primitive(*op, experimentalDetectronPrim);
 
     cldnn::primitive_id experimental_detectron_mutable_id_r = layer_type_name_ID(op) + ".1";
     cldnn::mutable_data experimental_detectron_mutable_prim_r(experimental_detectron_mutable_id_r,
                                                               {layerName},
                                                               shared_memory,
                                                               op->get_friendly_name());
-    p.primitiveIDs[experimental_detectron_mutable_id_r] = experimental_detectron_mutable_id_r;
-    p.AddPrimitive(experimental_detectron_mutable_prim_r);
-
-    p.AddPrimitiveToProfiler(layerName, op);
+    p.add_primitive(*op, experimental_detectron_mutable_prim_r);
 }
 
 REGISTER_FACTORY_IMPL(v6, ExperimentalDetectronROIFeatureExtractor);

--- a/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_roi_feature_extractor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_roi_feature_extractor.cpp
@@ -15,7 +15,7 @@ namespace intel_gpu {
 
 static void CreateExperimentalDetectronROIFeatureExtractorOp(Program& p, const std::shared_ptr<ngraph::op::v6::ExperimentalDetectronROIFeatureExtractor>& op) {
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
-    std::string layerName = layer_type_name_ID(op) + ".0";
+    std::string layerName = layer_type_name_ID(op) + ".out0";
 
     cldnn::layout mutableLayout = cldnn::layout(
         DataTypeFromPrecision(op->get_output_element_type(1)),
@@ -26,8 +26,7 @@ static void CreateExperimentalDetectronROIFeatureExtractorOp(Program& p, const s
 
     cldnn::primitive_id experimental_detectron_mutable_id_w = layer_type_name_ID(op) + "_md_write";
     cldnn::mutable_data experimenta_detectron_mutable_prim(experimental_detectron_mutable_id_w,
-                                                           shared_memory,
-                                                           op->get_friendly_name());
+                                                           shared_memory);
     p.add_primitive(*op, experimenta_detectron_mutable_prim);
     inputPrimitives.push_back(experimental_detectron_mutable_id_w);
 
@@ -41,11 +40,10 @@ static void CreateExperimentalDetectronROIFeatureExtractorOp(Program& p, const s
                                                                                   operation_attributes.aligned);
     p.add_primitive(*op, experimentalDetectronPrim);
 
-    cldnn::primitive_id experimental_detectron_mutable_id_r = layer_type_name_ID(op) + ".1";
+    cldnn::primitive_id experimental_detectron_mutable_id_r = layer_type_name_ID(op) + ".out1";
     cldnn::mutable_data experimental_detectron_mutable_prim_r(experimental_detectron_mutable_id_r,
                                                               {layerName},
-                                                              shared_memory,
-                                                              op->get_friendly_name());
+                                                              shared_memory);
     p.add_primitive(*op, experimental_detectron_mutable_prim_r);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_topk_rois.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_topk_rois.cpp
@@ -19,7 +19,7 @@ using namespace cldnn;
 
 void CreateExperimentalDetectronTopKROIsOp(Program &p,
                                            const std::shared_ptr<ngraph::op::v6::ExperimentalDetectronTopKROIs> &op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto input_primitives = p.GetInputPrimitiveIDs(op);
     auto max_rois = op->get_max_rois();
     auto layer_name = layer_type_name_ID(op);
@@ -29,15 +29,13 @@ void CreateExperimentalDetectronTopKROIsOp(Program &p,
                                      ov::op::TopKSortType::SORT_VALUES, false, "", cldnn::padding(), cldnn::data_types::i32);
 
 
-    p.AddPrimitive(top_k_indices);
-    p.AddInnerPrimitiveToProfiler(top_k_indices, argmax_layer_name, op);
+    p.add_primitive(*op, top_k_indices);
 
     auto experimental_detectron_topk_layer = cldnn::experimental_detectron_topk_rois(layer_name,
                                                                                      {input_primitives[0],
                                                                                       argmax_layer_name}, max_rois);
 
-    p.AddPrimitive(experimental_detectron_topk_layer);
-    p.AddPrimitiveToProfiler(experimental_detectron_topk_layer, op);
+    p.add_primitive(*op, experimental_detectron_topk_layer);
 }
 
 } // namespace

--- a/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_topk_rois.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_topk_rois.cpp
@@ -26,7 +26,7 @@ void CreateExperimentalDetectronTopKROIsOp(Program &p,
     auto argmax_layer_name = layer_name + "_topk";
     auto top_k_indices = arg_max_min(argmax_layer_name,
                                      {input_primitives[1]}, ov::op::TopKMode::MAX, max_rois, 0,
-                                     ov::op::TopKSortType::SORT_VALUES, false, "", cldnn::padding(), cldnn::data_types::i32);
+                                     ov::op::TopKSortType::SORT_VALUES, false, cldnn::padding(), cldnn::data_types::i32);
 
 
     p.add_primitive(*op, top_k_indices);

--- a/src/plugins/intel_gpu/src/plugin/ops/extract_image_patches.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/extract_image_patches.cpp
@@ -24,7 +24,7 @@ static inline std::string PadToString(ngraph::op::PadType pad) {
 }
 
 static void CreateExtractImagePatchesOp(Program& p, const std::shared_ptr<ngraph::op::v3::ExtractImagePatches>& op) {
-    p.ValidateInputs(op, {1});
+    validate_inputs_count(op, {1});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -42,8 +42,7 @@ static void CreateExtractImagePatchesOp(Program& p, const std::shared_ptr<ngraph
                                                                 tensor_from_dims(op->get_output_shape(0)),
                                                                 op->get_friendly_name());
 
-    p.AddPrimitive(extractImagePatchesPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, extractImagePatchesPrim);
 }
 
 REGISTER_FACTORY_IMPL(v3, ExtractImagePatches);

--- a/src/plugins/intel_gpu/src/plugin/ops/extract_image_patches.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/extract_image_patches.cpp
@@ -39,8 +39,7 @@ static void CreateExtractImagePatchesOp(Program& p, const std::shared_ptr<ngraph
                                                                 strides,
                                                                 rates,
                                                                 auto_pad,
-                                                                tensor_from_dims(op->get_output_shape(0)),
-                                                                op->get_friendly_name());
+                                                                tensor_from_dims(op->get_output_shape(0)));
 
     p.add_primitive(*op, extractImagePatchesPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/fake_quantize.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/fake_quantize.cpp
@@ -13,7 +13,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateFakeQuantizeOp(Program& p, const std::shared_ptr<ngraph::op::v0::FakeQuantize>& op) {
-    p.ValidateInputs(op, {5});
+    validate_inputs_count(op, {5});
     std::string layerName = layer_type_name_ID(op);
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
 
@@ -35,8 +35,7 @@ static void CreateFakeQuantizeOp(Program& p, const std::shared_ptr<ngraph::op::v
                                             dt,
                                             op->get_friendly_name());
 
-    p.AddPrimitive(quantizationPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, quantizationPrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, FakeQuantize);

--- a/src/plugins/intel_gpu/src/plugin/ops/fake_quantize.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/fake_quantize.cpp
@@ -32,8 +32,7 @@ static void CreateFakeQuantizeOp(Program& p, const std::shared_ptr<ngraph::op::v
                                             output_low_id,
                                             output_high_id,
                                             levels,
-                                            dt,
-                                            op->get_friendly_name());
+                                            dt);
 
     p.add_primitive(*op, quantizationPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/gather tree.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather tree.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateGatherTreeOp(Program& p, const std::shared_ptr<ngraph::op::v1::GatherTree>& op) {
-    p.ValidateInputs(op, {4});
+    validate_inputs_count(op, {4});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -35,8 +35,7 @@ static void CreateGatherTreeOp(Program& p, const std::shared_ptr<ngraph::op::v1:
                                                  std::vector<float>(),
                                                  cldnn::reorder_mean_mode::subtract,
                                                  op->get_friendly_name());
-            p.AddPrimitive(preprocessPrim);
-            p.AddInnerPrimitiveToProfiler(reorderPrimName, layerName, op);
+            p.add_primitive(*op, preprocessPrim);
             reorderedInputs[portIndex] = reorderPrimName;
         } else {
             reorderedInputs[portIndex] = inputPrimitives[portIndex];
@@ -50,8 +49,7 @@ static void CreateGatherTreeOp(Program& p, const std::shared_ptr<ngraph::op::v1:
                                              reorderedInputs[3],
                                              op->get_friendly_name());
 
-    p.AddPrimitive(gatherTreePrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, gatherTreePrim);
 }
 
 REGISTER_FACTORY_IMPL(v1, GatherTree);

--- a/src/plugins/intel_gpu/src/plugin/ops/gather tree.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather tree.cpp
@@ -33,8 +33,7 @@ static void CreateGatherTreeOp(Program& p, const std::shared_ptr<ngraph::op::v1:
                                                  targetFormat,
                                                  cldnn::data_types::i32,
                                                  std::vector<float>(),
-                                                 cldnn::reorder_mean_mode::subtract,
-                                                 op->get_friendly_name());
+                                                 cldnn::reorder_mean_mode::subtract);
             p.add_primitive(*op, preprocessPrim);
             reorderedInputs[portIndex] = reorderPrimName;
         } else {
@@ -46,8 +45,7 @@ static void CreateGatherTreeOp(Program& p, const std::shared_ptr<ngraph::op::v1:
                                              reorderedInputs[0],
                                              reorderedInputs[1],
                                              reorderedInputs[2],
-                                             reorderedInputs[3],
-                                             op->get_friendly_name());
+                                             reorderedInputs[3]);
 
     p.add_primitive(*op, gatherTreePrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
@@ -35,8 +35,7 @@ void CreateGatherOpBase(Program& p, const std::shared_ptr<T>& op, const int64_t 
                                                  targetFormat,
                                                  cldnn::data_types::i32,
                                                  std::vector<float>(),
-                                                 cldnn::reorder_mean_mode::subtract,
-                                                 op->get_friendly_name());
+                                                 cldnn::reorder_mean_mode::subtract);
             p.add_primitive(*op, preprocessPrim);
             reorderedInputs[portIndex] = reorderPrimName;
         } else {
@@ -50,8 +49,7 @@ void CreateGatherOpBase(Program& p, const std::shared_ptr<T>& op, const int64_t 
                                     axis,
                                     op->get_output_shape(0),
                                     batch_dim,
-                                    support_neg_ind,
-                                    op->get_friendly_name());
+                                    support_neg_ind);
 
     p.add_primitive(*op, gatherPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
@@ -37,8 +37,7 @@ void CreateGatherOpBase(Program& p, const std::shared_ptr<T>& op, const int64_t 
                                                  std::vector<float>(),
                                                  cldnn::reorder_mean_mode::subtract,
                                                  op->get_friendly_name());
-            p.AddPrimitive(preprocessPrim);
-            p.AddInnerPrimitiveToProfiler(reorderPrimName, layerName, op);
+            p.add_primitive(*op, preprocessPrim);
             reorderedInputs[portIndex] = reorderPrimName;
         } else {
             reorderedInputs[portIndex] = inputPrimitives[portIndex];
@@ -54,26 +53,25 @@ void CreateGatherOpBase(Program& p, const std::shared_ptr<T>& op, const int64_t 
                                     support_neg_ind,
                                     op->get_friendly_name());
 
-    p.AddPrimitive(gatherPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, gatherPrim);
 }
 
 static void CreateGatherOp(Program& p, const std::shared_ptr<ngraph::op::v1::Gather>& op) {
-    p.ValidateInputs(op, {2, 3});
+    validate_inputs_count(op, {2, 3});
     CreateGatherOpBase<ngraph::op::v1::Gather>(p, op);
 }
 
 REGISTER_FACTORY_IMPL(v1, Gather);
 
 static void CreateGatherOp(Program& p, const std::shared_ptr<ngraph::op::v7::Gather>& op) {
-    p.ValidateInputs(op, {2, 3, 4});
+    validate_inputs_count(op, {2, 3, 4});
     CreateGatherOpBase<ngraph::op::v7::Gather>(p, op, op->get_batch_dims());
 }
 
 REGISTER_FACTORY_IMPL(v7, Gather);
 
 static void CreateGatherOp(Program& p, const std::shared_ptr<ngraph::op::v8::Gather>& op) {
-    p.ValidateInputs(op, {2, 3, 4});
+    validate_inputs_count(op, {2, 3, 4});
     CreateGatherOpBase<ngraph::op::v8::Gather>(p, op, op->get_batch_dims(), true);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/gather_elements.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather_elements.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateGatherElementsOp(Program& p, const std::shared_ptr<ngraph::op::v6::GatherElements>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -35,8 +35,7 @@ static void CreateGatherElementsOp(Program& p, const std::shared_ptr<ngraph::op:
                                             axis,
                                             op->get_friendly_name());
 
-    p.AddPrimitive(primitive);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, primitive);
 }
 
 REGISTER_FACTORY_IMPL(v6, GatherElements);

--- a/src/plugins/intel_gpu/src/plugin/ops/gather_elements.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather_elements.cpp
@@ -32,8 +32,7 @@ static void CreateGatherElementsOp(Program& p, const std::shared_ptr<ngraph::op:
                                             inputPrimitives[1],
                                             outLayout,
                                             tensor_from_dims(op->get_output_shape(0)),
-                                            axis,
-                                            op->get_friendly_name());
+                                            axis);
 
     p.add_primitive(*op, primitive);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/gather_nd.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather_nd.cpp
@@ -29,8 +29,7 @@ static void CreateGatherNDOp(Program& p, const std::shared_ptr<ngraph::op::v5::G
                                       input_rank,
                                       indices_rank,
                                       batch_dims,
-                                      true,
-                                      op->get_friendly_name());
+                                      true);
 
     p.add_primitive(*op, primitive);
 }
@@ -53,8 +52,7 @@ static void CreateGatherNDOp(Program& p, const std::shared_ptr<ngraph::op::v8::G
                                       input_rank,
                                       indices_rank,
                                       batch_dims,
-                                      false,
-                                      op->get_friendly_name());
+                                      false);
 
     p.add_primitive(*op, primitive);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/gather_nd.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather_nd.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateGatherNDOp(Program& p, const std::shared_ptr<ngraph::op::v5::GatherND>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -32,14 +32,13 @@ static void CreateGatherNDOp(Program& p, const std::shared_ptr<ngraph::op::v5::G
                                       true,
                                       op->get_friendly_name());
 
-    p.AddPrimitive(primitive);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, primitive);
 }
 
 REGISTER_FACTORY_IMPL(v5, GatherND);
 
 static void CreateGatherNDOp(Program& p, const std::shared_ptr<ngraph::op::v8::GatherND>& op) {
-    p.ValidateInputs(op, { 2 });
+    validate_inputs_count(op, { 2 });
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -57,8 +56,7 @@ static void CreateGatherNDOp(Program& p, const std::shared_ptr<ngraph::op::v8::G
                                       false,
                                       op->get_friendly_name());
 
-    p.AddPrimitive(primitive);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, primitive);
 }
 
 REGISTER_FACTORY_IMPL(v8, GatherND);

--- a/src/plugins/intel_gpu/src/plugin/ops/grn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/grn.cpp
@@ -20,8 +20,7 @@ static void CreateGRNOp(Program& p, const std::shared_ptr<ngraph::op::v0::GRN>& 
     auto primitive = cldnn::grn(layerName,
                                 inputPrimitives[0],
                                 op->get_bias(),
-                                DataTypeFromPrecision(op->get_output_element_type(0)),
-                                op->get_friendly_name());
+                                DataTypeFromPrecision(op->get_output_element_type(0)));
 
     p.add_primitive(*op, primitive);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/grn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/grn.cpp
@@ -13,7 +13,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateGRNOp(Program& p, const std::shared_ptr<ngraph::op::v0::GRN>& op) {
-    p.ValidateInputs(op, {1});
+    validate_inputs_count(op, {1});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -23,8 +23,7 @@ static void CreateGRNOp(Program& p, const std::shared_ptr<ngraph::op::v0::GRN>& 
                                 DataTypeFromPrecision(op->get_output_element_type(0)),
                                 op->get_friendly_name());
 
-    p.AddPrimitive(primitive);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, primitive);
 }
 
 REGISTER_FACTORY_IMPL(v0, GRN);

--- a/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
@@ -15,7 +15,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateInterpolateOp(Program& p, const std::shared_ptr<ngraph::op::v4::Interpolate>& op) {
-    p.ValidateInputs(op, {3, 4});
+    validate_inputs_count(op, {3, 4});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -90,8 +90,7 @@ static void CreateInterpolateOp(Program& p, const std::shared_ptr<ngraph::op::v4
                                         attrs.nearest_mode,
                                         op->get_friendly_name());
 
-    p.AddPrimitive(resamplePrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, resamplePrim);
 }
 
 REGISTER_FACTORY_IMPL(v4, Interpolate);

--- a/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
@@ -87,8 +87,7 @@ static void CreateInterpolateOp(Program& p, const std::shared_ptr<ngraph::op::v4
                                         interpolateMode,
                                         attrs.shape_calculation_mode,
                                         attrs.coordinate_transformation_mode,
-                                        attrs.nearest_mode,
-                                        op->get_friendly_name());
+                                        attrs.nearest_mode);
 
     p.add_primitive(*op, resamplePrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/loop.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/loop.cpp
@@ -142,9 +142,7 @@ static void CreateLoopOp(Program& p, const std::shared_ptr<Loop>& op) {
     const cldnn::primitive_id num_iteration_id = layerName + "_numIteration";
     {
         cldnn::mutable_data num_iteration = CreateScalarData<cldnn::mutable_data>(p, num_iteration_id, 0, op->get_friendly_name());
-        p.primitiveIDs[num_iteration_id] = num_iteration_id;
-        p.AddPrimitive(num_iteration);
-        p.AddInnerPrimitiveToProfiler(num_iteration_id, layerName, op);
+        p.add_primitive(*op, num_iteration);
     }
 
     // set output mapping
@@ -158,13 +156,9 @@ static void CreateLoopOp(Program& p, const std::shared_ptr<Loop>& op) {
         std::string external_id;
         if (output_idx > 0) {
             cldnn::mutable_data output_data = CreateAdditionalOutputData(p, op, layerNameWithIndex, layerName, output_idx);
-            p.AddPrimitive(output_data);
-            p.AddInnerPrimitiveToProfiler(layerNameWithIndex, layerName, op);
-            p.primitiveIDs[layerNameWithIndex] = layerNameWithIndex;
+            p.add_primitive(*op, output_data);
             external_id = layerNameWithIndex;
         } else {
-            p.primitiveIDs[layerNameWithIndex] = layerName;
-            p.primitiveIDs[layerName] = layerName;
             external_id = layerName;
         }
         const auto& body_output = body_outputs.at(loop_output_desc->m_body_value_index);
@@ -198,8 +192,7 @@ static void CreateLoopOp(Program& p, const std::shared_ptr<Loop>& op) {
         body_execution_condition_id,
         op->get_friendly_name());
 
-    p.AddPrimitive(loopPrimitive);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, loopPrimitive);
 }
 
 REGISTER_FACTORY_IMPL(v5, Loop);

--- a/src/plugins/intel_gpu/src/plugin/ops/loop.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/loop.cpp
@@ -30,11 +30,11 @@ namespace ov {
 namespace intel_gpu {
 
 template<class DATA_TYPE>
-static DATA_TYPE CreateScalarData(Program &p, const cldnn::primitive_id& id, int64_t num, const cldnn::primitive_id& ext_prim_id) {
+static DATA_TYPE CreateScalarData(Program &p, const cldnn::primitive_id& id, int64_t num) {
     auto mem = p.GetEngine().allocate_memory({ cldnn::data_types::i64, cldnn::format::bfyx, { 1, 1, 1, 1 } });
     cldnn::mem_lock<int64_t> ptr{mem, p.GetEngine().get_program_stream()};
     *ptr.begin() = num;
-    return {id, mem, ext_prim_id};
+    return {id, mem};
 }
 
 static cldnn::mutable_data CreateAdditionalOutputData(Program &p, const std::shared_ptr<ngraph::Node>& op,
@@ -45,7 +45,7 @@ static cldnn::mutable_data CreateAdditionalOutputData(Program &p, const std::sha
     const auto tensor = tensor_from_dims(op->get_output_shape(output_idx));
     cldnn::layout output_layout = cldnn::layout(precision, format, tensor);
     auto mem = p.GetEngine().allocate_memory(output_layout);
-    auto md = cldnn::mutable_data(id, {input}, mem, op->get_friendly_name()); // cldnn::data cannot set dependency
+    auto md = cldnn::mutable_data(id, {input}, mem); // cldnn::data cannot set dependency
     return md;
 }
 
@@ -141,7 +141,7 @@ static void CreateLoopOp(Program& p, const std::shared_ptr<Loop>& op) {
     }
     const cldnn::primitive_id num_iteration_id = layerName + "_numIteration";
     {
-        cldnn::mutable_data num_iteration = CreateScalarData<cldnn::mutable_data>(p, num_iteration_id, 0, op->get_friendly_name());
+        cldnn::mutable_data num_iteration = CreateScalarData<cldnn::mutable_data>(p, num_iteration_id, 0);
         p.add_primitive(*op, num_iteration);
     }
 
@@ -152,7 +152,7 @@ static void CreateLoopOp(Program& p, const std::shared_ptr<Loop>& op) {
         // Add additional mutable_data for multiple outputs
         // primitive ID should be <TI primitive ID>.<output_idx> if output_idx > 0
         // otherwise primitive ID should be equals to TI primitive ID
-        const std::string layerNameWithIndex = layerName + "." + std::to_string(output_idx);
+        const std::string layerNameWithIndex = layerName + ".out" + std::to_string(output_idx);
         std::string external_id;
         if (output_idx > 0) {
             cldnn::mutable_data output_data = CreateAdditionalOutputData(p, op, layerNameWithIndex, layerName, output_idx);
@@ -189,8 +189,7 @@ static void CreateLoopOp(Program& p, const std::shared_ptr<Loop>& op) {
         back_edges,             /* back edge mapping */
         num_iterations,         /* max iteration, i.e. length of iteration axis */
         body_current_iteration_id,
-        body_execution_condition_id,
-        op->get_friendly_name());
+        body_execution_condition_id);
 
     p.add_primitive(*op, loopPrimitive);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/lrn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/lrn.cpp
@@ -39,8 +39,7 @@ static void CreateLRNOp(Program& p, const std::shared_ptr<ngraph::op::v0::LRN>& 
                               static_cast<float>(op->get_bias()),
                               static_cast<float>(op->get_alpha()),
                               static_cast<float>(op->get_beta()),
-                              GetNormRegion(axis_value),
-                              op->get_friendly_name());
+                              GetNormRegion(axis_value));
 
     p.add_primitive(*op, lrnPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/lrn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/lrn.cpp
@@ -22,7 +22,7 @@ static cldnn::lrn_norm_region GetNormRegion(std::vector<int64_t> axis_value) {
 }
 
 static void CreateLRNOp(Program& p, const std::shared_ptr<ngraph::op::v0::LRN>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -42,8 +42,7 @@ static void CreateLRNOp(Program& p, const std::shared_ptr<ngraph::op::v0::LRN>& 
                               GetNormRegion(axis_value),
                               op->get_friendly_name());
 
-    p.AddPrimitive(lrnPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, lrnPrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, LRN);

--- a/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
@@ -89,8 +89,7 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
             auto permuteName = op->get_friendly_name() + "/transpose_b";
             auto permutePrim = cldnn::permute(permuteName,
                                               weightsName,
-                                              transpose_order,
-                                              op->get_friendly_name());
+                                              transpose_order);
             p.add_primitive(*op, permutePrim);
             weightsName = permuteName;
         }
@@ -107,8 +106,7 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
             auto permuteName = op->get_friendly_name() + "/transpose_a";
             auto permutePrim = cldnn::permute(permuteName,
                                               inputName,
-                                              transpose_order,
-                                              op->get_friendly_name());
+                                              transpose_order);
             p.add_primitive(*op, permutePrim);
             inputName = permuteName;
         }
@@ -125,8 +123,7 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
             auto reshapeInName = op->get_friendly_name() + suffix;
             auto reshapeInPrim = cldnn::reshape(reshapeInName,
                                                 inputName,
-                                                tensor_from_dims(reshapeSize),
-                                                op->get_friendly_name());
+                                                tensor_from_dims(reshapeSize));
             p.add_primitive(*op, reshapeInPrim);
             return reshapeInName;
         };
@@ -145,7 +142,6 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
                                              weightsName,
                                              "",
                                              DataTypeFromPrecision(op->get_output_element_type(0)),
-                                             op->get_friendly_name(),
                                              cldnn::padding(),
                                              input_rank);
 
@@ -173,14 +169,13 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
                                             layerName,
                                             outputLayout,
                                             std::vector<float>(),
-                                            cldnn::reorder_mean_mode::subtract,
-                                            op->get_friendly_name());
+                                            cldnn::reorder_mean_mode::subtract);
                 p.add_primitive(*op, reorder_prim);
                 lastLayerName = reorderId;
             }
 
             // add reshape
-            auto outReshapePrim = cldnn::reshape(outReshapeName, lastLayerName, outTensor, op->get_friendly_name());
+            auto outReshapePrim = cldnn::reshape(outReshapeName, lastLayerName, outTensor);
 
             p.add_primitive(*op, outReshapePrim);
 
@@ -217,8 +212,7 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
                                                   targetFormat,
                                                   targetDatatype,
                                                   std::vector<float>(),
-                                                  cldnn::reorder_mean_mode::subtract,
-                                                  op->get_friendly_name());
+                                                  cldnn::reorder_mean_mode::subtract);
 
                 p.add_primitive(*op, reorderPrim);
 
@@ -256,7 +250,7 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
 
                 auto targetShape = gemmSpecificTensor(inputDims);
 
-                auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape, op->get_friendly_name());
+                auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape);
 
                 p.add_primitive(*op, reshapePrim);
 
@@ -276,8 +270,7 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
                                     transA,
                                     transB,
                                     alpha,
-                                    beta,
-                                    op->get_friendly_name());
+                                    beta);
 
         p.add_primitive(*op, gemmPrim);
 
@@ -287,7 +280,7 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
         if (outDimsN < 4) {
             auto outputShape = tensor_from_dims(outDims);
             auto outReshapeName = layerName + "_cldnn_out_reshape";
-            auto outReshapePrim = cldnn::reshape(outReshapeName, layerName, outputShape, op->get_friendly_name());
+            auto outReshapePrim = cldnn::reshape(outReshapeName, layerName, outputShape);
 
             p.add_primitive(*op, outReshapePrim);
 

--- a/src/plugins/intel_gpu/src/plugin/ops/mvn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/mvn.cpp
@@ -28,12 +28,11 @@ static void CreateCommonMVNOp(Program& p, const std::shared_ptr<ngraph::Node>& o
                               across_channels,
                               op->get_friendly_name());
 
-    p.AddPrimitive(mvnPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, mvnPrim);
 }
 
 static void CreateMVNOp(Program& p, const std::shared_ptr<ngraph::op::v0::MVN>& op) {
-    p.ValidateInputs(op, {1});
+    validate_inputs_count(op, {1});
 
     bool across_channels = op->get_across_channels();
     bool normalize_variance = op->get_normalize_variance();
@@ -43,7 +42,7 @@ static void CreateMVNOp(Program& p, const std::shared_ptr<ngraph::op::v0::MVN>& 
 }
 
 static void CreateMVNOp(Program& p, const std::shared_ptr<ngraph::op::v6::MVN>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
 
     auto inConst = std::dynamic_pointer_cast<ngraph::op::Constant>(op->get_input_node_shared_ptr(1));
     if (!inConst)

--- a/src/plugins/intel_gpu/src/plugin/ops/mvn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/mvn.cpp
@@ -25,8 +25,7 @@ static void CreateCommonMVNOp(Program& p, const std::shared_ptr<ngraph::Node>& o
                               normalize_variance,
                               eps,
                               eps_inside_sqrt,
-                              across_channels,
-                              op->get_friendly_name());
+                              across_channels);
 
     p.add_primitive(*op, mvnPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/non_max_suppression.cpp
@@ -18,7 +18,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateNonMaxSuppressionIEInternalOp(Program& p, const std::shared_ptr<ngraph::op::internal::NonMaxSuppressionIEInternal>& op) {
-    p.ValidateInputs(op, {2, 3, 4, 5, 6});
+    validate_inputs_count(op, {2, 3, 4, 5, 6});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::vector<cldnn::primitive_id> reorderedInputs;
     reorderedInputs.resize(inputPrimitives.size());
@@ -37,8 +37,7 @@ static void CreateNonMaxSuppressionIEInternalOp(Program& p, const std::shared_pt
                                                  std::vector<float>(),
                                                  cldnn::reorder_mean_mode::subtract,
                                                  op->get_friendly_name());
-            p.AddPrimitive(preprocessPrim);
-            p.AddInnerPrimitiveToProfiler(reorderPrimName, layer_type_name_ID(op), op);
+            p.add_primitive(*op, preprocessPrim);
             reorderedInputs[portIndex] = (reorderPrimName);
         } else {
             reorderedInputs[portIndex] = inputPrimitives[portIndex];
@@ -79,8 +78,7 @@ static void CreateNonMaxSuppressionIEInternalOp(Program& p, const std::shared_pt
             auto nms_mutable_prim_second = cldnn::mutable_data(non_max_supression_mutable_id_w_second,
                                                                shared_memory.back(),
                                                                op->get_friendly_name());
-            p.primitiveIDs[non_max_supression_mutable_id_w_second] = non_max_supression_mutable_id_w_second;
-            p.AddPrimitive(nms_mutable_prim_second);
+            p.add_primitive(*op, nms_mutable_prim_second);
             inputPrimitives.push_back(non_max_supression_mutable_id_w_second);
         }
         case 2: {
@@ -99,8 +97,7 @@ static void CreateNonMaxSuppressionIEInternalOp(Program& p, const std::shared_pt
             auto nms_mutable_prim_first = cldnn::mutable_data(non_max_supression_mutable_id_w_first,
                                                               shared_memory.back(),
                                                               op->get_friendly_name());
-            p.primitiveIDs[non_max_supression_mutable_id_w_first] = non_max_supression_mutable_id_w_first;
-            p.AddPrimitive(nms_mutable_prim_first);
+            p.add_primitive(*op, nms_mutable_prim_first);
             inputPrimitives.push_back(non_max_supression_mutable_id_w_first);
         }
         case 1: break;
@@ -136,7 +133,7 @@ static void CreateNonMaxSuppressionIEInternalOp(Program& p, const std::shared_pt
         default: break;
     }
 
-    p.AddPrimitive(prim);
+    p.add_primitive(*op, prim);
 
     switch (num_output) {
         case 3: {
@@ -145,8 +142,7 @@ static void CreateNonMaxSuppressionIEInternalOp(Program& p, const std::shared_pt
                                                                  { nonMaxSupressionLayerName },
                                                                  shared_memory.front(),
                                                                  op->get_friendly_name());
-            p.primitiveIDs[non_max_supression_id_r_second] = non_max_supression_id_r_second;
-            p.AddPrimitive(nms_mutable_prim_r_second);
+            p.add_primitive(*op, nms_mutable_prim_r_second);
         }
         case 2: {
             cldnn::primitive_id non_max_supression_id_r_first = layer_type_name_ID(op) + ".1";
@@ -154,13 +150,10 @@ static void CreateNonMaxSuppressionIEInternalOp(Program& p, const std::shared_pt
                                                                 { nonMaxSupressionLayerName },
                                                                 shared_memory.back(),
                                                                 op->get_friendly_name());
-            p.primitiveIDs[non_max_supression_id_r_first] = non_max_supression_id_r_first;
-            p.AddPrimitive(nms_mutable_prim_r_first);
+            p.add_primitive(*op, nms_mutable_prim_r_first);
         }
         default: break;
     }
-
-    p.AddPrimitiveToProfiler(nonMaxSupressionLayerName, op);
 }
 
 REGISTER_FACTORY_IMPL(internal, NonMaxSuppressionIEInternal);

--- a/src/plugins/intel_gpu/src/plugin/ops/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/non_max_suppression.cpp
@@ -35,8 +35,7 @@ static void CreateNonMaxSuppressionIEInternalOp(Program& p, const std::shared_pt
                                                  targetFormat,
                                                  cldnn::data_types::i32,
                                                  std::vector<float>(),
-                                                 cldnn::reorder_mean_mode::subtract,
-                                                 op->get_friendly_name());
+                                                 cldnn::reorder_mean_mode::subtract);
             p.add_primitive(*op, preprocessPrim);
             reorderedInputs[portIndex] = (reorderPrimName);
         } else {
@@ -76,8 +75,7 @@ static void CreateNonMaxSuppressionIEInternalOp(Program& p, const std::shared_pt
 
             cldnn::primitive_id non_max_supression_mutable_id_w_second = layer_type_name_ID(op) + "_md_write_second";
             auto nms_mutable_prim_second = cldnn::mutable_data(non_max_supression_mutable_id_w_second,
-                                                               shared_memory.back(),
-                                                               op->get_friendly_name());
+                                                               shared_memory.back());
             p.add_primitive(*op, nms_mutable_prim_second);
             inputPrimitives.push_back(non_max_supression_mutable_id_w_second);
         }
@@ -95,8 +93,7 @@ static void CreateNonMaxSuppressionIEInternalOp(Program& p, const std::shared_pt
 
             cldnn::primitive_id non_max_supression_mutable_id_w_first = layer_type_name_ID(op) + "_md_write_first";
             auto nms_mutable_prim_first = cldnn::mutable_data(non_max_supression_mutable_id_w_first,
-                                                              shared_memory.back(),
-                                                              op->get_friendly_name());
+                                                              shared_memory.back());
             p.add_primitive(*op, nms_mutable_prim_first);
             inputPrimitives.push_back(non_max_supression_mutable_id_w_first);
         }
@@ -104,7 +101,7 @@ static void CreateNonMaxSuppressionIEInternalOp(Program& p, const std::shared_pt
         default: IE_THROW() << "Incorrect number of output for layer: " << op->get_friendly_name();
     }
 
-    auto nonMaxSupressionLayerName = num_output > 1 ? layer_type_name_ID(op) + ".0" : layer_type_name_ID(op);
+    auto nonMaxSupressionLayerName = num_output > 1 ? layer_type_name_ID(op) + ".out0" : layer_type_name_ID(op);
 
     auto prim = cldnn::non_max_suppression(
             nonMaxSupressionLayerName,
@@ -113,8 +110,7 @@ static void CreateNonMaxSuppressionIEInternalOp(Program& p, const std::shared_pt
             static_cast<int>(outputIndices),
             op->m_center_point_box,
             op->m_sort_result_descending,
-            "", "", "", "", "", "",
-            op->get_friendly_name());
+            "", "", "", "", "", "");
 
     prim.output_data_type = DataTypeFromPrecision(out_type);
 
@@ -137,19 +133,17 @@ static void CreateNonMaxSuppressionIEInternalOp(Program& p, const std::shared_pt
 
     switch (num_output) {
         case 3: {
-            cldnn::primitive_id non_max_supression_id_r_second = layer_type_name_ID(op) + ".2";
+            cldnn::primitive_id non_max_supression_id_r_second = layer_type_name_ID(op) + ".out2";
             auto nms_mutable_prim_r_second = cldnn::mutable_data(non_max_supression_id_r_second,
                                                                  { nonMaxSupressionLayerName },
-                                                                 shared_memory.front(),
-                                                                 op->get_friendly_name());
+                                                                 shared_memory.front());
             p.add_primitive(*op, nms_mutable_prim_r_second);
         }
         case 2: {
-            cldnn::primitive_id non_max_supression_id_r_first = layer_type_name_ID(op) + ".1";
+            cldnn::primitive_id non_max_supression_id_r_first = layer_type_name_ID(op) + ".out1";
             auto nms_mutable_prim_r_first = cldnn::mutable_data(non_max_supression_id_r_first,
                                                                 { nonMaxSupressionLayerName },
-                                                                shared_memory.back(),
-                                                                op->get_friendly_name());
+                                                                shared_memory.back());
             p.add_primitive(*op, nms_mutable_prim_r_first);
         }
         default: break;

--- a/src/plugins/intel_gpu/src/plugin/ops/non_zero.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/non_zero.cpp
@@ -18,28 +18,15 @@ static void CreateNonZeroOp(Program& p, const std::shared_ptr<ngraph::Node>& op)
     std::string layer_name = layer_type_name_ID(op);
 
     cldnn::primitive_id count_prim_id = layer_name + "_count";
-    auto count_prim = std::make_shared<cldnn::count_nonzero>(count_prim_id,
-                                           input_primitives[0],
-                                           op->get_friendly_name());
+    auto count_prim = cldnn::count_nonzero(count_prim_id,
+                                           input_primitives[0]);
 
-    auto gather_prim = std::make_shared<cldnn::gather_nonzero>(layer_name,
+    auto gather_prim = cldnn::gather_nonzero(layer_name,
                                              input_primitives[0],
-                                             count_prim_id,
-                                             op->get_friendly_name());
+                                             count_prim_id);
 
     p.add_primitive(*op, count_prim);
     p.add_primitive(*op, gather_prim);
-    // auto count_prim = cldnn::count_nonzero(count_prim_id,
-    //                                        input_primitives[0],
-    //                                        op->get_friendly_name());
-
-    // auto gather_prim = cldnn::gather_nonzero(layer_name,
-    //                                          input_primitives[0],
-    //                                          count_prim_id,
-    //                                          op->get_friendly_name());
-
-    // p.add_primitive(*op, count_prim);
-    // p.add_primitive(*op, gather_prim);
 }
 
 REGISTER_FACTORY_IMPL(v3, NonZero);

--- a/src/plugins/intel_gpu/src/plugin/ops/non_zero.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/non_zero.cpp
@@ -13,23 +13,33 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateNonZeroOp(Program& p, const std::shared_ptr<ngraph::Node>& op) {
-    p.ValidateInputs(op, {1});
+    validate_inputs_count(op, {1});
     auto input_primitives = p.GetInputPrimitiveIDs(op);
     std::string layer_name = layer_type_name_ID(op);
 
     cldnn::primitive_id count_prim_id = layer_name + "_count";
-    auto count_prim = cldnn::count_nonzero(count_prim_id,
+    auto count_prim = std::make_shared<cldnn::count_nonzero>(count_prim_id,
                                            input_primitives[0],
                                            op->get_friendly_name());
 
-    auto gather_prim = cldnn::gather_nonzero(layer_name,
+    auto gather_prim = std::make_shared<cldnn::gather_nonzero>(layer_name,
                                              input_primitives[0],
                                              count_prim_id,
                                              op->get_friendly_name());
 
-    p.AddPrimitive(count_prim);
-    p.AddPrimitive(gather_prim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, count_prim);
+    p.add_primitive(*op, gather_prim);
+    // auto count_prim = cldnn::count_nonzero(count_prim_id,
+    //                                        input_primitives[0],
+    //                                        op->get_friendly_name());
+
+    // auto gather_prim = cldnn::gather_nonzero(layer_name,
+    //                                          input_primitives[0],
+    //                                          count_prim_id,
+    //                                          op->get_friendly_name());
+
+    // p.add_primitive(*op, count_prim);
+    // p.add_primitive(*op, gather_prim);
 }
 
 REGISTER_FACTORY_IMPL(v3, NonZero);

--- a/src/plugins/intel_gpu/src/plugin/ops/normalize_l2.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/normalize_l2.cpp
@@ -46,14 +46,13 @@ static void CreateNormalizeL2Op(Program& p, const std::shared_ptr<ngraph::op::v0
 
     std::memcpy(&buf[0], scale->get_data_ptr(), bufSize);
     auto scalesName = layerName + "_cldnn_input_scales";
-    p.add_primitive(*op, cldnn::data(scalesName, mem, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::data(scalesName, mem));
 
     auto normPrim = cldnn::normalize(layerName,
                                      inputPrimitives[0],
                                      scalesName,
                                      across_spatial,
-                                     eps,
-                                     op->get_friendly_name());
+                                     eps);
 
     p.add_primitive(*op, normPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/normalize_l2.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/normalize_l2.cpp
@@ -15,7 +15,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateNormalizeL2Op(Program& p, const std::shared_ptr<ngraph::op::v0::NormalizeL2>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -46,8 +46,7 @@ static void CreateNormalizeL2Op(Program& p, const std::shared_ptr<ngraph::op::v0
 
     std::memcpy(&buf[0], scale->get_data_ptr(), bufSize);
     auto scalesName = layerName + "_cldnn_input_scales";
-    p.AddPrimitive(cldnn::data(scalesName, mem, op->get_friendly_name()));
-    p.AddInnerPrimitiveToProfiler(scalesName, layerName, op);
+    p.add_primitive(*op, cldnn::data(scalesName, mem, op->get_friendly_name()));
 
     auto normPrim = cldnn::normalize(layerName,
                                      inputPrimitives[0],
@@ -56,8 +55,7 @@ static void CreateNormalizeL2Op(Program& p, const std::shared_ptr<ngraph::op::v0
                                      eps,
                                      op->get_friendly_name());
 
-    p.AddPrimitive(normPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, normPrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, NormalizeL2);

--- a/src/plugins/intel_gpu/src/plugin/ops/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/one_hot.cpp
@@ -64,8 +64,7 @@ static void CreateOneHotOp(Program& p, const std::shared_ptr<ngraph::op::v1::One
                                      axis,
                                      depth,
                                      on_value,
-                                     off_value,
-                                     op->get_friendly_name());
+                                     off_value);
 
     p.add_primitive(*op, oneHotPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/one_hot.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateOneHotOp(Program& p, const std::shared_ptr<ngraph::op::v1::OneHot>& op) {
-    p.ValidateInputs(op, {4});
+    validate_inputs_count(op, {4});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -67,8 +67,7 @@ static void CreateOneHotOp(Program& p, const std::shared_ptr<ngraph::op::v1::One
                                      off_value,
                                      op->get_friendly_name());
 
-    p.AddPrimitive(oneHotPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, oneHotPrim);
 }
 
 REGISTER_FACTORY_IMPL(v1, OneHot);

--- a/src/plugins/intel_gpu/src/plugin/ops/pad.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/pad.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreatePadOp(Program& p, const std::shared_ptr<ngraph::op::v1::Pad>& op) {
-    p.ValidateInputs(op, {3, 4});
+    validate_inputs_count(op, {3, 4});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
     size_t rank = std::max(op->get_input_shape(0).size(), static_cast<size_t>(4));
@@ -45,8 +45,7 @@ static void CreatePadOp(Program& p, const std::shared_ptr<ngraph::op::v1::Pad>& 
                                   pad_value,
                                   op->get_friendly_name());
 
-    p.AddPrimitive(tilePrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, tilePrim);
 }
 
 REGISTER_FACTORY_IMPL(v1, Pad);

--- a/src/plugins/intel_gpu/src/plugin/ops/pad.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/pad.cpp
@@ -42,8 +42,7 @@ static void CreatePadOp(Program& p, const std::shared_ptr<ngraph::op::v1::Pad>& 
                                   pads_begin,
                                   pads_end,
                                   op->get_pad_mode(),
-                                  pad_value,
-                                  op->get_friendly_name());
+                                  pad_value);
 
     p.add_primitive(*op, tilePrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/parameter.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/parameter.cpp
@@ -214,7 +214,7 @@ static void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::
                 std::string batched_name = inputName + "_" + std::to_string(i);
                 p.inputLayouts.insert({ inputInfo->name() + "_" + std::to_string(i), networkInputLayout });
                 inputs.emplace_back(batched_name);
-                p.add_primitive(*op, cldnn::input_layout(batched_name, networkInputLayout, inputInfo->name()));
+                p.add_primitive(*op, cldnn::input_layout(batched_name, networkInputLayout));
             }
             p.primitive_ids[inputName] = inputName;
         } else {
@@ -222,7 +222,7 @@ static void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::
                                             TensorValue(inputDims[2]), TensorValue(inputDims[1]) });
 
             p.inputLayouts.insert({ inputInfo->name(), networkInputLayout });
-            p.add_primitive(*op, cldnn::input_layout(inputName, networkInputLayout, inputInfo->name()));
+            p.add_primitive(*op, cldnn::input_layout(inputName, networkInputLayout));
         }
     } else {
         if (ColorFormat::NV12 == preProcess.getColorFormat() && p.GetConfig().nv12_two_inputs) {
@@ -246,8 +246,8 @@ static void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::
                                        cldnn::format::nv12, { 1, 1, width, height });
                 cldnn::layout uv_layout(DataTypeFromPrecision(ip),
                                         cldnn::format::nv12, { 1, 2, width / 2, height / 2 });
-                auto inputY = cldnn::input_layout(y_name, y_layout, inputInfo->name());
-                auto inputUV = cldnn::input_layout(uv_name, uv_layout, inputInfo->name());
+                auto inputY = cldnn::input_layout(y_name, y_layout);
+                auto inputUV = cldnn::input_layout(uv_name, uv_layout);
 
                 p.add_primitive(*op, inputY);
                 p.inputLayouts.insert({ inputInfo->name() + "_Y" + std::to_string(i), y_layout });
@@ -261,8 +261,7 @@ static void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::
                                                         uv_name,
                                                         networkInputLayout,
                                                         meanValues,
-                                                        cldnn::reorder_mean_mode::subtract,
-                                                        inputInfo->name()), {inputName});
+                                                        cldnn::reorder_mean_mode::subtract), {inputName});
                     break;
                 }
                 case MEAN_IMAGE: {
@@ -271,8 +270,7 @@ static void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::
                                                         uv_name,
                                                         networkInputLayout,
                                                         meanBlobID,
-                                                        cldnn::reorder_mean_mode::subtract,
-                                                        inputInfo->name()), {inputName});
+                                                        cldnn::reorder_mean_mode::subtract), {inputName});
                     break;
                 }
                 default: IE_THROW(Unexpected) << "Invalid mean variant in input " + inputName;
@@ -284,7 +282,7 @@ static void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::
 
             if (inputDims[0] > 1) {
                 auto concatPrimID = "concat:" + inputName + Program::m_preProcessTag;
-                p.add_primitive(*op, cldnn::concatenation(concatPrimID, reorders, 0, op->get_friendly_name()));
+                p.add_primitive(*op, cldnn::concatenation(concatPrimID, reorders, 0));
             }
         } else {
             auto preprocessPrimID = "reorder:" + inputName + Program::m_preProcessTag;
@@ -292,7 +290,7 @@ static void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::
             inputLayout.data_type = DataTypeFromPrecision(ip);
             p.inputLayouts.insert({ inputInfo->name(), inputLayout });
 
-            p.add_primitive(*op, cldnn::input_layout(inputName, inputLayout, inputInfo->name()));
+            p.add_primitive(*op, cldnn::input_layout(inputName, inputLayout));
 
             switch (preProcess.getMeanVariant()) {
             case NONE:
@@ -301,8 +299,7 @@ static void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::
                                                     inputName,
                                                     networkInputLayout,
                                                     meanValues,
-                                                    cldnn::reorder_mean_mode::subtract,
-                                                    op->get_friendly_name()), {inputName});
+                                                    cldnn::reorder_mean_mode::subtract), {inputName});
                 break;
             }
             case MEAN_IMAGE: {
@@ -310,8 +307,7 @@ static void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::
                                                     inputName,
                                                     networkInputLayout,
                                                     meanBlobID,
-                                                    cldnn::reorder_mean_mode::subtract,
-                                                    op->get_friendly_name()), {inputName});
+                                                    cldnn::reorder_mean_mode::subtract), {inputName});
                 break;
             }
             default: IE_THROW() << "Invalid mean variant in input " << inputName;

--- a/src/plugins/intel_gpu/src/plugin/ops/parameter.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/parameter.cpp
@@ -165,7 +165,7 @@ static void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::
 
             std::memcpy(&buf[0], &data[0], bufSize);
 
-            p.AddPrimitive(cldnn::data(meanBlobID, mem));
+            p.add_primitive(*op, cldnn::data(meanBlobID, mem));
             p.blobMemCache[std::make_pair(data, meanDims)] = meanBlobID;
         }
         break;
@@ -214,16 +214,15 @@ static void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::
                 std::string batched_name = inputName + "_" + std::to_string(i);
                 p.inputLayouts.insert({ inputInfo->name() + "_" + std::to_string(i), networkInputLayout });
                 inputs.emplace_back(batched_name);
-                p.AddPrimitive(cldnn::input_layout(batched_name, networkInputLayout, inputInfo->name()));
-                p.AddPrimitiveToProfiler(op);
+                p.add_primitive(*op, cldnn::input_layout(batched_name, networkInputLayout, inputInfo->name()));
             }
+            p.primitive_ids[inputName] = inputName;
         } else {
             networkInputLayout.set_tensor({ TensorValue(inputDims[0]), TensorValue(inputDims[3]),
                                             TensorValue(inputDims[2]), TensorValue(inputDims[1]) });
 
             p.inputLayouts.insert({ inputInfo->name(), networkInputLayout });
-            p.AddPrimitive(cldnn::input_layout(inputName, networkInputLayout, inputInfo->name()));
-            p.AddPrimitiveToProfiler(op);
+            p.add_primitive(*op, cldnn::input_layout(inputName, networkInputLayout, inputInfo->name()));
         }
     } else {
         if (ColorFormat::NV12 == preProcess.getColorFormat() && p.GetConfig().nv12_two_inputs) {
@@ -250,47 +249,42 @@ static void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::
                 auto inputY = cldnn::input_layout(y_name, y_layout, inputInfo->name());
                 auto inputUV = cldnn::input_layout(uv_name, uv_layout, inputInfo->name());
 
-                p.AddPrimitive(inputY);
+                p.add_primitive(*op, inputY);
                 p.inputLayouts.insert({ inputInfo->name() + "_Y" + std::to_string(i), y_layout });
-                p.AddPrimitive(inputUV);
+                p.add_primitive(*op, inputUV);
                 p.inputLayouts.insert({ inputInfo->name() + "_UV" + std::to_string(i), uv_layout });
                 switch (preProcess.getMeanVariant()) {
                 case NONE:
                 case MEAN_VALUE: {
-                    p.AddPrimitive(cldnn::reorder(preprocessPrimID,
-                                                  y_name,
-                                                  uv_name,
-                                                  networkInputLayout,
-                                                  meanValues,
-                                                  cldnn::reorder_mean_mode::subtract,
-                                                  inputInfo->name()));
+                    p.add_primitive(*op, cldnn::reorder(preprocessPrimID,
+                                                        y_name,
+                                                        uv_name,
+                                                        networkInputLayout,
+                                                        meanValues,
+                                                        cldnn::reorder_mean_mode::subtract,
+                                                        inputInfo->name()), {inputName});
                     break;
                 }
                 case MEAN_IMAGE: {
-                    p.AddPrimitive(cldnn::reorder(preprocessPrimID,
-                                                  y_name,
-                                                  uv_name,
-                                                  networkInputLayout,
-                                                  meanBlobID,
-                                                  cldnn::reorder_mean_mode::subtract,
-                                                  inputInfo->name()));
+                    p.add_primitive(*op, cldnn::reorder(preprocessPrimID,
+                                                        y_name,
+                                                        uv_name,
+                                                        networkInputLayout,
+                                                        meanBlobID,
+                                                        cldnn::reorder_mean_mode::subtract,
+                                                        inputInfo->name()), {inputName});
                     break;
                 }
                 default: IE_THROW(Unexpected) << "Invalid mean variant in input " + inputName;
                     break;
                 }
 
-                p.profilingIDs.push_back(preprocessPrimID);
-                p.InitProfileInfo(preprocessPrimID, "Reorder");
-                p.primitiveIDs[inputName] = preprocessPrimID;  // If it is batched blob, it will be overwritten afterwards.
-                p.primitiveIDs[preprocessPrimID] = preprocessPrimID;
                 reorders.push_back(preprocessPrimID);
             }
 
             if (inputDims[0] > 1) {
                 auto concatPrimID = "concat:" + inputName + Program::m_preProcessTag;
-                p.AddPrimitive(cldnn::concatenation(concatPrimID, reorders, 0, op->get_friendly_name()));
-                p.primitiveIDs[inputName] = concatPrimID;
+                p.add_primitive(*op, cldnn::concatenation(concatPrimID, reorders, 0, op->get_friendly_name()));
             }
         } else {
             auto preprocessPrimID = "reorder:" + inputName + Program::m_preProcessTag;
@@ -298,35 +292,31 @@ static void CreateParameterOp(Program& p, const std::shared_ptr<ngraph::op::v0::
             inputLayout.data_type = DataTypeFromPrecision(ip);
             p.inputLayouts.insert({ inputInfo->name(), inputLayout });
 
-            p.AddPrimitive(cldnn::input_layout(inputName, inputLayout, inputInfo->name()));
+            p.add_primitive(*op, cldnn::input_layout(inputName, inputLayout, inputInfo->name()));
 
             switch (preProcess.getMeanVariant()) {
             case NONE:
             case MEAN_VALUE: {
-                p.AddPrimitive(cldnn::reorder(preprocessPrimID,
-                                              inputName,
-                                              networkInputLayout,
-                                              meanValues,
-                                              cldnn::reorder_mean_mode::subtract,
-                                              op->get_friendly_name()));
+                p.add_primitive(*op, cldnn::reorder(preprocessPrimID,
+                                                    inputName,
+                                                    networkInputLayout,
+                                                    meanValues,
+                                                    cldnn::reorder_mean_mode::subtract,
+                                                    op->get_friendly_name()), {inputName});
                 break;
             }
             case MEAN_IMAGE: {
-                p.AddPrimitive(cldnn::reorder(preprocessPrimID,
-                                              inputName,
-                                              networkInputLayout,
-                                              meanBlobID,
-                                              cldnn::reorder_mean_mode::subtract,
-                                              op->get_friendly_name()));
+                p.add_primitive(*op, cldnn::reorder(preprocessPrimID,
+                                                    inputName,
+                                                    networkInputLayout,
+                                                    meanBlobID,
+                                                    cldnn::reorder_mean_mode::subtract,
+                                                    op->get_friendly_name()), {inputName});
                 break;
             }
             default: IE_THROW() << "Invalid mean variant in input " << inputName;
                 break;
             }
-            p.InitProfileInfo(preprocessPrimID, "reorder");
-            p.primitiveIDs[preprocessPrimID] = preprocessPrimID;
-            p.primitiveIDs[inputName] = preprocessPrimID;
-            p.profilingIDs.push_back(preprocessPrimID);
         }
     }
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/pooling.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/pooling.cpp
@@ -37,8 +37,7 @@ static void CreateAvgPoolOp(Program& p, const std::shared_ptr<ngraph::op::v1::Av
                                    strides,
                                    pads_begin,
                                    tensor_from_dims(op->get_output_shape(0)),
-                                   DataTypeFromPrecision(op->get_output_element_type(0)),
-                                   op->get_friendly_name());
+                                   DataTypeFromPrecision(op->get_output_element_type(0)));
     poolPrim.pad_end = pads_end;
     p.add_primitive(*op, poolPrim);
 }
@@ -66,8 +65,7 @@ static void CreateMaxPoolOp(Program& p, const std::shared_ptr<ngraph::op::v1::Ma
                                    strides,
                                    pads_begin,
                                    tensor_from_dims(op->get_output_shape(0)),
-                                   DataTypeFromPrecision(op->get_output_element_type(0)),
-                                   op->get_friendly_name());
+                                   DataTypeFromPrecision(op->get_output_element_type(0)));
     poolPrim.pad_end = pads_end;
     p.add_primitive(*op, poolPrim);
 }
@@ -79,7 +77,7 @@ static void CreateMaxPoolOp(Program& p, const std::shared_ptr<ngraph::op::v8::Ma
     }
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     const auto layer_type_name = layer_type_name_ID(op);
-    const auto layerName = layer_type_name + ".0";
+    const auto layerName = layer_type_name + ".out0";
 
     const auto mutable_precision = op->get_output_element_type(1);
     const auto output_shape = op->get_output_shape(1);
@@ -88,10 +86,8 @@ static void CreateMaxPoolOp(Program& p, const std::shared_ptr<ngraph::op::v8::Ma
                                                 tensor_from_dims(output_shape));
     const auto shared_memory = p.GetEngine().allocate_memory(mutableLayout);
     const cldnn::primitive_id maxpool_mutable_id_w = layer_type_name + "_md_write";
-    const auto op_friendly_name = op->get_friendly_name();
     auto indices_mutable_prim = cldnn::mutable_data(maxpool_mutable_id_w,
-                                                          shared_memory,
-                                                          op_friendly_name);
+                                                          shared_memory);
     p.add_primitive(*op, indices_mutable_prim);
     inputPrimitives.push_back(maxpool_mutable_id_w);
 
@@ -119,15 +115,13 @@ static void CreateMaxPoolOp(Program& p, const std::shared_ptr<ngraph::op::v8::Ma
                                    op->get_axis(),
                                    DataTypeFromPrecision(op->get_index_element_type()),
                                    tensor_from_dims(op->get_output_shape(0)),
-                                   DataTypeFromPrecision(op->get_output_element_type(0)),
-                                   op_friendly_name);
+                                   DataTypeFromPrecision(op->get_output_element_type(0)));
     p.add_primitive(*op, poolPrim);
 
-    const cldnn::primitive_id maxpool_mutable_id_r = layer_type_name + ".1";
+    const cldnn::primitive_id maxpool_mutable_id_r = layer_type_name + ".out1";
     auto indices_mutable_id_r = cldnn::mutable_data(maxpool_mutable_id_r,
-                                                          { layerName },
-                                                          shared_memory,
-                                                          op_friendly_name);
+                                                    { layerName },
+                                                    shared_memory);
     p.add_primitive(*op, indices_mutable_id_r);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/prior_box.cpp
@@ -60,8 +60,7 @@ static void CreatePriorBoxClusteredOp(Program& p, const std::shared_ptr<ngraph::
                                          offset,
                                          width,
                                          height,
-                                         DataTypeFromPrecision(op->get_output_element_type(0)),
-                                         op->get_friendly_name());
+                                         DataTypeFromPrecision(op->get_output_element_type(0)));
 
     p.add_primitive(*op, priorBoxPrim);
 }
@@ -112,8 +111,7 @@ static void CreatePriorBoxOp(Program& p, const std::shared_ptr<ngraph::op::v0::P
                                          scale_all_sizes,
                                          fixed_ratio,
                                          fixed_size,
-                                         density,
-                                         op->get_friendly_name());
+                                         density);
 
     p.add_primitive(*op, priorBoxPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/prior_box.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreatePriorBoxClusteredOp(Program& p, const std::shared_ptr<ngraph::op::v0::PriorBoxClustered>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -63,12 +63,11 @@ static void CreatePriorBoxClusteredOp(Program& p, const std::shared_ptr<ngraph::
                                          DataTypeFromPrecision(op->get_output_element_type(0)),
                                          op->get_friendly_name());
 
-    p.AddPrimitive(priorBoxPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, priorBoxPrim);
 }
 
 static void CreatePriorBoxOp(Program& p, const std::shared_ptr<ngraph::op::v0::PriorBox>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -116,8 +115,7 @@ static void CreatePriorBoxOp(Program& p, const std::shared_ptr<ngraph::op::v0::P
                                          density,
                                          op->get_friendly_name());
 
-    p.AddPrimitive(priorBoxPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, priorBoxPrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, PriorBoxClustered);

--- a/src/plugins/intel_gpu/src/plugin/ops/proposal.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/proposal.cpp
@@ -72,12 +72,11 @@ static void CreateProposalOp(Program& p, const std::shared_ptr<ngraph::op::v0::P
 
         cldnn::primitive_id proposal_mutable_id_w = layer_type_name_ID(op) + "_md_write";
         auto argmax_mutable_prim = cldnn::mutable_data(proposal_mutable_id_w,
-                                                       shared_memory,
-                                                       op->get_friendly_name());
+                                                       shared_memory);
         p.add_primitive(*op, argmax_mutable_prim);
         inputPrimitives.push_back(proposal_mutable_id_w);
 
-        std::string proposalLayerName = layer_type_name_ID(op) + ".0";
+        std::string proposalLayerName = layer_type_name_ID(op) + ".out0";
         auto proposalPrim = cldnn::proposal(proposalLayerName,
                                             inputPrimitives[0],  // cls_score
                                             inputPrimitives[1],  // bbox_pred
@@ -102,16 +101,14 @@ static void CreateProposalOp(Program& p, const std::shared_ptr<ngraph::op::v0::P
                                             clip_after_nms,
                                             round_ratios,
                                             shift_anchors,
-                                            normalize,
-                                            op->get_friendly_name());
+                                            normalize);
 
         p.add_primitive(*op, proposalPrim);
 
-        cldnn::primitive_id proposal_mutable_id_r = layer_type_name_ID(op) + ".1";
+        cldnn::primitive_id proposal_mutable_id_r = layer_type_name_ID(op) + ".out1";
         auto argmax_mutable_prim_r = cldnn::mutable_data(proposal_mutable_id_r,
                                                          { proposalLayerName },
-                                                         shared_memory,
-                                                         op->get_friendly_name());
+                                                         shared_memory);
         p.add_primitive(*op, argmax_mutable_prim_r);
         return;
     }
@@ -140,8 +137,7 @@ static void CreateProposalOp(Program& p, const std::shared_ptr<ngraph::op::v0::P
                                         clip_after_nms,
                                         round_ratios,
                                         shift_anchors,
-                                        normalize,
-                                        op->get_friendly_name());
+                                        normalize);
 
     p.add_primitive(*op, proposalPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/proposal.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/proposal.cpp
@@ -15,7 +15,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateProposalOp(Program& p, const std::shared_ptr<ngraph::op::v0::Proposal>& op) {
-    p.ValidateInputs(op, {3});
+    validate_inputs_count(op, {3});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
 
     auto attrs = op->get_attrs();
@@ -74,8 +74,7 @@ static void CreateProposalOp(Program& p, const std::shared_ptr<ngraph::op::v0::P
         auto argmax_mutable_prim = cldnn::mutable_data(proposal_mutable_id_w,
                                                        shared_memory,
                                                        op->get_friendly_name());
-        p.primitiveIDs[proposal_mutable_id_w] = proposal_mutable_id_w;
-        p.AddPrimitive(argmax_mutable_prim);
+        p.add_primitive(*op, argmax_mutable_prim);
         inputPrimitives.push_back(proposal_mutable_id_w);
 
         std::string proposalLayerName = layer_type_name_ID(op) + ".0";
@@ -106,17 +105,14 @@ static void CreateProposalOp(Program& p, const std::shared_ptr<ngraph::op::v0::P
                                             normalize,
                                             op->get_friendly_name());
 
-        p.AddPrimitive(proposalPrim);
+        p.add_primitive(*op, proposalPrim);
 
         cldnn::primitive_id proposal_mutable_id_r = layer_type_name_ID(op) + ".1";
         auto argmax_mutable_prim_r = cldnn::mutable_data(proposal_mutable_id_r,
                                                          { proposalLayerName },
                                                          shared_memory,
                                                          op->get_friendly_name());
-        p.primitiveIDs[proposal_mutable_id_r] = proposal_mutable_id_r;
-        p.AddPrimitive(argmax_mutable_prim_r);
-
-        p.AddPrimitiveToProfiler(proposalLayerName, op);
+        p.add_primitive(*op, argmax_mutable_prim_r);
         return;
     }
 
@@ -147,8 +143,7 @@ static void CreateProposalOp(Program& p, const std::shared_ptr<ngraph::op::v0::P
                                         normalize,
                                         op->get_friendly_name());
 
-    p.AddPrimitive(proposalPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, proposalPrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, Proposal);

--- a/src/plugins/intel_gpu/src/plugin/ops/random_uniform.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/random_uniform.cpp
@@ -25,8 +25,7 @@ void CreateRandomUniformOp(Program &p, const std::shared_ptr<ngraph::op::v8::Ran
                                                      op->get_op_seed(),
                                                      tensor_from_dims(output_shape),
                                                      outputFormat);
-    p.AddPrimitive(random_uniform_prim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, random_uniform_prim);
 }
 
 } // namespace

--- a/src/plugins/intel_gpu/src/plugin/ops/range.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/range.cpp
@@ -22,7 +22,7 @@ static void CreateRangeOp(Program &p, const std::shared_ptr<ngraph::op::v4::Rang
     cldnn::tensor outTensor { cldnn::spatial(outShape[0]) };
     auto outDataType = DataTypeFromPrecision(op->get_output_element_type(0));
     cldnn::layout outLayout { outDataType, cldnn::format::bfyx, outTensor };
-    cldnn::range prim { layer_type_name_ID(op), p.GetInputPrimitiveIDs(op), outLayout, op->get_friendly_name() };
+    cldnn::range prim { layer_type_name_ID(op), p.GetInputPrimitiveIDs(op), outLayout };
     p.add_primitive(*op, prim);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/range.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/range.cpp
@@ -12,7 +12,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateRangeOp(Program &p, const std::shared_ptr<ngraph::op::v4::Range> &op) {
-    p.ValidateInputs(op, { 3 });
+    validate_inputs_count(op, { 3 });
     auto &outShape = op->get_output_shape(0);
     {
         auto r = outShape.size();
@@ -23,8 +23,7 @@ static void CreateRangeOp(Program &p, const std::shared_ptr<ngraph::op::v4::Rang
     auto outDataType = DataTypeFromPrecision(op->get_output_element_type(0));
     cldnn::layout outLayout { outDataType, cldnn::format::bfyx, outTensor };
     cldnn::range prim { layer_type_name_ID(op), p.GetInputPrimitiveIDs(op), outLayout, op->get_friendly_name() };
-    p.AddPrimitive(prim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, prim);
 }
 
 REGISTER_FACTORY_IMPL(v4, Range);

--- a/src/plugins/intel_gpu/src/plugin/ops/reduce.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reduce.cpp
@@ -24,7 +24,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateReduceOp(Program& p, const std::shared_ptr<ngraph::Node>& op, cldnn::reduce_mode mode, bool keep_dims) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -51,7 +51,7 @@ static void CreateReduceOp(Program& p, const std::shared_ptr<ngraph::Node>& op, 
                                     keep_dims,
                                     op->get_friendly_name());
 
-    p.AddPrimitive(reducePrim);
+    p.add_primitive(*op, reducePrim);
 
     auto resultLayerName = layerName;
     auto out_dims = op->get_output_shape(0).size();
@@ -71,8 +71,7 @@ static void CreateReduceOp(Program& p, const std::shared_ptr<ngraph::Node>& op, 
                                           1, TensorValue(out_shape[2]));
         }
         auto reshape_prim = cldnn::reshape(resultLayerName, layerName, outTensor, op->get_friendly_name());
-        p.AddPrimitive(reshape_prim);
-        p.AddPrimitiveToProfiler(op, resultLayerName);
+        p.add_primitive(*op, reshape_prim);
     }
 
     auto reorderLayerName = layerName + "_reorder";
@@ -93,10 +92,7 @@ static void CreateReduceOp(Program& p, const std::shared_ptr<ngraph::Node>& op, 
                                            std::vector<float>(),
                                            cldnn::reorder_mean_mode::subtract,
                                            op->get_friendly_name());
-        p.AddPrimitive(reorder_prim);
-        p.AddPrimitiveToProfiler(op, reorderLayerName);
-    } else {
-        p.AddPrimitiveToProfiler(op);
+        p.add_primitive(*op, reorder_prim);
     }
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/reduce.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reduce.cpp
@@ -48,8 +48,7 @@ static void CreateReduceOp(Program& p, const std::shared_ptr<ngraph::Node>& op, 
                                     inputPrimitives[0],
                                     mode,
                                     axes,
-                                    keep_dims,
-                                    op->get_friendly_name());
+                                    keep_dims);
 
     p.add_primitive(*op, reducePrim);
 
@@ -70,7 +69,7 @@ static void CreateReduceOp(Program& p, const std::shared_ptr<ngraph::Node>& op, 
                 outTensor = cldnn::tensor(TensorValue(out_shape[0]), TensorValue(out_shape[1]),
                                           1, TensorValue(out_shape[2]));
         }
-        auto reshape_prim = cldnn::reshape(resultLayerName, layerName, outTensor, op->get_friendly_name());
+        auto reshape_prim = cldnn::reshape(resultLayerName, layerName, outTensor);
         p.add_primitive(*op, reshape_prim);
     }
 
@@ -90,8 +89,7 @@ static void CreateReduceOp(Program& p, const std::shared_ptr<ngraph::Node>& op, 
                                            out_format,
                                            out_dt,
                                            std::vector<float>(),
-                                           cldnn::reorder_mean_mode::subtract,
-                                           op->get_friendly_name());
+                                           cldnn::reorder_mean_mode::subtract);
         p.add_primitive(*op, reorder_prim);
     }
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/region_yolo.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/region_yolo.cpp
@@ -13,7 +13,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateRegionYoloOp(Program& p, const std::shared_ptr<ngraph::op::v0::RegionYolo>& op) {
-    p.ValidateInputs(op, {1});
+    validate_inputs_count(op, {1});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -32,8 +32,7 @@ static void CreateRegionYoloOp(Program& p, const std::shared_ptr<ngraph::op::v0:
                                          do_softmax,
                                          op->get_friendly_name());
 
-    p.AddPrimitive(regionPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, regionPrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, RegionYolo);

--- a/src/plugins/intel_gpu/src/plugin/ops/region_yolo.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/region_yolo.cpp
@@ -29,8 +29,7 @@ static void CreateRegionYoloOp(Program& p, const std::shared_ptr<ngraph::op::v0:
                                          classes,
                                          num,
                                          mask_size,
-                                         do_softmax,
-                                         op->get_friendly_name());
+                                         do_softmax);
 
     p.add_primitive(*op, regionPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/reorg_yolo.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reorg_yolo.cpp
@@ -21,8 +21,7 @@ static void CreateReorgYoloOp(Program& p, const std::shared_ptr<ngraph::op::v0::
 
     auto reorgPrim = cldnn::reorg_yolo(layerName,
                                        inputPrimitives[0],
-                                       stride,
-                                       op->get_friendly_name());
+                                       stride);
 
     p.add_primitive(*op, reorgPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/reorg_yolo.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reorg_yolo.cpp
@@ -13,7 +13,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateReorgYoloOp(Program& p, const std::shared_ptr<ngraph::op::v0::ReorgYolo>& op) {
-    p.ValidateInputs(op, {1});
+    validate_inputs_count(op, {1});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -24,8 +24,7 @@ static void CreateReorgYoloOp(Program& p, const std::shared_ptr<ngraph::op::v0::
                                        stride,
                                        op->get_friendly_name());
 
-    p.AddPrimitive(reorgPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, reorgPrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, ReorgYolo);

--- a/src/plugins/intel_gpu/src/plugin/ops/reshape.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reshape.cpp
@@ -44,15 +44,13 @@ static void CreateCommonReshapeOp(Program& p, const std::shared_ptr<ngraph::Node
                                             reshapeInputId,
                                             outputLayout,
                                             std::vector<float>(),
-                                            cldnn::reorder_mean_mode::subtract,
-                                            op->get_friendly_name()));
+                                            cldnn::reorder_mean_mode::subtract));
         reshapeInputId = reorderId;
     }
 
     auto reshapePrim = cldnn::reshape(layerName,
                                       reshapeInputId,
-                                      outTensor,
-                                      op->get_friendly_name());
+                                      outTensor);
 
     p.add_primitive(*op, reshapePrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/result.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/result.cpp
@@ -16,7 +16,7 @@ namespace intel_gpu {
 
 static void CreateResultOp(Program& p, const std::shared_ptr<ngraph::op::v0::Result>& op) {
     OutputsDataMap networkOutputs = p.GetNetworkOutputs();
-    p.ValidateInputs(op, {1});
+    validate_inputs_count(op, {1});
 
     auto prev = op->get_input_node_shared_ptr(0);
     NGRAPH_SUPPRESS_DEPRECATED_START
@@ -63,18 +63,14 @@ static void CreateResultOp(Program& p, const std::shared_ptr<ngraph::op::v0::Res
     Precision precision = outputData->getPrecision();
     std::string outputID = inputs[0];
 
-    p.AddPrimitive(cldnn::reorder(outLayerName,
-                                  outputID,
-                                  FormatFromLayout(outputlayout),
-                                  DataTypeFromPrecision(precision),
-                                  std::vector<float>(),
-                                  cldnn::reorder_mean_mode::subtract,
-                                  op->get_friendly_name()));
-    p.InitProfileInfo(outLayerName, "reorder");
-    p.profilingIDs.push_back(outLayerName);
-    p.primitiveIDs[outLayerName] = outLayerName;
-    p.primitiveIDs[originalOutName] = outLayerName;
-
+    auto reorder_primitive = cldnn::reorder(outLayerName,
+                                            outputID,
+                                            FormatFromLayout(outputlayout),
+                                            DataTypeFromPrecision(precision),
+                                            std::vector<float>(),
+                                            cldnn::reorder_mean_mode::subtract,
+                                            op->get_friendly_name());
+    p.add_primitive(*op, reorder_primitive, {originalOutName});
     p.outputDims[originalOutName] = outputDesc.getDims();
     p.prevPrimitiveIDs[outLayerName] = {originalOutName};
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/result.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/result.cpp
@@ -68,8 +68,7 @@ static void CreateResultOp(Program& p, const std::shared_ptr<ngraph::op::v0::Res
                                             FormatFromLayout(outputlayout),
                                             DataTypeFromPrecision(precision),
                                             std::vector<float>(),
-                                            cldnn::reorder_mean_mode::subtract,
-                                            op->get_friendly_name());
+                                            cldnn::reorder_mean_mode::subtract);
     p.add_primitive(*op, reorder_primitive, {originalOutName});
     p.outputDims[originalOutName] = outputDesc.getDims();
     p.prevPrimitiveIDs[outLayerName] = {originalOutName};

--- a/src/plugins/intel_gpu/src/plugin/ops/reverse.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reverse.cpp
@@ -12,6 +12,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateReverseOp(Program& p, const std::shared_ptr<ngraph::op::v1::Reverse>& op) {
+    validate_inputs_count(op, {2});
     const auto input_primitives = p.GetInputPrimitiveIDs(op);
     const auto layer_name = layer_type_name_ID(op);
     const auto op_friendly_name = op->get_friendly_name();
@@ -20,8 +21,7 @@ static void CreateReverseOp(Program& p, const std::shared_ptr<ngraph::op::v1::Re
 
     const cldnn::reverse reverse{layer_name, input_primitives[0], input_primitives[1], mode, op_friendly_name};
 
-    p.AddPrimitive(reverse);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, reverse);
 }
 
 REGISTER_FACTORY_IMPL(v1, Reverse);

--- a/src/plugins/intel_gpu/src/plugin/ops/reverse.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reverse.cpp
@@ -15,11 +15,10 @@ static void CreateReverseOp(Program& p, const std::shared_ptr<ngraph::op::v1::Re
     validate_inputs_count(op, {2});
     const auto input_primitives = p.GetInputPrimitiveIDs(op);
     const auto layer_name = layer_type_name_ID(op);
-    const auto op_friendly_name = op->get_friendly_name();
     const auto mode =
         op->get_mode() == ngraph::op::v1::Reverse::Mode::INDEX ? cldnn::reverse_mode::index : cldnn::reverse_mode::mask;
 
-    const cldnn::reverse reverse{layer_name, input_primitives[0], input_primitives[1], mode, op_friendly_name};
+    const cldnn::reverse reverse{layer_name, input_primitives[0], input_primitives[1], mode};
 
     p.add_primitive(*op, reverse);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/reverse_sequence.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reverse_sequence.cpp
@@ -13,7 +13,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateReverseSequenceOp(Program& p, const std::shared_ptr<ngraph::op::v0::ReverseSequence>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -26,8 +26,7 @@ static void CreateReverseSequenceOp(Program& p, const std::shared_ptr<ngraph::op
                                                        batch_axis,
                                                        op->get_friendly_name());
 
-    p.AddPrimitive(reverseSequencePrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, reverseSequencePrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, ReverseSequence);

--- a/src/plugins/intel_gpu/src/plugin/ops/reverse_sequence.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reverse_sequence.cpp
@@ -23,8 +23,7 @@ static void CreateReverseSequenceOp(Program& p, const std::shared_ptr<ngraph::op
                                                        inputPrimitives[0],
                                                        inputPrimitives[1],
                                                        seq_axis,
-                                                       batch_axis,
-                                                       op->get_friendly_name());
+                                                       batch_axis);
 
     p.add_primitive(*op, reverseSequencePrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/rnn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/rnn.cpp
@@ -63,7 +63,7 @@ void GetLSTMActivationParams(const std::shared_ptr<T>& op,
 }
 
 static void CreateLSTMCellOp(Program& p, const std::shared_ptr<ngraph::op::v4::LSTMCell>& op) {
-    p.ValidateInputs(op, {6});
+    validate_inputs_count(op, {6});
     int lstm_batch_size, lstm_input_size, lstm_hidden_size;
     bool hasBias = true;
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
@@ -108,45 +108,38 @@ static void CreateLSTMCellOp(Program& p, const std::shared_ptr<ngraph::op::v4::L
     cldnn::tensor inStateShape = { lstm_batch_size, 1, lstm_hidden_size, 1 };
     cldnn::layout inputLayout = cldnn::layout(lstm_dtype, cldnn::format::bfyx, inputShape);
     cldnn::layout hiddenLayout = cldnn::layout(lstm_dtype, cldnn::format::bfyx, inStateShape);
-    p.AddPrimitive(cldnn::reshape(inReshapeID, inputPrimitives[0], inputShape, op->get_friendly_name()));
-    p.AddPrimitive(cldnn::reorder(permuteID,
+    p.add_primitive(*op, cldnn::reshape(inReshapeID, inputPrimitives[0], inputShape, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reorder(permuteID,
                                   inReshapeID,
                                   inputLayout,
                                   std::vector<float>(),
                                   cldnn::reorder_mean_mode::subtract,
                                   op->get_friendly_name()));
 
-    p.AddInnerPrimitiveToProfiler(inReshapeID, op->get_friendly_name(), op);
-    p.AddInnerPrimitiveToProfiler(permuteID, op->get_friendly_name(), op);
 
     std::string hiddenInResh = inHiddenReshapeID + "_1";
     std::string hiddenInStr = inHiddenReorderID + "_1";
     std::string cellInResh = inHiddenReshapeID + "_2";
     std::string cellInStr = inHiddenReorderID + "_2";
-    p.AddPrimitive(cldnn::reshape(hiddenInResh, inputPrimitives[1], inStateShape, op->get_friendly_name()));
-    p.AddPrimitive(cldnn::reorder(hiddenInStr,
-                                  hiddenInResh,
-                                  hiddenLayout,
-                                  std::vector<float>(),
-                                  cldnn::reorder_mean_mode::subtract,
-                                  op->get_friendly_name()));
-    p.AddPrimitive(cldnn::reshape(cellInResh, inputPrimitives[2], inStateShape, op->get_friendly_name()));
-    p.AddPrimitive(cldnn::reorder(cellInStr,
-                                  cellInResh,
-                                  hiddenLayout,
-                                  std::vector<float>(),
-                                  cldnn::reorder_mean_mode::subtract,
-                                  op->get_friendly_name()));
-    p.AddPrimitive(cldnn::concatenation(input_concatID,
-                                        { permuteID, hiddenInStr },
-                                        3,
+    p.add_primitive(*op, cldnn::reshape(hiddenInResh, inputPrimitives[1], inStateShape, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reorder(hiddenInStr,
+                                        hiddenInResh,
+                                        hiddenLayout,
+                                        std::vector<float>(),
+                                        cldnn::reorder_mean_mode::subtract,
                                         op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reshape(cellInResh, inputPrimitives[2], inStateShape, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reorder(cellInStr,
+                                        cellInResh,
+                                        hiddenLayout,
+                                        std::vector<float>(),
+                                        cldnn::reorder_mean_mode::subtract,
+                                        op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::concatenation(input_concatID,
+                                              { permuteID, hiddenInStr },
+                                              3,
+                                              op->get_friendly_name()));
 
-    p.AddInnerPrimitiveToProfiler(hiddenInResh, op->get_friendly_name(), op);
-    p.AddInnerPrimitiveToProfiler(hiddenInStr, op->get_friendly_name(), op);
-    p.AddInnerPrimitiveToProfiler(cellInResh, op->get_friendly_name(), op);
-    p.AddInnerPrimitiveToProfiler(cellInStr, op->get_friendly_name(), op);
-    p.AddInnerPrimitiveToProfiler(input_concatID, op->get_friendly_name(), op);
 
     cldnn::tensor gemmSz = cldnn::tensor{ lstm_batch_size, 1, 4 * lstm_hidden_size, 1 };
     cldnn::layout gemmLayout = cldnn::layout(lstm_dtype, cldnn::format::bfyx, gemmSz);
@@ -158,50 +151,34 @@ static void CreateLSTMCellOp(Program& p, const std::shared_ptr<ngraph::op::v4::L
     std::string crop_id = layerName + "_crop";
 
     cldnn::primitive_id WRconcatID = layerName + "_WRconcat";
-    p.AddPrimitive(cldnn::concatenation(WRconcatID, { weightID, recurrentID }, 1, op->get_friendly_name()));
-    p.AddInnerPrimitiveToProfiler(WRconcatID, op->get_friendly_name(), op);
+    p.add_primitive(*op, cldnn::concatenation(WRconcatID, { weightID, recurrentID }, 1, op->get_friendly_name()));
 
-    p.AddPrimitive(cldnn::fully_connected(lstm_fc_id, input_concatID, WRconcatID, hasBias ? biasID : "", op->get_friendly_name()));
-    p.AddPrimitive(cldnn::reshape(gemmReshapeID, lstm_fc_id, gemmSz, op->get_friendly_name()));
-    p.AddPrimitive(cldnn::reorder(gemmReorderID,
-                                  gemmReshapeID,
-                                  gemmLayout,
-                                  std::vector<float>(),
-                                  cldnn::reorder_mean_mode::subtract,
-                                  op->get_friendly_name()));
-    p.AddPrimitive(cldnn::lstm_elt(lstm_elt_id, gemmReorderID, cellInStr, clip, 0, activations,
-                                   activation_params, cldnn::lstm_weights_order::fizo, 0, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::fully_connected(lstm_fc_id, input_concatID, WRconcatID, hasBias ? biasID : "", op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reshape(gemmReshapeID, lstm_fc_id, gemmSz, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reorder(gemmReorderID,
+                                        gemmReshapeID,
+                                        gemmLayout,
+                                        std::vector<float>(),
+                                        cldnn::reorder_mean_mode::subtract,
+                                        op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::lstm_elt(lstm_elt_id, gemmReorderID, cellInStr, clip, 0, activations,
+                                         activation_params, cldnn::lstm_weights_order::fizo, 0, op->get_friendly_name()));
 
-    p.AddInnerPrimitiveToProfiler(lstm_fc_id, op->get_friendly_name(), op);
-    p.AddInnerPrimitiveToProfiler(gemmReshapeID, op->get_friendly_name(), op);
-    p.AddInnerPrimitiveToProfiler(gemmReorderID, op->get_friendly_name(), op);
-    p.AddInnerPrimitiveToProfiler(lstm_elt_id, op->get_friendly_name(), op);
 
     cldnn::tensor outSz = cldnn::tensor{ lstm_batch_size, lstm_hidden_size, 1, 1 };
     cldnn::primitive_id outputHiddenCropID = layerName + "_hc";
     cldnn::primitive_id outputHiddenID = layerName + ".0";
-    p.AddPrimitive(cldnn::crop(outputHiddenCropID, lstm_elt_id, hiddenSz, cldnn::tensor{0, 0, 0, 0}, op->get_friendly_name()));
-    p.AddInnerPrimitiveToProfiler(outputHiddenCropID, op->get_friendly_name(), op);
-    p.AddPrimitive(cldnn::reshape(outputHiddenID, outputHiddenCropID, outSz, op->get_friendly_name()));
-    p.AddInnerPrimitiveToProfiler(outputHiddenID, op->get_friendly_name(), op);
+    p.add_primitive(*op, cldnn::crop(outputHiddenCropID, lstm_elt_id, hiddenSz, cldnn::tensor{0, 0, 0, 0}, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reshape(outputHiddenID, outputHiddenCropID, outSz, op->get_friendly_name()), {layerName});
 
     cldnn::primitive_id outputCellCropID = layerName + "_cc";
     cldnn::primitive_id outputCellID = layerName + ".1";
-    p.AddPrimitive(cldnn::crop(outputCellCropID, lstm_elt_id, hiddenSz, cellCropSz, op->get_friendly_name()));
-    p.AddInnerPrimitiveToProfiler(outputCellCropID, op->get_friendly_name(), op);
-    p.AddPrimitive(cldnn::reshape(outputCellID, outputCellCropID, outSz, op->get_friendly_name()));
-    p.AddInnerPrimitiveToProfiler(outputCellID, op->get_friendly_name(), op);
-
-    // output primitive IDs
-    p.primitiveIDs[outputHiddenID] = outputHiddenID;     // LSTMCell:LSTMCell - "concat hidden"
-    p.primitiveIDs[layerName] = outputHiddenID;          // LSTMCell:LSTMCell:0 - hidden state
-    p.primitiveIDs[outputCellID] = outputCellID;         // LSTMCell:LSTMCell:1 - cell state
-
-    p.AddPrimitiveToProfiler(layerName, op, outputHiddenID);
+    p.add_primitive(*op, cldnn::crop(outputCellCropID, lstm_elt_id, hiddenSz, cellCropSz, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reshape(outputCellID, outputCellCropID, outSz, op->get_friendly_name()));
 }
 
 static void CreateLSTMSequenceOp(Program& p, const std::shared_ptr<ngraph::op::v5::LSTMSequence>& op) {
-    p.ValidateInputs(op, {7});
+    validate_inputs_count(op, {7});
 
     std::string layerName = layer_type_name_ID(op);
     int lstm_batch_size, lstm_input_size, lstm_hidden_size, lstm_sequence_len;
@@ -247,21 +224,16 @@ static void CreateLSTMSequenceOp(Program& p, const std::shared_ptr<ngraph::op::v
     cldnn::tensor inputShape = { lstm_batch_size, lstm_sequence_len, lstm_input_size, 1 };
     cldnn::tensor inStateShape = { lstm_batch_size, 1, lstm_hidden_size, 1 };
     cldnn::layout inputLayout = cldnn::layout(lstm_dtype, cldnn::format::bfyx, inputShape);
-    p.AddPrimitive(cldnn::reshape(inReshapeID, inputPrimitives[0], inputShape, op->get_friendly_name()));
-    p.AddPrimitive(cldnn::reorder(permuteID,
-                                  inReshapeID,
-                                  inputLayout,
-                                  std::vector<float>(),
-                                  cldnn::reorder_mean_mode::subtract,
-                                  op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reshape(inReshapeID, inputPrimitives[0], inputShape, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reorder(permuteID,
+                                        inReshapeID,
+                                        inputLayout,
+                                        std::vector<float>(),
+                                        cldnn::reorder_mean_mode::subtract,
+                                        op->get_friendly_name()));
 
-    p.AddPrimitive(cldnn::reshape(inHiddenStateID, inputPrimitives[1], inStateShape, op->get_friendly_name()));
-    p.AddPrimitive(cldnn::reshape(inCellStateID, inputPrimitives[2], inStateShape, op->get_friendly_name()));
-
-    p.AddInnerPrimitiveToProfiler(inReshapeID, op->get_friendly_name(), op);
-    p.AddInnerPrimitiveToProfiler(permuteID, op->get_friendly_name(), op);
-    p.AddInnerPrimitiveToProfiler(inHiddenStateID, op->get_friendly_name(), op);
-    p.AddInnerPrimitiveToProfiler(inCellStateID, op->get_friendly_name(), op);
+    p.add_primitive(*op, cldnn::reshape(inHiddenStateID, inputPrimitives[1], inStateShape, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reshape(inCellStateID, inputPrimitives[2], inStateShape, op->get_friendly_name()));
 
     cldnn::tensor gemmSz = cldnn::tensor{ lstm_batch_size, 1, 4 * lstm_hidden_size, 1 };
     cldnn::layout gemmLayout = cldnn::layout(lstm_dtype, cldnn::format::bfyx, gemmSz);
@@ -272,14 +244,12 @@ static void CreateLSTMSequenceOp(Program& p, const std::shared_ptr<ngraph::op::v
     cldnn::primitive_id inputCropID = layerName + "_inputCrop";
 
     cldnn::primitive_id WRconcatID = layerName + "_WRconcat";
-    p.AddPrimitive(cldnn::concatenation(WRconcatID, { weightID, recurrentID }, 2, op->get_friendly_name()));
-    p.AddInnerPrimitiveToProfiler(WRconcatID, op->get_friendly_name(), op);
+    p.add_primitive(*op, cldnn::concatenation(WRconcatID, { weightID, recurrentID }, 2, op->get_friendly_name()));
 
     std::vector<size_t> WRreshapeSize = { 4 * size_t(lstm_hidden_size), size_t(lstm_input_size + lstm_hidden_size) };
     cldnn::primitive_id WRreshapeID = WRconcatID + "_reshape";
     auto reshapeInPrim = cldnn::reshape(WRreshapeID, WRconcatID, tensor_from_dims(WRreshapeSize), op->get_friendly_name());
-    p.AddPrimitive(reshapeInPrim);
-    p.AddInnerPrimitiveToProfiler(WRreshapeID, op->get_friendly_name(), op);
+    p.add_primitive(*op, reshapeInPrim);
 
     for (int i = 0; i < lstm_sequence_len; ++i) {
         const std::string id_str = std::to_string(i);
@@ -296,47 +266,35 @@ static void CreateLSTMSequenceOp(Program& p, const std::shared_ptr<ngraph::op::v
         cldnn::tensor crop_tensor{ inputShape.batch[0], 1, inputShape.spatial[0], inputShape.spatial[1] };
         cldnn::tensor offset_tensor{ 0, static_cast<cldnn::tensor::value_type>(seqIdx), 0, 0 };
         cldnn::primitive_id inputCrop_id = inputCropID + ":" + seqIdx_str;
-        p.AddPrimitive(cldnn::crop(inputCrop_id, permuteID, crop_tensor, offset_tensor, op->get_friendly_name()));
-        p.AddInnerPrimitiveToProfiler(inputCrop_id, op->get_friendly_name(), op);
+        p.add_primitive(*op, cldnn::crop(inputCrop_id, permuteID, crop_tensor, offset_tensor, op->get_friendly_name()));
 
-        p.AddPrimitive(cldnn::concatenation(concatID, { inputCrop_id, hiddenStr }, 3, op->get_friendly_name()));
-        p.AddInnerPrimitiveToProfiler(concatID, op->get_friendly_name(), op);
-        p.AddPrimitive(cldnn::fully_connected(lstm_fc_id, concatID, WRreshapeID, biasID, op->get_friendly_name()));
-        p.AddInnerPrimitiveToProfiler(lstm_fc_id, op->get_friendly_name(), op);
+        p.add_primitive(*op, cldnn::concatenation(concatID, { inputCrop_id, hiddenStr }, 3, op->get_friendly_name()));
+        p.add_primitive(*op, cldnn::fully_connected(lstm_fc_id, concatID, WRreshapeID, biasID, op->get_friendly_name()));
 
-        p.AddPrimitive(cldnn::reshape(lstm_fc_resh_id, lstm_fc_id, gemmSz, op->get_friendly_name()));
-        p.AddPrimitive(cldnn::reorder(lstm_fc_reor_id,
-                                      lstm_fc_resh_id,
-                                      gemmLayout,
-                                      std::vector<float>(),
-                                      cldnn::reorder_mean_mode::subtract,
-                                      op->get_friendly_name()));
-        p.AddPrimitive(cldnn::lstm_elt(lstm_elt_id, lstm_fc_reor_id, cellStr, clip, 0, activations,
-                                       activation_params, cldnn::lstm_weights_order::fizo, 0, op->get_friendly_name()));
-        p.AddInnerPrimitiveToProfiler(lstm_fc_resh_id, op->get_friendly_name(), op);
-        p.AddInnerPrimitiveToProfiler(lstm_fc_reor_id, op->get_friendly_name(), op);
-        p.AddInnerPrimitiveToProfiler(lstm_elt_id, op->get_friendly_name(), op);
+        p.add_primitive(*op, cldnn::reshape(lstm_fc_resh_id, lstm_fc_id, gemmSz, op->get_friendly_name()));
+        p.add_primitive(*op, cldnn::reorder(lstm_fc_reor_id,
+                                            lstm_fc_resh_id,
+                                            gemmLayout,
+                                            std::vector<float>(),
+                                            cldnn::reorder_mean_mode::subtract,
+                                            op->get_friendly_name()));
+        p.add_primitive(*op, cldnn::lstm_elt(lstm_elt_id, lstm_fc_reor_id, cellStr, clip, 0, activations,
+                                             activation_params, cldnn::lstm_weights_order::fizo, 0, op->get_friendly_name()));
 
         hiddenStr = crop_id + ":hidden";
         cellStr = crop_id + ":cell";
-        p.AddPrimitive(cldnn::crop(hiddenStr, lstm_elt_id, hiddenSz, cldnn::tensor{ 0, 0, 0, 0 }, op->get_friendly_name()));
-        p.AddInnerPrimitiveToProfiler(hiddenStr, op->get_friendly_name(), op);
+        cldnn::primitive_id outputHiddenID = layerName + ".1";
+        p.add_primitive(*op, cldnn::crop(hiddenStr, lstm_elt_id, hiddenSz, cldnn::tensor{ 0, 0, 0, 0 }, op->get_friendly_name()), {outputHiddenID});
         output_ids_offsets.push_back(hiddenStr);
 
         if (i < lstm_sequence_len - 1) {
-            p.AddPrimitive(cldnn::crop(cellStr, lstm_elt_id, hiddenSz, cellCropSz, op->get_friendly_name()));
-            p.AddInnerPrimitiveToProfiler(cellStr, op->get_friendly_name(), op);
+            p.add_primitive(*op, cldnn::crop(cellStr, lstm_elt_id, hiddenSz, cellCropSz, op->get_friendly_name()));
         } else {
             // last hidden state crop (output 2)
-            cldnn::primitive_id outputHiddenID = layerName + ".1";
-            p.primitiveIDs[hiddenStr] = hiddenStr;
-            p.primitiveIDs[outputHiddenID] = hiddenStr;
 
             // last cell state crop (output 3)
-            p.AddPrimitive(cldnn::crop(cellStr, lstm_elt_id, hiddenSz, cellCropSz, op->get_friendly_name()));
             cldnn::primitive_id outputCellID = layerName + ".2";
-            p.AddInnerPrimitiveToProfiler(cellStr, op->get_friendly_name(), op);
-            p.primitiveIDs[outputCellID] = cellStr;
+            p.add_primitive(*op, cldnn::crop(cellStr, lstm_elt_id, hiddenSz, cellCropSz, op->get_friendly_name()), {outputCellID});
         }
     }
 
@@ -344,11 +302,7 @@ static void CreateLSTMSequenceOp(Program& p, const std::shared_ptr<ngraph::op::v
     // concatenated hidden state (output 1)
     cldnn::primitive_id outputConcatID = layerName + ".0";
     cldnn::primitive_id concatStr = layerName + ":hiddenConcat";
-    p.AddPrimitive(cldnn::concatenation(concatStr, output_ids_offsets, 1, op->get_friendly_name()));
-
-    p.primitiveIDs[outputConcatID] = concatStr;
-    p.primitiveIDs[layerName] = concatStr;
-    p.AddPrimitiveToProfiler(layerName, op);
+    p.add_primitive(*op, cldnn::concatenation(concatStr, output_ids_offsets, 1, op->get_friendly_name()), {outputConcatID, layerName});
 }
 
 REGISTER_FACTORY_IMPL(v4, LSTMCell);

--- a/src/plugins/intel_gpu/src/plugin/ops/rnn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/rnn.cpp
@@ -108,37 +108,33 @@ static void CreateLSTMCellOp(Program& p, const std::shared_ptr<ngraph::op::v4::L
     cldnn::tensor inStateShape = { lstm_batch_size, 1, lstm_hidden_size, 1 };
     cldnn::layout inputLayout = cldnn::layout(lstm_dtype, cldnn::format::bfyx, inputShape);
     cldnn::layout hiddenLayout = cldnn::layout(lstm_dtype, cldnn::format::bfyx, inStateShape);
-    p.add_primitive(*op, cldnn::reshape(inReshapeID, inputPrimitives[0], inputShape, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reshape(inReshapeID, inputPrimitives[0], inputShape));
     p.add_primitive(*op, cldnn::reorder(permuteID,
                                   inReshapeID,
                                   inputLayout,
                                   std::vector<float>(),
-                                  cldnn::reorder_mean_mode::subtract,
-                                  op->get_friendly_name()));
+                                  cldnn::reorder_mean_mode::subtract));
 
 
     std::string hiddenInResh = inHiddenReshapeID + "_1";
     std::string hiddenInStr = inHiddenReorderID + "_1";
     std::string cellInResh = inHiddenReshapeID + "_2";
     std::string cellInStr = inHiddenReorderID + "_2";
-    p.add_primitive(*op, cldnn::reshape(hiddenInResh, inputPrimitives[1], inStateShape, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reshape(hiddenInResh, inputPrimitives[1], inStateShape));
     p.add_primitive(*op, cldnn::reorder(hiddenInStr,
                                         hiddenInResh,
                                         hiddenLayout,
                                         std::vector<float>(),
-                                        cldnn::reorder_mean_mode::subtract,
-                                        op->get_friendly_name()));
-    p.add_primitive(*op, cldnn::reshape(cellInResh, inputPrimitives[2], inStateShape, op->get_friendly_name()));
+                                        cldnn::reorder_mean_mode::subtract));
+    p.add_primitive(*op, cldnn::reshape(cellInResh, inputPrimitives[2], inStateShape));
     p.add_primitive(*op, cldnn::reorder(cellInStr,
                                         cellInResh,
                                         hiddenLayout,
                                         std::vector<float>(),
-                                        cldnn::reorder_mean_mode::subtract,
-                                        op->get_friendly_name()));
+                                        cldnn::reorder_mean_mode::subtract));
     p.add_primitive(*op, cldnn::concatenation(input_concatID,
                                               { permuteID, hiddenInStr },
-                                              3,
-                                              op->get_friendly_name()));
+                                              3));
 
 
     cldnn::tensor gemmSz = cldnn::tensor{ lstm_batch_size, 1, 4 * lstm_hidden_size, 1 };
@@ -151,30 +147,29 @@ static void CreateLSTMCellOp(Program& p, const std::shared_ptr<ngraph::op::v4::L
     std::string crop_id = layerName + "_crop";
 
     cldnn::primitive_id WRconcatID = layerName + "_WRconcat";
-    p.add_primitive(*op, cldnn::concatenation(WRconcatID, { weightID, recurrentID }, 1, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::concatenation(WRconcatID, { weightID, recurrentID }, 1));
 
-    p.add_primitive(*op, cldnn::fully_connected(lstm_fc_id, input_concatID, WRconcatID, hasBias ? biasID : "", op->get_friendly_name()));
-    p.add_primitive(*op, cldnn::reshape(gemmReshapeID, lstm_fc_id, gemmSz, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::fully_connected(lstm_fc_id, input_concatID, WRconcatID, hasBias ? biasID : ""));
+    p.add_primitive(*op, cldnn::reshape(gemmReshapeID, lstm_fc_id, gemmSz));
     p.add_primitive(*op, cldnn::reorder(gemmReorderID,
                                         gemmReshapeID,
                                         gemmLayout,
                                         std::vector<float>(),
-                                        cldnn::reorder_mean_mode::subtract,
-                                        op->get_friendly_name()));
+                                        cldnn::reorder_mean_mode::subtract));
     p.add_primitive(*op, cldnn::lstm_elt(lstm_elt_id, gemmReorderID, cellInStr, clip, 0, activations,
-                                         activation_params, cldnn::lstm_weights_order::fizo, 0, op->get_friendly_name()));
+                                         activation_params, cldnn::lstm_weights_order::fizo, 0));
 
 
     cldnn::tensor outSz = cldnn::tensor{ lstm_batch_size, lstm_hidden_size, 1, 1 };
     cldnn::primitive_id outputHiddenCropID = layerName + "_hc";
-    cldnn::primitive_id outputHiddenID = layerName + ".0";
-    p.add_primitive(*op, cldnn::crop(outputHiddenCropID, lstm_elt_id, hiddenSz, cldnn::tensor{0, 0, 0, 0}, op->get_friendly_name()));
-    p.add_primitive(*op, cldnn::reshape(outputHiddenID, outputHiddenCropID, outSz, op->get_friendly_name()), {layerName});
+    cldnn::primitive_id outputHiddenID = layerName + ".out0";
+    p.add_primitive(*op, cldnn::crop(outputHiddenCropID, lstm_elt_id, hiddenSz, cldnn::tensor{0, 0, 0, 0}));
+    p.add_primitive(*op, cldnn::reshape(outputHiddenID, outputHiddenCropID, outSz), {layerName});
 
     cldnn::primitive_id outputCellCropID = layerName + "_cc";
-    cldnn::primitive_id outputCellID = layerName + ".1";
-    p.add_primitive(*op, cldnn::crop(outputCellCropID, lstm_elt_id, hiddenSz, cellCropSz, op->get_friendly_name()));
-    p.add_primitive(*op, cldnn::reshape(outputCellID, outputCellCropID, outSz, op->get_friendly_name()));
+    cldnn::primitive_id outputCellID = layerName + ".out1";
+    p.add_primitive(*op, cldnn::crop(outputCellCropID, lstm_elt_id, hiddenSz, cellCropSz));
+    p.add_primitive(*op, cldnn::reshape(outputCellID, outputCellCropID, outSz));
 }
 
 static void CreateLSTMSequenceOp(Program& p, const std::shared_ptr<ngraph::op::v5::LSTMSequence>& op) {
@@ -224,16 +219,15 @@ static void CreateLSTMSequenceOp(Program& p, const std::shared_ptr<ngraph::op::v
     cldnn::tensor inputShape = { lstm_batch_size, lstm_sequence_len, lstm_input_size, 1 };
     cldnn::tensor inStateShape = { lstm_batch_size, 1, lstm_hidden_size, 1 };
     cldnn::layout inputLayout = cldnn::layout(lstm_dtype, cldnn::format::bfyx, inputShape);
-    p.add_primitive(*op, cldnn::reshape(inReshapeID, inputPrimitives[0], inputShape, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reshape(inReshapeID, inputPrimitives[0], inputShape));
     p.add_primitive(*op, cldnn::reorder(permuteID,
                                         inReshapeID,
                                         inputLayout,
                                         std::vector<float>(),
-                                        cldnn::reorder_mean_mode::subtract,
-                                        op->get_friendly_name()));
+                                        cldnn::reorder_mean_mode::subtract));
 
-    p.add_primitive(*op, cldnn::reshape(inHiddenStateID, inputPrimitives[1], inStateShape, op->get_friendly_name()));
-    p.add_primitive(*op, cldnn::reshape(inCellStateID, inputPrimitives[2], inStateShape, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::reshape(inHiddenStateID, inputPrimitives[1], inStateShape));
+    p.add_primitive(*op, cldnn::reshape(inCellStateID, inputPrimitives[2], inStateShape));
 
     cldnn::tensor gemmSz = cldnn::tensor{ lstm_batch_size, 1, 4 * lstm_hidden_size, 1 };
     cldnn::layout gemmLayout = cldnn::layout(lstm_dtype, cldnn::format::bfyx, gemmSz);
@@ -244,11 +238,11 @@ static void CreateLSTMSequenceOp(Program& p, const std::shared_ptr<ngraph::op::v
     cldnn::primitive_id inputCropID = layerName + "_inputCrop";
 
     cldnn::primitive_id WRconcatID = layerName + "_WRconcat";
-    p.add_primitive(*op, cldnn::concatenation(WRconcatID, { weightID, recurrentID }, 2, op->get_friendly_name()));
+    p.add_primitive(*op, cldnn::concatenation(WRconcatID, { weightID, recurrentID }, 2));
 
     std::vector<size_t> WRreshapeSize = { 4 * size_t(lstm_hidden_size), size_t(lstm_input_size + lstm_hidden_size) };
     cldnn::primitive_id WRreshapeID = WRconcatID + "_reshape";
-    auto reshapeInPrim = cldnn::reshape(WRreshapeID, WRconcatID, tensor_from_dims(WRreshapeSize), op->get_friendly_name());
+    auto reshapeInPrim = cldnn::reshape(WRreshapeID, WRconcatID, tensor_from_dims(WRreshapeSize));
     p.add_primitive(*op, reshapeInPrim);
 
     for (int i = 0; i < lstm_sequence_len; ++i) {
@@ -266,43 +260,42 @@ static void CreateLSTMSequenceOp(Program& p, const std::shared_ptr<ngraph::op::v
         cldnn::tensor crop_tensor{ inputShape.batch[0], 1, inputShape.spatial[0], inputShape.spatial[1] };
         cldnn::tensor offset_tensor{ 0, static_cast<cldnn::tensor::value_type>(seqIdx), 0, 0 };
         cldnn::primitive_id inputCrop_id = inputCropID + ":" + seqIdx_str;
-        p.add_primitive(*op, cldnn::crop(inputCrop_id, permuteID, crop_tensor, offset_tensor, op->get_friendly_name()));
+        p.add_primitive(*op, cldnn::crop(inputCrop_id, permuteID, crop_tensor, offset_tensor));
 
-        p.add_primitive(*op, cldnn::concatenation(concatID, { inputCrop_id, hiddenStr }, 3, op->get_friendly_name()));
-        p.add_primitive(*op, cldnn::fully_connected(lstm_fc_id, concatID, WRreshapeID, biasID, op->get_friendly_name()));
+        p.add_primitive(*op, cldnn::concatenation(concatID, { inputCrop_id, hiddenStr }, 3));
+        p.add_primitive(*op, cldnn::fully_connected(lstm_fc_id, concatID, WRreshapeID, biasID));
 
-        p.add_primitive(*op, cldnn::reshape(lstm_fc_resh_id, lstm_fc_id, gemmSz, op->get_friendly_name()));
+        p.add_primitive(*op, cldnn::reshape(lstm_fc_resh_id, lstm_fc_id, gemmSz));
         p.add_primitive(*op, cldnn::reorder(lstm_fc_reor_id,
                                             lstm_fc_resh_id,
                                             gemmLayout,
                                             std::vector<float>(),
-                                            cldnn::reorder_mean_mode::subtract,
-                                            op->get_friendly_name()));
+                                            cldnn::reorder_mean_mode::subtract));
         p.add_primitive(*op, cldnn::lstm_elt(lstm_elt_id, lstm_fc_reor_id, cellStr, clip, 0, activations,
-                                             activation_params, cldnn::lstm_weights_order::fizo, 0, op->get_friendly_name()));
+                                             activation_params, cldnn::lstm_weights_order::fizo, 0));
 
         hiddenStr = crop_id + ":hidden";
         cellStr = crop_id + ":cell";
-        cldnn::primitive_id outputHiddenID = layerName + ".1";
-        p.add_primitive(*op, cldnn::crop(hiddenStr, lstm_elt_id, hiddenSz, cldnn::tensor{ 0, 0, 0, 0 }, op->get_friendly_name()), {outputHiddenID});
+        cldnn::primitive_id outputHiddenID = layerName + ".out1";
+        p.add_primitive(*op, cldnn::crop(hiddenStr, lstm_elt_id, hiddenSz, cldnn::tensor{ 0, 0, 0, 0 }), {outputHiddenID});
         output_ids_offsets.push_back(hiddenStr);
 
         if (i < lstm_sequence_len - 1) {
-            p.add_primitive(*op, cldnn::crop(cellStr, lstm_elt_id, hiddenSz, cellCropSz, op->get_friendly_name()));
+            p.add_primitive(*op, cldnn::crop(cellStr, lstm_elt_id, hiddenSz, cellCropSz));
         } else {
             // last hidden state crop (output 2)
 
             // last cell state crop (output 3)
-            cldnn::primitive_id outputCellID = layerName + ".2";
-            p.add_primitive(*op, cldnn::crop(cellStr, lstm_elt_id, hiddenSz, cellCropSz, op->get_friendly_name()), {outputCellID});
+            cldnn::primitive_id outputCellID = layerName + ".out2";
+            p.add_primitive(*op, cldnn::crop(cellStr, lstm_elt_id, hiddenSz, cellCropSz), {outputCellID});
         }
     }
 
     if (!isForward) std::reverse(output_ids_offsets.begin(), output_ids_offsets.end());
     // concatenated hidden state (output 1)
-    cldnn::primitive_id outputConcatID = layerName + ".0";
+    cldnn::primitive_id outputConcatID = layerName + ".out0";
     cldnn::primitive_id concatStr = layerName + ":hiddenConcat";
-    p.add_primitive(*op, cldnn::concatenation(concatStr, output_ids_offsets, 1, op->get_friendly_name()), {outputConcatID, layerName});
+    p.add_primitive(*op, cldnn::concatenation(concatStr, output_ids_offsets, 1), {outputConcatID, layerName});
 }
 
 REGISTER_FACTORY_IMPL(v4, LSTMCell);

--- a/src/plugins/intel_gpu/src/plugin/ops/roi_align.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/roi_align.cpp
@@ -38,7 +38,7 @@ cldnn::roi_align::AlignedMode from(ngraph::op::v9::ROIAlign::AlignedMode mode) {
 }
 
 void CreateROIAlignOp(Program& p, const std::shared_ptr<ngraph::op::v3::ROIAlign>& op) {
-    p.ValidateInputs(op, {3});
+    validate_inputs_count(op, {3});
     auto roi_align_prim = cldnn::roi_align(layer_type_name_ID(op),
                                            p.GetInputPrimitiveIDs(op),
                                            op->get_pooled_h(),
@@ -48,12 +48,11 @@ void CreateROIAlignOp(Program& p, const std::shared_ptr<ngraph::op::v3::ROIAlign
                                            from(op->get_mode()),
                                            cldnn::roi_align::AlignedMode::asymmetric,
                                            op->get_friendly_name());
-    p.AddPrimitive(roi_align_prim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, roi_align_prim);
 }
 
 void CreateROIAlignOp(Program& p, const std::shared_ptr<ngraph::op::v9::ROIAlign>& op) {
-    p.ValidateInputs(op, {3});
+    validate_inputs_count(op, {3});
     auto roi_align_prim = cldnn::roi_align(layer_type_name_ID(op),
                                            p.GetInputPrimitiveIDs(op),
                                            op->get_pooled_h(),
@@ -63,8 +62,7 @@ void CreateROIAlignOp(Program& p, const std::shared_ptr<ngraph::op::v9::ROIAlign
                                            from(op->get_mode()),
                                            from(op->get_aligned_mode()),
                                            op->get_friendly_name());
-    p.AddPrimitive(roi_align_prim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, roi_align_prim);
 }
 
 }  // anonymous namespace

--- a/src/plugins/intel_gpu/src/plugin/ops/roi_align.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/roi_align.cpp
@@ -46,8 +46,7 @@ void CreateROIAlignOp(Program& p, const std::shared_ptr<ngraph::op::v3::ROIAlign
                                            op->get_sampling_ratio(),
                                            op->get_spatial_scale(),
                                            from(op->get_mode()),
-                                           cldnn::roi_align::AlignedMode::asymmetric,
-                                           op->get_friendly_name());
+                                           cldnn::roi_align::AlignedMode::asymmetric);
     p.add_primitive(*op, roi_align_prim);
 }
 
@@ -60,8 +59,7 @@ void CreateROIAlignOp(Program& p, const std::shared_ptr<ngraph::op::v9::ROIAlign
                                            op->get_sampling_ratio(),
                                            op->get_spatial_scale(),
                                            from(op->get_mode()),
-                                           from(op->get_aligned_mode()),
-                                           op->get_friendly_name());
+                                           from(op->get_aligned_mode()));
     p.add_primitive(*op, roi_align_prim);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/roi_pooling.cpp
@@ -26,7 +26,7 @@ static cldnn::pooling_mode GetPoolingMode(std::string method) {
 }
 
 static void CreateDeformablePSROIPoolingOp(Program& p, const std::shared_ptr<ngraph::op::v1::DeformablePSROIPooling>& op) {
-    p.ValidateInputs(op, {2, 3});
+    validate_inputs_count(op, {2, 3});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -60,12 +60,11 @@ static void CreateDeformablePSROIPoolingOp(Program& p, const std::shared_ptr<ngr
                                                spatial_bins_x,
                                                spatial_bins_y,
                                                op->get_friendly_name());
-    p.AddPrimitive(psROIPoolingPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, psROIPoolingPrim);
 }
 
 static void CreatePSROIPoolingOp(Program& p, const std::shared_ptr<ngraph::op::v0::PSROIPooling>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -89,12 +88,11 @@ static void CreatePSROIPoolingOp(Program& p, const std::shared_ptr<ngraph::op::v
                                                spatial_bins_x,
                                                spatial_bins_y,
                                                op->get_friendly_name());
-    p.AddPrimitive(psROIPoolingPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, psROIPoolingPrim);
 }
 
 static void CreateROIPoolingOp(Program& p, const std::shared_ptr<ngraph::op::v0::ROIPooling>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -119,8 +117,7 @@ static void CreateROIPoolingOp(Program& p, const std::shared_ptr<ngraph::op::v0:
                                              1,
                                              op->get_friendly_name());
 
-    p.AddPrimitive(roiPoolingPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, roiPoolingPrim);
 }
 
 REGISTER_FACTORY_IMPL(v1, DeformablePSROIPooling);

--- a/src/plugins/intel_gpu/src/plugin/ops/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/roi_pooling.cpp
@@ -58,8 +58,7 @@ static void CreateDeformablePSROIPoolingOp(Program& p, const std::shared_ptr<ngr
                                                group_size,
                                                output_dim,
                                                spatial_bins_x,
-                                               spatial_bins_y,
-                                               op->get_friendly_name());
+                                               spatial_bins_y);
     p.add_primitive(*op, psROIPoolingPrim);
 }
 
@@ -86,8 +85,7 @@ static void CreatePSROIPoolingOp(Program& p, const std::shared_ptr<ngraph::op::v
                                                spatial_scale,
                                                output_dim,
                                                spatial_bins_x,
-                                               spatial_bins_y,
-                                               op->get_friendly_name());
+                                               spatial_bins_y);
     p.add_primitive(*op, psROIPoolingPrim);
 }
 
@@ -114,8 +112,7 @@ static void CreateROIPoolingOp(Program& p, const std::shared_ptr<ngraph::op::v0:
                                              spatial_scale,
                                              0,
                                              1,
-                                             1,
-                                             op->get_friendly_name());
+                                             1);
 
     p.add_primitive(*op, roiPoolingPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/roll.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/roll.cpp
@@ -62,7 +62,7 @@ void CreateRollOp(Program& p, const std::shared_ptr<ngraph::op::v7::Roll>& op) {
         }
     }
 
-    const cldnn::roll roll_prim(layer_name, inputs.front(), {format, shift}, op_friendly_name);
+    const cldnn::roll roll_prim(layer_name, inputs.front(), {format, shift});
     p.add_primitive(*op, roll_prim);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/roll.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/roll.cpp
@@ -15,7 +15,7 @@ namespace intel_gpu {
 namespace {
 
 void CreateRollOp(Program& p, const std::shared_ptr<ngraph::op::v7::Roll>& op) {
-    p.ValidateInputs(op, {3});
+    validate_inputs_count(op, {3});
 
     const auto inputs = p.GetInputPrimitiveIDs(op);
     const auto layer_name = layer_type_name_ID(op);
@@ -63,8 +63,7 @@ void CreateRollOp(Program& p, const std::shared_ptr<ngraph::op::v7::Roll>& op) {
     }
 
     const cldnn::roll roll_prim(layer_name, inputs.front(), {format, shift}, op_friendly_name);
-    p.AddPrimitive(roll_prim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, roll_prim);
 }
 
 }  // namespace

--- a/src/plugins/intel_gpu/src/plugin/ops/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scatter_elements_update.cpp
@@ -28,8 +28,7 @@ static void CreateScatterElementsUpdateOp(Program& p, const std::shared_ptr<ngra
                                                     inputPrimitives[0],
                                                     inputPrimitives[1],
                                                     inputPrimitives[2],
-                                                    axis,
-                                                    op->get_friendly_name());
+                                                    axis);
 
     p.add_primitive(*op, primitive);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scatter_elements_update.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateScatterElementsUpdateOp(Program& p, const std::shared_ptr<ngraph::op::v3::ScatterElementsUpdate>& op) {
-    p.ValidateInputs(op, {4});
+    validate_inputs_count(op, {4});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -31,8 +31,7 @@ static void CreateScatterElementsUpdateOp(Program& p, const std::shared_ptr<ngra
                                                     axis,
                                                     op->get_friendly_name());
 
-    p.AddPrimitive(primitive);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, primitive);
 }
 
 REGISTER_FACTORY_IMPL(v3, ScatterElementsUpdate);

--- a/src/plugins/intel_gpu/src/plugin/ops/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scatter_nd_update.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateScatterNDUpdateOp(Program& p, const std::shared_ptr<ngraph::op::v3::ScatterNDUpdate>& op) {
-    p.ValidateInputs(op, {3});
+    validate_inputs_count(op, {3});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
     auto indices_rank = op->get_input_partial_shape(1).size();
@@ -26,8 +26,7 @@ static void CreateScatterNDUpdateOp(Program& p, const std::shared_ptr<ngraph::op
                                               indices_rank,
                                               op->get_friendly_name());
 
-    p.AddPrimitive(primitive);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, primitive);
 }
 
 REGISTER_FACTORY_IMPL(v3, ScatterNDUpdate);

--- a/src/plugins/intel_gpu/src/plugin/ops/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scatter_nd_update.cpp
@@ -23,8 +23,7 @@ static void CreateScatterNDUpdateOp(Program& p, const std::shared_ptr<ngraph::op
                                               inputPrimitives[0],
                                               inputPrimitives[1],
                                               inputPrimitives[2],
-                                              indices_rank,
-                                              op->get_friendly_name());
+                                              indices_rank);
 
     p.add_primitive(*op, primitive);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scatter_update.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateScatterUpdateOp(Program& p, const std::shared_ptr<ngraph::op::v3::ScatterUpdate>& op) {
-    p.ValidateInputs(op, {4});
+    validate_inputs_count(op, {4});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -30,8 +30,7 @@ static void CreateScatterUpdateOp(Program& p, const std::shared_ptr<ngraph::op::
                                            axis,
                                            op->get_friendly_name());
 
-    p.AddPrimitive(primitive);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, primitive);
 }
 
 REGISTER_FACTORY_IMPL(v3, ScatterUpdate);

--- a/src/plugins/intel_gpu/src/plugin/ops/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scatter_update.cpp
@@ -27,8 +27,7 @@ static void CreateScatterUpdateOp(Program& p, const std::shared_ptr<ngraph::op::
                                            inputPrimitives[0],
                                            inputPrimitives[1],
                                            inputPrimitives[2],
-                                           axis,
-                                           op->get_friendly_name());
+                                           axis);
 
     p.add_primitive(*op, primitive);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/select.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/select.cpp
@@ -15,7 +15,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateSelectOp(Program& p, const std::shared_ptr<ngraph::op::v1::Select>& op) {
-    p.ValidateInputs(op, {3});
+    validate_inputs_count(op, {3});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -51,8 +51,7 @@ static void CreateSelectOp(Program& p, const std::shared_ptr<ngraph::op::v1::Sel
                                                   cldnn::reorder_mean_mode::subtract,
                                                   op->get_friendly_name());
 
-                p.AddPrimitive(reorderPrim);
-                p.AddInnerPrimitiveToProfiler(reorderName, layerName, op);
+                p.add_primitive(*op, reorderPrim);
 
                 inputPrimitives[i] = reorderName;
             }
@@ -68,8 +67,7 @@ static void CreateSelectOp(Program& p, const std::shared_ptr<ngraph::op::v1::Sel
 
                 auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape, op->get_friendly_name());
 
-                p.AddPrimitive(reshapePrim);
-                p.AddInnerPrimitiveToProfiler(reshapeName, layerName, op);
+                p.add_primitive(*op, reshapePrim);
 
                 inputPrimitives[i] = reshapeName;
             }
@@ -86,8 +84,7 @@ static void CreateSelectOp(Program& p, const std::shared_ptr<ngraph::op::v1::Sel
                                     cldnn::padding(),
                                     bc_string);
 
-    p.AddPrimitive(selectPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, selectPrim);
 }
 
 REGISTER_FACTORY_IMPL(v1, Select);

--- a/src/plugins/intel_gpu/src/plugin/ops/select.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/select.cpp
@@ -48,8 +48,7 @@ static void CreateSelectOp(Program& p, const std::shared_ptr<ngraph::op::v1::Sel
                                                   targetFormat,
                                                   targetDatatype,
                                                   std::vector<float>(),
-                                                  cldnn::reorder_mean_mode::subtract,
-                                                  op->get_friendly_name());
+                                                  cldnn::reorder_mean_mode::subtract);
 
                 p.add_primitive(*op, reorderPrim);
 
@@ -65,7 +64,7 @@ static void CreateSelectOp(Program& p, const std::shared_ptr<ngraph::op::v1::Sel
 
                 auto targetShape = tensor_from_dims(input_shape);
 
-                auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape, op->get_friendly_name());
+                auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape);
 
                 p.add_primitive(*op, reshapePrim);
 
@@ -80,7 +79,6 @@ static void CreateSelectOp(Program& p, const std::shared_ptr<ngraph::op::v1::Sel
                                     inputPrimitives[0],
                                     inputPrimitives[1],
                                     inputPrimitives[2],
-                                    op->get_friendly_name(),
                                     cldnn::padding(),
                                     bc_string);
 

--- a/src/plugins/intel_gpu/src/plugin/ops/shape_of.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/shape_of.cpp
@@ -13,7 +13,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateShapeOfOpCommon(Program& p, const std::shared_ptr<ngraph::Node>& op) {
-    p.ValidateInputs(op, {1, 2});
+    validate_inputs_count(op, {1, 2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -23,8 +23,7 @@ static void CreateShapeOfOpCommon(Program& p, const std::shared_ptr<ngraph::Node
                                      DataTypeFromPrecision(op->get_output_element_type(0)),
                                      op->get_friendly_name());
 
-    p.AddPrimitive(primitive);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, primitive);
 }
 
 static void CreateShapeOfOp(Program& p, const std::shared_ptr<ngraph::op::v0::ShapeOf>& op) {

--- a/src/plugins/intel_gpu/src/plugin/ops/shape_of.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/shape_of.cpp
@@ -20,8 +20,7 @@ static void CreateShapeOfOpCommon(Program& p, const std::shared_ptr<ngraph::Node
     auto primitive = cldnn::shape_of(layerName,
                                      inputPrimitives[0],
                                      op->get_output_partial_shape(0).rank().get_length(),
-                                     DataTypeFromPrecision(op->get_output_element_type(0)),
-                                     op->get_friendly_name());
+                                     DataTypeFromPrecision(op->get_output_element_type(0)));
 
     p.add_primitive(*op, primitive);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/shuffle_channels.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/shuffle_channels.cpp
@@ -23,8 +23,7 @@ static void CreateShuffleChannelsOp(Program& p, const std::shared_ptr<ngraph::op
     auto shuffleChannelsPrim = cldnn::shuffle_channels(layerName,
                                                        inputPrimitives[0],
                                                        group,
-                                                       axis,
-                                                       op->get_friendly_name());
+                                                       axis);
 
     p.add_primitive(*op, shuffleChannelsPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/shuffle_channels.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/shuffle_channels.cpp
@@ -13,7 +13,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateShuffleChannelsOp(Program& p, const std::shared_ptr<ngraph::op::v0::ShuffleChannels>& op) {
-    p.ValidateInputs(op, {1, 2});
+    validate_inputs_count(op, {1, 2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -26,8 +26,7 @@ static void CreateShuffleChannelsOp(Program& p, const std::shared_ptr<ngraph::op
                                                        axis,
                                                        op->get_friendly_name());
 
-    p.AddPrimitive(shuffleChannelsPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, shuffleChannelsPrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, ShuffleChannels);

--- a/src/plugins/intel_gpu/src/plugin/ops/slice.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/slice.cpp
@@ -21,8 +21,7 @@ static void CreateSliceOp(Program& p, const std::shared_ptr<ngraph::op::v8::Slic
     auto input_primitives = p.GetInputPrimitiveIDs(op);
     auto output_shape = tensor_from_dims(op->get_output_shape(0));
     auto slice_prim = cldnn::slice(layer_type_name_ID(op),
-            input_primitives, output_shape,
-            op->get_friendly_name());
+            input_primitives, output_shape);
     p.add_primitive(*op, slice_prim);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/slice.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/slice.cpp
@@ -17,14 +17,13 @@ namespace intel_gpu {
 namespace {
 
 static void CreateSliceOp(Program& p, const std::shared_ptr<ngraph::op::v8::Slice>& op) {
-    p.ValidateInputs(op, { 4, 5 });
+    validate_inputs_count(op, { 4, 5 });
     auto input_primitives = p.GetInputPrimitiveIDs(op);
     auto output_shape = tensor_from_dims(op->get_output_shape(0));
     auto slice_prim = cldnn::slice(layer_type_name_ID(op),
             input_primitives, output_shape,
             op->get_friendly_name());
-    p.AddPrimitive(slice_prim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, slice_prim);
 }
 
 } // namespace

--- a/src/plugins/intel_gpu/src/plugin/ops/softmax.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/softmax.cpp
@@ -15,19 +15,18 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateSoftmaxOp(Program& p, const std::shared_ptr<ngraph::op::v1::Softmax>& op) {
-    p.ValidateInputs(op, {1});
+    validate_inputs_count(op, {1});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
     auto softmaxPrim = cldnn::softmax(layerName,
                                       inputPrimitives[0],
                                       op->get_axis(),
                                       op->get_friendly_name());
-    p.AddPrimitive(softmaxPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, softmaxPrim);
 }
 
 static void CreateSoftmaxOp(Program& p, const std::shared_ptr<ngraph::op::v8::Softmax>& op) {
-    p.ValidateInputs(op, {1});
+    validate_inputs_count(op, {1});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -37,12 +36,11 @@ static void CreateSoftmaxOp(Program& p, const std::shared_ptr<ngraph::op::v8::So
                                       inputPrimitives[0],
                                       axis,
                                       op->get_friendly_name());
-    p.AddPrimitive(softmaxPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, softmaxPrim);
 }
 
 static void CreateLogSoftmaxOp(Program& p, const std::shared_ptr<ngraph::op::v5::LogSoftmax>& op) {
-    p.ValidateInputs(op, {1});
+    validate_inputs_count(op, {1});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
     std::string layerNameSoftmax = layer_type_name_ID(op) + "_softmax";
@@ -56,10 +54,8 @@ static void CreateLogSoftmaxOp(Program& p, const std::shared_ptr<ngraph::op::v5:
 
     auto logPrim = cldnn::activation(layerName, layerNameSoftmax, cldnn::activation_func::log, {(0.0F), (0.0F)}, op->get_friendly_name());
 
-    p.AddPrimitive(softmaxPrim);
-    p.AddPrimitive(logPrim);
-    p.AddPrimitiveToProfiler(layerNameSoftmax, op);
-    p.AddPrimitiveToProfiler(layerName, op);
+    p.add_primitive(*op, softmaxPrim);
+    p.add_primitive(*op, logPrim);
 }
 
 REGISTER_FACTORY_IMPL(v1, Softmax);

--- a/src/plugins/intel_gpu/src/plugin/ops/softmax.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/softmax.cpp
@@ -20,8 +20,7 @@ static void CreateSoftmaxOp(Program& p, const std::shared_ptr<ngraph::op::v1::So
     std::string layerName = layer_type_name_ID(op);
     auto softmaxPrim = cldnn::softmax(layerName,
                                       inputPrimitives[0],
-                                      op->get_axis(),
-                                      op->get_friendly_name());
+                                      op->get_axis());
     p.add_primitive(*op, softmaxPrim);
 }
 
@@ -34,8 +33,7 @@ static void CreateSoftmaxOp(Program& p, const std::shared_ptr<ngraph::op::v8::So
 
     auto softmaxPrim = cldnn::softmax(layerName,
                                       inputPrimitives[0],
-                                      axis,
-                                      op->get_friendly_name());
+                                      axis);
     p.add_primitive(*op, softmaxPrim);
 }
 
@@ -49,10 +47,9 @@ static void CreateLogSoftmaxOp(Program& p, const std::shared_ptr<ngraph::op::v5:
 
     auto softmaxPrim = cldnn::softmax(layerNameSoftmax,
                                       inputPrimitives[0],
-                                      axis,
-                                      op->get_friendly_name());
+                                      axis);
 
-    auto logPrim = cldnn::activation(layerName, layerNameSoftmax, cldnn::activation_func::log, {(0.0F), (0.0F)}, op->get_friendly_name());
+    auto logPrim = cldnn::activation(layerName, layerNameSoftmax, cldnn::activation_func::log, {(0.0F), (0.0F)});
 
     p.add_primitive(*op, softmaxPrim);
     p.add_primitive(*op, logPrim);

--- a/src/plugins/intel_gpu/src/plugin/ops/space_to_batch.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/space_to_batch.cpp
@@ -46,8 +46,7 @@ static void CreateSpaceToBatchOp(Program& p, const std::shared_ptr<ngraph::op::v
                                                   inputs[0],          // block_shape
                                                   inputs[1],          // crops_begin
                                                   inputs[2],          // crops_end
-                                                  out_size,
-                                                  op->get_friendly_name());
+                                                  out_size);
 
     p.add_primitive(*op, batchToSpacePrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/space_to_batch.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/space_to_batch.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateSpaceToBatchOp(Program& p, const std::shared_ptr<ngraph::op::v1::SpaceToBatch>& op) {
-    p.ValidateInputs(op, {4});
+    validate_inputs_count(op, {4});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -49,8 +49,7 @@ static void CreateSpaceToBatchOp(Program& p, const std::shared_ptr<ngraph::op::v
                                                   out_size,
                                                   op->get_friendly_name());
 
-    p.AddPrimitive(batchToSpacePrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, batchToSpacePrim);
 }
 
 REGISTER_FACTORY_IMPL(v1, SpaceToBatch);

--- a/src/plugins/intel_gpu/src/plugin/ops/space_to_depth.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/space_to_depth.cpp
@@ -28,8 +28,7 @@ static void CreateSpaceToDepthOp(Program& p, const std::shared_ptr<ngraph::op::v
     auto spaceToDepthPrim = cldnn::space_to_depth(layerName,
                                                   inputPrimitives[0],
                                                   GetDepthMode(op->get_mode()),
-                                                  op->get_block_size(),
-                                                  op->get_friendly_name());
+                                                  op->get_block_size());
 
     p.add_primitive(*op, spaceToDepthPrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/space_to_depth.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/space_to_depth.cpp
@@ -22,7 +22,7 @@ static cldnn::space_to_depth::depth_mode GetDepthMode(ngraph::op::v0::SpaceToDep
 }
 
 static void CreateSpaceToDepthOp(Program& p, const std::shared_ptr<ngraph::op::v0::SpaceToDepth>& op) {
-    p.ValidateInputs(op, {1});
+    validate_inputs_count(op, {1});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
     auto spaceToDepthPrim = cldnn::space_to_depth(layerName,
@@ -31,8 +31,7 @@ static void CreateSpaceToDepthOp(Program& p, const std::shared_ptr<ngraph::op::v
                                                   op->get_block_size(),
                                                   op->get_friendly_name());
 
-    p.AddPrimitive(spaceToDepthPrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, spaceToDepthPrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, SpaceToDepth);

--- a/src/plugins/intel_gpu/src/plugin/ops/split.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/split.cpp
@@ -27,7 +27,7 @@ static void CreateCommonSplitOp(Program& p, const std::shared_ptr<ngraph::Node>&
     bool is_single_out_split = op->get_output_size() == 1;
 
     for (size_t i = 0; i < op->get_output_size(); i++) {
-        std::string outLayerName = layerName + (is_single_out_split ? "" : "." + std::to_string(i));
+        std::string outLayerName = layerName + (is_single_out_split ? "" : ".out" + std::to_string(i));
         const auto outLayerDims = op->get_output_shape(i);
         NGRAPH_SUPPRESS_DEPRECATED_START
         if (outLayerDims.size() != start_offset.size()) {
@@ -45,7 +45,7 @@ static void CreateCommonSplitOp(Program& p, const std::shared_ptr<ngraph::Node>&
         auto outTensor = tensor_from_dims(outLayerDims, 1);
         auto offsetTensor = tensor_from_dims(start_offset, 0);
 
-        auto cropPrim = cldnn::crop(outLayerName, inputPrimitives[0], outTensor, offsetTensor, op->get_friendly_name());
+        auto cropPrim = cldnn::crop(outLayerName, inputPrimitives[0], outTensor, offsetTensor);
         p.add_primitive(*op, cropPrim);
 
         for (size_t i = 0; i < input_shape.size(); i++) {

--- a/src/plugins/intel_gpu/src/plugin/ops/split.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/split.cpp
@@ -46,11 +46,7 @@ static void CreateCommonSplitOp(Program& p, const std::shared_ptr<ngraph::Node>&
         auto offsetTensor = tensor_from_dims(start_offset, 0);
 
         auto cropPrim = cldnn::crop(outLayerName, inputPrimitives[0], outTensor, offsetTensor, op->get_friendly_name());
-        p.primitiveIDs[outLayerName] = outLayerName;
-
-        p.AddPrimitive(cropPrim);
-        p.profilingIDs.push_back(outLayerName);
-        p.InitProfileInfo(outLayerName, "Crop");
+        p.add_primitive(*op, cropPrim);
 
         for (size_t i = 0; i < input_shape.size(); i++) {
             if (outLayerDims[i] != input_shape[i]) {
@@ -58,18 +54,15 @@ static void CreateCommonSplitOp(Program& p, const std::shared_ptr<ngraph::Node>&
             }
         }
     }
-
-    // set split as not_run
-    p.InitProfileInfo(op->get_friendly_name(), op->get_type_name(), false, InferenceEngine::InferenceEngineProfileInfo::OPTIMIZED_OUT);
 }
 
 static void CreateSplitOp(Program& p, const std::shared_ptr<ngraph::op::v1::Split>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     CreateCommonSplitOp(p, op);
 }
 
 static void CreateVariadicSplitOp(Program& p, const std::shared_ptr<ngraph::op::v1::VariadicSplit>& op) {
-    p.ValidateInputs(op, {3});
+    validate_inputs_count(op, {3});
     CreateCommonSplitOp(p, op);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/strided_slice.cpp
@@ -16,7 +16,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateStridedSliceOp(Program& p, const std::shared_ptr<ngraph::op::v1::StridedSlice>& op) {
-    p.ValidateInputs(op, {4});
+    validate_inputs_count(op, {4});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -197,8 +197,7 @@ static void CreateStridedSliceOp(Program& p, const std::shared_ptr<ngraph::op::v
             auto targetShape = tensor_from_dims(reshape_pattern);
             auto reshapeInName = op->get_friendly_name() + "/Reshape_before";
             auto reshapePrim = cldnn::reshape(reshapeInName, inputPrimitives[0], targetShape, op->get_friendly_name());
-            p.AddPrimitive(reshapePrim);
-            p.AddInnerPrimitiveToProfiler(reshapeInName, layerName, op);
+            p.add_primitive(*op, reshapePrim);
             inPrimitive = reshapeInName;
         }
 
@@ -223,7 +222,7 @@ static void CreateStridedSliceOp(Program& p, const std::shared_ptr<ngraph::op::v
 
 
         auto cropPrim = cldnn::crop(layerName, inPrimitive, refSize, offSize, op->get_friendly_name());
-        p.AddPrimitive(cropPrim);
+        p.add_primitive(*op, cropPrim);
         auto last_layer_primitive = layerName;
 
         // Reshape in case of deleting of axis
@@ -231,11 +230,9 @@ static void CreateStridedSliceOp(Program& p, const std::shared_ptr<ngraph::op::v
             auto targetShape = tensor_from_dims(output_shape);
             auto reshapeOutName = op->get_friendly_name() + "/Crop";
             auto reshapePrim = cldnn::reshape(reshapeOutName, layerName, targetShape, op->get_friendly_name());
-            p.AddPrimitive(reshapePrim);
-            p.AddInnerPrimitiveToProfiler(reshapeOutName, layerName, op);
+            p.add_primitive(*op, reshapePrim);
             last_layer_primitive = reshapeOutName;
         }
-        p.AddPrimitiveToProfiler(op, last_layer_primitive);
         return;
     } while (false);
 
@@ -256,8 +253,7 @@ static void CreateStridedSliceOp(Program& p, const std::shared_ptr<ngraph::op::v
                                                  output_shape,
                                                  op->get_friendly_name());
 
-    p.AddPrimitive(stridedSlicePrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, stridedSlicePrim);
 }
 
 REGISTER_FACTORY_IMPL(v1, StridedSlice);

--- a/src/plugins/intel_gpu/src/plugin/ops/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/strided_slice.cpp
@@ -196,7 +196,7 @@ static void CreateStridedSliceOp(Program& p, const std::shared_ptr<ngraph::op::v
         if (!new_axis_mask.empty()) {
             auto targetShape = tensor_from_dims(reshape_pattern);
             auto reshapeInName = op->get_friendly_name() + "/Reshape_before";
-            auto reshapePrim = cldnn::reshape(reshapeInName, inputPrimitives[0], targetShape, op->get_friendly_name());
+            auto reshapePrim = cldnn::reshape(reshapeInName, inputPrimitives[0], targetShape);
             p.add_primitive(*op, reshapePrim);
             inPrimitive = reshapeInName;
         }
@@ -221,7 +221,7 @@ static void CreateStridedSliceOp(Program& p, const std::shared_ptr<ngraph::op::v
         cldnn::tensor offSize = tensor_from_dims(offset, 0);
 
 
-        auto cropPrim = cldnn::crop(layerName, inPrimitive, refSize, offSize, op->get_friendly_name());
+        auto cropPrim = cldnn::crop(layerName, inPrimitive, refSize, offSize);
         p.add_primitive(*op, cropPrim);
         auto last_layer_primitive = layerName;
 
@@ -229,7 +229,7 @@ static void CreateStridedSliceOp(Program& p, const std::shared_ptr<ngraph::op::v
         if (!shrink_axis_mask.empty()) {
             auto targetShape = tensor_from_dims(output_shape);
             auto reshapeOutName = op->get_friendly_name() + "/Crop";
-            auto reshapePrim = cldnn::reshape(reshapeOutName, layerName, targetShape, op->get_friendly_name());
+            auto reshapePrim = cldnn::reshape(reshapeOutName, layerName, targetShape);
             p.add_primitive(*op, reshapePrim);
             last_layer_primitive = reshapeOutName;
         }
@@ -250,8 +250,7 @@ static void CreateStridedSliceOp(Program& p, const std::shared_ptr<ngraph::op::v
                                                  op->get_new_axis_mask(),
                                                  op->get_shrink_axis_mask(),
                                                  op->get_ellipsis_mask(),
-                                                 output_shape,
-                                                 op->get_friendly_name());
+                                                 output_shape);
 
     p.add_primitive(*op, stridedSlicePrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/tensor_iterator.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/tensor_iterator.cpp
@@ -114,23 +114,17 @@ static void CreateTensorIteratorOp(Program &p, const std::shared_ptr<TensorItera
     }
     {
         cldnn::data trip_count = CreateScalarData<cldnn::data>(p, trip_count_id, num_iterations, op->get_friendly_name());
-        p.primitiveIDs[trip_count_id] = trip_count_id;
-        p.AddPrimitive(trip_count);
-        p.AddInnerPrimitiveToProfiler(trip_count_id, layerName, op);
+        p.add_primitive(*op, trip_count);
     }
     const cldnn::primitive_id execution_condition_id = layerName + "_initialExecutionCondition";
     {
         cldnn::mutable_data execution_condition = CreateScalarData<cldnn::mutable_data>(p, execution_condition_id, 1, op->get_friendly_name());
-        p.primitiveIDs[execution_condition_id] = execution_condition_id;
-        p.AddPrimitive(execution_condition);
-        p.AddInnerPrimitiveToProfiler(execution_condition_id, layerName, op);
+        p.add_primitive(*op, execution_condition);
     }
     const cldnn::primitive_id num_iteration_id = layerName + "_numIteration";
     {
         cldnn::mutable_data num_iteration = CreateScalarData<cldnn::mutable_data>(p, num_iteration_id, 0, op->get_friendly_name());
-        p.primitiveIDs[num_iteration_id] = num_iteration_id;
-        p.AddPrimitive(num_iteration);
-        p.AddInnerPrimitiveToProfiler(num_iteration_id, layerName, op);
+        p.add_primitive(*op, num_iteration);
     }
 
     // set output mapping
@@ -144,13 +138,11 @@ static void CreateTensorIteratorOp(Program &p, const std::shared_ptr<TensorItera
         std::string external_id;
         if (output_idx > 0) {
             cldnn::mutable_data output_data = CreateAdditionalOutputData(p, op, layerNameWithIndex, layerName, output_idx);
-            p.AddPrimitive(output_data);
-            p.AddInnerPrimitiveToProfiler(layerNameWithIndex, layerName, op);
-            p.primitiveIDs[layerNameWithIndex] = layerNameWithIndex;
+            p.add_primitive(*op, output_data);
             external_id = layerNameWithIndex;
         } else {
-            p.primitiveIDs[layerNameWithIndex] = layerName;
-            p.primitiveIDs[layerName] = layerName;
+            p.primitive_ids[layerNameWithIndex] = layerName;
+            p.primitive_ids[layerName] = layerName;
             external_id = layerName;
         }
         const auto& body_output = body_outputs.at(loop_output_desc->m_body_value_index);
@@ -184,8 +176,7 @@ static void CreateTensorIteratorOp(Program &p, const std::shared_ptr<TensorItera
         "",
         op->get_friendly_name());
 
-    p.AddPrimitive(loopPrimitive);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, loopPrimitive);
 }
 
 REGISTER_FACTORY_IMPL(v0, TensorIterator);

--- a/src/plugins/intel_gpu/src/plugin/ops/tile.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/tile.cpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateTileOp(Program& p, const std::shared_ptr<ngraph::op::v0::Tile>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
     size_t rank = op->get_input_shape(0).size();
@@ -41,8 +41,7 @@ static void CreateTileOp(Program& p, const std::shared_ptr<ngraph::op::v0::Tile>
 
         auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[0], targetShape, op->get_friendly_name());
 
-        p.AddPrimitive(reshapePrim);
-        p.AddInnerPrimitiveToProfiler(reshapeName, layerName, op);
+        p.add_primitive(*op, reshapePrim);
 
         inputPrimitives[0] = reshapeName;
     }
@@ -52,8 +51,7 @@ static void CreateTileOp(Program& p, const std::shared_ptr<ngraph::op::v0::Tile>
                                 repeats,
                                 op->get_friendly_name());
 
-    p.AddPrimitive(tilePrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, tilePrim);
 }
 
 REGISTER_FACTORY_IMPL(v0, Tile);

--- a/src/plugins/intel_gpu/src/plugin/ops/tile.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/tile.cpp
@@ -39,7 +39,7 @@ static void CreateTileOp(Program& p, const std::shared_ptr<ngraph::op::v0::Tile>
 
         auto targetShape = tensor_from_dims(inputDims);
 
-        auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[0], targetShape, op->get_friendly_name());
+        auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[0], targetShape);
 
         p.add_primitive(*op, reshapePrim);
 
@@ -48,8 +48,7 @@ static void CreateTileOp(Program& p, const std::shared_ptr<ngraph::op::v0::Tile>
 
     auto tilePrim = cldnn::tile(layerName,
                                 inputPrimitives[0],
-                                repeats,
-                                op->get_friendly_name());
+                                repeats);
 
     p.add_primitive(*op, tilePrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/topk.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/topk.cpp
@@ -43,12 +43,11 @@ static void CreateTopKOp(Program& p, const std::shared_ptr<ngraph::op::v1::TopK>
 
         cldnn::primitive_id argmax_mutable_id_w = layer_type_name_ID(op) + "_md_write";
         auto argmax_mutable_prim = cldnn::mutable_data(argmax_mutable_id_w,
-                                                       shared_memory,
-                                                       op->get_friendly_name());
+                                                       shared_memory);
         p.add_primitive(*op, argmax_mutable_prim);
         inputPrimitives.push_back(argmax_mutable_id_w);
 
-        std::string ArgMaxLayerName = layerName + ".0";
+        std::string ArgMaxLayerName = layerName + ".out0";
         auto argmaxPrim = cldnn::arg_max_min(ArgMaxLayerName,
                                              inputPrimitives,
                                              mode,
@@ -56,17 +55,15 @@ static void CreateTopKOp(Program& p, const std::shared_ptr<ngraph::op::v1::TopK>
                                              chosen_axis,
                                              stype,
                                              true,
-                                             op->get_friendly_name(),
                                              cldnn::padding({0, 0, 0, 0}, 0),
                                              DataTypeFromPrecision(op->get_output_element_type(0)));
 
         p.add_primitive(*op, argmaxPrim);
 
-        cldnn::primitive_id argmax_mutable_id_r = layerName + ".1";
+        cldnn::primitive_id argmax_mutable_id_r = layerName + ".out1";
         auto argmax_mutable_prim_r = cldnn::mutable_data(argmax_mutable_id_r,
                                                          { ArgMaxLayerName },
-                                                         shared_memory,
-                                                         op->get_friendly_name());
+                                                         shared_memory);
         p.add_primitive(*op, argmax_mutable_prim_r);
     } else if (op->get_output_size() == 1) {
         auto argmaxPrim = cldnn::arg_max_min(layerName,
@@ -76,7 +73,6 @@ static void CreateTopKOp(Program& p, const std::shared_ptr<ngraph::op::v1::TopK>
                                              chosen_axis,
                                              stype,
                                              true,
-                                             op->get_friendly_name(),
                                              cldnn::padding({0, 0, 0, 0}, 0),
                                              DataTypeFromPrecision(op->get_output_element_type(0)));
 

--- a/src/plugins/intel_gpu/src/plugin/ops/transpose.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/transpose.cpp
@@ -56,8 +56,7 @@ static void CreateTransposeOp(Program& p, const std::shared_ptr<ngraph::op::v1::
                                       cldnn::format::bfyx,
                                       DataTypeFromPrecision(precision),
                                       std::vector<float>(),
-                                      cldnn::reorder_mean_mode::none,
-                                      op->get_friendly_name());
+                                      cldnn::reorder_mean_mode::none);
         p.add_primitive(*op, reorder_prim);
         return;
     }
@@ -71,8 +70,7 @@ static void CreateTransposeOp(Program& p, const std::shared_ptr<ngraph::op::v1::
 
     auto permutePrim = cldnn::permute(layerName,
                                       inputPrimitives[0],
-                                      order,
-                                      op->get_friendly_name());
+                                      order);
 
     p.add_primitive(*op, permutePrim);
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/transpose.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/transpose.cpp
@@ -15,7 +15,7 @@ namespace ov {
 namespace intel_gpu {
 
 static void CreateTransposeOp(Program& p, const std::shared_ptr<ngraph::op::v1::Transpose>& op) {
-    p.ValidateInputs(op, {1, 2});
+    validate_inputs_count(op, {1, 2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
 
@@ -51,14 +51,14 @@ static void CreateTransposeOp(Program& p, const std::shared_ptr<ngraph::op::v1::
     if (((input && is_convert_color_type(input)) || (input1 && is_convert_color_type(input1)))
             && order == std::vector<uint16_t>{0, 3, 1, 2}) {
         auto precision = input->get_element_type();
-        p.AddPrimitive(cldnn::reorder(layerName,
+        auto reorder_prim = cldnn::reorder(layerName,
                                       inputPrimitives[0],
                                       cldnn::format::bfyx,
                                       DataTypeFromPrecision(precision),
                                       std::vector<float>(),
                                       cldnn::reorder_mean_mode::none,
-                                      op->get_friendly_name()));
-        p.AddPrimitiveToProfiler(op);
+                                      op->get_friendly_name());
+        p.add_primitive(*op, reorder_prim);
         return;
     }
 
@@ -74,8 +74,7 @@ static void CreateTransposeOp(Program& p, const std::shared_ptr<ngraph::op::v1::
                                       order,
                                       op->get_friendly_name());
 
-    p.AddPrimitive(permutePrim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, permutePrim);
 }
 
 REGISTER_FACTORY_IMPL(v1, Transpose);

--- a/src/plugins/intel_gpu/src/plugin/ops/unary.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/unary.cpp
@@ -51,8 +51,7 @@ void CreateUnaryEltwiseOp(Program& p, const std::shared_ptr<ngraph::Node>& op,
     auto inputs = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
     auto activationPrimitive = cldnn::activation(layerName, inputs[0], func, params, op->get_friendly_name());
-    p.AddPrimitive(activationPrimitive);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, activationPrimitive);
 }
 
 static void CreateTanhOp(Program& p, const std::shared_ptr<ngraph::op::v0::Tanh>& op) {
@@ -73,7 +72,7 @@ static void CreateReluOp(Program& p, const std::shared_ptr<ngraph::op::v0::Relu>
 }
 
 static void CreatePReluOp(Program& p, const std::shared_ptr<ngraph::op::v0::PRelu>& op) {
-    p.ValidateInputs(op, {2});
+    validate_inputs_count(op, {2});
 
     auto slope_node = std::dynamic_pointer_cast<ngraph::op::v0::Constant>(op->get_input_node_shared_ptr(1));
     auto slope_shape = op->get_input_partial_shape(1);
@@ -92,8 +91,7 @@ static void CreatePReluOp(Program& p, const std::shared_ptr<ngraph::op::v0::PRel
                                                      inputs[1],
                                                      cldnn::activation_func::relu_negative_slope,
                                                      op->get_friendly_name());
-        p.AddPrimitive(activationPrimitive);
-        p.AddPrimitiveToProfiler(op);
+        p.add_primitive(*op, activationPrimitive);
     }
 }
 
@@ -156,7 +154,7 @@ static void CreateErfOp(Program& p, const std::shared_ptr<ngraph::op::v0::Erf>& 
 }
 
 static void CreateHardSigmoidOp(Program& p, const std::shared_ptr<ngraph::op::v0::HardSigmoid>& op) {
-    p.ValidateInputs(op, {3});
+    validate_inputs_count(op, {3});
     auto alpha_node = std::dynamic_pointer_cast<ngraph::op::v0::Constant>(op->get_input_node_shared_ptr(1));
     auto beta_node = std::dynamic_pointer_cast<ngraph::op::v0::Constant>(op->get_input_node_shared_ptr(2));
     if (!alpha_node || !beta_node) {
@@ -182,7 +180,7 @@ static void CreateNegativeOp(Program& p, const std::shared_ptr<ngraph::op::v0::N
 }
 
 static void CreateSeluOp(Program& p, const std::shared_ptr<ngraph::op::v0::Selu>& op) {
-    p.ValidateInputs(op, {3});
+    validate_inputs_count(op, {3});
     auto alpha_node = std::dynamic_pointer_cast<ngraph::op::v0::Constant>(op->get_input_node_shared_ptr(1));
     auto lambda_node = std::dynamic_pointer_cast<ngraph::op::v0::Constant>(op->get_input_node_shared_ptr(2));
     if (!alpha_node || !lambda_node) {
@@ -226,7 +224,7 @@ static void CreateCoshOp(Program& p, const std::shared_ptr<ngraph::op::v0::Cosh>
 }
 
 static void CreateSwishOp(Program& p, const std::shared_ptr<ngraph::op::v4::Swish>& op) {
-    p.ValidateInputs(op, {1, 2});
+    validate_inputs_count(op, {1, 2});
     if (op->get_input_size() == 2) {
         auto beta_node = std::dynamic_pointer_cast<ngraph::op::v0::Constant>(op->get_input_node_shared_ptr(1));
         if (beta_node) {

--- a/src/plugins/intel_gpu/src/plugin/ops/unary.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/unary.cpp
@@ -50,7 +50,7 @@ void CreateUnaryEltwiseOp(Program& p, const std::shared_ptr<ngraph::Node>& op,
                           cldnn::activation_func func, cldnn::activation_additional_params params) {
     auto inputs = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
-    auto activationPrimitive = cldnn::activation(layerName, inputs[0], func, params, op->get_friendly_name());
+    auto activationPrimitive = cldnn::activation(layerName, inputs[0], func, params);
     p.add_primitive(*op, activationPrimitive);
 }
 
@@ -89,8 +89,7 @@ static void CreatePReluOp(Program& p, const std::shared_ptr<ngraph::op::v0::PRel
         auto activationPrimitive = cldnn::activation(layerName,
                                                      inputs[0],
                                                      inputs[1],
-                                                     cldnn::activation_func::relu_negative_slope,
-                                                     op->get_friendly_name());
+                                                     cldnn::activation_func::relu_negative_slope);
         p.add_primitive(*op, activationPrimitive);
     }
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/variable.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/variable.cpp
@@ -17,7 +17,7 @@ namespace {
 template<typename T_PRIMITIVE>
 void CreateVariableAccessPrimitive(Program &p, const std::shared_ptr<ngraph::op::Op> &op,
                                    const std::string &variable_id) {
-    p.ValidateInputs(op, {1});
+    validate_inputs_count(op, {1});
 
     const auto output_data_type = DataTypeFromPrecision(op->get_output_element_type(0));
     const auto op_output_shape = op->get_output_shape(0);
@@ -35,8 +35,7 @@ void CreateVariableAccessPrimitive(Program &p, const std::shared_ptr<ngraph::op:
                                   variable_id,
                                   variable_layout};
 
-    p.AddPrimitive(prim);
-    p.AddPrimitiveToProfiler(op);
+    p.add_primitive(*op, prim);
 }
 
 void CreateReadValueOp(Program& p, const std::shared_ptr<ngraph::op::v6::ReadValue>& op) {

--- a/src/plugins/intel_gpu/src/plugin/program.cpp
+++ b/src/plugins/intel_gpu/src/plugin/program.cpp
@@ -7,8 +7,10 @@
 #include "ngraph_ops/nms_ie_internal.hpp"
 #include "openvino/core/graph_util.hpp"
 #include "intel_gpu/plugin/itt.hpp"
-#include "intel_gpu/runtime/debug_configuration.hpp"
 #include "intel_gpu/plugin/transformations_pipeline.hpp"
+#include "intel_gpu/runtime/debug_configuration.hpp"
+#include "intel_gpu/primitives/mutable_data.hpp"
+#include "intel_gpu/primitives/data.hpp"
 
 using namespace InferenceEngine;
 using namespace InferenceEngine::details;
@@ -375,8 +377,6 @@ bool Program::IsOpSupported(const InferenceEngine::CNNNetwork& network, const st
 
 void Program::CreateSingleLayerPrimitive(cldnn::topology& topology, const std::shared_ptr<ngraph::Node>& op) {
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "Program::CreateSingleLayerPrimitive");
-    InitProfileInfo(op->get_friendly_name(), op->get_type_name());
-
     GPU_DEBUG_GET_INSTANCE(debug_config);
     GPU_DEBUG_IF(debug_config->verbose >= 2) {
         GPU_DEBUG_COUT << "Process " << "op::v" << op->get_type_info().version << "::" << op->get_type_name() << " operation "
@@ -418,7 +418,7 @@ std::vector<cldnn::primitive_id> Program::GetInputPrimitiveIDs(const std::shared
         auto prevOp = op->get_input_node_ptr(i);
         std::string prevName = layer_type_name_ID(prevOp);
         if (prevOp->get_output_size() > 1) {
-            prevName += "." + std::to_string(op->get_input_source_output(i).get_index());
+            prevName += ".out" + std::to_string(op->get_input_source_output(i).get_index());
         }
 
         if (!queryMode) {
@@ -433,26 +433,14 @@ std::vector<cldnn::primitive_id> Program::GetInputPrimitiveIDs(const std::shared
     return inputPrimitives;
 }
 
-void Program::InitProfileInfo(const std::string& layerName,
-                              const std::string& layerType,
-                              bool isCPU,
-                              InferenceEngine::InferenceEngineProfileInfo::LayerStatus status, std::string parentId) {
-    std::string layer_type_lower = layerType;
-    for (auto& c : layer_type_lower)
-        c = tolower(c);
-
-    std::string name = layerName;
-    if (name.find(layer_type_lower + ":") != std::string::npos) {
-        name = layerName.substr(layerName.find(":") + 1, layerName.length());
-    }
-
-    perfMap[layer_type_lower + ":" + name].first = name;
-    auto& perfEntry = perfMap[layer_type_lower + ":" + name].second;
-    perfEntry.layerType = layerType;
-    perfEntry.status = status;
+void Program::init_profile_info(const cldnn::primitive& prim) {
+    perfMap[prim.id].first = prim.id;
+    auto& perfEntry = perfMap[prim.id].second;
+    perfEntry.layerType = prim.origin_op_type_name;
+    perfEntry.status = InferenceEngine::InferenceEngineProfileInfo::LayerStatus::EXECUTED;
     perfEntry.cpu_uSec = perfEntry.realTime_uSec = 0;
-    perfEntry.isCPU = isCPU;
-    perfEntry.parentPrimitive = parentId;
+    perfEntry.isCPU = false;
+    perfEntry.parentPrimitive = prim.origin_op_name;
 }
 
 void Program::AddVariableStateInfo(const std::string& variable_id, const cldnn::layout& layout) {
@@ -469,18 +457,28 @@ void Program::add_primitive(const ngraph::Node& op, std::shared_ptr<cldnn::primi
     prim->origin_op_name = op.get_friendly_name();
     prim->origin_op_type_name = op.get_type_name();
 
+    bool should_profile = prim->type != cldnn::mutable_data::type_id() &&
+                          prim->type != cldnn::data::type_id();
+
+    auto prim_id = prim->id;
     auto id = layer_type_name_ID(&op);
-    primitive_ids[id] = prim->id;
-    if (id != prim->id) {
-        InitProfileInfo(prim->id, prim->type_string(), false, InferenceEngine::InferenceEngineProfileInfo::EXECUTED, id);
-        primitive_ids[prim->id] = prim->id;
+    primitive_ids[id] = prim_id;
+
+    bool multi_output_case = ends_with(prim_id, ".out0") && prim_id.length() > 5 && prim_id.substr(0, prim_id.length() - 5) == id;
+    if (id != prim_id) {
+        primitive_ids[prim_id] = prim_id;
+
+        if (!multi_output_case)
+            prim->origin_op_type_name = prim->type_string();
+    }
+
+    if (this->m_config.useProfiling && should_profile) {
+        profiling_ids.push_back(prim_id);
+        init_profile_info(*prim);
     }
 
     for (auto& alias : aliases) {
-        primitive_ids[alias] = prim->id;
-    }
-    if (this->m_config.useProfiling) {
-        profiling_ids.push_back(prim->id);
+        primitive_ids[alias] = prim_id;
     }
 
     m_topology->add_primitive(prim);

--- a/src/plugins/intel_gpu/tests/fusions/concatenate_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/concatenate_fusion_test.cpp
@@ -104,7 +104,6 @@ TEST_P(concat_onednn_activation, along_f) {
                       { "input0", "input1" },
                       1,
                       data_types::f16,
-                      "",
                       padding{ { 0, 0, 0, 0 }, 0 }),
         activation("act", "concat", activation_func::relu),
         reorder("reorder_bfyx", "act", cldnn::format::bfyx, p.default_type)
@@ -127,7 +126,6 @@ TEST_P(concat_onednn_eltwise, along_f) {
                       { "input0", "input1" },
                       1,
                       data_types::f16,
-                      "",
                       padding{ { 0, 0, 0, 0 }, 0 }),
         eltwise("scale", { "concat", "scale_data" }, eltwise_mode::prod, p.default_type),
         reorder("reorder_bfyx", "scale", cldnn::format::bfyx, p.default_type)

--- a/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
@@ -1128,7 +1128,6 @@ TEST_P(conv_fp32_multi_eltwise_concat, basic) {
             { "eltwise1", "eltwise2" },
             1,
             data_types::i8,
-            "",
             padding{ { 0, 0, 0, 0 }, 0 }),
         reorder("reorder_bfyx", "concat", p.default_format, data_types::f32)
     );

--- a/src/plugins/intel_gpu/tests/fusions/fully_connected_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/fully_connected_fusion_test.cpp
@@ -183,7 +183,7 @@ TEST_P(fc_fp32_activation, basic) {
         input_layout("input", get_input_layout(p)),
         data("weights", get_mem(get_weights_layout(p))),
         data("bias", get_mem(get_bias_layout(p))),
-        fully_connected("fc_prim", "input", "weights", "bias", "", padding(), get_output_dim_size(p)),
+        fully_connected("fc_prim", "input", "weights", "bias", padding(), get_output_dim_size(p)),
         activation("activation", "fc_prim", activation_func::abs),
         reorder("reorder_bfyx", "activation", p.default_format, data_types::f32)
     );
@@ -207,7 +207,7 @@ TEST_P(fc_fp32_bias, basic) {
         input_layout("input", get_input_layout(p)),
         data("weights", get_mem(get_weights_layout(p))),
         data("bias", get_mem(get_bias_layout(p))),
-        fully_connected("fc_prim", "input", "weights", "", "", padding(), get_output_dim_size(p)),
+        fully_connected("fc_prim", "input", "weights", "", padding(), get_output_dim_size(p)),
         eltwise("bias_add", { "fc_prim", "bias" }, eltwise_mode::sum),
         reorder("reorder_bfyx", "bias_add", p.default_format, data_types::f32)
     );
@@ -233,7 +233,7 @@ TEST_P(fc_int8_scale, basic) {
         data("weights", get_mem(get_weights_layout(p))),
         data("bias", get_mem(get_bias_layout(p))),
         data("scale_data", get_mem(get_per_channel_layout(p), 1.0f / p.kernel.count())),
-        fully_connected("fc_prim", "input", "weights", "bias", data_types::f32, "", padding(), get_output_dim_size(p)),
+        fully_connected("fc_prim", "input", "weights", "bias", data_types::f32, padding(), get_output_dim_size(p)),
         scale("scale", "fc_prim", "scale_data"),
         reorder("reorder_bfyx", "scale", p.default_format, data_types::f32)
     );
@@ -249,7 +249,7 @@ TEST_P(fc_int8_scale, fp16_scale_out) {
         data("weights", get_mem(get_weights_layout(p))),
         data("bias", get_mem(get_bias_layout(p))),
         data("scale_data", get_mem(get_per_channel_layout(p), 1.0f / p.kernel.count())),
-        fully_connected("fc_prim", "input", "weights", "bias", data_types::f32, "", padding(), get_output_dim_size(p)),
+        fully_connected("fc_prim", "input", "weights", "bias", data_types::f32, padding(), get_output_dim_size(p)),
         scale("scale", "fc_prim", "scale_data", optional_data_type{ data_types::f16 }),
         reorder("reorder_bfyx", "scale", p.default_format, data_types::f32)
     );
@@ -278,7 +278,7 @@ TEST_P(fc_int8_quantize_u8, basic) {
         data("in_hi", get_mem(get_per_channel_layout(p), 1, max_random)),
         data("out_lo", get_mem(get_single_element_layout(p), 0)),
         data("out_hi", get_mem(get_single_element_layout(p), 255)),
-        fully_connected("fc_prim", "input", "weights", "bias", data_types::f32, "", padding(), get_output_dim_size(p)),
+        fully_connected("fc_prim", "input", "weights", "bias", data_types::f32, padding(), get_output_dim_size(p)),
         quantize("quantize", "fc_prim", "in_lo", "in_hi", "out_lo", "out_hi", 256, data_types::u8),
         reorder("reorder_bfyx", "quantize", p.default_format, data_types::f32)
     );
@@ -308,7 +308,7 @@ TEST_P(fc_int8_scale_quantize_i8, basic) {
         data("out_lo", get_mem(get_single_element_layout(p), -127)),
         data("out_hi", get_mem(get_single_element_layout(p), 127)),
         data("scale_data", get_mem(get_per_channel_layout(p), 1.0f / p.kernel.count() / 255)),
-        fully_connected("fc_prim", "input", "weights", "bias", data_types::f32, "", padding(), get_output_dim_size(p)),
+        fully_connected("fc_prim", "input", "weights", "bias", data_types::f32, padding(), get_output_dim_size(p)),
         scale("scale", "fc_prim", "scale_data"),
         quantize("quantize", "scale", "in_lo", "in_hi", "out_lo", "out_hi", 255, data_types::i8),
         reorder("reorder_bfyx", "quantize", p.default_format, data_types::f32)
@@ -339,7 +339,7 @@ TEST_P(fc_int8_scale_activation_quantize_i8, basic) {
         data("out_lo", get_mem(get_single_element_layout(p), -127)),
         data("out_hi", get_mem(get_single_element_layout(p), 127)),
         data("scale_data", get_mem(get_per_channel_layout(p), 1.0f / p.kernel.count() / 255)),
-        fully_connected("fc_prim", "input", "weights", "bias", data_types::f32, "", padding(), get_output_dim_size(p)),
+        fully_connected("fc_prim", "input", "weights", "bias", data_types::f32, padding(), get_output_dim_size(p)),
         scale("scale", "fc_prim", "scale_data"),
         activation("activation_scale", "scale", activation_func::exp),
         quantize("quantize", "activation_scale", "in_lo", "in_hi", "out_lo", "out_hi", 255, data_types::i8),
@@ -377,7 +377,7 @@ TEST_P(fc_int8_inputs_fused_fp32_sum, basic) {
         data("weights", get_mem(get_weights_layout(p))),
         data("bias", get_mem(get_bias_layout(p))),
         data("shift_data", get_mem(shift_layout, 1)),
-        fully_connected("fc_prim", "input", "weights", "bias", cldnn::data_types::f32, "", padding(), get_output_dim_size(p)),
+        fully_connected("fc_prim", "input", "weights", "bias", cldnn::data_types::f32, padding(), get_output_dim_size(p)),
         eltwise("shift", { "fc_prim", "shift_data" }, eltwise_mode::sum, cldnn::data_types::f32),
         crop("crop", "shift", get_output_layout(p).get_tensor(), { 0, 0, 0, 0 }),
         reorder("reorder_bfyx", "crop", p.default_format, data_types::f32)

--- a/src/plugins/intel_gpu/tests/test_cases/activation_simple_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/activation_simple_gpu_test.cpp
@@ -532,7 +532,7 @@ TEST(activation_f32_fw_gpu, relu_basic_yxfb) {
 
     topology topology(
         input_layout("input", input->get_layout()),
-        activation("relu", "input", activation_func::relu_negative_slope, { 0.5f, 0.f }, "", padding{ { 0, 0, 0, 0 }, 0 }));
+        activation("relu", "input", activation_func::relu_negative_slope, { 0.5f, 0.f }, padding{ { 0, 0, 0, 0 }, 0 }));
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -608,7 +608,7 @@ TEST(activation_f32_fw_gpu, relu_basic_bfzyx) {
 
     topology topology(
         input_layout("input", input->get_layout()),
-        activation("relu", "input", activation_func::relu_negative_slope, { 0.5f, 0.f }, "", padding{ { 0, 0, 0, 0, 0 }, 0 }));
+        activation("relu", "input", activation_func::relu_negative_slope, { 0.5f, 0.f }, padding{ { 0, 0, 0, 0, 0 }, 0 }));
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -1019,7 +1019,7 @@ TEST(activation_f32_fw_gpu, relu_basic_acosh_yxfb) {
     topology topology(
             input_layout("input", input->get_layout()),
             reorder("reorder", "input", input->get_layout().with_padding(padding{ { 0, 0, 2, 1 }, 0 })),
-            activation("relu", "reorder", activation_func::acosh, {0.5f, 0.f}, "", padding{ { 0, 0, 0, 0 }, 0 }));
+            activation("relu", "reorder", activation_func::acosh, {0.5f, 0.f}, padding{ { 0, 0, 0, 0 }, 0 }));
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -1085,7 +1085,7 @@ TEST(activation_f32_fw_gpu, relu_basic_input_padding_yxfb) {
     topology topology(
         input_layout("input", input->get_layout()),
         reorder("reorder", "input", input->get_layout().with_padding(padding{ { 0, 0, 2, 1 }, 0 })),
-        activation("relu", "reorder", activation_func::relu_negative_slope, { 0.5f, 0.f }, "", padding{ { 0, 0, 0, 0 }, 0 }));
+        activation("relu", "reorder", activation_func::relu_negative_slope, { 0.5f, 0.f }, padding{ { 0, 0, 0, 0 }, 0 }));
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -1172,7 +1172,7 @@ TEST(activation_f32_fw_gpu, relu_basic_input_padding_bfzyx) {
     topology topology(
         input_layout("input", input->get_layout()),
         reorder("reorder", "input", input->get_layout().with_padding(padding{ { 0, 0, 2, 1, 0 }, 0 })),
-        activation("relu", "reorder", activation_func::relu_negative_slope, { 0.5f, 0.f }, "", padding{ { 0, 0, 0, 0, 0 }, 0 }));
+        activation("relu", "reorder", activation_func::relu_negative_slope, { 0.5f, 0.f }, padding{ { 0, 0, 0, 0, 0 }, 0 }));
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -1245,7 +1245,7 @@ TEST(activation_f32_fw_gpu, relu_basic_output_padding_yxfb) {
 
     topology topology(
         input_layout("input", input->get_layout()),
-        activation("relu", "input", activation_func::relu_negative_slope, { 0.5f, 0.f }, "", padding{ { 0, 0, 3, 3 }, 0 }));
+        activation("relu", "input", activation_func::relu_negative_slope, { 0.5f, 0.f }, padding{ { 0, 0, 3, 3 }, 0 }));
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();

--- a/src/plugins/intel_gpu/tests/test_cases/arg_max_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/arg_max_gpu_test.cpp
@@ -64,7 +64,7 @@ TEST(arg_max_gpu_min_axis_batch, i32) {
     auto input = engine.allocate_memory({ data_types::f32, format::bfyx,{ batch_num, feature_num, x_size, y_size } });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(arg_max_min("arg_max", { "input" }, ov::op::TopKMode::MIN, top_k, 0, ov::op::TopKSortType::SORT_VALUES, false, "", padding(), data_types::i32));
+    topology.add(arg_max_min("arg_max", { "input" }, ov::op::TopKMode::MIN, top_k, 0, ov::op::TopKSortType::SORT_VALUES, false, padding(), data_types::i32));
 
     std::vector<float> input_vec = {
         //y0x0 y0x1 y1x0 y1x1
@@ -107,7 +107,7 @@ TEST(arg_max_gpu_min_axis_batch_bfzyx, i32) {
     auto input = engine.allocate_memory({ data_types::f32, format::bfzyx,{ batch_num, feature_num, x_size, y_size, z_size } });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(arg_max_min("arg_max", { "input" }, ov::op::TopKMode::MIN, top_k, 0, ov::op::TopKSortType::SORT_VALUES, false, "", padding(), data_types::i32));
+    topology.add(arg_max_min("arg_max", { "input" }, ov::op::TopKMode::MIN, top_k, 0, ov::op::TopKSortType::SORT_VALUES, false, padding(), data_types::i32));
 
     std::vector<float> input_vec = {
             //y0x0 y0x1 y1x0 y1x1
@@ -149,7 +149,7 @@ TEST(arg_max_gpu_min_axis_y_yxfb, f32) {
     auto input = engine.allocate_memory({ data_types::f32, format::yxfb,{ batch_num, feature_num, x_size, y_size } });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(arg_max_min("arg_max", { "input" }, ov::op::TopKMode::MAX, top_k, 2, ov::op::TopKSortType::SORT_VALUES, false, "", padding(), data_types::f32));
+    topology.add(arg_max_min("arg_max", { "input" }, ov::op::TopKMode::MAX, top_k, 2, ov::op::TopKSortType::SORT_VALUES, false, padding(), data_types::f32));
 
     std::vector<float> input_vec = {
             0.1f, -0.1f,
@@ -213,7 +213,7 @@ TEST(arg_max_gpu_min_axis_batch_yxfb, f32) {
     auto input = engine.allocate_memory({ data_types::f32, format::yxfb,{ batch_num, feature_num, x_size, y_size } });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(arg_max_min("arg_max", { "input" }, ov::op::TopKMode::MAX, top_k, 0, ov::op::TopKSortType::SORT_VALUES, false, "", padding(), data_types::f32));
+    topology.add(arg_max_min("arg_max", { "input" }, ov::op::TopKMode::MAX, top_k, 0, ov::op::TopKSortType::SORT_VALUES, false, padding(), data_types::f32));
 
     std::vector<float> input_vec = {
             0.1f, -0.1f,
@@ -277,7 +277,7 @@ TEST(arg_max_gpu_min_axis_y_yxfb_topk_2, f32) {
     auto input = engine.allocate_memory({ data_types::f32, format::yxfb,{ batch_num, feature_num, x_size, y_size } });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(arg_max_min("arg_max", { "input" }, ov::op::TopKMode::MAX, top_k, 2, ov::op::TopKSortType::SORT_VALUES, false, "", padding(), data_types::f32));
+    topology.add(arg_max_min("arg_max", { "input" }, ov::op::TopKMode::MAX, top_k, 2, ov::op::TopKSortType::SORT_VALUES, false, padding(), data_types::f32));
 
     std::vector<float> input_vec = {
             0.1f, -0.1f,
@@ -406,7 +406,7 @@ TEST(top_k_layer_tests, second_output2) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(cldnn::data("const", top_k_input));
     topology.add(mutable_data("second_output", second_output));
-    topology.add(arg_max_min("arg_max", { "input", "const", "second_output" }, ov::op::TopKMode::MAX, top_k, 0, ov::op::TopKSortType::SORT_VALUES, false, "", padding(), data_types::f32));
+    topology.add(arg_max_min("arg_max", { "input", "const", "second_output" }, ov::op::TopKMode::MAX, top_k, 0, ov::op::TopKSortType::SORT_VALUES, false, padding(), data_types::f32));
 
     std::vector<float> input_vec = {
             0.1f, -0.1f,
@@ -496,7 +496,7 @@ TEST(arg_max_gpu_min_axis_y_yxfb_topk_2, sort_by_values) {
     auto input = engine.allocate_memory({ data_types::f32, format::yxfb,{ batch_num, feature_num, x_size, y_size } });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(arg_max_min("arg_max", { "input" }, ov::op::TopKMode::MAX, top_k, 2, ov::op::TopKSortType::SORT_VALUES, false, "", padding(), data_types::f32));
+    topology.add(arg_max_min("arg_max", { "input" }, ov::op::TopKMode::MAX, top_k, 2, ov::op::TopKSortType::SORT_VALUES, false, padding(), data_types::f32));
 
     std::vector<float> input_vec = {
             0.1f, -0.1f,
@@ -570,7 +570,7 @@ TEST(arg_max_gpu_min_axis_y_yxfb_topk_2, sort_by_indices) {
     auto input = engine.allocate_memory({ data_types::f32, format::yxfb,{ batch_num, feature_num, x_size, y_size } });
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(arg_max_min("arg_max", { "input" }, ov::op::TopKMode::MAX, top_k, 2, ov::op::TopKSortType::SORT_INDICES, false, "", padding(), data_types::f32));
+    topology.add(arg_max_min("arg_max", { "input" }, ov::op::TopKMode::MAX, top_k, 2, ov::op::TopKSortType::SORT_INDICES, false, padding(), data_types::f32));
 
     std::vector<float> input_vec = {
             0.1f, -0.1f,
@@ -646,7 +646,7 @@ TEST(top_k_layer_tests, sort_probabilities_by_indices) {
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
     topology.add(arg_max_min("arg_max", { "input"}, ov::op::TopKMode::MAX, top_k, 3,
-                             ov::op::TopKSortType::SORT_VALUES, false, "", padding(), data_types::i32));
+                             ov::op::TopKSortType::SORT_VALUES, false, padding(), data_types::i32));
 
     std::vector<float> input_vec = {
            0.9f,

--- a/src/plugins/intel_gpu/tests/test_cases/average_unpooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/average_unpooling_gpu_test.cpp
@@ -186,7 +186,7 @@ TEST(average_unpooling_gpu, basic_in2x2x2x1_output_padding) {
 
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(average_unpooling("average_unpooling", "input", { 2, 2, 3, 2 }, { 1, 1, 2, 2 }, { 1, 1, 1, 1 }, "", padding({ 0, 0, 1, 1 }, 0)));
+    topology.add(average_unpooling("average_unpooling", "input", { 2, 2, 3, 2 }, { 1, 1, 2, 2 }, { 1, 1, 1, 1 }, padding({ 0, 0, 1, 1 }, 0)));
 
     network network(engine, topology);
 

--- a/src/plugins/intel_gpu/tests/test_cases/binary_convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/binary_convolution_gpu_test.cpp
@@ -364,7 +364,6 @@ TEST(binary_convolution, basic_convolution_1x1_single_packed_channel) {
                                { 1,4,2,2 },
                                0, 0.0f,
                                data_types::f32,
-                               "",
                                padding{ { 0,0,0,0 }, 0 })
     );
 
@@ -448,7 +447,6 @@ TEST(binary_convolution, basic_convolution_1x1_single_packed_channel_fp16) {
                                { 1,4,2,2 },
                                0, 0.0f,
                                data_types::f16,
-                               "",
                                padding{ { 0,0,0,0 }, 0 })
     );
 

--- a/src/plugins/intel_gpu/tests/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/concatenation_gpu_test.cpp
@@ -58,7 +58,6 @@ TEST(concat_gpu, mixed_input_types) {
                           { "input0", "input1", "input2", "input3", "input4" },
                           1,
                           data_types::f32,
-                          "",
                           padding{ { 0,0,0,0 }, 0 })
     );
 
@@ -132,7 +131,6 @@ TEST(concat_gpu, mixed_input_types_5d) {
                           { "input0", "input1", "input2", "input3" },
                           1,
                           data_types::f32,
-                          "",
                           padding{ { 0,0,0,0 }, 0 })
     );
 
@@ -207,7 +205,6 @@ TEST(concat_gpu, i8_optimization_with_pool) {
                                     {"pool0", "pool1"},
                                     1,
                                     data_types::i8,
-                                    "",
                                     padding{{0, 0, 0, 0}, 0}),
                       reorder("reorder", "concat", reorder_layout));
     cldnn::build_options options;
@@ -308,7 +305,6 @@ TEST(concat_gpu, i8_optimization_with_conv) {
                                     {"input0", "input1", "input2"},
                                     1,
                                     data_types::i8,
-                                    "",
                                     padding{{0, 0, 0, 0}, 0}),
                       data("weights", weights),
                       convolution("conv", "concat", { "weights" }, { 2, 1 }),
@@ -410,7 +406,6 @@ TEST(concat_gpu, i8_optimization_with_pool_conv) {
                                     {"pool0", "pool1"},
                                     1,
                                     data_types::i8,
-                                    "",
                                     padding{{0, 0, 0, 0}, 0}),
                       data("weights", weights),
                       convolution("conv", "concat", {"weights"}, {1, 1}, {0, 1}),
@@ -952,7 +947,6 @@ TEST(concat_gpu_onednn, basic_input_types) {
                           { "input0", "input1", "input2", "input3", "input4" },
                           1,
                           data_types::f32,
-                          "",
                           padding{ { 0,0,0,0 }, 0 })
     );
 

--- a/src/plugins/intel_gpu/tests/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/convolution_gpu_test.cpp
@@ -1472,7 +1472,6 @@ TEST(convolution_f32_fw_gpu, basic_convolution_input_padding) {
             { 1, 1 },
             { 2, 1 },
             { 1, 1 },
-            "",
             padding{ { 0, 0, 0, 0 }, 0 })
     );
 
@@ -1575,7 +1574,6 @@ TEST(convolution_f32_fw_gpu, basic_convolution_sym_input_padding) {
             { 1, 1 },
             { 2, 1 },
             { 2, 1 },
-            "",
             padding{ { 0, 0, 0, 0 }, 0 })
     );
 
@@ -1673,7 +1671,6 @@ TEST(convolution_f32_fw_gpu, basic_convolution_asym_input_padding) {
             { 1, 1 },
             { 2, 1 },
             { 3, 2 },
-            "",
             padding{ { 0, 0, 0, 0 }, 0 }));
 
     network network(engine, topology);
@@ -1780,7 +1777,6 @@ TEST(convolution_f32_fw_gpu, basic_convolution_sym_input_padding_with_pad) {
             { 1, 1 },
             { 2, 1 },
             { 2, 1 },
-            "",
             padding{ { 0, 0, 0, 0 }, 0 })
     );
 
@@ -1891,7 +1887,6 @@ TEST(convolution_f32_fw_gpu, basic_convolution_asym_input_padding_with_pad) {
             { 1, 1 },
             { 2, 1 },
             { 3, 2 },
-            "",
             padding{ { 0, 0, 0, 0 }, 0 }));
 
     network network(engine, topology);
@@ -1989,7 +1984,6 @@ TEST(convolution_f32_fw_gpu, basic_convolution_input_and_output_padding) {
             { 1, 1 },
             { 2, 1 },
             { 1, 1 },
-            "",
             padding{ { 0,0,x_pad,y_pad }, 0 })
     );
 
@@ -2561,7 +2555,6 @@ TEST(convolution_f32_fw_gpu, offsets_wsiz3x3_wstr2x2_in2x2x1x1_zeropad) {
             { 2, 2 },
             { 1, 1 },
             { 1, 1 },
-            "",
             padding{ { 0, 0, 1, 1 }, 0 })
     );
 
@@ -5423,7 +5416,7 @@ TEST(convolution_f32_fw_gpu, convolution_int8_b_fs_yx_fsv4_to_bfyx) {
         reorder("to_int", "input", { data_types::i8, format::bfyx, { batch_num, input_f, input_size_x, input_size_y } }),
         data("weights", weights),
         data("biases", biases),
-        convolution("conv", "to_int", { "weights" }, { "biases" }, { 1, 1 }, { 2, 2 }, { 1, 1 }, "",
+        convolution("conv", "to_int", { "weights" }, { "biases" }, { 1, 1 }, { 2, 2 }, { 1, 1 },
                     padding{ { 0, 0, output_padding, output_padding }, 0 }),
         reorder("output", "conv", { data_types::f32, format::bfyx, { batch_num, input_f, input_size_x, input_size_y } }));
 
@@ -5445,7 +5438,7 @@ TEST(convolution_f32_fw_gpu, convolution_int8_b_fs_yx_fsv4_to_bfyx) {
         reorder("to_int", "input", { data_types::i8,format::b_fs_yx_fsv4, { batch_num, input_f, input_size_x, input_size_y } }),
         data("weights", weights),
         data("biases", biases),
-        convolution("conv", "to_int", { "weights" }, { "biases" }, { 1, 1 }, { 2, 2 }, { 1, 1 }, "",
+        convolution("conv", "to_int", { "weights" }, { "biases" }, { 1, 1 }, { 2, 2 }, { 1, 1 },
             padding{ { 0, 0, output_padding, output_padding }, 0 }),
         reorder("output", "conv", { data_types::f32,format::bfyx, { batch_num, input_f, input_size_x, input_size_y } }));
 
@@ -8549,12 +8542,12 @@ public:
         all_layer_params.emplace_back(new convolution("convolution_no_relu", "reorder0", weights, bias, stride_sizes[3], pad_sizes[3], dilation_sizes[3]));
 
         // Output padding
-        all_layer_params.emplace_back(new convolution("convolution_no_relu", "input0", weights, bias, stride_sizes[1], pad_sizes[1], dilation_sizes[1], "", { { 0, 0, 2, 4 }, { 0, 0, 0, 19 } }));
-        all_layer_params.emplace_back(new convolution("convolution_no_relu", "input0", weights, bias, stride_sizes[2], pad_sizes[2], dilation_sizes[2], "", { { 0, 0, 1, 0 }, { 0, 0, 13, 9 } }));
+        all_layer_params.emplace_back(new convolution("convolution_no_relu", "input0", weights, bias, stride_sizes[1], pad_sizes[1], dilation_sizes[1], { { 0, 0, 2, 4 }, { 0, 0, 0, 19 } }));
+        all_layer_params.emplace_back(new convolution("convolution_no_relu", "input0", weights, bias, stride_sizes[2], pad_sizes[2], dilation_sizes[2], { { 0, 0, 1, 0 }, { 0, 0, 13, 9 } }));
 
         // Input + Output padding
-        all_layer_params.emplace_back(new convolution("convolution_no_relu", "reorder0", weights, bias, stride_sizes[0], pad_sizes[0], dilation_sizes[0], "", { { 0, 0, 1, 5 }, { 0, 0, 19, 4 } }));
-        all_layer_params.emplace_back(new convolution("convolution_no_relu", "reorder0", weights, bias, stride_sizes[3], pad_sizes[3], dilation_sizes[3], "", { { 0, 0, 1, 2 }, { 0, 0, 3, 4 } }));
+        all_layer_params.emplace_back(new convolution("convolution_no_relu", "reorder0", weights, bias, stride_sizes[0], pad_sizes[0], dilation_sizes[0], { { 0, 0, 1, 5 }, { 0, 0, 19, 4 } }));
+        all_layer_params.emplace_back(new convolution("convolution_no_relu", "reorder0", weights, bias, stride_sizes[3], pad_sizes[3], dilation_sizes[3], { { 0, 0, 1, 2 }, { 0, 0, 3, 4 } }));
 
         return all_layer_params;
     }

--- a/src/plugins/intel_gpu/tests/test_cases/eltwise_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/eltwise_gpu_test.cpp
@@ -91,7 +91,7 @@ void generic_eltwise_test(cldnn::format test_input_fmt, int input_b, int input_f
     topology.add(input_layout("input1", input1->get_layout()));
     topology.add(input_layout("input2", input2->get_layout()));
     topology.add(reorder("reorder1", "input1", input1->get_layout().with_padding(padding{{ 0, 0, input_padding_x, input_padding_y }, 0 })));
-    topology.add(eltwise("eltwise", {"reorder1", "input2"}, mode, "", padding{ { 0, 0, output_padding_x, output_padding_y }, 0 }));
+    topology.add(eltwise("eltwise", {"reorder1", "input2"}, mode, padding{ { 0, 0, output_padding_x, output_padding_y }, 0 }));
     primitive_id out_id = "eltwise";
     if (relu)
     {
@@ -2795,7 +2795,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_output_padding) {
     topology golden_topology;
     golden_topology.add(input_layout("input1", input1->get_layout()));
     golden_topology.add(input_layout("input2", input2->get_layout()));
-    golden_topology.add(eltwise("eltwise", "input1", "input2", eltwise_mode::sum, "", padding{ {0,0,5,10} , 0 }));
+    golden_topology.add(eltwise("eltwise", "input1", "input2", eltwise_mode::sum, padding{ {0,0,5,10} , 0 }));
 
     network golden_network(engine, golden_topology);
     golden_network.set_input_data("input1", input1);
@@ -2811,7 +2811,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_output_padding) {
     FS_B_YX_FSV32_OUTPUT_topology.add(input_layout("input2", input2->get_layout()));
     FS_B_YX_FSV32_OUTPUT_topology.add(reorder("reorder1", "input1", layout(data_types::f16, format::fs_b_yx_fsv32, input_tensor)));
     FS_B_YX_FSV32_OUTPUT_topology.add(reorder("reorder2", "input2", layout(data_types::f16, format::byxf, input_tensor)));
-    FS_B_YX_FSV32_OUTPUT_topology.add(eltwise("eltwise", "reorder1", "reorder2", eltwise_mode::sum, "", padding{ {0,0,5,10} , 0 }));
+    FS_B_YX_FSV32_OUTPUT_topology.add(eltwise("eltwise", "reorder1", "reorder2", eltwise_mode::sum, padding{ {0,0,5,10} , 0 }));
     FS_B_YX_FSV32_OUTPUT_topology.add(reorder("reorderOutput", "eltwise", layout(data_types::f16, format::bfyx, input_tensor,
                                               padding{ {0,0,5,10} , 0 })));
 
@@ -2829,7 +2829,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_output_padding) {
     BYXF_OUTPUT_topology.add(input_layout("input2", input2->get_layout()));
     BYXF_OUTPUT_topology.add(reorder("reorder1", "input1", layout(data_types::f16, format::byxf, input_tensor)));
     BYXF_OUTPUT_topology.add(reorder("reorder2", "input2", layout(data_types::f16, format::fs_b_yx_fsv32, input_tensor)));
-    BYXF_OUTPUT_topology.add(eltwise("eltwise", "reorder1", "reorder2", eltwise_mode::sum, "", padding{ {0,0,5,10} , 0 }));
+    BYXF_OUTPUT_topology.add(eltwise("eltwise", "reorder1", "reorder2", eltwise_mode::sum, padding{ {0,0,5,10} , 0 }));
     BYXF_OUTPUT_topology.add(reorder("reorderOutput", "eltwise", layout(data_types::f16, format::bfyx, input_tensor,
                                      padding{ {0,0,5,10} , 0 })));
 
@@ -3011,7 +3011,7 @@ void generic_eltwise_bool_test(cldnn::format test_input_fmt, int input_b, int in
     topology.add(input_layout("input1", input1->get_layout()));
     topology.add(input_layout("input2", input2->get_layout()));
     topology.add(reorder("reorder1", "input1", input1->get_layout().with_padding(padding{{ 0, 0, input_padding_x, input_padding_y }, 0 })));
-    topology.add(eltwise("eltwise", {"reorder1", "input2"}, mode, "", padding{ { 0, 0, output_padding_x, output_padding_y }, 0 }));
+    topology.add(eltwise("eltwise", {"reorder1", "input2"}, mode, padding{ { 0, 0, output_padding_x, output_padding_y }, 0 }));
 
     network network(engine, topology);
     network.set_input_data("input1", input1);

--- a/src/plugins/intel_gpu/tests/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/fully_connected_gpu_test.cpp
@@ -1738,7 +1738,7 @@ TEST(fully_connected_3d_onednn_gpu, no_biases_int8) {
     auto input = input_layout("input", input_prim->get_layout());
     auto w_data = data("weights", weights_prim);
     auto ri = reorder("reorder_to_int", "input", { data_types::i8, format::bfyx, { input_b, input_f, 1, input_y } });
-    auto fc = fully_connected("fc_prim", "reorder_to_int", "weights", "", "", padding(), 3);
+    auto fc = fully_connected("fc_prim", "reorder_to_int", "weights", "", padding(), 3);
     auto rf = reorder("reorder_to_float", "fc_prim", { data_types::f32, format::bfyx, { output_b, output_f, 1, 1 } });
     topology topology;
     topology.add(input);

--- a/src/plugins/intel_gpu/tests/test_cases/max_unpooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/max_unpooling_gpu_test.cpp
@@ -63,7 +63,7 @@ TEST(max_unpooling_gpu, basic_in2x3x2x2) {
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
     topology.add(data("arg_max", arg_max));
-    topology.add(max_unpooling("max_unpooling", "input", "arg_max", { 1, 1, 2, 2 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, ""));
+    topology.add(max_unpooling("max_unpooling", "input", "arg_max", { 1, 1, 2, 2 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }));
 
     network network(engine, topology);
 
@@ -145,7 +145,7 @@ TEST(max_unpooling_gpu, basic_in2x3x2x2_output_padding) {
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
     topology.add(data("arg_max", arg_max));
-    topology.add(max_unpooling("max_unpooling", "input", "arg_max", { 1, 1, 2, 2 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, "", padding({ 0, 0, 1, 1 }, 0)));
+    topology.add(max_unpooling("max_unpooling", "input", "arg_max", { 1, 1, 2, 2 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, padding({ 0, 0, 1, 1 }, 0)));
 
     network network(engine, topology);
 
@@ -317,7 +317,7 @@ TEST(max_unpooling_gpu, basic_in2x3x2x2_fp16) {
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
     topology.add(data("arg_max", arg_max));
-    topology.add(max_unpooling("max_unpooling", "input", "arg_max", { 1, 1, 2, 2 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, ""));
+    topology.add(max_unpooling("max_unpooling", "input", "arg_max", { 1, 1, 2, 2 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }));
 
     network network(engine, topology);
 
@@ -395,7 +395,7 @@ TEST(max_unpooling_gpu, basic_in2x2x3x2_max_with_argmax_pooling_unpooling) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mutable_data("arg_max", arg_max));
     topology.add(pooling("pooling_max_with_argmax", "input", "arg_max", pooling_mode::max_with_argmax, { 2, 2 }, { 1, 1 }));
-    topology.add(max_unpooling("max_unpooling", "pooling_max_with_argmax", "arg_max", { 1, 1, 2, 2 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }, ""));
+    topology.add(max_unpooling("max_unpooling", "pooling_max_with_argmax", "arg_max", { 1, 1, 2, 2 }, { 1, 1, 1, 1 }, { 0, 0, 0, 0 }));
 
     network network(engine, topology);
 

--- a/src/plugins/intel_gpu/tests/test_cases/pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/pooling_gpu_test.cpp
@@ -966,7 +966,7 @@ TEST(pooling_forward_gpu, offsets_avg_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i2x2x1x1_out
 
         topology topology;
         topology.add(input_layout("input_prim", input_prim->get_layout()));
-        topology.add(pooling("pool_prim", "input_prim", pooling_mode::average, {2, 2}, {2, 2}, {1, 1}, "", padding{{0, 0, 2, 2}, 0}));
+        topology.add(pooling("pool_prim", "input_prim", pooling_mode::average, {2, 2}, {2, 2}, {1, 1}, padding{{0, 0, 2, 2}, 0}));
 
         network network(engine, topology);
         set_values(input_prim, { 1.5f, -0.5f, -1.0f, 0.5f });
@@ -1027,7 +1027,7 @@ TEST(pooling_forward_gpu, offsets_max_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i3x3x1x1_out
 
         topology topology;
         topology.add(input_layout("input_prim", input_prim->get_layout()));
-        topology.add(pooling("pool_prim", "input_prim", pooling_mode::max, {2, 2}, {2, 2}, {1, 1}, "", padding{{0, 0, 1, 1}, 0}));
+        topology.add(pooling("pool_prim", "input_prim", pooling_mode::max, {2, 2}, {2, 2}, {1, 1}, padding{{0, 0, 1, 1}, 0}));
 
         network network(engine, topology);
 
@@ -1098,7 +1098,7 @@ TEST(pooling_forward_gpu, offsets_avg_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i2x2x1x1_inp
         topology topology;
         topology.add(input_layout("input_prim", input_prim->get_layout()));
         topology.add(reorder("reorder", "input_prim", input_prim->get_layout().with_padding(padding{ {0,0,1,2}, 0 })));
-        topology.add(pooling("pool_prim", "reorder", pooling_mode::average, {2, 2}, {2, 2}, {1, 1}, "", padding{{0, 0, 2, 2}, 0}));
+        topology.add(pooling("pool_prim", "reorder", pooling_mode::average, {2, 2}, {2, 2}, {1, 1}, padding{{0, 0, 2, 2}, 0}));
 
         network network(engine, topology);
         set_values(input_prim, { 1.5f, -0.5f, -1.0f, 0.5f });
@@ -1161,7 +1161,7 @@ TEST(pooling_forward_gpu, offsets_max_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i3x3x1x1_inp
         topology topology;
         topology.add(input_layout("input_prim", input_prim->get_layout()));
         topology.add(reorder("reorder", "input_prim", input_prim->get_layout().with_padding(padding{ { 0, 0, 1, 2 }, 0 })));
-        topology.add(pooling("pool_prim", "reorder", pooling_mode::max, {2, 2}, {2, 2}, {1, 1}, "", padding{{0, 0, 1, 1}, 0}));
+        topology.add(pooling("pool_prim", "reorder", pooling_mode::max, {2, 2}, {2, 2}, {1, 1}, padding{{0, 0, 1, 1}, 0}));
 
         network network(engine, topology);
 
@@ -1232,7 +1232,7 @@ TEST(pooling_forward_gpu, avg_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i2x2x1x1_inpad2x1_ou
         topology topology;
         topology.add(input_layout("input_prim", input_prim->get_layout()));
         topology.add(reorder("reorder", "input_prim", input_prim->get_layout().with_padding(padding{ { 0, 0, 2, 1 }, 0 })));
-        topology.add(pooling("pool_prim", "reorder", pooling_mode::average, { 2, 2 }, { 2, 2 }, { 0, 0 }, "", padding{ { 0, 0, 2, 2 }, 0 }));
+        topology.add(pooling("pool_prim", "reorder", pooling_mode::average, { 2, 2 }, { 2, 2 }, { 0, 0 }, padding{ { 0, 0, 2, 2 }, 0 }));
 
         network network(engine, topology);
         set_values(input_prim, {
@@ -1300,7 +1300,7 @@ TEST(pooling_forward_gpu, max_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i3x3x1x1_inpad2x1_ou
         topology topology;
         topology.add(input_layout("input_prim", input_prim->get_layout()));
         topology.add(reorder("reorder", "input_prim", input_prim->get_layout().with_padding(padding{ { 0, 0, 2, 1 }, 0 })));
-        topology.add(pooling("pool_prim", "reorder", pooling_mode::max, { 2, 2}, { 2, 2}, {1, 1}, "", padding{{0, 0, 1, 1}, 0}));
+        topology.add(pooling("pool_prim", "reorder", pooling_mode::max, { 2, 2}, { 2, 2}, {1, 1}, padding{{0, 0, 1, 1}, 0}));
 
         network network(engine, topology);
 
@@ -1611,7 +1611,7 @@ TEST(pooling_forward_gpu, basic_in2x2x3x2_max_with_argmax_output_padding) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reorder("reorder", "input", input->get_layout().with_padding(padding{ { 0, 0, 2, 2 }, 0 })));
     topology.add(mutable_data("arg_max", arg_max));
-    topology.add(pooling("pooling", "reorder", "arg_max", pooling_mode::max_with_argmax, { 2, 2 }, { 1, 1 }, { 0, 0 }, "", padding({ 0, 0, 1, 1 }, 0)));
+    topology.add(pooling("pooling", "reorder", "arg_max", pooling_mode::max_with_argmax, { 2, 2 }, { 1, 1 }, { 0, 0 }, padding({ 0, 0, 1, 1 }, 0)));
 
     network network(engine, topology);
 
@@ -1699,7 +1699,7 @@ TEST(pooling_forward_gpu, basic_in2x2x3x2_max_with_argmax_with_output_size) {
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mutable_data("arg_max", arg_max));
-    topology.add(pooling("pooling", "input", "arg_max", pooling_mode::max_with_argmax, { 2, 2 }, { 1, 1 }, { 0, 0 }, { 2, 2, 2, 1 }, ""));
+    topology.add(pooling("pooling", "input", "arg_max", pooling_mode::max_with_argmax, { 2, 2 }, { 1, 1 }, { 0, 0 }, { 2, 2, 2, 1 }));
 
     network network(engine, topology);
 
@@ -2259,7 +2259,7 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_max_1x1x3x3_input_2x2_pool_2x2_stride_2x
         topology topology;
         topology.add(input_layout("input_prim", input_prim->get_layout()));
         topology.add(reorder("reorder_input", "input_prim", layout(data_types::f16, format::fs_b_yx_fsv32, input_tensor)));
-        topology.add(pooling("pool_prim", "reorder_input", pooling_mode::max, {2, 2}, {2, 2}, {1, 1}, "", padding{{0, 0, 1, 1}, 0}));
+        topology.add(pooling("pool_prim", "reorder_input", pooling_mode::max, {2, 2}, {2, 2}, {1, 1}, padding{{0, 0, 1, 1}, 0}));
         topology.add(reorder("reorder_pooling", "pool_prim", layout(data_types::f16, format::bfyx, { 1,1,4,4 }, padding{ { 0, 0, 1, 1 }, 0 })));
 
         network network(engine, topology);
@@ -2332,7 +2332,7 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_max_1x1x5x5_input_2x2_pool_2x2_stride_2x
     topology topology;
     topology.add(input_layout("input_prim", input_prim->get_layout()));
     topology.add(reorder("reorder_input", "input_prim", layout(data_types::f16, format::fs_b_yx_fsv32, input_tensor, padding{ { 0, 0, 2, 1 } , 0 })));
-    topology.add(pooling("pool_prim", "reorder_input", pooling_mode::max, {2, 2}, {2, 2}, {1, 1}, "", padding{{0, 0, 1, 1}, 0}));
+    topology.add(pooling("pool_prim", "reorder_input", pooling_mode::max, {2, 2}, {2, 2}, {1, 1}, padding{{0, 0, 1, 1}, 0}));
     topology.add(reorder("reorder_pooling", "pool_prim", layout(data_types::f16, format::bfyx, input_tensor, padding{ { 0, 0, 1, 1 }, 0 })));
 
     network network(engine, topology);
@@ -2409,7 +2409,7 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_avg_65x5x6x7_input_3x3_pool_4x4_stride_3
         topology golden_topology;
         golden_topology.add(input_layout("input", input_prim->get_layout()));
         golden_topology.add(reorder("reorder_input", "input", input_prim->get_layout().with_padding(padding{ {0,0,x_in_pad,y_in_pad},0 })));
-        golden_topology.add(pooling("golden_pooling", "reorder_input", pooling_mode::average, { pool_size, pool_size }, { stride_size, stride_size }, { 0, 0 }, "", padding{ { 0, 0, x_out_pad, y_out_pad }, 0 }));
+        golden_topology.add(pooling("golden_pooling", "reorder_input", pooling_mode::average, { pool_size, pool_size }, { stride_size, stride_size }, { 0, 0 }, padding{ { 0, 0, x_out_pad, y_out_pad }, 0 }));
 
         network golden_network(engine, golden_topology);
         golden_network.set_input_data("input", input_prim);
@@ -2426,7 +2426,7 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_avg_65x5x6x7_input_3x3_pool_4x4_stride_3
         topology golden_topology;
         golden_topology.add(input_layout("input", input_prim->get_layout()));
         golden_topology.add(reorder("reorder_input", "input", layout(data_types::f16, format::fs_b_yx_fsv32, input_tensor, padding{ {0, 0, x_in_pad, y_in_pad}, 0 })));
-        golden_topology.add(pooling("fsv32_pooling", "reorder_input", pooling_mode::average, { pool_size, pool_size }, { stride_size, stride_size }, { 0, 0 }, "", padding{ { 0, 0, x_out_pad, y_out_pad }, 0 }));
+        golden_topology.add(pooling("fsv32_pooling", "reorder_input", pooling_mode::average, { pool_size, pool_size }, { stride_size, stride_size }, { 0, 0 }, padding{ { 0, 0, x_out_pad, y_out_pad }, 0 }));
         golden_topology.add(reorder("reorder_pooling", "fsv32_pooling", layout(data_types::f16, format::bfyx, input_tensor, padding{ { 0,0,x_out_pad,y_out_pad },0 })));
 
         network fsv32_network(engine, golden_topology);
@@ -3485,10 +3485,10 @@ public:
                     all_layer_params.emplace_back(new pooling("pooling", "reorder0", pooling_mode, size, stride));
 
                     // Output padding
-                    all_layer_params.emplace_back(new pooling("pooling", "input0", pooling_mode, size, stride, generate_pad(2, 3, size), "", { { 0, 0, 1, 5 }, { 0, 0, 19, 4 } }));
+                    all_layer_params.emplace_back(new pooling("pooling", "input0", pooling_mode, size, stride, generate_pad(2, 3, size), { { 0, 0, 1, 5 }, { 0, 0, 19, 4 } }));
 
                     // Input + output padding
-                    all_layer_params.emplace_back(new pooling("pooling", "reorder0", pooling_mode, size, stride, generate_pad(2, 3, size), "", { { 0, 0, 2, 1 }, { 0, 0, 3, 4 } }));
+                    all_layer_params.emplace_back(new pooling("pooling", "reorder0", pooling_mode, size, stride, generate_pad(2, 3, size), { { 0, 0, 2, 1 }, { 0, 0, 3, 4 } }));
                 }
             }
         }

--- a/src/plugins/intel_gpu/tests/test_cases/proposal_cpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/proposal_cpu_test.cpp
@@ -83,7 +83,6 @@ TestRunnerProposal<Dtype, ImInfoType>::TestRunnerProposal(cldnn::tensor image_in
                                         post_nms_topn,
                                         ratios,
                                         scales,
-                                        "",
                                         padding())
 {
     _topology.add(input_layout(cls_scores_name, _cls_scores_layout));

--- a/src/plugins/intel_gpu/tests/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reorder_gpu_test.cpp
@@ -935,7 +935,6 @@ TEST(reorder_gpu, basic_convert_uint8rgbabyxf_to_fp32_bfyx) {
              "reorder_input",               // primitive id of the cropping input
              crop_reference_input_tensor,   // input tensor
              crop_offset_tensor,            // bias primitive id
-             "",
              output_padding
             )
     );
@@ -1040,7 +1039,7 @@ TEST(reorder_gpu_f32, basic_yxfb_to_bfyx_input_padding)
 
     topology topology(
         input_layout("input", input->get_layout()),
-        reorder("reorder", "input", input->get_layout().format, input->get_layout().data_type, "", reorder_mean_mode::subtract, "", padding{ { 0, 0, 1, 2 }, 0 }),
+        reorder("reorder", "input", input->get_layout().format, input->get_layout().data_type, "", reorder_mean_mode::subtract, padding{ { 0, 0, 1, 2 }, 0 }),
         reorder("reorder2", "reorder", output_layout));
 
     network network(engine, topology);
@@ -1119,7 +1118,7 @@ TEST(reorder_gpu_f32, basic_bfyx_to_yxfb_input_padding)
 
     topology topology(
         input_layout("input", input->get_layout()),
-        reorder("reorder", "input", input->get_layout().format, input->get_layout().data_type, "", reorder_mean_mode::subtract, "", padding{ { 0, 0, 2, 1 }, 0 }),
+        reorder("reorder", "input", input->get_layout().format, input->get_layout().data_type, "", reorder_mean_mode::subtract, padding{ { 0, 0, 2, 1 }, 0 }),
         reorder("reorder2", "reorder", output_layout));
 
     network network(engine, topology);

--- a/src/plugins/intel_gpu/tests/test_cases/reshape_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reshape_gpu_test.cpp
@@ -62,7 +62,7 @@ void generic_reshape_test(format fmt, tensor const& input_size, tensor const& re
         tpl.add(reorder("reorder", "input", padded_input_layout));
         reshape_input = "reorder";
     }
-    tpl.add(reshape("reshape", reshape_input, reshape_size, "", output_padd));
+    tpl.add(reshape("reshape", reshape_input, reshape_size, output_padd));
 
     build_options bo;
     bo.set_option(build_option::outputs({reshape_input, "reshape"}));
@@ -525,7 +525,7 @@ TEST(reshape_gpu_f32, basic_bfwzyx) {
 
     topology topology;
     topology.add(input_layout("input", input->get_layout()));
-    topology.add(reshape("reshape", "input", tensor(batch(1), feature(1), spatial(2, 2, 3, 3)), "", padding({0, 0, 0, 0, 0, 1}, 0.f)));
+    topology.add(reshape("reshape", "input", tensor(batch(1), feature(1), spatial(2, 2, 3, 3)), padding({0, 0, 0, 0, 0, 1}, 0.f)));
 
     // clang-format off
     std::vector<float> input_data = {

--- a/src/plugins/intel_gpu/tests/test_cases/spatial_concatenate_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/spatial_concatenate_gpu_test.cpp
@@ -148,7 +148,7 @@ TEST(spatial_concatenate_f32_gpu, test03) {
     topology tpl;
     tpl.add(input_layout("in1", input1->get_layout()));
     tpl.add(input_layout("in2", input2->get_layout()));
-    tpl.add(concatenation("conc", { "in1", "in2" }, 2, "", padding({ 0, 0, 1, 1 }, 0.0f)));
+    tpl.add(concatenation("conc", { "in1", "in2" }, 2, padding({ 0, 0, 1, 1 }, 0.0f)));
 
     network net(engine, tpl);
     net.set_input_data("in1", input1);
@@ -203,7 +203,7 @@ TEST(spatial_concatenate_f32_gpu, test04) {
     topology tpl;
     tpl.add(input_layout("in1", input1->get_layout()));
     tpl.add(input_layout("in2", input2->get_layout()));
-    tpl.add(concatenation("conc", { "in1", "in2" }, 3, "", padding({ 0, 0, 2, 0 }, { 0, 0, 0, 0 })));
+    tpl.add(concatenation("conc", { "in1", "in2" }, 3, padding({ 0, 0, 2, 0 }, { 0, 0, 0, 0 })));
 
     network net(engine, tpl);
     net.set_input_data("in1", input1);

--- a/src/plugins/intel_gpu/tests/test_cases/streams_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/streams_test.cpp
@@ -28,7 +28,7 @@ TEST(gpu_streams, can_create_networks_for_stream) {
 
     topology topology(
             input_layout("input", input->get_layout()),
-            activation("relu", "input", activation_func::relu_negative_slope, activation_additional_params{ 0.5f, 0.f }, "", padding{ { 0, 0, 0, 0 }, 0 }));
+            activation("relu", "input", activation_func::relu_negative_slope, activation_additional_params{ 0.5f, 0.f }, padding{ { 0, 0, 0, 0 }, 0 }));
     network network(engine, topology, build_options());
 
     network.set_input_data("input", input);

--- a/src/plugins/intel_gpu/tests/test_utils/network_test.h
+++ b/src/plugins/intel_gpu/tests/test_utils/network_test.h
@@ -329,7 +329,7 @@ public:
                                                            std::shared_ptr<reference_node<BiasT, 2>> bias,
                                                            cldnn::implementation_desc force = cldnn::implementation_desc{cldnn::format::any, ""},
                                                            size_t input_dim_size = 3) {
-        topo.add(cldnn::fully_connected(id, input->id, weights->id, bias->id, cldnn::type_to_data_type<T>::value, "", cldnn::padding(), input_dim_size));
+        topo.add(cldnn::fully_connected(id, input->id, weights->id, bias->id, cldnn::type_to_data_type<T>::value, cldnn::padding(), input_dim_size));
         if (force.output_format != cldnn::format::any || force.kernel_name != "")
             forced_impls[id] = force;
         VVVVF<T> output_data = fully_connected_reference_typed_3d<T>(input->reference.reference,

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/behavior/ov_infer_request/perf_counters.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/behavior/ov_infer_request/perf_counters.cpp
@@ -15,6 +15,8 @@ TEST_P(OVInferRequestPerfCountersTest, CheckOperationInProfilingInfo) {
     ASSERT_NO_THROW(profiling_info = req.get_profiling_info());
 
     for (const auto& op : function->get_ops()) {
+        if (!strcmp(op->get_type_info().name, "Constant"))
+            continue;
         auto op_is_in_profiling_info = std::any_of(std::begin(profiling_info), std::end(profiling_info),
             [&] (const ov::ProfilingInfo& info) {
             if (info.node_name.find(op->get_friendly_name() + "_") != std::string::npos || info.node_name == op->get_friendly_name()) {


### PR DESCRIPTION
### Details:
 - fill primitive_ids map and profiling_ids within add_primitive implementation automatically (except several cases where primitives are reused)
 - friendly name and type name of original ov operation is saved now in each primitive. It will be used later for better aggregation and formatting of profiling info
 - minor code style refactoring (AddPrimitive -> add_primitive; ValidateInputs -> validate_inputs_count)
 - Small update to perf counters & profiling logic. Removed Constant layers from the report. 

```
// new
512.out0                      EXECUTED       layerType: VariadicSplit      realTime: 3         cpu: 1               execType: eltwise_b_fs_yx_fsv16__i8
512.out1                      EXECUTED       layerType: Crop               realTime: 3         cpu: 1               execType: eltwise_b_fs_yx_fsv16__i8
512.out2                      EXECUTED       layerType: Crop               realTime: 3         cpu: 1               execType: eltwise_b_fs_yx_fsv16__i8

6739.out0                     EXECUTED       layerType: NonMaxSuppressionIEInternal realTime: 312       cpu: 0               execType: non_max_suppression_impl__f16

1701_interp                   EXECUTED       layerType: DeformableInterp   realTime: 9882      cpu: 0               execType: deformable_convolution_gpu_bfyx_interp__f16
1701                          EXECUTED       layerType: DeformableConvolution realTime: 41807     cpu: 1               execType: deformable_convolution_gpu_bfyx_conv__f16

TopK_174007.out0              EXECUTED       layerType: TopK               realTime: 3448      cpu: 0               execType: arg_max_min_axis__f16




// old 
variadicsplit:512.0           NOT_RUN        layerType:                    realTime: 3         cpu: 1               execType: eltwise_b_fs_yx_fsv16__i8
variadicsplit:512.1           NOT_RUN        layerType:                    realTime: 3         cpu: 1               execType: eltwise_b_fs_yx_fsv16__i8
variadicsplit:512.2           NOT_RUN        layerType:                    realTime: 3         cpu: 1               execType: eltwise_b_fs_yx_fsv16__i8

nonmaxsuppressionieinterna... NOT_RUN        layerType:                    realTime: 368       cpu: 0               execType: non_max_suppression_impl__f16

1701_interp                   EXECUTED       layerType: Deformableconvolution realTime: 11071     cpu: 1               execType: deformable_convolution_gpu_bfyx_interp__f16
1701                          EXECUTED       layerType: DeformableConvolution realTime: 56880     cpu: 1               execType: deformable_convolution_gpu_bfyx_conv__f16

TopK_174007.0                 EXECUTED       layerType: Topk               realTime: 3453      cpu: 1               execType: arg_max_min_axis__f16
```
