### PR TITLE
Tests for CASTLIKE C++

### DIFF
--- a/src/frontends/onnx/tests/models/castlike_bfloat16_to_float32.prototxt
+++ b/src/frontends/onnx/tests/models/castlike_bfloat16_to_float32.prototxt
@@ -1,0 +1,63 @@
+ir_version: 8
+producer_name: "onnx-importer-test"
+graph {
+  node {
+    input: "input"
+    input: "like"
+    output: "output"
+    op_type: "CastLike"
+  }
+  name: "test-model"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 16
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "like"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 15
+}

--- a/src/frontends/onnx/tests/models/castlike_float32_to_bfloat16.prototxt
+++ b/src/frontends/onnx/tests/models/castlike_float32_to_bfloat16.prototxt
@@ -1,0 +1,63 @@
+ir_version: 8
+producer_name: "onnx-importer-test"
+graph {
+  node {
+    input: "input"
+    input: "like"
+    output: "output"
+    op_type: "CastLike"
+  }
+  name: "test-model"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "like"
+    type {
+      tensor_type {
+        elem_type: 16
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 16
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 15
+}

--- a/src/frontends/onnx/tests/models/castlike_float64_to_int32.prototxt
+++ b/src/frontends/onnx/tests/models/castlike_float64_to_int32.prototxt
@@ -1,0 +1,72 @@
+ir_version: 8
+producer_name: "onnx-importer-test"
+graph {
+  node {
+    input: "input"
+    input: "like"
+    output: "output"
+    op_type: "CastLike"
+  }
+  name: "test-model"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "like"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 15
+}

--- a/src/frontends/onnx/tests/models/castlike_int32_to_float64.prototxt
+++ b/src/frontends/onnx/tests/models/castlike_int32_to_float64.prototxt
@@ -1,0 +1,72 @@
+ir_version: 8
+producer_name: "onnx-importer-test"
+graph {
+  node {
+    input: "input"
+    input: "like"
+    output: "output"
+    op_type: "CastLike"
+  }
+  name: "test-model"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "like"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 15
+}

--- a/src/frontends/onnx/tests/models/castlike_int8_to_float16.prototxt
+++ b/src/frontends/onnx/tests/models/castlike_int8_to_float16.prototxt
@@ -1,0 +1,72 @@
+ir_version: 8
+producer_name: "onnx-importer-test"
+graph {
+  node {
+    input: "input"
+    input: "like"
+    output: "output"
+    op_type: "CastLike"
+  }
+  name: "test-model"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "like"
+    type {
+      tensor_type {
+        elem_type: 10
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 10
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 15
+}

--- a/src/frontends/onnx/tests/models/castlike_int8_to_int16.prototxt
+++ b/src/frontends/onnx/tests/models/castlike_int8_to_int16.prototxt
@@ -1,0 +1,72 @@
+ir_version: 8
+producer_name: "onnx-importer-test"
+graph {
+  node {
+    input: "input"
+    input: "like"
+    output: "output"
+    op_type: "CastLike"
+  }
+  name: "test-model"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "like"
+    type {
+      tensor_type {
+        elem_type: 5
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 5
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 15
+}

--- a/src/frontends/onnx/tests/models/castlike_int8_to_uint16.prototxt
+++ b/src/frontends/onnx/tests/models/castlike_int8_to_uint16.prototxt
@@ -1,0 +1,72 @@
+ir_version: 8
+producer_name: "onnx-importer-test"
+graph {
+  node {
+    input: "input"
+    input: "like"
+    output: "output"
+    op_type: "CastLike"
+  }
+  name: "test-model"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "like"
+    type {
+      tensor_type {
+        elem_type: 4
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 4
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 15
+}

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -5609,18 +5609,18 @@ NGRAPH_TEST(${BACKEND_NAME}, castlike_float16_to_int64) {
     test_case.run();
 }
 
-// NGRAPH_TEST(${BACKEND_NAME}, castlike_int8_to_uint16) {
-    //     auto function = onnx_import::import_onnx_model(
-    //         file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_int8_to_uint16.onnx"));
+NGRAPH_TEST(${BACKEND_NAME}, castlike_int8_to_uint16) {
+        auto function = onnx_import::import_onnx_model(
+            file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_int8_to_uint16.onnx"));
             
-    //     auto test_case = test::TestCase(function, s_device);
+        auto test_case = test::TestCase(function, s_device);
         
-    //     test_case.add_input<int8_t>(Shape{1,1,2,2},std::vector<int8_t>{-1, -2, 3, 4});
-    //     test_case.add_input<uint16_t>(Shape{4},{1, 2, 3, 4});
-    //     test_case.add_expected_output<uint16_t>(std::vector<uint16_t>{65535, 65534, 3, 4});
+        test_case.add_input<int8_t>(Shape{1,1,2,2},std::vector<int8_t>{-1, -2, 3, 4});
+        test_case.add_input<uint16_t>(Shape{4},{1, 2, 3, 4});
+        test_case.add_expected_output<uint16_t>(std::vector<uint16_t>{65535, 65534, 3, 4});
         
-    //     test_case.run();
-    // }
+        test_case.run();
+    }
 
     // [ RUN      ] INTERPRETER.castlike_int8_to_uint16
     // >>>>>>>>>>>>>>>  === castlike_int8_to_uint16 test
@@ -5651,3 +5651,85 @@ NGRAPH_TEST(${BACKEND_NAME}, castlike_float64_to_int64) {
     
     test_case.run();
 }
+// ===============================
+NGRAPH_TEST(${BACKEND_NAME}, castlike_int8_to_float16) {
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_int8_to_float16.onnx"));
+    
+    auto test_case = test::TestCase(function, s_device);
+        
+    test_case.add_input<int8_t>(Shape{1,1,2,2},std::vector<int8_t>{-127, -2, 3, 4});
+    test_case.add_input<ngraph::float16>(Shape{4},{1, 2, 3, 4});
+    test_case.add_expected_output<ngraph::float16>(std::vector<ngraph::float16>{-127.0,-2.0,3.0,4.0});
+    
+    test_case.run();
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, castlike_int32_to_float) {
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_int32_to_float64.onnx"));
+    
+    auto test_case = test::TestCase(function, s_device);
+        
+    test_case.add_input<int32_t>(Shape{1,1,2,2},std::vector<int32_t>{-1, 2, 3, 4});
+    test_case.add_input<float>(Shape{4},{1, 2, 3, 4});
+    test_case.add_expected_output<float>(std::vector<float>{-1.0,2.0,3.0,4.0});
+    
+    test_case.run();
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, castlike_float64_to_int32) {
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_float64_to_int32.onnx"));
+    
+    auto test_case = test::TestCase(function, s_device);
+        
+    test_case.add_input<float>(Shape{1,1,2,2},std::vector<float>{-107374.9876543, -2.2, 3.3, 4.4});
+    test_case.add_input<int32_t>(Shape{4},{1, 2, 3, 4});
+    test_case.add_expected_output<int32_t>(std::vector<int32_t>{-107374,-2,3,4});
+    
+    test_case.run();
+}
+
+// NGRAPH_TEST(${BACKEND_NAME}, castlike_float32_to_bfloat16) {
+//     auto function = onnx_import::import_onnx_model(
+//         file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_float32_to_bfloat16.onnx"));
+    
+//     auto test_case = test::TestCase(function, s_device);
+    
+//     test_case.add_input<float>(Shape{3,4},std::vector<float>{1.5, 2.4, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+//     test_case.add_input<bfloat16>(Shape{3,4},{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+//     test_case.add_expected_output<bfloat16>(std::vector<bfloat16>{1.5, 2.4, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+    
+//     test_case.run();
+// }
+
+NGRAPH_TEST(${BACKEND_NAME}, DISABLED_castlike_bfloat16_to_float32) {
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_bfloat16_to_float32.onnx"));
+    
+    auto test_case = test::TestCase(function, s_device);
+    
+    test_case.add_input<bfloat16>(Shape{3,4},std::vector<bfloat16>{121.5, 122.7, 3, 4, 5, 6, 7, 8.8, 9, 10, 11, 12}); // 122.7 is not 122.5, might be a bug, create a ticket in JIRA for CPU team
+    test_case.add_input<float>(Shape{3,4},{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+    test_case.add_expected_output<float>(       std::vector<float>{121.5, 122.7, 3, 4, 5, 6, 7, 8.75, 9, 10, 11, 12});
+    
+    test_case.run();
+}
+
+//double -> float32
+
+/**
+ * castlike_float16_to_uint32
+ * castlike_float16_to_int64
+ * castlike_int8_to_uint16      // trouble with IE_CPU.castlike_int8_to_uint16, INTERPRETER.castlike_int8_to_uint16 is OK
+ * castlike_float64_to_int64
+ * castlike_int8_to_float16
+ * castlike_int32_to_float64
+ * castlike_float64_to_int32
+ * castlike_float32_to_bfloat16 <--
+ * castlike_bfloat16_to_float32
+ * 
+ * add double, bfloat, string, bool
+**/
+// create a BUG in jira, assign to CPU team (auto, component field ... dmitry gorohov)

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -5634,7 +5634,7 @@ NGRAPH_TEST(${BACKEND_NAME}, castlike_float64_to_int64) {
     
     test_case.run();
 }
-// ===============================
+
 NGRAPH_TEST(${BACKEND_NAME}, castlike_int8_to_float16) {
     auto function = onnx_import::import_onnx_model(
         file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_int8_to_float16.onnx"));

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -15,8 +15,6 @@
 #include <stdexcept>
 #include <vector>
 
-#include <iostream>
-
 // clang-format off
 #ifdef ${BACKEND_NAME}_FLOAT_TOLERANCE_BITS
 #define DEFAULT_FLOAT_TOLERANCE_BITS ${BACKEND_NAME}_FLOAT_TOLERANCE_BITS
@@ -5584,118 +5582,131 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_concat_empty_init) {
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, castlike_float16_to_uint32) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_float16_to_uint32.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/castlike_float16_to_uint32.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
-    
-    test_case.add_input<ngraph::float16>(Shape{1,1,2,2},std::vector<ngraph::float16>{1.5, 2.3, 3, 4});
-    test_case.add_input<uint32_t>(Shape{4},{1, 2, 3, 4});
-    test_case.add_expected_output<uint32_t>(std::vector<uint32_t>{1,2,3,4});
-    
+
+    test_case.add_input<ngraph::float16>(Shape{1, 1, 2, 2}, std::vector<ngraph::float16>{1.5, 2.3, 3, 4});
+    test_case.add_input<uint32_t>(Shape{4}, {1, 2, 3, 4});
+    test_case.add_expected_output<uint32_t>(std::vector<uint32_t>{1, 2, 3, 4});
+
     test_case.run();
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, castlike_float16_to_int64) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_float16_to_int64.onnx"));
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/castlike_float16_to_int64.onnx"));
 
     auto test_case = test::TestCase(function, s_device);
-    
-    test_case.add_input<ngraph::float16>(Shape{1,1,2,2},std::vector<ngraph::float16>{1.5, 2.3, 3, 4});
-    test_case.add_input<int64_t>(Shape{4},{1, 2, 3, 4});
-    test_case.add_expected_output<int64_t>(std::vector<int64_t>{1,2,3,4});
-    
+
+    test_case.add_input<ngraph::float16>(Shape{1, 1, 2, 2}, std::vector<ngraph::float16>{1.5, 2.3, 3, 4});
+    test_case.add_input<int64_t>(Shape{4}, {1, 2, 3, 4});
+    test_case.add_expected_output<int64_t>(std::vector<int64_t>{1, 2, 3, 4});
+
     test_case.run();
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, castlike_int8_to_uint16) {
-        auto function = onnx_import::import_onnx_model(
-            file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_int8_to_uint16.onnx"));
-            
-        auto test_case = test::TestCase(function, s_device);
-        
-        test_case.add_input<int8_t>(Shape{1,1,2,2},std::vector<int8_t>{-1, -2, 3, 4});
-        test_case.add_input<uint16_t>(Shape{4},{1, 2, 3, 4});
-        test_case.add_expected_output<uint16_t>(std::vector<uint16_t>{65535, 65534, 3, 4});
-        
-        test_case.run();
-    }
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/castlike_int8_to_uint16.onnx"));
+
+    auto test_case = test::TestCase(function, s_device);
+
+    test_case.add_input<int8_t>(Shape{1, 1, 2, 2}, std::vector<int8_t>{-1, -2, 3, 4});
+    test_case.add_input<uint16_t>(Shape{4}, {1, 2, 3, 4});
+    test_case.add_expected_output<uint16_t>(std::vector<uint16_t>{65535, 65534, 3, 4});
+
+    test_case.run();
+}
 
 NGRAPH_TEST(${BACKEND_NAME}, castlike_float64_to_int64) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_float64_to_int64.onnx"));
-    
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/castlike_float64_to_int64.onnx"));
+
     auto test_case = test::TestCase(function, s_device);
-    
-    test_case.add_input<float>(Shape{1,1,2,2},std::vector<float>{1.5, 2.3, 3, 4});
-    test_case.add_input<int64_t>(Shape{4},{1, 2, 3, 4});
-    test_case.add_expected_output<int64_t>(std::vector<int64_t>{1,2,3,4});
-    
+
+    test_case.add_input<float>(Shape{1, 1, 2, 2}, std::vector<float>{1.5, 2.3, 3, 4});
+    test_case.add_input<int64_t>(Shape{4}, {1, 2, 3, 4});
+    test_case.add_expected_output<int64_t>(std::vector<int64_t>{1, 2, 3, 4});
+
     test_case.run();
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, castlike_int8_to_float16) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_int8_to_float16.onnx"));
-    
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/castlike_int8_to_float16.onnx"));
+
     auto test_case = test::TestCase(function, s_device);
-        
-    test_case.add_input<int8_t>(Shape{1,1,2,2},std::vector<int8_t>{-127, -2, 3, 4});
-    test_case.add_input<ngraph::float16>(Shape{4},{1, 2, 3, 4});
-    test_case.add_expected_output<ngraph::float16>(std::vector<ngraph::float16>{-127.0,-2.0,3.0,4.0});
-    
+
+    test_case.add_input<int8_t>(Shape{1, 1, 2, 2}, std::vector<int8_t>{-127, -2, 3, 4});
+    test_case.add_input<ngraph::float16>(Shape{4}, {1, 2, 3, 4});
+    test_case.add_expected_output<ngraph::float16>(std::vector<ngraph::float16>{-127.0, -2.0, 3.0, 4.0});
+
     test_case.run();
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, castlike_int32_to_float) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_int32_to_float64.onnx"));
-    
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/castlike_int32_to_float64.onnx"));
+
     auto test_case = test::TestCase(function, s_device);
-        
-    test_case.add_input<int32_t>(Shape{1,1,2,2},std::vector<int32_t>{-1, 2, 3, 4});
-    test_case.add_input<float>(Shape{4},{1, 2, 3, 4});
-    test_case.add_expected_output<float>(std::vector<float>{-1.0,2.0,3.0,4.0});
-    
+
+    test_case.add_input<int32_t>(Shape{1, 1, 2, 2}, std::vector<int32_t>{-1, 2, 3, 4});
+    test_case.add_input<float>(Shape{4}, {1, 2, 3, 4});
+    test_case.add_expected_output<float>(std::vector<float>{-1.0, 2.0, 3.0, 4.0});
+
     test_case.run();
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, castlike_float64_to_int32) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_float64_to_int32.onnx"));
-    
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/castlike_float64_to_int32.onnx"));
+
     auto test_case = test::TestCase(function, s_device);
-        
-    test_case.add_input<float>(Shape{1,1,2,2},std::vector<float>{-107374.9876543, -2.2, 3.3, 4.4});
-    test_case.add_input<int32_t>(Shape{4},{1, 2, 3, 4});
-    test_case.add_expected_output<int32_t>(std::vector<int32_t>{-107374,-2,3,4});
-    
+
+    test_case.add_input<float>(Shape{1, 1, 2, 2}, std::vector<float>{-107374.9876543, -2.2, 3.3, 4.4});
+    test_case.add_input<int32_t>(Shape{4}, {1, 2, 3, 4});
+    test_case.add_expected_output<int32_t>(std::vector<int32_t>{-107374, -2, 3, 4});
+
     test_case.run();
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, DISABLED_castlike_float32_to_bfloat16) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_float32_to_bfloat16.onnx"));
-    
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/castlike_float32_to_bfloat16.onnx"));
+
     auto test_case = test::TestCase(function, s_device);
-    
-    test_case.add_input<float>(Shape{3,4},std::vector<float>{121.5, 122.7, 3, 4, 5, 6, 7, 8.8, 9, 10, 11, 12});
-    test_case.add_input<bfloat16>(Shape{3,4},{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+
+    test_case.add_input<float>(Shape{3, 4}, std::vector<float>{121.5, 122.7, 3, 4, 5, 6, 7, 8.8, 9, 10, 11, 12});
+    test_case.add_input<bfloat16>(Shape{3, 4}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
     test_case.add_expected_output<bfloat16>(std::vector<bfloat16>{121.5, 122.7, 3, 4, 5, 6, 7, 8.8, 9, 10, 11, 12});
-    
+
     test_case.run();
 }
 
 NGRAPH_TEST(${BACKEND_NAME}, DISABLED_castlike_bfloat16_to_float32) {
-    auto function = onnx_import::import_onnx_model(
-        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_bfloat16_to_float32.onnx"));
-    
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/castlike_bfloat16_to_float32.onnx"));
+
     auto test_case = test::TestCase(function, s_device);
-    
-    test_case.add_input<bfloat16>(Shape{3,4},std::vector<bfloat16>{121.5, 122.7, 3, 4, 5, 6, 7, 8.8, 9, 10, 11, 12}); // 122.7 is not 122.5, might be a bug, create a ticket in JIRA for CPU team
-    test_case.add_input<float>(Shape{3,4},{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
-    test_case.add_expected_output<float>(       std::vector<float>{121.5, 122.7, 3, 4, 5, 6, 7, 8.75, 9, 10, 11, 12});
-    
+
+    test_case.add_input<bfloat16>(
+        Shape{3, 4},
+        std::vector<bfloat16>{121.5, 122.7, 3, 4, 5, 6, 7, 8.8, 9, 10, 11, 12});  // 122.7 is not 122.5, might be a bug,
+                                                                                  // create a ticket in JIRA for CPU
+                                                                                  // team
+    test_case.add_input<float>(Shape{3, 4}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+    test_case.add_expected_output<float>(std::vector<float>{121.5, 122.7, 3, 4, 5, 6, 7, 8.75, 9, 10, 11, 12});
+
     test_case.run();
 }

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -5622,23 +5622,6 @@ NGRAPH_TEST(${BACKEND_NAME}, castlike_int8_to_uint16) {
         test_case.run();
     }
 
-    // [ RUN      ] INTERPRETER.castlike_int8_to_uint16
-    // >>>>>>>>>>>>>>>  === castlike_int8_to_uint16 test
-    // [       OK ] INTERPRETER.castlike_int8_to_uint16 (39 ms)
-
-    // [ RUN      ] IE_CPU.castlike_int8_to_uint16
-    // >>>>>>>>>>>>>>>  === castlike_int8_to_uint16 test
-    // 65535 is not close to 0 at index 0
-    // 65534 is not close to 0 at index 1
-
-    // /home/vzilkov/openvino/src/tests/engines_util/../engines_util/test_case.hpp:190: Failure
-    // Value of: res
-    //   Actual: false (65535 is not close to 0 at index 0
-    // 65534 is not close to 0 at index 1
-    // )
-    // Expected: true
-    // [  FAILED  ] IE_CPU.castlike_int8_to_uint16 (75 ms)
-
 NGRAPH_TEST(${BACKEND_NAME}, castlike_float64_to_int64) {
     auto function = onnx_import::import_onnx_model(
         file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_float64_to_int64.onnx"));
@@ -5691,18 +5674,18 @@ NGRAPH_TEST(${BACKEND_NAME}, castlike_float64_to_int32) {
     test_case.run();
 }
 
-// NGRAPH_TEST(${BACKEND_NAME}, castlike_float32_to_bfloat16) {
-//     auto function = onnx_import::import_onnx_model(
-//         file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_float32_to_bfloat16.onnx"));
+NGRAPH_TEST(${BACKEND_NAME}, DISABLED_castlike_float32_to_bfloat16) {
+    auto function = onnx_import::import_onnx_model(
+        file_util::path_join(CommonTestUtils::getExecutableDirectory(), SERIALIZED_ZOO, "onnx/castlike_float32_to_bfloat16.onnx"));
     
-//     auto test_case = test::TestCase(function, s_device);
+    auto test_case = test::TestCase(function, s_device);
     
-//     test_case.add_input<float>(Shape{3,4},std::vector<float>{1.5, 2.4, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
-//     test_case.add_input<bfloat16>(Shape{3,4},{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
-//     test_case.add_expected_output<bfloat16>(std::vector<bfloat16>{1.5, 2.4, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+    test_case.add_input<float>(Shape{3,4},std::vector<float>{121.5, 122.7, 3, 4, 5, 6, 7, 8.8, 9, 10, 11, 12});
+    test_case.add_input<bfloat16>(Shape{3,4},{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+    test_case.add_expected_output<bfloat16>(std::vector<bfloat16>{121.5, 122.7, 3, 4, 5, 6, 7, 8.8, 9, 10, 11, 12});
     
-//     test_case.run();
-// }
+    test_case.run();
+}
 
 NGRAPH_TEST(${BACKEND_NAME}, DISABLED_castlike_bfloat16_to_float32) {
     auto function = onnx_import::import_onnx_model(
@@ -5716,20 +5699,3 @@ NGRAPH_TEST(${BACKEND_NAME}, DISABLED_castlike_bfloat16_to_float32) {
     
     test_case.run();
 }
-
-//double -> float32
-
-/**
- * castlike_float16_to_uint32
- * castlike_float16_to_int64
- * castlike_int8_to_uint16      // trouble with IE_CPU.castlike_int8_to_uint16, INTERPRETER.castlike_int8_to_uint16 is OK
- * castlike_float64_to_int64
- * castlike_int8_to_float16
- * castlike_int32_to_float64
- * castlike_float64_to_int32
- * castlike_float32_to_bfloat16 <--
- * castlike_bfloat16_to_float32
- * 
- * add double, bfloat, string, bool
-**/
-// create a BUG in jira, assign to CPU team (auto, component field ... dmitry gorohov)


### PR DESCRIPTION
### Details:
Added tests:
 * castlike_float16_to_uint32
 * castlike_float16_to_int64
 * castlike_int8_to_uint16  // trouble with IE_CPU.castlike_int8_to_uint16, INTERPRETER.castlike_int8_to_uint16 is OK
 * castlike_float64_to_int64
 * castlike_int8_to_float16
 * castlike_int32_to_float64
 * castlike_float64_to_int32
 * castlike_float32_to_bfloat16    x
 * castlike_bfloat16_to_float32   x

P.S. tests with "x" at the end are not working (bug)

### Ticket:
82470
