### PR TITLE
[GPU] Minor fix for dynamic reshape

### DIFF
--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -59,7 +59,7 @@ std::vector<layout> reshape_inst::calc_output_layouts(reshape_node const& /*node
     // On program build stage for the cases with pattern being stored in a runtime tensor
     // we return output_partial_shape taken from the original model intead of something like PartialShape::dynamic(rank)
     // as ngraph may refine output shape using interval arithmetic
-    if (memory_deps.empty() && prim->output_pattern.empty()) {
+    if ((memory_deps.empty() && prim->output_pattern.empty()) || input_layout.is_dynamic()) {
         return { layout{prim->output_partial_shape, input_layout.data_type, format::adjust_to_rank(input_layout.format, prim->output_partial_shape.size())} };
     }
 
@@ -143,19 +143,25 @@ reshape_inst::typed_primitive_inst(network& network, reshape_node const& node) :
                                     "output layout data type",
                                     output_layout.data_type,
                                     "");
-    CLDNN_ERROR_NOT_EQUAL(node.id(),
-                          "Output layout count",
-                          output_layout.count(),
-                          "input layout count",
-                          input_layout.count(),
-                          "Output layout of reshape primitive changes size of input buffer");
+    if (output_layout.is_static())
+        CLDNN_ERROR_NOT_EQUAL(node.id(),
+                              "Output layout count",
+                              output_layout.count(),
+                              "input layout count",
+                              input_layout.count(),
+                              "Output layout of reshape primitive changes size of input buffer");
 
     // if reshape operated in-place, postpone creation of the output until network run,
     // then create new memory object as the reinterpreted output of the previous primitive
-    if (!node.can_be_optimized())
-        _output = allocate_output();
-    else
-        reuse_input();
+    if (_node.get_output_layout().is_static()) {
+        if (!node.can_be_optimized())
+            _output = allocate_output();
+        else
+            reuse_input();
+    } else {
+        if (_exec_deps.size() > 0 && input_memory_ptr())
+            reuse_input();
+    }
 }
 
 void reshape_inst::on_execute() {
@@ -170,7 +176,8 @@ void reshape_inst::on_execute() {
 
 void reshape_inst::reuse_input() {
     build_deps();  // reshape need deps
-    _output = _network.get_engine().reinterpret_buffer(input_memory(), node.get_output_layout());
+    OPENVINO_ASSERT(input_memory_ptr() != nullptr, "[GPU] Failed to reuse input in ", id(), " primitive: input memory was not allocated");
+    _output = _network.get_engine().reinterpret_buffer(input_memory(), _impl_params->output_layout);
 }
 
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/tests/shape_infer/reshape_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/shape_infer/reshape_si_test.cpp
@@ -81,6 +81,11 @@ INSTANTIATE_TEST_SUITE_P(smoke, reshape_test_two_inputs,
             layout{ov::PartialShape{4}, data_types::i64, format::bfyx}, {0, 0, 16, 64}, ov::PartialShape::dynamic(4), true,
             layout{ov::PartialShape{1, 384, 16, 64}, data_types::f32, format::bfyx}
         },
+        {
+            layout{ov::PartialShape::dynamic(2), data_types::f32, format::bfyx},
+            layout{ov::PartialShape{4}, data_types::i64, format::bfyx}, {0, 1, 2, 3}, ov::PartialShape::dynamic(4), true,
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx}
+        },
     }));
 
 class reshape_test_single_input : public testing::TestWithParam<reshape_test_params> {};
@@ -124,6 +129,16 @@ INSTANTIATE_TEST_SUITE_P(smoke, reshape_test_single_input,
             layout{ov::PartialShape{1, 384, 1024}, data_types::f32, format::bfyx},
             layout{ov::PartialShape{4}, data_types::i64, format::bfyx}, {}, ov::PartialShape::dynamic(2), true,
             layout{ov::PartialShape::dynamic(2), data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape::dynamic(2), data_types::f32, format::bfyx},
+            layout{ov::PartialShape{4}, data_types::i64, format::bfyx}, {0, 1, 2, 3}, ov::PartialShape{0, 1, 2, 3}, true,
+            layout{ov::PartialShape{0, 1, 2, 3}, data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape::dynamic(2), data_types::f32, format::bfyx},
+            layout{ov::PartialShape{4}, data_types::i64, format::bfyx}, {}, ov::PartialShape::dynamic(4), true,
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx}
         },
     }));
 


### PR DESCRIPTION
### Details:
 - Return `output_partial_shape` if input layout is dynamic
 - Additional checks for static/dynamic layout in reshape
 - Get rid of TensorDesc usages for exec graph construction
