### PR TITLE
[Python API, Tools] Replace deprecated NumPy types

### DIFF
--- a/src/bindings/python/src/compatibility/ngraph/utils/types.py
+++ b/src/bindings/python/src/compatibility/ngraph/utils/types.py
@@ -22,7 +22,7 @@ ScalarData = Union[int, float]
 NodeInput = Union[Node, NumericData]
 
 ngraph_to_numpy_types_map = [
-    (NgraphType.boolean, np.bool),
+    (NgraphType.boolean, np.bool_),
     (NgraphType.f16, np.float16),
     (NgraphType.f32, np.float32),
     (NgraphType.f64, np.float64),
@@ -38,7 +38,7 @@ ngraph_to_numpy_types_map = [
 ]
 
 ngraph_to_numpy_types_str_map = [
-    ("boolean", np.bool),
+    ("boolean", np.bool_),
     ("f16", np.float16),
     ("f32", np.float32),
     ("f64", np.float64),

--- a/src/bindings/python/src/openvino/runtime/utils/types.py
+++ b/src/bindings/python/src/openvino/runtime/utils/types.py
@@ -22,7 +22,7 @@ ScalarData = Union[int, float]
 NodeInput = Union[Node, NumericData]
 
 openvino_to_numpy_types_map = [
-    (Type.boolean, np.bool),
+    (Type.boolean, np.bool_),
     (Type.f16, np.float16),
     (Type.f32, np.float32),
     (Type.f64, np.float64),
@@ -38,7 +38,7 @@ openvino_to_numpy_types_map = [
 ]
 
 openvino_to_numpy_types_str_map = [
-    ("boolean", np.bool),
+    ("boolean", np.bool_),
     ("f16", np.float16),
     ("f32", np.float32),
     ("f64", np.float64),

--- a/src/bindings/python/tests/test_frontend/test_frontend_onnx.py
+++ b/src/bindings/python/tests/test_frontend/test_frontend_onnx.py
@@ -75,15 +75,15 @@ def create_onnx_model_with_custom_attributes():
                                 attribute_i32=np.int32(10),
                                 attribute_i64=np.int64(10),
                                 attribute_str="string",
-                                attribute_f32=np.float(10),
+                                attribute_f32=np.float32(10),
                                 attribute_f64=np.float64(10),
-                                attribute_bool=np.bool(True),
+                                attribute_bool=np.bool_(True),
                                 attribute_type=onnx.TensorProto.INT32,
 
                                 attribute_list_i32=np.array([1, 2, 3], dtype=np.int32),
                                 attribute_list_i64=np.array([1, 2, 3], dtype=np.int64),
-                                attribute_list_str=np.array(["a", "b", "c"], dtype=np.str),
-                                attribute_list_f32=np.array([1, 2, 3], dtype=np.float),
+                                attribute_list_str=np.array(["a", "b", "c"], dtype=np.str_),
+                                attribute_list_f32=np.array([1, 2, 3], dtype=np.float32),
                                 attribute_list_f64=np.array([1, 2, 3], dtype=np.float64),
                                 attribute_list_bool=[True, False, True],
                                 attribute_list_type=np.array([onnx.TensorProto.INT32,
@@ -340,15 +340,15 @@ def test_onnx_conversion_extension_attribute_with_default_value():
         check_attribute(node, "attribute_str", "abc")
         check_attribute(node, "attribute_f32", np.float32(5))
         check_attribute(node, "attribute_f64", np.float64(5))
-        check_attribute(node, "attribute_bool", np.bool(False))
+        check_attribute(node, "attribute_bool", np.bool_(False))
         check_attribute(node, "attribute_type", onnx.TensorProto.FLOAT)
 
         check_attribute(node, "attribute_list_i32", np.array([4, 5, 6], dtype=np.int32))
         check_attribute(node, "attribute_list_i64", np.array([4, 5, 6], dtype=np.int64))
-        check_attribute(node, "attribute_list_str", np.array(["d", "e", "f"], dtype=np.str))
-        check_attribute(node, "attribute_list_f32", np.array([4, 5, 6], dtype=np.float))
+        check_attribute(node, "attribute_list_str", np.array(["d", "e", "f"], dtype=np.str_))
+        check_attribute(node, "attribute_list_f32", np.array([4, 5, 6], dtype=np.float32))
         check_attribute(node, "attribute_list_f64", np.array([4, 5, 6], dtype=np.float64))
-        check_attribute(node, "attribute_list_bool", np.array([True, False, True], dtype=np.bool))
+        check_attribute(node, "attribute_list_bool", np.array([True, False, True], dtype=np.bool_))
         check_attribute(node, "attribute_list_type", np.array([onnx.TensorProto.INT32,
                                                                onnx.TensorProto.FLOAT]))
 
@@ -395,7 +395,7 @@ def test_onnx_conversion_extension_cast_attributes():
 
         check_attribute(node, "attribute_i32", 10, float)
         check_attribute(node, "attribute_i64", 10, float)
-        check_attribute(node, "attribute_str", "string", np.str)
+        check_attribute(node, "attribute_str", "string", np.str_)
         check_attribute(node, "attribute_f32", 10, int)
         check_attribute(node, "attribute_f64", 10, int)
         check_attribute(node, "attribute_bool", True, bool)
@@ -403,7 +403,7 @@ def test_onnx_conversion_extension_cast_attributes():
 
         check_attribute(node, "attribute_list_i32", [1., 2., 3.], float)
         check_attribute(node, "attribute_list_i64", [1., 2., 3.], float)
-        check_attribute(node, "attribute_list_str", ["a", "b", "c"], np.str)
+        check_attribute(node, "attribute_list_str", ["a", "b", "c"], np.str_)
         check_attribute(node, "attribute_list_f32", [1, 2, 3], int)
         check_attribute(node, "attribute_list_f64", [1, 2, 3], int)
         check_attribute(node, "attribute_list_bool", [True, False, True], bool)

--- a/src/bindings/python/tests/test_inference_engine/test_infer_request.py
+++ b/src/bindings/python/tests/test_inference_engine/test_infer_request.py
@@ -380,7 +380,7 @@ def test_infer_mixed_keys(device):
     (Type.u16, np.uint16),
     (Type.i64, np.int64),
     (Type.u64, np.uint64),
-    (Type.boolean, np.bool),
+    (Type.boolean, np.bool_),
 ])
 def test_infer_mixed_values(device, ov_type, numpy_dtype):
     request, tensor1, array1 = concat_model_with_data(device, ov_type, numpy_dtype)
@@ -404,7 +404,7 @@ def test_infer_mixed_values(device, ov_type, numpy_dtype):
     (Type.u16, np.uint16),
     (Type.i64, np.int64),
     (Type.u64, np.uint64),
-    (Type.boolean, np.bool),
+    (Type.boolean, np.bool_),
 ])
 def test_async_mixed_values(device, ov_type, numpy_dtype):
     request, tensor1, array1 = concat_model_with_data(device, ov_type, numpy_dtype)

--- a/src/bindings/python/tests/test_inference_engine/test_tensor.py
+++ b/src/bindings/python/tests/test_inference_engine/test_tensor.py
@@ -30,7 +30,7 @@ from ..test_utils.test_utils import generate_image  # TODO: reformat into an abs
     (ov.Type.u16, np.uint16),
     (ov.Type.i64, np.int64),
     (ov.Type.u64, np.uint64),
-    (ov.Type.boolean, np.bool),
+    (ov.Type.boolean, np.bool_),
     (ov.Type.u1, np.uint8),
     (ov.Type.u4, np.uint8),
     (ov.Type.i4, np.int8),
@@ -64,7 +64,7 @@ def test_subprocess():
     (ov.Type.u16, np.uint16),
     (ov.Type.i64, np.int64),
     (ov.Type.u64, np.uint64),
-    (ov.Type.boolean, np.bool),
+    (ov.Type.boolean, np.bool_),
 ])
 def test_init_with_numpy_dtype(ov_type, numpy_dtype):
     shape = (1, 3, 127, 127)
