### PR TITLE
[MO] cleanup fused names after all transformations

### DIFF
--- a/src/bindings/python/src/openvino/_offline_transformations/__init__.py
+++ b/src/bindings/python/src/openvino/_offline_transformations/__init__.py
@@ -10,6 +10,7 @@ add_openvino_libs_to_path()
 from openvino.pyopenvino import get_version
 __version__ = get_version()
 
+from openvino.pyopenvino._offline_transformations import apply_fused_names_cleanup
 from openvino.pyopenvino._offline_transformations import apply_moc_transformations
 from openvino.pyopenvino._offline_transformations import apply_moc_legacy_transformations
 from openvino.pyopenvino._offline_transformations import apply_pot_transformations

--- a/src/bindings/python/src/openvino/offline_transformations/__init__.py
+++ b/src/bindings/python/src/openvino/offline_transformations/__init__.py
@@ -34,6 +34,14 @@ def serialize(model, xml_path, bin_path, version):
             message="The module is private and following namespace "
                     "`offline_transformations` will be removed in "
                     "the future.")
+def apply_fused_names_cleanup(model):
+    _base.apply_fused_names_cleanup(model)
+
+
+@deprecated(version="2023.1",
+            message="The module is private and following namespace "
+                    "`offline_transformations` will be removed in "
+                    "the future.")
 def apply_moc_transformations(model, cf):
     _base.apply_moc_transformations(model, cf)
 

--- a/src/bindings/python/src/pyopenvino/core/offline_transformations.cpp
+++ b/src/bindings/python/src/pyopenvino/core/offline_transformations.cpp
@@ -13,6 +13,7 @@
 #include <pot_transformations.hpp>
 #include <pruning.hpp>
 #include <transformations/common_optimizations/compress_float_constants.hpp>
+#include <transformations/common_optimizations/fused_names_cleanup.hpp>
 #include <transformations/common_optimizations/mark_precision_sensitive_subgraphs.hpp>
 #include <transformations/common_optimizations/moc_legacy_transformations.hpp>
 #include <transformations/common_optimizations/moc_transformations.hpp>
@@ -125,6 +126,15 @@ void regmodule_offline_transformations(py::module m) {
         [](std::shared_ptr<ov::Model> model) {
             ov::pass::Manager manager;
             manager.register_pass<ngraph::pass::ConvertSequenceToTensorIterator>();
+            manager.run_passes(model);
+        },
+        py::arg("model"));
+
+    m_offline_transformations.def(
+        "apply_fused_names_cleanup",
+        [](std::shared_ptr<ov::Model> model) {
+            ov::pass::Manager manager;
+            manager.register_pass<ov::pass::FusedNamesCleanup>();
             manager.run_passes(model);
         },
         py::arg("model"));

--- a/src/bindings/python/tests/test_transformations/test_offline_api.py
+++ b/src/bindings/python/tests/test_transformations/test_offline_api.py
@@ -13,6 +13,7 @@ from openvino.offline_transformations import (
     apply_make_stateful_transformation,
     compress_model_transformation,
     convert_sequence_to_tensor_iterator_transformation,
+    apply_fused_names_cleanup,
 )
 
 from openvino.runtime import Model, PartialShape, Core
@@ -136,6 +137,21 @@ def test_make_stateful_transformations():
     assert model is not None
     assert len(model.get_parameters()) == 0
     assert len(model.get_results()) == 0
+
+
+def test_fused_names_cleanup():
+    model = get_test_model()
+
+    for node in model.get_ops():
+        node.get_rt_info()["fused_names_0"] = "test_op_name"
+
+    apply_fused_names_cleanup(model)
+
+    assert model is not None
+    assert len(model.get_ops()) == 3
+
+    for node in model.get_ops():
+        assert len(node.get_rt_info()) == 0
 
 
 def test_serialize_pass_v2():

--- a/src/common/transformations/include/transformations/common_optimizations/fused_names_cleanup.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/fused_names_cleanup.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <openvino/pass/pass.hpp>
+#include <transformations_visibility.hpp>
+
+namespace ov {
+namespace pass {
+
+class TRANSFORMATIONS_API FusedNamesCleanup;
+
+}  // namespace pass
+}  // namespace ov
+
+/**
+ * @ingroup ie_transformation_common_api
+ * @brief FusedNamesCleanup removes fused_names attribute
+ */
+class ov::pass::FusedNamesCleanup : public ov::pass::ModelPass {
+public:
+    OPENVINO_RTTI("FusedNamesCleanup", "0");
+    bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
+};

--- a/src/common/transformations/src/transformations/common_optimizations/fused_names_cleanup.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fused_names_cleanup.cpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/common_optimizations/fused_names_cleanup.hpp"
+
+#include <openvino/cc/ngraph/itt.hpp>
+#include <transformations/rt_info/fused_names_attribute.hpp>
+
+bool ov::pass::FusedNamesCleanup::run_on_model(const std::shared_ptr<ov::Model>& f) {
+    RUN_ON_FUNCTION_SCOPE(FusedNamesCleanup);
+
+    for (auto& node : f->get_ordered_ops()) {
+        RTMap& rt_info = node->get_rt_info();
+        auto it = rt_info.find(ngraph::FusedNames::get_type_info_static());
+        if (it != rt_info.end()) {
+            rt_info.erase(it);
+        }
+    }
+    return false;
+}

