### PR TITLE
[GPU] Removed mark field from program_node

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/trim_to_outputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/trim_to_outputs.cpp
@@ -58,4 +58,8 @@ void trim_to_outputs::run(program& p) {
             to_rem.push_back(node);
     }
     p.remove_nodes(to_rem);
+
+    for (auto& node : p.get_processing_order()) {
+        node->unmark();
+    }
 }

--- a/src/plugins/intel_gpu/src/graph/include/pass_manager.h
+++ b/src/plugins/intel_gpu/src/graph/include/pass_manager.h
@@ -31,11 +31,6 @@ public:
     explicit base_pass(const std::string& pass_name) : name(pass_name) {}
     virtual void run(program& p) = 0;
     std::string get_name() { return name; }
-    void clean_marks(program& p) {
-        for (auto& node : p.get_processing_order()) {
-            node->unmark();
-        }
-    }
 
 private:
     const std::string name;

--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -266,8 +266,6 @@ public:
     }
     void unmark() { user_mark = 0; }
     bool is_marked() const { return user_mark != 0; }
-    bool is_marked(uint8_t val) const { return user_mark == val; }
-    uint8_t get_user_mark() const { return user_mark; }
 
     void add_fused_activation(activation_func activation_func,
                               activation_additional_params additional_params) {

--- a/src/plugins/intel_gpu/src/graph/pass_manager.cpp
+++ b/src/plugins/intel_gpu/src/graph/pass_manager.cpp
@@ -69,6 +69,5 @@ void pass_manager::run(program& p, base_pass& pass) {
         dump_file_name += "0";
     dump_file_name += std::to_string(pass_count) + "_" + pass.get_name();
     p.dump_program(dump_file_name.c_str(), true);
-    pass.clean_marks(p);
     pass_count++;
 }


### PR DESCRIPTION
### Details:
 - Marks are needed in several passes only (graph traversal only), but it's mark itself is a node field and we clean them after each pass. So this patch removes marks cleanup from common pass manager code and moves it only to passes which requires it. May provide ~2-3% load time gain for some models
