### PR TITLE
[GNA] Add decomposition of one type of unsupported Concat

### DIFF
--- a/src/plugins/intel_gna/transformations/decompose_concat.cpp
+++ b/src/plugins/intel_gna/transformations/decompose_concat.cpp
@@ -1,0 +1,104 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <openvino/cc/ngraph/itt.hpp>
+
+#include "transformations/decompose_concat.hpp"
+
+#include <ngraph/opsets/opset9.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+#include <ngraph/rt_info.hpp>
+#include <transformations/utils/utils.hpp>
+#include "backend/gna_limitations.hpp"
+
+
+using namespace ov::intel_gna::pass;
+using namespace ngraph;
+
+struct ConcatData {
+    size_t num_inputs;
+    size_t split_axis = 0;
+    size_t leading_shape_product = 1;
+    int64_t axis;
+    OutputVector concat_parents;
+};
+
+static bool GetVerifiedConcatData(const std::shared_ptr<opset9::Concat> concat, ConcatData& concat_data) {
+    std::vector<ov::Shape> input_shape;
+    concat_data.num_inputs = concat->inputs().size();
+
+    for (size_t i = 0; i < concat_data.num_inputs; i++) {
+        concat_data.concat_parents.push_back(concat->input_value(i));
+        input_shape.push_back(concat->input_value(i).get_shape());
+    }
+
+    concat_data.axis = concat->get_axis();
+    int32_t non_one_axis_count = 0;
+
+    for (int64_t i = 0; i < concat_data.axis; i++) {
+        if (input_shape[0][i] != 1) {
+            concat_data.leading_shape_product *= input_shape[0][i];
+            concat_data.split_axis = i;
+            non_one_axis_count++;
+        }
+    }
+    // Simple Concats are GNA-compatible already
+    if (concat_data.leading_shape_product == 1 ||
+        // Difficult cases not yet implemented
+        non_one_axis_count > 1) {
+        return false;
+    }
+
+    return true;
+}
+
+static void Decompose(const std::shared_ptr<opset9::Concat> concat, const ConcatData& concat_data) {
+    OutputVector splits;
+    OutputVector chunks;
+
+    for (size_t i = 0; i < concat_data.num_inputs; i++) {
+        const auto axis_node = opset9::Constant::create(element::i64, Shape{}, {concat_data.split_axis});
+        const auto split = std::make_shared<opset9::Split>(concat_data.concat_parents[i], axis_node, concat_data.leading_shape_product);
+        splits.push_back(split);
+    }
+
+    for (size_t c = 0; c < concat_data.leading_shape_product; c++) {
+        OutputVector sub_chunks;
+        for (size_t i = 0; i < concat_data.num_inputs; i++) {
+            sub_chunks.push_back(splits[i].get_node()->output(c));
+        }
+        auto new_sub_concat = std::make_shared<opset9::Concat>(sub_chunks, concat_data.axis);
+        chunks.push_back(new_sub_concat->output(0));
+    }
+
+    auto new_concat = std::make_shared<opset9::Concat>(chunks, concat_data.split_axis);
+    replace_node(concat, new_concat);
+    new_concat->set_friendly_name(concat->get_friendly_name());
+}
+
+static bool Convert(std::shared_ptr<Node> concat_node) {
+    const auto concat = std::dynamic_pointer_cast<opset9::Concat>(concat_node);
+    ConcatData concat_data = {};
+
+    if (!GetVerifiedConcatData(concat, concat_data))
+        return false;
+
+    Decompose(concat, concat_data);
+
+    return true;
+}
+
+DecomposeConcat::DecomposeConcat() {
+    MATCHER_SCOPE(DecomposeConcat);
+
+    auto concat = pattern::wrap_type<opset9::Concat>();
+
+    matcher_pass_callback callback = [=](pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        return Convert(pattern_map.at(concat).get_node_shared_ptr());
+    };
+
+    auto m = std::make_shared<pattern::Matcher>(concat, matcher_name);
+    this->register_matcher(m, callback);
+}

--- a/src/plugins/intel_gna/transformations/decompose_concat.hpp
+++ b/src/plugins/intel_gna/transformations/decompose_concat.hpp
@@ -1,0 +1,27 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ngraph/pass/graph_rewrite.hpp>
+
+namespace ov {
+namespace intel_gna {
+namespace pass {
+
+/**
+ * @brief Decompose Concat operation
+ * Some types of Concat operations which are not supported
+ * natively by GNA HW are handled by this decomposition.
+ * 
+ */
+class DecomposeConcat : public ngraph::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("DecomposeConcat", "0");
+    DecomposeConcat();
+};
+
+}  // namespace pass
+}  // namespace intel_gna
+}  // namespace ov

