### PR TITLE
Mo indices fix

### DIFF
--- a/tools/mo/openvino/tools/mo/front/tf/loader.py
+++ b/tools/mo/openvino/tools/mo/front/tf/loader.py
@@ -238,7 +238,6 @@ def load_tf_graph_def(graph_file_name: str = "", is_binary: bool = True, checkpo
                     # tf.keras.models.load_model function throws TypeError,KeyError or IndexError
                     # for TF 1.x SavedModel format in case TF 1.x installed
                     imported = tf.keras.models.load_model(model_dir, compile=False)
-
                 except:
                     imported = tf.saved_model.load(model_dir, saved_model_tags)  # pylint: disable=E1120
 

--- a/tools/mo/openvino/tools/mo/front/tf/loader.py
+++ b/tools/mo/openvino/tools/mo/front/tf/loader.py
@@ -238,6 +238,8 @@ def load_tf_graph_def(graph_file_name: str = "", is_binary: bool = True, checkpo
                     # tf.keras.models.load_model function throws TypeError,KeyError or IndexError
                     # for TF 1.x SavedModel format in case TF 1.x installed
                     imported = tf.keras.models.load_model(model_dir, compile=False)
+
+                    print('ok')
                 except:
                     imported = tf.saved_model.load(model_dir, saved_model_tags)  # pylint: disable=E1120
 
@@ -257,7 +259,7 @@ def load_tf_graph_def(graph_file_name: str = "", is_binary: bool = True, checkpo
                 tf_v1.disable_eager_execution()
 
                 input_names = []
-                if hasattr(imported, 'inputs'):
+                if hasattr(imported, 'inputs') and imported.inputs is not None:
                     # Extract tensor names order from Keras model
                     input_names = [tensor.name for tensor in imported.inputs]
 

--- a/tools/mo/openvino/tools/mo/front/tf/loader.py
+++ b/tools/mo/openvino/tools/mo/front/tf/loader.py
@@ -239,7 +239,6 @@ def load_tf_graph_def(graph_file_name: str = "", is_binary: bool = True, checkpo
                     # for TF 1.x SavedModel format in case TF 1.x installed
                     imported = tf.keras.models.load_model(model_dir, compile=False)
 
-                    print('ok')
                 except:
                     imported = tf.saved_model.load(model_dir, saved_model_tags)  # pylint: disable=E1120
 


### PR DESCRIPTION
Root cause analysis: 
In model BiT-M-R50x1 'inputs' field is not set which caused failing of input indices determining and failing of TF2 import. So MO tried to import model as TF1 model and it failed.

Solution: Add check that 'inputs' is not None.

Ticket: 90495


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update
