### PR TITLE
[GPU] Tile fix for dyn flow

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/program.hpp
@@ -162,6 +162,8 @@ public:
 
     const variables_state_info_map& GetVariablesStatesInfo() const { return m_variablesStateInfo; }
 
+    bool use_new_shape_infer() const { return allow_new_shape_infer; }
+
 private:
     static factories_map_t factories_map;
     std::vector<std::shared_ptr<cldnn::program>> m_programs;
@@ -172,6 +174,8 @@ private:
     InferenceEngine::InputsDataMap m_networkInputs;
     InferenceEngine::OutputsDataMap m_networkOutputs;
     variables_state_info_map m_variablesStateInfo;
+
+    bool allow_new_shape_infer = false;
 
     bool queryMode;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
@@ -29,6 +29,17 @@ public:
         auto tile_optional_params =
             get_default_optional_params<kernel_selector::tile_optional_params>(arg.get_program());
 
+        auto repeats = impl_param.typed_desc<tile>()->repeats;
+        auto in_layout = impl_param.get_input_layout(0);
+        auto in_shape = in_layout.get_partial_shape();
+
+        // Extend input shape by prepending ones if repeats rank is higher than input rank.
+        if (in_shape.size() < repeats.size()) {
+            in_shape.insert(in_shape.begin(), repeats.size() - in_shape.size(), 1);
+            in_layout.set_partial_shape(in_shape);
+            tile_params.inputs[0] = convert_data_tensor(in_layout);
+        }
+
         auto& kernel_selector = kernel_selector::tile_kernel_selector::Instance();
         auto best_kernels = kernel_selector.GetBestKernels(tile_params, tile_optional_params);
 

--- a/src/plugins/intel_gpu/src/plugin/ops/tile.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/tile.cpp
@@ -17,7 +17,6 @@ static void CreateTileOp(Program& p, const std::shared_ptr<ngraph::op::v0::Tile>
     validate_inputs_count(op, {2});
     auto inputPrimitives = p.GetInputPrimitiveIDs(op);
     std::string layerName = layer_type_name_ID(op);
-    size_t rank = op->get_input_shape(0).size();
 
     auto repeatsNode = std::dynamic_pointer_cast<ngraph::op::Constant>(op->get_input_node_shared_ptr(1));
     if (!repeatsNode)
@@ -25,25 +24,29 @@ static void CreateTileOp(Program& p, const std::shared_ptr<ngraph::op::v0::Tile>
                                                         " (" << op->get_type_name() << ")";
     std::vector<int64_t> repeats = repeatsNode->cast_vector<int64_t>();
 
-    int64_t defaultSize = 1;
-    for (size_t i = repeats.size(); i < rank; ++i) {
-        repeats.insert(repeats.begin(), defaultSize);
-    }
+    // TODO: Remove code below once new shape infer is enabled
+    if (!op->is_dynamic() && !p.use_new_shape_infer()) {
+        size_t rank = op->get_input_shape(0).size();
+        int64_t defaultSize = 1;
+        for (size_t i = repeats.size(); i < rank; ++i) {
+            repeats.insert(repeats.begin(), defaultSize);
+        }
 
-    if (repeats.size() > rank) {
-        std::string reshapeName = layerName + "_reshape";
-        auto inputDims = op->get_input_shape(0);
+        if (repeats.size() > rank) {
+            std::string reshapeName = layerName + "_reshape";
+            auto inputDims = op->get_input_shape(0);
 
-        // Extend input dimensions to the same size as repeats dimensions by prepending ones
-        inputDims.insert(inputDims.begin(), repeats.size() - rank, defaultSize);
+            // Extend input dimensions to the same size as repeats dimensions by prepending ones
+            inputDims.insert(inputDims.begin(), repeats.size() - rank, defaultSize);
 
-        auto targetShape = tensor_from_dims(inputDims);
+            auto targetShape = tensor_from_dims(inputDims);
 
-        auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[0], targetShape);
+            auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[0], targetShape);
 
-        p.add_primitive(*op, reshapePrim);
+            p.add_primitive(*op, reshapePrim);
 
-        inputPrimitives[0] = reshapeName;
+            inputPrimitives[0] = reshapeName;
+        }
     }
 
     auto tilePrim = cldnn::tile(layerName,

--- a/src/plugins/intel_gpu/src/plugin/program.cpp
+++ b/src/plugins/intel_gpu/src/plugin/program.cpp
@@ -318,6 +318,14 @@ std::shared_ptr<cldnn::program> Program::BuildProgram(const std::vector<std::sha
         options.set_option(cldnn::build_option::graph_dumps_dir(m_config.graph_dumps_dir));
     }
 
+    for (const auto& op : ops) {
+        if (op->is_dynamic()) {
+            allow_new_shape_infer = true;
+            break;
+        }
+    }
+
+    options.set_option(cldnn::build_option::allow_new_shape_infer(allow_new_shape_infer));
     options.set_option(cldnn::build_option::optimize_data(true));
     options.set_option(cldnn::build_option::tuning_config(m_config.tuningConfig));
     if (partialBuild) {


### PR DESCRIPTION
### Details:
 - Added search for any dynamic op in the the model which may set allow_new_shape_infer build option
 - Modified tile op factory to avoid reshape for dynamic or new shape infer cases
 - Added proper alignment of input shape in tile impl
 - Always return use partial shape in reorder shape infer
