### PR TITLE
[GPU] GPU Plugin functional tests fixes

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/device_config.cpp
+++ b/src/plugins/intel_gpu/src/plugin/device_config.cpp
@@ -73,7 +73,8 @@ void Config::UpdateFromMap(const std::map<std::string, std::string>& configMap) 
             std::stringstream ss(val);
             ss >> inference_precision;
             OPENVINO_ASSERT(inference_precision == ov::element::f16 ||
-                            inference_precision == ov::element::f32,
+                            inference_precision == ov::element::f32 ||
+                            inference_precision == ov::element::undefined,
                             "Unexpected inference precision set: ", inference_precision);
         } else if (key.compare(PluginConfigParams::KEY_PERF_COUNT) == 0 || key == ov::enable_profiling) {
             if (val.compare(PluginConfigParams::YES) == 0) {

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
@@ -100,5 +100,9 @@ std::vector<std::string> disabledTestPatterns() {
             R"(.*CoreThreadingTests.*smoke.*Network.*)",
             // Assign-3/ReadValue-3 does not have evaluate() methods; ref implementation does not save the value across the inferences.
             R"(smoke_MemoryTestV3.*)",
+            // Unsupported 8d tensors
+            R"(smoke_Basic/SqueezeUnsqueezeLayerTest.CompareWithRefs/OpType=Unsqueeze_IS=\(1.1.1.1\)_Axes=\((0.1.2|0.2.3|1.2.3|0.1.2.3|)\)_.*)",
+            // Issue: 90539
+            R"(smoke_AutoBatch_BehaviorTests/OVInferRequestIOTensorTest.InferStaticNetworkSetInputTensor/targetDevice=BATCH.*)",
     };
 }

--- a/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/get_metric.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/get_metric.hpp
@@ -71,7 +71,8 @@ protected:
 
 public:
     void SetUp() override {
-        target_device = CommonTestUtils::DEVICE_HETERO + std::string(":") + GetParam() + std::string(",") + CommonTestUtils::DEVICE_CPU;;
+        target_device = GetParam();
+        heteroDeviceName = CommonTestUtils::DEVICE_HETERO + std::string(":") + target_device + std::string(",") + CommonTestUtils::DEVICE_CPU;;
         SKIP_IF_CURRENT_TEST_IS_DISABLED();
         APIBaseTest::SetUp();
         OVClassNetworkTest::SetUp();
@@ -271,8 +272,8 @@ TEST_P(OVClassHeteroExecutableNetworkGetMetricTest_SUPPORTED_CONFIG_KEYS, GetMet
         ov::Any heteroConfigValue = heteroExeNetwork.get_property(deviceConf);
         ov::Any deviceConfigValue = deviceExeNetwork.get_property(deviceConf);
 
-        // HETERO returns EXCLUSIVE_ASYNC_REQUESTS as a boolean value
-        if (CONFIG_KEY(EXCLUSIVE_ASYNC_REQUESTS) != deviceConf) {
+        if (CONFIG_KEY(EXCLUSIVE_ASYNC_REQUESTS) != deviceConf &&
+            ov::supported_properties.name() != deviceConf) {
             std::stringstream strm;
             deviceConfigValue.print(strm);
             strm << " ";

--- a/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/io_tensor.cpp
@@ -198,7 +198,12 @@ TEST_P(OVInferRequestIOTensorTest, InferStaticNetworkSetInputTensor) {
 
 TEST_P(OVInferRequestIOTensorTest, InferStaticNetworkSetOutputTensor) {
     const ov::Shape shape1 = {1, 1, 32, 32};
-    const ov::Shape shape2 = {1, 20};
+    ov::Shape shape2;
+    if (target_device.find(CommonTestUtils::DEVICE_BATCH) == std::string::npos)
+        shape2 = ov::Shape{1, 20};
+    else
+        shape2 = ov::Shape{1, 4, 20, 20};
+
     std::map<std::string, ov::PartialShape> shapes;
     shapes[function->inputs().back().get_any_name()] = shape1;
     OV_ASSERT_NO_THROW(function->reshape(shapes));


### PR DESCRIPTION
### Details:
 - Skipped SqueezeUnsqueezeLayerTest due to unsupported dimensions size (8D)
 - Skipped OVInferRequestIOTensorTest due to unsupported tensor reshaping (in case of bigger shape) of default allocator in AUTO_BATCH Plugin
 - Fixed InferStaticNetworkSetOutputTensor. nightly_OVClassGetMetricTest,nightly_OVClassHeteroExecutableNetworlGetMetricTest and nightly_OVClassGetMetricTest

### Tickets:
 - *ticket-id*
