### PR TITLE
enabled LTO for GPU plugin helper libs

### DIFF
--- a/src/plugins/intel_gpu/src/graph/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/CMakeLists.txt
@@ -49,9 +49,9 @@ if(COMMAND add_cpplint_target)
   add_cpplint_target(${TARGET_NAME}_cpplint FOR_TARGETS ${TARGET_NAME})
 endif()
 
-if(COMMAND set_ie_threading_interface_for)
-  set_ie_threading_interface_for(${TARGET_NAME})
-endif()
+set_ie_threading_interface_for(${TARGET_NAME})
+
+set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
 
 if(WIN32)
   target_link_libraries(${TARGET_NAME} PRIVATE setupapi)

--- a/src/plugins/intel_gpu/src/kernel_selector/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/kernel_selector/CMakeLists.txt
@@ -77,6 +77,8 @@ endif()
 
 target_link_libraries(${TARGET_NAME} PUBLIC OpenCL rapidjson inference_engine_plugin_api)
 
+set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
+
 if(WIN32)
   target_link_libraries(${TARGET_NAME} PRIVATE setupapi)
 elseif((NOT ANDROID) AND (UNIX))

--- a/src/plugins/intel_gpu/src/runtime/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/runtime/CMakeLists.txt
@@ -34,9 +34,7 @@ if(COMMAND add_cpplint_target)
   add_cpplint_target(${TARGET_NAME}_cpplint FOR_TARGETS ${TARGET_NAME})
 endif()
 
-if(COMMAND set_ie_threading_interface_for)
-  set_ie_threading_interface_for(${TARGET_NAME})
-endif()
+set_ie_threading_interface_for(${TARGET_NAME})
 
 target_link_libraries(${TARGET_NAME} PRIVATE
     OpenCL
@@ -47,6 +45,8 @@ target_link_libraries(${TARGET_NAME} PRIVATE
 if(ENABLE_ONEDNN_FOR_GPU)
   target_link_libraries(${TARGET_NAME} PUBLIC onednn_gpu_tgt)
 endif()
+
+set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
 
 if(WIN32)
   target_link_libraries(${TARGET_NAME} PRIVATE setupapi)

--- a/src/plugins/intel_gpu/tests/CMakeLists.txt
+++ b/src/plugins/intel_gpu/tests/CMakeLists.txt
@@ -28,14 +28,14 @@ set(SOURCES_ALL
 
 add_executable(${TARGET_NAME} ${SOURCES_ALL})
 
-if(COMMAND set_ie_threading_interface_for)
-  set_ie_threading_interface_for(${TARGET_NAME})
-endif()
+set_ie_threading_interface_for(${TARGET_NAME})
 
 # Workaround to avoid warnings during LTO build
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set_target_properties(${TARGET_NAME} PROPERTIES LINK_FLAGS_RELEASE "-Wno-error=maybe-uninitialized -Wno-maybe-uninitialized")
 endif()
+
+set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
 
 target_link_libraries(${TARGET_NAME} PRIVATE openvino_intel_gpu_graph
                                              inference_engine
@@ -50,6 +50,7 @@ target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
                                                   $<TARGET_PROPERTY:openvino_intel_gpu_kernels,INTERFACE_INCLUDE_DIRECTORIES>
                                                   $<TARGET_PROPERTY:openvino_intel_gpu_runtime,INTERFACE_INCLUDE_DIRECTORIES>
                                                   ${CMAKE_HOME_DIRECTORY}/src/core/reference/include/)
+
 if(WIN32)
   target_link_libraries(${TARGET_NAME} PRIVATE setupapi)
 elseif((NOT ANDROID) AND (UNIX))


### PR DESCRIPTION
### Details:
 - Diff in sizes (smaller is with more LTO, collected with gcc-10):
 ```
-rwxr-xr-x 1 root root 19468168 9月   5 01:08 libopenvino_intel_gpu_plugin.so
-rwxr-xr-x 1 root root 20770720 9月   5 00:59 libopenvino_intel_gpu_plugin.so
```