### PR TITLE
Move TF2 Keras layer tests from private repo and adapt them

### DIFF
--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -436,7 +436,15 @@ jobs:
       python3 -m pip install -r $(LAYER_TESTS_DIR)/requirements.txt
       export PYTHONPATH=$(LAYER_TESTS_DIR):$PYTHONPATH
       $(RUN_PREFIX) python3 -m pytest $(LAYER_TESTS_DIR)/tensorflow_tests/test_tf_Roll.py --ir_version=10 --junitxml=$(INSTALL_TEST_DIR)/TEST-tf_Roll.xmlTEST
-    displayName: 'Layer Tests'
+    displayName: 'Layer Tests - Tensorflow'
+    continueOnError: false
+
+  - script: |
+      python3 -m pip install -r $(LAYER_TESTS_DIR)/requirements.txt
+      export PYTHONPATH=$(LAYER_TESTS_DIR):$PYTHONPATH
+      export TEST_DEVICE=CPU
+      $(RUN_PREFIX) python3 -m pytest $(LAYER_TESTS_DIR)/tensorflow2_keras_tests/test_tf2_keras_activation.py --ir_version=11 --junitxml=./TEST-tf2_Activation.xmlTEST -k "sigmoid"
+    displayName: 'Layer Tests - Tensorflow2 Keras'
     continueOnError: false
 
   - task: PublishTestResults@2

--- a/tests/layer_tests/common/logger.py
+++ b/tests/layer_tests/common/logger.py
@@ -1,0 +1,31 @@
+import logging as log
+import os
+import re
+
+
+class TagFilter(log.Filter):
+    def __init__(self, regex):
+        log.Filter.__init__(self)
+        self.regex = regex
+
+    def filter(self, record):
+        if record.__dict__['funcName'] == 'load_grammar':  # for nx not to log into our logs
+            return False
+        if self.regex:
+            if 'tag' in record.__dict__.keys():
+                tag = record.__dict__['tag']
+                return re.findall(self.regex, tag)
+            else:
+                return False
+        else:  # if regex wasn't set print all logs
+            return True
+
+
+def init_logger(lvl):
+    logger = log.getLogger(__name__)
+    log_exp = os.environ.get('MO_LOG_PATTERN')
+    log.basicConfig(
+        format='%(levelname)s: %(module)s. %(funcName)s():%(lineno)d - %(message)s',
+        level=lvl
+    )
+    logger.addFilter(TagFilter(log_exp))

--- a/tests/layer_tests/common/logger.py
+++ b/tests/layer_tests/common/logger.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging as log
 import os
 import re

--- a/tests/layer_tests/common/tf2_layer_test_class.py
+++ b/tests/layer_tests/common/tf2_layer_test_class.py
@@ -1,0 +1,70 @@
+import os
+
+from common.layer_test_class import CommonLayerTest
+
+
+def save_to_tf2_savedmodel(tf2_model, path_to_saved_tf2_model):
+    import tensorflow as tf
+    assert int(tf.__version__.split('.')[0]) >= 2, "TensorFlow 2 must be used for this suite validation"
+    tf.keras.models.save_model(tf2_model, path_to_saved_tf2_model, save_format='tf')
+    assert os.path.isdir(path_to_saved_tf2_model), "the model haven't been saved " \
+                                                   "here: {}".format(path_to_saved_tf2_model)
+    return path_to_saved_tf2_model
+
+
+class CommonTF2LayerTest(CommonLayerTest):
+    input_model_key = "saved_model_dir"
+
+    def produce_model_path(self, framework_model, save_path):
+        return save_to_tf2_savedmodel(framework_model, save_path)
+
+    def get_framework_results(self, inputs_dict, model_path):
+        import tensorflow as tf
+        import numpy as np
+
+        # load a model
+        loaded_model = tf.keras.models.load_model(model_path, custom_objects=None)
+
+        # prepare input
+        input_for_model = []
+
+        # order inputs based on input names in tests
+        # since TF2 Keras model accepts a list of tensors for prediction
+        for input_name in sorted(inputs_dict):
+            input_value = inputs_dict[input_name]
+            # convert NCHW to NHWC layout of tensor rank greater 3
+            if not self.api_2:
+                if len(input_value.shape) == 4:
+                    input_value = np.transpose(input_value, (0, 2, 3, 1))
+                elif len(input_value.shape) == 5:
+                    input_value = np.transpose(input_value, (0, 2, 3, 4, 1))
+            input_for_model.append(input_value)
+        if len(input_for_model) == 1:
+            input_for_model = input_for_model[0]
+
+        # infer by original framework and complete a dictionary with reference results
+        tf_res_list = loaded_model(input_for_model)
+        if tf.is_tensor(tf_res_list):
+            tf_res_list = [tf_res_list]
+        else:
+            # in this case tf_res_list is a list of the single tuple of outputs
+            tf_res_list = tf_res_list[0]
+
+        result = dict()
+        for ind, tf_res in enumerate(tf_res_list):
+            if ind == 0:
+                output = "Identity"
+            else:
+                output = "Identity_{}".format(ind)
+
+            tf_res = tf_res.numpy()
+            tf_res_rank = len(tf_res.shape)
+            if not self.api_2 and tf_res_rank > 3:
+                # create axis order for NCHW layout
+                axis_order = np.arange(tf_res_rank)
+                axis_order = np.insert(axis_order, 1, axis_order[-1])
+                axis_order = np.delete(axis_order, [-1])
+                result[output] = tf_res.transpose(axis_order)
+            else:
+                result[output] = tf_res
+        return result

--- a/tests/layer_tests/common/tf2_layer_test_class.py
+++ b/tests/layer_tests/common/tf2_layer_test_class.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 
 from common.layer_test_class import CommonLayerTest

--- a/tests/layer_tests/common/tf2_layer_test_class.py
+++ b/tests/layer_tests/common/tf2_layer_test_class.py
@@ -33,7 +33,7 @@ class CommonTF2LayerTest(CommonLayerTest):
         for input_name in sorted(inputs_dict):
             input_value = inputs_dict[input_name]
             # convert NCHW to NHWC layout of tensor rank greater 3
-            if not self.api_2:
+            if self.use_old_api:
                 if len(input_value.shape) == 4:
                     input_value = np.transpose(input_value, (0, 2, 3, 1))
                 elif len(input_value.shape) == 5:
@@ -59,7 +59,7 @@ class CommonTF2LayerTest(CommonLayerTest):
 
             tf_res = tf_res.numpy()
             tf_res_rank = len(tf_res.shape)
-            if not self.api_2 and tf_res_rank > 3:
+            if self.use_old_api and tf_res_rank > 3:
                 # create axis order for NCHW layout
                 axis_order = np.arange(tf_res_rank)
                 axis_order = np.insert(axis_order, 1, axis_order[-1])

