### PR TITLE
[GPU] Disable blocked format support in Softmax

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
@@ -72,19 +72,9 @@ attach_softmax_impl::attach_softmax_impl() {
     auto types = {data_types::f16, data_types::f32};
     auto formats = {
             format::bfyx,
+            format::byxf,
             format::yxfb,
-            format::b_fs_yx_fsv16,
-            format::b_fs_yx_fsv32,
-            format::bs_fs_yx_bsv16_fsv16,
-            format::bs_fs_yx_bsv32_fsv16,
-            format::bs_fs_yx_bsv32_fsv32,
-            format::bfzyx,
-            format::b_fs_zyx_fsv16,
-            format::b_fs_zyx_fsv32,
-            format::bs_fs_zyx_bsv16_fsv32,
-            format::bs_fs_zyx_bsv16_fsv16,
-            format::bs_fs_zyx_bsv32_fsv32,
-            format::bs_fs_zyx_bsv32_fsv16
+            format::bfzyx
     };
 
     implementation_map<softmax>::add(impl_types::ocl, softmax_impl::create, types, formats);


### PR DESCRIPTION
### Details:
 - Performance regression happens in mobilenet v1 after PR(https://github.com/openvinotoolkit/openvino/pull/12467). Network compiler changed from reorder+Softmax opt kernel to Softmax ref kernel which supports blocked format. And  it caused performance regression
 - Removed blocked format support in Softmax ref kernel until fix.

### Tickets:
 - *ticket-id*
