### PR TITLE
[CMake] Enable Protobuf based readers for Android

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -144,7 +144,7 @@ ie_dependent_option (ENABLE_GPU_DEBUG_CAPS "enable GPU debug capabilities at run
 
 ie_dependent_option (ENABLE_CPU_DEBUG_CAPS "enable CPU debug capabilities at runtime" ON "ENABLE_DEBUG_CAPS" OFF)
 
-if(ANDROID OR WINDOWS_STORE OR (MSVC AND (ARM OR AARCH64)))
+if(WINDOWS_STORE OR (MSVC AND (ARM OR AARCH64)))
     set(protoc_available OFF)
 else()
     set(protoc_available ON)


### PR DESCRIPTION
Android toolchain is able build ONNX/PDPD/TF readers.

test build: https://github.com/dkurt/openvino_java/actions/runs/3043828663/jobs/4903532041