--- a/src/tests/functional/inference_engine/transformations/common_optimizations/fused_names_cleanup.cpp
+++ b/src/tests/functional/inference_engine/transformations/common_optimizations/fused_names_cleanup.cpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#define _USE_MATH_DEFINES
+
+#include <gtest/gtest.h>
+
+#include <ngraph/function.hpp>
+#include <ngraph/opsets/opset9.hpp>
+#include <ngraph/pass/constant_folding.hpp>
+#include <ngraph/pass/manager.hpp>
+#include <transformations/common_optimizations/fused_names_cleanup.hpp>
+#include <transformations/init_node_info.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+
+using namespace testing;
+using namespace ngraph;
+
+TEST(TransformationTests, FusedNamesCleanup) {
+    std::shared_ptr<ngraph::Function> function(nullptr), function_ref(nullptr);
+    {
+        auto data =
+            std::make_shared<opset9::Parameter>(element::f32, Shape{2, 2});
+
+        auto add1_const =
+            opset9::Constant::create(element::f32, Shape{1}, {1.0});
+        auto add2_const =
+            opset9::Constant::create(element::f32, Shape{1}, {2.0});
+        auto add1 = std::make_shared<opset9::Add>(add1_const, add2_const);
+        auto add2 = std::make_shared<opset9::Add>(data, add1);
+        function = std::make_shared<Function>(NodeVector{add2}, ParameterVector{data});
+
+        ngraph::pass::Manager manager;
+        manager.register_pass<pass::InitNodeInfo>();
+        manager.register_pass<pass::ConstantFolding>();
+        manager.run_passes(function);
+        ASSERT_NO_THROW(check_rt_info(function));
+
+        manager.register_pass<ov::pass::FusedNamesCleanup>();
+        manager.run_passes(function);
+        ASSERT_THROW(check_rt_info(function), ngraph::ngraph_error);
+    }
+    {
+        auto data =
+            std::make_shared<opset9::Parameter>(element::f32, Shape{2, 2});
+
+        auto add_const =
+            opset9::Constant::create(element::f32, Shape{1}, {3.0});
+        auto add = std::make_shared<opset9::Add>(data, add_const);
+        function_ref = std::make_shared<Function>(NodeVector{add}, ParameterVector{data});
+    }
+    const FunctionsComparator func_comparator = FunctionsComparator::with_default().enable(FunctionsComparator::RUNTIME_KEYS);
+    const FunctionsComparator::Result result = func_comparator(function, function_ref);
+    ASSERT_TRUE(result.valid);
+}

--- a/tools/mo/openvino/tools/mo/back/offline_transformations.py
+++ b/tools/mo/openvino/tools/mo/back/offline_transformations.py
@@ -48,6 +48,9 @@ def compress_model(func: object):
     from openvino._offline_transformations import compress_model_transformation  # pylint: disable=import-error,no-name-in-module
     compress_model_transformation(func)
 
+def apply_fused_names_cleanup(func: object):
+    from openvino.offline_transformations import apply_fused_names_cleanup  # pylint: disable=import-error,no-name-in-module
+    apply_fused_names_cleanup(func)
 
 
 def apply_offline_transformations(func: Model, argv: argparse.Namespace):
@@ -65,4 +68,7 @@ def apply_offline_transformations(func: Model, argv: argparse.Namespace):
     if "compress_fp16" in argv and argv.compress_fp16:
         compress_model(func)
 
+    apply_fused_names_cleanup(func)
+
     return func
+

--- a/tools/mo/openvino/tools/mo/moc_frontend/serialize.py
+++ b/tools/mo/openvino/tools/mo/moc_frontend/serialize.py
@@ -20,7 +20,7 @@ def moc_emit_ir(ngraph_function: Model, argv: argparse.Namespace):
 
     # Apply transformations
     from openvino.tools.mo.back.offline_transformations import apply_user_transformations, apply_moc_transformations, \
-        apply_moc_legacy_transformations
+        apply_moc_legacy_transformations, apply_fused_names_cleanup
 
     apply_moc_transformations(ngraph_function)
     from openvino._offline_transformations import compress_quantize_weights_transformation
@@ -37,6 +37,8 @@ def moc_emit_ir(ngraph_function: Model, argv: argparse.Namespace):
     if argv.compress_fp16:
         from openvino.tools.mo.back.offline_transformations import compress_model
         compress_model(ngraph_function)
+
+    apply_fused_names_cleanup(ngraph_function)
 
     del argv.feManager
     return ngraph_function

--- a/tools/mo/openvino/tools/mo/utils/check_ie_bindings.py
+++ b/tools/mo/openvino/tools/mo/utils/check_ie_bindings.py
@@ -49,7 +49,7 @@ def import_core_modules(silent: bool, path_to_module: str):
     """
     try:
         from openvino._offline_transformations import apply_moc_transformations, apply_moc_legacy_transformations,\
-            apply_low_latency_transformation  # pylint: disable=import-error,no-name-in-module
+            apply_low_latency_transformation, apply_fused_names_cleanup  # pylint: disable=import-error,no-name-in-module
         from openvino._offline_transformations import apply_make_stateful_transformation, generate_mapping_file  # pylint: disable=import-error,no-name-in-module
         from openvino._offline_transformations import generate_mapping_file, apply_make_stateful_transformation  # pylint: disable=import-error,no-name-in-module
 


### PR DESCRIPTION
### Details:
 - *MO runs MOC transformation pipeline which insert fused_names into the runtime info of operations. This names should not cross boundaries of our API and be visible in IR.*

### Tickets:
 - *91551*, *91782*
