### PR TITLE
Add relu after convolution FQ post-ops

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/relu_fake_quantize_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/relu_fake_quantize_fusion.cpp
@@ -48,6 +48,7 @@ ngraph::pass::ReluFakeQuantizeFusion::ReluFakeQuantizeFusion() {
                                                                       fq->input_value(4),
                                                                       fq->get_levels());
         new_fq->set_friendly_name(fq->get_friendly_name());
+        new_fq->get_rt_info()["hasRelu"] = 1;
 
         copy_runtime_info({relu.get_node_shared_ptr(), fq}, new_fq);
         replace_node(fq, new_fq);

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -640,6 +640,9 @@ void Convolution::setPostOps(dnnl::primitive_attr &attr, const VectorDims &dims,
                             for (size_t k = 0; k < OC; k++)
                                 fqScale[k] = fqScale[0];
                         }
+                        if (fakeQuantizeNode->fuseRelu()) {
+                            ops.append_eltwise(1.0f, dnnl::algorithm::eltwise_relu, 0.f, 0.f);
+                        }
 
                         attr.set_output_scales(1 << 1, fqScale);
 

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -1182,6 +1182,11 @@ FakeQuantize::FakeQuantize(const std::shared_ptr<ngraph::Node>& op, const dnnl::
                     fqScales.push_back(1 / ((ih - il) / (oh - ol)));
                 }
             }
+            const auto& rtInfo = op->get_rt_info();
+
+            if (rtInfo.count("hasRelu")) {
+                hasRelu = true;
+            }
 
             algorithm = quantizationOnly ? Algorithm::FQQuantization :
                         (isFakeQuantization || isFakeQuantizationWithScale) ? Algorithm::FQCommon : Algorithm::FQRequantization;

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.h
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.h
@@ -82,6 +82,7 @@ public:
 
     bool needPrepareParams() const override;
     void prepareParams() override;
+    bool fuseRelu() { return hasRelu;}
 
     const float* getBinarizationTresholdsPtr() const { return &binarizationThresholds[0]; }
     const float* getBinarizationOutputMaskPtr() const { return reinterpret_cast<const float*>(&binarizationOutputMask[0]); }
@@ -177,6 +178,7 @@ private:
     size_t levels = 0;
 
     bool binarization = false;
+    bool hasRelu = false;
 
     std::vector<float> binarizationThresholds;
     std::vector<uint32_t> binarizationOutputMask;


### PR DESCRIPTION
### Details:
 - *Openvino ngraph transformation optimize relu+fakequantize by removing relu and leverage the clamp of fakequantize if FQ input_low has non negative values. But if we optimize FQ post-op to outputScale, the relu operation is missing. In this PR, we add relu back if FQ canbe optimized to outputScale*
 

### Tickets:
 - *CVS-91177*
