### PR TITLE
[BENCHAMRK_APP/PYTHON] CV2 module required only when loading images

### DIFF
--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -137,7 +137,7 @@ def get_input_data(paths_to_input, app_input_info):
 
 
 def get_image_tensors(image_paths, info, batch_sizes):
-    if cv2 == None:
+    if cv2 is None:
         import_cv2()
 
     processed_frames = 0

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import cv2
 import re
 import numpy as np
+from types import ModuleType
 from collections import defaultdict
 from pathlib import Path
 
@@ -14,6 +14,7 @@ from openvino.runtime.utils.types import get_dtype
 from .constants import IMAGE_EXTENSIONS, BINARY_EXTENSIONS
 from .logging import logger
 
+cv2: ModuleType = None
 
 class DataQueue:
     def __init__(self, input_data: dict, batch_sizes: list):
@@ -37,6 +38,15 @@ class DataQueue:
     def get_next_batch_size(self):
         return self.batch_sizes[self.current_group_id]
 
+def import_cv2():
+    global cv2
+    
+    try:
+        import cv2
+    except ImportError as ex:
+        raise Exception("Loading images requires opencv-python module. " \
+            "Please install it before continuing or run benchmark without "\
+            "the -i flag to fill vectors with random data") from ex
 
 def get_group_batch_sizes(app_input_info):
     batch_sizes = []
@@ -127,6 +137,9 @@ def get_input_data(paths_to_input, app_input_info):
 
 
 def get_image_tensors(image_paths, info, batch_sizes):
+    if cv2 == None:
+        import_cv2()
+
     processed_frames = 0
     widthes = info.widthes if info.is_dynamic else [info.width]
     heights = info.heights if info.is_dynamic else [info.height]

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -36,6 +36,7 @@ class DataQueue:
     def get_next_batch_size(self):
         return self.batch_sizes[self.current_group_id]
 
+
 def get_group_batch_sizes(app_input_info):
     batch_sizes = []
     niter = max(len(info.shapes) for info in app_input_info)

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -128,10 +128,13 @@ def get_input_data(paths_to_input, app_input_info):
 def get_image_tensors(image_paths, info, batch_sizes):   
     try:
         import cv2
-    except ImportError as ex:
+    except ModuleNotFoundError as ex:
         raise Exception("Loading images requires the opencv-python or opencv-python-headless package. " \
             "Please install it before continuing or run benchmark without "\
             "the -i flag to fill vectors with random data.") from ex
+    except ImportError as ex:
+        raise Exception("Failed to import opencv module. Please try to uninstall opencv-python " \
+        "and install opencv-python-headless instead.") from ex
 
     processed_frames = 0
     widthes = info.widthes if info.is_dynamic else [info.width]

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -4,7 +4,6 @@
 import os
 import re
 import numpy as np
-from types import ModuleType
 from collections import defaultdict
 from pathlib import Path
 
@@ -13,6 +12,7 @@ from openvino.runtime.utils.types import get_dtype
 
 from .constants import IMAGE_EXTENSIONS, BINARY_EXTENSIONS
 from .logging import logger
+
 
 class DataQueue:
     def __init__(self, input_data: dict, batch_sizes: list):

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -14,8 +14,6 @@ from openvino.runtime.utils.types import get_dtype
 from .constants import IMAGE_EXTENSIONS, BINARY_EXTENSIONS
 from .logging import logger
 
-cv2: ModuleType = None
-
 class DataQueue:
     def __init__(self, input_data: dict, batch_sizes: list):
         self.input_data = input_data
@@ -37,16 +35,6 @@ class DataQueue:
 
     def get_next_batch_size(self):
         return self.batch_sizes[self.current_group_id]
-
-def import_cv2():
-    global cv2
-    
-    try:
-        import cv2
-    except ImportError as ex:
-        raise Exception("Loading images requires opencv-python module. " \
-            "Please install it before continuing or run benchmark without "\
-            "the -i flag to fill vectors with random data") from ex
 
 def get_group_batch_sizes(app_input_info):
     batch_sizes = []
@@ -136,9 +124,13 @@ def get_input_data(paths_to_input, app_input_info):
     return DataQueue(data, get_group_batch_sizes(app_input_info))
 
 
-def get_image_tensors(image_paths, info, batch_sizes):
-    if cv2 is None:
-        import_cv2()
+def get_image_tensors(image_paths, info, batch_sizes):   
+    try:
+        import cv2
+    except ImportError as ex:
+        raise Exception("Loading images requires opencv-python module. " \
+            "Please install it before continuing or run benchmark without "\
+            "the -i flag to fill vectors with random data.") from ex
 
     processed_frames = 0
     widthes = info.widthes if info.is_dynamic else [info.width]

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -129,7 +129,7 @@ def get_image_tensors(image_paths, info, batch_sizes):
     try:
         import cv2
     except ImportError as ex:
-        raise Exception("Loading images requires opencv-python module. " \
+        raise Exception("Loading images requires the opencv-python or opencv-python-headless package. " \
             "Please install it before continuing or run benchmark without "\
             "the -i flag to fill vectors with random data.") from ex
 


### PR DESCRIPTION
### Details:
 - OpenCV module is now optional when using benchmark app - it will be imported only when images are provided in the console.

### Tickets:
 - 88029
