### PR TITLE
[CPU] Lazy oneDNN memory object creation

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -47,7 +47,7 @@ size_t Memory::GetSize() const {
     return size;
 }
 
-void Memory::Create(const dnnl::memory::desc& desc, const void *data, bool pads_zeroing) const {
+void Memory::createDnnlPrim(const dnnl::memory::desc& desc, const void *data, bool pads_zeroing) const {
     // OneDNN accepts not a const data, probably need to remove some level of consteness in a call stack
 
     // ========================
@@ -178,7 +178,7 @@ void Memory::resetDnnlPrim() {
 dnnl::memory Memory::GetPrimitive() const {
     if (!testDnnlPrim()) {
         if (pMemDesc->isDefined()) {
-            Create(MemoryDescUtils::convertToDnnlMemoryDesc(pMemDesc)->getDnnlDesc(), mgrHandle->getRawPtr(), padsZeroing);
+            createDnnlPrim(MemoryDescUtils::convertToDnnlMemoryDesc(pMemDesc)->getDnnlDesc(), mgrHandle->getRawPtr(), padsZeroing);
         } else {
             IE_THROW() << "Can not create oneDNN memory from undefined memory descriptor";
         }

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -177,6 +177,10 @@ void Memory::resetDnnlPrim() {
 
 dnnl::memory Memory::GetPrimitive() const {
     if (!testDnnlPrim()) {
+        std::lock_guard<std::mutex> guard(primCachingLock);
+        if (testDnnlPrim()) {
+            return prim;
+        }
         if (pMemDesc->isDefined()) {
             createDnnlPrim(MemoryDescUtils::convertToDnnlMemoryDesc(pMemDesc)->getDnnlDesc(), mgrHandle->getRawPtr(), padsZeroing);
         } else {

--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -205,11 +205,11 @@ public:
      * @return
      */
     void* GetData() const {
-        void* data = mgrHandle->getRawPtr();
+        void* data = getDataNoThrow();
         if (data == nullptr &&
             pMemDesc->getShape().isStatic() &&
             pMemDesc->getShape().getElementsCount() != 0)
-            IE_THROW() << "Cannot get memory!";
+            IE_THROW() << "Memory has not been allocated";
         return data;
     }
 
@@ -283,6 +283,10 @@ private:
         mutable dnnl::memory m_prim;
         const Memory* m_memObjPtr;
     } dnnlMemHandle;
+
+    void* getDataNoThrow() const noexcept {
+        return mgrHandle->getRawPtr();
+    }
 };
 
 using MemoryPtr = std::shared_ptr<Memory>;

--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -167,13 +167,19 @@ public:
     dnnl::memory GetPrimitive() const;
 
     bool isAllocated() const noexcept {
-        if (nullptr == pMemDesc) {
+        if (mgrHandle->getRawPtr()) {
+            return true;
+        }
+        if (!pMemDesc) {
             return false;
         }
-        if (pMemDesc->isDefined() && nullptr == mgrHandle->getRawPtr()) {
-            return false;
+        if (!(pMemDesc->isDefined())) {
+            return true;
         }
-        return true;
+        if (pMemDesc->getCurrentMemSize() == 0) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -70,7 +70,7 @@ public:
 };
 
 /**
- * @brief An implementation of the mem manager where memory reallocation occures only if bigger buffer is requested.
+ * @brief An implementation of the mem manager where memory reallocation occurs only if a bigger buffer is requested.
  */
 class MemoryMngrWithReuse : public IMemoryMngr {
 public:
@@ -264,18 +264,26 @@ private:
     friend DnnlMemoryMngr;
 
 private:
-    void createDnnlPrim(const dnnl::memory::desc& desc, const void* data = nullptr, bool pads_zeroing = true) const;
     void update();
-    void resetDnnlPrim();
-    bool testDnnlPrim() const;
 
 private:
     MemoryDescPtr pMemDesc;
     dnnl::engine eng;
     DnnlMemMngrHandle mgrHandle;
     bool padsZeroing = true;
-    mutable std::mutex primCachingLock;
-    mutable dnnl::memory prim;
+    class DnnlMemPrimHandle {
+    public:
+        explicit DnnlMemPrimHandle(const Memory* memObjPtr): m_memObjPtr(memObjPtr) {}
+        bool isInit() const;
+        dnnl::memory getPrim() const;
+        void resetDnnlPrim();
+
+    private:
+        mutable std::mutex m_primCachingLock;
+        mutable dnnl::memory m_prim;
+        const Memory* m_memObjPtr;
+    } dnnlMemHandle;
+
 };
 
 using MemoryPtr = std::shared_ptr<Memory>;

--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -279,6 +279,8 @@ private:
         void resetDnnlPrim();
 
     private:
+        // Since getPrim should behave as a constant method, even though it changes state, it must be thread safe.
+        // To provide thead safety we use this mutex
         mutable std::mutex m_primCachingLock;
         mutable dnnl::memory m_prim;
         const Memory* m_memObjPtr;

--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -264,7 +264,7 @@ private:
     friend DnnlMemoryMngr;
 
 private:
-    void Create(const dnnl::memory::desc& desc, const void* data = nullptr, bool pads_zeroing = true) const;
+    void createDnnlPrim(const dnnl::memory::desc& desc, const void* data = nullptr, bool pads_zeroing = true) const;
     void update();
     void resetDnnlPrim();
     bool testDnnlPrim() const;

--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -283,7 +283,6 @@ private:
         mutable dnnl::memory m_prim;
         const Memory* m_memObjPtr;
     } dnnlMemHandle;
-
 };
 
 using MemoryPtr = std::shared_ptr<Memory>;

--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -271,10 +271,11 @@ private:
 
 private:
     MemoryDescPtr pMemDesc;
-    mutable dnnl::memory prim;
     dnnl::engine eng;
     DnnlMemMngrHandle mgrHandle;
     bool padsZeroing = true;
+    mutable std::mutex primCachingLock;
+    mutable dnnl::memory prim;
 };
 
 using MemoryPtr = std::shared_ptr<Memory>;

--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -164,16 +164,16 @@ public:
     Memory(Memory&&) = delete;
     Memory& operator= (Memory&&) = delete;
 
-    dnnl::memory GetPrimitive() const {
-        if (isAllocated()) {
-            return prim;
-        } else {
-            IE_THROW() << "Can not perform GetPrimitive call to the not allocated memory";
-        }
-    }
+    dnnl::memory GetPrimitive() const;
 
     bool isAllocated() const noexcept {
-        return prim.get(true) != nullptr;
+        if (nullptr == pMemDesc) {
+            return false;
+        }
+        if (pMemDesc->isDefined() && nullptr == mgrHandle->getRawPtr()) {
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -258,14 +258,17 @@ private:
     friend DnnlMemoryMngr;
 
 private:
-    void Create(const dnnl::memory::desc& desc, const void* data = nullptr, bool pads_zeroing = true);
+    void Create(const dnnl::memory::desc& desc, const void* data = nullptr, bool pads_zeroing = true) const;
     void update();
+    void resetDnnlPrim();
+    bool testDnnlPrim() const;
 
 private:
     MemoryDescPtr pMemDesc;
-    dnnl::memory prim;
+    mutable dnnl::memory prim;
     dnnl::engine eng;
     DnnlMemMngrHandle mgrHandle;
+    bool padsZeroing = true;
 };
 
 using MemoryPtr = std::shared_ptr<Memory>;

--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -173,7 +173,7 @@ public:
     }
 
     bool isAllocated() const noexcept {
-        return static_cast<bool>(prim);
+        return prim.get(true) != nullptr;
     }
 
     /**

--- a/src/plugins/intel_cpu/src/dnnl_extension_utils.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_extension_utils.cpp
@@ -87,10 +87,8 @@ dnnl::memory::dim DnnlExtensionUtils::convertToDnnlDim(const Dim &dim) {
 }
 
 VectorDims DnnlExtensionUtils::convertToVectorDims(const memory::dims& dims) {
-    std::vector<size_t> vecResult;
-    vecResult.reserve(dims.size());
-    std::back_insert_iterator<std::vector<size_t>> itr(vecResult);
-    std::transform(dims.begin(), dims.end(), itr, convertToDim);
+    std::vector<size_t> vecResult(dims.size());
+    std::transform(dims.begin(), dims.end(), vecResult.begin(), convertToDim);
     return vecResult;
 }
 
@@ -99,10 +97,8 @@ VectorDims DnnlExtensionUtils::convertToVectorDims(const dnnl::impl::dims_t dims
 }
 
 memory::dims DnnlExtensionUtils::convertToDnnlDims(const VectorDims& dims) {
-    memory::dims vecResult;
-    vecResult.reserve(dims.size());
-    std::back_insert_iterator<memory::dims> itr(vecResult);
-    std::transform(dims.begin(), dims.end(), itr, convertToDnnlDim);
+    memory::dims vecResult(dims.size());
+    std::transform(dims.begin(), dims.end(), vecResult.begin(), convertToDnnlDim);
     return vecResult;
 }
 

--- a/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.h
@@ -45,13 +45,6 @@ public:
     virtual const VectorDims& getOffsetPaddingToData() const = 0;
 
     /**
-     * @brief Returns the offset to the current memory block
-     *
-     * @return offset
-     */
-    virtual size_t getOffsetPadding() const = 0;
-
-    /**
      * @brief Returns strides for each dimension
      *
      * @return strides

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
@@ -54,8 +54,7 @@ CpuBlockedMemoryDesc::CpuBlockedMemoryDesc(InferenceEngine::Precision prc, const
         } else if (std::any_of(this->blockedDims.begin(), this->blockedDims.end(), [](size_t val) { return val == Shape::UNDEFINED_DIM; })) {
             this->strides.resize(order.size(), Shape::UNDEFINED_DIM);
         } else {
-            this->strides.resize(order.size());
-            this->strides[order.size() - 1] = 1;
+            this->strides.resize(order.size(), 1);
             for (size_t i = 2; i <= order.size(); i++) {
                 this->strides[order.size() - i] = this->strides[order.size() - (i - 1)] * this->blockedDims[blockedDims.size() - (i - 1)];
             }

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc.h
@@ -63,6 +63,13 @@ public:
     virtual MemoryDescPtr clone() const = 0;
 
     /**
+     * @brief Returns the offset to the current memory block
+     *
+     * @return offset
+     */
+    virtual size_t getOffsetPadding() const = 0;
+
+    /**
      * @brief Clone descriptor with new dims.
      * Throws an exception if relaxedCheck is false and some of the new dims conflicts with the internal shape (i.e. its defined dims ,rank, upper bounds)
      * or if internal shape and dims have different ranks

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
@@ -455,9 +455,7 @@ MemoryDescPtr DnnlBlockedMemoryDesc::cloneWithNewDimsImp(const VectorDims &dims)
         IE_THROW() << "Can't clone desc if new dims are undefined";
     }
 
-    // // TODO [DS]: add stride recalculation for strided blobs
-    // getStrides();
-    // getBlockDims();
+    // TODO [DS]: add stride recalculation for strided blobs
     for (int i = strides.size() - 2; i >= 0 ; i--) {
         if (strides[i] == Shape::UNDEFINED_DIM)
             break;

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
@@ -328,9 +328,6 @@ static VectorDims extractOrder(const dnnl::memory::desc& desc) {
     return blk_order;
 }
 
-DnnlBlockedMemoryDesc::DnnlBlockedMemoryDesc(const dnnl::memory::desc& mdesc) :
-    DnnlBlockedMemoryDesc(mdesc.get()) {}
-
 DnnlBlockedMemoryDesc::DnnlBlockedMemoryDesc(const_dnnl_memory_desc_t cdesc) :
     MemoryDesc(DnnlExtensionUtils::convertToVectorDims(cdesc->dims, cdesc->ndims), DnnlBlocked) {
     desc = dnnl::memory::desc(DnnlExtensionUtils::clone_desc(cdesc));
@@ -464,7 +461,7 @@ MemoryDescPtr DnnlBlockedMemoryDesc::cloneWithNewDimsImp(const VectorDims &dims)
             IE_THROW(NotImplemented) << "Can't clone desc with new dims for not dense tensor";
     }
 
-    return DnnlBlockedMemoryDescPtr(new DnnlBlockedMemoryDesc(cloneDescWithNewDims(desc, dims, order)));
+    return DnnlBlockedMemoryDescPtr(new DnnlBlockedMemoryDesc(cloneDescWithNewDims(desc, dims, order).get()));
 }
 
 bool DnnlBlockedMemoryDesc::isSame(dnnl::memory::format_tag fmt) const {

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
@@ -190,7 +190,7 @@ DnnlBlockedMemoryDesc::DnnlBlockedMemoryDesc(InferenceEngine::Precision prc, con
     std::copy(order.end() - inner_ndims, order.end(), dnn_blk_desc.inner_idxs);
 
     this->order = order;
-    initBlockDims();
+    this->blockedDims = blockedDims;
     initOffsetPadding();
 
     if (strides.empty()) {
@@ -200,7 +200,7 @@ DnnlBlockedMemoryDesc::DnnlBlockedMemoryDesc(InferenceEngine::Precision prc, con
             auto dnnlStrides = DnnlExtensionUtils::convertToDnnlDims(strides);
             dnn_blk_desc.strides[order[i]] = dnnlStrides[i];
         }
-        initStrides();
+        this->strides = strides;
     }
 }
 
@@ -455,9 +455,9 @@ MemoryDescPtr DnnlBlockedMemoryDesc::cloneWithNewDimsImp(const VectorDims &dims)
         IE_THROW() << "Can't clone desc if new dims are undefined";
     }
 
-    // TODO [DS]: add stride recalculation for strided blobs
-    getStrides();
-    getBlockDims();
+    // // TODO [DS]: add stride recalculation for strided blobs
+    // getStrides();
+    // getBlockDims();
     for (int i = strides.size() - 2; i >= 0 ; i--) {
         if (strides[i] == Shape::UNDEFINED_DIM)
             break;

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.h
@@ -64,9 +64,6 @@ public:
     using DnnlMemoryDesc::setPrecision;
     using DnnlMemoryDesc::getPrecision;
 
-    explicit DnnlBlockedMemoryDesc(const dnnl::memory::desc& mdesc);
-    explicit DnnlBlockedMemoryDesc(const_dnnl_memory_desc_t cdesc);
-
 private:
     DnnlBlockedMemoryDesc(InferenceEngine::Precision prc, const Shape& shape, const VectorDims& blockedDims,
                           const VectorDims& order, size_t offsetPadding = 0, const VectorDims& offsetPaddingToData = {},
@@ -76,6 +73,8 @@ private:
     // the mdesc own shape is ignored. The main purpose of this constructor is making dynamic descriptor from some dummy mdesc, which stores info about
     // layout, blocking, strides, etc., and the provided dynamic shape.
     DnnlBlockedMemoryDesc(const dnnl::memory::desc& mdesc, const Shape& shape);
+
+    explicit DnnlBlockedMemoryDesc(const_dnnl_memory_desc_t cdesc);
 
     MemoryDescPtr cloneWithNewDimsImp(const VectorDims& dims) const override;
 
@@ -97,7 +96,7 @@ private:
 
     void recomputeDefaultStrides();
 
-    friend DnnlMemoryDescPtr DnnlExtensionUtils::makeDescriptor(const dnnl::memory::desc &desc);
+    friend DnnlMemoryDescPtr DnnlExtensionUtils::makeDescriptor(const_dnnl_memory_desc_t desc);
     friend std::shared_ptr<DnnlBlockedMemoryDesc> DnnlExtensionUtils::makeUndefinedDesc(const dnnl::memory::desc &desc, const Shape& shape);
     friend class MemoryDescUtils;
 };

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.h
@@ -43,10 +43,6 @@ public:
         return offsetPaddingToData;
     }
 
-    size_t getOffsetPadding() const override {
-        return DnnlExtensionUtils::convertToDim(desc.get()->offset0);
-    }
-
     const VectorDims& getStrides() const override {
         return strides;
     }

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_memory_desc.cpp
@@ -115,5 +115,11 @@ MemoryDescPtr DnnlMemoryDesc::cloneWithNewDimsImp(const VectorDims &dims) const 
     IE_THROW(Unexpected) << "Cannot clone non blocked oneDNN desc with new dims";
 }
 
+size_t DnnlMemoryDesc::getOffsetPadding() const {
+    dnnl::impl::memory_desc_wrapper wrap(desc.get());
+    return DnnlExtensionUtils::convertToDim(wrap.offset0());
+}
+
+
 }   // namespace intel_cpu
 }   // namespace ov

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_memory_desc.h
@@ -45,9 +45,7 @@ public:
 
     bool hasEmptyExtraData() const;
 
-    size_t getOffsetPadding() const override {
-        return DnnlExtensionUtils::convertToDim(desc.data.offset0);
-    }
+    size_t getOffsetPadding() const override;
 
 protected:
     DnnlMemoryDesc() {}

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_memory_desc.h
@@ -45,6 +45,10 @@ public:
 
     bool hasEmptyExtraData() const;
 
+    size_t getOffsetPadding() const override {
+        return DnnlExtensionUtils::convertToDim(desc.data.offset0);
+    }
+
 protected:
     DnnlMemoryDesc() {}
     static constexpr size_t UNREACHABLE_DIM = std::numeric_limits<size_t>::max();

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -784,19 +784,6 @@ void Node::initDescriptor(const NodeConfig& config) {
 }
 
 void Node::prepareMemory(const std::vector<DnnlMemoryDescPtr>& intDescs) {
-    for (size_t i = 0; i < getChildEdges().size(); i++) {
-        auto &dstMemPtr = getChildEdgeAt(i)->getMemoryPtr();
-        if (!dstMemPtr || !dstMemPtr->isAllocated())
-            IE_THROW() << "Destination memory didn't allocate for node " << getName()
-                               << " to node " << getChildEdgeAt(i)->getChild()->getName() << ".";
-    }
-    for (size_t i = 0; i < getParentEdges().size(); i++) {
-        auto &srcMemPtr = getParentEdgeAt(i)->getMemoryPtr();
-        if (!srcMemPtr || !srcMemPtr->isAllocated())
-            IE_THROW() << "Destination memory didn't allocate for node " << getName()
-                               << " from node " << getParentEdgeAt(i)->getParent()->getName() << ".";
-    }
-
     if (internalBlobs.size() != intDescs.size()) {
         IE_THROW() << "Can't prepare memory for internal blob, internal blob and internal descs number do not match "
                    << internalBlobs.size() << " vs " << intDescs.size();


### PR DESCRIPTION
CPU memory class was previously designed as a wrapper for oneDNN memory class. However, in the plugin we do not always need oneDNN memory object in our own node implementations, while  oneDNN memory instantiation is not free and we see this overhead especially in the dynamic shapes scenario. This PR changes the logic, now we insatiate oneDNN memory object on demand.

Ticket id:
* 99122