### PR TITLE
Porting: Change notebooks fetching link for documentation #12750

### DIFF
--- a/docs/nbdoc/consts.py
+++ b/docs/nbdoc/consts.py
@@ -8,7 +8,7 @@ repo_owner = "openvinotoolkit"
 
 repo_name = "openvino_notebooks"
 
-artifacts_link = "https://repository.toolbox.iotg.sclab.intel.com/projects/ov-notebook/0.1.0-latest/latest/dist/rst_files/"
+artifacts_link = "https://repository.toolbox.iotg.sclab.intel.com/projects/ov-notebook/0.1.0-latest/20220713220805/dist/rst_files/"
 
 blacklisted_extensions = ['.xml', '.bin']
 

--- a/docs/nbdoc/consts.py
+++ b/docs/nbdoc/consts.py
@@ -8,7 +8,7 @@ repo_owner = "openvinotoolkit"
 
 repo_name = "openvino_notebooks"
 
-artifacts_link = "https://repository.toolbox.iotg.sclab.intel.com/projects/ov-notebook/0.1.0-latest/20220713220805/dist/rst_files/"
+artifacts_link = "https://repository.toolbox.iotg.sclab.intel.com/projects/ov-notebook/0.1.0-latest/20220913220807/dist/rst_files/"
 
 blacklisted_extensions = ['.xml', '.bin']
 


### PR DESCRIPTION
Porting:

#12750

There are newly generated files (since 30.08.2022) that seem to be fine but apparently "latest" is not build in the docs:

https://repository.toolbox.iotg.sclab.intel.com/projects/ov-notebook/0.1.0-latest/20220913220807/dist/rst_files/

The question remains, why is it so?