--- a/tests/layer_tests/tensorflow2_keras_tests/conftest.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/conftest.py
@@ -1,0 +1,10 @@
+import inspect
+
+from common.layer_test_class import get_params
+from common.logger import *
+
+
+def pytest_generate_tests(metafunc):
+    test_gen_attrs_names = list(inspect.signature(get_params).parameters)
+    params = get_params()
+    metafunc.parametrize(test_gen_attrs_names, params, scope="function")

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activation.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activation.py
@@ -67,6 +67,7 @@ class TestKerasActivation(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activation_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                      api_2):
+                                      api_2, use_new_frontend):
         self._test(*self.create_keras_activation_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activation.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activation.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activation.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activation.py
@@ -1,0 +1,72 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasActivation(CommonTF2LayerTest):
+    def create_keras_activation_net(self, activation_func, input_names, input_shapes, input_type,
+                                    ir_version):
+        activation_func_structure = {
+            # pytest-xdist can't execute the tests in parallel because workers can't compare tests scopes before run
+            # tf.nn.<activation> operation have no "==" operation to be compared
+            "elu": tf.nn.elu,
+            "relu": tf.nn.relu,
+            "sigmoid": tf.nn.sigmoid,
+            "softmax": tf.nn.softmax,
+            "softsign": tf.nn.softsign,
+            "swish": tf.nn.swish,
+            "tanh": tf.nn.tanh,
+            "softplus": tf.nn.softplus,
+            "selu": tf.nn.selu
+        }
+        activation_func = activation_func_structure[activation_func]
+
+        # create TensorFlow 2 model with Keras Activation operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:],
+                            name=input_names[0])  # Variable-length sequence of ints
+        y = tf.keras.layers.Activation(activation_func)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(activation_func="elu", input_names=["x1"], input_shapes=[[5, 4]],
+             input_type=tf.float32),
+        dict(activation_func="relu", input_names=["x1"], input_shapes=[[5, 4, 8]],
+             input_type=tf.float32),
+        dict(activation_func="sigmoid", input_names=["x1"], input_shapes=[[5, 4, 8, 3]],
+             input_type=tf.float32),
+        dict(activation_func="softmax", input_names=["x1"], input_shapes=[[5, 4, 8]],
+             input_type=tf.float32),
+        dict(activation_func="softsign", input_names=["x1"], input_shapes=[[5, 4]],
+             input_type=tf.float32),
+        dict(activation_func="swish", input_names=["x1"], input_shapes=[[5, 4, 8]],
+             input_type=tf.float32),
+        dict(activation_func="tanh", input_names=["x1"], input_shapes=[[5, 4, 8, 3]],
+             input_type=tf.float32),
+        dict(activation_func="softsign", input_names=["x1"], input_shapes=[[5]],
+             input_type=tf.float32),
+        dict(activation_func="relu", input_names=["x1"], input_shapes=[[1]], input_type=tf.float32),
+        dict(activation_func="swish", input_names=["x1"], input_shapes=[[5, 4, 8, 3, 4]],
+             input_type=tf.float32),
+
+        pytest.param(dict(activation_func="softplus", input_names=["x1"], input_shapes=[[5, 7, 6]],
+                          input_type=tf.float32), marks=pytest.mark.xfail(reason="49516")),
+        pytest.param(dict(activation_func="selu", input_names=["x1"], input_shapes=[[5, 7, 6]],
+                          input_type=tf.float32), marks=[pytest.mark.xfail(reason="49512"),
+                                                         pytest.mark.skip(
+                                                             reason="Selu is unsupported in MO")])
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_activation_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                      api_2):
+        self._test(*self.create_keras_activation_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activation.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activation.py
@@ -67,7 +67,7 @@ class TestKerasActivation(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activation_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                      api_2, use_new_frontend):
+                                      use_old_api, use_new_frontend):
         self._test(*self.create_keras_activation_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activity_regularization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activity_regularization.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activity_regularization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activity_regularization.py
@@ -29,10 +29,10 @@ class TestKerasActivityRegularization(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activity_regularization_case1_float32(self, params, ie_device, precision,
-                                                         ir_version, temp_dir, api_2,
+                                                         ir_version, temp_dir, use_old_api,
                                                          use_new_frontend):
         self._test(*self.create_keras_activity_regularization_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
@@ -53,7 +53,7 @@ class TestKerasActivityRegularization(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_activity_regularization_case_2_float32(self, params, ie_device, precision,
-                                                          ir_version, temp_dir, api_2):
+                                                          ir_version, temp_dir, use_old_api):
         self._test(*self.create_keras_activity_regularization_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activity_regularization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activity_regularization.py
@@ -29,10 +29,11 @@ class TestKerasActivityRegularization(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activity_regularization_case1_float32(self, params, ie_device, precision,
-                                                         ir_version, temp_dir, api_2):
+                                                         ir_version, temp_dir, api_2,
+                                                         use_new_frontend):
         self._test(*self.create_keras_activity_regularization_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
         dict(l1_param=0.07, l2_param=0.05, input_names=["x1"], input_shapes=[[1]],

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activity_regularization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_activity_regularization.py
@@ -1,0 +1,58 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasActivityRegularization(CommonTF2LayerTest):
+    def create_keras_activity_regularization_net(self, l1_param, l2_param, input_names,
+                                                 input_shapes, input_type,
+                                                 ir_version):
+        # create TensorFlow 2 model with Keras ActivityRegularization operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:],
+                            name=input_names[0])  # Variable-length sequence of ints
+        y = tf.keras.layers.ActivityRegularization(l1=l1_param, l2=l2_param)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(l1_param=0.05, l2_param=0.08, input_names=["x1"], input_shapes=[[5, 4, 8, 3]],
+             input_type=tf.float32),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_activity_regularization_case1_float32(self, params, ie_device, precision,
+                                                         ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_activity_regularization_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_extended_float32 = [
+        dict(l1_param=0.07, l2_param=0.05, input_names=["x1"], input_shapes=[[1]],
+             input_type=tf.float32),
+        dict(l1_param=0.05, l2_param=0.06, input_names=["x1"], input_shapes=[[4]],
+             input_type=tf.float32),
+        dict(l1_param=0.05, l2_param=0.05, input_names=["x1"], input_shapes=[[5, 4]],
+             input_type=tf.float32),
+        dict(l1_param=0.0, l2_param=0.05, input_names=["x1"], input_shapes=[[5, 4, 8]],
+             input_type=tf.float32),
+        dict(l1_param=0.05, l2_param=0.0, input_names=["x1"], input_shapes=[[5, 4, 8, 3]],
+             input_type=tf.float32),
+        dict(l1_param=0.05, l2_param=0.08, input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]],
+             input_type=tf.float32)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_extended_float32)
+    @pytest.mark.nightly
+    def test_keras_activity_regularization_case_2_float32(self, params, ie_device, precision,
+                                                          ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_activity_regularization_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_add.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_add.py
@@ -89,9 +89,9 @@ class TestKerasAdd(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_add_float32_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                         api_2, use_new_frontend):
+                                         use_old_api, use_new_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
@@ -106,10 +106,10 @@ class TestKerasAdd(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_add_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_add_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                use_new_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
-                   ie_device, precision, ir_version=ir_version, temp_dir=temp_dir, api_2=api_2,
+                   ie_device, precision, ir_version=ir_version, temp_dir=temp_dir, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
@@ -120,10 +120,10 @@ class TestKerasAdd(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
     @pytest.mark.precommit
     def test_keras_add_float32_several_inputs_precommit(self, params, ie_device, precision,
-                                                        ir_version, temp_dir, api_2,
+                                                        ir_version, temp_dir, use_old_api,
                                                         use_new_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
-                   ie_device, precision, ir_version=ir_version, temp_dir=temp_dir, api_2=api_2,
+                   ie_device, precision, ir_version=ir_version, temp_dir=temp_dir, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs = [dict(input_names=["x1", "x2", "x3"],
@@ -144,7 +144,7 @@ class TestKerasAdd(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_add_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                              temp_dir, api_2, use_new_frontend):
+                                              temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_add.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_add.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 from common.layer_test_class import check_ir_version

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_add.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_add.py
@@ -1,0 +1,148 @@
+import pytest
+import tensorflow as tf
+from common.layer_test_class import check_ir_version
+from common.tf2_layer_test_class import CommonTF2LayerTest
+from unit_tests.utils.graph import build_graph
+
+
+class TestKerasAdd(CommonTF2LayerTest):
+    def create_keras_add_net(self, input_names, input_shapes, input_type, ir_version):
+        """
+               Tensorflow2 Keras net:                     IR net:
+                 Input1    Input2            =>      Input1     Input2
+                   \         /                           \       /
+                       Add                                  Add
+        """
+        # create TensorFlow 2 model with Keras Add operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        inputs = []
+        for ind in range(len(input_names)):
+            inputs.append(tf.keras.Input(shape=input_shapes[ind][1:], name=input_names[ind]))
+        y = tf.keras.layers.Add()(inputs)
+        tf2_net = tf.keras.Model(inputs=inputs, outputs=[y])
+
+        # create reference IR net
+        ref_net = None
+
+        op_name = "Add"
+        if check_ir_version(10, None, ir_version):
+            # convert NHWC to NCHW layout if tensor rank greater 3
+            converted_input_shape = input_shapes[0].copy()
+            if len(converted_input_shape) > 3:
+                converted_input_shape[1] = input_shapes[0][-1]
+                converted_input_shape[2:] = input_shapes[0][1:-1]
+            if len(input_names) == 2:
+                nodes_attributes = {
+                    'input1': {'kind': 'op', 'type': 'Parameter'},
+                    'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'input2': {'kind': 'op', 'type': 'Parameter'},
+                    'input2_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'op': {'kind': 'op', 'type': op_name},
+                    'op_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'result': {'kind': 'op', 'type': 'Result'}
+                }
+
+                ref_net = build_graph(nodes_attributes,
+                                      [('input1', 'input1_data'),
+                                       ('input2', 'input2_data'),
+                                       ('input1_data', 'op', {'in': 0}),
+                                       ('input2_data', 'op', {'in': 1}),
+                                       ('op', 'op_data'),
+                                       ('op_data', 'result')
+                                       ])
+            elif len(input_names) == 3:
+                nodes_attributes = {
+                    'input1': {'kind': 'op', 'type': 'Parameter'},
+                    'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'input2': {'kind': 'op', 'type': 'Parameter'},
+                    'input2_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'op1': {'kind': 'op', 'type': op_name},
+                    'op1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'input3': {'kind': 'op', 'type': 'Parameter'},
+                    'input3_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'op2': {'kind': 'op', 'type': op_name},
+                    'op2_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'result': {'kind': 'op', 'type': 'Result'}
+                }
+
+                ref_net = build_graph(nodes_attributes,
+                                      [('input1', 'input1_data'),
+                                       ('input2', 'input2_data'),
+                                       ('input1_data', 'op1', {'in': 0}),
+                                       ('input2_data', 'op1', {'in': 1}),
+                                       ('op1', 'op1_data'),
+                                       ('input3', 'input3_data'),
+                                       ('op1_data', 'op2', {'in': 0}),
+                                       ('input3_data', 'op2', {'in': 1}),
+                                       ('op2', 'op2_data'),
+                                       ('op2_data', 'result')
+                                       ])
+            else:
+                AssertionError("Not supported case with input number greater 2")
+
+        return tf2_net, ref_net
+
+    test_data_float32_precommit = [
+        dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_precommit)
+    @pytest.mark.precommit
+    def test_keras_add_float32_precommit(self, params, ie_device, precision, ir_version, temp_dir,
+                                         api_2):
+        self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8], [5, 4, 8]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8, 2], [5, 4, 8, 2]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"],
+                              input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+                              input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_add_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
+                   ie_device, precision, ir_version=ir_version, temp_dir=temp_dir, api_2=api_2,
+                   **params)
+
+    test_data_float32_several_inputs_precommit = [
+        dict(input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
+    @pytest.mark.precommit
+    def test_keras_add_float32_several_inputs_precommit(self, params, ie_device, precision,
+                                                        ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
+                   ie_device, precision, ir_version=ir_version, temp_dir=temp_dir, api_2=api_2,
+                   **params)
+
+    test_data_float32_several_inputs = [dict(input_names=["x1", "x2", "x3"],
+                                             input_shapes=[[5, 4], [5, 4], [5, 4]],
+                                             input_type=tf.float32),
+                                        dict(input_names=["x1", "x2", "x3"],
+                                             input_shapes=[[5, 4, 8], [5, 4, 8], [5, 4, 8]],
+                                             input_type=tf.float32),
+                                        dict(input_names=["x1", "x2", "x3"],
+                                             input_shapes=[[5, 4, 8, 2], [5, 4, 8, 2],
+                                                           [5, 4, 8, 2]],
+                                             input_type=tf.float32),
+                                        dict(input_names=["x1", "x2", "x3"],
+                                             input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3],
+                                                           [5, 4, 8, 2, 3]],
+                                             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_several_inputs)
+    @pytest.mark.nightly
+    def test_keras_add_float32_several_inputs(self, params, ie_device, precision, ir_version,
+                                              temp_dir, api_2):
+        self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_add.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_add.py
@@ -89,10 +89,10 @@ class TestKerasAdd(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_add_float32_precommit(self, params, ie_device, precision, ir_version, temp_dir,
-                                         api_2):
+                                         api_2, use_new_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
                               input_type=tf.float32),
@@ -106,10 +106,11 @@ class TestKerasAdd(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_add_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_add_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                               use_new_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
         dict(input_names=["x1", "x2", "x3"],
@@ -119,10 +120,11 @@ class TestKerasAdd(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
     @pytest.mark.precommit
     def test_keras_add_float32_several_inputs_precommit(self, params, ie_device, precision,
-                                                        ir_version, temp_dir, api_2):
+                                                        ir_version, temp_dir, api_2,
+                                                        use_new_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
                    ie_device, precision, ir_version=ir_version, temp_dir=temp_dir, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs = [dict(input_names=["x1", "x2", "x3"],
                                              input_shapes=[[5, 4], [5, 4], [5, 4]],
@@ -142,7 +144,7 @@ class TestKerasAdd(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_add_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                              temp_dir, api_2):
+                                              temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_add_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_additive_attention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_additive_attention.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_additive_attention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_additive_attention.py
@@ -1,0 +1,72 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasAdditiveAttention(CommonTF2LayerTest):
+    def create_keras_additive_attention_net(self, causal, dropout, use_scale, input_names,
+                                            input_shapes, input_type,
+                                            ir_version):
+        # create TensorFlow 2 model with Keras AdditiveAttention operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        inputs = []
+        for ind in range(len(input_names)):
+            inputs.append(tf.keras.Input(shape=input_shapes[ind][1:], name=input_names[ind]))
+        y = tf.keras.layers.AdditiveAttention(causal=causal, dropout=dropout, use_scale=use_scale)(
+            inputs,
+            training=False)
+        tf2_net = tf.keras.Model(inputs=inputs, outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(use_scale=True, causal=True, dropout=0.0, input_names=["input1_query", "input2_value"],
+             input_shapes=[[5, 4, 3], [5, 4, 3]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_additive_attention_float32_case1(self, params, ie_device, precision, ir_version,
+                                                    temp_dir, api_2):
+        self._test(*self.create_keras_additive_attention_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_extended_float32 = [
+        dict(use_scale=False, causal=True, dropout=0.5,
+             input_names=["input1_query", "input2_value"],
+             input_shapes=[[1, 5, 4], [1, 5, 4]], input_type=tf.float32),
+        dict(use_scale=True, causal=False, dropout=0.5,
+             input_names=["input1_query", "input2_value"],
+             input_shapes=[[2, 1, 4], [2, 1, 4]], input_type=tf.float32),
+        dict(use_scale=False, causal=False, dropout=0.8,
+             input_names=["input1_query", "input2_value"],
+             input_shapes=[[3, 2, 5], [3, 2, 5]], input_type=tf.float32),
+        dict(use_scale=True, causal=True, dropout=0.0,
+             input_names=["input1_query", "input2_value", "input3_key"],
+             input_shapes=[[2, 4, 3], [2, 4, 3], [2, 4, 3]], input_type=tf.float32),
+        dict(use_scale=False, causal=True, dropout=0.5,
+             input_names=["input1_query", "input2_value", "input3_key"],
+             input_shapes=[[5, 3, 4], [5, 3, 4], [5, 3, 4]],
+             input_type=tf.float32),
+        dict(use_scale=True, causal=False, dropout=0.5,
+             input_names=["input1_query", "input2_value", "input3_key"],
+             input_shapes=[[2, 1, 1], [2, 1, 1], [2, 1, 1]],
+             input_type=tf.float32),
+        dict(use_scale=False, causal=False, dropout=0.8,
+             input_names=["input1_query", "input2_value", "input3_key"],
+             input_shapes=[[5, 3, 3], [5, 3, 3], [5, 3, 3]],
+             input_type=tf.float32)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_extended_float32)
+    @pytest.mark.nightly
+    def test_keras_additive_attention_float32_case2(self, params, ie_device, precision, ir_version,
+                                                    temp_dir, api_2):
+        self._test(*self.create_keras_additive_attention_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_additive_attention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_additive_attention.py
@@ -31,9 +31,9 @@ class TestKerasAdditiveAttention(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_additive_attention_float32_case1(self, params, ie_device, precision, ir_version,
-                                                    temp_dir, api_2, use_new_frontend):
+                                                    temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_additive_attention_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
@@ -66,7 +66,7 @@ class TestKerasAdditiveAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_additive_attention_float32_case2(self, params, ie_device, precision, ir_version,
-                                                    temp_dir, api_2, use_new_frontend):
+                                                    temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_additive_attention_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_additive_attention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_additive_attention.py
@@ -31,10 +31,10 @@ class TestKerasAdditiveAttention(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_additive_attention_float32_case1(self, params, ie_device, precision, ir_version,
-                                                    temp_dir, api_2):
+                                                    temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_additive_attention_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
         dict(use_scale=False, causal=True, dropout=0.5,
@@ -66,7 +66,7 @@ class TestKerasAdditiveAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_additive_attention_float32_case2(self, params, ie_device, precision, ir_version,
-                                                    temp_dir, api_2):
+                                                    temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_additive_attention_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_alpha_dropout.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_alpha_dropout.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_alpha_dropout.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_alpha_dropout.py
@@ -26,9 +26,9 @@ class TestKerasAlphaDropout(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_keras_alpha_dropout_case1_float32(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, api_2, use_new_frontend):
+                                                     temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_alpha_dropout_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [dict(rate=0.5, input_names=["x1"], input_shapes=[[1]],
@@ -45,7 +45,7 @@ class TestKerasAlphaDropout(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_keras_alpha_dropout_case2_float32(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, api_2, use_new_frontend):
+                                                     temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_alpha_dropout_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_alpha_dropout.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_alpha_dropout.py
@@ -26,9 +26,10 @@ class TestKerasAlphaDropout(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_keras_alpha_dropout_case1_float32(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, api_2):
+                                                     temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_alpha_dropout_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [dict(rate=0.5, input_names=["x1"], input_shapes=[[1]],
                                        input_type=tf.float32),
@@ -44,6 +45,7 @@ class TestKerasAlphaDropout(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_keras_alpha_dropout_case2_float32(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, api_2):
+                                                     temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_alpha_dropout_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_alpha_dropout.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_alpha_dropout.py
@@ -1,0 +1,49 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasAlphaDropout(CommonTF2LayerTest):
+    def create_keras_alpha_dropout_net(self, rate, input_names, input_shapes, input_type,
+                                       ir_version):
+        # create TensorFlow 2 model with Keras AlphaDropout operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:],
+                            name=input_names[0])  # Variable-length sequence of ints
+        y = tf.keras.layers.AlphaDropout(rate=rate)(x1, training=False)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(rate=0.5, input_names=["x1"], input_shapes=[[5, 4, 3]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_keras_alpha_dropout_case1_float32(self, params, ie_device, precision, ir_version,
+                                                     temp_dir, api_2):
+        self._test(*self.create_keras_alpha_dropout_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+
+    test_data_extended_float32 = [dict(rate=0.5, input_names=["x1"], input_shapes=[[1]],
+                                       input_type=tf.float32),
+                                  dict(rate=0.7, input_names=["x1"], input_shapes=[[5]],
+                                       input_type=tf.float32),
+                                  dict(rate=0.0, input_names=["x1"], input_shapes=[[5, 4]],
+                                       input_type=tf.float32),
+                                  dict(rate=-0.9, input_names=["x1"], input_shapes=[[5, 4, 8, 3]],
+                                       input_type=tf.float32),
+                                  dict(rate=1.8, input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]],
+                                       input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_extended_float32)
+    @pytest.mark.nightly
+    def test_keras_keras_alpha_dropout_case2_float32(self, params, ie_device, precision, ir_version,
+                                                     temp_dir, api_2):
+        self._test(*self.create_keras_alpha_dropout_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_attention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_attention.py
@@ -29,9 +29,10 @@ class TestKerasAttention(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_attention_float32_case1(self, params, ie_device, precision, ir_version, temp_dir,
-                                           api_2):
+                                           api_2, use_new_frontend):
         self._test(*self.create_keras_attention_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
         dict(use_scale=False, causal=True, dropout=0.0,
@@ -64,6 +65,7 @@ class TestKerasAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_attention_float32_case2(self, params, ie_device, precision, ir_version, temp_dir,
-                                           api_2):
+                                           api_2, use_new_frontend):
         self._test(*self.create_keras_attention_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_attention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_attention.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_attention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_attention.py
@@ -1,0 +1,69 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasAttention(CommonTF2LayerTest):
+    def create_keras_attention_net(self, causal, dropout, use_scale, input_names, input_shapes,
+                                   input_type, ir_version):
+        # create TensorFlow 2 model with Keras Attention operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        inputs = []
+        for ind in range(len(input_names)):
+            inputs.append(tf.keras.Input(shape=input_shapes[ind][1:], name=input_names[ind]))
+        y = tf.keras.layers.Attention(causal=causal, dropout=dropout, use_scale=use_scale)(inputs,
+                                                                                           training=False)
+        tf2_net = tf.keras.Model(inputs=inputs, outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(use_scale=True, causal=True, dropout=0.5, input_names=["query", "value"],
+             input_shapes=[[5, 4, 3], [5, 4, 3]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_attention_float32_case1(self, params, ie_device, precision, ir_version, temp_dir,
+                                           api_2):
+        self._test(*self.create_keras_attention_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+
+    test_data_extended_float32 = [
+        dict(use_scale=False, causal=True, dropout=0.0,
+             input_names=["input1_query", "input2_value"],
+             input_shapes=[[5, 4], [5, 4]], input_type=tf.float32),
+        dict(use_scale=True, causal=False, dropout=0.5,
+             input_names=["input1_query", "input2_value"],
+             input_shapes=[[2, 1, 4], [2, 1, 4]], input_type=tf.float32),
+        dict(use_scale=False, causal=False, dropout=0.8,
+             input_names=["input1_query", "input2_value"],
+             input_shapes=[[3, 2, 5], [3, 2, 5]], input_type=tf.float32),
+        dict(use_scale=True, causal=True, dropout=0.0,
+             input_names=["input1_query", "input2_value", "input3_key"],
+             input_shapes=[[4, 3], [4, 3], [4, 3]], input_type=tf.float32),
+        dict(use_scale=False, causal=True, dropout=0.5,
+             input_names=["input1_query", "input2_value", "input3_key"],
+             input_shapes=[[5, 3, 4], [5, 3, 4], [5, 3, 4]],
+             input_type=tf.float32),
+        dict(use_scale=True, causal=False, dropout=0.5,
+             input_names=["input1_query", "input2_value", "input3_key"],
+             input_shapes=[[2, 1, 1], [2, 1, 1], [2, 1, 1]],
+             input_type=tf.float32),
+        dict(use_scale=False, causal=False, dropout=0.8,
+             input_names=["input1_query", "input2_value", "input3_key"],
+             input_shapes=[[5, 3, 3], [5, 3, 3], [5, 3, 3]],
+             input_type=tf.float32)
+    ]
+
+    # TODO: Extend test with const inputs, ticket: 49295
+    @pytest.mark.parametrize("params", test_data_extended_float32)
+    @pytest.mark.nightly
+    def test_keras_attention_float32_case2(self, params, ie_device, precision, ir_version, temp_dir,
+                                           api_2):
+        self._test(*self.create_keras_attention_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_attention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_attention.py
@@ -29,9 +29,9 @@ class TestKerasAttention(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_attention_float32_case1(self, params, ie_device, precision, ir_version, temp_dir,
-                                           api_2, use_new_frontend):
+                                           use_old_api, use_new_frontend):
         self._test(*self.create_keras_attention_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
@@ -65,7 +65,7 @@ class TestKerasAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_attention_float32_case2(self, params, ie_device, precision, ir_version, temp_dir,
-                                           api_2, use_new_frontend):
+                                           use_old_api, use_new_frontend):
         self._test(*self.create_keras_attention_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_average.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_average.py
@@ -37,9 +37,10 @@ class TestKerasAverage(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_average_case1_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                         api_2):
+                                         api_2, use_new_frontend):
         self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[1], [1]],
                                        input_type=tf.float32),
@@ -55,9 +56,10 @@ class TestKerasAverage(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_average_case2_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                         api_2):
+                                         api_2, use_new_frontend):
         self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs = [
         dict(input_names=["x1", "x2", "x3"], input_shapes=[[1], [1], [1]], input_type=tf.float32),
@@ -71,6 +73,7 @@ class TestKerasAverage(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_average_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, api_2):
+                                                  temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_average.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_average.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_average.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_average.py
@@ -37,9 +37,9 @@ class TestKerasAverage(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_average_case1_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                         api_2, use_new_frontend):
+                                         use_old_api, use_new_frontend):
         self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[1], [1]],
@@ -56,9 +56,9 @@ class TestKerasAverage(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_average_case2_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                         api_2, use_new_frontend):
+                                         use_old_api, use_new_frontend):
         self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs = [
@@ -73,7 +73,7 @@ class TestKerasAverage(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_average_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, api_2, use_new_frontend):
+                                                  temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_average.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_average.py
@@ -1,0 +1,76 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasAverage(CommonTF2LayerTest):
+    def create_keras_average_net(self, input_names, input_shapes, input_type, ir_version):
+        # create TensorFlow 2 model with Keras Average operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+
+        inputs = []
+        for ind in range(len(input_names)):
+            inputs.append(tf.keras.Input(shape=input_shapes[ind][1:], name=input_names[ind]))
+
+        y = tf.keras.layers.Average()(inputs)
+        tf2_net = tf.keras.Model(inputs=inputs, outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8], [5, 4, 8]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8, 2], [5, 4, 8, 2]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2", "x3"],
+                              input_shapes=[[5, 4, 8], [5, 4, 8], [5, 4, 8]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2", "x3"],
+                              input_shapes=[[5, 4, 8, 2], [5, 4, 8, 2], [5, 4, 8, 2]],
+                              input_type=tf.float32),
+                         ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_average_case1_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                         api_2):
+        self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+
+    test_data_extended_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[1], [1]],
+                                       input_type=tf.float32),
+                                  dict(input_names=["x1", "x2"], input_shapes=[[5], [5]],
+                                       input_type=tf.float32),
+                                  dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
+                                       input_type=tf.float32),
+                                  dict(input_names=["x1", "x2"],
+                                       input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+                                       input_type=tf.float32)
+                                  ]
+
+    @pytest.mark.parametrize("params", test_data_extended_float32)
+    @pytest.mark.nightly
+    def test_keras_average_case2_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                         api_2):
+        self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+
+    test_data_float32_several_inputs = [
+        dict(input_names=["x1", "x2", "x3"], input_shapes=[[1], [1], [1]], input_type=tf.float32),
+        dict(input_names=["x1", "x2", "x3"], input_shapes=[[4], [4], [4]], input_type=tf.float32),
+        dict(input_names=["x1", "x2", "x3"], input_shapes=[[5, 4], [5, 4], [5, 4]],
+             input_type=tf.float32),
+        dict(input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_several_inputs)
+    @pytest.mark.nightly
+    def test_keras_average_float32_several_inputs(self, params, ie_device, precision, ir_version,
+                                                  temp_dir, api_2):
+        self._test(*self.create_keras_average_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_1D.py
@@ -31,9 +31,9 @@ class TestKerasAveragePooling1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_avg_pool_1D_case1_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, api_2, use_new_frontend):
+                                             temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_avg_pool_1D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
@@ -47,7 +47,7 @@ class TestKerasAveragePooling1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_avg_pool_1D_case2_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, api_2, use_new_frontend):
+                                             temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_avg_pool_1D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_1D.py
@@ -1,0 +1,51 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasAveragePooling1D(CommonTF2LayerTest):
+    def create_keras_avg_pool_1D_net(self, pool_size, strides, padding, data_format, input_names,
+                                     input_shapes,
+                                     input_type, ir_version):
+        # create TensorFlow 2 model with Keras AvgPool1D operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+
+        inputs = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+
+        y = tf.keras.layers.AvgPool1D(
+            pool_size=pool_size, strides=strides, padding=padding, data_format=data_format)(inputs)
+        tf2_net = tf.keras.Model(inputs=[inputs], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(pool_size=3, strides=2, padding='valid', data_format='channels_last',
+             input_names=["x1"],
+             input_shapes=[[3, 4, 5]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_avg_pool_1D_case1_float32(self, params, ie_device, precision, ir_version,
+                                             temp_dir, api_2):
+        self._test(*self.create_keras_avg_pool_1D_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+
+    test_data_extended_float32 = [
+        dict(pool_size=3, strides=None, padding='same', data_format='channels_first',
+             input_names=["x1"], input_shapes=[[3, 4, 5]], input_type=tf.float32),
+        dict(pool_size=5, strides=None, padding='same', data_format='channels_last',
+             input_names=["x1"], input_shapes=[[3, 4, 5]], input_type=tf.float32),
+        dict(pool_size=5, strides=3, padding='valid', data_format='channels_first',
+             input_names=["x1"], input_shapes=[[3, 4, 5]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_extended_float32)
+    @pytest.mark.nightly
+    def test_keras_avg_pool_1D_case2_float32(self, params, ie_device, precision, ir_version,
+                                             temp_dir, api_2):
+        self._test(*self.create_keras_avg_pool_1D_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_1D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_1D.py
@@ -31,9 +31,10 @@ class TestKerasAveragePooling1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_avg_pool_1D_case1_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, api_2):
+                                             temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_avg_pool_1D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
         dict(pool_size=3, strides=None, padding='same', data_format='channels_first',
@@ -46,6 +47,7 @@ class TestKerasAveragePooling1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_avg_pool_1D_case2_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, api_2):
+                                             temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_avg_pool_1D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_2D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_2D.py
@@ -31,9 +31,9 @@ class TestKerasAvgPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_avg_pool_2D_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       api_2, use_new_frontend):
+                                       use_old_api, use_new_frontend):
         self._test(*self.create_keras_avg_pool_2D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
@@ -50,7 +50,7 @@ class TestKerasAvgPool2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_avg_pool_2D_extended_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, api_2, use_new_frontend):
+                                                temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_avg_pool_2D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_2D.py
@@ -1,0 +1,54 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasAvgPool2D(CommonTF2LayerTest):
+    def create_keras_avg_pool_2D_net(self, pool_size, strides, padding, data_format, input_names,
+                                     input_shapes,
+                                     input_type, ir_version):
+        # create TensorFlow 2 model with Keras AvgPool2D operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+
+        inputs = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+
+        y = tf.keras.layers.AvgPool2D(
+            pool_size=pool_size, strides=strides, padding=padding, data_format=data_format)(inputs)
+        tf2_net = tf.keras.Model(inputs=[inputs], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(pool_size=(3, 3), strides=(2, 2), padding='valid', data_format='channels_last',
+             input_names=["x1"],
+             input_shapes=[[3, 4, 5, 6]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_avg_pool_2D_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                       api_2):
+        self._test(*self.create_keras_avg_pool_2D_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+
+    test_data_extended_float32 = [
+        dict(pool_size=(3, 3), strides=None, padding='same', data_format='channels_last',
+             input_names=["x1"],
+             input_shapes=[[3, 4, 5, 6]], input_type=tf.float32),
+        dict(pool_size=(5, 5), strides=None, padding='same', data_format='channels_last',
+             input_names=["x1"],
+             input_shapes=[[3, 4, 5, 6]], input_type=tf.float32),
+        dict(pool_size=(5, 5), strides=(3, 3), padding='valid', data_format='channels_last',
+             input_names=["x1"],
+             input_shapes=[[3, 7, 6, 5]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_extended_float32)
+    @pytest.mark.nightly
+    def test_keras_avg_pool_2D_extended_float32(self, params, ie_device, precision, ir_version,
+                                                temp_dir, api_2):
+        self._test(*self.create_keras_avg_pool_2D_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_2D.py
@@ -31,9 +31,10 @@ class TestKerasAvgPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_avg_pool_2D_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       api_2):
+                                       api_2, use_new_frontend):
         self._test(*self.create_keras_avg_pool_2D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
         dict(pool_size=(3, 3), strides=None, padding='same', data_format='channels_last',
@@ -49,6 +50,7 @@ class TestKerasAvgPool2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_avg_pool_2D_extended_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, api_2):
+                                                temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_avg_pool_2D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_3D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_3D.py
@@ -1,0 +1,53 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasAvgPool3D(CommonTF2LayerTest):
+    def create_keras_avg_pool_3D_net(self, pool_size, strides, padding, data_format, input_names,
+                                     input_shapes, input_type, ir_version):
+        # create TensorFlow 2 model with Keras AvgPool3D operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+
+        inputs = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+
+        y = tf.keras.layers.AvgPool3D(
+            pool_size=pool_size, strides=strides, padding=padding, data_format=data_format)(inputs)
+        tf2_net = tf.keras.Model(inputs=[inputs], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(pool_size=(3, 3, 3), strides=(2, 2, 2), padding='valid', data_format='channels_first',
+             input_names=["x1"],
+             input_shapes=[[3, 4, 5, 6, 7]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_avg_pool_3D_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                       api_2):
+        self._test(*self.create_keras_avg_pool_3D_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+
+    test_data_extended_float32 = [
+        dict(pool_size=(3, 3, 3), strides=None, padding='same', data_format='channels_last',
+             input_names=["x1"],
+             input_shapes=[[3, 4, 5, 6, 7]], input_type=tf.float32),
+        dict(pool_size=(5, 5, 5), strides=None, padding='same', data_format='channels_first',
+             input_names=["x1"],
+             input_shapes=[[3, 4, 5, 6, 7]], input_type=tf.float32),
+        dict(pool_size=(5, 5, 5), strides=(3, 3, 3), padding='valid', data_format='channels_last',
+             input_names=["x1"],
+             input_shapes=[[3, 8, 7, 6, 5]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_extended_float32)
+    @pytest.mark.nightly
+    def test_keras_avg_pool_3D_extended_float32(self, params, ie_device, precision, ir_version,
+                                                temp_dir, api_2):
+        self._test(*self.create_keras_avg_pool_3D_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_3D.py
@@ -30,9 +30,9 @@ class TestKerasAvgPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_avg_pool_3D_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       api_2, use_new_frontend):
+                                       use_old_api, use_new_frontend):
         self._test(*self.create_keras_avg_pool_3D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
@@ -49,7 +49,7 @@ class TestKerasAvgPool3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_avg_pool_3D_extended_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, api_2, use_new_frontend):
+                                                temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_avg_pool_3D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_avg_pool_3D.py
@@ -30,9 +30,10 @@ class TestKerasAvgPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_avg_pool_3D_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       api_2):
+                                       api_2, use_new_frontend):
         self._test(*self.create_keras_avg_pool_3D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
         dict(pool_size=(3, 3, 3), strides=None, padding='same', data_format='channels_last',
@@ -48,6 +49,7 @@ class TestKerasAvgPool3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_avg_pool_3D_extended_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, api_2):
+                                                temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_avg_pool_3D_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_batch_normalization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_batch_normalization.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_batch_normalization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_batch_normalization.py
@@ -1,0 +1,60 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasBatchNormalization(CommonTF2LayerTest):
+    def create_keras_batch_normalization_net(self, axis, momentum, epsilon, center, scale,
+                                             input_names, input_shapes,
+                                             input_type, ir_version):
+        # create TensorFlow 2 model with Keras BatchNormalization operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+
+        inputs = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+
+        y = tf.keras.layers.BatchNormalization(axis=axis, momentum=momentum, epsilon=epsilon,
+                                               center=center, scale=scale)(inputs)
+        tf2_net = tf.keras.Model(inputs=[inputs], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(axis=3, momentum=0.99, epsilon=1e-5, center=True, scale=True, input_names=["x1"],
+             input_shapes=[[3, 4, 5, 6]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_batch_normalization_float32(self, params, ie_device, precision, ir_version,
+                                               temp_dir, api_2):
+        self._test(*self.create_keras_batch_normalization_net(**params, ir_version=ir_version),
+                   ie_device, precision,
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_extended_float32 = [dict(axis=1, momentum=0.5, epsilon=1e-4, center=True, scale=False,
+                                       input_names=["x1"], input_shapes=[[3, 4]],
+                                       input_type=tf.float32),
+                                  dict(axis=1, momentum=0.3, epsilon=1e-3, center=False,
+                                       scale=False,
+                                       input_names=["x1"], input_shapes=[[3, 4, 5]],
+                                       input_type=tf.float32),
+                                  dict(axis=-1, momentum=0.0, epsilon=1e-5, center=True, scale=True,
+                                       input_names=["x1"], input_shapes=[[3, 4, 5, 6]],
+                                       input_type=tf.float32),
+                                  dict(axis=[2, 1, 4], momentum=0.99, epsilon=1e-2, center=False,
+                                       scale=True,
+                                       input_names=["x1"], input_shapes=[[3, 4, 5, 6, 7]],
+                                       input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_extended_float32)
+    @pytest.mark.nightly
+    def test_keras_batch_normalization_extended_float32(self, params, ie_device, precision,
+                                                        ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_batch_normalization_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_batch_normalization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_batch_normalization.py
@@ -30,11 +30,11 @@ class TestKerasBatchNormalization(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_batch_normalization_float32(self, params, ie_device, precision, ir_version,
-                                               temp_dir, api_2):
+                                               temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_batch_normalization_net(**params, ir_version=ir_version),
                    ie_device, precision,
                    temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [dict(axis=1, momentum=0.5, epsilon=1e-4, center=True, scale=False,
                                        input_names=["x1"], input_shapes=[[3, 4]],
@@ -54,7 +54,7 @@ class TestKerasBatchNormalization(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_batch_normalization_extended_float32(self, params, ie_device, precision,
-                                                        ir_version, temp_dir, api_2):
+                                                        ir_version, temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_batch_normalization_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_batch_normalization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_batch_normalization.py
@@ -30,10 +30,10 @@ class TestKerasBatchNormalization(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_batch_normalization_float32(self, params, ie_device, precision, ir_version,
-                                               temp_dir, api_2, use_new_frontend):
+                                               temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_batch_normalization_net(**params, ir_version=ir_version),
                    ie_device, precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [dict(axis=1, momentum=0.5, epsilon=1e-4, center=True, scale=False,
@@ -54,7 +54,7 @@ class TestKerasBatchNormalization(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_batch_normalization_extended_float32(self, params, ie_device, precision,
-                                                        ir_version, temp_dir, api_2, use_new_frontend):
+                                                        ir_version, temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_batch_normalization_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_bidirectional.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_bidirectional.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_bidirectional.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_bidirectional.py
@@ -43,7 +43,7 @@ class TestKerasBidirectional(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_bidirectional_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                         api_2, use_new_frontend):
+                                         use_old_api, use_new_frontend):
         self._test(*self.create_keras_bidirectional_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_bidirectional.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_bidirectional.py
@@ -43,6 +43,7 @@ class TestKerasBidirectional(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_bidirectional_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                         api_2):
+                                         api_2, use_new_frontend):
         self._test(*self.create_keras_bidirectional_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_bidirectional.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_bidirectional.py
@@ -1,0 +1,48 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasBidirectional(CommonTF2LayerTest):
+    def create_keras_bidirectional_net(self, n_units, RNN_layer, input_names, input_shapes,
+                                       input_type, ir_version):
+        RNN_layer_structure = {
+            # pytest-xdist can't execute the tests in parallel because workers can't compare tests scopes before run
+            # tf.keras.layers.<cell> operation have no "==" operation to be compared
+            "LSTM": tf.keras.layers.LSTM,
+            "GRU": tf.keras.layers.GRU,
+            "SimpleRNN": tf.keras.layers.SimpleRNN
+        }
+        RNN_layer = RNN_layer_structure[RNN_layer]
+
+        # create TensorFlow 2 model with Keras Bidirectional operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        forward_layer = RNN_layer(n_units, return_sequences=False)
+        backward_layer = RNN_layer(n_units, activation='relu', return_sequences=False,
+                                   go_backwards=True)
+        bd_layer = tf.keras.layers.Bidirectional(forward_layer, backward_layer=backward_layer,
+                                                 input_shape=input_shapes[0][1:])
+        tf2_net = tf.keras.Model(inputs=[x], outputs=bd_layer(x))
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(n_units=3, RNN_layer="LSTM", input_names=["x"], input_shapes=[[3, 4, 5]],
+             input_type=tf.float32),
+        dict(n_units=4, RNN_layer="GRU", input_names=["x"], input_shapes=[[3, 4, 5]],
+             input_type=tf.float32),
+        dict(n_units=5, RNN_layer="SimpleRNN", input_names=["x"],
+             input_shapes=[[3, 4, 5]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_bidirectional_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                         api_2):
+        self._test(*self.create_keras_bidirectional_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_concatenate.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_concatenate.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_concatenate.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_concatenate.py
@@ -30,10 +30,11 @@ class TestKerasConcatenate(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_concatenate_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       api_2):
+                                       api_2, use_new_frontend):
         self._test(*self.create_keras_concatenate_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
         dict(axis=-1, input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
@@ -54,7 +55,8 @@ class TestKerasConcatenate(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_concatenate_extended_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, api_2):
+                                                temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_concatenate_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_concatenate.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_concatenate.py
@@ -1,0 +1,60 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasConcatenate(CommonTF2LayerTest):
+    def create_keras_concatenate_net(self, axis, input_names, input_shapes, input_type, ir_version):
+        # create TensorFlow 2 model with Keras Concatenate operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        inputs = []
+        for ind in range(len(input_names)):
+            inputs.append(tf.keras.Input(shape=input_shapes[ind][1:], name=input_names[ind]))
+        y = tf.keras.layers.Concatenate(axis=axis)(inputs)
+        tf2_net = tf.keras.Model(inputs=inputs, outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(axis=2, input_names=["x1", "x2"], input_shapes=[[5, 4, 8, 2], [5, 4, 8, 2]],
+             input_type=tf.float32),
+        dict(axis=3, input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4, 8, 2], [5, 4, 8, 2], [5, 4, 8, 2]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_concatenate_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                       api_2):
+        self._test(*self.create_keras_concatenate_net(**params, ir_version=ir_version), ie_device,
+                   precision,
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+
+    test_data_extended_float32 = [
+        dict(axis=-1, input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
+             input_type=tf.float32),
+        dict(axis=2, input_names=["x1", "x2"], input_shapes=[[5, 4, 8], [5, 4, 8]],
+             input_type=tf.float32),
+        dict(axis=3, input_names=["x1", "x2"], input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+             input_type=tf.float32),
+        dict(axis=-1, input_names=["x1", "x2", "x3"], input_shapes=[[5, 4], [5, 4], [5, 4]],
+             input_type=tf.float32),
+        dict(axis=2, input_names=["x1", "x2", "x3"], input_shapes=[[5, 4, 8], [5, 4, 8], [5, 4, 8]],
+             input_type=tf.float32),
+        dict(axis=2, input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+             input_type=tf.float32)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_extended_float32)
+    @pytest.mark.nightly
+    def test_keras_concatenate_extended_float32(self, params, ie_device, precision, ir_version,
+                                                temp_dir, api_2):
+        self._test(*self.create_keras_concatenate_net(**params, ir_version=ir_version), ie_device,
+                   precision,
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_concatenate.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_concatenate.py
@@ -30,10 +30,10 @@ class TestKerasConcatenate(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_concatenate_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       api_2, use_new_frontend):
+                                       use_old_api, use_new_frontend):
         self._test(*self.create_keras_concatenate_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_extended_float32 = [
@@ -55,8 +55,8 @@ class TestKerasConcatenate(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_extended_float32)
     @pytest.mark.nightly
     def test_keras_concatenate_extended_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, api_2, use_new_frontend):
+                                                temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_concatenate_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d.py
@@ -56,7 +56,9 @@ class TestKerasConv1D(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_conv_1d_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_conv_1d_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_conv1d_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d.py
@@ -56,9 +56,9 @@ class TestKerasConv1D(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_conv_1d_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_conv_1d_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_conv1d_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d.py
@@ -1,0 +1,62 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasConv1D(CommonTF2LayerTest):
+    def create_keras_conv1d_net(self, conv_params, input_names, input_shapes, input_type,
+                                ir_version):
+        activation_func_structure = {
+            # pytest-xdist can't execute the tests in parallel because workers can't compare tests scopes before run
+            # tf.nn.<activation> operation have no "==" operation to be compared
+            "softmax": tf.nn.softmax,
+            "swish": tf.nn.swish
+        }
+        if "activation" in conv_params:
+            conv_params["activation"] = activation_func_structure[conv_params["activation"]]
+
+        # create TensorFlow 2 model with Keras Conv1D operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], dtype=input_type,
+                           name=input_names[0])  # Variable-length sequence of ints
+        y = tf.keras.layers.Conv1D(**conv_params, input_shape=input_shapes[0][1:])(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        pytest.param(dict(conv_params=dict(filters=27, kernel_size=3, padding="valid", strides=2),
+                          input_names=["x"],
+                          input_shapes=[[5, 7, 6]], input_type=tf.float32),
+                     marks=pytest.mark.precommit),
+        pytest.param(
+            dict(conv_params=dict(filters=10, kernel_size=5, padding="same", dilation_rate=4),
+                 input_names=["x"], input_shapes=[[5, 7, 8]], input_type=tf.float32),
+            marks=pytest.mark.precommit),
+
+        dict(conv_params=dict(filters=10, kernel_size=5, padding="same", strides=3),
+             input_names=["x"],
+             input_shapes=[[5, 7, 8]], input_type=tf.float32),
+        dict(conv_params=dict(filters=27, kernel_size=3, padding="valid", dilation_rate=3),
+             input_names=["x"],
+             input_shapes=[[5, 7, 6]], input_type=tf.float32),
+        dict(conv_params=dict(filters=27, kernel_size=3, padding="valid", dilation_rate=3,
+                              activation="swish",
+                              use_bias=True), input_names=["x"], input_shapes=[[5, 7, 6]],
+             input_type=tf.float32),
+        dict(conv_params=dict(filters=10, kernel_size=5, padding="same", dilation_rate=4,
+                              activation="softmax",
+                              use_bias=False), input_names=["x"], input_shapes=[[5, 7, 8]],
+             input_type=tf.float32)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_conv_1d_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_conv1d_net(**params, ir_version=ir_version), ie_device,
+                   precision,
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d_transpose.py
@@ -64,8 +64,8 @@ class TestKerasConv1DTranspose(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail(reason="Needs tensorflow 2.3.0.")
     def test_keras_conv_1d_case1_transpose_float32(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, api_2, use_new_frontend):
+                                                   temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_conv1d_transpose_net(**params, ir_version=ir_version),
                    ie_device, precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d_transpose.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d_transpose.py
@@ -64,7 +64,8 @@ class TestKerasConv1DTranspose(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail(reason="Needs tensorflow 2.3.0.")
     def test_keras_conv_1d_case1_transpose_float32(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, api_2):
+                                                   temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_conv1d_transpose_net(**params, ir_version=ir_version),
                    ie_device, precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_1d_transpose.py
@@ -1,0 +1,70 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasConv1DTranspose(CommonTF2LayerTest):
+    def create_keras_conv1d_transpose_net(self, params, input_names, input_shapes, input_type,
+                                          ir_version):
+        activation_func_structure = {
+            # pytest-xdist can't execute the tests in parallel because workers can't compare tests scopes before run
+            # tf.nn.<activation> operation have no "==" operation to be compared
+            "relu": tf.nn.relu
+        }
+        if "activation" in params:
+            params["activation"] = activation_func_structure[params["activation"]]
+
+        # create TensorFlow 2 model with Keras Conv1DTranspose operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], dtype=input_type,
+                           name=input_names[0])  # Variable-length sequence of ints
+
+        y = tf.keras.layers.Conv1DTranspose(**params, input_shape=input_shapes[0][1:])(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32_set1 = [
+        pytest.param(dict(params=dict(filters=27, kernel_size=3, padding="valid", strides=2),
+                          input_names=["x"],
+                          input_shapes=[[5, 7, 6]], input_type=tf.float32),
+                     marks=pytest.mark.precommit),
+        pytest.param(dict(params=dict(filters=10, kernel_size=5, padding="same", activation="relu",
+                                      use_bias=True),
+                          input_names=["x"], input_shapes=[[5, 7, 8]], input_type=tf.float32),
+                     marks=pytest.mark.precommit),
+
+        pytest.param(dict(params=dict(filters=27, kernel_size=3, padding="valid", dilation_rate=3),
+                          input_names=["x"],
+                          input_shapes=[[5, 7, 6]], input_type=tf.float32),
+                     marks=pytest.mark.xfail(reason="49505")),
+        pytest.param(dict(
+            params=dict(filters=20, kernel_size=7, padding="valid", data_format="channels_first"),
+            input_names=["x"], input_shapes=[[5, 7, 8]], input_type=tf.float32),
+                     marks=pytest.mark.xfail(reason="49505")),
+
+        dict(params=dict(filters=10, kernel_size=5, padding="same", strides=3), input_names=["x"],
+             input_shapes=[[5, 7, 8]], input_type=tf.float32),
+        dict(params=dict(filters=20, kernel_size=7, padding="valid", strides=4), input_names=["x"],
+             input_shapes=[[5, 7, 8]], input_type=tf.float32),
+        dict(params=dict(filters=27, kernel_size=3, padding="valid", dilation_rate=3),
+             input_names=["x"],
+             input_shapes=[[5, 7, 6]], input_type=tf.float32),
+        dict(params=dict(filters=20, kernel_size=7, padding="valid", data_format="channels_first"),
+             input_names=["x"],
+             input_shapes=[[5, 7, 8]], input_type=tf.float32),
+    ]
+
+    # TODO: This test works only with tensorflow 2.3.0 or higher version
+    @pytest.mark.parametrize("params", test_data_float32_set1)
+    @pytest.mark.nightly
+    @pytest.mark.xfail(reason="Needs tensorflow 2.3.0.")
+    def test_keras_conv_1d_case1_transpose_float32(self, params, ie_device, precision, ir_version,
+                                                   temp_dir, api_2):
+        self._test(*self.create_keras_conv1d_transpose_net(**params, ir_version=ir_version),
+                   ie_device, precision,
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d.py
@@ -1,0 +1,62 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasConv2D(CommonTF2LayerTest):
+    def create_keras_conv2d_net(self, conv_params, input_names, input_shapes, input_type,
+                                ir_version):
+        activation_func_structure = {
+            # pytest-xdist can't execute the tests in parallel because workers can't compare tests scopes before run
+            # tf.nn.<activation> operation have no "==" operation to be compared
+            "relu": tf.nn.relu,
+            "sigmoid": tf.nn.sigmoid
+        }
+        if "activation" in conv_params:
+            conv_params["activation"] = activation_func_structure[conv_params["activation"]]
+
+        # create TensorFlow 2 model with Keras Conv2D operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], dtype=input_type,
+                           name=input_names[0])  # Variable-length sequence of ints
+
+        y = tf.keras.layers.Conv2D(**conv_params, input_shape=input_shapes[0][1:])(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        pytest.param(
+            dict(conv_params=dict(filters=27, kernel_size=3, padding="valid", strides=(2, 2)),
+                 input_names=["x"], input_shapes=[[3, 5, 7, 6]], input_type=tf.float32),
+            marks=pytest.mark.precommit),
+        pytest.param(
+            dict(conv_params=dict(filters=10, kernel_size=5, padding="same", strides=(3, 3),
+                                  activation="relu", use_bias=True),
+                 input_names=["x"], input_shapes=[[3, 5, 7, 8]], input_type=tf.float32),
+            marks=pytest.mark.precommit),
+        dict(conv_params=dict(filters=10, kernel_size=5, padding="same", strides=(3, 3)),
+             input_names=["x"], input_shapes=[[3, 5, 7, 8]], input_type=tf.float32),
+        dict(conv_params=dict(filters=27, kernel_size=3, padding="valid", dilation_rate=3),
+             input_names=["x"], input_shapes=[[3, 9, 7, 6]], input_type=tf.float32),
+        dict(conv_params=dict(filters=10, kernel_size=5, padding="same", dilation_rate=4),
+             input_names=["x"], input_shapes=[[3, 9, 7, 8]], input_type=tf.float32),
+        dict(conv_params=dict(filters=27, kernel_size=3, padding="valid", dilation_rate=3,
+                              activation="sigmoid",
+                              use_bias=False), input_names=["x"], input_shapes=[[3, 9, 7, 6]],
+             input_type=tf.float32),
+        dict(conv_params=dict(filters=10, kernel_size=5, padding="same", dilation_rate=4,
+                              use_bias=True),
+             input_names=["x"], input_shapes=[[3, 9, 7, 8]], nput_type=tf.float32)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_conv_2d_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_conv2d_net(**params, ir_version=ir_version), ie_device,
+                   precision,
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d.py
@@ -56,7 +56,9 @@ class TestKerasConv2D(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_conv_2d_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_conv_2d_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_conv2d_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d.py
@@ -56,9 +56,9 @@ class TestKerasConv2D(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_conv_2d_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_conv_2d_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_conv2d_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d_transpose.py
@@ -61,7 +61,8 @@ class TestKerasConv2DTranspose(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_conv_2d_transpose_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, api_2):
+                                             temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_conv_2d_transpose_net(**params, ir_version=ir_version),
                    ie_device, precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d_transpose.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d_transpose.py
@@ -61,8 +61,8 @@ class TestKerasConv2DTranspose(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_conv_2d_transpose_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, api_2, use_new_frontend):
+                                             temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_conv_2d_transpose_net(**params, ir_version=ir_version),
                    ie_device, precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_2d_transpose.py
@@ -1,0 +1,67 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasConv2DTranspose(CommonTF2LayerTest):
+    def create_keras_conv_2d_transpose_net(self, conv_params, input_names, input_shapes, input_type,
+                                           ir_version):
+        activation_func_structure = {
+            # pytest-xdist can't execute the tests in parallel because workers can't compare tests scopes before run
+            # tf.nn.<activation> operation have no "==" operation to be compared
+            "relu": tf.nn.relu,
+            "sigmoid": tf.nn.sigmoid
+        }
+        if "activation" in conv_params:
+            conv_params["activation"] = activation_func_structure[conv_params["activation"]]
+
+        # create TensorFlow 2 model with Keras Conv2DTranspose operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], dtype=input_type,
+                           name=input_names[0])  # Variable-length sequence of ints
+
+        y = tf.keras.layers.Conv2DTranspose(**conv_params, input_shape=input_shapes[0][1:])(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        pytest.param(
+            dict(conv_params=dict(filters=27, kernel_size=3, padding="valid", strides=(2, 2),
+                                  data_format="channels_first"), input_names=["x"],
+                 input_shapes=[[3, 5, 7, 6]], input_type=tf.float32),
+            marks=pytest.mark.precommit),
+        pytest.param(
+            dict(conv_params=dict(filters=10, kernel_size=5, padding="same", strides=(7, 7),
+                                  activation="relu", use_bias=True, output_padding=(3, 3)),
+                 input_names=["x"], input_shapes=[[3, 5, 7, 8]], input_type=tf.float32),
+            marks=pytest.mark.precommit),
+        dict(conv_params=dict(filters=10, kernel_size=5, padding="same", strides=(7, 7),
+                              output_padding=(5, 5)),
+             input_names=["x"], input_shapes=[[3, 5, 7, 8]], input_type=tf.float32),
+        dict(conv_params=dict(filters=27, kernel_size=3, padding="valid", dilation_rate=3),
+             input_names=["x"],
+             input_shapes=[[3, 9, 7, 6]], input_type=tf.float32),
+        dict(conv_params=dict(filters=10, kernel_size=5, padding="same", dilation_rate=4),
+             input_names=["x"],
+             input_shapes=[[3, 9, 7, 8]], input_type=tf.float32),
+        dict(conv_params=dict(filters=27, kernel_size=3, padding="valid", dilation_rate=3,
+                              activation="sigmoid",
+                              use_bias=False), input_names=["x"], input_shapes=[[3, 9, 7, 6]],
+             input_type=tf.float32),
+        dict(conv_params=dict(filters=10, kernel_size=5, padding="same", dilation_rate=4,
+                              use_bias=True),
+             input_names=["x"], input_shapes=[[3, 9, 7, 8]], input_type=tf.float32)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_conv_2d_transpose_float32(self, params, ie_device, precision, ir_version,
+                                             temp_dir, api_2):
+        self._test(*self.create_keras_conv_2d_transpose_net(**params, ir_version=ir_version),
+                   ie_device, precision,
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d.py
@@ -1,0 +1,64 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasConv3D(CommonTF2LayerTest):
+    def create_keras_conv3d_net(self, conv_params, input_names, input_shapes, input_type,
+                                ir_version):
+        activation_func_structure = {
+            # pytest-xdist can't execute the tests in parallel because workers can't compare tests scopes before run
+            # tf.nn.<activation> operation have no "==" operation to be compared
+            "relu": tf.nn.relu,
+            "sigmoid": tf.nn.sigmoid
+        }
+        if "activation" in conv_params:
+            conv_params["activation"] = activation_func_structure[conv_params["activation"]]
+
+        # create TensorFlow 2 model with Keras Conv3D operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], dtype=input_type,
+                           name=input_names[0])  # Variable-length sequence of ints
+
+        y = tf.keras.layers.Conv3D(**conv_params, input_shape=input_shapes[0][1:])(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        pytest.param(
+            dict(conv_params=dict(filters=27, kernel_size=3, padding="valid", strides=(2, 2, 2)),
+                 input_names=["x"], input_shapes=[[5, 3, 5, 7, 6]], input_type=tf.float32),
+            marks=pytest.mark.precommit),
+        pytest.param(
+            dict(conv_params=dict(filters=10, kernel_size=5, padding="same", strides=(3, 3, 3),
+                                  activation="relu", use_bias=True), input_names=["x"],
+                 input_shapes=[[5, 3, 5, 7, 8]], input_type=tf.float32),
+            marks=pytest.mark.precommit),
+        dict(conv_params=dict(filters=10, kernel_size=5, padding="same", strides=(3, 3, 3)),
+             input_names=["x"],
+             input_shapes=[[5, 3, 5, 7, 8]], input_type=tf.float32),
+        dict(conv_params=dict(filters=27, kernel_size=3, padding="valid", dilation_rate=3),
+             input_names=["x"],
+             input_shapes=[[5, 8, 9, 7, 6]], input_type=tf.float32),
+        dict(conv_params=dict(filters=10, kernel_size=5, padding="same", dilation_rate=4),
+             input_names=["x"],
+             input_shapes=[[5, 3, 9, 7, 8]], input_type=tf.float32),
+        dict(conv_params=dict(filters=27, kernel_size=3, padding="valid",
+                              dilation_rate=3, activation="sigmoid", use_bias=False),
+             input_names=["x"],
+             input_shapes=[[5, 8, 9, 7, 6]], input_type=tf.float32),
+        dict(conv_params=dict(filters=10, kernel_size=5, padding="same", dilation_rate=4,
+                              use_bias=True),
+             input_names=["x"], input_shapes=[[5, 3, 9, 7, 8]], input_type=tf.float32)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_conv_3d_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_conv3d_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d.py
@@ -59,6 +59,8 @@ class TestKerasConv3D(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_conv_3d_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_conv_3d_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_conv3d_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d.py
@@ -59,8 +59,8 @@ class TestKerasConv3D(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_conv_3d_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_conv_3d_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_conv3d_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d_transpose.py
@@ -1,0 +1,68 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasConv3DTranspose(CommonTF2LayerTest):
+    def create_keras_conv_3d_transpose_net(self, conv_params, input_names, input_shapes, input_type,
+                                           ir_version):
+        activation_func_structure = {
+            # pytest-xdist can't execute the tests in parallel because workers can't compare tests scopes before run
+            # tf.nn.<activation> operation have no "==" operation to be compared
+            "relu": tf.nn.relu,
+            "sigmoid": tf.nn.sigmoid
+        }
+        if "activation" in conv_params:
+            conv_params["activation"] = activation_func_structure[conv_params["activation"]]
+
+        # create TensorFlow 2 model with Keras Conv3DTranspose operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], dtype=input_type,
+                           name=input_names[0])  # Variable-length sequence of ints
+
+        y = tf.keras.layers.Conv3DTranspose(**conv_params, input_shape=input_shapes[0][1:])(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        pytest.param(
+            dict(conv_params=dict(filters=27, kernel_size=3, padding="valid", strides=(1, 1, 2)),
+                 input_names=["x"], input_shapes=[[5, 3, 5, 7, 6]], input_type=tf.float32),
+            marks=pytest.mark.precommit),
+        pytest.param(
+            dict(conv_params=dict(filters=10, kernel_size=5, padding="same", strides=(3, 4, 5),
+                                  activation="relu", use_bias=True, output_padding=2),
+                 input_names=["x"], input_shapes=[[5, 3, 5, 7, 8]], input_type=tf.float32),
+            marks=pytest.mark.precommit),
+
+        pytest.param(dict(conv_params=dict(filters=27, kernel_size=3, data_format="channels_first"),
+                          input_names=["x"], input_shapes=[[5, 3, 5, 7, 6]], input_type=tf.float32),
+                     marks=pytest.mark.xfail(reason="49529")),
+
+        dict(conv_params=dict(filters=10, kernel_size=5, padding="same", strides=(4, 3, 2),
+                              output_padding=1),
+             input_names=["x"], input_shapes=[[5, 3, 5, 7, 8]], input_type=tf.float32),
+        dict(conv_params=dict(filters=27, kernel_size=3, padding="valid", dilation_rate=3),
+             input_names=["x"],
+             input_shapes=[[5, 8, 9, 7, 6]], input_type=tf.float32),
+        dict(conv_params=dict(filters=10, kernel_size=3, padding="same", dilation_rate=4),
+             input_names=["x"],
+             input_shapes=[[5, 3, 9, 7, 8]], input_type=tf.float32),
+        dict(conv_params=dict(filters=27, kernel_size=3, padding="valid", dilation_rate=3,
+                              activation="sigmoid",
+                              use_bias=False), input_names=["x"], input_shapes=[[5, 8, 9, 7, 6]],
+             input_type=tf.float32),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_conv_3D_transpose_float32(self, params, ie_device, precision, ir_version,
+                                             temp_dir, api_2):
+        self._test(*self.create_keras_conv_3d_transpose_net(**params, ir_version=ir_version),
+                   ie_device, precision,
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d_transpose.py
@@ -62,8 +62,8 @@ class TestKerasConv3DTranspose(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_conv_3D_transpose_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, api_2, use_new_frontend):
+                                             temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_conv_3d_transpose_net(**params, ir_version=ir_version),
                    ie_device, precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d_transpose.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d_transpose.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_3d_transpose.py
@@ -62,7 +62,8 @@ class TestKerasConv3DTranspose(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_conv_3D_transpose_float32(self, params, ie_device, precision, ir_version,
-                                             temp_dir, api_2):
+                                             temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_conv_3d_transpose_net(**params, ir_version=ir_version),
                    ie_device, precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_lstm_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_lstm_2d.py
@@ -1,0 +1,58 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasConvLSTM2D(CommonTF2LayerTest):
+    def create_keras_conv_lstm_2d_net(self, params, input_names, input_shapes,
+                                      input_type, ir_version):
+        activation_func_structure = {
+            # pytest-xdist can't execute the tests in parallel because workers can't compare tests scopes before run
+            # tf.nn.<activation> operation have no "==" operation to be compared
+            "relu": tf.nn.relu,
+            "swish": tf.nn.swish,
+            "elu": tf.nn.elu,
+        }
+        if "activation" in params:
+            params["activation"] = activation_func_structure[params["activation"]]
+
+        # create TensorFlow 2 model with Keras ConvLSTM2D operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.ConvLSTM2D(**params)(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(params=dict(filters=16, kernel_size=(3, 3), padding='valid', return_sequences=False),
+             input_names=["x"], input_shapes=[[10, 10, 300, 300, 1]], input_type=tf.float32),
+        dict(params=dict(filters=16, kernel_size=(3, 3), padding='same', return_sequences=False,
+                         activation="swish"),
+             input_names=["x"], input_shapes=[[10, 10, 300, 300, 1]], input_type=tf.float32),
+        dict(params=dict(filters=16, kernel_size=(3, 3), padding='valid', strides=(2, 2),
+                         return_sequences=False),
+             input_names=["x"], input_shapes=[[10, 10, 300, 300, 1]], input_type=tf.float32),
+        dict(params=dict(filters=16, kernel_size=(3, 3), padding='valid', dilation_rate=3,
+                         activation="relu", return_sequences=False, use_bias=True,
+                         data_format="channels_last"),
+             input_names=["x"], input_shapes=[[10, 10, 300, 300, 1]], input_type=tf.float32),
+        dict(params=dict(filters=16, kernel_size=(3, 3), padding='valid', dilation_rate=3,
+                         recurrent_activation="elu", return_sequences=False, use_bias=True,
+                         data_format="channels_first"),
+             input_names=["x"], input_shapes=[[10, 10, 1, 300, 300]], input_type=tf.float32)]
+
+    # TODO: This test works only with tensorflow 2.3.0 or higher version
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.xfail(reason="50141")
+    def test_keras_conv_lstm_2d_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                        api_2):
+        self._test(*self.create_keras_conv_lstm_2d_net(**params, ir_version=ir_version), ie_device,
+                   precision,
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_lstm_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_lstm_2d.py
@@ -52,7 +52,8 @@ class TestKerasConvLSTM2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail(reason="50141")
     def test_keras_conv_lstm_2d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                        api_2):
+                                        api_2, use_new_frontend):
         self._test(*self.create_keras_conv_lstm_2d_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_lstm_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_lstm_2d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_lstm_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_conv_lstm_2d.py
@@ -52,8 +52,8 @@ class TestKerasConvLSTM2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.xfail(reason="50141")
     def test_keras_conv_lstm_2d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                        api_2, use_new_frontend):
+                                        use_old_api, use_new_frontend):
         self._test(*self.create_keras_conv_lstm_2d_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_1d.py
@@ -1,0 +1,36 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasCropping1D(CommonTF2LayerTest):
+    def create_keras_cropping_1d_net(self, cropping, input_names, input_shapes, input_type,
+                                     ir_version):
+        # create TensorFlow 2 model with Keras Cropping1D operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], dtype=input_type,
+                           name=input_names[0])  # Variable-length sequence of ints
+
+        y = tf.keras.layers.Cropping1D(cropping=cropping, input_shape=input_shapes[0][1:])(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        pytest.param(
+            dict(cropping=2, input_names=["x"], input_shapes=[[3, 5, 4]], input_type=tf.float32),
+            marks=pytest.mark.precommit),
+
+        dict(cropping=(1, 1), input_names=["x"], input_shapes=[[2, 3, 4]], input_type=tf.float32),
+        dict(cropping=(2, 3), input_names=["x"], input_shapes=[[3, 7, 5]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_cropping_1d_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                       api_2):
+        self._test(*self.create_keras_cropping_1d_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_1d.py
@@ -31,6 +31,7 @@ class TestKerasCropping1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_cropping_1d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       api_2):
+                                       api_2, use_new_frontend):
         self._test(*self.create_keras_cropping_1d_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_1d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_1d.py
@@ -31,7 +31,7 @@ class TestKerasCropping1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_cropping_1d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       api_2, use_new_frontend):
+                                       use_old_api, use_new_frontend):
         self._test(*self.create_keras_cropping_1d_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_2d.py
@@ -1,0 +1,39 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasCropping2D(CommonTF2LayerTest):
+    def create_keras_cropping_2d_net(self, cropping, input_names, input_shapes, input_type,
+                                     ir_version):
+        # create TensorFlow 2 model with Keras Cropping2D operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], dtype=input_type,
+                           name=input_names[0])  # Variable-length sequence of ints
+
+        y = tf.keras.layers.Cropping2D(cropping=cropping, input_shape=input_shapes[0][1:])(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        pytest.param(
+            dict(cropping=2, input_names=["x"], input_shapes=[[3, 5, 7, 5]], input_type=tf.float32),
+            marks=pytest.mark.precommit),
+
+        dict(cropping=(1, 2), input_names=["x"], input_shapes=[[2, 3, 7, 5]],
+             input_type=tf.float32),
+        dict(cropping=((2, 1), (3, 2)), input_names=["x"], input_shapes=[[5, 7, 9, 7]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_cropping_2d_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                       api_2):
+        self._test(*self.create_keras_cropping_2d_net(**params, ir_version=ir_version), ie_device,
+                   precision,
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_2d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_2d.py
@@ -33,7 +33,8 @@ class TestKerasCropping2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_cropping_2d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       api_2):
+                                       api_2, use_new_frontend):
         self._test(*self.create_keras_cropping_2d_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_2d.py
@@ -33,8 +33,8 @@ class TestKerasCropping2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_cropping_2d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       api_2, use_new_frontend):
+                                       use_old_api, use_new_frontend):
         self._test(*self.create_keras_cropping_2d_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_3d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_3d.py
@@ -1,0 +1,39 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasCropping3D(CommonTF2LayerTest):
+    def create_keras_cropping_3d_net(self, cropping, input_names, input_shapes, input_type,
+                                     ir_version):
+        # create TensorFlow 2 model with Keras Cropping3D operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], dtype=input_type,
+                           name=input_names[0])  # Variable-length sequence of ints
+
+        y = tf.keras.layers.Cropping3D(cropping=cropping, input_shape=input_shapes[0][1:])(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        pytest.param(dict(cropping=2, input_names=["x"], input_shapes=[[3, 5, 7, 5, 6]],
+                          input_type=tf.float32),
+                     marks=pytest.mark.precommit),
+
+        dict(cropping=(1, 2, 1), input_names=["x"], input_shapes=[[2, 3, 7, 5, 6]],
+             input_type=tf.float32),
+        dict(cropping=((2, 1), (3, 2), (1, 1)), input_names=["x"], input_shapes=[[5, 7, 9, 7, 6]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_cropping_3d_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                       api_2):
+        self._test(*self.create_keras_cropping_3d_net(**params, ir_version=ir_version), ie_device,
+                   precision,
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_3d.py
@@ -33,7 +33,8 @@ class TestKerasCropping3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_cropping_3d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       api_2):
+                                       api_2, use_new_frontend):
         self._test(*self.create_keras_cropping_3d_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_cropping_3d.py
@@ -33,8 +33,8 @@ class TestKerasCropping3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_cropping_3d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       api_2, use_new_frontend):
+                                       use_old_api, use_new_frontend):
         self._test(*self.create_keras_cropping_3d_net(**params, ir_version=ir_version), ie_device,
                    precision,
-                   temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dense.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dense.py
@@ -39,10 +39,10 @@ class TestKerasDense(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_simple)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_dense_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_dense_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                  use_new_frontend):
         self._test(*self.create_keras_dense_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_activation = [
@@ -64,7 +64,7 @@ class TestKerasDense(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activation_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                      api_2, use_new_frontend):
+                                      use_old_api, use_new_frontend):
         self._test(*self.create_keras_dense_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dense.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dense.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dense.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dense.py
@@ -1,0 +1,69 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasDense(CommonTF2LayerTest):
+    def create_keras_dense_net(self, input_names, input_shapes, input_type, units, activation,
+                               use_bias, ir_version):
+        """
+            create TensorFlow 2 model with Keras Dense operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.Dense(units=units, activation=activation, use_bias=use_bias)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32_simple = [
+        dict(input_names=["x"], input_shapes=[[5, 4]], input_type=tf.float32, units=1,
+             activation=None, use_bias=False),
+        dict(input_names=["x"], input_shapes=[[5, 4, 8]], input_type=tf.float32, units=4,
+             activation=None, use_bias=False),
+        dict(input_names=["x"], input_shapes=[[5, 4, 8, 12]], input_type=tf.float32, units=16,
+             activation=None, use_bias=False),
+        dict(input_names=["x"], input_shapes=[[5, 4, 8, 6, 8]], input_type=tf.float32, units=10,
+             activation=None, use_bias=True),
+        dict(input_names=["x"], input_shapes=[[5, 4, 12, 3]], input_type=tf.float32, units=16,
+             activation=None, use_bias=True),
+        dict(input_names=["x"], input_shapes=[[5, 4, 2, 2, 2]], input_type=tf.float32, units=3,
+             activation=None, use_bias=True)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32_simple)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_dense_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_dense_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_float32_activation = [
+        dict(input_names=["x"], input_shapes=[[5, 4]], input_type=tf.float32, units=1,
+             activation='relu', use_bias=False),
+        dict(input_names=["x"], input_shapes=[[5, 4, 8]], input_type=tf.float32, units=4,
+             activation='elu', use_bias=False),
+        dict(input_names=["x"], input_shapes=[[5, 4]], input_type=tf.float32, units=1,
+             activation='sigmoid', use_bias=True),
+        dict(input_names=["x"], input_shapes=[[5, 4, 8]], input_type=tf.float32, units=4,
+             activation='tanh', use_bias=True),
+        dict(input_names=["x"], input_shapes=[[5, 4, 8, 8]], input_type=tf.float32, units=5,
+             activation='linear', use_bias=True),
+        dict(input_names=["x"], input_shapes=[[5, 4, 8, 6, 4]], input_type=tf.float32, units=4,
+             activation='softmax', use_bias=True)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32_activation)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_activation_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                      api_2):
+        self._test(*self.create_keras_dense_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dense.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dense.py
@@ -39,10 +39,11 @@ class TestKerasDense(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_simple)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_dense_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_dense_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                 use_new_frontend):
         self._test(*self.create_keras_dense_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_activation = [
         dict(input_names=["x"], input_shapes=[[5, 4]], input_type=tf.float32, units=1,
@@ -63,7 +64,7 @@ class TestKerasDense(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activation_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                      api_2):
+                                      api_2, use_new_frontend):
         self._test(*self.create_keras_dense_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_depthwiseconv2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_depthwiseconv2D.py
@@ -48,10 +48,11 @@ class TestKerasDepthwiseConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_format_padding)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_dconv2D_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_dconv2D_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_use_bias_true = [
         dict(input_names=["x"], input_shapes=[[5, 7, 3, 3]], input_type=tf.float32, kernel_size=1,
@@ -74,10 +75,10 @@ class TestKerasDepthwiseConv2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_use_bias_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2):
+                                    api_2, use_new_frontend):
         self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_activations = [
         dict(input_names=["x"], input_shapes=[[5, 7, 16, 3]], input_type=tf.float32, kernel_size=1,
@@ -100,7 +101,7 @@ class TestKerasDepthwiseConv2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activations_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       api_2):
+                                       api_2, use_new_frontend):
         self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_depthwiseconv2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_depthwiseconv2D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_depthwiseconv2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_depthwiseconv2D.py
@@ -1,0 +1,106 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasDepthwiseConv2D(CommonTF2LayerTest):
+    def create_keras_dconv2D_net(self, input_names, input_shapes, input_type, kernel_size, strides,
+                                 padding,
+                                 depth_multiplier, data_format, dilation_rate, activation, use_bias,
+                                 ir_version):
+        """
+               create TensorFlow 2 model with Keras DeptwiseConv2D operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.DepthwiseConv2D(kernel_size=kernel_size, strides=strides,
+                                            padding=padding,
+                                            depth_multiplier=depth_multiplier,
+                                            data_format=data_format,
+                                            dilation_rate=dilation_rate, activation=activation,
+                                            use_bias=use_bias)(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_format_padding = [
+        dict(input_names=["x"], input_shapes=[[5, 7, 16, 3]], input_type=tf.float32, kernel_size=1,
+             strides=1, padding='valid', depth_multiplier=2, data_format='channels_last',
+             dilation_rate=2, activation=None, use_bias=False),
+        dict(input_names=["x"], input_shapes=[[5, 16, 4, 4]], input_type=tf.float32,
+             kernel_size=(3, 3), strides=(4, 4), padding='valid', depth_multiplier=2,
+             data_format='channels_first', dilation_rate=1, activation=None, use_bias=False),
+        dict(input_names=["x"], input_shapes=[[5, 8, 16, 4]], input_type=tf.float32,
+             kernel_size=(2, 2), strides=1, padding='same', depth_multiplier=2,
+             data_format='channels_last',
+             dilation_rate=(2, 2), activation=None, use_bias=False),
+        dict(input_names=["x"], input_shapes=[[5, 16, 8, 4]], input_type=tf.float32,
+             kernel_size=(2, 2), strides=(3, 3), padding='same', depth_multiplier=54,
+             data_format='channels_first',
+             dilation_rate=1, activation=None, use_bias=False),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_format_padding)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_dconv2D_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_use_bias_true = [
+        dict(input_names=["x"], input_shapes=[[5, 7, 3, 3]], input_type=tf.float32, kernel_size=1,
+             strides=1, padding='valid', depth_multiplier=2, data_format='channels_last',
+             dilation_rate=2, activation=None, use_bias=True),
+        dict(input_names=["x"], input_shapes=[[5, 16, 16, 4]], input_type=tf.float32,
+             kernel_size=(3, 3), strides=(4, 4), padding='valid', depth_multiplier=2,
+             data_format='channels_first', dilation_rate=1, activation=None, use_bias=True),
+        dict(input_names=["x"], input_shapes=[[5, 8, 16, 4]], input_type=tf.float32,
+             kernel_size=(2, 2), strides=1, padding='same', depth_multiplier=2,
+             data_format='channels_last',
+             dilation_rate=(2, 2), activation=None, use_bias=True),
+        dict(input_names=["x"], input_shapes=[[5, 16, 8, 4]], input_type=tf.float32,
+             kernel_size=(2, 2), strides=(3, 3), padding='same', depth_multiplier=54,
+             data_format='channels_first',
+             dilation_rate=1, activation=None, use_bias=True),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_use_bias_true)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_use_bias_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                    api_2):
+        self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_activations = [
+        dict(input_names=["x"], input_shapes=[[5, 7, 16, 3]], input_type=tf.float32, kernel_size=1,
+             strides=1, padding='valid', depth_multiplier=2, data_format='channels_last',
+             dilation_rate=2, activation='softmax', use_bias=True),
+        dict(input_names=["x"], input_shapes=[[5, 16, 16, 4]], input_type=tf.float32,
+             kernel_size=(3, 3), strides=(4, 4), padding='valid', depth_multiplier=2,
+             data_format='channels_first', dilation_rate=1, activation='elu', use_bias=True),
+        dict(input_names=["x"], input_shapes=[[5, 8, 16, 4]], input_type=tf.float32,
+             kernel_size=(2, 2), strides=1, padding='same', depth_multiplier=2,
+             data_format='channels_last',
+             dilation_rate=(2, 2), activation='linear', use_bias=True),
+        dict(input_names=["x"], input_shapes=[[5, 16, 8, 4]], input_type=tf.float32,
+             kernel_size=(2, 2), strides=(3, 3), padding='same', depth_multiplier=54,
+             data_format='channels_first',
+             dilation_rate=1, activation='tanh', use_bias=True),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_activations)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_activations_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                       api_2):
+        self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_depthwiseconv2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_depthwiseconv2D.py
@@ -48,10 +48,10 @@ class TestKerasDepthwiseConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_format_padding)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_dconv2D_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_dconv2D_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_use_bias_true = [
@@ -75,9 +75,9 @@ class TestKerasDepthwiseConv2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_use_bias_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2, use_new_frontend):
+                                    use_old_api, use_new_frontend):
         self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_activations = [
@@ -101,7 +101,7 @@ class TestKerasDepthwiseConv2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_activations_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                       api_2, use_new_frontend):
+                                       use_old_api, use_new_frontend):
         self._test(*self.create_keras_dconv2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dot.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dot.py
@@ -41,10 +41,10 @@ class TestKerasDot(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_dot_normalize_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                         api_2, use_new_frontend):
+                                         use_old_api, use_new_frontend):
         self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   api_2=api_2, use_new_frontend=use_new_frontend, **params)
+                   use_old_api=use_old_api, use_new_frontend=use_new_frontend, **params)
 
     test_data_difficult_axes_float32 = [
         dict(input_names=["x", "y"], input_shapes=[[5, 4, 4], [5, 4, 4]], input_type=tf.float32,
@@ -67,10 +67,10 @@ class TestKerasDot(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_dot_difficult_axes_float32(self, params, ie_device, precision, temp_dir,
-                                              ir_version, api_2, use_new_frontend):
+                                              ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   api_2=api_2, use_new_frontend=use_new_frontend, **params)
+                   use_old_api=use_old_api, use_new_frontend=use_new_frontend, **params)
 
     test_data_normalize_higher_rank = [
         dict(input_names=["x", "y"], input_shapes=[[5, 1, 4], [5, 1, 4]], input_type=tf.float32,
@@ -96,7 +96,7 @@ class TestKerasDot(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_dot_normalize_higher_rank(self, params, ie_device, precision, temp_dir,
-                                             ir_version, api_2, use_new_frontend):
+                                             ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   api_2=api_2, use_new_frontend=use_new_frontend, **params)
+                   use_old_api=use_old_api, use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dot.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dot.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dot.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dot.py
@@ -1,0 +1,102 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasDot(CommonTF2LayerTest):
+    def create_keras_dot_net(self, input_names, input_shapes, input_type, axes, normalize,
+                             ir_version):
+        """
+                create TensorFlow 2 model with Keras Dot operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        inputs = [tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0]),
+                  tf.keras.Input(shape=input_shapes[1][1:], name=input_names[1])]
+        y = tf.keras.layers.Dot(axes, normalize=normalize)(inputs)
+        tf2_net = tf.keras.Model(inputs=inputs, outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_normalize_float32 = [
+        dict(input_names=["x", "y"], input_shapes=[[5, 4], [5, 4]], input_type=tf.float32, axes=1,
+             normalize=False),
+        dict(input_names=["x", "y"], input_shapes=[[5, 1, 4], [5, 1, 4]], input_type=tf.float32,
+             axes=2,
+             normalize=False),
+        dict(input_names=["x", "y"], input_shapes=[[5, 1, 4], [5, 1, 4]], input_type=tf.float32,
+             axes=1,
+             normalize=False),
+        dict(input_names=["x", "y"], input_shapes=[[5, 4], [5, 4]], input_type=tf.float32, axes=1,
+             normalize=True),
+        dict(input_names=["x", "y"], input_shapes=[[5, 1, 4], [5, 1, 4]], input_type=tf.float32,
+             axes=1, normalize=True),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_normalize_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_dot_normalize_float32(self, params, ie_device, precision, temp_dir, ir_version,
+                                         api_2):
+        self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
+                   api_2=api_2, **params)
+
+    test_data_difficult_axes_float32 = [
+        dict(input_names=["x", "y"], input_shapes=[[5, 4, 4], [5, 4, 4]], input_type=tf.float32,
+             axes=(1, 2),
+             normalize=False),
+        dict(input_names=["x", "y"], input_shapes=[[5, 1, 5, 2], [5, 1, 2, 5]],
+             input_type=tf.float32, axes=(2, 3),
+             normalize=False),
+        dict(input_names=["x", "y"], input_shapes=[[5, 1, 64, 2], [5, 1, 16, 64]],
+             input_type=tf.float32,
+             axes=(2, 3), normalize=False),
+        dict(input_names=["x", "y"], input_shapes=[[5, 1, 4], [5, 1, 4]], input_type=tf.float32,
+             axes=-2, normalize=False),
+        dict(input_names=["x", "y"], input_shapes=[[5, 1, 1024, 2], [5, 1, 8, 1024]],
+             input_type=tf.float32,
+             axes=(-2, -1), normalize=False),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_difficult_axes_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_dot_difficult_axes_float32(self, params, ie_device, precision, temp_dir,
+                                              ir_version, api_2):
+        self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
+                   api_2=api_2, **params)
+
+    test_data_normalize_higher_rank = [
+        dict(input_names=["x", "y"], input_shapes=[[5, 1, 4], [5, 1, 4]], input_type=tf.float32,
+             axes=2, normalize=True),
+        dict(input_names=["x", "y"], input_shapes=[[5, 1, 1024, 2], [5, 1, 8, 1024]],
+             input_type=tf.float32,
+             axes=(2, 3), normalize=True),
+        dict(input_names=["x", "y"], input_shapes=[[5, 4, 4], [5, 4, 4]], input_type=tf.float32,
+             axes=(1, 2),
+             normalize=True),
+        dict(input_names=["x", "y"], input_shapes=[[5, 1, 5, 2], [5, 1, 2, 5]],
+             input_type=tf.float32, axes=(2, 3),
+             normalize=True),
+        dict(input_names=["x", "y"], input_shapes=[[5, 1, 4], [5, 1, 4]], input_type=tf.float32,
+             axes=-2, normalize=True),
+        dict(input_names=["x", "y"], input_shapes=[[5, 1, 1024, 2], [5, 1, 4, 1024]],
+             input_type=tf.float32,
+             axes=(-2, -1), normalize=True),
+
+    ]
+
+    @pytest.mark.parametrize("params", test_data_normalize_higher_rank)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_dot_normalize_higher_rank(self, params, ie_device, precision, temp_dir,
+                                             ir_version, api_2):
+        self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
+                   api_2=api_2, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dot.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dot.py
@@ -41,10 +41,10 @@ class TestKerasDot(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_dot_normalize_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                         api_2):
+                                         api_2, use_new_frontend):
         self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   api_2=api_2, **params)
+                   api_2=api_2, use_new_frontend=use_new_frontend, **params)
 
     test_data_difficult_axes_float32 = [
         dict(input_names=["x", "y"], input_shapes=[[5, 4, 4], [5, 4, 4]], input_type=tf.float32,
@@ -67,10 +67,10 @@ class TestKerasDot(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_dot_difficult_axes_float32(self, params, ie_device, precision, temp_dir,
-                                              ir_version, api_2):
+                                              ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   api_2=api_2, **params)
+                   api_2=api_2, use_new_frontend=use_new_frontend, **params)
 
     test_data_normalize_higher_rank = [
         dict(input_names=["x", "y"], input_shapes=[[5, 1, 4], [5, 1, 4]], input_type=tf.float32,
@@ -96,7 +96,7 @@ class TestKerasDot(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_dot_normalize_higher_rank(self, params, ie_device, precision, temp_dir,
-                                             ir_version, api_2):
+                                             ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_dot_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   api_2=api_2, **params)
+                   api_2=api_2, use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dropout.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dropout.py
@@ -1,0 +1,57 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasDropout(CommonTF2LayerTest):
+    def create_keras_dropout_net(self, input_names, input_shapes, input_type, rate, noise_shape,
+                                 ir_version):
+        """
+               create TensorFlow 2 model with Keras Dropout operation
+        """
+
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.Dropout(rate=rate, noise_shape=noise_shape, seed=4)(x, training=False)
+
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more important and needs to be checked
+        #  in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32_precommit = [
+        dict(input_names=["x"], input_shapes=[[5, 4, 4, 12, 6]], input_type=tf.float32, rate=.5,
+             noise_shape=(4, 4, 12, 6)),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32_precommit)
+    @pytest.mark.precommit
+    def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_dropout_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 2]], input_type=tf.float32, rate=0.1,
+             noise_shape=(2,)),
+        dict(input_names=["x"], input_shapes=[[5, 4, 4]], input_type=tf.float32, rate=0.9,
+             noise_shape=(4,)),
+        dict(input_names=["x"], input_shapes=[[5, 4, 4]], input_type=tf.float32, rate=0.4,
+             noise_shape=(4, 4)),
+        dict(input_names=["x"], input_shapes=[[5, 4, 4]], input_type=tf.float32, rate=0.,
+             noise_shape=(4, 4)),
+        dict(input_names=["x"], input_shapes=[[5, 4, 4, 4]], input_type=tf.float32, rate=.999,
+             noise_shape=(4, 4, 4)),
+        dict(input_names=["x"], input_shapes=[[5, 4, 4, 12, 6]], input_type=tf.float32, rate=.5,
+             noise_shape=(4, 4, 12, 6)),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_dropout_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dropout.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dropout.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dropout.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dropout.py
@@ -29,10 +29,10 @@ class TestKerasDropout(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_dropout_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [
@@ -52,8 +52,8 @@ class TestKerasDropout(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_dropout_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dropout.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dropout.py
@@ -29,10 +29,11 @@ class TestKerasDropout(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_dropout_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [
         dict(input_names=["x"], input_shapes=[[5, 2]], input_type=tf.float32, rate=0.1,
@@ -51,7 +52,8 @@ class TestKerasDropout(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_dropout_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_dropout_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_elu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_elu.py
@@ -103,10 +103,10 @@ class TestKerasELU(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                use_new_frontend):
         self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [
@@ -117,10 +117,10 @@ class TestKerasELU(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                use_new_frontend):
         self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_alpha2 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
@@ -137,7 +137,7 @@ class TestKerasELU(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="51109")
     def test_keras_elu_float32_alpha2(self, params, ie_device, precision, ir_version, temp_dir,
-                                      api_2, use_new_frontend):
+                                      use_old_api, use_new_frontend):
         self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_elu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_elu.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 from common.layer_test_class import check_ir_version

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_elu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_elu.py
@@ -103,10 +103,11 @@ class TestKerasELU(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                               use_new_frontend):
         self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [
         dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32, alpha=1.0),
@@ -116,10 +117,11 @@ class TestKerasELU(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                               use_new_frontend):
         self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_alpha2 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
                                      input_type=tf.float32, alpha=2.0),
@@ -135,7 +137,7 @@ class TestKerasELU(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="51109")
     def test_keras_elu_float32_alpha2(self, params, ie_device, precision, ir_version, temp_dir,
-                                      api_2):
+                                      api_2, use_new_frontend):
         self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_elu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_elu.py
@@ -1,0 +1,141 @@
+import pytest
+import tensorflow as tf
+from common.layer_test_class import check_ir_version
+from common.tf2_layer_test_class import CommonTF2LayerTest
+from unit_tests.utils.graph import build_graph
+
+
+class TestKerasELU(CommonTF2LayerTest):
+    def create_keras_elu_net(self, input_names, input_shapes, input_type, alpha, ir_version):
+        """
+               Tensorflow2 Keras net:                     IR net:
+                      Input               =>               Input
+                        |                                    |
+                       ELU                                  Elu
+        """
+        # create TensorFlow 2 model with Keras ELU operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:],
+                            name=input_names[0])  # Variable-length sequence of ints
+        y = tf.keras.layers.ELU(alpha=alpha)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # create reference IR net
+        ref_net = None
+
+        if check_ir_version(10, None, ir_version):
+            # convert NHWC to NCHW layout if tensor rank greater 3
+            converted_input_shape = input_shapes[0].copy()
+            if len(converted_input_shape) > 3:
+                converted_input_shape[1] = input_shapes[0][-1]
+                converted_input_shape[2:] = input_shapes[0][1:-1]
+            if alpha == 1.0:
+                nodes_attributes = {
+                    'input1': {'kind': 'op', 'type': 'Parameter'},
+                    'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'elu': {'kind': 'op', 'type': 'Elu'},
+                    'elu_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'result': {'kind': 'op', 'type': 'Result'}
+                }
+
+                ref_net = build_graph(nodes_attributes,
+                                      [('input1', 'input1_data'),
+                                       ('input1_data', 'elu', {'in': 0}),
+                                       ('elu', 'elu_data'),
+                                       ('elu_data', 'result')])
+            else:
+                nodes_attributes = {
+                    'input1': {'kind': 'op', 'type': 'Parameter'},
+                    'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+
+                    'alpha_input_data': {'kind': 'data', 'shape': [1], 'value': [0.0]},
+                    'alpha': {'kind': 'op', 'type': 'Const'},
+                    'alpha_data': {'kind': 'data'},
+
+                    'const_input_data': {'kind': 'data', 'shape': [1], 'value': [alpha]},
+                    'const': {'kind': 'op', 'type': 'Const'},
+                    'const_data': {'kind': 'data'},
+
+                    'greater': {'kind': 'op', 'type': 'Greater'},
+                    'greater_data': {'shape': converted_input_shape, 'kind': 'data'},
+
+                    'elu': {'kind': 'op', 'type': 'Elu'},
+                    'elu_data': {'shape': converted_input_shape, 'kind': 'data'},
+
+                    '1select': {'kind': 'op', 'type': 'Select'},
+                    'select_data': {'shape': converted_input_shape, 'kind': 'data'},
+
+                    '2multiply': {'kind': 'op', 'type': 'Multiply'},
+                    'multiply_data': {'shape': converted_input_shape, 'kind': 'data'},
+
+                    'result': {'kind': 'op', 'type': 'Result'}
+                }
+
+                ref_net = build_graph(nodes_attributes,
+                                      [('input1', 'input1_data'),
+                                       ('alpha_input_data', 'alpha'),
+                                       ('alpha', 'alpha_data'),
+                                       ('const_input_data', 'const'),
+                                       ('const', 'const_data'),
+
+                                       ('input1_data', 'greater', {'in': 0}),
+                                       ('alpha_data', 'greater', {'in': 1}),
+                                       ('greater', 'greater_data'),
+
+                                       ('input1_data', 'elu', {'in': 0}),
+                                       ('elu', 'elu_data'),
+
+                                       ('const_data', '2multiply', {'in': 0}),
+                                       ('elu_data', '2multiply', {'in': 1}),
+                                       ('2multiply', 'multiply_data'),
+
+                                       ('greater_data', '1select', {'in': 0}),
+                                       ('elu_data', '1select', {'in': 1}),
+                                       ('multiply_data', '1select', {'in': 2}),
+                                       ('1select', 'select_data'),
+
+                                       ('select_data', 'result')])
+
+        return tf2_net, ref_net
+
+    test_data_float32_precommit = [dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]],
+                                        input_type=tf.float32, alpha=1.0)]
+
+    @pytest.mark.parametrize("params", test_data_float32_precommit)
+    @pytest.mark.precommit
+    def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_float32 = [
+        dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32, alpha=1.0),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8]], input_type=tf.float32, alpha=1.0),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3]], input_type=tf.float32, alpha=1.0),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]], input_type=tf.float32, alpha=1.0)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_elu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_float32_alpha2 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
+                                     input_type=tf.float32, alpha=2.0),
+                                dict(input_names=["x1"], input_shapes=[[5, 4, 8]],
+                                     input_type=tf.float32, alpha=3.0),
+                                dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3]],
+                                     input_type=tf.float32, alpha=4.0),
+                                dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]],
+                                     input_type=tf.float32, alpha=5.0)]
+
+    @pytest.mark.parametrize("params", test_data_float32_alpha2)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.xfail(reason="51109")
+    def test_keras_elu_float32_alpha2(self, params, ie_device, precision, ir_version, temp_dir,
+                                      api_2):
+        self._test(*self.create_keras_elu_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
@@ -37,10 +37,11 @@ class TestKerasEmbedding(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_emb_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_emb_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                               use_new_frontend):
         self._test(*self.create_keras_emb_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_mask_zero_false = [
         dict(input_names=["x"], input_shapes=[[5, 16]], input_type=tf.float32, input_dim=256,
@@ -57,7 +58,7 @@ class TestKerasEmbedding(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_emb_without_zero_mask_float32(self, params, ie_device, precision, ir_version,
-                                                 temp_dir, api_2):
+                                                 temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_emb_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
@@ -37,10 +37,10 @@ class TestKerasEmbedding(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_emb_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_emb_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                use_new_frontend):
         self._test(*self.create_keras_emb_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_mask_zero_false = [
@@ -58,7 +58,7 @@ class TestKerasEmbedding(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_emb_without_zero_mask_float32(self, params, ie_device, precision, ir_version,
-                                                 temp_dir, api_2, use_new_frontend):
+                                                 temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_emb_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
@@ -1,0 +1,63 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasEmbedding(CommonTF2LayerTest):
+    def create_keras_emb_net(self, input_names, input_shapes, input_type, input_dim, output_dim,
+                             mask_zero,
+                             input_length, ir_version):
+        """
+                create TensorFlow 2 model with Keras Embedding operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0], dtype=input_type)
+        layer = tf.keras.layers.PReLU()(x)
+        y = tf.keras.layers.Embedding(input_dim, output_dim, mask_zero=mask_zero,
+                                      input_length=input_length)(layer)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 16]], input_type=tf.float32, input_dim=256,
+             output_dim=8, mask_zero=True, input_length=4),
+        dict(input_names=["x"], input_shapes=[[5, 16]], input_type=tf.float32, input_dim=256,
+             output_dim=324, mask_zero=True, input_length=16),
+        dict(input_names=["x"], input_shapes=[[5, 16]], input_type=tf.float32, input_dim=256,
+             output_dim=256, mask_zero=True, input_length=8),
+        dict(input_names=["x"], input_shapes=[[5, 16]], input_type=tf.float32, input_dim=256,
+             output_dim=32, mask_zero=True, input_length=4)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_emb_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_emb_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_mask_zero_false = [
+        dict(input_names=["x"], input_shapes=[[5, 16]], input_type=tf.float32, input_dim=256,
+             output_dim=32, mask_zero=False, input_length=1),
+        dict(input_names=["x"], input_shapes=[[5, 16]], input_type=tf.float32, input_dim=256,
+             output_dim=128, mask_zero=False, input_length=2),
+        dict(input_names=["x"], input_shapes=[[5, 16]], input_type=tf.float32, input_dim=256,
+             output_dim=256, mask_zero=False, input_length=4),
+        dict(input_names=["x"], input_shapes=[[5, 16]], input_type=tf.float32, input_dim=256,
+             output_dim=16, mask_zero=False, input_length=8)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_mask_zero_false)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_emb_without_zero_mask_float32(self, params, ie_device, precision, ir_version,
+                                                 temp_dir, api_2):
+        self._test(*self.create_keras_emb_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_flatten.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_flatten.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_flatten.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_flatten.py
@@ -31,7 +31,8 @@ class TestKerasFlatten(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_flatten_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_flatten_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_flatten_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_flatten.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_flatten.py
@@ -31,8 +31,8 @@ class TestKerasFlatten(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_flatten_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_flatten_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_flatten_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_flatten.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_flatten.py
@@ -1,0 +1,37 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasFlatten(CommonTF2LayerTest):
+    def create_keras_flatten_net(self, input_names, input_shapes, input_type, data_format,
+                                 ir_version):
+        """
+                create TensorFlow 2 model with Keras Flatten operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.Flatten(data_format)(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 4, 3]], input_type=tf.float32, data_format=None),
+        dict(input_names=["x"], input_shapes=[[5, 4, 8, 16]], input_type=tf.float32,
+             data_format="channels_first"),
+        dict(input_names=["x"], input_shapes=[[5, 1, 16, 8, 3]], input_type=tf.float32,
+             data_format="channels_last"),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_flatten_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_flatten_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling1D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling1D.py
@@ -1,0 +1,38 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasGlobalAvgPool1D(CommonTF2LayerTest):
+    def create_keras_global_avg_pooling1D_net(self, input_names, input_shapes, input_type,
+                                              dataformat, ir_version):
+        """
+                create TensorFlow 2 model with Keras GlobalAveragePooling1D operation
+        """
+
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.GlobalAveragePooling1D(data_format=dataformat)(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 16, 9]], input_type=tf.float32,
+             dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[4, 10, 12]], input_type=tf.float32,
+             dataformat='channels_first'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_global_avg_pooling1D_float32(self, params, ie_device, precision, ir_version,
+                                                temp_dir, api_2):
+        self._test(*self.create_keras_global_avg_pooling1D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling1D.py
@@ -32,7 +32,7 @@ class TestKerasGlobalAvgPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_avg_pooling1D_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, api_2, use_new_frontend):
+                                                temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_global_avg_pooling1D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling1D.py
@@ -32,7 +32,7 @@ class TestKerasGlobalAvgPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_avg_pooling1D_float32(self, params, ie_device, precision, ir_version,
-                                                temp_dir, api_2):
+                                                temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_global_avg_pooling1D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling2D.py
@@ -31,7 +31,7 @@ class TestKerasGlobalAvgPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_avg_pooling2D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, api_2, use_new_frontend):
+                                                ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_global_avg_pooling2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling2D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling2D.py
@@ -1,0 +1,37 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasGlobalAvgPool2D(CommonTF2LayerTest):
+    def create_keras_global_avg_pooling2D_net(self, input_names, input_shapes, input_type,
+                                              dataformat, ir_version):
+        """
+                create TensorFlow 2 model with Keras GlobalAveragePooling2D operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.GlobalAveragePooling2D(data_format=dataformat)(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 9, 4, 2]], input_type=tf.float32,
+             dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 3, 8, 8]], input_type=tf.float32,
+             dataformat='channels_first'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_global_avg_pooling2D_float32(self, params, ie_device, precision, temp_dir,
+                                                ir_version, api_2):
+        self._test(*self.create_keras_global_avg_pooling2D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling2D.py
@@ -31,7 +31,7 @@ class TestKerasGlobalAvgPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_avg_pooling2D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, api_2):
+                                                ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_global_avg_pooling2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling3D.py
@@ -31,7 +31,7 @@ class TestKerasGlobalAvgPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_avg_pooling3D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, api_2):
+                                                ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_global_avg_pooling3D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling3D.py
@@ -31,7 +31,7 @@ class TestKerasGlobalAvgPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_avg_pooling3D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, api_2, use_new_frontend):
+                                                ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_global_avg_pooling3D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling3D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_average_pooling3D.py
@@ -1,0 +1,37 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasGlobalAvgPool3D(CommonTF2LayerTest):
+    def create_keras_global_avg_pooling3D_net(self, input_names, input_shapes, input_type,
+                                              dataformat, ir_version):
+        """
+                create TensorFlow 2 model with Keras GlobalAveragePooling3D operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.GlobalAveragePooling3D(data_format=dataformat)(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 2, 4, 5, 6]], input_type=tf.float32,
+             dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 4, 1, 8, 6]], input_type=tf.float32,
+             dataformat='channels_first'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_global_avg_pooling3D_float32(self, params, ie_device, precision, temp_dir,
+                                                ir_version, api_2):
+        self._test(*self.create_keras_global_avg_pooling3D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool1D.py
@@ -1,0 +1,38 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasGlobalMaxPool1D(CommonTF2LayerTest):
+    def create_keras_global_max_pooling1D_net(self, input_names, input_shapes, input_type,
+                                              dataformat, ir_version):
+        """
+                create TensorFlow 2 model with Keras GlobalMaxPool1D operation
+        """
+
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.GlobalMaxPool1D(data_format=dataformat)(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 256, 1]], input_type=tf.float32,
+             dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 6, 8]], input_type=tf.float32,
+             dataformat='channels_first'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_global_max_pooling1D_float32(self, params, ie_device, precision, temp_dir,
+                                                ir_version, api_2):
+        self._test(*self.create_keras_global_max_pooling1D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool1D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool1D.py
@@ -32,7 +32,7 @@ class TestKerasGlobalMaxPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_max_pooling1D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, api_2, use_new_frontend):
+                                                ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_global_max_pooling1D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool1D.py
@@ -32,7 +32,7 @@ class TestKerasGlobalMaxPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_max_pooling1D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, api_2):
+                                                ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_global_max_pooling1D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool2D.py
@@ -1,0 +1,38 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasGlobalMaxPool2D(CommonTF2LayerTest):
+    def create_keras_global_maxpool2D_net(self, input_names, input_shapes, input_type, dataformat,
+                                          ir_version):
+        """
+                create TensorFlow 2 model with Keras GlobalMaxPool2D operation
+        """
+
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.GlobalMaxPool2D(data_format=dataformat)(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 12, 4, 1]], input_type=tf.float32,
+             dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 3, 2, 6]], input_type=tf.float32,
+             dataformat='channels_first'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_global_max_pooling2D_float32(self, params, ie_device, precision, temp_dir,
+                                                ir_version, api_2):
+        self._test(*self.create_keras_global_maxpool2D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool2D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool2D.py
@@ -32,7 +32,7 @@ class TestKerasGlobalMaxPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_max_pooling2D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, api_2):
+                                                ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_global_maxpool2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool2D.py
@@ -32,7 +32,7 @@ class TestKerasGlobalMaxPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_max_pooling2D_float32(self, params, ie_device, precision, temp_dir,
-                                                ir_version, api_2, use_new_frontend):
+                                                ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_global_maxpool2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool3D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool3D.py
@@ -31,7 +31,7 @@ class TestKerasGlobalMaxPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_maxpool3D_float32(self, params, ie_device, precision, temp_dir,
-                                            ir_version, api_2):
+                                            ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_global_maxpool3D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool3D.py
@@ -1,0 +1,37 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasGlobalMaxPool3D(CommonTF2LayerTest):
+    def create_keras_global_maxpool3D_net(self, input_names, input_shapes, input_type, dataformat,
+                                          ir_version):
+        """
+                create TensorFlow 2 model with Keras GlobalMaxPool3D operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.GlobalMaxPool3D(data_format=dataformat)(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 2, 3, 4, 5]], input_type=tf.float32,
+             dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 12, 2, 5, 3]], input_type=tf.float32,
+             dataformat='channels_first'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_global_maxpool3D_float32(self, params, ie_device, precision, temp_dir,
+                                            ir_version, api_2):
+        self._test(*self.create_keras_global_maxpool3D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_global_maxpool3D.py
@@ -31,7 +31,7 @@ class TestKerasGlobalMaxPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_global_maxpool3D_float32(self, params, ie_device, precision, temp_dir,
-                                            ir_version, api_2, use_new_frontend):
+                                            ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_global_maxpool3D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru.py
@@ -52,10 +52,10 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_gru_with_bias_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                         api_2):
+                                         api_2, use_new_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_without_bias = [
         dict(input_names=["x"], input_shapes=[[2, 2, 7]], input_type=tf.float32, units=1,
@@ -73,10 +73,10 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_gru_without_bias_float32(self, params, ie_device, precision, temp_dir,
-                                            ir_version, api_2):
+                                            ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_different_flags = [
         dict(input_names=["x"], input_shapes=[[2, 3, 2]], input_type=tf.float32, units=1,
@@ -100,10 +100,10 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_gru_flags_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                     api_2):
+                                     api_2, use_new_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_zero_recurrent_dropout = [
         dict(input_names=["x"], input_shapes=[[8, 2, 3]], input_type=tf.float32, units=3,
@@ -125,7 +125,8 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="50176")
     def test_keras_gru_flags_zero_recurrent_dropout_float32(self, params, ie_device, precision,
-                                                            temp_dir, ir_version, api_2):
+                                                            temp_dir, ir_version, api_2,
+                                                            use_new_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru.py
@@ -52,9 +52,9 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_gru_with_bias_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                         api_2, use_new_frontend):
+                                         use_old_api, use_new_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_without_bias = [
@@ -73,9 +73,9 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_gru_without_bias_float32(self, params, ie_device, precision, temp_dir,
-                                            ir_version, api_2, use_new_frontend):
+                                            ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_different_flags = [
@@ -100,9 +100,9 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_gru_flags_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                     api_2, use_new_frontend):
+                                     use_old_api, use_new_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_zero_recurrent_dropout = [
@@ -125,8 +125,8 @@ class TestKerasGru(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="50176")
     def test_keras_gru_flags_zero_recurrent_dropout_float32(self, params, ie_device, precision,
-                                                            temp_dir, ir_version, api_2,
+                                                            temp_dir, ir_version, use_old_api,
                                                             use_new_frontend):
         self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru.py
@@ -1,0 +1,131 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasGru(CommonTF2LayerTest):
+    def create_keras_gru_net(self, input_names, input_shapes, input_type, units, activation,
+                             recurrent_activation,
+                             use_bias, dropouts, flags, ir_version):
+        """
+                create TensorFlow 2 model with Keras GRU operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        dropout, recurrent_dropout = dropouts
+        go_backwards, reset_after, time_major = flags
+        y = tf.keras.layers.GRU(units=units, activation=activation,
+                                recurrent_activation=recurrent_activation,
+                                use_bias=use_bias, dropout=dropout,
+                                recurrent_dropout=recurrent_dropout,
+                                return_sequences=False, return_state=False,
+                                go_backwards=go_backwards,
+                                time_major=time_major, reset_after=reset_after)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_simple = [
+        dict(input_names=["x"], input_shapes=[[2, 2, 3]], input_type=tf.float32, units=1,
+             activation='tanh', recurrent_activation='sigmoid', dropouts=(.0, .3), use_bias=True,
+             flags=(False, False, False)),
+        dict(input_names=["x"], input_shapes=[[1, 2, 3]], input_type=tf.float32, units=4,
+             activation='relu', recurrent_activation='sigmoid', dropouts=(.2, .4), use_bias=True,
+             flags=(False, False, False)),
+        dict(input_names=["x"], input_shapes=[[3, 2, 3]], input_type=tf.float32, units=2,
+             activation='elu', recurrent_activation='tanh', dropouts=(.3, .5), use_bias=True,
+             flags=(False, False, False)),
+        dict(input_names=["x"], input_shapes=[[2, 3, 4]], input_type=tf.float32, units=1,
+             activation='elu', recurrent_activation='softmax', dropouts=(.0, .5), use_bias=True,
+             flags=(False, False, False)),
+        dict(input_names=["x"], input_shapes=[[1, 3, 4]], input_type=tf.float32, units=3,
+             activation='linear', recurrent_activation='sigmoid', dropouts=(.4, .6),
+             flags=(False, False, False), use_bias=True)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_simple)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_gru_with_bias_float32(self, params, ie_device, precision, temp_dir, ir_version,
+                                         api_2):
+        self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_without_bias = [
+        dict(input_names=["x"], input_shapes=[[2, 2, 7]], input_type=tf.float32, units=1,
+             activation='tanh', recurrent_activation='sigmoid', dropouts=(.0, .3), use_bias=False,
+             flags=(False, False, False)),
+        dict(input_names=["x"], input_shapes=[[3, 8, 3]], input_type=tf.float32, units=4,
+             activation='relu', recurrent_activation='sigmoid', dropouts=(.7, .4), use_bias=False,
+             flags=(False, False, False)),
+        dict(input_names=["x"], input_shapes=[[4, 2, 2]], input_type=tf.float32, units=2,
+             activation='elu', recurrent_activation='tanh', dropouts=(.0, .5), use_bias=False,
+             flags=(False, False, False))
+    ]
+
+    @pytest.mark.parametrize("params", test_data_without_bias)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_gru_without_bias_float32(self, params, ie_device, precision, temp_dir,
+                                            ir_version, api_2):
+        self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_different_flags = [
+        dict(input_names=["x"], input_shapes=[[2, 3, 2]], input_type=tf.float32, units=1,
+             activation='elu', recurrent_activation='sigmoid', dropouts=(.0, .3), use_bias=True,
+             flags=(True, False, False)),
+        dict(input_names=["x"], input_shapes=[[4, 8, 3]], input_type=tf.float32, dropouts=(.1, .3),
+             units=3, activation='relu', use_bias=False, recurrent_activation='tanh',
+             flags=(False, True, False)),
+        dict(input_names=["x"], input_shapes=[[4, 2, 7]], input_type=tf.float32, units=5,
+             activation='relu', recurrent_activation='tanh', dropouts=(.2, .6),
+             use_bias=True, flags=(False, False, True)),
+        dict(input_names=["x"], input_shapes=[[4, 16, 2]], input_type=tf.float32, units=5,
+             activation='relu', recurrent_activation='tanh', dropouts=(.2, .6),
+             use_bias=True, flags=(False, True, True)),
+        dict(input_names=["x"], input_shapes=[[4, 8, 7]], input_type=tf.float32, units=5,
+             activation='elu', recurrent_activation='sigmoid', dropouts=(.2, .6),
+             use_bias=True, flags=(True, True, True)),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_different_flags)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_gru_flags_float32(self, params, ie_device, precision, temp_dir, ir_version,
+                                     api_2):
+        self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_zero_recurrent_dropout = [
+        dict(input_names=["x"], input_shapes=[[8, 2, 3]], input_type=tf.float32, units=3,
+             activation='elu', recurrent_activation='tanh', dropouts=(.7, .0), use_bias=True,
+             flags=(False, False, False)),
+        dict(input_names=["x"], input_shapes=[[4, 8, 5]], input_type=tf.float32, dropouts=(.6, .0),
+             units=2, activation='elu', use_bias=True, recurrent_activation='tanh',
+             flags=(False, False, True)),
+        dict(input_names=["x"], input_shapes=[[4, 3, 1]], input_type=tf.float32, units=8,
+             activation='elu', recurrent_activation='tanh', dropouts=(.5, .0),
+             use_bias=True, flags=(True, False, False)),
+        dict(input_names=["x"], input_shapes=[[3, 4, 2]], input_type=tf.float32, units=3,
+             activation='elu', recurrent_activation='tanh', dropouts=(.7, .0), use_bias=True,
+             flags=(True, False, True)),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_zero_recurrent_dropout)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.xfail(reason="50176")
+    def test_keras_gru_flags_zero_recurrent_dropout_float32(self, params, ie_device, precision,
+                                                            temp_dir, ir_version, api_2):
+        self._test(*self.create_keras_gru_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru_cell.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru_cell.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru_cell.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru_cell.py
@@ -1,0 +1,52 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasGRUCell(CommonTF2LayerTest):
+    def create_keras_grucell_net(self, input_names, input_shapes, input_type, units, activation,
+                                 recurrent_activation,
+                                 use_bias, reset_after, dropouts, ir_version):
+        """
+                create TensorFlow 2 model with Keras GRUCell operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        dropout, recurrent_dropout = dropouts
+        cell = tf.keras.layers.GRUCell(units=units, activation=activation,
+                                       recurrent_activation=recurrent_activation,
+                                       use_bias=use_bias, reset_after=reset_after, dropout=dropout,
+                                       recurrent_dropout=recurrent_dropout)
+        y = tf.keras.layers.RNN(cell=cell, return_sequences=True, return_state=True)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=y)
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_simple = [
+        dict(input_names=["x"], input_shapes=[[2, 3, 4]], input_type=tf.float32, units=1,
+             activation='relu', recurrent_activation='sigmoid', dropouts=(.0, .0), use_bias=True,
+             reset_after=True),
+        dict(input_names=["x"], input_shapes=[[5, 4, 6]], input_type=tf.float32, units=4,
+             activation='elu', recurrent_activation='tanh', dropouts=(.2, .1), use_bias=False,
+             reset_after=True),
+        dict(input_names=["x"], input_shapes=[[3, 7, 5]], input_type=tf.float32, units=5,
+             activation='linear', recurrent_activation='tanh', dropouts=(.9, .1), use_bias=True,
+             reset_after=False),
+        dict(input_names=["x"], input_shapes=[[5, 3, 3]], input_type=tf.float32, units=4,
+             activation='softmax', recurrent_activation='sigmoid', dropouts=(.4, .2),
+             use_bias=False, reset_after=False)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_simple)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.xfail(reason="49537")
+    def test_keras_grucell_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2):
+        self._test(*self.create_keras_grucell_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru_cell.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru_cell.py
@@ -46,7 +46,8 @@ class TestKerasGRUCell(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49537")
-    def test_keras_grucell_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2):
+    def test_keras_grucell_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_grucell_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru_cell.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_gru_cell.py
@@ -46,8 +46,8 @@ class TestKerasGRUCell(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49537")
-    def test_keras_grucell_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2,
+    def test_keras_grucell_float32(self, params, ie_device, precision, temp_dir, ir_version, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_grucell_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lambda.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lambda.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lambda.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lambda.py
@@ -1,0 +1,82 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+def x2_fun(x):
+    return x + x
+
+
+def x2_fun_shape(input_shape):
+    return input_shape
+
+
+def x1_plus_x2(inputs):
+    x1 = inputs[0]
+    x2 = inputs[1]
+    return x1 + x2
+
+
+def x1_plus_x2_shape(shapes):
+    return shapes[0]
+
+
+def x1_add_x2(inputs):
+    return tf.keras.layers.Add()(inputs)
+
+
+def x1_add_x2_shape(shapes):
+    return shapes[0]
+
+
+class TestKerasLambda(CommonTF2LayerTest):
+    def create_keras_lambda_net(self, input_names, input_shapes, input_type, lmbd, exp_shapes,
+                                ir_version):
+        """
+                create TensorFlow 2 model with Keras Lambda operation
+        """
+        lambda_operations = {
+            "x2_fun": x2_fun,
+            "x2_fun_shape": x2_fun_shape,
+            "x1_plus_x2": x1_plus_x2,
+            "x1_plus_x2_shape": x1_plus_x2_shape,
+            "x1_add_x2": x1_add_x2,
+            "x1_add_x2_shape": x1_add_x2_shape
+        }
+
+        lmbd = lambda_operations[lmbd]
+        exp_shapes = lambda_operations[exp_shapes]
+
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+
+        inputs = [tf.keras.Input(shape=input_shapes[idx][1:], name=input_names[idx]) for idx in
+                  range(len(input_shapes))]
+        if len(inputs) > 1:
+            y = tf.keras.layers.Lambda(function=lmbd, output_shape=exp_shapes)(inputs)
+        else:
+            y = tf.keras.layers.Lambda(function=lmbd, output_shape=exp_shapes)(inputs[0])
+
+        tf2_net = tf.keras.Model(inputs=inputs, outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 3]], input_type=tf.float32,
+             lmbd="x2_fun", exp_shapes="x2_fun_shape"),
+        dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 3], [5, 4, 3]], input_type=tf.float32,
+             lmbd="x1_plus_x2", exp_shapes="x1_plus_x2_shape"),
+        dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 3], [5, 4, 3]], input_type=tf.float32,
+             lmbd="x1_add_x2", exp_shapes="x1_add_x2_shape"),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_lambda_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2):
+        self._test(*self.create_keras_lambda_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
+                   api_2=api_2, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lambda.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lambda.py
@@ -76,8 +76,8 @@ class TestKerasLambda(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_lambda_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2,
+    def test_keras_lambda_float32(self, params, ie_device, precision, temp_dir, ir_version, use_old_api,
                                   use_new_frontend):
         self._test(*self.create_keras_lambda_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   api_2=api_2, use_new_frontend=use_new_frontend, **params)
+                   use_old_api=use_old_api, use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lambda.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lambda.py
@@ -76,7 +76,8 @@ class TestKerasLambda(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_lambda_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2):
+    def test_keras_lambda_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2,
+                                  use_new_frontend):
         self._test(*self.create_keras_lambda_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
-                   api_2=api_2, **params)
+                   api_2=api_2, use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_layer_normalization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_layer_normalization.py
@@ -1,0 +1,55 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasLayerNormalization(CommonTF2LayerTest):
+    def create_keras_lnorm_net(self, input_names, input_shapes, input_type, axis, epsilon, center,
+                               scale, ir_version):
+        """
+               create TensorFlow 2 model with Keras LayerNormalization operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.LayerNormalization(axis=axis, epsilon=epsilon, center=center,
+                                               scale=scale,
+                                               trainable=False)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32_precommit = [
+        dict(input_names=["x"], input_shapes=[[2, 2, 3, 5]], input_type=tf.float32,
+             axis=(1, 2, 3), epsilon=1e-5, center=True, scale=True)]
+
+    @pytest.mark.parametrize("params", test_data_float32_precommit)
+    @pytest.mark.precommit
+    def test_keras_dense_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2):
+        self._test(*self.create_keras_lnorm_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 10]], input_type=tf.float32, axis=1, epsilon=1e-6,
+             center=False, scale=False),
+        dict(input_names=["x"], input_shapes=[[3, 3, 5]], input_type=tf.float32, axis=1,
+             epsilon=1e-7,
+             center=True, scale=False),
+        dict(input_names=["x"], input_shapes=[[2, 3, 8]], input_type=tf.float32, axis=2,
+             epsilon=1e-6,
+             center=False, scale=True),
+        dict(input_names=["x"], input_shapes=[[2, 2, 3, 5]], input_type=tf.float32, axis=(1, 2, 3),
+             epsilon=1e-5,
+             center=True, scale=True)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_dense_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2):
+        self._test(*self.create_keras_lnorm_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_layer_normalization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_layer_normalization.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_layer_normalization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_layer_normalization.py
@@ -29,10 +29,10 @@ class TestKerasLayerNormalization(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_dense_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2,
+    def test_keras_dense_float32(self, params, ie_device, precision, temp_dir, ir_version, use_old_api,
                                  use_new_frontend):
         self._test(*self.create_keras_lnorm_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [
@@ -50,7 +50,7 @@ class TestKerasLayerNormalization(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_dense_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2):
+    def test_keras_dense_float32(self, params, ie_device, precision, temp_dir, ir_version, use_old_api):
         self._test(*self.create_keras_lnorm_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_layer_normalization.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_layer_normalization.py
@@ -29,10 +29,11 @@ class TestKerasLayerNormalization(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_dense_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2):
+    def test_keras_dense_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2,
+                                 use_new_frontend):
         self._test(*self.create_keras_lnorm_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [
         dict(input_names=["x"], input_shapes=[[5, 10]], input_type=tf.float32, axis=1, epsilon=1e-6,

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_leakyrelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_leakyrelu.py
@@ -1,0 +1,36 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasLeakyRelu(CommonTF2LayerTest):
+    def create_keras_leaky_relu_net(self, input_names, input_shapes, input_type, alpha, ir_version):
+        """
+                create TensorFlow 2 model with Keras LeakyReLU operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.LeakyReLU(alpha)(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 4, 3]], input_type=tf.float32, alpha=0.),
+        dict(input_names=["x"], input_shapes=[[5, 4, 3]], input_type=tf.float32, alpha=0.5),
+        dict(input_names=["x"], input_shapes=[[5, 2, 3, 4]], input_type=tf.float32, alpha=-1.),
+        dict(input_names=["x"], input_shapes=[[5, 2, 3, 5, 3]], input_type=tf.float32, alpha=-1.7),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_leaky_relu_float32(self, params, ie_device, precision, temp_dir, ir_version,
+                                      api_2):
+        self._test(*self.create_keras_leaky_relu_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_leakyrelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_leakyrelu.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_leakyrelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_leakyrelu.py
@@ -30,7 +30,7 @@ class TestKerasLeakyRelu(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_leaky_relu_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                      api_2):
+                                      api_2, use_new_frontend):
         self._test(*self.create_keras_leaky_relu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_leakyrelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_leakyrelu.py
@@ -30,7 +30,7 @@ class TestKerasLeakyRelu(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_leaky_relu_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                      api_2, use_new_frontend):
+                                      use_old_api, use_new_frontend):
         self._test(*self.create_keras_leaky_relu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected1D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected1D.py
@@ -46,10 +46,10 @@ class TestKerasLocallyConnected1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_locally_connected1D_float32(self, params, ie_device, precision, temp_dir,
-                                               ir_version, api_2):
+                                               ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_locally_connected1D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_simple_channels_first = [
         dict(input_names=["x"], input_shapes=[[5, 14, 14]], input_type=tf.float32, filters=3,
@@ -70,7 +70,8 @@ class TestKerasLocallyConnected1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_locally_connected1D_channels_first_float32(self, params, ie_device, precision,
-                                                              temp_dir, ir_version, api_2):
+                                                              temp_dir, ir_version, api_2,
+                                                              use_new_frontend):
         self._test(*self.create_keras_locally_connected1D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected1D.py
@@ -46,9 +46,9 @@ class TestKerasLocallyConnected1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_locally_connected1D_float32(self, params, ie_device, precision, temp_dir,
-                                               ir_version, api_2, use_new_frontend):
+                                               ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_locally_connected1D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_simple_channels_first = [
@@ -70,8 +70,8 @@ class TestKerasLocallyConnected1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_locally_connected1D_channels_first_float32(self, params, ie_device, precision,
-                                                              temp_dir, ir_version, api_2,
+                                                              temp_dir, ir_version, use_old_api,
                                                               use_new_frontend):
         self._test(*self.create_keras_locally_connected1D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected1D.py
@@ -1,0 +1,76 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasLocallyConnected1D(CommonTF2LayerTest):
+    def create_keras_locally_connected1D_net(self, input_names, input_shapes, input_type, filters,
+                                             kernel_size, strides,
+                                             padding, data_format, activation, use_bias, ir_version,
+                                             impl=1):
+        """
+                create TensorFlow 2 model with Keras LocallyConnected1D operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.LocallyConnected1D(filters, kernel_size, strides=strides,
+                                               padding=padding,
+                                               data_format=data_format, activation=activation,
+                                               use_bias=use_bias,
+                                               implementation=impl)(x1)
+        tf2_net = tf.keras.Model(inputs=x1, outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_simple_channel_last = [
+        dict(input_names=["x"], input_shapes=[[1, 4, 7]], input_type=tf.float32, filters=2,
+             kernel_size=(3,),
+             strides=(2,), padding='valid', data_format='channels_last', activation="linear",
+             use_bias=False),
+        dict(input_names=["x"], input_shapes=[[2, 4, 12]], input_type=tf.float32, filters=4,
+             kernel_size=(2,),
+             strides=(2,), padding='valid', data_format='channels_last', activation='relu',
+             use_bias=True),
+        dict(input_names=["x"], input_shapes=[[4, 8, 8]], input_type=tf.float32, filters=5,
+             kernel_size=(3,),
+             strides=(4,), padding='valid', data_format='channels_last', activation='tanh',
+             use_bias=False),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_simple_channel_last)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_locally_connected1D_float32(self, params, ie_device, precision, temp_dir,
+                                               ir_version, api_2):
+        self._test(*self.create_keras_locally_connected1D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_simple_channels_first = [
+        dict(input_names=["x"], input_shapes=[[5, 14, 14]], input_type=tf.float32, filters=3,
+             kernel_size=(4,),
+             strides=(2,), padding='valid', data_format='channels_first', activation='softmax',
+             use_bias=True),
+        dict(input_names=["x"], input_shapes=[[5, 8, 5]], input_type=tf.float32, filters=4,
+             kernel_size=(3,),
+             strides=(1,), padding='valid', data_format='channels_first', activation='elu',
+             use_bias=False),
+        dict(input_names=["x"], input_shapes=[[5, 10, 10]], input_type=tf.float32, filters=2,
+             kernel_size=(3,),
+             strides=(4,), padding='valid', data_format='channels_first', activation='sigmoid',
+             use_bias=True),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_simple_channels_first)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_locally_connected1D_channels_first_float32(self, params, ie_device, precision,
+                                                              temp_dir, ir_version, api_2):
+        self._test(*self.create_keras_locally_connected1D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected2D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected2D.py
@@ -46,9 +46,9 @@ class TestKerasLocallyConnected2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_locally_connected2D_float32(self, params, ie_device, precision, temp_dir,
-                                               ir_version, api_2, use_new_frontend):
+                                               ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_locally_connected2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_simple_channels_first = [
@@ -70,8 +70,8 @@ class TestKerasLocallyConnected2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_locally_connected2D_channels_first_float32(self, params, ie_device, precision,
-                                                              temp_dir, ir_version, api_2,
+                                                              temp_dir, ir_version, use_old_api,
                                                               use_new_frontend):
         self._test(*self.create_keras_locally_connected2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected2D.py
@@ -46,10 +46,10 @@ class TestKerasLocallyConnected2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_locally_connected2D_float32(self, params, ie_device, precision, temp_dir,
-                                               ir_version, api_2):
+                                               ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_locally_connected2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_simple_channels_first = [
         dict(input_names=["x"], input_shapes=[[5, 7, 7, 4]], input_type=tf.float32, filters=3,
@@ -70,7 +70,8 @@ class TestKerasLocallyConnected2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_locally_connected2D_channels_first_float32(self, params, ie_device, precision,
-                                                              temp_dir, ir_version, api_2):
+                                                              temp_dir, ir_version, api_2,
+                                                              use_new_frontend):
         self._test(*self.create_keras_locally_connected2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_locally_connected2D.py
@@ -1,0 +1,76 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasLocallyConnected2D(CommonTF2LayerTest):
+    def create_keras_locally_connected2D_net(self, input_names, input_shapes, input_type, filters,
+                                             kernel_size, strides,
+                                             padding, data_format, activation, use_bias, ir_version,
+                                             impl=1):
+        """
+                create TensorFlow 2 model with Keras LocallyConnected2D operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.LocallyConnected2D(filters, kernel_size, strides=strides,
+                                               padding=padding,
+                                               data_format=data_format, activation=activation,
+                                               use_bias=use_bias,
+                                               implementation=impl)(x1)
+        tf2_net = tf.keras.Model(inputs=x1, outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_simple_channel_last = [
+        dict(input_names=["x"], input_shapes=[[1, 4, 3, 2]], input_type=tf.float32, filters=2,
+             kernel_size=(3, 2),
+             strides=(2, 2), padding='valid', data_format='channels_last', activation="linear",
+             use_bias=False),
+        dict(input_names=["x"], input_shapes=[[2, 4, 4, 4]], input_type=tf.float32, filters=4,
+             kernel_size=(2, 1),
+             strides=(2, 2), padding='valid', data_format='channels_last', activation='relu',
+             use_bias=True),
+        dict(input_names=["x"], input_shapes=[[4, 4, 8, 6]], input_type=tf.float32, filters=5,
+             kernel_size=(4, 2),
+             strides=(2, 2), padding='valid', data_format='channels_last', activation='tanh',
+             use_bias=False),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_simple_channel_last)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_locally_connected2D_float32(self, params, ie_device, precision, temp_dir,
+                                               ir_version, api_2):
+        self._test(*self.create_keras_locally_connected2D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_simple_channels_first = [
+        dict(input_names=["x"], input_shapes=[[5, 7, 7, 4]], input_type=tf.float32, filters=3,
+             kernel_size=(4, 4),
+             strides=(2, 4), padding='valid', data_format='channels_first', activation='softmax',
+             use_bias=True),
+        dict(input_names=["x"], input_shapes=[[5, 2, 5, 4]], input_type=tf.float32, filters=4,
+             kernel_size=(3, 2),
+             strides=(1, 1), padding='valid', data_format='channels_first', activation='elu',
+             use_bias=False),
+        dict(input_names=["x"], input_shapes=[[5, 2, 2, 25]], input_type=tf.float32, filters=2,
+             kernel_size=(1, 5),
+             strides=(2, 10), padding='valid', data_format='channels_first', activation='sigmoid',
+             use_bias=True),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_simple_channels_first)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_locally_connected2D_channels_first_float32(self, params, ie_device, precision,
+                                                              temp_dir, ir_version, api_2):
+        self._test(*self.create_keras_locally_connected2D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm.py
@@ -1,0 +1,102 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasLSTM(CommonTF2LayerTest):
+    def create_keras_lstm_net(self, input_names, input_shapes, input_type, units, activation,
+                              recurrent_activation,
+                              use_bias, dropouts, flags, ir_version):
+        """
+                create TensorFlow 2 model with Keras LSTM operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        dropout, recurrent_dropout = dropouts
+        go_backwards, time_major = flags
+        y = tf.keras.layers.LSTM(units=units, activation=activation,
+                                 recurrent_activation=recurrent_activation,
+                                 use_bias=use_bias, dropout=dropout,
+                                 recurrent_dropout=recurrent_dropout,
+                                 return_sequences=False, return_state=False,
+                                 go_backwards=go_backwards,
+                                 time_major=time_major)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_simple = [
+        dict(input_names=["x"], input_shapes=[[2, 2, 3]], input_type=tf.float32, units=1,
+             activation='tanh', recurrent_activation='sigmoid', dropouts=(.0, .3), use_bias=True,
+             flags=(False, False)),
+        dict(input_names=["x"], input_shapes=[[1, 2, 3]], input_type=tf.float32, units=4,
+             activation='relu', recurrent_activation='sigmoid', dropouts=(.2, .4), use_bias=True,
+             flags=(False, False)),
+        dict(input_names=["x"], input_shapes=[[3, 2, 3]], input_type=tf.float32, units=2,
+             activation='elu', recurrent_activation='tanh', dropouts=(.3, .5), use_bias=True,
+             flags=(False, False)),
+        dict(input_names=["x"], input_shapes=[[2, 3, 4]], input_type=tf.float32, units=1,
+             activation='elu', recurrent_activation='softmax', dropouts=(.0, .5), use_bias=True,
+             flags=(False, False)),
+        dict(input_names=["x"], input_shapes=[[1, 3, 4]], input_type=tf.float32, units=3,
+             activation='linear', recurrent_activation='sigmoid', dropouts=(.4, .6),
+             flags=(False, False), use_bias=True)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_simple)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_lstm_with_bias_float32(self, params, ie_device, precision, temp_dir, ir_version,
+                                          api_2):
+        self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_without_bias = [
+        dict(input_names=["x"], input_shapes=[[2, 2, 7]], input_type=tf.float32, units=1,
+             activation='tanh',
+             recurrent_activation='sigmoid', dropouts=(.0, .3), use_bias=False,
+             flags=(False, False)),
+        dict(input_names=["x"], input_shapes=[[3, 8, 3]], input_type=tf.float32, units=4,
+             activation='relu',
+             recurrent_activation='sigmoid', dropouts=(.7, .4), use_bias=False,
+             flags=(False, False)),
+        dict(input_names=["x"], input_shapes=[[4, 2, 2]], input_type=tf.float32, units=2,
+             activation='elu',
+             recurrent_activation='tanh', dropouts=(.0, .5), use_bias=False, flags=(False, False)),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_without_bias)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_lstm_without_bias_float32(self, params, ie_device, precision, temp_dir,
+                                             ir_version, api_2):
+        self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_different_flags = [
+        dict(input_names=["x"], input_shapes=[[2, 3, 2]], input_type=tf.float32, units=1,
+             activation='elu',
+             recurrent_activation='sigmoid', dropouts=(.0, .3), use_bias=True, flags=(False, True)),
+        dict(input_names=["x"], input_shapes=[[4, 8, 3]], input_type=tf.float32, dropouts=(.1, .3),
+             units=3,
+             activation='relu', use_bias=False, recurrent_activation='tanh', flags=(True, False)),
+        dict(input_names=["x"], input_shapes=[[4, 2, 7]], input_type=tf.float32, units=5,
+             activation='relu',
+             recurrent_activation='tanh', dropouts=(.2, .6), use_bias=True, flags=(True, True)),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_different_flags)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_lstm_flags_float32(self, params, ie_device, precision, temp_dir, ir_version,
+                                      api_2):
+        self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm.py
@@ -52,10 +52,10 @@ class TestKerasLSTM(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_lstm_with_bias_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                          api_2):
+                                          api_2, use_new_frontend):
         self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_without_bias = [
         dict(input_names=["x"], input_shapes=[[2, 2, 7]], input_type=tf.float32, units=1,
@@ -75,10 +75,10 @@ class TestKerasLSTM(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_lstm_without_bias_float32(self, params, ie_device, precision, temp_dir,
-                                             ir_version, api_2):
+                                             ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_different_flags = [
         dict(input_names=["x"], input_shapes=[[2, 3, 2]], input_type=tf.float32, units=1,
@@ -96,7 +96,7 @@ class TestKerasLSTM(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_lstm_flags_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                      api_2):
+                                      api_2, use_new_frontend):
         self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm.py
@@ -52,9 +52,9 @@ class TestKerasLSTM(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_lstm_with_bias_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                          api_2, use_new_frontend):
+                                          use_old_api, use_new_frontend):
         self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_without_bias = [
@@ -75,9 +75,9 @@ class TestKerasLSTM(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_lstm_without_bias_float32(self, params, ie_device, precision, temp_dir,
-                                             ir_version, api_2, use_new_frontend):
+                                             ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_different_flags = [
@@ -96,7 +96,7 @@ class TestKerasLSTM(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_lstm_flags_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                      api_2, use_new_frontend):
+                                      use_old_api, use_new_frontend):
         self._test(*self.create_keras_lstm_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm_cell.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm_cell.py
@@ -51,7 +51,7 @@ class TestKerasLSTMCell(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49537")
     def test_keras_lstmcell_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                    api_2):
+                                    api_2, use_new_frontend):
         self._test(*self.create_keras_lstmcell_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm_cell.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm_cell.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm_cell.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm_cell.py
@@ -1,0 +1,57 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasLSTMCell(CommonTF2LayerTest):
+    def create_keras_lstmcell_net(self, input_names, input_shapes, input_type, units, activation,
+                                  recurrent_activation,
+                                  use_bias, unit_forget_bias, dropouts, ir_version):
+        """
+                create TensorFlow 2 model with Keras LSTMCell operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        dropout, recurrent_dropout = dropouts
+        cell = tf.keras.layers.LSTMCell(units=units, activation=activation,
+                                        recurrent_activation=recurrent_activation,
+                                        use_bias=use_bias, unit_forget_bias=unit_forget_bias,
+                                        dropout=dropout,
+                                        recurrent_dropout=recurrent_dropout)
+        y = tf.keras.layers.RNN(cell=cell, return_sequences=True, return_state=True)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=y)
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_simple = [
+        dict(input_names=["x"], input_shapes=[[5, 5, 4]], input_type=tf.float32, units=1,
+             activation='softmax',
+             recurrent_activation='sigmoid', dropouts=(.0, .0), use_bias=True,
+             unit_forget_bias=True),
+        dict(input_names=["x"], input_shapes=[[2, 8, 2]], input_type=tf.float32, units=4,
+             activation='relu',
+             recurrent_activation='sigmoid', dropouts=(.2, .1), use_bias=False,
+             unit_forget_bias=True),
+        dict(input_names=["x"], input_shapes=[[3, 4, 3]], input_type=tf.float32, units=5,
+             activation='softsign',
+             recurrent_activation='elu', dropouts=(.9, .1), use_bias=True, unit_forget_bias=False),
+        dict(input_names=["x"], input_shapes=[[1, 6, 5]], input_type=tf.float32, units=6,
+             activation='softplus',
+             recurrent_activation='softsign', dropouts=(.4, .2), use_bias=False,
+             unit_forget_bias=False)
+    ]
+
+    @pytest.mark.parametrize("params", test_data_simple)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.xfail(reason="49537")
+    def test_keras_lstmcell_float32(self, params, ie_device, precision, temp_dir, ir_version,
+                                    api_2):
+        self._test(*self.create_keras_lstmcell_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm_cell.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_lstm_cell.py
@@ -51,7 +51,7 @@ class TestKerasLSTMCell(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49537")
     def test_keras_lstmcell_float32(self, params, ie_device, precision, temp_dir, ir_version,
-                                    api_2, use_new_frontend):
+                                    use_old_api, use_new_frontend):
         self._test(*self.create_keras_lstmcell_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_masking.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_masking.py
@@ -33,7 +33,8 @@ class TestKerasMasking(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49567")
-    def test_keras_masking_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2):
+    def test_keras_masking_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_masking_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_masking.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_masking.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_masking.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_masking.py
@@ -33,8 +33,8 @@ class TestKerasMasking(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49567")
-    def test_keras_masking_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2,
+    def test_keras_masking_float32(self, params, ie_device, precision, temp_dir, ir_version, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_masking_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_masking.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_masking.py
@@ -1,0 +1,39 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasMasking(CommonTF2LayerTest):
+    def create_keras_masking_net(self, input_names, input_shapes, input_type, mask_value,
+                                 ir_version):
+        """
+                create TensorFlow 2 model with Keras Masking operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        l1 = tf.keras.layers.Dense(4)(x)
+        y = tf.keras.layers.Masking(mask_value=mask_value)(l1)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 4, 8]], input_type=tf.float32, mask_value=0.),
+        dict(input_names=["x"], input_shapes=[[5, 4, 8, 16]], input_type=tf.float32, mask_value=1.),
+        dict(input_names=["x"], input_shapes=[[9, 4, 8, 47]], input_type=tf.float32,
+             mask_value=0.3),
+        dict(input_names=["x"], input_shapes=[[8, 4, 32]], input_type=tf.float32, mask_value=-132.),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.xfail(reason="49567")
+    def test_keras_masking_float32(self, params, ie_device, precision, temp_dir, ir_version, api_2):
+        self._test(*self.create_keras_masking_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maximum.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maximum.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 from common.layer_test_class import check_ir_version

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maximum.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maximum.py
@@ -88,10 +88,10 @@ class TestKerasMaximum(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
@@ -106,10 +106,10 @@ class TestKerasMaximum(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
@@ -120,9 +120,9 @@ class TestKerasMaximum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
     @pytest.mark.precommit
     def test_keras_maximum_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, api_2, use_new_frontend):
+                                                  temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs = [
@@ -142,7 +142,7 @@ class TestKerasMaximum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_maximum_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, api_2, use_new_frontend):
+                                                  temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maximum.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maximum.py
@@ -88,10 +88,11 @@ class TestKerasMaximum(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
                               input_type=tf.float32),
@@ -105,10 +106,11 @@ class TestKerasMaximum(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
         dict(input_names=["x1", "x2", "x3"],
@@ -118,10 +120,10 @@ class TestKerasMaximum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
     @pytest.mark.precommit
     def test_keras_maximum_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, api_2):
+                                                  temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs = [
         dict(input_names=["x1", "x2", "x3"],
@@ -140,7 +142,7 @@ class TestKerasMaximum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_maximum_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, api_2):
+                                                  temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maximum.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maximum.py
@@ -1,0 +1,146 @@
+import pytest
+import tensorflow as tf
+from common.layer_test_class import check_ir_version
+from common.tf2_layer_test_class import CommonTF2LayerTest
+from unit_tests.utils.graph import build_graph
+
+
+class TestKerasMaximum(CommonTF2LayerTest):
+    def create_keras_maximum_net(self, input_names, input_shapes, input_type, ir_version):
+        """
+               Tensorflow2 Keras net:                     IR net:
+                      Input               =>               Input
+                        |                                    |
+                    Maximum                               Maximum
+        """
+        # create TensorFlow 2 model with Keras Add operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        inputs = []
+        for ind in range(len(input_names)):
+            inputs.append(tf.keras.Input(shape=input_shapes[ind][1:], name=input_names[ind]))
+        y = tf.keras.layers.Maximum()(inputs)
+        tf2_net = tf.keras.Model(inputs=inputs, outputs=[y])
+
+        # create reference IR net
+        ref_net = None
+
+        op_name = "Maximum"
+        if check_ir_version(10, None, ir_version):
+            # convert NHWC to NCHW layout if tensor rank greater 3
+            converted_input_shape = input_shapes[0].copy()
+            if len(converted_input_shape) > 3:
+                converted_input_shape[1] = input_shapes[0][-1]
+                converted_input_shape[2:] = input_shapes[0][1:-1]
+            if len(input_names) == 2:
+                nodes_attributes = {
+                    'input1': {'kind': 'op', 'type': 'Parameter'},
+                    'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'input2': {'kind': 'op', 'type': 'Parameter'},
+                    'input2_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'op': {'kind': 'op', 'type': op_name},
+                    'op_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'result': {'kind': 'op', 'type': 'Result'}
+                }
+
+                ref_net = build_graph(nodes_attributes,
+                                      [('input1', 'input1_data'),
+                                       ('input2', 'input2_data'),
+                                       ('input1_data', 'op', {'in': 0}),
+                                       ('input2_data', 'op', {'in': 1}),
+                                       ('op', 'op_data'),
+                                       ('op_data', 'result')
+                                       ])
+            elif len(input_names) == 3:
+                nodes_attributes = {
+                    'input1': {'kind': 'op', 'type': 'Parameter'},
+                    'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'input2': {'kind': 'op', 'type': 'Parameter'},
+                    'input2_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'op1': {'kind': 'op', 'type': op_name},
+                    'op1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'input3': {'kind': 'op', 'type': 'Parameter'},
+                    'input3_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'op2': {'kind': 'op', 'type': op_name},
+                    'op2_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'result': {'kind': 'op', 'type': 'Result'}
+                }
+
+                ref_net = build_graph(nodes_attributes,
+                                      [('input1', 'input1_data'),
+                                       ('input2', 'input2_data'),
+                                       ('input1_data', 'op1', {'in': 0}),
+                                       ('input2_data', 'op1', {'in': 1}),
+                                       ('op1', 'op1_data'),
+                                       ('input3', 'input3_data'),
+                                       ('op1_data', 'op2', {'in': 0}),
+                                       ('input3_data', 'op2', {'in': 1}),
+                                       ('op2', 'op2_data'),
+                                       ('op2_data', 'result')
+                                       ])
+            else:
+                AssertionError("Not supported case with input number greater 2")
+
+        return tf2_net, ref_net
+
+    test_data_float32_precommit = [
+        dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_precommit)
+    @pytest.mark.precommit
+    def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8], [5, 4, 8]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8, 2], [5, 4, 8, 2]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"],
+                              input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+                              input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_maximum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_float32_several_inputs_precommit = [
+        dict(input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
+    @pytest.mark.precommit
+    def test_keras_maximum_float32_several_inputs(self, params, ie_device, precision, ir_version,
+                                                  temp_dir, api_2):
+        self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_float32_several_inputs = [
+        dict(input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4], [5, 4], [5, 4]],
+             input_type=tf.float32),
+        dict(input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4, 8], [5, 4, 8], [5, 4, 8]],
+             input_type=tf.float32),
+        dict(input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4, 8, 2], [5, 4, 8, 2], [5, 4, 8, 2]],
+             input_type=tf.float32),
+        dict(input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_several_inputs)
+    @pytest.mark.nightly
+    def test_keras_maximum_float32_several_inputs(self, params, ie_device, precision, ir_version,
+                                                  temp_dir, api_2):
+        self._test(*self.create_keras_maximum_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool1D.py
@@ -41,10 +41,10 @@ class TestKerasMaxPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool1D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
-                                                  ir_version, api_2):
+                                                  ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_maxpool1D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_p_dformat_float32 = [
         dict(input_names=["x"], input_shapes=[[5, 6, 1]], input_type=tf.float32, pool_size=1,
@@ -61,7 +61,7 @@ class TestKerasMaxPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool1D_padding_and_data_format(self, params, ie_device, precision, temp_dir,
-                                                     ir_version, api_2):
+                                                     ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_maxpool1D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool1D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool1D.py
@@ -41,9 +41,9 @@ class TestKerasMaxPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool1D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
-                                                  ir_version, api_2, use_new_frontend):
+                                                  ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_maxpool1D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_p_dformat_float32 = [
@@ -61,7 +61,7 @@ class TestKerasMaxPool1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool1D_padding_and_data_format(self, params, ie_device, precision, temp_dir,
-                                                     ir_version, api_2, use_new_frontend):
+                                                     ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_maxpool1D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool1D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool1D.py
@@ -1,0 +1,67 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasMaxPool1D(CommonTF2LayerTest):
+    def create_keras_maxpool1D_net(self, input_names, input_shapes, input_type, pool_size, strides,
+                                   padding, dataformat,
+                                   ir_version):
+        """
+                create TensorFlow 2 model with Keras MaxPool1D operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.MaxPool1D(pool_size=pool_size, strides=strides, padding=padding,
+                                      data_format=dataformat)(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 4, 1]], input_type=tf.float32, pool_size=1,
+             strides=None, padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 8, 2]], input_type=tf.float32, pool_size=1,
+             strides=None, padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 6, 12]], input_type=tf.float32, pool_size=4,
+             strides=None, padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 4, 5]], input_type=tf.float32, pool_size=1,
+             strides=4, padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 8, 12]], input_type=tf.float32, pool_size=4,
+             strides=4, padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 4, 4]], input_type=tf.float32, pool_size=2,
+             strides=2, padding='valid', dataformat='channels_last'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_maxpool1D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
+                                                  ir_version, api_2):
+        self._test(*self.create_keras_maxpool1D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_p_dformat_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 6, 1]], input_type=tf.float32, pool_size=1,
+             strides=1, padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 7, 8]], input_type=tf.float32, pool_size=3,
+             strides=2, padding='same', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 4, 4]], input_type=tf.float32, pool_size=4,
+             strides=2, padding='valid', dataformat='channels_first'),
+        dict(input_names=["x"], input_shapes=[[5, 6, 6]], input_type=tf.float32, pool_size=2,
+             strides=3, padding='same', dataformat='channels_first'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_p_dformat_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_maxpool1D_padding_and_data_format(self, params, ie_device, precision, temp_dir,
+                                                     ir_version, api_2):
+        self._test(*self.create_keras_maxpool1D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool2D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool2D.py
@@ -45,7 +45,7 @@ class TestKerasMaxPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool2D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
-                                                  ir_version, api_2):
+                                                  ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_maxpool2D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool2D.py
@@ -1,0 +1,51 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasMaxPool2D(CommonTF2LayerTest):
+    def create_keras_maxpool2D_net(self, input_names, input_shapes, input_type, pool_size, strides,
+                                   padding, dataformat,
+                                   ir_version):
+        """
+                create TensorFlow 2 model with Keras MaxPool2D operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.MaxPool2D(pool_size=pool_size, strides=strides, padding=padding,
+                                      data_format=dataformat)(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[5, 4, 2, 6]], input_type=tf.float32,
+             pool_size=(1, 1),
+             strides=None, padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 8, 4, 8]], input_type=tf.float32,
+             pool_size=(3, 4),
+             strides=None, padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 3, 6, 4]], input_type=tf.float32,
+             pool_size=(2, 2),
+             strides=None, padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 4, 5, 12]], input_type=tf.float32, pool_size=1,
+             strides=4, padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 4, 6, 6]], input_type=tf.float32,
+             pool_size=(2, 3),
+             strides=(3, 3), padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 4, 4, 8]], input_type=tf.float32, pool_size=2,
+             strides=2, padding='valid', dataformat='channels_last'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_maxpool2D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
+                                                  ir_version, api_2):
+        self._test(*self.create_keras_maxpool2D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool2D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool2D.py
@@ -45,7 +45,7 @@ class TestKerasMaxPool2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool2D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
-                                                  ir_version, api_2, use_new_frontend):
+                                                  ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_maxpool2D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool3D.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool3D.py
@@ -42,9 +42,9 @@ class TestKerasMaxPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool3D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
-                                                  ir_version, api_2, use_new_frontend):
+                                                  ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_maxpool3D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_p_dformat_float32 = [
@@ -62,7 +62,7 @@ class TestKerasMaxPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool3D_padding_and_data_format(self, params, ie_device, precision, temp_dir,
-                                                     ir_version, api_2, use_new_frontend):
+                                                     ir_version, use_old_api, use_new_frontend):
         self._test(*self.create_keras_maxpool3D_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool3D.py
@@ -42,10 +42,10 @@ class TestKerasMaxPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool3D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
-                                                  ir_version, api_2):
+                                                  ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_maxpool3D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_p_dformat_float32 = [
         dict(input_names=["x"], input_shapes=[[2, 2, 4, 6, 8]], input_type=tf.float32, pool_size=1,
@@ -62,7 +62,7 @@ class TestKerasMaxPool3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_maxpool3D_padding_and_data_format(self, params, ie_device, precision, temp_dir,
-                                                     ir_version, api_2):
+                                                     ir_version, api_2, use_new_frontend):
         self._test(*self.create_keras_maxpool3D_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool3D.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_maxpool3D.py
@@ -1,0 +1,68 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasMaxPool3D(CommonTF2LayerTest):
+    def create_keras_maxpool3D_net(self, input_names, input_shapes, input_type, pool_size, strides,
+                                   padding, dataformat, ir_version):
+        """
+                create TensorFlow 2 model with Keras MaxPool3D operation
+        """
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.MaxPool3D(pool_size=pool_size, strides=strides, padding=padding,
+                                      data_format=dataformat)(x)
+        tf2_net = tf.keras.Model(inputs=[x], outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted since inference is more
+        #  important and needs to be checked in the first
+        ref_net = None
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x"], input_shapes=[[2, 2, 9, 4, 3]], input_type=tf.float32, pool_size=1,
+             strides=None, padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[2, 3, 4, 5, 6]], input_type=tf.float32, pool_size=2,
+             strides=None, padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[2, 3, 4, 5, 6]], input_type=tf.float32,
+             pool_size=(2, 3, 4),
+             strides=None, padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[2, 3, 5, 7, 9]], input_type=tf.float32, pool_size=1,
+             strides=(2, 2, 2), padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[5, 4, 4, 4, 4]], input_type=tf.float32, pool_size=2,
+             strides=(2, 3, 2), padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[2, 6, 8, 4, 12]], input_type=tf.float32,
+             pool_size=(3, 2, 4),
+             strides=(3, 4, 2), padding='valid', dataformat='channels_last'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_maxpool3D_pool_strides_float32(self, params, ie_device, precision, temp_dir,
+                                                  ir_version, api_2):
+        self._test(*self.create_keras_maxpool3D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_p_dformat_float32 = [
+        dict(input_names=["x"], input_shapes=[[2, 2, 4, 6, 8]], input_type=tf.float32, pool_size=1,
+             strides=1, padding='valid', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[2, 2, 4, 6, 8]], input_type=tf.float32, pool_size=2,
+             strides=2, padding='same', dataformat='channels_last'),
+        dict(input_names=["x"], input_shapes=[[2, 2, 4, 6, 8]], input_type=tf.float32, pool_size=4,
+             strides=(2, 3, 2), padding='valid', dataformat='channels_first'),
+        dict(input_names=["x"], input_shapes=[[2, 2, 4, 6, 8]], input_type=tf.float32, pool_size=2,
+             strides=3, padding='same', dataformat='channels_first'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_p_dformat_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_maxpool3D_padding_and_data_format(self, params, ie_device, precision, temp_dir,
+                                                     ir_version, api_2):
+        self._test(*self.create_keras_maxpool3D_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_minimum.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_minimum.py
@@ -1,0 +1,144 @@
+import pytest
+import tensorflow as tf
+from common.layer_test_class import check_ir_version
+from common.tf2_layer_test_class import CommonTF2LayerTest
+from unit_tests.utils.graph import build_graph
+
+
+class TestKerasMinimum(CommonTF2LayerTest):
+    def create_keras_minimum_net(self, input_names, input_shapes, input_type, ir_version):
+        """
+               Tensorflow2 Keras net:                     IR net:
+                      Input               =>               Input
+                        |                                    |
+                    Minimum                               Minimum
+        """
+        # create TensorFlow 2 model with Keras Minimum operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        inputs = []
+        for ind in range(len(input_names)):
+            inputs.append(tf.keras.Input(shape=input_shapes[ind][1:], name=input_names[ind]))
+        y = tf.keras.layers.Minimum()(inputs)
+        tf2_net = tf.keras.Model(inputs=inputs, outputs=[y])
+
+        # create reference IR net
+        ref_net = None
+
+        op_name = "Minimum"
+        if check_ir_version(10, None, ir_version):
+            # convert NHWC to NCHW layout if tensor rank greater 3
+            converted_input_shape = input_shapes[0].copy()
+            if len(converted_input_shape) > 3:
+                converted_input_shape[1] = input_shapes[0][-1]
+                converted_input_shape[2:] = input_shapes[0][1:-1]
+            if len(input_names) == 2:
+                nodes_attributes = {
+                    'input1': {'kind': 'op', 'type': 'Parameter'},
+                    'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'input2': {'kind': 'op', 'type': 'Parameter'},
+                    'input2_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'op': {'kind': 'op', 'type': op_name},
+                    'op_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'result': {'kind': 'op', 'type': 'Result'}
+                }
+
+                ref_net = build_graph(nodes_attributes,
+                                      [('input1', 'input1_data'),
+                                       ('input2', 'input2_data'),
+                                       ('input1_data', 'op', {'in': 0}),
+                                       ('input2_data', 'op', {'in': 1}),
+                                       ('op', 'op_data'),
+                                       ('op_data', 'result')
+                                       ])
+            elif len(input_names) == 3:
+                nodes_attributes = {
+                    'input1': {'kind': 'op', 'type': 'Parameter'},
+                    'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'input2': {'kind': 'op', 'type': 'Parameter'},
+                    'input2_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'op1': {'kind': 'op', 'type': op_name},
+                    'op1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'input3': {'kind': 'op', 'type': 'Parameter'},
+                    'input3_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'op2': {'kind': 'op', 'type': op_name},
+                    'op2_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'result': {'kind': 'op', 'type': 'Result'}
+                }
+
+                ref_net = build_graph(nodes_attributes,
+                                      [('input1', 'input1_data'),
+                                       ('input2', 'input2_data'),
+                                       ('input1_data', 'op1', {'in': 0}),
+                                       ('input2_data', 'op1', {'in': 1}),
+                                       ('op1', 'op1_data'),
+                                       ('input3', 'input3_data'),
+                                       ('op1_data', 'op2', {'in': 0}),
+                                       ('input3_data', 'op2', {'in': 1}),
+                                       ('op2', 'op2_data'),
+                                       ('op2_data', 'result')
+                                       ])
+            else:
+                AssertionError("Not supported case with input number greater 2")
+
+        return tf2_net, ref_net
+
+    test_data_float32_precommit = [
+        dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_precommit)
+    @pytest.mark.precommit
+    def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+
+    test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8], [5, 4, 8]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8, 2], [5, 4, 8, 2]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"],
+                              input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+                              input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+
+    test_data_float32_several_inputs_precommit = [
+        dict(input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
+    @pytest.mark.precommit
+    def test_keras_minimum_float32_several_inputs(self, params, ie_device, precision, ir_version,
+                                                  temp_dir, api_2):
+        self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_float32_several_inputs = [
+        dict(input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4], [5, 4], [5, 4]],
+             input_type=tf.float32),
+        dict(input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4, 8], [5, 4, 8], [5, 4, 8]],
+             input_type=tf.float32),
+        dict(input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4, 8, 2], [5, 4, 8, 2], [5, 4, 8, 2]],
+             input_type=tf.float32),
+        dict(input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_several_inputs)
+    @pytest.mark.nightly
+    def test_keras_minimum_float32_several_inputs(self, params, ie_device, precision, ir_version,
+                                                  temp_dir, api_2):
+        self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_minimum.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_minimum.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 from common.layer_test_class import check_ir_version

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_minimum.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_minimum.py
@@ -88,9 +88,11 @@ class TestKerasMinimum(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
                               input_type=tf.float32),
@@ -104,9 +106,11 @@ class TestKerasMinimum(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version, **params)
+                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
         dict(input_names=["x1", "x2", "x3"],
@@ -138,7 +142,7 @@ class TestKerasMinimum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_minimum_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, api_2):
+                                                  temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_minimum.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_minimum.py
@@ -88,10 +88,10 @@ class TestKerasMinimum(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
@@ -106,10 +106,10 @@ class TestKerasMinimum(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_minimum_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
@@ -120,9 +120,9 @@ class TestKerasMinimum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
     @pytest.mark.precommit
     def test_keras_minimum_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, api_2):
+                                                  temp_dir, use_old_api):
         self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    **params)
 
     test_data_float32_several_inputs = [
@@ -142,7 +142,7 @@ class TestKerasMinimum(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_minimum_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, api_2, use_new_frontend):
+                                                  temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_minimum_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiheadattention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiheadattention.py
@@ -77,9 +77,9 @@ class TestKerasMultiHeadAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.precommit
     def test_keras_multiheadattention(self, params, ie_device, precision, ir_version, temp_dir,
-                                      api_2, use_new_frontend):
+                                      use_old_api, use_new_frontend):
         self._test(*self.create_keras_multiheadattention_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests to cover no bias cases
@@ -105,7 +105,7 @@ class TestKerasMultiHeadAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_no_bias)
     @pytest.mark.nightly
     def test_keras_multiheadattention_no_bias(self, params, ie_device, precision, ir_version,
-                                              temp_dir, api_2, use_new_frontend):
+                                              temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_multiheadattention_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiheadattention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiheadattention.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiheadattention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiheadattention.py
@@ -77,10 +77,10 @@ class TestKerasMultiHeadAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.precommit
     def test_keras_multiheadattention(self, params, ie_device, precision, ir_version, temp_dir,
-                                      api_2):
+                                      api_2, use_new_frontend):
         self._test(*self.create_keras_multiheadattention_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     # Tests to cover no bias cases
     test_data_no_bias = [
@@ -105,7 +105,7 @@ class TestKerasMultiHeadAttention(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_no_bias)
     @pytest.mark.nightly
     def test_keras_multiheadattention_no_bias(self, params, ie_device, precision, ir_version,
-                                              temp_dir, api_2):
+                                              temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_multiheadattention_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiheadattention.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiheadattention.py
@@ -1,0 +1,111 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasMultiHeadAttention(CommonTF2LayerTest):
+    def create_keras_multiheadattention_net(self,
+                                            input_names, input_shapes, input_types,
+                                            attention_mask_value,
+                                            num_heads, key_dim, value_dim, dropout, use_bias,
+                                            output_shape, attention_axes,
+                                            return_attention_scores, training,
+                                            ir_version):
+        # create TensorFlow 2 model with Keras MultiHeadAttention operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+
+        query = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0], dtype=input_types[0])
+        value = tf.keras.Input(shape=input_shapes[1][1:], name=input_names[1], dtype=input_types[1])
+        inputs = [query, value]
+        key = None
+        if len(input_shapes) > 2:
+            key = tf.keras.Input(shape=input_shapes[2][1:], name=input_names[2],
+                                 dtype=input_types[2])
+            inputs.append(key)
+        attention_mask = None
+        if attention_mask_value is not None:
+            attention_mask = tf.keras.Input(tensor=attention_mask_value)
+            inputs.append(attention_mask)
+
+        y = tf.keras.layers.MultiHeadAttention(num_heads=num_heads, key_dim=key_dim,
+                                               value_dim=value_dim,
+                                               dropout=dropout, use_bias=use_bias,
+                                               output_shape=output_shape,
+                                               attention_axes=attention_axes)(query=query,
+                                                                              value=value,
+                                                                              key=key,
+                                                                              attention_mask=attention_axes,
+                                                                              return_attention_scores=return_attention_scores,
+                                                                              training=training)
+        tf2_net = tf.keras.Model(inputs=inputs, outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    # Now all test cases fail due to Einsum operation is not supported
+    # Tests with default attributes
+    test_data = [
+        pytest.param(
+            dict(input_names=["query", "value"], input_shapes=[[2, 8, 16], [2, 4, 16]],
+                 input_types=[tf.float32, tf.float32], attention_mask_value=None,
+                 num_heads=2, key_dim=3, value_dim=4, dropout=0.0, use_bias=True,
+                 output_shape=None, attention_axes=None,
+                 return_attention_scores=False, training=False),
+            marks=pytest.mark.xfail(reason="45432")),
+        pytest.param(
+            dict(input_names=["query", "value", "key"],
+                 input_shapes=[[3, 8, 16], [3, 5, 16], [3, 5, 16]],
+                 input_types=[tf.float32, tf.float32, tf.float32], attention_mask_value=None,
+                 num_heads=3, key_dim=4, value_dim=2, dropout=0.0, use_bias=True,
+                 output_shape=None, attention_axes=None,
+                 return_attention_scores=False, training=False),
+            marks=pytest.mark.xfail(reason="45432")),
+        pytest.param(
+            dict(input_names=["query", "value", "key"],
+                 input_shapes=[[1, 8, 16], [1, 2, 4], [1, 2, 4]],
+                 input_types=[tf.float32, tf.float32, tf.float32], attention_mask_value=None,
+                 num_heads=1, key_dim=3, value_dim=4, dropout=0.0, use_bias=True,
+                 output_shape=None, attention_axes=None,
+                 return_attention_scores=True, training=False),
+            marks=pytest.mark.xfail(reason="45432"))
+    ]
+
+    @pytest.mark.skip(reason='Einsum is unsupported in MO')
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.precommit
+    def test_keras_multiheadattention(self, params, ie_device, precision, ir_version, temp_dir,
+                                      api_2):
+        self._test(*self.create_keras_multiheadattention_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    # Tests to cover no bias cases
+    test_data_no_bias = [
+        pytest.param(
+            dict(input_names=["query", "value"], input_shapes=[[3, 5, 7], [3, 4, 16]],
+                 input_types=[tf.float32, tf.float32], attention_mask_value=None,
+                 num_heads=2, key_dim=3, value_dim=4, dropout=0.0, use_bias=True,
+                 output_shape=None, attention_axes=None,
+                 return_attention_scores=False, training=False),
+            marks=pytest.mark.xfail(reason="45432")),
+        pytest.param(
+            dict(input_names=["query", "value", "key"],
+                 input_shapes=[[2, 8, 16], [2, 4, 16], [2, 4, 16]],
+                 input_types=[tf.float32, tf.float32, tf.float32], attention_mask_value=None,
+                 num_heads=3, key_dim=4, value_dim=2, dropout=0.0, use_bias=False,
+                 output_shape=None, attention_axes=None,
+                 return_attention_scores=False, training=False),
+            marks=pytest.mark.xfail(reason="45432"))
+    ]
+
+    @pytest.mark.skip(reason='Einsum is unsupported in MO')
+    @pytest.mark.parametrize("params", test_data_no_bias)
+    @pytest.mark.nightly
+    def test_keras_multiheadattention_no_bias(self, params, ie_device, precision, ir_version,
+                                              temp_dir, api_2):
+        self._test(*self.create_keras_multiheadattention_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiply.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiply.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 from common.layer_test_class import check_ir_version

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiply.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiply.py
@@ -89,9 +89,9 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_multiply_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2, use_new_frontend):
+                                    use_old_api, use_new_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
@@ -107,9 +107,9 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_multiply_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2, use_new_frontend):
+                                    use_old_api, use_new_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
@@ -120,9 +120,9 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
     @pytest.mark.precommit
     def test_keras_multiply_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, api_2, use_new_frontend):
+                                                   temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs = [dict(input_names=["x1", "x2", "x3"],
@@ -143,7 +143,7 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_multiply_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, api_2, use_new_frontend):
+                                                   temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiply.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiply.py
@@ -1,0 +1,149 @@
+import pytest
+import tensorflow as tf
+from common.layer_test_class import check_ir_version
+from common.tf2_layer_test_class import CommonTF2LayerTest
+from unit_tests.utils.graph import build_graph
+
+
+class TestKerasMultiply(CommonTF2LayerTest):
+    def create_keras_multiply_net(self, input_names, input_shapes, input_type, ir_version):
+        """
+               Tensorflow2 Keras net:                     IR net:
+                 Input1    Input2            =>      Input1     Input2
+                   \         /                           \       /
+                    Multiply                              Multiply
+        """
+        # create TensorFlow 2 model with Keras Multiply operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        inputs = []
+        for ind in range(len(input_names)):
+            inputs.append(tf.keras.Input(shape=input_shapes[ind][1:], name=input_names[ind]))
+        y = tf.keras.layers.Multiply()(inputs)
+        tf2_net = tf.keras.Model(inputs=inputs, outputs=[y])
+
+        # create reference IR net
+        ref_net = None
+
+        op_name = "Multiply"
+        if check_ir_version(10, None, ir_version):
+            # convert NHWC to NCHW layout if tensor rank greater 3
+            converted_input_shape = input_shapes[0].copy()
+            if len(converted_input_shape) > 3:
+                converted_input_shape[1] = input_shapes[0][-1]
+                converted_input_shape[2:] = input_shapes[0][1:-1]
+            if len(input_names) == 2:
+                nodes_attributes = {
+                    'input1': {'kind': 'op', 'type': 'Parameter'},
+                    'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'input2': {'kind': 'op', 'type': 'Parameter'},
+                    'input2_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'op': {'kind': 'op', 'type': op_name},
+                    'op_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'result': {'kind': 'op', 'type': 'Result'}
+                }
+
+                ref_net = build_graph(nodes_attributes,
+                                      [('input1', 'input1_data'),
+                                       ('input2', 'input2_data'),
+                                       ('input1_data', 'op', {'in': 0}),
+                                       ('input2_data', 'op', {'in': 1}),
+                                       ('op', 'op_data'),
+                                       ('op_data', 'result')
+                                       ])
+            elif len(input_names) == 3:
+                nodes_attributes = {
+                    'input1': {'kind': 'op', 'type': 'Parameter'},
+                    'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'input2': {'kind': 'op', 'type': 'Parameter'},
+                    'input2_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'op1': {'kind': 'op', 'type': op_name},
+                    'op1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'input3': {'kind': 'op', 'type': 'Parameter'},
+                    'input3_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'op2': {'kind': 'op', 'type': op_name},
+                    'op2_data': {'shape': converted_input_shape, 'kind': 'data'},
+                    'result': {'kind': 'op', 'type': 'Result'}
+                }
+
+                ref_net = build_graph(nodes_attributes,
+                                      [('input1', 'input1_data'),
+                                       ('input2', 'input2_data'),
+                                       ('input1_data', 'op1', {'in': 0}),
+                                       ('input2_data', 'op1', {'in': 1}),
+                                       ('op1', 'op1_data'),
+                                       ('input3', 'input3_data'),
+                                       ('op1_data', 'op2', {'in': 0}),
+                                       ('input3_data', 'op2', {'in': 1}),
+                                       ('op2', 'op2_data'),
+                                       ('op2_data', 'result')
+                                       ])
+            else:
+                AssertionError("Not supported case with input number greater 2")
+
+        return tf2_net, ref_net
+
+    test_data_float32_precommit = [
+        dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_precommit)
+    @pytest.mark.precommit
+    def test_keras_multiply_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                    api_2):
+        self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8], [5, 4, 8]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8, 2], [5, 4, 8, 2]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"],
+                              input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+                              input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_multiply_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                    api_2):
+        self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_float32_several_inputs_precommit = [
+        dict(input_names=["x1", "x2", "x3"],
+             input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
+    @pytest.mark.precommit
+    def test_keras_multiply_float32_several_inputs(self, params, ie_device, precision, ir_version,
+                                                   temp_dir, api_2):
+        self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_float32_several_inputs = [dict(input_names=["x1", "x2", "x3"],
+                                             input_shapes=[[5, 4], [5, 4], [5, 4]],
+                                             input_type=tf.float32),
+                                        dict(input_names=["x1", "x2", "x3"],
+                                             input_shapes=[[5, 4, 8], [5, 4, 8], [5, 4, 8]],
+                                             input_type=tf.float32),
+                                        dict(input_names=["x1", "x2", "x3"],
+                                             input_shapes=[[5, 4, 8, 2], [5, 4, 8, 2],
+                                                           [5, 4, 8, 2]],
+                                             input_type=tf.float32),
+                                        dict(input_names=["x1", "x2", "x3"],
+                                             input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3],
+                                                           [5, 4, 8, 2, 3]],
+                                             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_several_inputs)
+    @pytest.mark.nightly
+    def test_keras_multiply_float32_several_inputs(self, params, ie_device, precision, ir_version,
+                                                   temp_dir, api_2):
+        self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiply.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_multiply.py
@@ -89,10 +89,10 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_multiply_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2):
+                                    api_2, use_new_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
                               input_type=tf.float32),
@@ -107,10 +107,10 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_multiply_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2):
+                                    api_2, use_new_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs_precommit = [
         dict(input_names=["x1", "x2", "x3"],
@@ -120,10 +120,10 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs_precommit)
     @pytest.mark.precommit
     def test_keras_multiply_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, api_2):
+                                                   temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_several_inputs = [dict(input_names=["x1", "x2", "x3"],
                                              input_shapes=[[5, 4], [5, 4], [5, 4]],
@@ -143,7 +143,7 @@ class TestKerasMultiply(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_several_inputs)
     @pytest.mark.nightly
     def test_keras_multiply_float32_several_inputs(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, api_2):
+                                                   temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_multiply_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_permute.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_permute.py
@@ -1,0 +1,33 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasPermute(CommonTF2LayerTest):
+    def create_keras_permute_net(self, input_names, input_shapes, input_type, dims, ir_version):
+        # create TensorFlow 2 model with Keras Permute operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0], dtype=input_type)
+        y = tf.keras.layers.Permute(dims)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32 = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8]], input_type=tf.float32, dims=(1, 2)),
+        dict(input_names=["x1"], input_shapes=[[2, 3, 8, 2]], input_type=tf.float32,
+             dims=(3, 2, 1)),
+        dict(input_names=["x1"], input_shapes=[[1, 4, 1, 4, 2]], input_type=tf.float32,
+             dims=(1, 2, 3, 4))]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_permute_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_permute_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_permute.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_permute.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_permute.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_permute.py
@@ -27,7 +27,8 @@ class TestKerasPermute(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_permute_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_permute_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_permute_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_permute.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_permute.py
@@ -27,8 +27,8 @@ class TestKerasPermute(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_permute_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_permute_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_permute_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_prelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_prelu.py
@@ -24,10 +24,11 @@ class TestKerasPReLU(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                 use_new_frontend):
         self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [
         dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32, shared_axes=None),
@@ -39,10 +40,11 @@ class TestKerasPReLU(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                 use_new_frontend):
         self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_shared_axes = [
         dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32, shared_axes=[1]),
@@ -55,7 +57,7 @@ class TestKerasPReLU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_shared_axes)
     @pytest.mark.nightly
     def test_keras_prelu_float32_shared_axes(self, params, ie_device, precision, ir_version,
-                                             temp_dir, api_2):
+                                             temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_prelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_prelu.py
@@ -1,0 +1,61 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasPReLU(CommonTF2LayerTest):
+    def create_keras_prelu_net(self, input_names, input_shapes, input_type, shared_axes,
+                               ir_version):
+        # create TensorFlow 2 model with Keras PReLU operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.PReLU(shared_axes=shared_axes)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_float32_precommit = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]], input_type=tf.float32,
+             shared_axes=None)]
+
+    @pytest.mark.parametrize("params", test_data_float32_precommit)
+    @pytest.mark.precommit
+    def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_float32 = [
+        dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32, shared_axes=None),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8]], input_type=tf.float32, shared_axes=None),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3]], input_type=tf.float32,
+             shared_axes=None),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]], input_type=tf.float32,
+             shared_axes=None)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_float32_shared_axes = [
+        dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32, shared_axes=[1]),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8]], input_type=tf.float32, shared_axes=[1]),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3]], input_type=tf.float32,
+             shared_axes=[1, 2]),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]], input_type=tf.float32,
+             shared_axes=[1, 2, 3])]
+
+    @pytest.mark.parametrize("params", test_data_float32_shared_axes)
+    @pytest.mark.nightly
+    def test_keras_prelu_float32_shared_axes(self, params, ie_device, precision, ir_version,
+                                             temp_dir, api_2):
+        self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_prelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_prelu.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_prelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_prelu.py
@@ -24,10 +24,10 @@ class TestKerasPReLU(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                  use_new_frontend):
         self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [
@@ -40,10 +40,10 @@ class TestKerasPReLU(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_prelu_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                  use_new_frontend):
         self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32_shared_axes = [
@@ -57,7 +57,7 @@ class TestKerasPReLU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_shared_axes)
     @pytest.mark.nightly
     def test_keras_prelu_float32_shared_axes(self, params, ie_device, precision, ir_version,
-                                             temp_dir, api_2, use_new_frontend):
+                                             temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_prelu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_relu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_relu.py
@@ -1,0 +1,72 @@
+import pytest
+import tensorflow as tf
+from common.layer_test_class import check_ir_version
+from common.tf2_layer_test_class import CommonTF2LayerTest
+from unit_tests.utils.graph import build_graph
+
+
+class TestKerasRelu(CommonTF2LayerTest):
+    def create_keras_relu_net(self, input_names, input_shapes, input_type, ir_version):
+        """
+               Tensorflow2 Keras net:                     IR net:
+                      Input               =>               Input
+                        |                                    |
+                      Relu                                 Relu
+        """
+        # create TensorFlow 2 model with Keras ReLU operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:],
+                            name=input_names[0])  # Variable-length sequence of ints
+        y = tf.keras.layers.ReLU()(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # create reference IR net
+        ref_net = None
+
+        if check_ir_version(10, None, ir_version):
+            # convert NHWC to NCHW layout if tensor rank greater 3
+            converted_input_shape = input_shapes[0].copy()
+            if len(converted_input_shape) > 3:
+                converted_input_shape[1] = input_shapes[0][-1]
+                converted_input_shape[2:] = input_shapes[0][1:-1]
+            nodes_attributes = {
+                'input1': {'kind': 'op', 'type': 'Parameter'},
+                'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                'relu': {'kind': 'op', 'type': 'ReLU'},
+                'relu_data': {'shape': converted_input_shape, 'kind': 'data'},
+                'result': {'kind': 'op', 'type': 'Result'}
+            }
+
+            ref_net = build_graph(nodes_attributes,
+                                  [('input1', 'input1_data'),
+                                   ('input1_data', 'relu', {'in': 0}),
+                                   ('relu', 'relu_data'),
+                                   ('relu_data', 'result')])
+
+        return tf2_net, ref_net
+
+    test_data_float32_precommit = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_precommit)
+    @pytest.mark.precommit
+    def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_relu_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1"], input_shapes=[[5, 4, 8]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]],
+                              input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_relu_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_relu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_relu.py
@@ -50,10 +50,11 @@ class TestKerasRelu(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                use_new_frontend):
         self._test(*self.create_keras_relu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
                               input_type=tf.float32),
@@ -66,7 +67,8 @@ class TestKerasRelu(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                use_new_frontend):
         self._test(*self.create_keras_relu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_relu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_relu.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 from common.layer_test_class import check_ir_version

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_relu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_relu.py
@@ -50,10 +50,10 @@ class TestKerasRelu(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                 use_new_frontend):
         self._test(*self.create_keras_relu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
@@ -67,8 +67,8 @@ class TestKerasRelu(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_relu_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                 use_new_frontend):
         self._test(*self.create_keras_relu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_repeatvector.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_repeatvector.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_repeatvector.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_repeatvector.py
@@ -1,0 +1,32 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasRepeatVector(CommonTF2LayerTest):
+    def create_keras_repeatvector_net(self, input_names, input_shapes, input_type, n, ir_version):
+        # create TensorFlow 2 model with Keras RepeatVector operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0], dtype=input_type)
+        y = tf.keras.layers.RepeatVector(n=n)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data = [
+        dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32, n=2),
+        dict(input_names=["x1"], input_shapes=[[2, 1]], input_type=tf.float32, n=3),
+        dict(input_names=["x1"], input_shapes=[[3, 6]], input_type=tf.float32, n=4),
+    ]
+
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_repeatvector(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_repeatvector_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_repeatvector.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_repeatvector.py
@@ -26,7 +26,8 @@ class TestKerasRepeatVector(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_repeatvector(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_repeatvector(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                use_new_frontend):
         self._test(*self.create_keras_repeatvector_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_repeatvector.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_repeatvector.py
@@ -26,8 +26,8 @@ class TestKerasRepeatVector(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_repeatvector(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_repeatvector(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                 use_new_frontend):
         self._test(*self.create_keras_repeatvector_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_reshape.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_reshape.py
@@ -30,7 +30,8 @@ class TestKerasReshape(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_reshape(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_reshape(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                           use_new_frontend):
         self._test(*self.create_keras_reshape_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_reshape.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_reshape.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_reshape.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_reshape.py
@@ -30,8 +30,8 @@ class TestKerasReshape(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_reshape(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_reshape(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                            use_new_frontend):
         self._test(*self.create_keras_reshape_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_reshape.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_reshape.py
@@ -1,0 +1,36 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasReshape(CommonTF2LayerTest):
+    def create_keras_reshape_net(self, input_names, input_shapes, input_type, target_shape,
+                                 ir_version):
+        # create TensorFlow 2 model with Keras Reshape operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.Reshape(target_shape=target_shape)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data = [
+        dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32, target_shape=(2, 2)),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8]], input_type=tf.float32,
+             target_shape=(2, 2, 8)),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3]], input_type=tf.float32,
+             target_shape=(4, 24)),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]], input_type=tf.float32,
+             target_shape=(32, 3, 2))]
+
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_reshape(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_reshape_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_rnn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_rnn.py
@@ -55,10 +55,10 @@ class TestKerasRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_rnn(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_rnn(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                        use_new_frontend):
         self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for default parameter values
@@ -78,9 +78,9 @@ class TestKerasRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_multiple_outputs)
     @pytest.mark.nightly
     def test_keras_rnn_multiple_outputs(self, params, ie_device, precision, ir_version, temp_dir,
-                                        api_2, use_new_frontend):
+                                        use_old_api, use_new_frontend):
         self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for other attributes: go_backward and time_major
@@ -99,8 +99,8 @@ class TestKerasRNN(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_others)
     @pytest.mark.nightly
-    def test_keras_rnn_others(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_rnn_others(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                               use_new_frontend):
         self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_rnn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_rnn.py
@@ -1,0 +1,104 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasRNN(CommonTF2LayerTest):
+    def create_keras_rnn_net(self, input_names, input_shapes,
+                             cell, return_sequences, return_state, go_backwards,
+                             stateful, unroll, time_major,
+                             ir_version):
+        cells_structure = {
+            # pytest-xdist can't execute the tests in parallel because workers can't compare tests scopes before run
+            # tf.keras.layers.<cell> operation have no "==" operation to be compared
+            "LSTMCell": tf.keras.layers.LSTMCell(6),
+            "GRUCell": tf.keras.layers.GRUCell(3),
+            "SimpleRNNCell": tf.keras.layers.SimpleRNNCell(5)
+        }
+        cell = cells_structure[cell]
+
+        # create TensorFlow 2 model with Keras RNN operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.RNN(cell=cell, return_sequences=return_sequences,
+                                return_state=return_state,
+                                go_backwards=go_backwards, stateful=stateful, unroll=unroll,
+                                time_major=time_major
+                                )(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    # Tests for default parameter values
+    test_data = [
+        dict(input_names=["x1"], input_shapes=[[2, 4, 5]],
+             cell="LSTMCell", return_sequences=False,
+             return_state=False, go_backwards=False,
+             stateful=False, unroll=False, time_major=False,
+             ),
+        dict(input_names=["x1"], input_shapes=[[1, 3, 2]],
+             cell="GRUCell", return_sequences=False,
+             return_state=False, go_backwards=False,
+             stateful=False, unroll=False, time_major=False,
+             ),
+        dict(input_names=["x1"], input_shapes=[[3, 2, 1]],
+             cell="SimpleRNNCell", return_sequences=False,
+             return_state=False, go_backwards=False,
+             stateful=False, unroll=False, time_major=False,
+             )
+    ]
+
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_rnn(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    # Tests for default parameter values
+    test_data_multiple_outputs = [
+        pytest.param(
+            dict(input_names=["x1"], input_shapes=[[2, 4, 5]],
+                 cell="LSTMCell", return_sequences=True,
+                 return_state=True, go_backwards=False,
+                 stateful=False, unroll=False, time_major=False),
+            marks=pytest.mark.xfail(reason="49537")),
+        dict(input_names=["x1"], input_shapes=[[1, 3, 6]],
+             cell="GRUCell", return_sequences=True,
+             return_state=False, go_backwards=False,
+             stateful=False, unroll=False, time_major=False),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_multiple_outputs)
+    @pytest.mark.nightly
+    def test_keras_rnn_multiple_outputs(self, params, ie_device, precision, ir_version, temp_dir,
+                                        api_2):
+        self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    # Tests for other attributes: go_backward and time_major
+    test_data_others = [
+        dict(input_names=["x1"], input_shapes=[[2, 4, 5]],
+             cell="LSTMCell", return_sequences=False,
+             return_state=False, go_backwards=True,
+             stateful=False, unroll=False, time_major=False,
+             ),
+        dict(input_names=["x1"], input_shapes=[[3, 2, 1]],
+             cell="SimpleRNNCell", return_sequences=False,
+             return_state=False, go_backwards=False,
+             stateful=False, unroll=False, time_major=True,
+             )
+    ]
+
+    @pytest.mark.parametrize("params", test_data_others)
+    @pytest.mark.nightly
+    def test_keras_rnn_others(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_rnn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_rnn.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_rnn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_rnn.py
@@ -55,10 +55,11 @@ class TestKerasRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_rnn(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_rnn(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                       use_new_frontend):
         self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     # Tests for default parameter values
     test_data_multiple_outputs = [
@@ -77,10 +78,10 @@ class TestKerasRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_multiple_outputs)
     @pytest.mark.nightly
     def test_keras_rnn_multiple_outputs(self, params, ie_device, precision, ir_version, temp_dir,
-                                        api_2):
+                                        api_2, use_new_frontend):
         self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     # Tests for other attributes: go_backward and time_major
     test_data_others = [
@@ -98,7 +99,8 @@ class TestKerasRNN(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_others)
     @pytest.mark.nightly
-    def test_keras_rnn_others(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_rnn_others(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                              use_new_frontend):
         self._test(*self.create_keras_rnn_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_roll.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_roll.py
@@ -1,0 +1,44 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasRoll(CommonTF2LayerTest):
+    def create_keras_roll_net(self, shift, axis, input_names, input_shapes, input_type, ir_version):
+        # create TensorFlow 2 model with Roll operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        inputs = []
+        for ind in range(len(input_names)):
+            inputs.append(tf.keras.Input(shape=input_shapes[ind][1:], name=input_names[ind]))
+        y = tf.roll(inputs, shift=shift, axis=axis)
+        tf2_net = tf.keras.Model(inputs=inputs, outputs=[y])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data = [
+        dict(shift=[-20, 3, 0], axis=[0, 0, 0], input_names=["x1"], input_shapes=[[7]],
+             input_type=tf.half),
+        dict(shift=[1], axis=[-1], input_names=["x1"], input_shapes=[[4, 3]],
+             input_type=tf.float32),
+        dict(shift=[1, 5, -7], axis=[0, 1, 1], input_names=["x1"], input_shapes=[[2, 3, 5]],
+             input_type=tf.float16),
+        dict(shift=[11, -8], axis=[-1, -2], input_names=["x1"], input_shapes=[[3, 4, 3, 1]],
+             input_type=tf.int32),
+        dict(shift=[7, -2, 5], axis=[0, -1, -1], input_names=["x1"], input_shapes=[[5, 2, 3, 7]],
+             input_type=tf.int64),
+        pytest.param(
+            dict(shift=[1, -2], axis=[0, 1], input_names=["x1"], input_shapes=[[2, 4, 3, 5]],
+                 input_type=tf.float32),
+            marks=pytest.mark.precommit)]
+
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.nightly
+    def test_keras_roll(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        if ie_device == 'GPU':
+            pytest.skip("Roll is not supported on GPU")
+        self._test(*self.create_keras_roll_net(**params, ir_version=ir_version), ie_device,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_roll.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_roll.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_roll.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_roll.py
@@ -37,10 +37,10 @@ class TestKerasRoll(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_keras_roll(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_roll(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                         use_new_frontend):
         if ie_device == 'GPU':
             pytest.skip("Roll is not supported on GPU")
         self._test(*self.create_keras_roll_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_roll.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_roll.py
@@ -37,8 +37,10 @@ class TestKerasRoll(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
-    def test_keras_roll(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_roll(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                        use_new_frontend):
         if ie_device == 'GPU':
             pytest.skip("Roll is not supported on GPU")
         self._test(*self.create_keras_roll_net(**params, ir_version=ir_version), ie_device,
-                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv1d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv1d.py
@@ -43,10 +43,11 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_separableconv1d(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_separableconv1d(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     # Tests for different activations
     test_data_different_activations = [
@@ -76,10 +77,11 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_activations)
     @pytest.mark.nightly
     def test_keras_separableconv1d_different_activations(self, params, ie_device, precision,
-                                                         ir_version, temp_dir, api_2):
+                                                         ir_version, temp_dir, api_2,
+                                                         use_new_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     # Tests for different padding
     test_data_different_padding = [
@@ -97,10 +99,10 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_padding)
     @pytest.mark.nightly
     def test_keras_separableconv1d_different_padding(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, api_2):
+                                                     temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     # Tests for different bias
     test_data_different_bias = [
@@ -115,7 +117,7 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_bias)
     @pytest.mark.nightly
     def test_keras_separableconv1d_different_bias(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, api_2):
+                                                  temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv1d.py
@@ -1,0 +1,121 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasSeparableConv1D(CommonTF2LayerTest):
+    def create_keras_separableconv1d_net(self, input_names, input_shapes, input_type,
+                                         filters, kernel_size, strides, padding, data_format,
+                                         dilation_rate, depth_multiplier, activation, use_bias,
+                                         ir_version):
+        # create TensorFlow 2 model with Keras SeparableConv1D operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.SeparableConv1D(
+            filters=filters, kernel_size=kernel_size, strides=strides, padding=padding,
+            data_format=data_format,
+            dilation_rate=dilation_rate, depth_multiplier=depth_multiplier,
+            activation=activation, use_bias=use_bias)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    # Tests for different filters number, kernel size, strides, and dilation
+    test_data = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 10]], input_type=tf.float32,
+             filters=3, kernel_size=(2), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=1, depth_multiplier=1, activation='relu', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[1, 10, 6]], input_type=tf.float32,
+             filters=4, kernel_size=(3), strides=3, padding='valid', data_format='channels_last',
+             dilation_rate=1, depth_multiplier=1, activation='relu', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[2, 18, 5]], input_type=tf.float32,
+             filters=2, kernel_size=(3), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=4, depth_multiplier=1, activation='relu', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[2, 22, 4]], input_type=tf.float32,
+             filters=3, kernel_size=(2), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=4, depth_multiplier=6, activation='relu', use_bias=True),
+    ]
+
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_separableconv1d(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    # Tests for different activations
+    test_data_different_activations = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 10]], input_type=tf.float32,
+             filters=3, kernel_size=(2), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=1, depth_multiplier=1, activation=None, use_bias=True),
+        pytest.param(
+            dict(input_names=["x1"], input_shapes=[[2, 22, 4]], input_type=tf.float32,
+                 filters=3, kernel_size=(2), strides=1, padding='valid',
+                 data_format='channels_last',
+                 dilation_rate=4, depth_multiplier=6, activation='selu', use_bias=True),
+            marks=pytest.mark.xfail(reason="49512")),
+        dict(input_names=["x1"], input_shapes=[[1, 10, 6]], input_type=tf.float32,
+             filters=4, kernel_size=(3), strides=3, padding='valid', data_format='channels_last',
+             dilation_rate=1, depth_multiplier=1, activation='tanh', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[2, 18, 5]], input_type=tf.float32,
+             filters=2, kernel_size=(3), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=4, depth_multiplier=1, activation='swish', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[2, 22, 4]], input_type=tf.float32,
+             filters=3, kernel_size=(2), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=4, depth_multiplier=6, activation='linear', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[2, 22, 4]], input_type=tf.float32,
+             filters=3, kernel_size=(2), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=4, depth_multiplier=6, activation='elu', use_bias=True),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_different_activations)
+    @pytest.mark.nightly
+    def test_keras_separableconv1d_different_activations(self, params, ie_device, precision,
+                                                         ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    # Tests for different padding
+    test_data_different_padding = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 10]], input_type=tf.float32,
+             filters=3, kernel_size=(2), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=1, depth_multiplier=1, activation='relu', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[3, 8, 15]], input_type=tf.float32,
+             filters=3, kernel_size=(4), strides=1, padding='same', data_format='channels_last',
+             dilation_rate=1, depth_multiplier=1, activation='relu', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[3, 8, 15]], input_type=tf.float32,
+             filters=3, kernel_size=(4), strides=1, padding='causal', data_format='channels_last',
+             dilation_rate=1, depth_multiplier=1, activation='relu', use_bias=True),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_different_padding)
+    @pytest.mark.nightly
+    def test_keras_separableconv1d_different_padding(self, params, ie_device, precision, ir_version,
+                                                     temp_dir, api_2):
+        self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    # Tests for different bias
+    test_data_different_bias = [
+        dict(input_names=["x1"], input_shapes=[[5, 7, 14]], input_type=tf.float32,
+             filters=3, kernel_size=(2), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=1, depth_multiplier=1, activation='relu', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[1, 14, 12]], input_type=tf.float32,
+             filters=4, kernel_size=(2), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=2, depth_multiplier=3, activation='relu', use_bias=False),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_different_bias)
+    @pytest.mark.nightly
+    def test_keras_separableconv1d_different_bias(self, params, ie_device, precision, ir_version,
+                                                  temp_dir, api_2):
+        self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv1d.py
@@ -43,10 +43,10 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_separableconv1d(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_separableconv1d(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for different activations
@@ -77,10 +77,10 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_activations)
     @pytest.mark.nightly
     def test_keras_separableconv1d_different_activations(self, params, ie_device, precision,
-                                                         ir_version, temp_dir, api_2,
+                                                         ir_version, temp_dir, use_old_api,
                                                          use_new_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for different padding
@@ -99,9 +99,9 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_padding)
     @pytest.mark.nightly
     def test_keras_separableconv1d_different_padding(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, api_2, use_new_frontend):
+                                                     temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for different bias
@@ -117,7 +117,7 @@ class TestKerasSeparableConv1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_bias)
     @pytest.mark.nightly
     def test_keras_separableconv1d_different_bias(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, api_2, use_new_frontend):
+                                                  temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_separableconv1d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv2d.py
@@ -1,0 +1,123 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasSeparableConv2D(CommonTF2LayerTest):
+    def create_keras_separableconv2d_net(self, input_names, input_shapes, input_type,
+                                         filters, kernel_size, strides, padding, data_format,
+                                         dilation_rate, depth_multiplier, activation, use_bias,
+                                         ir_version):
+        # create TensorFlow 2 model with Keras SeparableConv2D operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.SeparableConv2D(
+            filters=filters, kernel_size=kernel_size, strides=strides, padding=padding,
+            data_format=data_format,
+            dilation_rate=dilation_rate, depth_multiplier=depth_multiplier,
+            activation=activation, use_bias=use_bias)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    # Tests for different filters number, kernel size, strides, and dilation
+    test_data = [
+        dict(input_names=["x1"], input_shapes=[[5, 14, 10, 3]], input_type=tf.float32,
+             filters=3, kernel_size=(2), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=1, depth_multiplier=1, activation='relu', use_bias=True),
+        pytest.param(
+            dict(input_names=["x1"], input_shapes=[[1, 10, 16, 2]], input_type=tf.float32,
+                 filters=4, kernel_size=(3, 2), strides=3, padding='valid',
+                 data_format='channels_last',
+                 dilation_rate=(1, 2), depth_multiplier=1, activation='relu', use_bias=True),
+            marks=pytest.mark.xfail(reason="49539")),
+        dict(input_names=["x1"], input_shapes=[[2, 18, 15, 3]], input_type=tf.float32,
+             filters=2, kernel_size=(1, 3), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=4, depth_multiplier=1, activation='relu', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[2, 22, 4, 8]], input_type=tf.float32,
+             filters=3, kernel_size=(2, 2), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=(4, 3), depth_multiplier=6, activation='relu', use_bias=True),
+    ]
+
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_separableconv2d(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    # Tests for different activations
+    test_data_different_activations = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 10, 13]], input_type=tf.float32,
+             filters=3, kernel_size=(2, 3), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=1, depth_multiplier=1, activation=None, use_bias=True),
+        pytest.param(
+            dict(input_names=["x1"], input_shapes=[[2, 22, 14, 5]], input_type=tf.float32,
+                 filters=3, kernel_size=(2, 1), strides=1, padding='valid',
+                 data_format='channels_last',
+                 dilation_rate=4, depth_multiplier=6, activation='selu', use_bias=True),
+            marks=pytest.mark.xfail(reason="49512")),
+        dict(input_names=["x1"], input_shapes=[[1, 10, 16, 2]], input_type=tf.float32,
+             filters=4, kernel_size=(3, 4), strides=(3, 3), padding='valid',
+             data_format='channels_last',
+             dilation_rate=1, depth_multiplier=1, activation='tanh', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[2, 18, 15, 7]], input_type=tf.float32,
+             filters=2, kernel_size=(3, 5), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=2, depth_multiplier=1, activation='swish', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[2, 22, 14, 5]], input_type=tf.float32,
+             filters=3, kernel_size=(2, 4), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=4, depth_multiplier=6, activation='linear', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[2, 22, 14, 6]], input_type=tf.float32,
+             filters=3, kernel_size=(2, 3), strides=(1, 1), padding='valid',
+             data_format='channels_last',
+             dilation_rate=1, depth_multiplier=6, activation='elu', use_bias=True),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_different_activations)
+    @pytest.mark.nightly
+    def test_keras_separableconv2d_different_activations(self, params, ie_device, precision,
+                                                         ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    # Tests for different padding
+    test_data_different_padding = [
+        dict(input_names=["x1"], input_shapes=[[5, 14, 10, 3]], input_type=tf.float32,
+             filters=3, kernel_size=(2), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=1, depth_multiplier=1, activation='relu', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[3, 18, 15, 4]], input_type=tf.float32,
+             filters=3, kernel_size=(4, 1), strides=1, padding='same', data_format='channels_last',
+             dilation_rate=1, depth_multiplier=1, activation='relu', use_bias=True),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_different_padding)
+    @pytest.mark.nightly
+    def test_keras_separableconv2d_different_padding(self, params, ie_device, precision, ir_version,
+                                                     temp_dir, api_2):
+        self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    # Tests for different bias
+    test_data_different_bias = [
+        dict(input_names=["x1"], input_shapes=[[5, 17, 14, 3]], input_type=tf.float32,
+             filters=3, kernel_size=(2, 1), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=1, depth_multiplier=1, activation='relu', use_bias=True),
+        dict(input_names=["x1"], input_shapes=[[1, 14, 12, 2]], input_type=tf.float32,
+             filters=4, kernel_size=(2, 2), strides=1, padding='valid', data_format='channels_last',
+             dilation_rate=2, depth_multiplier=3, activation='relu', use_bias=False),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_different_bias)
+    @pytest.mark.nightly
+    def test_keras_separableconv2d_different_bias(self, params, ie_device, precision, ir_version,
+                                                  temp_dir, api_2):
+        self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv2d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv2d.py
@@ -46,10 +46,10 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_separableconv2d(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_separableconv2d(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for different activations
@@ -82,10 +82,10 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_activations)
     @pytest.mark.nightly
     def test_keras_separableconv2d_different_activations(self, params, ie_device, precision,
-                                                         ir_version, temp_dir, api_2,
+                                                         ir_version, temp_dir, use_old_api,
                                                          use_new_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for different padding
@@ -101,9 +101,9 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_padding)
     @pytest.mark.nightly
     def test_keras_separableconv2d_different_padding(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, api_2, use_new_frontend):
+                                                     temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for different bias
@@ -119,7 +119,7 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_bias)
     @pytest.mark.nightly
     def test_keras_separableconv2d_different_bias(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, api_2, use_new_frontend):
+                                                  temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_separableconv2d.py
@@ -46,10 +46,11 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_separableconv2d(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_separableconv2d(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     # Tests for different activations
     test_data_different_activations = [
@@ -81,10 +82,11 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_activations)
     @pytest.mark.nightly
     def test_keras_separableconv2d_different_activations(self, params, ie_device, precision,
-                                                         ir_version, temp_dir, api_2):
+                                                         ir_version, temp_dir, api_2,
+                                                         use_new_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     # Tests for different padding
     test_data_different_padding = [
@@ -99,10 +101,10 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_padding)
     @pytest.mark.nightly
     def test_keras_separableconv2d_different_padding(self, params, ie_device, precision, ir_version,
-                                                     temp_dir, api_2):
+                                                     temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     # Tests for different bias
     test_data_different_bias = [
@@ -117,7 +119,7 @@ class TestKerasSeparableConv2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_different_bias)
     @pytest.mark.nightly
     def test_keras_separableconv2d_different_bias(self, params, ie_device, precision, ir_version,
-                                                  temp_dir, api_2):
+                                                  temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_separableconv2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_simplernn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_simplernn.py
@@ -53,10 +53,10 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_simplernn_different_activations(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, api_2):
+                                                   temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     # Tests for RNN with dropout
     test_data_dropout = [
@@ -73,10 +73,10 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_dropout)
     @pytest.mark.nightly
     def test_keras_simplernn_dropout(self, params, ie_device, precision, ir_version, temp_dir,
-                                     api_2):
+                                     api_2, use_new_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     # Tests for RNN with other attributes
     test_data_other = [
@@ -92,10 +92,11 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_other)
     @pytest.mark.nightly
-    def test_keras_simplernn_other(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_simplernn_other(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     # Tests for RNN with multiple outputs
     test_data_multipleoutput = [
@@ -120,7 +121,7 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_multipleoutput)
     @pytest.mark.nightly
     def test_keras_simplernn_test_data_multipleoutput(self, params, ie_device, precision,
-                                                      ir_version, temp_dir, api_2):
+                                                      ir_version, temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_simplernn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_simplernn.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_simplernn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_simplernn.py
@@ -1,0 +1,126 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasSimpleRNN(CommonTF2LayerTest):
+    def create_keras_simplernn_net(self, input_names, input_shapes, input_type,
+                                   units, activation, use_bias, dropout, recurrent_dropout,
+                                   return_sequences,
+                                   return_state, go_backwards, stateful, unroll,
+                                   ir_version):
+        # create TensorFlow 2 model with Keras SimpleRNN operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.SimpleRNN(units=units, activation=activation, use_bias=use_bias,
+                                      dropout=dropout,
+                                      recurrent_dropout=recurrent_dropout,
+                                      return_sequences=return_sequences,
+                                      return_state=return_state, go_backwards=go_backwards,
+                                      stateful=stateful,
+                                      unroll=unroll)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    # Tests for different activation functions
+    test_data_different_activations = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 2]], input_type=tf.float32,
+             units=3, activation='tanh', use_bias=True, dropout=0.0, recurrent_dropout=0.0,
+             return_sequences=False,
+             return_state=False, go_backwards=False, stateful=False, unroll=False),
+        dict(input_names=["x1"], input_shapes=[[2, 3, 6]], input_type=tf.float32,
+             units=3, activation='relu', use_bias=True, dropout=0.0, recurrent_dropout=0.0,
+             return_sequences=False,
+             return_state=False, go_backwards=False, stateful=False, unroll=False),
+        dict(input_names=["x1"], input_shapes=[[3, 4, 1]], input_type=tf.float32,
+             units=3, activation='elu', use_bias=True, dropout=0.0, recurrent_dropout=0.0,
+             return_sequences=False,
+             return_state=False, go_backwards=False, stateful=False, unroll=False),
+        pytest.param(
+            dict(input_names=["x1"], input_shapes=[[5, 1, 3]], input_type=tf.float32,
+                 units=3, activation='selu', use_bias=True, dropout=0.0, recurrent_dropout=0.0,
+                 return_sequences=False,
+                 return_state=False, go_backwards=False, stateful=False, unroll=False),
+            marks=pytest.mark.xfail(reason="49512")),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_different_activations)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_simplernn_different_activations(self, params, ie_device, precision, ir_version,
+                                                   temp_dir, api_2):
+        self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    # Tests for RNN with dropout
+    test_data_dropout = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 2]], input_type=tf.float32,
+             units=3, activation='tanh', use_bias=True, dropout=0.8, recurrent_dropout=0.0,
+             return_sequences=False,
+             return_state=False, go_backwards=False, stateful=False, unroll=False),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 2]], input_type=tf.float32,
+             units=3, activation='tanh', use_bias=True, dropout=0.8, recurrent_dropout=0.3,
+             return_sequences=False,
+             return_state=False, go_backwards=False, stateful=False, unroll=False),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_dropout)
+    @pytest.mark.nightly
+    def test_keras_simplernn_dropout(self, params, ie_device, precision, ir_version, temp_dir,
+                                     api_2):
+        self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    # Tests for RNN with other attributes
+    test_data_other = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 2]], input_type=tf.float32,
+             units=3, activation='tanh', use_bias=False, dropout=0.0, recurrent_dropout=0.0,
+             return_sequences=False,
+             return_state=False, go_backwards=False, stateful=False, unroll=False),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 2]], input_type=tf.float32,
+             units=3, activation='tanh', use_bias=True, dropout=0.0, recurrent_dropout=0.0,
+             return_sequences=False,
+             return_state=False, go_backwards=True, stateful=False, unroll=False),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_other)
+    @pytest.mark.nightly
+    def test_keras_simplernn_other(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    # Tests for RNN with multiple outputs
+    test_data_multipleoutput = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 2]], input_type=tf.float32,
+             units=3, activation='tanh', use_bias=True, dropout=0.0, recurrent_dropout=0.0,
+             return_sequences=True, return_state=False,
+             go_backwards=False, stateful=False, unroll=False),
+        pytest.param(
+            dict(input_names=["x1"], input_shapes=[[5, 4, 2]], input_type=tf.float32,
+                 units=3, activation='tanh', use_bias=True, dropout=0.0, recurrent_dropout=0.0,
+                 return_sequences=False, return_state=True,
+                 go_backwards=False, stateful=False, unroll=False),
+            marks=pytest.mark.xfail(reason="49537")),
+        pytest.param(
+            dict(input_names=["x1"], input_shapes=[[5, 4, 2]], input_type=tf.float32,
+                 units=3, activation='tanh', use_bias=True, dropout=0.0, recurrent_dropout=0.0,
+                 return_sequences=True, return_state=True,
+                 go_backwards=False, stateful=False, unroll=False),
+            marks=pytest.mark.xfail(reason="49537")),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_multipleoutput)
+    @pytest.mark.nightly
+    def test_keras_simplernn_test_data_multipleoutput(self, params, ie_device, precision,
+                                                      ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_simplernn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_simplernn.py
@@ -53,9 +53,9 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_simplernn_different_activations(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, api_2, use_new_frontend):
+                                                   temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for RNN with dropout
@@ -73,9 +73,9 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_dropout)
     @pytest.mark.nightly
     def test_keras_simplernn_dropout(self, params, ie_device, precision, ir_version, temp_dir,
-                                     api_2, use_new_frontend):
+                                     use_old_api, use_new_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for RNN with other attributes
@@ -92,10 +92,10 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_other)
     @pytest.mark.nightly
-    def test_keras_simplernn_other(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_simplernn_other(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for RNN with multiple outputs
@@ -121,7 +121,7 @@ class TestKerasSimpleRNN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_multipleoutput)
     @pytest.mark.nightly
     def test_keras_simplernn_test_data_multipleoutput(self, params, ie_device, precision,
-                                                      ir_version, temp_dir, api_2, use_new_frontend):
+                                                      ir_version, temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_simplernn_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softmax.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softmax.py
@@ -1,0 +1,72 @@
+import pytest
+import tensorflow as tf
+from common.layer_test_class import check_ir_version
+from common.tf2_layer_test_class import CommonTF2LayerTest
+from unit_tests.utils.graph import build_graph
+
+
+class TestKerasSoftmax(CommonTF2LayerTest):
+    def create_keras_softmax_net(self, input_names, input_shapes, input_type, ir_version):
+        """
+               Tensorflow2 Keras net:                     IR net:
+                      Input               =>               Input
+                        |                                    |
+                     Softmax                               Softmax
+        """
+        # create TensorFlow 2 model with Keras Softmax operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], dtype=input_type,
+                            name=input_names[0])  # Variable-length sequence of ints
+        y = tf.keras.layers.Softmax()(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # create reference IR net
+        ref_net = None
+
+        if check_ir_version(10, None, ir_version):
+            # convert NHWC to NCHW layout if tensor rank greater 3
+            converted_input_shape = input_shapes[0].copy()
+            if len(converted_input_shape) > 3:
+                converted_input_shape[1] = input_shapes[0][-1]
+                converted_input_shape[2:] = input_shapes[0][1:-1]
+            nodes_attributes = {
+                'input1': {'kind': 'op', 'type': 'Parameter'},
+                'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                'softmax': {'kind': 'op', 'type': 'SoftMax'},
+                'softmax_data': {'shape': converted_input_shape, 'kind': 'data'},
+                'result': {'kind': 'op', 'type': 'Result'}
+            }
+
+            ref_net = build_graph(nodes_attributes,
+                                  [('input1', 'input1_data'),
+                                   ('input1_data', 'softmax', {'in': 0}),
+                                   ('softmax', 'softmax_data'),
+                                   ('softmax_data', 'result')])
+
+        return tf2_net, ref_net
+
+    test_data_float32_precommit = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_precommit)
+    @pytest.mark.precommit
+    def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_softmax_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1"], input_shapes=[[5, 4, 8]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]],
+                              input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_softmax_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softmax.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softmax.py
@@ -50,10 +50,10 @@ class TestKerasSoftmax(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_softmax_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
@@ -67,8 +67,8 @@ class TestKerasSoftmax(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_softmax_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softmax.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softmax.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 from common.layer_test_class import check_ir_version

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softmax.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softmax.py
@@ -50,10 +50,11 @@ class TestKerasSoftmax(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_softmax_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5, 4]],
                               input_type=tf.float32),
@@ -66,7 +67,8 @@ class TestKerasSoftmax(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_softmax_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_softmax_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softplus.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softplus.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 from common.layer_test_class import check_ir_version

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softplus.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softplus.py
@@ -52,9 +52,9 @@ class TestKerasSoftplus(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49516")
     def test_keras_softplus_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2, use_new_frontend):
+                                    use_old_api, use_new_frontend):
         self._test(*self.create_keras_softplus_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5]], input_type=tf.float32),
@@ -70,7 +70,7 @@ class TestKerasSoftplus(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49516")
     def test_keras_softplus_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2, use_new_frontend):
+                                    use_old_api, use_new_frontend):
         self._test(*self.create_keras_softplus_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softplus.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softplus.py
@@ -1,0 +1,76 @@
+import pytest
+import tensorflow as tf
+from common.layer_test_class import check_ir_version
+from common.tf2_layer_test_class import CommonTF2LayerTest
+from unit_tests.utils.graph import build_graph
+
+
+class TestKerasSoftplus(CommonTF2LayerTest):
+    def create_keras_softplus_net(self, input_names, input_shapes, input_type, ir_version):
+        """
+               Tensorflow2 Keras net:                     IR net:
+                      Input               =>               Input
+                        |                                    |
+                     Softplus                             Softplus
+        """
+        # create TensorFlow 2 model with Keras Softplus operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:],
+                            name=input_names[0])  # Variable-length sequence of ints
+        y = tf.keras.activations.softplus()(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # create reference IR net
+        ref_net = None
+
+        if check_ir_version(10, None, ir_version):
+            # convert NHWC to NCHW layout if tensor rank greater 3
+            converted_input_shape = input_shapes[0].copy()
+            if len(converted_input_shape) > 3:
+                converted_input_shape[1] = input_shapes[0][-1]
+                converted_input_shape[2:] = input_shapes[0][1:-1]
+            nodes_attributes = {
+                'input1': {'kind': 'op', 'type': 'Parameter'},
+                'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                'softplus': {'kind': 'op', 'type': 'SoftPlus'},
+                'softplus_data': {'shape': converted_input_shape, 'kind': 'data'},
+                'result': {'kind': 'op', 'type': 'Result'}
+            }
+
+            ref_net = build_graph(nodes_attributes,
+                                  [('input1', 'input1_data'),
+                                   ('input1_data', 'softplus', {'in': 0}),
+                                   ('softplus', 'softplus_data'),
+                                   ('softplus_data', 'result')])
+
+        return tf2_net, ref_net
+
+    test_data_float32_precommit = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_precommit)
+    @pytest.mark.precommit
+    @pytest.mark.xfail(reason="49516")
+    def test_keras_softplus_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                    api_2):
+        self._test(*self.create_keras_softplus_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5]], input_type=tf.float32),
+                         dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32),
+                         dict(input_names=["x1"], input_shapes=[[5, 4, 8]], input_type=tf.float32),
+                         dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]],
+                              input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.xfail(reason="49516")
+    def test_keras_softplus_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                    api_2):
+        self._test(*self.create_keras_softplus_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softplus.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_softplus.py
@@ -52,10 +52,10 @@ class TestKerasSoftplus(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49516")
     def test_keras_softplus_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2):
+                                    api_2, use_new_frontend):
         self._test(*self.create_keras_softplus_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5]], input_type=tf.float32),
                          dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32),
@@ -70,7 +70,7 @@ class TestKerasSoftplus(CommonTF2LayerTest):
     @pytest.mark.precommit
     @pytest.mark.xfail(reason="49516")
     def test_keras_softplus_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2):
+                                    api_2, use_new_frontend):
         self._test(*self.create_keras_softplus_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout1d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout1d.py
@@ -1,0 +1,34 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasSpatialDropout1D(CommonTF2LayerTest):
+    def create_keras_spatialdropout1d_net(self, input_names, input_shapes, input_type, rate,
+                                          ir_version):
+        # create TensorFlow 2 model with Keras SpatialDropout1D operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0], dtype=input_type)
+        y = tf.keras.layers.SpatialDropout1D(rate=rate)(x1, False)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data = [
+        dict(input_names=["x1"], input_shapes=[[1, 3, 2]], input_type=tf.float32, rate=0.0),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 3]], input_type=tf.float32, rate=0.5),
+        dict(input_names=["x1"], input_shapes=[[3, 2, 6]], input_type=tf.float32, rate=0.8),
+    ]
+
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_spatialdropout1d(self, params, ie_device, precision, ir_version, temp_dir,
+                                    api_2):
+        self._test(*self.create_keras_spatialdropout1d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout1d.py
@@ -28,7 +28,7 @@ class TestKerasSpatialDropout1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_spatialdropout1d(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2):
+                                    api_2, use_new_frontend):
         self._test(*self.create_keras_spatialdropout1d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout1d.py
@@ -28,7 +28,7 @@ class TestKerasSpatialDropout1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_spatialdropout1d(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2, use_new_frontend):
+                                    use_old_api, use_new_frontend):
         self._test(*self.create_keras_spatialdropout1d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout2d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout2d.py
@@ -31,9 +31,9 @@ class TestKerasSpatialDropout2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_spatialdropout2d(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2, use_new_frontend):
+                                    use_old_api, use_new_frontend):
         self._test(*self.create_keras_spatialdropout2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_channels_first = [
@@ -48,7 +48,7 @@ class TestKerasSpatialDropout2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_spatialdropout2d_channels_first(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, api_2, use_new_frontend):
+                                                   temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_spatialdropout2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout2d.py
@@ -31,10 +31,10 @@ class TestKerasSpatialDropout2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_spatialdropout2d(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2):
+                                    api_2, use_new_frontend):
         self._test(*self.create_keras_spatialdropout2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_channels_first = [
         dict(input_names=["x1"], input_shapes=[[4, 3, 2, 1]], input_type=tf.float32, rate=0.0,
@@ -48,7 +48,7 @@ class TestKerasSpatialDropout2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_spatialdropout2d_channels_first(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, api_2):
+                                                   temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_spatialdropout2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout2d.py
@@ -1,0 +1,54 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasSpatialDropout2D(CommonTF2LayerTest):
+    def create_keras_spatialdropout2d_net(self, input_names, input_shapes, input_type, rate,
+                                          data_format, ir_version):
+        # create TensorFlow 2 model with Keras SpatialDropout2D operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0], dtype=input_type)
+        y = tf.keras.layers.SpatialDropout2D(rate=rate, data_format=data_format)(x1, False)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data = [
+        dict(input_names=["x1"], input_shapes=[[1, 2, 3, 4]], input_type=tf.float32, rate=0.0,
+             data_format='channels_last'),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 3, 2]], input_type=tf.float32, rate=0.5,
+             data_format='channels_last'),
+        dict(input_names=["x1"], input_shapes=[[3, 2, 6, 1]], input_type=tf.float32, rate=0.8,
+             data_format='channels_last'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_spatialdropout2d(self, params, ie_device, precision, ir_version, temp_dir,
+                                    api_2):
+        self._test(*self.create_keras_spatialdropout2d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_channels_first = [
+        dict(input_names=["x1"], input_shapes=[[4, 3, 2, 1]], input_type=tf.float32, rate=0.0,
+             data_format='channels_first'),
+        dict(input_names=["x1"], input_shapes=[[2, 3, 4, 5]], input_type=tf.float32, rate=0.5,
+             data_format='channels_first'),
+        dict(input_names=["x1"], input_shapes=[[1, 6, 2, 3]], input_type=tf.float32, rate=0.8,
+             data_format='channels_first'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_channels_first)
+    @pytest.mark.nightly
+    def test_keras_spatialdropout2d_channels_first(self, params, ie_device, precision, ir_version,
+                                                   temp_dir, api_2):
+        self._test(*self.create_keras_spatialdropout2d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout3d.py
@@ -1,0 +1,54 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasSpatialDropout3D(CommonTF2LayerTest):
+    def create_keras_spatialdropout3d_net(self, input_names, input_shapes, input_type, rate,
+                                          data_format, ir_version):
+        # create TensorFlow 2 model with Keras SpatialDropout3D operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0], dtype=input_type)
+        y = tf.keras.layers.SpatialDropout3D(rate=rate, data_format=data_format)(x1, False)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 3, 2, 3]], input_type=tf.float32, rate=0.0,
+             data_format='channels_last'),
+        dict(input_names=["x1"], input_shapes=[[5, 4, 3, 2, 3]], input_type=tf.float32, rate=0.5,
+             data_format='channels_last'),
+        dict(input_names=["x1"], input_shapes=[[3, 2, 6, 1, 3]], input_type=tf.float32, rate=0.8,
+             data_format='channels_last'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_spatialdropout3d(self, params, ie_device, precision, ir_version, temp_dir,
+                                    api_2):
+        self._test(*self.create_keras_spatialdropout3d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_channels_first = [
+        dict(input_names=["x1"], input_shapes=[[3, 2, 3, 4, 5]], input_type=tf.float32, rate=0.0,
+             data_format='channels_first'),
+        dict(input_names=["x1"], input_shapes=[[3, 2, 3, 4, 1]], input_type=tf.float32, rate=0.5,
+             data_format='channels_first'),
+        dict(input_names=["x1"], input_shapes=[[2, 3, 1, 6, 3]], input_type=tf.float32, rate=0.8,
+             data_format='channels_first'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_channels_first)
+    @pytest.mark.nightly
+    def test_keras_spatialdropout3d_channels_first(self, params, ie_device, precision, ir_version,
+                                                   temp_dir, api_2):
+        self._test(*self.create_keras_spatialdropout3d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout3d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout3d.py
@@ -31,10 +31,10 @@ class TestKerasSpatialDropout3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_spatialdropout3d(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2):
+                                    api_2, use_new_frontend):
         self._test(*self.create_keras_spatialdropout3d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_channels_first = [
         dict(input_names=["x1"], input_shapes=[[3, 2, 3, 4, 5]], input_type=tf.float32, rate=0.0,
@@ -48,7 +48,7 @@ class TestKerasSpatialDropout3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_spatialdropout3d_channels_first(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, api_2):
+                                                   temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_spatialdropout3d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_spatialdropout3d.py
@@ -31,9 +31,9 @@ class TestKerasSpatialDropout3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_spatialdropout3d(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2, use_new_frontend):
+                                    use_old_api, use_new_frontend):
         self._test(*self.create_keras_spatialdropout3d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_channels_first = [
@@ -48,7 +48,7 @@ class TestKerasSpatialDropout3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_spatialdropout3d_channels_first(self, params, ie_device, precision, ir_version,
-                                                   temp_dir, api_2, use_new_frontend):
+                                                   temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_spatialdropout3d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
@@ -1,0 +1,44 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasStackedRNNCells(CommonTF2LayerTest):
+    def create_keras_stackedrnncells_net(self, input_names, input_shapes, input_type, rnn_cells,
+                                         ir_version):
+        cells_structure = {
+            # pytest-xdist can't execute the tests in parallel because workers can't compare tests scopes before run
+            # tf.keras.layers.<cell> operation have no "==" operation to be compared
+            "LSTMCell": [tf.keras.layers.LSTMCell(128) for _ in range(2)],
+            "GRUCell": [tf.keras.layers.GRUCell(50) for _ in range(3)]
+        }
+        rnn_cells = cells_structure[rnn_cells]
+
+        # create TensorFlow 2 model with Keras StackedRNNCells operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        stacked_lstm = tf.keras.layers.StackedRNNCells(rnn_cells)
+        y = tf.keras.layers.RNN(stacked_lstm)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 3]], input_type=tf.float32,
+             rnn_cells="LSTMCell"),
+        pytest.param(dict(input_names=["x1"], input_shapes=[[5, 4, 3]], input_type=tf.float32,
+                          rnn_cells="GRUCell"),
+                     marks=pytest.mark.xfail(reason="Needs tensorflow 2.3 or higher version."))
+    ]
+
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_stackedrnncells(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_stackedrnncells_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
@@ -38,7 +38,8 @@ class TestKerasStackedRNNCells(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_stackedrnncells(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_stackedrnncells(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_stackedrnncells_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_stackedrnncells.py
@@ -38,8 +38,8 @@ class TestKerasStackedRNNCells(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_stackedrnncells(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_stackedrnncells(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_stackedrnncells_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_subtract.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_subtract.py
@@ -59,10 +59,10 @@ class TestKerasSubtract(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_subtract_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2):
+                                    api_2, use_new_frontend):
         self._test(*self.create_keras_subtract_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
                               input_type=tf.float32),
@@ -77,7 +77,7 @@ class TestKerasSubtract(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_subtract_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2):
+                                    api_2, use_new_frontend):
         self._test(*self.create_keras_subtract_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_subtract.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_subtract.py
@@ -1,0 +1,83 @@
+import pytest
+import tensorflow as tf
+from common.layer_test_class import check_ir_version
+from common.tf2_layer_test_class import CommonTF2LayerTest
+from unit_tests.utils.graph import build_graph
+
+
+class TestKerasSubtract(CommonTF2LayerTest):
+    def create_keras_subtract_net(self, input_names, input_shapes, input_type, ir_version):
+        """
+               Tensorflow2 Keras net:                     IR net:
+                 Input1    Input2            =>      Input1     Input2
+                   \         /                           \       /
+                    Subtract                              Subtract
+        """
+        # create TensorFlow 2 model with Keras Subtract operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        inputs = []
+        for ind in range(len(input_names)):
+            inputs.append(tf.keras.Input(shape=input_shapes[ind][1:], name=input_names[ind]))
+        y = tf.keras.layers.Subtract()(inputs)
+        tf2_net = tf.keras.Model(inputs=inputs, outputs=[y])
+
+        # create reference IR net
+        ref_net = None
+
+        op_name = "Subtract"
+        if check_ir_version(10, None, ir_version):
+            # convert NHWC to NCHW layout if tensor rank greater 3
+            converted_input_shape = input_shapes[0].copy()
+            if len(converted_input_shape) > 3:
+                converted_input_shape[1] = input_shapes[0][-1]
+                converted_input_shape[2:] = input_shapes[0][1:-1]
+            nodes_attributes = {
+                'input1': {'kind': 'op', 'type': 'Parameter'},
+                'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                'input2': {'kind': 'op', 'type': 'Parameter'},
+                'input2_data': {'shape': converted_input_shape, 'kind': 'data'},
+                'op': {'kind': 'op', 'type': op_name},
+                'op_data': {'shape': converted_input_shape, 'kind': 'data'},
+                'result': {'kind': 'op', 'type': 'Result'}
+            }
+
+            ref_net = build_graph(nodes_attributes,
+                                  [('input1', 'input1_data'),
+                                   ('input2', 'input2_data'),
+                                   ('input1_data', 'op', {'in': 0}),
+                                   ('input2_data', 'op', {'in': 1}),
+                                   ('op', 'op_data'),
+                                   ('op_data', 'result')
+                                   ])
+
+        return tf2_net, ref_net
+
+    test_data_float32_precommit = [
+        dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+             input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_precommit)
+    @pytest.mark.precommit
+    def test_keras_subtract_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                    api_2):
+        self._test(*self.create_keras_subtract_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)
+
+    test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8], [5, 4, 8]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"], input_shapes=[[5, 4, 8, 2], [5, 4, 8, 2]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1", "x2"],
+                              input_shapes=[[5, 4, 8, 2, 3], [5, 4, 8, 2, 3]],
+                              input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_subtract_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                    api_2):
+        self._test(*self.create_keras_subtract_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_subtract.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_subtract.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 from common.layer_test_class import check_ir_version

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_subtract.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_subtract.py
@@ -59,9 +59,9 @@ class TestKerasSubtract(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
     def test_keras_subtract_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2, use_new_frontend):
+                                    use_old_api, use_new_frontend):
         self._test(*self.create_keras_subtract_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1", "x2"], input_shapes=[[5, 4], [5, 4]],
@@ -77,7 +77,7 @@ class TestKerasSubtract(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
     def test_keras_subtract_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                    api_2, use_new_frontend):
+                                    use_old_api, use_new_frontend):
         self._test(*self.create_keras_subtract_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_swish.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_swish.py
@@ -50,10 +50,11 @@ class TestKerasSWish(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                 use_new_frontend):
         self._test(*self.create_keras_swish_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5]], input_type=tf.float32),
                          dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32),
@@ -65,7 +66,8 @@ class TestKerasSWish(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                 use_new_frontend):
         self._test(*self.create_keras_swish_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_swish.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_swish.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 from common.layer_test_class import check_ir_version

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_swish.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_swish.py
@@ -50,10 +50,10 @@ class TestKerasSWish(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32_precommit)
     @pytest.mark.precommit
-    def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                  use_new_frontend):
         self._test(*self.create_keras_swish_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5]], input_type=tf.float32),
@@ -66,8 +66,8 @@ class TestKerasSWish(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_data_float32)
     @pytest.mark.nightly
-    def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                  use_new_frontend):
         self._test(*self.create_keras_swish_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_swish.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_swish.py
@@ -1,0 +1,71 @@
+import pytest
+import tensorflow as tf
+from common.layer_test_class import check_ir_version
+from common.tf2_layer_test_class import CommonTF2LayerTest
+from unit_tests.utils.graph import build_graph
+
+
+class TestKerasSWish(CommonTF2LayerTest):
+    def create_keras_swish_net(self, input_names, input_shapes, input_type, ir_version):
+        """
+               Tensorflow2 Keras net:                 IR net:
+                      Input               =>           Input
+                        |                                |
+                      Swish                            Swish
+        """
+        # create TensorFlow 2 model with Keras Swish operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:],
+                            name=input_names[0])  # Variable-length sequence of ints
+        y = tf.keras.activations.swish(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # create reference IR net
+        ref_net = None
+
+        if check_ir_version(10, None, ir_version):
+            # convert NHWC to NCHW layout if tensor rank greater 3
+            converted_input_shape = input_shapes[0].copy()
+            if len(converted_input_shape) > 3:
+                converted_input_shape[1] = input_shapes[0][-1]
+                converted_input_shape[2:] = input_shapes[0][1:-1]
+            nodes_attributes = {
+                'input1': {'kind': 'op', 'type': 'Parameter'},
+                'input1_data': {'shape': converted_input_shape, 'kind': 'data'},
+                'swish': {'kind': 'op', 'type': 'Swish'},
+                'swish_data': {'shape': converted_input_shape, 'kind': 'data'},
+                'result': {'kind': 'op', 'type': 'Result'}
+            }
+
+            ref_net = build_graph(nodes_attributes,
+                                  [('input1', 'input1_data'),
+                                   ('input1_data', 'swish', {'in': 0}),
+                                   ('swish', 'swish_data'),
+                                   ('swish_data', 'result')])
+
+        return tf2_net, ref_net
+
+    test_data_float32_precommit = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]], input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32_precommit)
+    @pytest.mark.precommit
+    def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_swish_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_float32 = [dict(input_names=["x1"], input_shapes=[[5]], input_type=tf.float32),
+                         dict(input_names=["x1"], input_shapes=[[5, 4]], input_type=tf.float32),
+                         dict(input_names=["x1"], input_shapes=[[5, 4, 8]], input_type=tf.float32),
+                         dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3]],
+                              input_type=tf.float32),
+                         dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]],
+                              input_type=tf.float32)]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    def test_keras_swish_float32(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_swish_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_thresholdedrelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_thresholdedrelu.py
@@ -25,9 +25,9 @@ class TestKerasThresholdedReLU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
     def test_keras_thresholdedrelu_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                           api_2, use_new_frontend):
+                                           use_old_api, use_new_frontend):
         self._test(*self.create_keras_thresholdedrelu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data = [
@@ -40,7 +40,7 @@ class TestKerasThresholdedReLU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_keras_thresholdedrelu_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                           api_2, use_new_frontend):
+                                           use_old_api, use_new_frontend):
         self._test(*self.create_keras_thresholdedrelu_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_thresholdedrelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_thresholdedrelu.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_thresholdedrelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_thresholdedrelu.py
@@ -25,10 +25,10 @@ class TestKerasThresholdedReLU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.precommit
     def test_keras_thresholdedrelu_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                           api_2):
+                                           api_2, use_new_frontend):
         self._test(*self.create_keras_thresholdedrelu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data = [
         dict(input_names=["x1"], input_shapes=[[5, 2]], input_type=tf.float32, theta=0.0),
@@ -40,7 +40,7 @@ class TestKerasThresholdedReLU(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     def test_keras_thresholdedrelu_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                           api_2):
+                                           api_2, use_new_frontend):
         self._test(*self.create_keras_thresholdedrelu_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_thresholdedrelu.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_thresholdedrelu.py
@@ -1,0 +1,46 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasThresholdedReLU(CommonTF2LayerTest):
+    def create_keras_thresholdedrelu_net(self, input_names, input_shapes, input_type, theta,
+                                         ir_version):
+        # create TensorFlow 2 model with Keras ThresholdedReLU operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.ThresholdedReLU(theta=theta)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_precommit = [
+        dict(input_names=["x1"], input_shapes=[[3, 5, 3, 5, 2]], input_type=tf.float32, theta=0.2),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_precommit)
+    @pytest.mark.precommit
+    def test_keras_thresholdedrelu_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                           api_2):
+        self._test(*self.create_keras_thresholdedrelu_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data = [
+        dict(input_names=["x1"], input_shapes=[[5, 2]], input_type=tf.float32, theta=0.0),
+        dict(input_names=["x1"], input_shapes=[[1, 4, 3]], input_type=tf.float32, theta=1.0),
+        dict(input_names=["x1"], input_shapes=[[2, 5, 3, 6]], input_type=tf.float32, theta=10.0),
+        dict(input_names=["x1"], input_shapes=[[3, 5, 3, 5, 2]], input_type=tf.float32, theta=0.2),
+    ]
+
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.nightly
+    def test_keras_thresholdedrelu_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                           api_2):
+        self._test(*self.create_keras_thresholdedrelu_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_timedistributed.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_timedistributed.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_timedistributed.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_timedistributed.py
@@ -1,0 +1,38 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasTimeDistributed(CommonTF2LayerTest):
+    def create_keras_timedistributed_net(self, input_names, input_shapes, input_type, conv_2d_layer,
+                                         ir_version):
+        conv_layers_structure = {
+            # pytest-xdist can't execute the tests in parallel because workers can't compare tests scopes before run
+            # tf.keras.layers.<cell> operation have no "==" operation to be compared
+            "Conv2D": tf.keras.layers.Conv2D(64, (3, 3))
+        }
+        conv_2d_layer = conv_layers_structure[conv_2d_layer]
+
+        # create TensorFlow 2 model with Keras TimeDistributed operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0])
+        y = tf.keras.layers.TimeDistributed(conv_2d_layer)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data = [
+        dict(input_names=["x1"], input_shapes=[[2, 10, 128, 128, 3]], input_type=tf.float32,
+             conv_2d_layer="Conv2D"),
+    ]
+
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_timedistributed(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_timedistributed_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_timedistributed.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_timedistributed.py
@@ -33,8 +33,8 @@ class TestKerasTimeDistributed(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_timedistributed(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_timedistributed(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                    use_new_frontend):
         self._test(*self.create_keras_timedistributed_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_timedistributed.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_timedistributed.py
@@ -33,6 +33,8 @@ class TestKerasTimeDistributed(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_timedistributed(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_timedistributed(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                   use_new_frontend):
         self._test(*self.create_keras_timedistributed_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   ie_device, precision, temp_dir=temp_dir, ir_version=ir_version, api_2=api_2,
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling1d.py
@@ -29,7 +29,7 @@ class TestKerasUpSampling1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_upsampling1d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                        api_2):
+                                        api_2, use_new_frontend):
         self._test(*self.create_keras_upsampling1d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling1d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling1d.py
@@ -1,0 +1,35 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasUpSampling1D(CommonTF2LayerTest):
+    def create_keras_upsampling1d_net(self, input_names, input_shapes, input_type, size,
+                                      ir_version):
+        # create TensorFlow 2 model with Keras UpSampling1D operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0], dtype=input_type)
+        y = tf.keras.layers.UpSampling1D(size=size)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    # Tests for float32 input
+    test_data_float32 = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8]], input_type=tf.float32, size=2),
+        dict(input_names=["x1"], input_shapes=[[3, 2, 4]], input_type=tf.float32, size=3),
+        dict(input_names=["x1"], input_shapes=[[1, 3, 8]], input_type=tf.float32, size=5),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_float32)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_upsampling1d_float32(self, params, ie_device, precision, ir_version, temp_dir,
+                                        api_2):
+        self._test(*self.create_keras_upsampling1d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling1d.py
@@ -29,7 +29,7 @@ class TestKerasUpSampling1D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_upsampling1d_float32(self, params, ie_device, precision, ir_version, temp_dir,
-                                        api_2, use_new_frontend):
+                                        use_old_api, use_new_frontend):
         self._test(*self.create_keras_upsampling1d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
@@ -1,0 +1,73 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasUpSampling2D(CommonTF2LayerTest):
+    def create_keras_upsampling2d_net(self, input_names, input_shapes, input_type, size,
+                                      data_format, interpolation,
+                                      ir_version):
+        # create TensorFlow 2 model with Keras UpSampling2D operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0], dtype=input_type)
+        y = tf.keras.layers.UpSampling2D(size=size, data_format=data_format,
+                                         interpolation=interpolation)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    # Tests for nearest interpolation
+    test_data_nearest = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 2]], input_type=tf.float32,
+             size=(2, 3), data_format='channels_last', interpolation='nearest'),
+        dict(input_names=["x1"], input_shapes=[[3, 2, 4, 2]], input_type=tf.float32,
+             size=(3, 1), data_format='channels_last', interpolation='nearest'),
+        dict(input_names=["x1"], input_shapes=[[1, 3, 8, 6]], input_type=tf.float32,
+             size=(5, 2), data_format='channels_last', interpolation='nearest'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_nearest)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_upsampling2d_nearest(self, params, ie_device, precision, ir_version, temp_dir,
+                                        api_2):
+        self._test(*self.create_keras_upsampling2d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    # Tests for bilinear interpolation
+    test_data_bilinear = [
+        dict(input_names=["x1"], input_shapes=[[1, 6, 2, 1]], input_type=tf.float32,
+             size=(3, 1), data_format='channels_last', interpolation='bilinear'),
+        dict(input_names=["x1"], input_shapes=[[1, 3, 1, 6]], input_type=tf.float32,
+             size=(5, 2), data_format='channels_last', interpolation='bilinear'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_bilinear)
+    @pytest.mark.nightly
+    def test_keras_upsampling2d_bilinear(self, params, ie_device, precision, ir_version, temp_dir,
+                                         api_2):
+        self._test(*self.create_keras_upsampling2d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_channels_first = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 5, 3]], input_type=tf.float32,
+             size=(3, 4), data_format='channels_first', interpolation='nearest'),
+        dict(input_names=["x1"], input_shapes=[[3, 2, 7, 2]], input_type=tf.float32,
+             size=(2, 3), data_format='channels_first', interpolation='nearest'),
+        dict(input_names=["x1"], input_shapes=[[3, 5, 4, 6]], input_type=tf.float32,
+             size=(5, 2), data_format='channels_first', interpolation='nearest'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_channels_first)
+    @pytest.mark.nightly
+    def test_keras_upsampling2d_channels_first(self, params, ie_device, precision, ir_version,
+                                               temp_dir, api_2):
+        self._test(*self.create_keras_upsampling2d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
@@ -34,9 +34,9 @@ class TestKerasUpSampling2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_upsampling2d_nearest(self, params, ie_device, precision, ir_version, temp_dir,
-                                        api_2, use_new_frontend):
+                                        use_old_api, use_new_frontend):
         self._test(*self.create_keras_upsampling2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     # Tests for bilinear interpolation
@@ -50,9 +50,9 @@ class TestKerasUpSampling2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_bilinear)
     @pytest.mark.nightly
     def test_keras_upsampling2d_bilinear(self, params, ie_device, precision, ir_version, temp_dir,
-                                         api_2, use_new_frontend):
+                                         use_old_api, use_new_frontend):
         self._test(*self.create_keras_upsampling2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_channels_first = [
@@ -67,7 +67,7 @@ class TestKerasUpSampling2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_upsampling2d_channels_first(self, params, ie_device, precision, ir_version,
-                                               temp_dir, api_2, use_new_frontend):
+                                               temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_upsampling2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling2d.py
@@ -34,10 +34,10 @@ class TestKerasUpSampling2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_upsampling2d_nearest(self, params, ie_device, precision, ir_version, temp_dir,
-                                        api_2):
+                                        api_2, use_new_frontend):
         self._test(*self.create_keras_upsampling2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     # Tests for bilinear interpolation
     test_data_bilinear = [
@@ -50,10 +50,10 @@ class TestKerasUpSampling2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_bilinear)
     @pytest.mark.nightly
     def test_keras_upsampling2d_bilinear(self, params, ie_device, precision, ir_version, temp_dir,
-                                         api_2):
+                                         api_2, use_new_frontend):
         self._test(*self.create_keras_upsampling2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_channels_first = [
         dict(input_names=["x1"], input_shapes=[[5, 4, 5, 3]], input_type=tf.float32,
@@ -67,7 +67,7 @@ class TestKerasUpSampling2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_upsampling2d_channels_first(self, params, ie_device, precision, ir_version,
-                                               temp_dir, api_2):
+                                               temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_upsampling2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling3d.py
@@ -31,10 +31,10 @@ class TestKerasUpSampling3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_upsampling3(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_upsampling3(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                use_new_frontend):
         self._test(*self.create_keras_upsampling3d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_channels_first = [
@@ -51,7 +51,7 @@ class TestKerasUpSampling3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_upsampling2d_channels_first(self, params, ie_device, precision, ir_version,
-                                               temp_dir, api_2, use_new_frontend):
+                                               temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_upsampling3d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling3d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling3d.py
@@ -1,0 +1,56 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasUpSampling3D(CommonTF2LayerTest):
+    def create_keras_upsampling3d_net(self, input_names, input_shapes, input_type, size,
+                                      data_format, ir_version):
+        # create TensorFlow 2 model with Keras UpSampling3D operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0], dtype=input_type)
+        y = tf.keras.layers.UpSampling3D(size=size, data_format=data_format)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    # Tests for nearest interpolation
+    test_data = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 6, 2]], input_type=tf.float32,
+             size=(2, 4, 3), data_format='channels_last'),
+        dict(input_names=["x1"], input_shapes=[[3, 2, 4, 2, 2]], input_type=tf.float32,
+             size=(2, 3, 1), data_format='channels_last'),
+        dict(input_names=["x1"], input_shapes=[[1, 3, 8, 9, 6]], input_type=tf.float32,
+             size=(3, 5, 2), data_format='channels_last'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_upsampling3(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_upsampling3d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_channels_first = [
+        pytest.param(
+            dict(input_names=["x1"], input_shapes=[[5, 4, 5, 1, 3]], input_type=tf.float32,
+                 size=(3, 2, 4), data_format='channels_first'),
+            marks=pytest.mark.xfail(reason="49540")),
+        pytest.param(
+            dict(input_names=["x1"], input_shapes=[[3, 2, 7, 2, 8]], input_type=tf.float32,
+                 size=(2, 3, 3), data_format='channels_first'),
+            marks=pytest.mark.xfail(reason="49540"))
+    ]
+
+    @pytest.mark.parametrize("params", test_data_channels_first)
+    @pytest.mark.nightly
+    def test_keras_upsampling2d_channels_first(self, params, ie_device, precision, ir_version,
+                                               temp_dir, api_2):
+        self._test(*self.create_keras_upsampling3d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_upsampling3d.py
@@ -31,10 +31,11 @@ class TestKerasUpSampling3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_upsampling3(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_upsampling3(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                               use_new_frontend):
         self._test(*self.create_keras_upsampling3d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_channels_first = [
         pytest.param(
@@ -50,7 +51,7 @@ class TestKerasUpSampling3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_upsampling2d_channels_first(self, params, ie_device, precision, ir_version,
-                                               temp_dir, api_2):
+                                               temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_upsampling3d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding1d.py
@@ -27,8 +27,8 @@ class TestKerasZeroPadding1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_zeropadding1d(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+    def test_keras_zeropadding1d(self, params, ie_device, precision, ir_version, temp_dir, use_old_api,
                                  use_new_frontend):
         self._test(*self.create_keras_zeropadding1d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding1d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding1d.py
@@ -1,0 +1,33 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasZeroPadding1D(CommonTF2LayerTest):
+    def create_keras_zeropadding1d_net(self, input_names, input_shapes, input_type, padding,
+                                       ir_version):
+        # create TensorFlow 2 model with Keras ZeroPadding1D operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0], dtype=input_type)
+        y = tf.keras.layers.ZeroPadding1D(padding=padding)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8]], input_type=tf.float32, padding=2),
+        dict(input_names=["x1"], input_shapes=[[3, 2, 4]], input_type=tf.float32, padding=(3, 0)),
+        dict(input_names=["x1"], input_shapes=[[1, 3, 8]], input_type=tf.float32, padding=(5, 1)),
+    ]
+
+    @pytest.mark.parametrize("params", test_data)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_zeropadding1d(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_keras_zeropadding1d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding1d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding1d.py
@@ -27,7 +27,8 @@ class TestKerasZeroPadding1D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.nightly
     @pytest.mark.precommit
-    def test_keras_zeropadding1d(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_keras_zeropadding1d(self, params, ie_device, precision, ir_version, temp_dir, api_2,
+                                 use_new_frontend):
         self._test(*self.create_keras_zeropadding1d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
@@ -31,9 +31,9 @@ class TestKerasZeroPadding2D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_zeropadding2d_channels_last(self, params, ie_device, precision, ir_version,
-                                               temp_dir, api_2):
+                                               temp_dir, use_old_api):
         self._test(*self.create_keras_zeropadding2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    **params)
 
     test_data_channels_first = [
@@ -48,7 +48,7 @@ class TestKerasZeroPadding2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_zeropadding2d_channels_first(self, params, ie_device, precision, ir_version,
-                                                temp_dir, api_2, use_new_frontend):
+                                                temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_zeropadding2d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
@@ -1,0 +1,54 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasZeroPadding2D(CommonTF2LayerTest):
+    def create_keras_zeropadding2d_net(self, input_names, input_shapes, input_type, padding,
+                                       data_format, ir_version):
+        # create TensorFlow 2 model with Keras ZeroPadding2D operation
+        tf.keras.backend.clear_session()
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0], dtype=input_type)
+        y = tf.keras.layers.ZeroPadding2D(padding=padding, data_format=data_format)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_channels_last = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3]], input_type=tf.float32,
+             padding=2, data_format='channels_last'),
+        dict(input_names=["x1"], input_shapes=[[3, 2, 4, 6]], input_type=tf.float32,
+             padding=(3, 0), data_format='channels_last'),
+        dict(input_names=["x1"], input_shapes=[[1, 3, 8, 7]], input_type=tf.float32,
+             padding=((5, 1), (3, 4)), data_format='channels_last'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_channels_last)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_zeropadding2d_channels_last(self, params, ie_device, precision, ir_version,
+                                               temp_dir, api_2):
+        self._test(*self.create_keras_zeropadding2d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_channels_first = [
+        dict(input_names=["x1"], input_shapes=[[3, 8, 4, 5]], input_type=tf.float32,
+             padding=1, data_format='channels_first'),
+        dict(input_names=["x1"], input_shapes=[[6, 4, 2, 3]], input_type=tf.float32,
+             padding=(3, 0), data_format='channels_first'),
+        dict(input_names=["x1"], input_shapes=[[7, 8, 3, 4]], input_type=tf.float32,
+             padding=((0, 0), (3, 4)), data_format='channels_first'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_channels_first)
+    @pytest.mark.nightly
+    def test_keras_zeropadding2d_channels_first(self, params, ie_device, precision, ir_version,
+                                                temp_dir, api_2):
+        self._test(*self.create_keras_zeropadding2d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding2d.py
@@ -48,7 +48,7 @@ class TestKerasZeroPadding2D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_zeropadding2d_channels_first(self, params, ie_device, precision, ir_version,
-                                                temp_dir, api_2):
+                                                temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_zeropadding2d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding3d.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding3d.py
@@ -1,0 +1,54 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class TestKerasZeroPadding3D(CommonTF2LayerTest):
+    def create_keras_zeropadding3d_net(self, input_names, input_shapes, input_type, padding,
+                                       data_format, ir_version):
+        # create TensorFlow 2 model with Keras ZeroPadding3D operation
+        tf.keras.backend.clear_session()  # For easy reset of notebook state
+        x1 = tf.keras.Input(shape=input_shapes[0][1:], name=input_names[0], dtype=input_type)
+        y = tf.keras.layers.ZeroPadding3D(padding=padding, data_format=data_format)(x1)
+        tf2_net = tf.keras.Model(inputs=[x1], outputs=[y])
+
+        # TODO: create a reference net. Now it is ommitted and tests only inference since it is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_data_channels_last = [
+        dict(input_names=["x1"], input_shapes=[[5, 4, 8, 3, 2]], input_type=tf.float32,
+             padding=2, data_format='channels_last'),
+        dict(input_names=["x1"], input_shapes=[[3, 2, 4, 6, 1]], input_type=tf.float32,
+             padding=(3, 0, 1), data_format='channels_last'),
+        dict(input_names=["x1"], input_shapes=[[1, 3, 8, 7, 3]], input_type=tf.float32,
+             padding=((5, 1), (2, 3), (4, 2)), data_format='channels_last'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_channels_last)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_keras_zeropadding3d_channels_last(self, params, ie_device, precision, ir_version,
+                                               temp_dir, api_2):
+        self._test(*self.create_keras_zeropadding3d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)
+
+    test_data_channels_first = [
+        dict(input_names=["x1"], input_shapes=[[1, 3, 8, 4, 5]], input_type=tf.float32,
+             padding=1, data_format='channels_first'),
+        dict(input_names=["x1"], input_shapes=[[2, 6, 4, 2, 3]], input_type=tf.float32,
+             padding=(3, 0, 1), data_format='channels_first'),
+        dict(input_names=["x1"], input_shapes=[[3, 7, 8, 3, 4]], input_type=tf.float32,
+             padding=((0, 0), (1, 0), (3, 4)), data_format='channels_first'),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_channels_first)
+    @pytest.mark.nightly
+    def test_keras_zeropadding3d_channels_first(self, params, ie_device, precision, ir_version,
+                                                temp_dir, api_2):
+        self._test(*self.create_keras_zeropadding3d_net(**params, ir_version=ir_version),
+                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding3d.py
@@ -31,10 +31,10 @@ class TestKerasZeroPadding3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_zeropadding3d_channels_last(self, params, ie_device, precision, ir_version,
-                                               temp_dir, api_2):
+                                               temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_zeropadding3d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)
 
     test_data_channels_first = [
         dict(input_names=["x1"], input_shapes=[[1, 3, 8, 4, 5]], input_type=tf.float32,
@@ -48,7 +48,7 @@ class TestKerasZeroPadding3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_zeropadding3d_channels_first(self, params, ie_device, precision, ir_version,
-                                                temp_dir, api_2):
+                                                temp_dir, api_2, use_new_frontend):
         self._test(*self.create_keras_zeropadding3d_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
-                   **params)
+                   use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding3d.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_zeropadding3d.py
@@ -31,9 +31,9 @@ class TestKerasZeroPadding3D(CommonTF2LayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_keras_zeropadding3d_channels_last(self, params, ie_device, precision, ir_version,
-                                               temp_dir, api_2, use_new_frontend):
+                                               temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_zeropadding3d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)
 
     test_data_channels_first = [
@@ -48,7 +48,7 @@ class TestKerasZeroPadding3D(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_data_channels_first)
     @pytest.mark.nightly
     def test_keras_zeropadding3d_channels_first(self, params, ie_device, precision, ir_version,
-                                                temp_dir, api_2, use_new_frontend):
+                                                temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_keras_zeropadding3d_net(**params, ir_version=ir_version),
-                   ie_device, precision, temp_dir=temp_dir, api_2=api_2, ir_version=ir_version,
+                   ie_device, precision, temp_dir=temp_dir, use_old_api=use_old_api, ir_version=ir_version,
                    use_new_frontend=use_new_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
@@ -1,0 +1,112 @@
+import pytest
+import tensorflow as tf
+
+from common.tf2_layer_test_class import CommonTF2LayerTest
+
+
+class MapFNLayer(tf.keras.layers.Layer):
+    def __init__(self, fn, input_type, fn_output_signature, back_prop):
+        super(MapFNLayer, self).__init__()
+        self.fn = fn
+        self.input_type = input_type
+        self.fn_output_signature = fn_output_signature
+        self.back_prop = back_prop
+
+    def call(self, x):
+        return tf.map_fn(self.fn, x, dtype=self.input_type,
+                         fn_output_signature=self.fn_output_signature,
+                         back_prop=self.back_prop)
+
+
+class TestMapFN(CommonTF2LayerTest):
+    def create_map_fn_net(self, fn, input_type, fn_output_signature, back_prop,
+                          input_names, input_shapes, ir_version):
+        # create TensorFlow 2 model using MapFN construction
+        tf.keras.backend.clear_session()
+        inputs = []
+        for ind in range(len(input_names)):
+            inputs.append(tf.keras.Input(shape=input_shapes[ind][1:], name=input_names[ind],
+                                         dtype=input_type))
+        map_fn_layer = MapFNLayer(fn, input_type, fn_output_signature, back_prop)(inputs)
+        tf2_net = tf.keras.Model(inputs=inputs, outputs=[map_fn_layer])
+
+        # TODO: add reference IR net. Now it is omitted and tests only inference result that is more important
+        ref_net = None
+
+        return tf2_net, ref_net
+
+    test_basic = [
+        dict(fn=lambda x: x[0] * x[1] + x[2], input_type=tf.float32,
+             fn_output_signature=tf.float32, back_prop=False,
+             input_names=["x1", "x2", "x3"], input_shapes=[[2, 3, 4], [2, 3, 4], [2, 3, 4]]),
+        pytest.param(dict(fn=lambda x: (x[0] + x[1] + x[2], x[0] - x[2] + x[1], 2 + x[2]),
+                          input_type=tf.float32,
+                          fn_output_signature=(tf.float32, tf.float32, tf.float32), back_prop=True,
+                          input_names=["x1", "x2", "x3"],
+                          input_shapes=[[2, 1, 3, 4], [2, 1, 3, 4], [2, 1, 3, 4]]),
+                     marks=pytest.mark.xfail(reason="61587"))
+    ]
+
+    @pytest.mark.parametrize("params", test_basic)
+    @pytest.mark.precommit
+    @pytest.mark.nightly
+    def test_basic(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
+                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+
+    test_multiple_inputs = [
+        dict(fn=lambda x: x[0] * x[1], input_type=tf.float32,
+             fn_output_signature=tf.float32, back_prop=True,
+             input_names=["x1", "x2"], input_shapes=[[2, 4], [2, 4]]),
+        dict(fn=lambda x: x[0] * x[1] + 2 * x[2], input_type=tf.float32,
+             fn_output_signature=tf.float32, back_prop=False,
+             input_names=["x1", "x2", "x3"], input_shapes=[[2, 1, 3, 4],
+                                                           [2, 1, 3, 4],
+                                                           [2, 1, 3, 4]])
+    ]
+
+    @pytest.mark.parametrize("params", test_multiple_inputs)
+    @pytest.mark.nightly
+    def test_multiple_inputs(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
+                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+
+    test_multiple_outputs = [
+        pytest.param(dict(fn=lambda x: (x[0] * x[1], x[0] + x[1]), input_type=tf.float32,
+                          fn_output_signature=(tf.float32, tf.float32), back_prop=True,
+                          input_names=["x1", "x2"], input_shapes=[[2, 4], [2, 4]]),
+                     marks=pytest.mark.xfail(reason="61587")),
+        pytest.param(dict(fn=lambda x: (x[0] * x[1] + x[2], x[0] + x[2] * x[1], 2 * x[2]),
+                          input_type=tf.float32,
+                          fn_output_signature=(tf.float32, tf.float32, tf.float32), back_prop=True,
+                          input_names=["x1", "x2", "x3"],
+                          input_shapes=[[2, 1, 3], [2, 1, 3], [2, 1, 3]]),
+                     marks=pytest.mark.xfail(reason="61587"))
+    ]
+
+    @pytest.mark.parametrize("params", test_multiple_outputs)
+    @pytest.mark.nightly
+    def test_multiple_outputs(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+        self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
+                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+
+    test_multiple_inputs_outputs_int32 = [
+        dict(fn=lambda x: x[0] * x[1] + x[2],
+             input_type=tf.int32,
+             fn_output_signature=tf.int32, back_prop=True,
+             input_names=["x1", "x2", "x3"],
+             input_shapes=[[2, 1, 3], [2, 1, 3], [2, 1, 3]]),
+        pytest.param(dict(fn=lambda x: (x[0] + x[1] + x[2], x[0] - x[2] + x[1], 2 + x[2]),
+                          input_type=tf.int32,
+                          fn_output_signature=(tf.int32, tf.int32, tf.int32), back_prop=True,
+                          input_names=["x1", "x2", "x3"],
+                          input_shapes=[[2, 1, 3, 4], [2, 1, 3, 4], [2, 1, 3, 4]]),
+                     marks=pytest.mark.xfail(reason="61587"))
+    ]
+
+    @pytest.mark.parametrize("params", test_multiple_inputs_outputs_int32)
+    @pytest.mark.nightly
+    def test_multiple_inputs_outputs_int32(self, params, ie_device, precision, ir_version, temp_dir,
+                                           api_2):
+        self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
+                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import tensorflow as tf
 

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
@@ -50,9 +50,10 @@ class TestMapFN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_basic)
     @pytest.mark.precommit
     @pytest.mark.nightly
-    def test_basic(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_basic(self, params, ie_device, precision, ir_version, temp_dir, api_2, use_new_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, use_new_frontend=use_new_frontend,
+                   **params)
 
     test_multiple_inputs = [
         dict(fn=lambda x: x[0] * x[1], input_type=tf.float32,
@@ -67,9 +68,10 @@ class TestMapFN(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_multiple_inputs)
     @pytest.mark.nightly
-    def test_multiple_inputs(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_multiple_inputs(self, params, ie_device, precision, ir_version, temp_dir, api_2, use_new_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, use_new_frontend=use_new_frontend,
+                   **params)
 
     test_multiple_outputs = [
         pytest.param(dict(fn=lambda x: (x[0] * x[1], x[0] + x[1]), input_type=tf.float32,
@@ -86,9 +88,10 @@ class TestMapFN(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_multiple_outputs)
     @pytest.mark.nightly
-    def test_multiple_outputs(self, params, ie_device, precision, ir_version, temp_dir, api_2):
+    def test_multiple_outputs(self, params, ie_device, precision, ir_version, temp_dir, api_2, use_new_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, use_new_frontend=use_new_frontend,
+                   **params)
 
     test_multiple_inputs_outputs_int32 = [
         dict(fn=lambda x: x[0] * x[1] + x[2],
@@ -107,6 +110,7 @@ class TestMapFN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_multiple_inputs_outputs_int32)
     @pytest.mark.nightly
     def test_multiple_inputs_outputs_int32(self, params, ie_device, precision, ir_version, temp_dir,
-                                           api_2):
+                                           api_2, use_new_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, **params)
+                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, use_new_frontend=use_new_frontend,
+                   **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_map_fn.py
@@ -50,9 +50,9 @@ class TestMapFN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_basic)
     @pytest.mark.precommit
     @pytest.mark.nightly
-    def test_basic(self, params, ie_device, precision, ir_version, temp_dir, api_2, use_new_frontend):
+    def test_basic(self, params, ie_device, precision, ir_version, temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api, use_new_frontend=use_new_frontend,
                    **params)
 
     test_multiple_inputs = [
@@ -68,9 +68,9 @@ class TestMapFN(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_multiple_inputs)
     @pytest.mark.nightly
-    def test_multiple_inputs(self, params, ie_device, precision, ir_version, temp_dir, api_2, use_new_frontend):
+    def test_multiple_inputs(self, params, ie_device, precision, ir_version, temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api, use_new_frontend=use_new_frontend,
                    **params)
 
     test_multiple_outputs = [
@@ -88,9 +88,9 @@ class TestMapFN(CommonTF2LayerTest):
 
     @pytest.mark.parametrize("params", test_multiple_outputs)
     @pytest.mark.nightly
-    def test_multiple_outputs(self, params, ie_device, precision, ir_version, temp_dir, api_2, use_new_frontend):
+    def test_multiple_outputs(self, params, ie_device, precision, ir_version, temp_dir, use_old_api, use_new_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api, use_new_frontend=use_new_frontend,
                    **params)
 
     test_multiple_inputs_outputs_int32 = [
@@ -110,7 +110,7 @@ class TestMapFN(CommonTF2LayerTest):
     @pytest.mark.parametrize("params", test_multiple_inputs_outputs_int32)
     @pytest.mark.nightly
     def test_multiple_inputs_outputs_int32(self, params, ie_device, precision, ir_version, temp_dir,
-                                           api_2, use_new_frontend):
+                                           use_old_api, use_new_frontend):
         self._test(*self.create_map_fn_net(**params, ir_version=ir_version), ie_device, precision,
-                   temp_dir=temp_dir, ir_version=ir_version, api_2=api_2, use_new_frontend=use_new_frontend,
+                   temp_dir=temp_dir, ir_version=ir_version, use_old_api=use_old_api, use_new_frontend=use_new_frontend,
                    **params)


### PR DESCRIPTION
**Details:** Moving the TF2 layer tests from the private repository and adapting them to be run in the scope of the public repo.

Moving layer tests for TensorFlow2 Keras
Fixed behavior of use_new_framework flag
Fixed handling of transpose operation in case of OV2.0