### PR TITLE
Use TBB as default threading

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -145,6 +145,7 @@ function(ov_download_tbb)
                 SHA256 "ad9cf52e657660058aa6c6844914bc0fc66241fec89a392d8b79a7ff69c3c7f6")
     else()
         message(WARNING "TBB is not available on current platform")
+        return()
     endif()
 
     update_deps_cache(TBBROOT "${TBB}" "Path to TBB root folder")

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -144,7 +144,7 @@ function(ov_download_tbb)
                 ENVIRONMENT "TBBROOT"
                 SHA256 "ad9cf52e657660058aa6c6844914bc0fc66241fec89a392d8b79a7ff69c3c7f6")
     else()
-        message(FATAL_ERROR "TBB is not available on current platform")
+        message(WARNING "TBB is not available on current platform")
     endif()
 
     update_deps_cache(TBBROOT "${TBB}" "Path to TBB root folder")

--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -50,19 +50,14 @@ ie_option (ENABLE_DOCS "Build docs using Doxygen" OFF)
 #
 
 # "OneDNN library based on OMP or TBB or Sequential implementation: TBB|OMP|SEQ"
-if(X86 OR ARM OR (MSVC AND (ARM OR AARCH64)) )
-    set(THREADING_DEFAULT "SEQ")
-else()
-    set(THREADING_DEFAULT "TBB")
-endif()
-set(THREADING "${THREADING_DEFAULT}" CACHE STRING "Threading")
+set(THREADING "TBB" CACHE STRING "Threading")
 set_property(CACHE THREADING PROPERTY STRINGS "TBB" "TBB_AUTO" "OMP" "SEQ")
 list (APPEND IE_OPTIONS THREADING)
 if (NOT THREADING STREQUAL "TBB" AND
     NOT THREADING STREQUAL "TBB_AUTO" AND
     NOT THREADING STREQUAL "OMP" AND
     NOT THREADING STREQUAL "SEQ")
-    message(FATAL_ERROR "THREADING should be set to TBB, TBB_AUTO, OMP or SEQ. Default option is ${THREADING_DEFAULT}")
+    message(FATAL_ERROR "THREADING should be set to TBB (default), TBB_AUTO, OMP or SEQ")
 endif()
 
 if((THREADING STREQUAL "TBB" OR THREADING STREQUAL "TBB_AUTO") AND

--- a/src/cmake/ie_parallel.cmake
+++ b/src/cmake/ie_parallel.cmake
@@ -25,12 +25,16 @@ macro(ov_find_package_tbb)
             # if TBBROOT env variable is not defined
             ov_download_tbb()
 
+            # fallback variant for TBB 2018 and older where TBB have not had cmake interface
+            if(DEFINED TBBROOT OR DEFINED ENV{TBBROOT})
+                set(_tbb_paths PATHS ${IEDevScripts_DIR})
+            endif()
+
             # try to find one more time
             find_package(TBB QUIET COMPONENTS tbb tbbmalloc
                          # can be provided by ov_download_tbb
                          HINTS ${TBB_DIR}
-                         # fallback variant for TBB 2018 and older
-                         PATHS ${IEDevScripts_DIR}
+                         ${_tbb_paths}
                          ${_find_package_no_args})
         endif()
 


### PR DESCRIPTION
### Details:
 - If TBB is not found, cmake scripts automatically fallback to SEQ with explicit warning message

### Tickets:
 - CVS-90218
