### PR TITLE
[CPU] The registers pool implementation for JIT kernels.

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/kernels/registers_pool.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/registers_pool.hpp
@@ -55,6 +55,7 @@ public:
         Reg(const RegistersPool::Ptr& regPool, int requestedIdx) { initialize(regPool, requestedIdx); }
         ~Reg() { release(); }
         Reg& operator=(Reg&& other)  noexcept {
+            release();
             reg = other.reg;
             regPool = std::move(other.regPool);
             return *this;

--- a/src/plugins/intel_cpu/src/nodes/kernels/registers_pool.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/registers_pool.hpp
@@ -1,0 +1,260 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "cpu/x64/jit_generator.hpp"
+#include <dnnl_types.h>
+#include "ie_common.h"
+#include <utility>
+
+namespace ov {
+namespace intel_cpu {
+
+using namespace dnnl::impl::cpu;
+
+/**
+ * The RegistersPool is the base class for the IsaRegistersPool template:
+ *      template <x64::cpu_isa_t isa>
+ *      class IsaRegistersPool : public RegistersPool;
+ *
+ * The registers pool must be created by instantiating the IsaRegistersPool template, like the next:
+ *      RegistersPool::Ptr regPool = RegistersPool::create<isa>({
+ *          // the list of the registers to be excluded from pool
+ *          Reg64(Operand::RAX), Reg64(Operand::RCX), Reg64(Operand::RDX), Reg64(Operand::RBX),
+ *          Reg64(Operand::RSP), Reg64(Operand::RBP), Reg64(Operand::RSI), Reg64(Operand::RDI)
+ *      });
+ */
+class RegistersPool {
+public:
+    using Ptr = std::shared_ptr<RegistersPool>;
+
+    /**
+     * The scoped wrapper for the Xbyak registers.
+     * By creating it you are getting the register from the pool RegistersPool.
+     * It could be created by using constructor with RegistersPool as an argument, like the next:
+     *      const RegistersPool::Reg<Xbyak::Reg64> reg {regPool};
+     * The destructor will return the register to the pool. Or it could be returned manually:
+     *      reg.returnToPool();
+     * @tparam TReg Xbyak register class
+     */
+    template<typename TReg>
+    class Reg {
+        friend class RegistersPool;
+    public:
+        Reg(const RegistersPool::Ptr& regPool);
+        ~Reg() { returnToPool(); }
+        Reg& operator=(Reg&& other)  noexcept {
+            reg = other.reg;
+            regPool = std::move(other.regPool);
+            return *this;
+        }
+        Reg(Reg&& other)  noexcept : reg(other.reg), regPool(std::move(other.regPool)) {}
+        operator TReg&() { ensureValid(); return reg; }
+        operator const TReg&() const { ensureValid(); return reg; }
+        operator Xbyak::RegExp() const { ensureValid(); return reg; }
+        int getIdx() const { ensureValid(); return reg.getIdx(); }
+        friend Xbyak::RegExp operator+(const Reg& lhs, const Xbyak::RegExp& rhs) {
+            lhs.ensureValid();
+            return lhs.operator Xbyak::RegExp() + rhs;
+        }
+        void returnToPool() {
+            if (regPool) {
+                regPool->returnToPool(reg);
+            }
+            regPool.reset();
+        }
+
+    private:
+        void ensureValid() const {
+            if (!regPool) {
+                IE_THROW() << "Invalid instance of RegistersPool::Reg was used";
+            }
+        }
+
+    private:
+        TReg reg;
+        RegistersPool::Ptr regPool;
+    };
+
+    virtual ~RegistersPool() {
+        checkUniqueAndUpdate(false);
+    }
+
+    template <x64::cpu_isa_t isa>
+    static Ptr create(std::initializer_list<Xbyak::Reg> regsToExclude);
+
+    template<typename TReg>
+    size_t countFree() const {
+        if (std::is_same<TReg, Xbyak::Xmm>::value || std::is_same<TReg, Xbyak::Ymm>::value || std::is_same<TReg, Xbyak::Zmm>::value) {
+            return simdSet.countUnused();
+        } else if (std::is_same<TReg, Xbyak::Reg64>::value || std::is_same<TReg, Xbyak::Reg32>::value) {
+            return generalSet.countUnused();
+        } else if (std::is_same<TReg, Xbyak::Opmask>::value) {
+            return countUnusedOpmask();
+        }
+    }
+
+protected:
+    class PhysicalSet {
+    public:
+        PhysicalSet(int size)
+                : size(size) {
+            for (int i = 0; i < size; ++i) {
+                unusedIndexes.emplace(i);
+            }
+        }
+
+        void setAsUsed(int regIdx) {
+            assert(regIdx < size && regIdx >= 0);
+            auto it = unusedIndexes.find(regIdx);
+            if (it == unusedIndexes.end()) {
+                IE_THROW() << "Inconsistency in RegistersPool::PhysicalSet::setAsUsed()";
+            }
+            unusedIndexes.erase(it);
+        }
+
+        void setAsUnused(int regIdx) {
+            assert(regIdx < size && regIdx >= 0);
+            unusedIndexes.insert(regIdx);
+        }
+
+        int getUnused() {
+            if (unusedIndexes.empty()) {
+                IE_THROW() << "Not enough registers in the RegistersPool";
+            }
+            return *unusedIndexes.begin();
+        }
+
+        void exclude(Xbyak::Reg reg) {
+            unusedIndexes.erase(reg.getIdx());
+        }
+
+        size_t countUnused() const {
+            return unusedIndexes.size();
+        }
+
+    private:
+        std::unordered_set<int> unusedIndexes;
+        int size;
+    };
+
+    virtual int getFreeOpmask() { IE_THROW() << "getFreeOpmask: The Opmask is not supported in current instruction set"; }
+    virtual void returnOpmaskToPool(int idx) { IE_THROW() << "returnOpmaskToPool: The Opmask is not supported in current instruction set"; }
+    virtual size_t countUnusedOpmask() const { IE_THROW() << "countUnusedOpmask: The Opmask is not supported in current instruction set"; }
+
+    virtual void excludeOpmask(const Xbyak::Opmask& reg) {
+    }
+
+    RegistersPool(std::initializer_list<Xbyak::Reg> regsToExclude, int simdRegistersNumber)
+            : simdSet(simdRegistersNumber) {
+        checkUniqueAndUpdate();
+        for (auto& reg : regsToExclude) {
+            if (reg.isXMM() || reg.isYMM() || reg.isZMM()) {
+                simdSet.exclude(reg);
+            } else if (reg.isOPMASK()) {
+                excludeOpmask(Xbyak::Opmask{reg.getIdx()});
+            } else if (reg.isREG()) {
+                generalSet.exclude(reg);
+            }
+        }
+        generalSet.exclude(Xbyak::Reg64(Xbyak::Operand::RSP));
+    }
+
+private:
+    template<typename TReg>
+    int getFree() {
+        static_assert(std::is_same<TReg, Xbyak::Xmm>::value || std::is_same<TReg, Xbyak::Ymm>::value || std::is_same<TReg, Xbyak::Zmm>::value ||
+                      std::is_same<TReg, Xbyak::Reg64>::value || std::is_same<TReg, Xbyak::Reg32>::value || std::is_same<TReg, Xbyak::Opmask>::value,
+                      "The AvxRegistersGuardPool::getFree() method unsupported type");
+        if (std::is_same<TReg, Xbyak::Xmm>::value || std::is_same<TReg, Xbyak::Ymm>::value || std::is_same<TReg, Xbyak::Zmm>::value) {
+            auto idx = simdSet.getUnused();
+            simdSet.setAsUsed(idx);
+            return idx;
+        } else if (std::is_same<TReg, Xbyak::Reg64>::value || std::is_same<TReg, Xbyak::Reg32>::value) {
+            auto idx = generalSet.getUnused();
+            generalSet.setAsUsed(idx);
+            return idx;
+        } else if (std::is_same<TReg, Xbyak::Opmask>::value) {
+            return getFreeOpmask();
+        }
+    }
+
+    template<typename TReg>
+    void returnToPool(TReg reg) {
+        if (std::is_same<TReg, Xbyak::Xmm>::value || std::is_same<TReg, Xbyak::Ymm>::value || std::is_same<TReg, Xbyak::Zmm>::value) {
+            simdSet.setAsUnused(reg.getIdx());
+        } else if (std::is_same<TReg, Xbyak::Reg64>::value || std::is_same<TReg, Xbyak::Reg32>::value) {
+            generalSet.setAsUnused(reg.getIdx());
+        } else if (std::is_same<TReg, Xbyak::Opmask>::value) {
+            returnOpmaskToPool(reg.getIdx());
+        }
+    }
+
+    void checkUniqueAndUpdate(bool isCtor = true) {
+        static thread_local bool isCreated = false;
+        if (isCtor) {
+            if (isCreated) {
+                IE_THROW() << "There should be only one instance of RegistersPool per thread";
+            }
+            isCreated = true;
+        } else {
+            isCreated = false;
+        }
+    }
+
+    PhysicalSet generalSet {16};
+    PhysicalSet simdSet;
+};
+
+template<typename TReg>
+RegistersPool::Reg<TReg>::Reg(const RegistersPool::Ptr& regPool) {
+    static_assert(std::is_same<TReg, Xbyak::Xmm>::value || std::is_same<TReg, Xbyak::Ymm>::value || std::is_same<TReg, Xbyak::Zmm>::value ||
+                  std::is_same<TReg, Xbyak::Reg64>::value || std::is_same<TReg, Xbyak::Reg32>::value || std::is_same<TReg, Xbyak::Opmask>::value,
+                  "The type is not supported for the RegistersPool::Reg template");
+    reg = TReg(regPool->template getFree<TReg>());
+    this->regPool = regPool;
+}
+
+template <x64::cpu_isa_t isa>
+class IsaRegistersPool : public RegistersPool {
+public:
+    IsaRegistersPool(std::initializer_list<Xbyak::Reg> regsToExclude) : RegistersPool(regsToExclude, x64::cpu_isa_traits<isa>::n_vregs) {}
+};
+
+template <>
+class IsaRegistersPool<x64::avx512_core> : public RegistersPool {
+public:
+    IsaRegistersPool(std::initializer_list<Xbyak::Reg> regsToExclude)
+            : RegistersPool(regsToExclude, x64::cpu_isa_traits<x64::avx512_core>::n_vregs) {}
+
+    int getFreeOpmask() override {
+        auto idx = opmaskSet.getUnused();
+        opmaskSet.setAsUsed(idx);
+        return idx;
+    }
+
+    void returnOpmaskToPool(int idx) override {
+        opmaskSet.setAsUnused(idx);
+    }
+
+    void excludeOpmask(const Xbyak::Opmask& reg) override {
+        opmaskSet.exclude(reg);
+    }
+
+    size_t countUnusedOpmask() const override {
+        return opmaskSet.countUnused();
+    }
+
+protected:
+    PhysicalSet opmaskSet {8};
+};
+
+template <x64::cpu_isa_t isa>
+RegistersPool::Ptr RegistersPool::create(std::initializer_list<Xbyak::Reg> regsToExclude) {
+    return std::make_shared<IsaRegistersPool<isa>>(regsToExclude);
+}
+
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/kernels/registers_pool.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/registers_pool.hpp
@@ -328,6 +328,18 @@ RegistersPool::Ptr RegistersPool::create(x64::cpu_isa_t isa, std::initializer_li
         ISA_SWITCH_CASE(x64::avx512_core)
         ISA_SWITCH_CASE(x64::avx512_core_vnni)
         ISA_SWITCH_CASE(x64::avx512_core_bf16)
+        case x64::avx_vnni: return std::make_shared<IsaRegistersPool<x64::avx>>(regsToExclude);
+        case x64::avx512_core_bf16_ymm: return std::make_shared<IsaRegistersPool<x64::avx512_core>>(regsToExclude);
+        case x64::avx512_core_bf16_amx_int8: return std::make_shared<IsaRegistersPool<x64::avx512_core>>(regsToExclude);
+        case x64::avx512_core_bf16_amx_bf16: return std::make_shared<IsaRegistersPool<x64::avx512_core>>(regsToExclude);
+        case x64::avx512_core_amx: return std::make_shared<IsaRegistersPool<x64::avx512_core>>(regsToExclude);
+        case x64::avx512_vpopcnt: return std::make_shared<IsaRegistersPool<x64::avx512_core>>(regsToExclude);
+        case x64::isa_any:
+        case x64::amx_tile:
+        case x64::amx_int8:
+        case x64::amx_bf16:
+        case x64::isa_all:
+            IE_THROW() << "Invalid isa argument in RegistersPool::create()";
     }
     IE_THROW() << "Invalid isa argument in RegistersPool::create()";
 #undef ISA_SWITCH_CASE

--- a/src/plugins/intel_cpu/src/utils/cpu_utils.hpp
+++ b/src/plugins/intel_cpu/src/utils/cpu_utils.hpp
@@ -10,9 +10,22 @@
 
 #include "ie_common.h"
 #include "ie_layouts.h"
+#include "general_utils.h"
 
 namespace ov {
 namespace intel_cpu {
+
+// helper struct to tell wheter type T is any of given types U...
+// termination case when U... is empty -> return std::false_type
+template <class T, class... U>
+struct is_any_of : public std::false_type {};
+
+// helper struct to tell whether type is any of given types (U, Rest...)
+// recurrence case when at least one type U is present -> returns std::true_type if std::same<T, U>::value is true,
+// otherwise call is_any_of<T, Rest...> recurrently
+template <class T, class U, class... Rest>
+struct is_any_of<T, U, Rest...>
+        : public std::conditional<std::is_same<T, U>::value, std::true_type, is_any_of<T, Rest...>>::type {};
 
 /**
 * @brief Returns normalized by size dims where missing dimensions are filled with units from the beginning

--- a/src/plugins/intel_cpu/tests/unit/registers_pool.cpp
+++ b/src/plugins/intel_cpu/tests/unit/registers_pool.cpp
@@ -80,7 +80,12 @@ TYPED_TEST_P(RegPoolTest, move) {
     RegistersPool::Reg<XbyakRegT> reg{regPool};
     ASSERT_NO_THROW(static_cast<XbyakRegT &>(reg));
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
-    RegistersPool::Reg<XbyakRegT> reg2 = std::move(reg);
+    RegistersPool::Reg<XbyakRegT> reg2{regPool};
+    ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 2);
+    auto regIdx = reg.getIdx();
+    reg2 = std::move(reg);
+    ASSERT_EQ(reg2.getIdx(), regIdx);
+    ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
     ASSERT_ANY_THROW(static_cast<XbyakRegT &>(reg));
     ASSERT_NO_THROW(static_cast<XbyakRegT &>(reg2));
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);

--- a/src/plugins/intel_cpu/tests/unit/registers_pool.cpp
+++ b/src/plugins/intel_cpu/tests/unit/registers_pool.cpp
@@ -6,11 +6,196 @@
 #include "nodes/kernels/registers_pool.hpp"
 
 using namespace ov::intel_cpu;
+
+template <class T>
+class RegPoolTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (typename T::RegT(0).isREG()) { // for general purpose registers Reg8, Reg16, Reg32, Reg64
+            regNumber = 15; // the RSP register excluded by default
+        } else if (typename T::RegT(0).isOPMASK()) {
+            regNumber = 8;
+        } else { // SIMD registers
+            regNumber = x64::cpu_isa_traits<T::IsaParam::isa>::n_vregs;
+        }
+    }
+
+    int regNumber;
+};
+
+TYPED_TEST_SUITE_P(RegPoolTest);
+
+TYPED_TEST_P(RegPoolTest, get_return_by_scope) {
+    using XbyakRegT = typename TypeParam::RegT;
+    RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({});
+    ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
+    {
+        RegistersPool::Reg<XbyakRegT> reg{regPool};
+        ASSERT_NO_THROW(static_cast<XbyakRegT &>(reg));
+        ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
+    }
+    ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
+}
+
+TYPED_TEST_P(RegPoolTest, get_return_by_method) {
+    using XbyakRegT = typename TypeParam::RegT;
+    RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({});
+    ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
+    RegistersPool::Reg<XbyakRegT> reg{regPool};
+    ASSERT_NO_THROW(static_cast<XbyakRegT &>(reg));
+    ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
+    reg.release();
+    ASSERT_ANY_THROW(static_cast<XbyakRegT &>(reg));
+    ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
+    reg = RegistersPool::Reg<XbyakRegT>{regPool};
+    ASSERT_NO_THROW(static_cast<XbyakRegT &>(reg));
+    ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
+}
+
+TYPED_TEST_P(RegPoolTest, default_ctor) {
+    using XbyakRegT = typename TypeParam::RegT;
+    RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({});
+    RegistersPool::Reg<XbyakRegT> reg;
+    ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
+    ASSERT_ANY_THROW(static_cast<XbyakRegT &>(reg));
+}
+
+TYPED_TEST_P(RegPoolTest, get_all) {
+    using XbyakRegT = typename TypeParam::RegT;
+    RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({});
+    using Ptr = std::shared_ptr<RegistersPool::Reg<XbyakRegT>>;
+    std::vector<Ptr> regs(this->regNumber);
+    for (int c = 0; c < this->regNumber; ++c) {
+        regs[c] = std::make_shared<RegistersPool::Reg<XbyakRegT>>(regPool);
+    }
+    ASSERT_EQ(regPool->countFree<XbyakRegT>(), 0);
+    ASSERT_ANY_THROW(RegistersPool::Reg<XbyakRegT>{regPool});
+    regs.clear();
+    ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
+}
+
+TYPED_TEST_P(RegPoolTest, move) {
+    using XbyakRegT = typename TypeParam::RegT;
+    RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({});
+    RegistersPool::Reg<XbyakRegT> reg{regPool};
+    ASSERT_NO_THROW(static_cast<XbyakRegT &>(reg));
+    ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
+    RegistersPool::Reg<XbyakRegT> reg2 = std::move(reg);
+    ASSERT_ANY_THROW(static_cast<XbyakRegT &>(reg));
+    ASSERT_NO_THROW(static_cast<XbyakRegT &>(reg2));
+    ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
+}
+
+
+TYPED_TEST_P(RegPoolTest, fixed_idx) {
+    using XbyakRegT = typename TypeParam::RegT;
+    RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({});
+    using Ptr = std::shared_ptr<RegistersPool::Reg<XbyakRegT>>;
+    std::vector<Ptr> regs(this->regNumber);
+    for (int c = 0; c < this->regNumber; ++c) {
+        if (c == Xbyak::Operand::RSP) continue;
+        regs[c] = std::make_shared<RegistersPool::Reg<XbyakRegT>>(regPool, c);
+        ASSERT_EQ(regs[c]->getIdx(), c);
+    }
+    regs[0]->release();
+    ASSERT_ANY_THROW(RegistersPool::Reg<XbyakRegT>(regPool, 1));
+    ASSERT_NO_THROW(RegistersPool::Reg<XbyakRegT>(regPool, 0));
+}
+
+TYPED_TEST_P(RegPoolTest, exclude) {
+    using XbyakRegT = typename TypeParam::RegT;
+    static constexpr int excludedIdx = 0;
+    RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({
+                                                                                         XbyakRegT(excludedIdx)
+                                                                                 });
+    using Ptr = std::shared_ptr<RegistersPool::Reg<XbyakRegT>>;
+    std::vector<Ptr> regs(this->regNumber - 1);
+    std::set<int> idxsInUse;
+    for (int c = 0; c < this->regNumber - 1; ++c) {
+        regs[c] = std::make_shared<RegistersPool::Reg<XbyakRegT>>(regPool);
+        idxsInUse.emplace(regs[c]->getIdx());
+    }
+    ASSERT_EQ(regPool->countFree<XbyakRegT>(), 0);
+    ASSERT_TRUE(idxsInUse.find(excludedIdx) == idxsInUse.end());
+}
+
+namespace combiner {
+
+template<class Reg, class Isa>
+struct Case {
+    using RegT = Reg;
+    using IsaParam = Isa;
+};
+
+template<class TupleType, class TupleParam, std::size_t I>
+struct make_case {
+    static constexpr std::size_t N = std::tuple_size<TupleParam>::value;
+
+    using type = Case<typename std::tuple_element<I / N, TupleType>::type,
+            typename std::tuple_element<I % N, TupleParam>::type>;
+};
+
+template<class T1, class T2, class Is>
+struct make_combinations;
+
+template<class TupleType, class TupleParam, std::size_t... Is>
+struct make_combinations<TupleType, TupleParam, tbb::internal::index_sequence<Is...>> {
+    using tuples = std::tuple<typename make_case<TupleType, TupleParam, Is>::type...>;
+};
+
+template<class TupleTypes, class... Params>
+using Combinations_t = typename make_combinations
+        <TupleTypes,
+                std::tuple<Params...>,
+                tbb::internal::make_index_sequence<(std::tuple_size<TupleTypes>::value) *(sizeof...(Params))>>::tuples;
+
+template<class T>
+struct TestTypesCombiner;
+
+template<class ...T>
+struct TestTypesCombiner<std::tuple<T...>> {
+    using Types = ::testing::Types<T...>;
+};
+
+} // namespace combiner
+
+template<x64::cpu_isa_t Isa>
+struct IsaParam { static constexpr x64::cpu_isa_t isa = Isa; };
+
+using TestTypes = combiner::TestTypesCombiner<combiner::Combinations_t<
+        std::tuple<
+                Xbyak::Reg8, Xbyak::Reg16, Xbyak::Reg32, Xbyak::Reg64, Xbyak::Xmm, Xbyak::Ymm, Xbyak::Zmm
+        >,
+        IsaParam<x64::sse41>,
+        IsaParam<x64::avx>,
+        IsaParam<x64::avx2>,
+        IsaParam<x64::avx2_vnni> >>::Types;
+
+using TestTypesAvx512 = combiner::TestTypesCombiner<combiner::Combinations_t<
+        std::tuple<
+                Xbyak::Reg8, Xbyak::Reg16, Xbyak::Reg32, Xbyak::Reg64, Xbyak::Xmm, Xbyak::Ymm, Xbyak::Zmm, Xbyak::Opmask
+        >,
+        IsaParam<x64::avx512_core>,
+        IsaParam<x64::avx512_core_vnni>,
+        IsaParam<x64::avx512_core_bf16> >>::Types;
+
+REGISTER_TYPED_TEST_SUITE_P(RegPoolTest,
+                            get_return_by_scope,
+                            get_return_by_method,
+                            default_ctor,
+                            get_all,
+                            move,
+                            fixed_idx,
+                            exclude);
+
+INSTANTIATE_TYPED_TEST_SUITE_P(testIsaAndRegTypes, RegPoolTest, TestTypes);
+INSTANTIATE_TYPED_TEST_SUITE_P(testIsaAndRegTypesAvx512, RegPoolTest, TestTypesAvx512);
+
+
 const int simdRegNumber = x64::cpu_isa_traits<x64::avx2>::n_vregs;
 const int freeGeneralRegNumber = 15;
 
-TEST(RegistersPoolTests, get_return_by_scope) {
-    if (!x64::mayiuse(x64::avx2)) { return; }
+TEST(RegistersPoolTests, simd_and_general) {
     RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({});
     ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber);
     ASSERT_EQ(regPool->countFree<Xbyak::Reg64>(), freeGeneralRegNumber);
@@ -22,39 +207,15 @@ TEST(RegistersPoolTests, get_return_by_scope) {
         ASSERT_EQ(regPool->countFree<Xbyak::Reg64>(), freeGeneralRegNumber);
     }
     ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber);
-}
-
-TEST(RegistersPoolTests, get_return_by_method) {
-    if (!x64::mayiuse(x64::avx2)) { return; }
-    RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({});
-    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber);
-    RegistersPool::Reg<Xbyak::Xmm> reg{regPool};
-    ASSERT_NO_THROW(static_cast<Xbyak::Xmm &>(reg));
-    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber - 1);
-    reg.release();
-    ASSERT_ANY_THROW(static_cast<Xbyak::Xmm &>(reg));
-    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber);
-    reg = RegistersPool::Reg<Xbyak::Xmm>{regPool};
-    ASSERT_NO_THROW(static_cast<Xbyak::Xmm &>(reg));
-    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber - 1);
+    ASSERT_EQ(regPool->countFree<Xbyak::Reg64>(), freeGeneralRegNumber);
 }
 
 TEST(RegistersPoolTests, second_pool_exception) {
-    if (!x64::mayiuse(x64::avx2)) { return; }
     RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({});
     ASSERT_ANY_THROW(RegistersPool::create<x64::avx2>({}));
 }
 
-TEST(RegistersPoolTests, default_ctor) {
-    if (!x64::mayiuse(x64::avx2)) { return; }
-    RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({});
-    RegistersPool::Reg<Xbyak::Xmm> reg;
-    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber);
-    ASSERT_ANY_THROW(static_cast<Xbyak::Xmm &>(reg));
-}
-
 TEST(RegistersPoolTests, get_all) {
-    if (!x64::mayiuse(x64::avx2)) { return; }
     RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({});
     using Ptr = std::shared_ptr<RegistersPool::Reg<Xbyak::Xmm>>;
     std::vector<Ptr> regs(simdRegNumber);
@@ -73,46 +234,3 @@ TEST(RegistersPoolTests, get_all) {
     ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber);
 }
 
-TEST(RegistersPoolTests, move) {
-    if (!x64::mayiuse(x64::avx2)) { return; }
-    RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({});
-    RegistersPool::Reg<Xbyak::Xmm> reg{regPool};
-    ASSERT_NO_THROW(static_cast<Xbyak::Xmm &>(reg));
-    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber - 1);
-    RegistersPool::Reg<Xbyak::Xmm> reg2 = std::move(reg);
-    ASSERT_ANY_THROW(static_cast<Xbyak::Xmm &>(reg));
-    ASSERT_NO_THROW(static_cast<Xbyak::Xmm &>(reg2));
-    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber - 1);
-}
-
-
-TEST(RegistersPoolTests, fixed_idx) {
-    if (!x64::mayiuse(x64::avx2)) { return; }
-    RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({});
-    using Ptr = std::shared_ptr<RegistersPool::Reg<Xbyak::Xmm>>;
-    std::vector<Ptr> regs(simdRegNumber);
-    for (int c = 0; c < simdRegNumber; ++c) {
-        regs[c] = std::make_shared<RegistersPool::Reg<Xbyak::Xmm>>(regPool, c);
-        ASSERT_EQ(regs[c]->getIdx(), c);
-    }
-    regs[0]->release();
-    ASSERT_ANY_THROW(RegistersPool::Reg<Xbyak::Xmm>(regPool, 1));
-    ASSERT_NO_THROW(RegistersPool::Reg<Xbyak::Xmm>(regPool, 0));
-}
-
-TEST(RegistersPoolTests, exclude) {
-    if (!x64::mayiuse(x64::avx2)) { return; }
-    static constexpr int excludedIdx = 0;
-    RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({
-        Xbyak::Xmm(excludedIdx)
-    });
-    using Ptr = std::shared_ptr<RegistersPool::Reg<Xbyak::Xmm>>;
-    std::vector<Ptr> regs(simdRegNumber - 1);
-    std::set<int> idxsInUse;
-    for (int c = 0; c < simdRegNumber - 1; ++c) {
-        regs[c] = std::make_shared<RegistersPool::Reg<Xbyak::Xmm>>(regPool);
-        idxsInUse.emplace(regs[c]->getIdx());
-    }
-    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), 0);
-    ASSERT_TRUE(idxsInUse.find(excludedIdx) == idxsInUse.end());
-}

--- a/src/plugins/intel_cpu/tests/unit/registers_pool.cpp
+++ b/src/plugins/intel_cpu/tests/unit/registers_pool.cpp
@@ -1,0 +1,118 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+#include "nodes/kernels/registers_pool.hpp"
+
+using namespace ov::intel_cpu;
+const int simdRegNumber = x64::cpu_isa_traits<x64::avx2>::n_vregs;
+const int freeGeneralRegNumber = 15;
+
+TEST(RegistersPoolTests, get_return_by_scope) {
+    if (!x64::mayiuse(x64::avx2)) { return; }
+    RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({});
+    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber);
+    ASSERT_EQ(regPool->countFree<Xbyak::Reg64>(), freeGeneralRegNumber);
+    {
+        RegistersPool::Reg<Xbyak::Xmm> reg{regPool};
+        ASSERT_NO_THROW(static_cast<Xbyak::Xmm &>(reg));
+        ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber - 1);
+        ASSERT_EQ(regPool->countFree<Xbyak::Ymm>(), simdRegNumber - 1);
+        ASSERT_EQ(regPool->countFree<Xbyak::Reg64>(), freeGeneralRegNumber);
+    }
+    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber);
+}
+
+TEST(RegistersPoolTests, get_return_by_method) {
+    if (!x64::mayiuse(x64::avx2)) { return; }
+    RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({});
+    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber);
+    RegistersPool::Reg<Xbyak::Xmm> reg{regPool};
+    ASSERT_NO_THROW(static_cast<Xbyak::Xmm &>(reg));
+    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber - 1);
+    reg.release();
+    ASSERT_ANY_THROW(static_cast<Xbyak::Xmm &>(reg));
+    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber);
+    reg = RegistersPool::Reg<Xbyak::Xmm>{regPool};
+    ASSERT_NO_THROW(static_cast<Xbyak::Xmm &>(reg));
+    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber - 1);
+}
+
+TEST(RegistersPoolTests, second_pool_exception) {
+    if (!x64::mayiuse(x64::avx2)) { return; }
+    RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({});
+    ASSERT_ANY_THROW(RegistersPool::create<x64::avx2>({}));
+}
+
+TEST(RegistersPoolTests, default_ctor) {
+    if (!x64::mayiuse(x64::avx2)) { return; }
+    RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({});
+    RegistersPool::Reg<Xbyak::Xmm> reg;
+    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber);
+    ASSERT_ANY_THROW(static_cast<Xbyak::Xmm &>(reg));
+}
+
+TEST(RegistersPoolTests, get_all) {
+    if (!x64::mayiuse(x64::avx2)) { return; }
+    RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({});
+    using Ptr = std::shared_ptr<RegistersPool::Reg<Xbyak::Xmm>>;
+    std::vector<Ptr> regs(simdRegNumber);
+    std::vector<int> idxs(simdRegNumber);
+    for (int c = 0; c < simdRegNumber; ++c) {
+        regs[c] = std::make_shared<RegistersPool::Reg<Xbyak::Xmm>>(regPool);
+        idxs[c] = regs[c]->getIdx();
+    }
+    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), 0);
+    ASSERT_ANY_THROW(RegistersPool::Reg<Xbyak::Xmm>{regPool});
+    std::sort(idxs.begin(), idxs.end());
+    for (int c = 0; c < simdRegNumber; ++c) {
+        ASSERT_EQ(c, idxs[c]);
+    }
+    regs.clear();
+    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber);
+}
+
+TEST(RegistersPoolTests, move) {
+    if (!x64::mayiuse(x64::avx2)) { return; }
+    RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({});
+    RegistersPool::Reg<Xbyak::Xmm> reg{regPool};
+    ASSERT_NO_THROW(static_cast<Xbyak::Xmm &>(reg));
+    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber - 1);
+    RegistersPool::Reg<Xbyak::Xmm> reg2 = std::move(reg);
+    ASSERT_ANY_THROW(static_cast<Xbyak::Xmm &>(reg));
+    ASSERT_NO_THROW(static_cast<Xbyak::Xmm &>(reg2));
+    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber - 1);
+}
+
+
+TEST(RegistersPoolTests, fixed_idx) {
+    if (!x64::mayiuse(x64::avx2)) { return; }
+    RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({});
+    using Ptr = std::shared_ptr<RegistersPool::Reg<Xbyak::Xmm>>;
+    std::vector<Ptr> regs(simdRegNumber);
+    for (int c = 0; c < simdRegNumber; ++c) {
+        regs[c] = std::make_shared<RegistersPool::Reg<Xbyak::Xmm>>(regPool, c);
+        ASSERT_EQ(regs[c]->getIdx(), c);
+    }
+    regs[0]->release();
+    ASSERT_ANY_THROW(RegistersPool::Reg<Xbyak::Xmm>(regPool, 1));
+    ASSERT_NO_THROW(RegistersPool::Reg<Xbyak::Xmm>(regPool, 0));
+}
+
+TEST(RegistersPoolTests, exclude) {
+    if (!x64::mayiuse(x64::avx2)) { return; }
+    static constexpr int excludedIdx = 0;
+    RegistersPool::Ptr regPool = RegistersPool::create<x64::avx2>({
+        Xbyak::Xmm(excludedIdx)
+    });
+    using Ptr = std::shared_ptr<RegistersPool::Reg<Xbyak::Xmm>>;
+    std::vector<Ptr> regs(simdRegNumber - 1);
+    std::set<int> idxsInUse;
+    for (int c = 0; c < simdRegNumber - 1; ++c) {
+        regs[c] = std::make_shared<RegistersPool::Reg<Xbyak::Xmm>>(regPool);
+        idxsInUse.emplace(regs[c]->getIdx());
+    }
+    ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), 0);
+    ASSERT_TRUE(idxsInUse.find(excludedIdx) == idxsInUse.end());
+}

--- a/src/plugins/intel_cpu/tests/unit/registers_pool.cpp
+++ b/src/plugins/intel_cpu/tests/unit/registers_pool.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include "nodes/kernels/registers_pool.hpp"
+#include "common/nstl.hpp"
 
 using namespace ov::intel_cpu;
 
@@ -143,8 +144,13 @@ struct make_case {
 template<class T1, class T2, class Is>
 struct make_combinations;
 
+template<size_t ...> struct index_sequence  { };
+template<size_t N, size_t ...S> struct make_index_sequence_impl : make_index_sequence_impl <N - 1, N - 1, S...> { };
+template<size_t ...S> struct make_index_sequence_impl <0, S...> { using type = index_sequence<S...>; };
+template<size_t N> using make_index_sequence = typename make_index_sequence_impl<N>::type;
+
 template<class TupleType, class TupleParam, std::size_t... Is>
-struct make_combinations<TupleType, TupleParam, tbb::internal::index_sequence<Is...>> {
+struct make_combinations<TupleType, TupleParam, index_sequence<Is...>> {
     using tuples = std::tuple<typename make_case<TupleType, TupleParam, Is>::type...>;
 };
 
@@ -152,7 +158,7 @@ template<class TupleTypes, class... Params>
 using Combinations_t = typename make_combinations
         <TupleTypes,
                 std::tuple<Params...>,
-                tbb::internal::make_index_sequence<(std::tuple_size<TupleTypes>::value) *(sizeof...(Params))>>::tuples;
+                make_index_sequence<(std::tuple_size<TupleTypes>::value) *(sizeof...(Params))>>::tuples;
 
 template<class T>
 struct TestTypesCombiner;

--- a/src/plugins/intel_cpu/tests/unit/registers_pool.cpp
+++ b/src/plugins/intel_cpu/tests/unit/registers_pool.cpp
@@ -32,7 +32,7 @@ TYPED_TEST_P(RegPoolTest, get_return_by_scope) {
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
     {
         RegistersPool::Reg<XbyakRegT> reg{regPool};
-        ASSERT_NO_THROW(static_cast<XbyakRegT &>(reg));
+        ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg));
         ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
     }
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
@@ -43,13 +43,13 @@ TYPED_TEST_P(RegPoolTest, get_return_by_method) {
     RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({});
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
     RegistersPool::Reg<XbyakRegT> reg{regPool};
-    ASSERT_NO_THROW(static_cast<XbyakRegT &>(reg));
+    ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg));
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
     reg.release();
-    ASSERT_ANY_THROW(static_cast<XbyakRegT &>(reg));
+    ASSERT_ANY_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg));
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
     reg = RegistersPool::Reg<XbyakRegT>{regPool};
-    ASSERT_NO_THROW(static_cast<XbyakRegT &>(reg));
+    ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg));
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
 }
 
@@ -58,7 +58,7 @@ TYPED_TEST_P(RegPoolTest, default_ctor) {
     RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({});
     RegistersPool::Reg<XbyakRegT> reg;
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
-    ASSERT_ANY_THROW(static_cast<XbyakRegT &>(reg));
+    ASSERT_ANY_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg));
 }
 
 TYPED_TEST_P(RegPoolTest, get_all) {
@@ -79,7 +79,7 @@ TYPED_TEST_P(RegPoolTest, move) {
     using XbyakRegT = typename TypeParam::RegT;
     RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({});
     RegistersPool::Reg<XbyakRegT> reg{regPool};
-    ASSERT_NO_THROW(static_cast<XbyakRegT &>(reg));
+    ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg));
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
     RegistersPool::Reg<XbyakRegT> reg2{regPool};
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 2);
@@ -87,8 +87,8 @@ TYPED_TEST_P(RegPoolTest, move) {
     reg2 = std::move(reg);
     ASSERT_EQ(reg2.getIdx(), regIdx);
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
-    ASSERT_ANY_THROW(static_cast<XbyakRegT &>(reg));
-    ASSERT_NO_THROW(static_cast<XbyakRegT &>(reg2));
+    ASSERT_ANY_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg));
+    ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg2));
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
 }
 
@@ -212,7 +212,7 @@ TEST(RegistersPoolTests, simd_and_general) {
     ASSERT_EQ(regPool->countFree<Xbyak::Reg64>(), freeGeneralRegNumber);
     {
         RegistersPool::Reg<Xbyak::Xmm> reg{regPool};
-        ASSERT_NO_THROW(static_cast<Xbyak::Xmm &>(reg));
+        ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<Xbyak::Xmm &>(reg));
         ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber - 1);
         ASSERT_EQ(regPool->countFree<Xbyak::Ymm>(), simdRegNumber - 1);
         ASSERT_EQ(regPool->countFree<Xbyak::Reg64>(), freeGeneralRegNumber);


### PR DESCRIPTION
The RegistersPool class was implemented. It is helpful for managing registers while developing jit kernels.
This is done as the first part of the Gather JIT kernel improvement to cover all execution cases.
