### PR TITLE
adjustments for 2022.2 release on rh platform

### DIFF
--- a/scripts/install_dependencies/install_NEO_OCL_driver.sh
+++ b/scripts/install_dependencies/install_NEO_OCL_driver.sh
@@ -374,10 +374,10 @@ add_user_to_video_group()
 _check_distro_version()
 {
     if [[ $DISTRO == redhat ]]; then
-        RHEL_MINOR_VERSION_SUPPORTED="[3-5]"
+        RHEL_MINOR_VERSION_SUPPORTED="[3-6]"
         RHEL_VERSION=$(grep -m1 'VERSION_ID' /etc/os-release | grep -Eo "8.${RHEL_MINOR_VERSION_SUPPORTED}")
         if [[ $? -ne 0 ]]; then
-            echo "Warning: This runtime can be installed only on RHEL 8.3, RHEL8.4 or RHEL 8.5"
+            echo "Warning: This runtime can be installed only on RHEL 8.3 up to RHEL 8.6"
             echo "More info https://dgpu-docs.intel.com/releases/releases-20211130.html" >&2
             echo "Installation of Intel® Graphics Compute Runtime for oneAPI Level Zero and OpenCL™ Driver interrupted"
             exit $EXIT_FAILURE

--- a/scripts/install_dependencies/install_openvino_dependencies.sh
+++ b/scripts/install_dependencies/install_openvino_dependencies.sh
@@ -142,7 +142,7 @@ elif [ "$os" == "ubuntu20.04" ] ; then
 elif [ "$os" == "rhel8" ] ; then
 
     pkgs_opencv_req=(gtk3)
-    pkgs_python=(python38 python38-devel python38-setuptools python38-pip)
+    pkgs_python=(python38 python38-setuptools python38-pip)
     pkgs_dev=(gcc gcc-c++ make glibc libstdc++ libgcc cmake pkg-config zlib-devel.i686 curl sudo)
     pkgs_myriad=()
     pkgs_opencv_opt=(


### PR DESCRIPTION
### Details:
dropped python-dev as a redundant component
added option to install NEO drivers on UBI8.6 