@@ -94,7 +94,7 @@ def test_init_with_numpy_dtype(ov_type, numpy_dtype):
     (ov.Type.u16, np.uint16),
     (ov.Type.i64, np.int64),
     (ov.Type.u64, np.uint64),
-    (ov.Type.boolean, np.bool),
+    (ov.Type.boolean, np.bool_),
 ])
 def test_init_with_numpy_shared_memory(ov_type, numpy_dtype):
     arr = generate_image().astype(numpy_dtype)
@@ -131,7 +131,7 @@ def test_init_with_numpy_shared_memory(ov_type, numpy_dtype):
     (ov.Type.u16, np.uint16),
     (ov.Type.i64, np.int64),
     (ov.Type.u64, np.uint64),
-    (ov.Type.boolean, np.bool),
+    (ov.Type.boolean, np.bool_),
 ])
 def test_init_with_numpy_copy_memory(ov_type, numpy_dtype):
     arr = generate_image().astype(numpy_dtype)
@@ -178,7 +178,7 @@ def test_init_with_roi_tensor():
     (ov.Type.u16, np.uint16),
     (ov.Type.i64, np.int64),
     (ov.Type.u64, np.uint64),
-    (ov.Type.boolean, np.bool),
+    (ov.Type.boolean, np.bool_),
 ])
 def test_write_to_buffer(ov_type, numpy_dtype):
     ov_tensor = Tensor(ov_type, ov.Shape([1, 3, 32, 32]))
@@ -200,7 +200,7 @@ def test_write_to_buffer(ov_type, numpy_dtype):
     (ov.Type.u16, np.uint16),
     (ov.Type.i64, np.int64),
     (ov.Type.u64, np.uint64),
-    (ov.Type.boolean, np.bool),
+    (ov.Type.boolean, np.bool_),
 ])
 def test_set_shape(ov_type, numpy_dtype):
     shape = ov.Shape([1, 3, 32, 32])

--- a/src/bindings/python/tests/test_ngraph/test_basic.py
+++ b/src/bindings/python/tests/test_ngraph/test_basic.py
@@ -162,13 +162,13 @@ def test_broadcast_3():
 
 @pytest.mark.parametrize(
     ("destination_type", "input_data"),
-    [(bool, np.zeros((2, 2), dtype=np.int32)), ("boolean", np.zeros((2, 2), dtype=np.int32))],
+    [(np.bool_, np.zeros((2, 2), dtype=np.int32)), ("boolean", np.zeros((2, 2), dtype=np.int32))],
 )
 def test_convert_to_bool(destination_type, input_data):
-    expected = np.array(input_data, dtype=bool)
+    expected = np.array(input_data, dtype=np.bool_)
     result = run_op_node([input_data], ops.convert, destination_type)
     assert np.allclose(result, expected)
-    assert np.array(result).dtype == bool
+    assert np.array(result).dtype == np.bool_
 
 
 @pytest.mark.parametrize(

--- a/src/bindings/python/tests/test_ngraph/test_basic.py
+++ b/src/bindings/python/tests/test_ngraph/test_basic.py
@@ -249,7 +249,7 @@ def test_bad_data_shape():
 
 def test_constant_get_data_bool():
     input_data = np.array([True, False, False, True])
-    node = ops.constant(input_data, dtype=np.bool)
+    node = ops.constant(input_data, dtype=np.bool_)
     retrieved_data = node.get_data()
     assert np.allclose(input_data, retrieved_data)
 

--- a/src/bindings/python/tests/test_ngraph/test_create_op.py
+++ b/src/bindings/python/tests/test_ngraph/test_create_op.py
@@ -1816,11 +1816,11 @@ def test_multiclass_nms():
                            0.0, -0.1, 1.0, 0.9, 0.0, 10.0, 1.0, 11.0,
                            0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0], dtype="float32")
     boxes_data = boxes_data.reshape([1, 6, 4])
-    box = ov.constant(boxes_data, dtype=np.float)
+    box = ov.constant(boxes_data, dtype=np.float32)
     scores_data = np.array([0.9, 0.75, 0.6, 0.95, 0.5, 0.3,
                             0.95, 0.75, 0.6, 0.80, 0.5, 0.3], dtype="float32")
     scores_data = scores_data.reshape([1, 2, 6])
-    score = ov.constant(scores_data, dtype=np.float)
+    score = ov.constant(scores_data, dtype=np.float32)
 
     nms_node = ov.multiclass_nms(box, score, None, output_type="i32", nms_top_k=3,
                                  iou_threshold=0.5, score_threshold=0.0, sort_result_type="classid",
@@ -1841,11 +1841,11 @@ def test_multiclass_nms():
                             [9.66, 3.36, 18.57, 13.26]],
                            [[6.50, 7.00, 13.33, 17.63],
                             [0.73, 5.34, 19.97, 19.97]]]).astype("float32")