--- a/src/plugins/intel_gna/transformations/utils/transformation_helper.cpp
+++ b/src/plugins/intel_gna/transformations/utils/transformation_helper.cpp
@@ -3,7 +3,8 @@
 //
 
 
-#include <ngraph/opsets/opset7.hpp>
+#include <legacy/ngraph_ops/crop_ie.hpp>
+#include <ngraph/opsets/opset9.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 #include "transformation_helper.hpp"
@@ -105,6 +106,20 @@ std::shared_ptr<ngraph::Node> InsertFQLayer(const std::shared_ptr<ngraph::opset7
     }
     return last_node;
 }
+
+bool IsGNANonFunctionalNode(std::shared_ptr<ngraph::Node> node) {
+    return std::dynamic_pointer_cast<ngraph::opset9::Reshape>(node) ||
+           std::dynamic_pointer_cast<ngraph::opset9::Squeeze>(node) ||
+           std::dynamic_pointer_cast<ngraph::opset9::Unsqueeze>(node) ||
+           std::dynamic_pointer_cast<ngraph::op::CropIE>(node) ||
+           std::dynamic_pointer_cast<ngraph::opset9::Split>(node) ||
+           std::dynamic_pointer_cast<ngraph::opset9::VariadicSplit>(node) ||
+           std::dynamic_pointer_cast<ngraph::opset9::Parameter>(node) ||
+           std::dynamic_pointer_cast<ngraph::opset9::Constant>(node) ||
+           std::dynamic_pointer_cast<ngraph::opset9::Concat>(node) ||
+           std::dynamic_pointer_cast<ngraph::opset9::Result>(node);
+}
+
 } // namespace helper
 } // namespace pass
 } // namespace intel_gna

--- a/src/plugins/intel_gna/transformations/utils/transformation_helper.hpp
+++ b/src/plugins/intel_gna/transformations/utils/transformation_helper.hpp
@@ -83,6 +83,13 @@ std::shared_ptr<ngraph::Node> VerifyBiasGetConst(std::shared_ptr<ngraph::Node> c
  */
 std::shared_ptr<ngraph::Node> InsertFQLayer(const std::shared_ptr<ngraph::opset7::FakeQuantize> fq_layer, std::shared_ptr<ngraph::Node> last_node);
 
+/**
+ * @brief checks whether a node is non-functional on GNA
+ * @param node node to check
+ * @return true if node is non-functional, false otherwise
+ */
+bool IsGNANonFunctionalNode(std::shared_ptr<ngraph::Node> node);
+
 } // namespace helper
 } // namespace pass
 } // namespace intel_gna

