### PR TITLE
DOCS: Fixing missing heading in Infer Request for 22.2

### DIFF
--- a/docs/OV_Runtime_UG/ov_infer_request.md
+++ b/docs/OV_Runtime_UG/ov_infer_request.md
@@ -222,6 +222,7 @@ You can use the `ov::InferRequest::cancel` method if you want to abort execution
 
     @endsphinxtabset
 
+
 ## Examples of Infer Request Usages
 
 Presented below are examples of what the Infer Request can be used for.


### PR DESCRIPTION
Fixing missing "Examples of Infer Request Usages" heading in "Infer Request" article.

