### PR TITLE
[TF FE] Add Transpose Sinking for Prelu operation

### DIFF
--- a/src/frontends/tensorflow/src/pass/transpose_sinking.cpp
+++ b/src/frontends/tensorflow/src/pass/transpose_sinking.cpp
@@ -348,6 +348,18 @@ static void sink_concat(const shared_ptr<Concat>& n,
     write_transposemap(reorders, new_concat, new_transpose);
 }
 
+static void sink_prelu(const shared_ptr<PRelu>& prelu, TransposeMap& reorders) {
+    FRONT_END_GENERAL_CHECK(prelu, "Null pointer is given to PRelu node.");
+    FRONT_END_GENERAL_CHECK(prelu->get_input_size() > 1, "The PRelu node must contain at least two inputs.");
+    auto slope_shape = prelu->input_value(1).get_partial_shape();
+    if (slope_shape.is_static() && shape_size(slope_shape.to_shape()) == 1) {
+        // handle a case covering LeakyRelu decomposition
+        auto arg_transpose = read_transposemap(reorders, prelu->input_value(0));
+        write_transposemap(reorders, prelu, arg_transpose);
+    }
+    // TODO: handle other cases with non-scalar slope
+}
+
 // The goal of TransposeSinking is to remove
 // round-trip transposes(i.e. nhwc->nchw(nchw-only-op)->nhwc)
 // around nchw-only-op (e.g.Convolution, Batchnorm, Avg/MaxPool)
@@ -383,6 +395,8 @@ bool ov::frontend::tensorflow::pass::TransposeSinking::run_on_model(const shared
                 sink_pad(pad, reorders, transposes_to_delete);
             } else if (auto concat = as_type_ptr<Concat>(n)) {
                 sink_concat(concat, reorders, transposes_to_delete);
+            } else if (auto prelu = as_type_ptr<PRelu>(n)) {
+                sink_prelu(prelu, reorders);
             } else {
                 materialize_shapes(n, reorders, transposes_to_delete);
             }

--- a/src/frontends/tensorflow/src/pass/transpose_sinking.cpp
+++ b/src/frontends/tensorflow/src/pass/transpose_sinking.cpp
@@ -348,16 +348,21 @@ static void sink_concat(const shared_ptr<Concat>& n,
     write_transposemap(reorders, new_concat, new_transpose);
 }
 
-static void sink_prelu(const shared_ptr<PRelu>& prelu, TransposeMap& reorders) {
+static void sink_prelu(const shared_ptr<PRelu>& prelu,
+                       TransposeMap& reorders,
+                       set<shared_ptr<Node>>& transposes_to_delete) {
     FRONT_END_GENERAL_CHECK(prelu, "Null pointer is given to PRelu node.");
     FRONT_END_GENERAL_CHECK(prelu->get_input_size() > 1, "The PRelu node must contain at least two inputs.");
     auto slope_shape = prelu->input_value(1).get_partial_shape();
     if (slope_shape.is_static() && shape_size(slope_shape.to_shape()) == 1) {
         // handle a case covering LeakyRelu decomposition
         auto arg_transpose = read_transposemap(reorders, prelu->input_value(0));
+        OPENVINO_DEBUG << "Propagating " << describe<Transpose>(arg_transpose) << " for " << prelu->get_name();
         write_transposemap(reorders, prelu, arg_transpose);
+    } else {
+        // TODO: handle other cases with non-scalar slope
+        materialize_shapes(prelu, reorders, transposes_to_delete);
     }
-    // TODO: handle other cases with non-scalar slope
 }
 
 // The goal of TransposeSinking is to remove
@@ -396,7 +401,7 @@ bool ov::frontend::tensorflow::pass::TransposeSinking::run_on_model(const shared
             } else if (auto concat = as_type_ptr<Concat>(n)) {
                 sink_concat(concat, reorders, transposes_to_delete);
             } else if (auto prelu = as_type_ptr<PRelu>(n)) {
-                sink_prelu(prelu, reorders);
+                sink_prelu(prelu, reorders, transposes_to_delete);
             } else {
                 materialize_shapes(n, reorders, transposes_to_delete);
             }


### PR DESCRIPTION
**Details:** Prelu operation is not simple unary operation so it requires a separate pass with handling different cases: a scalar slope, 1D slope, ND slope, etc. Now it covers a case with a scalar slope that is sufficient to quickly enable OVTF model.

**Ticket:** 90409

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
