### PR TITLE
Added version generation as in CI (#12521)

### DIFF
--- a/cmake/developer_package/version.cmake
+++ b/cmake/developer_package/version.cmake
@@ -33,7 +33,13 @@ macro(ie_parse_ci_build_number)
         set(IE_VERSION_MINOR ${CMAKE_MATCH_2})
         set(IE_VERSION_PATCH ${CMAKE_MATCH_3})
         set(IE_VERSION_BUILD ${CMAKE_MATCH_4})
-        set(ci_build_number_available_parsed ON)
+        set(the_whole_version_is_defined_by_ci ON)
+    elseif(CI_BUILD_NUMBER MATCHES "^[0-9]+$")
+        set(IE_VERSION_BUILD ${CI_BUILD_NUMBER})
+        # only build number is defined by CI
+        set(the_whole_version_is_defined_by_ci OFF)
+    elseif(CI_BUILD_NUMBER)
+        message(FATAL_ERROR "Failed to parse CI_BUILD_NUMBER which is ${CI_BUILD_NUMBER}")
     endif()
 
     if(NOT DEFINED repo_root)
@@ -94,7 +100,7 @@ macro(ie_parse_ci_build_number)
     set(IE_VERSION "${IE_VERSION_MAJOR}.${IE_VERSION_MINOR}.${IE_VERSION_PATCH}")
     message(STATUS "OpenVINO version is ${IE_VERSION} (Build ${IE_VERSION_BUILD})")
 
-    if(NOT ci_build_number_available_parsed)
+    if(NOT the_whole_version_is_defined_by_ci)
         # create CI_BUILD_NUMBER
 
         branchName(GIT_BRANCH)
@@ -110,13 +116,13 @@ macro(ie_parse_ci_build_number)
         unset(GIT_BRANCH)
         unset(GIT_COMMIT_HASH)
     else()
-        unset(ci_build_number_available_parsed)
+        unset(the_whole_version_is_defined_by_ci)
     endif()
 endmacro()
 
 # provides Inference Engine version
 # 1. If CI_BUILD_NUMBER is defined, parses this information
-# 2. Otherwise, parses openvino/core/version.hpp, 
+# 2. Otherwise, parses openvino/core/version.hpp
 if (DEFINED ENV{CI_BUILD_NUMBER})
     set(CI_BUILD_NUMBER $ENV{CI_BUILD_NUMBER})
 endif()


### PR DESCRIPTION
### Details:
 - Port of https://github.com/openvinotoolkit/openvino/pull/12521
 - Additionally `CI_BUILD_NUMBER` can really specify just a build number as integer, so it will be used as `IE_VERSION_BUILD`

### Tickets:
 - EISW-41342
