### PR TITLE
DOCS: Fixing note admonition in Converting a PyTorch RNN-T Model for 22.2

### DIFF
--- a/docs/MO_DG/prepare_model/convert_model/pytorch_specific/Convert_RNNT.md
+++ b/docs/MO_DG/prepare_model/convert_model/pytorch_specific/Convert_RNNT.md
@@ -103,6 +103,4 @@ mo --input_model rnnt_encoder.onnx --input "input[157 1 240],feature_length->157
 mo --input_model rnnt_prediction.onnx --input "symbol[1 1],hidden_in_1[2 1 320],hidden_in_2[2 1 320]"
 mo --input_model rnnt_joint.onnx --input "0[1 1 1024],1[1 1 320]"
 ```
-> **NOTE**: The hardcoded value for sequence length = 157 was taken from the MLCommons, but conversion to IR preserves
-network [reshapeability](../../../../OV_Runtime_UG/ShapeInference.md). Therefore, input shapes can be changed manually to any value during either conversion or
-inference.
+> **NOTE**: The hardcoded value for sequence length = 157 was taken from the MLCommons, but conversion to IR preserves network [reshapeability](../../../../OV_Runtime_UG/ShapeInference.md). Therefore, input shapes can be changed manually to any value during either conversion or inference.


### PR DESCRIPTION
A small fix for a broken admonition.