### PR TITLE
[ONNX FE Tests] Fix ONNX FE tests on Debian

### DIFF
--- a/.ci/azure/linux_debian.yml
+++ b/.ci/azure/linux_debian.yml
@@ -301,7 +301,9 @@ jobs:
     displayName: 'ONNX Frontend Tests'
     continueOnError: false
 
-  - script: $(INSTALL_TEST_DIR)/paddle_tests --gtest_print_time=1 --gtest_output=xml:$(INSTALL_TEST_DIR)/TEST-Paddle.xml
+  - script: |
+      export OV_FRONTEND_PATH=$(INSTALL_TEST_DIR):/usr/lib/x86_64-linux-gnu/
+      $(INSTALL_TEST_DIR)/paddle_tests --gtest_print_time=1 --gtest_output=xml:$(INSTALL_TEST_DIR)/TEST-Paddle.xml
     displayName: 'Paddle Frontend UT'
     continueOnError: false
 

--- a/.ci/azure/linux_debian.yml
+++ b/.ci/azure/linux_debian.yml
@@ -302,7 +302,7 @@ jobs:
     continueOnError: false
 
   - script: |
-      export OV_FRONTEND_PATH=$(INSTALL_TEST_DIR):/usr/lib/x86_64-linux-gnu/
+      export LD_LIBRARY_PATH=$(INSTALL_TEST_DIR)
       $(INSTALL_TEST_DIR)/paddle_tests --gtest_print_time=1 --gtest_output=xml:$(INSTALL_TEST_DIR)/TEST-Paddle.xml
     displayName: 'Paddle Frontend UT'
     continueOnError: false

--- a/.ci/azure/linux_debian.yml
+++ b/.ci/azure/linux_debian.yml
@@ -295,7 +295,9 @@ jobs:
     displayName: 'OV Core UT'
     continueOnError: false
 
-  - script: $(INSTALL_TEST_DIR)/ov_onnx_frontend_tests --gtest_print_time=1 --gtest_filter=-*IE_GPU* --gtest_output=xml:$(INSTALL_TEST_DIR)/TEST-ONNXFrontend.xml
+  - script: |
+      export OV_FRONTEND_PATH=$(INSTALL_TEST_DIR):/usr/lib/x86_64-linux-gnu/
+      $(INSTALL_TEST_DIR)/ov_onnx_frontend_tests --gtest_print_time=1 --gtest_filter=-*IE_GPU* --gtest_output=xml:$(INSTALL_TEST_DIR)/TEST-ONNXFrontend.xml
     displayName: 'ONNX Frontend Tests'
     continueOnError: false
 


### PR DESCRIPTION
**Details:** Fixing error "Cannot load library libtest_builtin_extensions_1.so libopenvino_tensorflow_fe.so"

**Ticket:** TBD

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