--- a/src/tests/functional/plugin/gna/pass_tests/decompose_concat.cpp
+++ b/src/tests/functional/plugin/gna/pass_tests/decompose_concat.cpp
@@ -1,0 +1,128 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_common.hpp"
+#include <string>
+#include <sstream>
+#include <fstream>
+#include <memory>
+#include <queue>
+#include <map>
+
+#include "transformations/init_node_info.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "shared_test_classes/base/layer_test_utils.hpp"
+
+
+using namespace ngraph;
+using namespace opset8;
+
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+        std::vector<std::vector<size_t>>,   // Input shapes
+        int64_t,                            // Concat axis
+        InferenceEngine::Precision,         // Network Precision
+        std::string,                        // Target Device
+        std::map<std::string, std::string>  // Configuration
+> decomposeConcatParams;
+
+class DecomposeConcatTest : public testing::WithParamInterface<decomposeConcatParams>,
+    virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<decomposeConcatParams> obj) {
+        std::vector<std::vector<size_t>> inputShapes;
+        int64_t concatAxis;
+        InferenceEngine::Precision netPrecision;
+        std::string targetDevice;
+        std::map<std::string, std::string> configuration;
+        std::tie(inputShapes, concatAxis, netPrecision, targetDevice, configuration) = obj.param;
+
+        std::ostringstream result;
+        result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+        result << "concatAxis=" << std::to_string(concatAxis) << "_";
+        result << "netPRC=" << netPrecision.name() << "_";
+        result << "targetDevice=" << targetDevice << "_";
+        for (auto const& configItem : configuration) {
+            result << "_configItem=" << configItem.first << "_" << configItem.second;
+        }
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        std::vector<std::vector<size_t>> inputShapes;
+        int64_t concatAxis;
+        InferenceEngine::Precision netPrecision;
+        std::tie(inputShapes, concatAxis, netPrecision, targetDevice, configuration) = this->GetParam();
+
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        auto params = builder::makeParams(ngPrc, inputShapes);
+        auto paramOuts = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(params));
+
+        std::vector<int64_t> startOffset = {0, 0, 0, 0};
+        std::vector<int64_t> endOffset(startOffset);
+        OutputVector concatInput;
+        std::vector<std::shared_ptr<opset9::Relu>> ssArray;
+
+        for (size_t i = 0; i < inputShapes.size(); ++i) {
+            std::vector<size_t> shape(inputShapes[i]);
+            std::transform(shape.begin(), shape.end(), startOffset.begin(), endOffset.begin(), std::plus<int>());
+            auto begin = std::make_shared<op::Constant>(element::i64, Shape{4}, startOffset);
+            auto end = std::make_shared<op::Constant>(element::i64, Shape{4}, endOffset);
+            auto stride = std::make_shared<op::Constant>(element::i64, Shape{4}, std::vector<int64_t>{1, 1, 1, 1});
+            auto ss = std::make_shared<opset9::StridedSlice>(paramOuts[0], begin, end, stride,
+                                                             std::vector<int64_t>{0, 0, 0, 0},
+                                                             std::vector<int64_t>{0, 0, 0, 0});
+            auto relu = std::make_shared<opset9::Relu>(paramOuts[i]);
+            ssArray.push_back(relu);
+            concatInput.push_back(ssArray[i]);
+            startOffset[concatAxis] += shape[concatAxis];
+        }
+
+        auto concat = std::make_shared<opset9::Concat>(concatInput, concatAxis);
+        auto relu = std::make_shared<opset9::Relu>(concat);
+
+        ResultVector results{std::make_shared<opset9::Result>(relu)};
+        function = std::make_shared<Function>(results, params, "DecomposeConcat");
+    }
+};
+
+TEST_P(DecomposeConcatTest, CompareWithRefs) {
+    Run();
+}
+
+const std::vector<std::vector<std::vector<size_t>>> inShapes = {
+    {{1, 2, 4, 64}, {1, 2, 4, 64}},
+};
+
+const std::vector<int64_t> concatAxis = {
+    1,
+    2
+};
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16
+};
+
+const std::vector<std::map<std::string, std::string>> configs = {
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_DecomposeConcat, DecomposeConcatTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(inShapes),
+        ::testing::ValuesIn(concatAxis),
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configs)),
+    DecomposeConcatTest::getTestCaseName);
+
+} // namespace LayerTestsDefinitions

