### PR TITLE
Fixed incorrect behavior in case incorrect arguments are passed

### DIFF
--- a/src/tests/functional/plugin/conformance/subgraphs_dumper/src/main.cpp
+++ b/src/tests/functional/plugin/conformance/subgraphs_dumper/src/main.cpp
@@ -133,7 +133,14 @@ int main(int argc, char *argv[]) {
 
     std::vector<std::string> local_cache_dirs = CommonTestUtils::splitStringByDelimiter(FLAGS_local_cache);
     std::vector<std::string> dirs = CommonTestUtils::splitStringByDelimiter(FLAGS_input_folders);
-    auto models = findModelsInDirs(dirs);
+
+    std::vector<SubgraphsDumper::Model> models;
+    try {
+        models = findModelsInDirs(dirs);
+    } catch (std::runtime_error& e) {
+        std::cout << "Try 'subgraphdumper -h' for more information" << std::endl;
+        return 1;
+    }
 
     auto cache = SubgraphsDumper::OPCache::make_cache();
     if (!FLAGS_local_cache.empty()) {


### PR DESCRIPTION
Fixed incorrect behavior in case incorrect arguments are passed or in case some arguments are missed.

Otherwise SubgraphDumper is failing silently.