-    box = ov.constant(boxes_data, dtype=np.float)
+    box = ov.constant(boxes_data, dtype=np.float32)
     scores_data = np.array([[0.34, 0.66],
                             [0.45, 0.61],
                             [0.39, 0.59]]).astype("float32")
-    score = ov.constant(scores_data, dtype=np.float)
+    score = ov.constant(scores_data, dtype=np.float32)
     rois_num_data = np.array([3]).astype("int32")
     roisnum = ov.constant(rois_num_data, dtype=np.int)
     nms_node = ov.multiclass_nms(box, score, roisnum, output_type="i32", nms_top_k=3,
@@ -1867,11 +1867,11 @@ def test_matrix_nms():
                            0.0, -0.1, 1.0, 0.9, 0.0, 10.0, 1.0, 11.0,
                            0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0], dtype="float32")
     boxes_data = boxes_data.reshape([1, 6, 4])
-    box = ov.constant(boxes_data, dtype=np.float)
+    box = ov.constant(boxes_data, dtype=np.float32)
     scores_data = np.array([0.9, 0.75, 0.6, 0.95, 0.5, 0.3,
                             0.95, 0.75, 0.6, 0.80, 0.5, 0.3], dtype="float32")
     scores_data = scores_data.reshape([1, 2, 6])
-    score = ov.constant(scores_data, dtype=np.float)
+    score = ov.constant(scores_data, dtype=np.float32)
 
     nms_node = ov.matrix_nms(box, score, output_type="i32", nms_top_k=3,
                              score_threshold=0.0, sort_result_type="score", background_class=0,

--- a/src/bindings/python/tests/test_ngraph/test_if.py
+++ b/src/bindings/python/tests/test_ngraph/test_if.py
@@ -12,7 +12,7 @@ from openvino.runtime.op.util import InvariantInputDescription, BodyOutputDescri
 
 
 def create_simple_if_with_two_outputs(condition_val):
-    condition = ov.constant(condition_val, dtype=np.bool)
+    condition = ov.constant(condition_val, dtype=np.bool_)
 
     # then_body
     x_t = ov.parameter([], np.float32, "X")
@@ -54,7 +54,7 @@ def create_simple_if_with_two_outputs(condition_val):
 
 
 def create_diff_if_with_two_outputs(condition_val):
-    condition = ov.constant(condition_val, dtype=np.bool)
+    condition = ov.constant(condition_val, dtype=np.bool_)
 
     # then_body
     x_t = ov.parameter([2], np.float32, "X")
@@ -90,7 +90,7 @@ def create_diff_if_with_two_outputs(condition_val):
 
 
 def simple_if(condition_val):
-    condition = ov.constant(condition_val, dtype=np.bool)
+    condition = ov.constant(condition_val, dtype=np.bool_)
     # then_body
     x_t = ov.parameter([2], np.float32, "X")
     y_t = ov.parameter([2], np.float32, "Y")
@@ -121,15 +121,15 @@ def simple_if(condition_val):
 
 
 def simple_if_without_parameters(condition_val):
-    condition = ov.constant(condition_val, dtype=np.bool)
+    condition = ov.constant(condition_val, dtype=np.bool_)
 
     # then_body
-    then_constant = ov.constant(0.7, dtype=np.float)
+    then_constant = ov.constant(0.7, dtype=np.float32)
     then_body_res_1 = ov.result(then_constant)
     then_body = Model([then_body_res_1], [])
 
     # else_body
-    else_const = ov.constant(9.0, dtype=np.float)
+    else_const = ov.constant(9.0, dtype=np.float32)
     else_body_res_1 = ov.result(else_const)
     else_body = Model([else_body_res_1], [])
 
@@ -180,7 +180,7 @@ def test_simple_if_without_body_parameters():
 
 
 def test_simple_if_basic():
-    condition = ov.constant(True, dtype=np.bool)
+    condition = ov.constant(True, dtype=np.bool_)
     # then_body
     x_t = ov.parameter([2], np.float32, "X")
     y_t = ov.parameter([2], np.float32, "Y")

--- a/src/bindings/python/tests/test_ngraph/test_loop.py
+++ b/src/bindings/python/tests/test_ngraph/test_loop.py
@@ -26,11 +26,11 @@ def test_simple_loop():
     x_i = ov.parameter(input_shape, np.float32)
     y_i = ov.parameter(input_shape, np.float32)
     m_body = ov.parameter(input_shape, np.float32)
-    bool_val = np.array([1], dtype=np.bool)
+    bool_val = np.array([1], dtype=np.bool_)
     bool_val[0] = True
     body_condition = ov.constant(bool_val)
     trip_count = ov.constant(10, dtype=np.int64)
-    exec_condition = ov.constant(True, dtype=np.bool)
+    exec_condition = ov.constant(True, dtype=np.bool_)
 
     add = ov.add(x_i, y_i)
     zo = ov.multiply(add, m_body)
@@ -66,7 +66,7 @@ def test_simple_loop():
 
 
 def test_loop_basic():
-    bool_val = np.array([1], dtype=np.bool)
+    bool_val = np.array([1], dtype=np.bool_)
     bool_val[0] = True
     condition = ov.constant(bool_val)
     trip_count = ov.constant(16, dtype=np.int32)

--- a/src/bindings/python/tests/test_ngraph/test_ops.py
+++ b/src/bindings/python/tests/test_ngraph/test_ops.py
@@ -556,7 +556,7 @@ def test_select():
     runtime = get_runtime()
     computation = runtime.computation(function, *parameter_list)
     result = computation(
-        np.array([[True, False]], dtype=np.bool),
+        np.array([[True, False]], dtype=np.bool_),
         np.array([[5, 6]], dtype=np.float32),
         np.array([[7, 8]], dtype=np.float32),
     )[0]

--- a/src/bindings/python/tests/test_ngraph/test_ops_binary.py
+++ b/src/bindings/python/tests/test_ngraph/test_ops_binary.py
@@ -91,14 +91,14 @@ def test_binary_logical_op(ng_api_helper, numpy_function):
     runtime = get_runtime()
 
     shape = [2, 2]
-    parameter_a = ov.parameter(shape, name="A", dtype=np.bool)
-    parameter_b = ov.parameter(shape, name="B", dtype=np.bool)
+    parameter_a = ov.parameter(shape, name="A", dtype=np.bool_)
+    parameter_b = ov.parameter(shape, name="B", dtype=np.bool_)
 
     model = ng_api_helper(parameter_a, parameter_b)
     computation = runtime.computation(model, parameter_a, parameter_b)
 
-    value_a = np.array([[True, False], [False, True]], dtype=np.bool)
-    value_b = np.array([[False, True], [False, True]], dtype=np.bool)
+    value_a = np.array([[True, False], [False, True]], dtype=np.bool_)
+    value_b = np.array([[False, True], [False, True]], dtype=np.bool_)
 
     result = computation(value_a, value_b)
     expected = numpy_function(value_a, value_b)
@@ -112,11 +112,11 @@ def test_binary_logical_op(ng_api_helper, numpy_function):
 def test_binary_logical_op_with_scalar(ng_api_helper, numpy_function):
     runtime = get_runtime()
 
-    value_a = np.array([[True, False], [False, True]], dtype=np.bool)
-    value_b = np.array([[False, True], [False, True]], dtype=np.bool)
+    value_a = np.array([[True, False], [False, True]], dtype=np.bool_)
+    value_b = np.array([[False, True], [False, True]], dtype=np.bool_)
 
     shape = [2, 2]
-    parameter_a = ov.parameter(shape, name="A", dtype=np.bool)
+    parameter_a = ov.parameter(shape, name="A", dtype=np.bool_)
 
     model = ng_api_helper(parameter_a, value_b)
     computation = runtime.computation(model, parameter_a)

--- a/src/bindings/python/tests/test_ngraph/test_ops_reshape.py
+++ b/src/bindings/python/tests/test_ngraph/test_ops_reshape.py
@@ -26,7 +26,7 @@ def test_concat():
 
 
 @pytest.mark.parametrize(
-    ("val_type", "value"), [(bool, False), (bool, np.empty((2, 2), dtype=bool))],
+    ("val_type", "value"), [(np.bool_, False), (np.bool_, np.empty((2, 2), dtype=np.bool_))],
 )
 def test_constant_from_bool(val_type, value):
     expected = np.array(value, dtype=val_type)

--- a/src/bindings/python/tests/test_ngraph/test_reduction.py
+++ b/src/bindings/python/tests/test_ngraph/test_reduction.py
@@ -53,7 +53,7 @@ def test_reduction_ops(ng_api_helper, numpy_function, reduction_axes):
 def test_reduction_logical_ops(ng_api_helper, numpy_function, reduction_axes):
     shape = [2, 4, 3, 2]
     np.random.seed(133391)
-    input_data = np.random.randn(*shape).astype(np.bool)
+    input_data = np.random.randn(*shape).astype(np.bool_)
 
     expected = numpy_function(input_data, axis=tuple(reduction_axes))
     result = run_op_node([input_data], ng_api_helper, reduction_axes)

--- a/src/bindings/python/tests/test_onnx/test_ops_logical.py
+++ b/src/bindings/python/tests/test_onnx/test_ops_logical.py
@@ -12,9 +12,9 @@ from tests.test_onnx.utils import run_node
 @pytest.mark.parametrize(
     ("onnx_op", "numpy_func", "data_type"),
     [
-        pytest.param("And", np.logical_and, np.bool),
-        pytest.param("Or", np.logical_or, np.bool),
-        pytest.param("Xor", np.logical_xor, np.bool),
+        pytest.param("And", np.logical_and, np.bool_),
+        pytest.param("Or", np.logical_or, np.bool_),
+        pytest.param("Xor", np.logical_xor, np.bool_),
         pytest.param("Equal", np.equal, np.int32),
         pytest.param("Greater", np.greater, np.int32),
         pytest.param("Less", np.less, np.int32),

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_basic.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_basic.py
@@ -213,7 +213,7 @@ def test_bad_data_shape():
 
 def test_constant_get_data_bool():
     input_data = np.array([True, False, False, True])
-    node = ng.constant(input_data, dtype=np.bool)
+    node = ng.constant(input_data, dtype=np.bool_)
     retrieved_data = node.get_data()
     assert np.allclose(input_data, retrieved_data)
 

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_create_op.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_create_op.py
@@ -831,7 +831,7 @@ def test_loop():
         TensorIteratorConcatOutputDesc,
     )
 
-    condition = ng.constant(True, dtype=np.bool)
+    condition = ng.constant(True, dtype=np.bool_)
     trip_count = ng.constant(16, dtype=np.int32)
     #  Body parameters
     body_timestep = ng.parameter([], np.int32, "timestep")
@@ -854,7 +854,7 @@ def test_loop():
     initial_cma = ng.constant(np.zeros([2, 2], dtype=np.float32), dtype=np.float32)
     iter_cnt = ng.range(zero, np.int32(16), np.int32(1))
     ti_inputs = [iter_cnt, data, initial_cma, one]
-    body_const_condition = ng.constant(True, dtype=np.bool)
+    body_const_condition = ng.constant(True, dtype=np.bool_)
 
     graph_body = GraphBody([body_timestep, body_data_in, body_prev_cma, body_const_one],
                            [curr_cma, cma_hist, body_const_condition])
@@ -1881,11 +1881,11 @@ def test_multiclass_nms():
                            0.0, -0.1, 1.0, 0.9, 0.0, 10.0, 1.0, 11.0,
                            0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0], dtype="float32")
     boxes_data = boxes_data.reshape([1, 6, 4])
