### PR TITLE
[Python API] Port from the master - Replace deprecated NumPy type np.bool (#12786)

### DIFF
--- a/src/bindings/python/src/compatibility/ngraph/utils/types.py
+++ b/src/bindings/python/src/compatibility/ngraph/utils/types.py
@@ -22,7 +22,7 @@ ScalarData = Union[int, float]
 NodeInput = Union[Node, NumericData]
 
 ngraph_to_numpy_types_map = [
-    (NgraphType.boolean, np.bool),
+    (NgraphType.boolean, bool),
     (NgraphType.f16, np.float16),
     (NgraphType.f32, np.float32),
     (NgraphType.f64, np.float64),
@@ -38,7 +38,7 @@ ngraph_to_numpy_types_map = [
 ]
 
 ngraph_to_numpy_types_str_map = [
-    ("boolean", np.bool),
+    ("boolean", bool),
     ("f16", np.float16),
     ("f32", np.float32),
     ("f64", np.float64),

--- a/src/bindings/python/src/openvino/runtime/utils/types.py
+++ b/src/bindings/python/src/openvino/runtime/utils/types.py
@@ -22,7 +22,7 @@ ScalarData = Union[int, float]
 NodeInput = Union[Node, NumericData]
 
 openvino_to_numpy_types_map = [
-    (Type.boolean, np.bool),
+    (Type.boolean, bool),
     (Type.f16, np.float16),
     (Type.f32, np.float32),
     (Type.f64, np.float64),
@@ -38,7 +38,7 @@ openvino_to_numpy_types_map = [
 ]
 
 openvino_to_numpy_types_str_map = [
-    ("boolean", np.bool),
+    ("boolean", bool),
     ("f16", np.float16),
     ("f32", np.float32),
     ("f64", np.float64),


### PR DESCRIPTION
**Details:** NumPy import raises a warning about deprecated type np.bool in 1.20 release.

**Ticket:** 90079

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>