### PR TITLE
[GPU] Support corss-data type from detection output

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -332,7 +332,7 @@ void remove_redundant_reorders::run(program& p) {
 
             bool same_data_type = input.get_output_layout().data_type == output_layout.data_type;
             bool allowed_dt_conversion_fuse = (input.is_type<one_hot>() || input.is_type<permute>() ||
-                                               input.is_type<depth_to_space>() || input.is_type<region_yolo>());
+                                               input.is_type<depth_to_space>() || input.is_type<region_yolo>() || input.is_type<detection_output>());
             if (!same_data_type && !allowed_dt_conversion_fuse)
                 continue;
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -580,21 +580,6 @@ void reorder_inputs::run(program& p, layout_optimizer& lo, reorder_factory& rf) 
         n->recalc_output_layout(true);
     }
 
-    const auto reorder_input_detection_output = [&p, &rf](typed_program_node<detection_output>& detection_output_node) {
-        auto detection_output_prim = detection_output_node.get_primitive();
-
-        for (size_t i = 0; i < detection_output_node.get_dependencies().size(); i++) {
-            auto& input = detection_output_node.get_dependency(i);
-            auto new_input = rf.get_reorder(input.id(),
-                                            input.get_output_layout(),
-                                            layout{ data_types::f32, format::bfyx, input.get_output_layout().get_tensor() });
-
-            if (new_input.first) {
-                p.add_intermediate(new_input.first, detection_output_node, i, !new_input.second);
-            }
-        }
-    };
-
     const auto reorder_input_binary_convolution = [&p, &rf](typed_program_node<binary_convolution>& binary_conv_node) {
         auto& input = binary_conv_node.input();
         auto input_layout = input.get_output_layout();
@@ -781,9 +766,8 @@ void reorder_inputs::run(program& p, layout_optimizer& lo, reorder_factory& rf) 
     };
 
     for (auto& prim : p.get_processing_order()) {
-        program_helpers::do_for_types<detection_output, binary_convolution, deconvolution, convolution, fully_connected, pooling>(
+        program_helpers::do_for_types<binary_convolution, deconvolution, convolution, fully_connected, pooling>(
             *prim,
-            reorder_input_detection_output,
             reorder_input_binary_convolution,
             reorder_input_and_weights_deconvolution,
             reorder_convolution,

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1302,10 +1302,9 @@ impl_types layout_optimizer::get_preferred_impl_type(program_node& node, format 
         auto confidence_layout = detection_output_node.confidence().get_output_layout();
         auto prim = detection_output_node.get_primitive();
         auto batch_size_limitations = (device_info.supports_immad && device_info.execution_units_count >= 256) ? true : confidence_layout.batch() >= 4;
-        if ((confidence_layout.batch() <= lws_max && batch_size_limitations &&
+        if (confidence_layout.batch() <= lws_max && batch_size_limitations &&
             prim->confidence_threshold >= 0.1 &&
-            prim->top_k <= 400 && prim->num_classes >= 16 && confidence_layout.feature() > 10000) ||
-            confidence_layout.data_type == data_types::f16) // fp16 has accuracy issue in impl_types::cpu
+            prim->top_k <= 400 && prim->num_classes >= 16 && confidence_layout.feature() > 10000)
             preferred_impl = impl_types::ocl;
         else
             preferred_impl = impl_types::cpu;

--- a/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/detection_output/detection_output_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/core/actual_kernels/detection_output/detection_output_kernel_ref.cpp
@@ -17,6 +17,7 @@ ParamsKey DetectionOutputKernelRef::GetSupportedKey() const {
     k.EnableOutputDataType(Datatype::F32);
     k.EnableInputLayout(DataLayout::bfyx);
     k.EnableOutputLayout(DataLayout::bfyx);
+    k.EnableDifferentTypes();
     k.EnableTensorOffset();
     k.EnableTensorPitches();
     k.EnableBatching();


### PR DESCRIPTION
detection_output kernel support cross-type(fp16/fp32), so graph-optimization also support croos-type detection_output

Signed-off-by: hyunback <hyunback.kim@intel.com>

### Tickets:
 - *87095*