-    box = ng.constant(boxes_data, dtype=np.float)
+    box = ng.constant(boxes_data, dtype=np.float32)
     scores_data = np.array([0.9, 0.75, 0.6, 0.95, 0.5, 0.3,
                             0.95, 0.75, 0.6, 0.80, 0.5, 0.3], dtype="float32")
     scores_data = scores_data.reshape([1, 2, 6])
-    score = ng.constant(scores_data, dtype=np.float)
+    score = ng.constant(scores_data, dtype=np.float32)
 
     nms_node = ng.multiclass_nms(box, score, None, output_type="i32", nms_top_k=3,
                                  iou_threshold=0.5, score_threshold=0.0, sort_result_type="classid",
@@ -1906,11 +1906,11 @@ def test_multiclass_nms():
                             [9.66, 3.36, 18.57, 13.26]],
                            [[6.50, 7.00, 13.33, 17.63],
                             [0.73, 5.34, 19.97, 19.97]]]).astype("float32")
-    box = ng.constant(boxes_data, dtype=np.float)
+    box = ng.constant(boxes_data, dtype=np.float32)
     scores_data = np.array([[0.34, 0.66],
                             [0.45, 0.61],
                             [0.39, 0.59]]).astype("float32")
-    score = ng.constant(scores_data, dtype=np.float)
+    score = ng.constant(scores_data, dtype=np.float32)
     rois_num_data = np.array([3]).astype("int32")
     roisnum = ng.constant(rois_num_data, dtype=np.int)
     nms_node = ng.multiclass_nms(box, score, roisnum, output_type="i32", nms_top_k=3,
@@ -1932,11 +1932,11 @@ def test_matrix_nms():
                            0.0, -0.1, 1.0, 0.9, 0.0, 10.0, 1.0, 11.0,
                            0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0], dtype="float32")
     boxes_data = boxes_data.reshape([1, 6, 4])
