### PR TITLE
[Frontend, TF FE] Fix RTTI for ConversionExtension on MacOS

### DIFF
--- a/src/frontends/common/include/openvino/frontend/extension/conversion.hpp
+++ b/src/frontends/common/include/openvino/frontend/extension/conversion.hpp
@@ -29,13 +29,21 @@ private:
 class FRONTEND_API ConversionExtension : public ConversionExtensionBase {
 public:
     using Ptr = std::shared_ptr<ConversionExtension>;
-    ConversionExtension(const std::string& op_type, const CreatorFunction& converter);
+    ConversionExtension(const std::string& op_type, const CreatorFunction& converter)
+        : ConversionExtensionBase(op_type),
+          m_converter(converter) {}
 
-    ConversionExtension(const std::string& op_type, const CreatorFunctionNamed& converter);
+    ConversionExtension(const std::string& op_type, const CreatorFunctionNamed& converter)
+        : ConversionExtensionBase(op_type),
+          m_converter_named(converter) {}
 
-    const CreatorFunction& get_converter() const;
+    const CreatorFunction& get_converter() const {
+        return m_converter;
+    };
 
-    const CreatorFunctionNamed& get_converter_named() const;
+    const CreatorFunctionNamed& get_converter_named() const {
+        return m_converter_named;
+    };
 
     ~ConversionExtension() override;
 

--- a/src/frontends/common/include/openvino/frontend/extension/conversion.hpp
+++ b/src/frontends/common/include/openvino/frontend/extension/conversion.hpp
@@ -29,23 +29,15 @@ private:
 class FRONTEND_API ConversionExtension : public ConversionExtensionBase {
 public:
     using Ptr = std::shared_ptr<ConversionExtension>;
-    ConversionExtension(const std::string& op_type, const CreatorFunction& converter)
-        : ConversionExtensionBase(op_type),
-          m_converter(converter) {}
+    ConversionExtension(const std::string& op_type, const CreatorFunction& converter);
 
-    ConversionExtension(const std::string& op_type, const CreatorFunctionNamed& converter)
-        : ConversionExtensionBase(op_type),
-          m_converter_named(converter) {}
+    ConversionExtension(const std::string& op_type, const CreatorFunctionNamed& converter);
 
-    const CreatorFunction& get_converter() const {
-        return m_converter;
-    };
+    const CreatorFunction& get_converter() const;
 
-    const CreatorFunctionNamed& get_converter_named() const {
-        return m_converter_named;
-    };
+    const CreatorFunctionNamed& get_converter_named() const;
 
-    ~ConversionExtension() override = default;
+    ~ConversionExtension() override;
 
 private:
     CreatorFunction m_converter;

--- a/src/frontends/common/src/extension/conversion.cpp
+++ b/src/frontends/common/src/extension/conversion.cpp
@@ -7,20 +7,4 @@
 using namespace ov::frontend;
 ConversionExtensionBase::~ConversionExtensionBase() = default;
 
-ConversionExtension::ConversionExtension(const std::string& op_type, const CreatorFunction& converter)
-    : ConversionExtensionBase(op_type),
-      m_converter(converter) {}
-
-ConversionExtension::ConversionExtension(const std::string& op_type, const CreatorFunctionNamed& converter)
-    : ConversionExtensionBase(op_type),
-      m_converter_named(converter) {}
-
-const CreatorFunction& ConversionExtension::get_converter() const {
-    return m_converter;
-};
-
-const CreatorFunctionNamed& ConversionExtension::get_converter_named() const {
-    return m_converter_named;
-};
-
 ConversionExtension::~ConversionExtension() = default;

--- a/src/frontends/common/src/extension/conversion.cpp
+++ b/src/frontends/common/src/extension/conversion.cpp
@@ -6,3 +6,21 @@
 
 using namespace ov::frontend;
 ConversionExtensionBase::~ConversionExtensionBase() = default;
+
+ConversionExtension::ConversionExtension(const std::string& op_type, const CreatorFunction& converter)
+    : ConversionExtensionBase(op_type),
+      m_converter(converter) {}
+
+ConversionExtension::ConversionExtension(const std::string& op_type, const CreatorFunctionNamed& converter)
+    : ConversionExtensionBase(op_type),
+      m_converter_named(converter) {}
+
+const CreatorFunction& ConversionExtension::get_converter() const {
+    return m_converter;
+};
+
+const CreatorFunctionNamed& ConversionExtension::get_converter_named() const {
+    return m_converter_named;
+};
+
+ConversionExtension::~ConversionExtension() = default;

--- a/src/frontends/tensorflow/include/openvino/frontend/tensorflow/extension/conversion.hpp
+++ b/src/frontends/tensorflow/include/openvino/frontend/tensorflow/extension/conversion.hpp
@@ -19,9 +19,13 @@ public:
 
     ConversionExtension() = delete;
 
-    ConversionExtension(const std::string& op_type, const ov::frontend::CreatorFunction& converter);
+    ConversionExtension(const std::string& op_type, const ov::frontend::CreatorFunction& converter)
+        : ConversionExtensionBase(op_type),
+          m_converter(converter) {}
 
-    const ov::frontend::CreatorFunction& get_converter() const;
+    const ov::frontend::CreatorFunction& get_converter() const {
+        return m_converter;
+    }
 
     ~ConversionExtension() override;
 

--- a/src/frontends/tensorflow/include/openvino/frontend/tensorflow/extension/conversion.hpp
+++ b/src/frontends/tensorflow/include/openvino/frontend/tensorflow/extension/conversion.hpp
@@ -19,13 +19,11 @@ public:
 
     ConversionExtension() = delete;
 
-    ConversionExtension(const std::string& op_type, const ov::frontend::CreatorFunction& converter)
-        : ConversionExtensionBase(op_type),
-          m_converter(converter) {}
+    ConversionExtension(const std::string& op_type, const ov::frontend::CreatorFunction& converter);
 
-    const ov::frontend::CreatorFunction& get_converter() const {
-        return m_converter;
-    }
+    const ov::frontend::CreatorFunction& get_converter() const;
+
+    ~ConversionExtension() override;
 
 private:
     ov::frontend::CreatorFunction m_converter;

--- a/src/frontends/tensorflow/src/extension/conversion.cpp
+++ b/src/frontends/tensorflow/src/extension/conversion.cpp
@@ -6,12 +6,4 @@
 
 using namespace ov::frontend::tensorflow;
 
-ConversionExtension::ConversionExtension(const std::string& op_type, const ov::frontend::CreatorFunction& converter)
-    : ConversionExtensionBase(op_type),
-      m_converter(converter) {}
-
-const ov::frontend::CreatorFunction& ConversionExtension::get_converter() const {
-    return m_converter;
-}
-
 ConversionExtension ::~ConversionExtension() = default;

--- a/src/frontends/tensorflow/src/extension/conversion.cpp
+++ b/src/frontends/tensorflow/src/extension/conversion.cpp
@@ -1,0 +1,17 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/tensorflow/extension/conversion.hpp"
+
+using namespace ov::frontend::tensorflow;
+
+ConversionExtension::ConversionExtension(const std::string& op_type, const ov::frontend::CreatorFunction& converter)
+    : ConversionExtensionBase(op_type),
+      m_converter(converter) {}
+
+const ov::frontend::CreatorFunction& ConversionExtension::get_converter() const {
+    return m_converter;
+}
+
+ConversionExtension ::~ConversionExtension() = default;

--- a/src/frontends/tensorflow/src/extension/conversion.cpp
+++ b/src/frontends/tensorflow/src/extension/conversion.cpp
@@ -6,4 +6,4 @@
 
 using namespace ov::frontend::tensorflow;
 
-ConversionExtension ::~ConversionExtension() = default;
+ConversionExtension::~ConversionExtension() = default;


### PR DESCRIPTION
**Details:** On MacOS there is problem with RTTI when all class definitions are put into the header file. For this reason, for example, OVTF can't register `ConversionExtension` into TF FE.

**Ticket:** 91854

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>