### PR TITLE
fix inconsistent tbb config due to executor used in multi

### DIFF
--- a/src/plugins/auto/plugin.cpp
+++ b/src/plugins/auto/plugin.cpp
@@ -491,7 +491,7 @@ IExecutableNetworkInternal::Ptr MultiDeviceInferencePlugin::LoadNetworkImpl(cons
     auto executor = executorManager()->getIdleCPUStreamsExecutor(
             IStreamsExecutor::Config{"MultiDeviceAsyncLoad",
                                      static_cast<int>(std::thread::hardware_concurrency()) /* max possible #streams*/,
-                                     0 /*single thread per stream*/,
+                                     0 /*default threads per stream, workaround for ticket 62376*/,
                                      IStreamsExecutor::ThreadBindingType::NONE});
     executor->runAndWait(loads);
     if (executableNetworkPerDevice.empty())

--- a/src/plugins/auto/plugin.cpp
+++ b/src/plugins/auto/plugin.cpp
@@ -491,7 +491,7 @@ IExecutableNetworkInternal::Ptr MultiDeviceInferencePlugin::LoadNetworkImpl(cons
     auto executor = executorManager()->getIdleCPUStreamsExecutor(
             IStreamsExecutor::Config{"MultiDeviceAsyncLoad",
                                      static_cast<int>(std::thread::hardware_concurrency()) /* max possible #streams*/,
-                                     1 /*single thread per stream*/,
+                                     0 /*single thread per stream*/,
                                      IStreamsExecutor::ThreadBindingType::NONE});
     executor->runAndWait(loads);
     if (executableNetworkPerDevice.empty())


### PR DESCRIPTION
Signed-off-by: fishbell <bell.song@intel.com>

### Details:
 - fix performance gap between MULTI:CPU vs. CPU
 - multi use stream executor for async load, this will unexpectedly affect CPU stream executor tbb config, we had workaround in auto, and now apply same to MULTI

### Tickets:
 - 91302
