### PR TITLE
Enabled LTO for ONNX

### DIFF
--- a/cmake/developer_package/compile_flags/os_flags.cmake
+++ b/cmake/developer_package/compile_flags/os_flags.cmake
@@ -163,10 +163,18 @@ endfunction()
 #
 function(ov_disable_all_warnings)
     foreach(target IN LISTS ARGN)
+        get_target_property(target_type ${target} TYPE)
+
         if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
             target_compile_options(${target} PRIVATE /WX-)
         elseif(CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG)
             target_compile_options(${target} PRIVATE -w)
+            # required for LTO
+            set(link_interface INTERFACE_LINK_OPTIONS)
+            if(target_type STREQUAL "SHARED_LIBRARY" OR target_type STREQUAL "EXECUTABLE")
+                set(link_interface LINK_OPTIONS)
+            endif()
+            set_target_properties(${target} PROPERTIES ${link_interface} "-Wno-error=maybe-uninitialized;-Wno-maybe-uninitialized")
         elseif(UNIX AND CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
             # 193: zero used for undefined preprocessing identifier "XXX"
             # 1011: missing return statement at end of non-void function "XXX"

--- a/thirdparty/onnx/CMakeLists.txt
+++ b/thirdparty/onnx/CMakeLists.txt
@@ -6,8 +6,6 @@
 # Configure and install libonnx ...
 #------------------------------------------------------------------------------
 
-# TODO: enable LTO
-set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
 set(OV_ONNX_NAMESPACE openvino_onnx)
 
 if(NOT DEFINED ONNX_USE_MSVC_STATIC_RUNTIME)


### PR DESCRIPTION
### Details:
 - 3.6 mb versus 3.9 w/o the change

### Tickets:
 - *ticket-id*
