### PR TITLE
[GPU] Assign-3/ReadValue-3 for GPU plugin

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/primitives_list.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/primitives_list.hpp
@@ -161,13 +161,13 @@ REGISTER_FACTORY(v3, ScatterUpdate);
 REGISTER_FACTORY(v3, ScatterElementsUpdate);
 REGISTER_FACTORY(v3, ScatterNDUpdate);
 REGISTER_FACTORY(v3, ShapeOf);
+REGISTER_FACTORY(v3, Assign);
+REGISTER_FACTORY(v3, ReadValue);
 // REGISTER_FACTORY(v3, NonMaxSuppression); Supported via v3 -> v5 internal conversion
 
 // ----------------------------- Unsupported v3 ops ----------------------------- //
-// REGISTER_FACTORY(v3, Assign);
 // REGISTER_FACTORY(v3, GRUCell);
 // REGISTER_FACTORY(v3, NonZero);
-// REGISTER_FACTORY(v3, ReadValue);
 // REGISTER_FACTORY(v3, TopK);
 
 // ------------------------------ Supported v4 ops ------------------------------ //

--- a/src/plugins/intel_gpu/src/plugin/ops/variable.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/variable.cpp
@@ -38,6 +38,14 @@ void CreateVariableAccessPrimitive(Program &p, const std::shared_ptr<ngraph::op:
     p.add_primitive(*op, prim);
 }
 
+void CreateReadValueOp(Program& p, const std::shared_ptr<ngraph::op::v3::ReadValue>& op) {
+    CreateVariableAccessPrimitive<cldnn::read_value>(p, op, op->get_variable_id());
+}
+
+void CreateAssignOp(Program& p, const std::shared_ptr<ngraph::op::v3::Assign>& op) {
+    CreateVariableAccessPrimitive<cldnn::assign>(p, op, op->get_variable_id());
+}
+
 void CreateReadValueOp(Program& p, const std::shared_ptr<ngraph::op::v6::ReadValue>& op) {
     CreateVariableAccessPrimitive<cldnn::read_value>(p, op, op->get_variable_id());
 }
@@ -48,7 +56,9 @@ void CreateAssignOp(Program& p, const std::shared_ptr<ngraph::op::v6::Assign>& o
 
 } // namespace
 
+REGISTER_FACTORY_IMPL(v3, Assign);
 REGISTER_FACTORY_IMPL(v6, Assign);
+REGISTER_FACTORY_IMPL(v3, ReadValue);
 REGISTER_FACTORY_IMPL(v6, ReadValue);
 
 }  // namespace intel_gpu

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/memory.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/memory.cpp
@@ -33,4 +33,13 @@ INSTANTIATE_TEST_SUITE_P(smoke_MemoryTest, MemoryTest,
                 ::testing::Values(CommonTestUtils::DEVICE_GPU)),
         MemoryTest::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_MemoryTestV3, MemoryTestV3,
+        ::testing::Combine(
+                ::testing::Values(ngraph::helpers::MemoryTransformation::NONE),
+                ::testing::ValuesIn(iterationCount),
+                ::testing::ValuesIn(inShapes),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::Values(CommonTestUtils::DEVICE_GPU)),
+        MemoryTest::getTestCaseName);
+
 } // namespace

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
@@ -98,5 +98,7 @@ std::vector<std::string> disabledTestPatterns() {
             R"(.*VirtualPlugin.*BehaviorTests.*OVHoldersTest.*LoadedTensor.*target_device=AUTO.*)",
             // TODO: Issue: 89555
             R"(.*CoreThreadingTests.*smoke.*Network.*)",
+            // Assign-3/ReadValue-3 does not have evaluate() methods; ref implementation does not save the value across the inferences.
+            R"(smoke_MemoryTestV3.*)",
     };
 }

--- a/src/tests/functional/plugin/shared/include/single_layer_tests/memory.h
+++ b/src/tests/functional/plugin/shared/include/single_layer_tests/memory.h
@@ -12,4 +12,8 @@ TEST_P(MemoryTest, CompareWithRefs) {
     Run();
 };
 
+TEST_P(MemoryTestV3, CompareWithRefs) {
+    Run();
+};
+
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/memory.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/memory.hpp
@@ -9,6 +9,9 @@
 #include <tuple>
 #include <vector>
 
+#include "ngraph/opsets/opset6.hpp"
+#include "ngraph/opsets/opset3.hpp"
+
 #include "shared_test_classes/base/layer_test_utils.hpp"
 
 namespace LayerTestsDefinitions {
@@ -25,10 +28,20 @@ class MemoryTest : public testing::WithParamInterface<MemoryTestParams>, virtual
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<MemoryTestParams> &obj);
     void Run() override;
+
 protected:
     std::vector<std::pair<ngraph::element::Type, std::vector<std::uint8_t>>> CalculateRefs() override;
     void SetUp() override;
     void Infer() override;
+    virtual std::shared_ptr<ov::op::util::ReadValueBase> CreateReadValueOp(
+            const ov::Output<ov::Node>& value, const std::shared_ptr<ov::op::util::Variable>& variable) const {
+        return std::make_shared<ngraph::opset6::ReadValue>(value, variable);
+    }
+    virtual std::shared_ptr<ov::op::util::AssignBase> CreateAssignOp(
+            const ov::Output<ov::Node>& value, const std::shared_ptr<ov::op::util::Variable>& variable) const {
+        return std::make_shared<ngraph::opset6::Assign>(value, variable);
+    }
+
 private:
     void CreateTIFunc();
     void CreateCommonFunc();
@@ -41,6 +54,19 @@ private:
     int64_t iteration_count;
     ngraph::element::Type ngPrc;
     InferenceEngine::SizeVector inputShape;
+};
+
+class MemoryTestV3 : public MemoryTest {
+protected:
+    std::shared_ptr<ov::op::util::ReadValueBase> CreateReadValueOp(
+            const ov::Output<ov::Node>& value, const std::shared_ptr<ov::op::util::Variable>& variable) const override {
+        return std::make_shared<ngraph::opset3::ReadValue>(value, variable->get_info().variable_id);
+    }
+
+    std::shared_ptr<ov::op::util::AssignBase> CreateAssignOp(
+            const ov::Output<ov::Node>& value, const std::shared_ptr<ov::op::util::Variable>& variable) const override {
+        return std::make_shared<ngraph::opset3::Assign>(value, variable->get_info().variable_id);
+    }
 };
 
 }  // namespace LayerTestsDefinitions

--- a/src/tests/functional/shared_test_classes/src/single_layer/memory.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/memory.cpp
@@ -186,9 +186,9 @@ namespace LayerTestsDefinitions {
         const auto variable_info = targetDevice == CommonTestUtils::DEVICE_GPU ?
             VariableInfo{Shape{inputShape}, ngPrc, "v0"} : VariableInfo{PartialShape::dynamic(), element::dynamic, "v0"};
         auto variable = std::make_shared<Variable>(variable_info);
-        auto read_value = std::make_shared<ReadValue>(param.at(0), variable);
+        auto read_value = CreateReadValueOp(param.at(0), variable);
         auto add = std::make_shared<Add>(read_value, param.at(0));
-        auto assign = std::make_shared<Assign>(add, variable);
+        auto assign = CreateAssignOp(add, variable);
         auto res = std::make_shared<Result>(add);
         function = std::make_shared<Function>(ResultVector{res}, SinkVector{assign}, param, "TestMemory");
     }


### PR DESCRIPTION
Enable v3 operations for GPU plugin.
Add single-layer tests for v3 operations (disabled until v3 reference implementation is fixed).