--- a/src/tests/unit/gna/ngraph/transformations/gna_decompose_concat.cpp
+++ b/src/tests/unit/gna/ngraph/transformations/gna_decompose_concat.cpp
@@ -1,0 +1,168 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <tuple>
+
+#include <ngraph/opsets/opset9.hpp>
+#include "transformations/decompose_concat.hpp"
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+using namespace ngraph;
+
+namespace decomposeConcat {
+
+struct ConcatData {
+    size_t num_inputs;
+    size_t split_axis = 0;
+    size_t leading_shape_product = 1;
+    int64_t axis;
+    OutputVector concat_parents;
+};
+
+std::shared_ptr<Function> create_function(const std::vector<Shape>& input_shapes, const int64_t& concat_axis) {
+    ParameterVector params;
+
+    for (const auto& shape : input_shapes) {
+        auto param_node = std::make_shared<opset9::Parameter>(element::i32, Shape(shape));
+        params.push_back(param_node);
+    }
+
+    auto inputs = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(params));
+    auto concat = std::make_shared<opset9::Concat>(inputs, concat_axis);
+    auto result = std::make_shared<opset9::Result>(concat);
+
+    return std::make_shared<Function>(ResultVector{result}, params);
+}
+
+static bool should_decompose(const ParameterVector& params, const int64_t& concat_axis, ConcatData& concat_data) {
+    std::vector<Shape> input_shapes;
+    concat_data.num_inputs = params.size();
+
+    for (size_t i = 0; i < concat_data.num_inputs; i++) {
+        concat_data.concat_parents.push_back(params[i]);
+        input_shapes.push_back(params[i]->get_shape());
+    }
+
+    concat_data.axis = concat_axis;
+    int32_t non_one_axis_count = 0;
+
+    for (int64_t i = 0; i < concat_data.axis; i++) {
+        if (input_shapes[0][i] != 1) {
+            concat_data.leading_shape_product *= input_shapes[0][i];
+            concat_data.split_axis = i;
+            non_one_axis_count++;
+        }
+    }
+
+    // Simple Concats are GNA-compatible already
+    if (concat_data.leading_shape_product == 1 ||
+        // Difficult cases not yet implemented
+        non_one_axis_count > 1) {
+        return false;
+    }
+
+    return true;
+}
+
+static std::shared_ptr<Node> decompose_concat(const ConcatData& concat_data) {
+    OutputVector splits;
+    OutputVector chunks;
+
+    for (size_t i = 0; i < concat_data.num_inputs; i++) {
+        const auto axis_node = opset9::Constant::create(element::i64, Shape{}, {concat_data.split_axis});
+        const auto split = std::make_shared<opset9::Split>(concat_data.concat_parents[i], axis_node, concat_data.leading_shape_product);
+        splits.push_back(split);
+    }
+
+    for (size_t c = 0; c < concat_data.leading_shape_product; c++) {
+        OutputVector sub_chunks;
+        for (size_t i = 0; i < concat_data.num_inputs; i++) {
+            sub_chunks.push_back(splits[i].get_node()->output(c));
+        }
+        auto new_sub_concat = std::make_shared<opset9::Concat>(sub_chunks, concat_data.axis);
+        chunks.push_back(new_sub_concat->output(0));
+    }
+
+    auto concat = std::make_shared<opset9::Concat>(chunks, concat_data.split_axis);
+    return concat;
+}
+
+std::shared_ptr<Function> create_reference_function(const std::vector<Shape>& input_shapes, const int64_t& concat_axis) {
+    ParameterVector params;
+    ConcatData concat_data = {};
+    std::shared_ptr<Node> concat;
+
+    for (const auto& shape : input_shapes) {
+        auto param_node = std::make_shared<opset9::Parameter>(element::i32, Shape(shape));
+        params.push_back(param_node);
+    }
+
+    if (should_decompose(params, concat_axis, concat_data)) {
+        concat = decompose_concat(concat_data);
+    } else {
+        auto inputs = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(params));
+        concat = std::make_shared<opset9::Concat>(inputs, concat_axis);
+    }
+
+    auto result = std::make_shared<opset9::Result>(concat);
+    return std::make_shared<Function>(ResultVector{result}, params);
+}
+
+} // namespace decomposeConcat
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FixtureInputShapes = std::tuple<std::vector<Shape>, int64_t>;
+
+class DecomposeConcatFixture
+    : public CommonTestUtils::TestsCommon,
+      public ::testing::WithParamInterface<FixtureInputShapes> {
+public:
+    void SetUp() override;
+
+public:
+    std::shared_ptr<Function> function, reference_function;
+};
+
+void DecomposeConcatFixture::SetUp() {
+    std::vector<Shape> input_shapes;
+    int64_t concat_axis;
+    std::tie(input_shapes, concat_axis) = this->GetParam();
+
+    function = decomposeConcat::create_function(input_shapes, concat_axis);
+    reference_function = decomposeConcat::create_reference_function(input_shapes, concat_axis);
+}
+
+void execute_test(std::shared_ptr<Function> function, std::shared_ptr<Function> reference_function) {
+    pass::Manager manager, manager_ref;
+    manager.register_pass<pass::InitNodeInfo>();
+    manager.register_pass<ov::intel_gna::pass::DecomposeConcat>();
+    manager.run_passes(function);
+    const FunctionsComparator func_comparator = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
+    const FunctionsComparator::Result result = func_comparator(function, reference_function);
+    ASSERT_TRUE(result.valid);
+}
+
+std::vector<std::vector<Shape>> input_shapes = {{{10, 10, 10, 10}, {10, 10, 10, 10}},
+                                                {{10, 10, 10, 10}, {10, 10, 10, 10}, {10, 10, 10, 10}},
+                                                {{10, 10, 10, 10}, {10, 10, 10, 10}, {10, 10, 10, 10}, {10, 10, 10, 10}}};
+
+std::vector<int64_t> concat_axis = {
+    0,
+    1,
+    2,
+};
+
+TEST_P(DecomposeConcatFixture, CompareFunctions) {
+    execute_test(function, reference_function);
+}
+
+INSTANTIATE_TEST_SUITE_P(DecomposeConcatTestSuite,
+                         DecomposeConcatFixture,
+                         ::testing::Combine(
+                            ::testing::ValuesIn(input_shapes),
+                            ::testing::ValuesIn(concat_axis)));


### PR DESCRIPTION
### Details:
 - decompose one type of GNA-unsupported Concat
 - currently no limitations set
 - decomposition is skipped for trivial networks.

### Tickets:
 - 80268
