### PR TITLE
Fixed installation of pugixml on U22 for ie_wheel

### DIFF
--- a/src/bindings/python/tests/test_runtime/test_compiled_model.py
+++ b/src/bindings/python/tests/test_runtime/test_compiled_model.py
@@ -7,7 +7,7 @@ import pytest
 import numpy as np
 
 # TODO: refactor into absolute paths
-from ..conftest import model_path, get_model_with_template_extension
+from ..conftest import model_path
 from ..test_utils.test_utils import generate_image
 from openvino.runtime import Model, ConstOutput, Shape
 

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -69,8 +69,9 @@ if(ENABLE_SYSTEM_PUGIXML)
         get_target_property(target_type ${pugixml_target} TYPE)
         if(target_type STREQUAL "SHARED_LIBRARY")
             ie_cpack_add_component(pugixml HIDDEN)
-            get_target_property(pugixml_loc ${pugixml_target} IMPORTED_LOCATION_NOCONFIG)
-            get_target_property(pugixml_soname_loc ${pugixml_target} IMPORTED_SONAME_NOCONFIG)
+            get_target_property(imported_config ${pugixml_target} IMPORTED_CONFIGURATIONS)
+            get_target_property(pugixml_loc ${pugixml_target} IMPORTED_LOCATION_${imported_config})
+            get_target_property(pugixml_soname_loc ${pugixml_target} IMPORTED_SONAME_${imported_config})
             get_filename_component(pugixml_dir "${pugixml_loc}" DIRECTORY)
             install(FILES "${pugixml_loc}"
                           "${pugixml_dir}/${pugixml_soname_loc}"


### PR DESCRIPTION
### Details:
 - On U22 imported configuration is named as `NONE` instead of `NOCONFIG`. Let's request imported configuration name and use it later instead of hardcoded name