-    box = ng.constant(boxes_data, dtype=np.float)
+    box = ng.constant(boxes_data, dtype=np.float32)
     scores_data = np.array([0.9, 0.75, 0.6, 0.95, 0.5, 0.3,
                             0.95, 0.75, 0.6, 0.80, 0.5, 0.3], dtype="float32")
     scores_data = scores_data.reshape([1, 2, 6])
-    score = ng.constant(scores_data, dtype=np.float)
+    score = ng.constant(scores_data, dtype=np.float32)
 
     nms_node = ng.matrix_nms(box, score, output_type="i32", nms_top_k=3,
                              score_threshold=0.0, sort_result_type="score", background_class=0,

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_if.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_if.py
@@ -14,7 +14,7 @@ from tests_compatibility.runtime import get_runtime
 
 
 def create_simple_if_with_two_outputs(condition_val):
-    condition = ng.constant(condition_val, dtype=np.bool)
+    condition = ng.constant(condition_val, dtype=np.bool_)
 
     # then_body
     X_t = ng.parameter([], np.float32, "X")
@@ -54,7 +54,7 @@ def create_simple_if_with_two_outputs(condition_val):
 
 
 def create_diff_if_with_two_outputs(condition_val):
-    condition = ng.constant(condition_val, dtype=np.bool)
+    condition = ng.constant(condition_val, dtype=np.bool_)
 
     # then_body
     X_t = ng.parameter([2], np.float32, "X")
@@ -86,7 +86,7 @@ def create_diff_if_with_two_outputs(condition_val):
 
 
 def simple_if(condition_val):
-    condition = ng.constant(condition_val, dtype=np.bool)
+    condition = ng.constant(condition_val, dtype=np.bool_)
     # then_body
     X_t = ng.parameter([2], np.float32, "X")
     Y_t = ng.parameter([2], np.float32, "Y")
@@ -115,17 +115,17 @@ def simple_if(condition_val):
 
 
 def simple_if_without_parameters(condition_val):
-    condition = ng.constant(condition_val, dtype=np.bool)
+    condition = ng.constant(condition_val, dtype=np.bool_)
 
     # then_body
-    then_constant = ng.constant(0.7, dtype=np.float)
+    then_constant = ng.constant(0.7, dtype=np.float32)
     then_body_res_1 = ng.result(then_constant)
     then_body = GraphBody([], [then_body_res_1])
     then_body_inputs = []
     then_body_outputs = [TensorIteratorBodyOutputDesc(0, 0)]
 
     # else_body
-    else_const = ng.constant(9.0, dtype=np.float)
+    else_const = ng.constant(9.0, dtype=np.float32)
     else_body_res_1 = ng.result(else_const)
     else_body = GraphBody([], [else_body_res_1])
     else_body_inputs = []

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_ops.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_ops.py
@@ -532,7 +532,7 @@ def test_select():
     runtime = get_runtime()
     computation = runtime.computation(function, *parameter_list)
     result = computation(
-        np.array([[True, False]], dtype=np.bool),
+        np.array([[True, False]], dtype=np.bool_),
         np.array([[5, 6]], dtype=np.float32),
         np.array([[7, 8]], dtype=np.float32),
     )[0]

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_ops_binary.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_ops_binary.py
@@ -90,14 +90,14 @@ def test_binary_logical_op(ng_api_helper, numpy_function):
     runtime = get_runtime()
 
     shape = [2, 2]
-    parameter_a = ng.parameter(shape, name="A", dtype=np.bool)
-    parameter_b = ng.parameter(shape, name="B", dtype=np.bool)
+    parameter_a = ng.parameter(shape, name="A", dtype=np.bool_)
+    parameter_b = ng.parameter(shape, name="B", dtype=np.bool_)
 
     model = ng_api_helper(parameter_a, parameter_b)
     computation = runtime.computation(model, parameter_a, parameter_b)
 
-    value_a = np.array([[True, False], [False, True]], dtype=np.bool)
-    value_b = np.array([[False, True], [False, True]], dtype=np.bool)
+    value_a = np.array([[True, False], [False, True]], dtype=np.bool_)
+    value_b = np.array([[False, True], [False, True]], dtype=np.bool_)
 
     result = computation(value_a, value_b)
     expected = numpy_function(value_a, value_b)
@@ -111,11 +111,11 @@ def test_binary_logical_op(ng_api_helper, numpy_function):
 def test_binary_logical_op_with_scalar(ng_api_helper, numpy_function):
     runtime = get_runtime()
 
-    value_a = np.array([[True, False], [False, True]], dtype=np.bool)
-    value_b = np.array([[False, True], [False, True]], dtype=np.bool)
+    value_a = np.array([[True, False], [False, True]], dtype=np.bool_)
+    value_b = np.array([[False, True], [False, True]], dtype=np.bool_)
 
     shape = [2, 2]
-    parameter_a = ng.parameter(shape, name="A", dtype=np.bool)
+    parameter_a = ng.parameter(shape, name="A", dtype=np.bool_)
 
     model = ng_api_helper(parameter_a, value_b)
     computation = runtime.computation(model, parameter_a)

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_ops_reshape.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_ops_reshape.py
@@ -25,7 +25,7 @@ def test_concat():
 
 
 @pytest.mark.parametrize(
-    "val_type, value", [(bool, False), (bool, np.empty((2, 2), dtype=bool))]
+    "val_type, value", [(np.bool_, False), (np.bool_, np.empty((2, 2), dtype=np.bool_))]
 )
 def test_constant_from_bool(val_type, value):
     expected = np.array(value, dtype=val_type)

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_reduction.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_reduction.py
@@ -52,7 +52,7 @@ def test_reduction_ops(ng_api_helper, numpy_function, reduction_axes):
 def test_reduction_logical_ops(ng_api_helper, numpy_function, reduction_axes):
     shape = [2, 4, 3, 2]
     np.random.seed(133391)
-    input_data = np.random.randn(*shape).astype(np.bool)
+    input_data = np.random.randn(*shape).astype(np.bool_)
 
     expected = numpy_function(input_data, axis=tuple(reduction_axes))
     result = run_op_node([input_data], ng_api_helper, reduction_axes)

--- a/src/bindings/python/tests_compatibility/test_onnx/test_ops_logical.py
+++ b/src/bindings/python/tests_compatibility/test_onnx/test_ops_logical.py
@@ -11,9 +11,9 @@ from tests_compatibility.test_onnx.utils import run_node
 @pytest.mark.parametrize(
     "onnx_op, numpy_func, data_type",
     [
-        pytest.param("And", np.logical_and, np.bool),
-        pytest.param("Or", np.logical_or, np.bool),
-        pytest.param("Xor", np.logical_xor, np.bool),
+        pytest.param("And", np.logical_and, np.bool_),
+        pytest.param("Or", np.logical_or, np.bool_),
+        pytest.param("Xor", np.logical_xor, np.bool_),
         pytest.param("Equal", np.equal, np.int32),
         pytest.param("Greater", np.greater, np.int32),
         pytest.param("Less", np.less, np.int32),

--- a/tools/mo/openvino/tools/mo/analysis/boolean_input.py
+++ b/tools/mo/openvino/tools/mo/analysis/boolean_input.py
@@ -10,7 +10,7 @@ from openvino.tools.mo.utils.model_analysis import AnalyzeAction
 class TrainingPhaseAnalysis(AnalyzeAction):
 
     def analyze(self, graph: Graph):
-        nodes = graph.get_op_nodes(op='Parameter', data_type=np.bool)
+        nodes = graph.get_op_nodes(op='Parameter', data_type=np.bool_)
         names = ""
         params = ""
         if not nodes:

--- a/tools/mo/openvino/tools/mo/front/common/partial_infer/concat.py
+++ b/tools/mo/openvino/tools/mo/front/common/partial_infer/concat.py
@@ -31,7 +31,7 @@ def concat_infer(node):
     axis = get_canonical_axis_index(shape, node.axis)
     node.axis = axis
 
-    mask = np.zeros_like(shape, dtype=np.bool)
+    mask = np.zeros_like(shape, dtype=np.bool_)
     mask[axis] = True  # pylint: disable=unsupported-assignment-operation
     not_mask = np.logical_not(mask)  # pylint: disable=assignment-from-no-return
     for s in shapes[1:]:

--- a/tools/mo/openvino/tools/mo/front/freeze_placeholder_value.py
+++ b/tools/mo/openvino/tools/mo/front/freeze_placeholder_value.py
@@ -46,7 +46,7 @@ class FreezePlaceholderValue(FrontReplacementSubgraph):
                 data_type = SUPPORTED_DATA_TYPES[graph.graph['cmd_params'].data_type][0]
             string_value = graph.graph['freeze_placeholder'][name]
             try:
-                if data_type != np.bool:
+                if data_type != np.bool_:
                     value = mo_array(string_value, dtype=data_type)
                 # TODO: investigate why boolean type is allowed only for TensorFlow
                 elif data_type == np.bool and graph.graph['fw'] == 'tf':

--- a/tools/mo/openvino/tools/mo/front/freeze_placeholder_value.py
+++ b/tools/mo/openvino/tools/mo/front/freeze_placeholder_value.py
@@ -49,7 +49,7 @@ class FreezePlaceholderValue(FrontReplacementSubgraph):
                 if data_type != np.bool_:
                     value = mo_array(string_value, dtype=data_type)
                 # TODO: investigate why boolean type is allowed only for TensorFlow
-                elif data_type == np.bool and graph.graph['fw'] == 'tf':
+                elif data_type == np.bool_ and graph.graph['fw'] == 'tf':
                     from openvino.tools.mo.front.tf.common import tf_data_type_cast
                     if isinstance(string_value, list):
                         casted_list = list()

--- a/tools/mo/openvino/tools/mo/front/kaldi/extractors/lstm_nonlinearity_ext.py
+++ b/tools/mo/openvino/tools/mo/front/kaldi/extractors/lstm_nonlinearity_ext.py
@@ -22,7 +22,7 @@ class LSTMNonlinearityFrontExtractor(FrontExtractorOp):
         ifo_x_weights, ifo_x_weights_shape = read_binary_matrix(pb)
 
         try:
-            use_dropout = collect_until_token_and_read(pb, b'<UseDropout>', np.bool)
+            use_dropout = collect_until_token_and_read(pb, b'<UseDropout>', np.bool_)
         except Error:
             # layer have not UseDropout attribute, so setup it to False
             use_dropout = False

--- a/tools/mo/openvino/tools/mo/front/kaldi/loader/utils.py
+++ b/tools/mo/openvino/tools/mo/front/kaldi/loader/utils.py
@@ -257,7 +257,7 @@ def read_token_value(file_desc: io.BufferedReader, token: bytes = b'', value_typ
     getters = {
         np.uint32: read_binary_integer32_token,
         np.uint64: read_binary_integer64_token,
-        np.bool: read_binary_bool_token
+        np.bool_: read_binary_bool_token
     }
     current_token = collect_until_whitespace(file_desc)
     if token != b'' and token != current_token:
@@ -313,7 +313,7 @@ def collect_until_token_and_read(file_desc: io.BufferedReader, token, value_type
     getters = {
         np.uint32: read_binary_integer32_token,
         np.uint64: read_binary_integer64_token,
-        np.bool: read_binary_bool_token,
+        np.bool_: read_binary_bool_token,
         np.string_: read_string
     }
     collect_until_token(file_desc, token)

--- a/tools/mo/openvino/tools/mo/front/onnx/LoopNormalize.py
+++ b/tools/mo/openvino/tools/mo/front/onnx/LoopNormalize.py
@@ -39,7 +39,7 @@ class ONNXLoopNormalize(FrontReplacementSubgraph):
         # connect "execution condition" input if it is not connected with default value True
         if not loop_node.is_in_port_connected(1):
             loop_node.add_input_port(1, skip_if_exist=True)
-            Const(loop_node.graph, {'name': loop_name + '/execution_cond', 'value': mo_array(True, dtype=np.bool)}).\
+            Const(loop_node.graph, {'name': loop_name + '/execution_cond', 'value': mo_array(True, dtype=np.bool_)}).\
                 create_node().out_port(0).connect(loop_node.in_port(1))
 
         # scan output need Unsqueeze over axis 0

--- a/tools/mo/openvino/tools/mo/front/onnx/extractors/utils.py
+++ b/tools/mo/openvino/tools/mo/front/onnx/extractors/utils.py
@@ -56,7 +56,7 @@ def get_onnx_opset_version(node: Node):
 def get_onnx_datatype_as_numpy(value):
     datatype_to_numpy = {
         1: np.float32,
-        9: np.bool,
+        9: np.bool_,
         11: np.double,
         10: np.float16,
         5: np.int16,

--- a/tools/mo/openvino/tools/mo/front/onnx/group_norm_ext.py
+++ b/tools/mo/openvino/tools/mo/front/onnx/group_norm_ext.py
@@ -16,7 +16,7 @@ class ExperimentalDetectronGroupNorm(FrontExtractorOp):
     @classmethod
     def extract(cls, node):
         attrs = {
-            'eps': mo_array(onnx_attr(node, 'eps', 'f', default=1e-6), dtype=np.float),
+            'eps': mo_array(onnx_attr(node, 'eps', 'f', default=1e-6), dtype=np.float32),
             'num_groups': int64_array(onnx_attr(node, 'num_groups', 'i', default=1)),
         }
         GroupNorm.update_node_stat(node, attrs)
@@ -30,7 +30,7 @@ class GroupNormExtractor(FrontExtractorOp):
     @classmethod
     def extract(cls, node):
         attrs = {
-            'eps': mo_array(onnx_attr(node, 'eps', 'f', default=1e-6), dtype=np.float),
+            'eps': mo_array(onnx_attr(node, 'eps', 'f', default=1e-6), dtype=np.float32),
             'num_groups': int64_array(onnx_attr(node, 'num_groups', 'i', default=1)),
         }
         GroupNorm.update_node_stat(node, attrs)

--- a/tools/mo/openvino/tools/mo/front/tf/MapFNTransformation.py
+++ b/tools/mo/openvino/tools/mo/front/tf/MapFNTransformation.py
@@ -243,7 +243,7 @@ class MapFNOutputConcatenation(FrontReplacementSubgraph):
             if 'purpose' in record and record['purpose'] == 'execution_condition':
                 exec_cond_layer_id = record['internal_layer_id']
                 exec_cond_node = Loop.get_body_node_by_internal_id(loop_node, exec_cond_layer_id)
-                const_true = Const(body_graph, {'value': mo_array(True, dtype=np.bool)}).create_node()
+                const_true = Const(body_graph, {'value': mo_array(True, dtype=np.bool_)}).create_node()
                 exec_cond_node.in_port(0).get_connection().set_source(const_true.out_port(0))
 
         # remove back edge

--- a/tools/mo/openvino/tools/mo/front/tf/WhileNormalize.py
+++ b/tools/mo/openvino/tools/mo/front/tf/WhileNormalize.py
@@ -34,7 +34,7 @@ class WhileNormalize(FrontReplacementSubgraph):
 
         # connect execution condition port
         exec_cond_node = Const(graph, {'name': loop_name + '/ExecutionConditionValue',
-                                       'value': mo_array(True, dtype=np.bool)}).create_node()
+                                       'value': mo_array(True, dtype=np.bool_)}).create_node()
         loop_node.in_port(1).get_connection().set_source(exec_cond_node.out_port(0))
 
         loop_node.body.clean_up()

--- a/tools/mo/openvino/tools/mo/front/tf/common.py
+++ b/tools/mo/openvino/tools/mo/front/tf/common.py
@@ -7,7 +7,7 @@ from tensorflow.core.framework import types_pb2 as tf_types  # pylint: disable=n
 # Suppress false positive pylint warning about function with too many arguments
 # pylint: disable=E1121
 # mapping between TF data type and numpy data type and function to extract data from TF tensor
-_tf_np_mapping = [('DT_BOOL', np.bool, lambda pb: pb.bool_val, lambda x: bool_cast(x)),
+_tf_np_mapping = [('DT_BOOL', np.bool_, lambda pb: pb.bool_val, lambda x: bool_cast(x)),
                   ('DT_INT8', np.int8, lambda pb: pb.int_val, lambda x: np.int8(x)),
                   ('DT_INT16', np.int16, lambda pb: pb.int_val, lambda x: np.int16(x)),
                   ('DT_INT32', np.int32, lambda pb: pb.int_val, lambda x: np.int32(x)),
@@ -19,7 +19,7 @@ _tf_np_mapping = [('DT_BOOL', np.bool, lambda pb: pb.bool_val, lambda x: bool_ca
                   ('DT_HALF', np.float16, lambda pb: np.uint16(pb.half_val).view(np.float16), lambda x: np.float16(x)),
                   ('DT_FLOAT', np.float32, lambda pb: pb.float_val, lambda x: np.float32(x)),
                   ('DT_DOUBLE', np.double, lambda pb: pb.double_val, lambda x: np.double(x)),
-                  ('DT_STRING', np.str, lambda pb: pb.string_val, lambda x: np.str(x)),
+                  ('DT_STRING', np.str_, lambda pb: pb.string_val, lambda x: np.str_(x)),
                   ]
 
 tf_data_type_decode = {getattr(tf_types, tf_dt): (np_type, func) for tf_dt, np_type, func, _ in _tf_np_mapping if
@@ -32,4 +32,4 @@ def bool_cast(x):
     if isinstance(x, str):
         return False if x.lower() in ['false', '0'] else True if x.lower() in ['true', '1'] else 'unknown_boolean_cast'
     else:
-        return np.bool(x)
+        return np.bool_(x)

--- a/tools/mo/openvino/tools/mo/front/tf/extractors/utils.py
+++ b/tools/mo/openvino/tools/mo/front/tf/extractors/utils.py
@@ -63,7 +63,7 @@ def tf_tensor_content(tf_dtype, shape, pb_tensor):
         value = mo_array(np.frombuffer(pb_tensor.tensor_content, type_helper[0]))
     else:
         # load typed value
-        if type_helper[0] != np.str:
+        if type_helper[0] != np.str_:
             value = mo_array(type_helper[1](pb_tensor), dtype=type_helper[0])
         else:
             try:

--- a/tools/mo/openvino/tools/mo/middle/passes/convert_data_type.py
+++ b/tools/mo/openvino/tools/mo/middle/passes/convert_data_type.py
@@ -40,7 +40,7 @@ SUPPORTED_DATA_TYPES = {
     'int8': (np.int8, 'I8', 'i8'),
     'int32': (np.int32, 'I32', 'i32'),
     'int64': (np.int64, 'I64', 'i64'),
-    'bool': (np.bool, 'BOOL', 'boolean'),
+    'bool': (np.bool_, 'BOOL', 'boolean'),
     'uint8': (np.uint8, 'U8', 'u8'),
     'uint32': (np.uint32, 'U32', 'u32'),
     'uint64': (np.uint64, 'U64', 'u64'),

--- a/tools/mo/openvino/tools/mo/ops/ReduceOps.py
+++ b/tools/mo/openvino/tools/mo/ops/ReduceOps.py
@@ -43,7 +43,7 @@ def reduce_helper(func: callable, x: np.array, axis: tuple, keepdims: bool):
     if is_fully_defined(x):
         return result
     else:
-        return np.ma.masked_array(result, mask=np.ones(result.shape, dtype=np.bool))
+        return np.ma.masked_array(result, mask=np.ones(result.shape, dtype=np.bool_))
 
 
 def reduce_infer(node: Node):
@@ -73,7 +73,7 @@ def reduce_infer(node: Node):
         value = reduce_helper(reduce_map[node.op], in_value.copy(), axis=tuple(axis), keepdims=node.keep_dims)
         node.out_port(0).data.set_value(value)
     else:
-        used_dims = np.zeros(len(in_shape), dtype=np.bool)
+        used_dims = np.zeros(len(in_shape), dtype=np.bool_)
         output_shape = in_shape.copy()
 
         for dim in axis:

--- a/tools/mo/openvino/tools/mo/ops/activation_ops.py
+++ b/tools/mo/openvino/tools/mo/ops/activation_ops.py
@@ -231,7 +231,7 @@ class LogicalNot(Activation):
 
     @staticmethod
     def type_infer(node: Node):
-        node.out_port(0).set_data_type(np.bool)
+        node.out_port(0).set_data_type(np.bool_)
 
 
 class Log(Activation):

--- a/tools/mo/openvino/tools/mo/ops/elementwise.py
+++ b/tools/mo/openvino/tools/mo/ops/elementwise.py
@@ -115,7 +115,7 @@ class LogicalElementwise(Elementwise):
     @staticmethod
     def type_infer(node):
         override_data_type_of_constant(node)
-        node.out_port(0).set_data_type(np.bool)
+        node.out_port(0).set_data_type(np.bool_)
 
 
 class Greater(LogicalElementwise):

--- a/tools/mo/openvino/tools/mo/ops/select.py
+++ b/tools/mo/openvino/tools/mo/ops/select.py
@@ -90,7 +90,7 @@ class Select(Op):
                 # one of the branches is None (which is not selected)
                 # if we use np.where for such cases then dtype of output_value will be object (non numeric type)
                 # and subsequent numpy operation on such tensors will fail
-                output_value = resulting_tensors[not np.bool(condition_value.item(0))]
+                output_value = resulting_tensors[not np.bool_(condition_value.item(0))]
                 if output_value is None:
                     return
                 if broadcast_rule == 'numpy':

--- a/tools/mo/openvino/tools/mo/ops/unique.py
+++ b/tools/mo/openvino/tools/mo/ops/unique.py
@@ -152,6 +152,6 @@ class Unique(Op):
         # write result to output nodes
         j = 0
         for out_node_ind in node.out_nodes():
-            node.out_node(out_node_ind).value = mo_array(unique_output[j], dtype=np.float)
+            node.out_node(out_node_ind).value = mo_array(unique_output[j], dtype=np.float32)
             node.out_node(out_node_ind).shape = int64_array(node.out_node(out_node_ind).value.shape)
             j += 1

--- a/tools/mo/openvino/tools/mo/utils/ir_engine/ir_engine.py
+++ b/tools/mo/openvino/tools/mo/utils/ir_engine/ir_engine.py
@@ -337,7 +337,7 @@ class IREngine(object):
             'U1': (1, np.uint8),
             'U4': (1, np.uint8),
             'I4': (1, np.uint8),
-            'BOOL': (1, np.bool),
+            'BOOL': (1, np.bool_),
             'BIN': (1, np.uint8),
             'U64': (8, np.uint64)
         }

--- a/tools/mo/unit_tests/mo/front/tf/identityN_to_identity_test.py
+++ b/tools/mo/unit_tests/mo/front/tf/identityN_to_identity_test.py
@@ -19,7 +19,7 @@ nodes = {
     **empty_data('identityN_1_d'),
     **regular_op_with_empty_data('identity0', {'op': 'Identity', 'type': None, 'data_type': np.int32,
                                                'name': 'my_identity/0_port'}),
-    **regular_op_with_empty_data('identity1', {'op': 'Identity', 'type': None, 'data_type': np.float,
+    **regular_op_with_empty_data('identity1', {'op': 'Identity', 'type': None, 'data_type': np.float32,
                                                'name': 'my_identity/1_port'}),
 
     **result('output0'),

--- a/tools/mo/unit_tests/mo/ops/If_test.py
+++ b/tools/mo/unit_tests/mo/ops/If_test.py
@@ -25,8 +25,8 @@ from unit_tests.utils.graph import regular_op_with_empty_data, connect, result, 
 @generator
 class TestIf(unittest.TestCase):
     @generate(*[
-        (np.array([True], dtype=np.bool), shape_array([3]), shape_array([3])),
-        (np.array([False], dtype=np.bool), shape_array([3]), shape_array([2])),
+        (np.array([True], dtype=np.bool_), shape_array([3]), shape_array([3])),
+        (np.array([False], dtype=np.bool_), shape_array([3]), shape_array([2])),
         (shape_array(dynamic_dimension_value), shape_array([3]), shape_array([dynamic_dimension_value])),
     ])
     def test_simple_shape_inf(self, cond, output_port_0_shape, output_port_1_shape):

--- a/tools/mo/unit_tests/mo/ops/pad_test.py
+++ b/tools/mo/unit_tests/mo/ops/pad_test.py
@@ -107,7 +107,7 @@ class TestPadOps(unittest.TestCase):
             nodes_with_edges_only=True,
         )
         out_shape = (1, 1, 5, 8)
-        mask = np.zeros(out_shape, dtype=np.bool)
+        mask = np.zeros(out_shape, dtype=np.bool_)
         mask[0][0][1][2] = True
         ref_value = np.ma.masked_array(np.zeros(out_shape, dtype=np.int64), mask=mask, dtype=np.int64)
         ref_value[0][0][1][3] = 3


### PR DESCRIPTION
**Details:** NumPy import raises a warning about deprecated types (`np.bool`, `np.str`, `np.float`) in 1.20 release.

**Ticket:** 90079

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>