### PR TITLE
Python Benchmark App reduce impact not installed opencv

### DIFF
--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -4,7 +4,6 @@
 import os
 
 import re
-import warnings
 import numpy as np
 from collections import defaultdict
 from pathlib import Path
@@ -16,11 +15,6 @@ try:
     import cv2
 except ImportError:
     cv2 = None
-
-try:
-    from pip._internal import main as pip_main
-except ImportError:
-    from pip import main as pip_main
 
 from .constants import IMAGE_EXTENSIONS, BINARY_EXTENSIONS
 from .logging import logger
@@ -139,9 +133,7 @@ def get_input_data(paths_to_input, app_input_info):
 
 def get_image_tensors(image_paths, info, batch_sizes):
     if cv2 is None:
-        warnings.warn('failed to import opencv. opencv-python-headless package will be installed')
-        pip_main(['install', 'opencv-python-headless'])
-        import cv2
+        raise ImportError('opencv required for image processing in benchmark_app, please install it')
         
     processed_frames = 0
     widthes = info.widthes if info.is_dynamic else [info.width]

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -2,14 +2,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import cv2
+
 import re
+import warnings
 import numpy as np
 from collections import defaultdict
 from pathlib import Path
 
 from openvino.runtime import Tensor, PartialShape
 from openvino.runtime.utils.types import get_dtype
+
+try:
+    import cv2
+except ImportError:
+    cv2 = None
+
+try:
+    from pip._internal import main as pip_main
+except ImportError:
+    from pip import main as pip_main
 
 from .constants import IMAGE_EXTENSIONS, BINARY_EXTENSIONS
 from .logging import logger
@@ -127,6 +138,11 @@ def get_input_data(paths_to_input, app_input_info):
 
 
 def get_image_tensors(image_paths, info, batch_sizes):
+    if cv2 is None:
+        warnings.warn('failed to import opencv. opencv-python-headless package will be installed')
+        pip_main(['install', 'opencv-python-headless'])
+        import cv2
+        
     processed_frames = 0
     widthes = info.widthes if info.is_dynamic else [info.width]
     heights = info.heights if info.is_dynamic else [info.height]

--- a/tools/benchmark_tool/setup.py
+++ b/tools/benchmark_tool/setup.py
@@ -8,9 +8,7 @@ Use this script to create a wheel with OpenVINO™ Python* tools:
 
 $ python setup.py sdist bdist_wheel
 """
-import importlib
 import pkg_resources
-import warnings
 from setuptools import setup, find_packages
 
 with open('README.md', 'r', encoding='utf-8') as f:
@@ -22,14 +20,6 @@ with open('requirements.txt') as requirements_txt:
         for requirement
         in pkg_resources.parse_requirements(requirements_txt)
     ]
-
-try:
-    importlib.import_module('cv2')
-except ImportError as opencv_import_error:
-    warnings.warn(
-            "Problem with cv2 import: \n{}\n opencv-python-headless will be added to requirements".format(opencv_import_error)
-    )
-    reqs.append('opencv-python-headless==4.5.*')
 
 setup(
     name='benchmark_tool',


### PR DESCRIPTION
### Details:
 - *during installing wheels conditional installation opencv does work if user environment different from environment where wheel created. In the same time these is benchmark app working modes where opencv does not required at all, so this PR relax impact for case if opencv is not installed for them and give error when it is necessary*

### Tickets:
 - *91440*
