### PR TITLE
[TF FE] Fix translator for Conv3DBackpropInputV2

### DIFF
--- a/src/frontends/tensorflow/src/op/conv_3d_backprop.cpp
+++ b/src/frontends/tensorflow/src/op/conv_3d_backprop.cpp
@@ -14,12 +14,12 @@ namespace tensorflow {
 namespace op {
 
 OutputVector translate_conv_3d_backprop_input_v2_op(const NodeContext& node) {
-    default_op_checks(node, 3, {"Conv3DBackpropInput"});
+    default_op_checks(node, 3, {"Conv3DBackpropInputV2"});
     auto input_sizes = node.get_input(0);
     auto filter = node.get_input(1);
     auto out_backprop = node.get_input(2);
 
-    // retrieve attributes for Conv3DBackpropInput
+    // retrieve attributes for Conv3DBackpropInputV2
     auto tf_strides = node.get_attribute<std::vector<int64_t>>("strides");
     auto tf_padding_type = node.get_attribute<std::string>("padding");
     ov::op::PadType auto_pad = convert_tf_padding(node, tf_padding_type);
@@ -34,11 +34,11 @@ OutputVector translate_conv_3d_backprop_input_v2_op(const NodeContext& node) {
 
     TENSORFLOW_OP_VALIDATION(node,
                              tf_data_format == "NDHWC" || tf_data_format == "NCDHW",
-                             "Conv3DBackpropInput data format is neither NDHWC nor NCDHW");
+                             "Conv3DBackpropInputV2 data format is neither NDHWC nor NCDHW");
     if (auto_pad == ov::op::PadType::EXPLICIT) {
         TENSORFLOW_OP_VALIDATION(node,
                                  tf_explicit_paddings.size() == 10,
-                                 "Conv3DBackpropInput expects 10 padding values for EXPLICIT padding mode.");
+                                 "Conv3DBackpropInputV2 expects 10 padding values for EXPLICIT padding mode.");
     }
     bool is_nhwc = (tf_data_format == "NDHWC");
 
@@ -108,8 +108,8 @@ OutputVector translate_conv_3d_backprop_input_v2_op(const NodeContext& node) {
     auto conv_backprop_output = conv_backprop->output(0);
     convert_nchw_to_nhwc(is_nhwc, conv_backprop_output, ov::Rank(5));
 
-    // move the original name to new ConvolutionBackpropData if original layout is NCHW
-    // move the original name to Transpose if original layout is NHWC
+    // move the original name to new ConvolutionBackpropData if original layout is NCDHW
+    // move the original name to Transpose if original layout is NDHWC
     set_node_name(node.get_name(), conv_backprop_output.get_node_shared_ptr());
     return {conv_backprop_output};
 }


### PR DESCRIPTION
**Details:** It is a partial port from [PR-12764](https://github.com/openvinotoolkit/openvino/pull/12764) for `Conv3DBackpropInputV2`.

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
