### PR TITLE
Fixed error in indices processing.

### DIFF
--- a/tools/mo/openvino/tools/mo/front/tf/loader.py
+++ b/tools/mo/openvino/tools/mo/front/tf/loader.py
@@ -255,7 +255,7 @@ def load_tf_graph_def(graph_file_name: str = "", is_binary: bool = True, checkpo
                 tf_v1.disable_eager_execution()
 
                 input_names = []
-                if hasattr(imported, 'inputs'):
+                if hasattr(imported, 'inputs') and imported.inputs is not None:
                     # Extract tensor names order from Keras model
                     input_names = [tensor.name for tensor in imported.inputs]
 


### PR DESCRIPTION
Root cause analysis: 
In model BiT-M-R50x1 'inputs' field is not set which caused failing of input indices determining and failing of TF2 import. So MO tries to import model as TF1 model and in this case model is not frozen properly.

Solution: Add check that 'inputs' is not None.

Ticket: 90495


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update
