### PR TITLE
[POT][OV 2022.2] fix: incorrect fq type (cherry-pick from #12234)

### DIFF
--- a/tools/pot/openvino/tools/pot/graph/passes.py
+++ b/tools/pot/openvino/tools/pot/graph/passes.py
@@ -148,8 +148,7 @@ class InsertFakeQuantize(BackReplacementPattern):
             return
 
         if m_op.type in ['Convolution', 'ConvolutionBackpropData', 'MatMul']:
-            insert_fake_quantize(graph, m_op, [0, 1], ['fq_input', 'fq_weights'], ['activations', 'weights'],
-                                 hw_config=self.hardware_config)
+            insert_fake_quantize(graph, m_op, [0, 1], hw_config=self.hardware_config)
         elif m_op.type == 'LSTMCell':
             insert_fake_quantize(graph, m_op, [0, 1, 2, 3, 4], hw_config=self.hardware_config)
         elif self.quantize_only_input(m_op):


### PR DESCRIPTION
(cherry picked from commit 0592ba3e8c143f9c016dbe2c4a8ad8b2b247e2fe)

### Details:
 - *Cherry-picked fix from the master for the POT. This fix is applicable for the transformer-like architecture models that contain MatMuls without weights*
 - *For the details see original PR: [!12234](https://github.com/openvinotoolkit/openvino/pull/12234)*

### Tickets:
 - *89866*
