### PR TITLE
[GPU] Fix infer() for queue sharing case

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/async_infer_request.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/async_infer_request.hpp
@@ -22,7 +22,6 @@ public:
 
     ~AsyncInferRequest();
 
-    void Infer_ThreadUnsafe() override;
     void StartAsync_ThreadUnsafe() override;
 
 private:

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/async_infer_request_legacy.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/async_infer_request_legacy.hpp
@@ -22,7 +22,6 @@ public:
 
     ~AsyncInferRequestLegacy();
 
-    void Infer_ThreadUnsafe() override;
     void StartAsync_ThreadUnsafe() override;
 
 private:

--- a/src/plugins/intel_gpu/src/plugin/async_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/async_infer_request.cpp
@@ -33,14 +33,6 @@ AsyncInferRequest::AsyncInferRequest(const InferRequest::Ptr &inferRequest,
     }
 }
 
-void AsyncInferRequest::Infer_ThreadUnsafe() {
-    if (_inferRequest->use_external_queue()) {
-        _inferRequest->setup_stream_graph();
-        _inferRequest->enqueue_notify();
-    }
-    Parent::Infer_ThreadUnsafe();
-}
-
 void AsyncInferRequest::StartAsync_ThreadUnsafe() {
     if (_inferRequest->use_external_queue()) {
         _inferRequest->setup_stream_graph();

--- a/src/plugins/intel_gpu/src/plugin/async_infer_request_legacy.cpp
+++ b/src/plugins/intel_gpu/src/plugin/async_infer_request_legacy.cpp
@@ -34,15 +34,6 @@ AsyncInferRequestLegacy::AsyncInferRequestLegacy(const InferRequestLegacy::Ptr &
     }
 }
 
-void AsyncInferRequestLegacy::Infer_ThreadUnsafe() {
-    if (_inferRequest->use_external_queue()) {
-        _inferRequest->setup_stream_graph();
-        _inferRequest->preprocess_notify();
-        _inferRequest->enqueue_notify();
-    }
-    Parent::Infer_ThreadUnsafe();
-}
-
 void AsyncInferRequestLegacy::StartAsync_ThreadUnsafe() {
     if (_inferRequest->use_external_queue()) {
         _inferRequest->setup_stream_graph();

--- a/src/tests/functional/plugin/gpu/remote_blob_tests/cldnn_remote_blob_tests.cpp
+++ b/src/tests/functional/plugin/gpu/remote_blob_tests/cldnn_remote_blob_tests.cpp
@@ -453,6 +453,101 @@ TEST_P(RemoteBlob_Test, smoke_canInferOnUserQueue_in_order) {
     }
 }
 
+TEST_P(RemoteBlob_Test, smoke_canInferOnUserQueue_infer_call_many_times) {
+#if defined _WIN32
+    GTEST_SKIP();
+#endif
+
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    CNNNetwork net(fn_ptr);
+
+    net.getInputsInfo().begin()->second->setLayout(Layout::NCHW);
+    net.getInputsInfo().begin()->second->setPrecision(Precision::U8);
+
+    auto blob = FuncTestUtils::createAndFillBlob(net.getInputsInfo().begin()->second->getTensorDesc());
+
+    auto ie = PluginCache::get().ie();
+    auto exec_net_regular = ie->LoadNetwork(net, deviceName);
+
+    // regular inference
+    auto inf_req_regular = exec_net_regular.CreateInferRequest();
+    auto fakeImageData = FuncTestUtils::createAndFillBlob(net.getInputsInfo().begin()->second->getTensorDesc());
+    inf_req_regular.SetBlob(net.getInputsInfo().begin()->first, fakeImageData);
+
+    inf_req_regular.Infer();
+    auto outputBlob_regular = inf_req_regular.GetBlob(net.getOutputsInfo().begin()->first);
+
+    // inference using remote blob
+    auto ocl_instance = std::make_shared<OpenCL>();
+    ocl_instance->_queue = cl::CommandQueue(ocl_instance->_context, ocl_instance->_device);
+    cl_int err;
+
+    auto in_desc = net.getInputsInfo().begin()->second->getTensorDesc();
+    auto out_desc = net.getOutputsInfo().begin()->second->getTensorDesc();
+    auto in_dims = in_desc.getDims();
+    auto out_dims = out_desc.getDims();
+    size_t in_size = std::accumulate(in_desc.getDims().begin(), in_desc.getDims().end(),
+                                     in_desc.getPrecision().size(),
+                                     std::multiplies<size_t>());
+    size_t out_size = std::accumulate(out_desc.getDims().begin(), out_desc.getDims().end(),
+                                      out_desc.getPrecision().size(),
+                                      std::multiplies<size_t>());
+
+    // In this scenario we create shared OCL queue and run simple pre-process action and post-process action (buffer copies in both cases)
+    // without calling thread blocks
+    auto remote_context = make_shared_context(*ie, deviceName, ocl_instance->_queue.get());
+    auto exec_net_shared = ie->LoadNetwork(net, remote_context); // no auto-batching support, so no config is passed
+    auto inf_req_shared = exec_net_shared.CreateInferRequest();
+
+    // Allocate shared buffers for input and output data which will be set to infer request
+    cl::Buffer shared_input_buffer(ocl_instance->_context, CL_MEM_READ_WRITE, in_size, NULL, &err);
+    cl::Buffer shared_output_buffer(ocl_instance->_context, CL_MEM_READ_WRITE, out_size, NULL, &err);
+    // Allocate output buffer where inference result will be put as a post-processing step
+    cl::Buffer output_buffer(ocl_instance->_context, CL_MEM_READ_WRITE, out_size, NULL, &err);
+
+    // Wrap buffers above with IE blobs
+    Blob::Ptr shared_input_blob = make_shared_blob(in_desc, remote_context, shared_input_buffer);
+    Blob::Ptr shared_output_blob = make_shared_blob(out_desc, remote_context, shared_output_buffer);
+    Blob::Ptr output_blob = make_shared_blob(out_desc, remote_context, output_buffer);
+    // Allocate is needed to actually trigger memory handle sharing. For other buffers it's called inside SetBlob impl
+    // TODO: Why do we need to call it explicitly? Consider doing it internally
+    output_blob->allocate();
+
+    // Pass shared blobs to infer request
+    inf_req_shared.SetBlob(net.getInputsInfo().begin()->first, shared_input_blob);
+    inf_req_shared.SetBlob(net.getOutputsInfo().begin()->first, shared_output_blob);
+
+    // 1. Pre-processing. Enqueue non-blocking copy from host ptr to shared device input buffer
+    {
+        void *buffer = fakeImageData->buffer();
+        ocl_instance->_queue.enqueueWriteBuffer(shared_input_buffer, false, 0, in_size, buffer);
+    }
+
+    // 2. Enqueue inference primitives. Synchronous infer() call waits for completion of the result, thus results of the first iterations are discarded
+    for (size_t i = 0; i < 10; i++) {
+        inf_req_shared.Infer();
+    }
+
+    // 3. Post-processing. Enqueue copy from shared blob with inference result to another output blob
+    // Note: inf_req_shared.Wait() can be dropped in some cases, but if plugin-side post-processing is required,
+    // then the result may be incorrect without Wait().
+    {
+        ocl_instance->_queue.enqueueCopyBuffer(shared_output_buffer, output_buffer, 0, 0, output_blob->byteSize());
+    }
+
+    // 4. Wait for infer request and post-processing completion
+    ocl_instance->_queue.finish();
+
+    // compare results
+    {
+        ASSERT_EQ(net.getOutputsInfo().begin()->second->getPrecision(), InferenceEngine::Precision::FP32);
+        ASSERT_EQ(outputBlob_regular->size(), output_blob->size());
+        auto thr = FuncTestUtils::GetComparisonThreshold(InferenceEngine::Precision::FP32);
+        FuncTestUtils::compareBlobs(outputBlob_regular, output_blob, thr);
+    }
+}
+
 std::vector<bool> with_auto_batching {true, false};
 INSTANTIATE_TEST_SUITE_P(smoke_RemoteBlob, RemoteBlob_Test, ::testing::ValuesIn(with_auto_batching),
         RemoteBlob_Test::getTestCaseName);


### PR DESCRIPTION
### Details:
 - Use default sync pipeline for queue sharing case when request.infer() is called
 - Fixes #13099