### PR TITLE
[GPU] Weights reorder cache

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
@@ -248,6 +248,7 @@ public:
     void load_tuning_cache();
     std::shared_ptr<kernel_selector::TuningCache> get_tuning_cache() const { return tuning_cache; }
     ImplementationsCache& get_implementations_cache() const { return *_impls_cache; }
+    KernelsCache& get_in_mem_kernels_cache() const { return *_in_mem_kernels_cache; }
 
     // returns {-1, -1} if it failed to estimate by allocating given batch size
     std::pair<int64_t/*const alloc*/, int64_t/*general alloc*/> get_estimated_device_mem_usage();
@@ -261,6 +262,10 @@ private:
     // TODO: Consider moving it to engine
     std::unique_ptr<kernels_cache> _kernels_cache;
     std::unique_ptr<ImplementationsCache> _impls_cache;
+    std::unique_ptr<KernelsCache> _in_mem_kernels_cache;
+    // TODO: initial version use unlimited caches. Need to adjust it once dynamic flow works on wide set of models.
+    const size_t _impls_cache_capacity = 0;
+    const size_t _in_mem_kernels_cache_capacity = 0;
     build_options options;
     std::list<program_node*> inputs;
     std::vector<program_node*> outputs;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/lru_cache.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/lru_cache.hpp
@@ -164,4 +164,5 @@ private:
 };
 
 using ImplementationsCache = cldnn::LruCache<std::string, std::shared_ptr<primitive_impl>>;
+using KernelsCache = cldnn::LruCache<std::string, cldnn::kernel::ptr>;
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -471,19 +471,50 @@ event::ptr primitive_inst::update_weights() {
     if (requires_reorder) {
         auto weights_idx = _node.get_primitive()->input.size();
         auto original_weights_memory = dep_memory_ptr(weights_idx);
+        auto original_layout = original_weights_memory->get_layout();
         layout expected_layout = from_weights_tensor(weights_params.dest);
+
         auto& program = _node.get_program();
         auto& engine = _network.get_engine();
-        auto& stream = _network.get_stream();
-        auto _kernel_id = program.add_kernel(weights_params.clKernel->code.kernelString);
-        program.compile();
-        auto kernel = program.get_kernel(_kernel_id);
 
-        GPU_DEBUG_IF(debug_config->verbose >= 4) {
-            GPU_DEBUG_COUT << id() << ": reorder weights from " << original_weights_memory->get_layout() << "\nto " << expected_layout << std::endl;
+        auto get_layout_key = [&]() -> std::string {
+            std::string layout_key_str = id() + "_" + std::to_string(_node.get_unique_id());
+            layout_key_str += "_" + expected_layout.to_string();
+            layout_key_str += "_" + original_layout.to_string();
+            return layout_key_str;
+        };
+
+        cldnn::kernel::ptr kernel = nullptr;
+        auto layout_key = get_layout_key();
+        if (layout_key != "") {
+            auto& cache = program.get_in_mem_kernels_cache();
+            if (cache.has(layout_key)) {
+                GPU_DEBUG_IF(debug_config->verbose >= 4) {
+                    GPU_DEBUG_COUT << id() << ": reorder weights (cached) from " << original_layout << "\nto " << expected_layout << std::endl;
+                }
+                kernel = cache.get(layout_key);
+            } else {
+                GPU_DEBUG_IF(debug_config->verbose >= 4) {
+                    GPU_DEBUG_COUT << id() << ": reorder weights from " << original_layout << "\nto " << expected_layout << std::endl;
+                }
+                auto _kernel_id = program.add_kernel(weights_params.clKernel->code.kernelString);
+                program.compile();
+                kernel = program.get_kernel(_kernel_id);
+                cache.add(layout_key, kernel);
+            }
         }
 
-        _impl_params->reordered_weights = engine.allocate_memory(expected_layout, allocation_type::usm_device);
+        auto& stream = _network.get_stream();
+
+        bool can_reuse = _impl_params->reordered_weights != nullptr && _impl_params->reordered_weights->size() <= expected_layout.bytes_count();
+        if (can_reuse) {
+            GPU_DEBUG_IF(debug_config->verbose >= 4) {
+                GPU_DEBUG_COUT << id() << ": reuse weights memory" << std::endl;
+            }
+            _impl_params->reordered_weights = engine.reinterpret_buffer(*_impl_params->reordered_weights, expected_layout);
+        } else {
+            _impl_params->reordered_weights = engine.allocate_memory(expected_layout, allocation_type::usm_device);
+        }
 
         kernel_arguments_data args;
         args.inputs.push_back(original_weights_memory);

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -109,7 +109,8 @@ program::program(engine& engine_ref,
     prepare_nodes(topology);
     _kernels_cache = std::unique_ptr<kernels_cache>(new kernels_cache(_engine, prog_id,
                                                                       kernel_selector::KernelBase::get_db().get_batch_header_str()));
-    _impls_cache = std::unique_ptr<ImplementationsCache>(new ImplementationsCache(0));
+    _impls_cache = std::unique_ptr<ImplementationsCache>(new ImplementationsCache(_impls_cache_capacity));
+    _in_mem_kernels_cache = std::unique_ptr<KernelsCache>(new KernelsCache(_in_mem_kernels_cache_capacity));
     program_node::reset_unique_id();
     if (no_optimizations) {
         init_graph();
@@ -131,7 +132,8 @@ program::program(engine& engine_ref,
     set_options();
     _kernels_cache = std::unique_ptr<kernels_cache>(new kernels_cache(_engine, prog_id,
                                                                       kernel_selector::KernelBase::get_db().get_batch_header_str()));
-    _impls_cache = std::unique_ptr<ImplementationsCache>(new ImplementationsCache(0));
+    _impls_cache = std::unique_ptr<ImplementationsCache>(new ImplementationsCache(_impls_cache_capacity));
+    _in_mem_kernels_cache = std::unique_ptr<KernelsCache>(new KernelsCache(_in_mem_kernels_cache_capacity));
     pm = std::unique_ptr<pass_manager>(new pass_manager(*this));
     prepare_nodes(nodes);
     build_program(is_internal);


### PR DESCRIPTION
### Details:
 - Use LRU cache for weight reorder kernels. Since primitive_impl is not created for that case, we introduce separate cache object which operates with `kernel::ptr`.

### Tickets:
 - *90373*
