### PR TITLE
Fix benchmark perf counter stats output

### DIFF
--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -32,7 +32,7 @@ def parse_and_check_command_line():
                         "should explicitely set -hint option to none. This is not OpenVINO limitation " \
                         "(those options can be used in OpenVINO together), but a benchmark_app UI rule.")
     
-    if args.report_type == "average_counters" and args.target_device.contains("MULTI"):
+    if args.report_type == "average_counters" and "MULTI" in args.target_device:
         raise Exception("only detailed_counters report type is supported for MULTI device")
     
     _, ext = os.path.splitext(args.path_to_model)

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/statistics_report.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/statistics_report.py
@@ -62,13 +62,17 @@ class StatisticsReport:
     def dump_performance_counters_request(self, f, prof_info):
         total = timedelta()
         total_cpu = timedelta()
-        f.write(self.csv_separator.join(['layerName', 'execStatus', 'layerType', 'execType', 'realTime (ms)', 'cpuTime (ms)\n']))
+        f.write(self.csv_separator.join(['layerName', 'execStatus', 'layerType', 'execType', 'realTime (µs)', 'cpuTime (µs)\n']))
         for pi in prof_info:
-            f.write(self.csv_separator.join([pi.node_name, str(pi.status), pi.node_type, pi.exec_type, str(pi.real_time/1000.0), str(pi.cpu_time/1000.0)]))
+            f.write(self.csv_separator.join([pi.node_name, str(pi.status), pi.node_type, pi.exec_type, 
+                str(pi.real_time // timedelta(microseconds=1)), 
+                str(pi.cpu_time // timedelta(microseconds=1))]))
             f.write('\n')
             total += pi.real_time
             total_cpu += pi.cpu_time
-        f.write(self.csv_separator.join(['Total','','','',str(total/1000.0),str(total_cpu/1000.0)]))
+        f.write(self.csv_separator.join(['Total','','','',
+            str(total // timedelta(microseconds=1)),
+            str(total_cpu // timedelta(microseconds=1))]))
         f.write('\n\n')
 
     def dump_performance_counters(self, prof_info_list):

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/statistics_report.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/statistics_report.py
@@ -62,17 +62,17 @@ class StatisticsReport:
     def dump_performance_counters_request(self, f, prof_info):
         total = timedelta()
         total_cpu = timedelta()
-        f.write(self.csv_separator.join(['layerName', 'execStatus', 'layerType', 'execType', 'realTime (µs)', 'cpuTime (µs)\n']))
+        f.write(self.csv_separator.join(['layerName', 'execStatus', 'layerType', 'execType', 'realTime (ms)', 'cpuTime (ms)\n']))
         for pi in prof_info:
             f.write(self.csv_separator.join([pi.node_name, str(pi.status), pi.node_type, pi.exec_type, 
-                str(pi.real_time // timedelta(microseconds=1)), 
-                str(pi.cpu_time // timedelta(microseconds=1))]))
+                str((pi.real_time // timedelta(microseconds=1))/1000.0), 
+                str((pi.cpu_time // timedelta(microseconds=1))/1000.0)]))
             f.write('\n')
             total += pi.real_time
             total_cpu += pi.cpu_time
         f.write(self.csv_separator.join(['Total','','','',
-            str(total // timedelta(microseconds=1)),
-            str(total_cpu // timedelta(microseconds=1))]))
+            str((total // timedelta(microseconds=1))/1000.0),
+            str((total_cpu // timedelta(microseconds=1))/1000.0)]))
         f.write('\n\n')
 
     def dump_performance_counters(self, prof_info_list):

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/utils.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/utils.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import defaultdict
-import datetime
+from datetime import timedelta
 from openvino.runtime import Core, Model, PartialShape, Dimension, Layout, Type, serialize
 from openvino.preprocess import PrePostProcessor
 
@@ -314,20 +314,20 @@ def print_perf_counters(perf_counts_list):
     max_layer_name = 30
     for ni in range(len(perf_counts_list)):
         perf_counts = perf_counts_list[ni]
-        total_time = datetime.timedelta()
-        total_time_cpu = datetime.timedelta()
+        total_time = timedelta()
+        total_time_cpu = timedelta()
         logger.info(f"Performance counts for {ni}-th infer request")
         for pi in perf_counts:
             print(f"{pi.node_name[:max_layer_name - 4] + '...' if (len(pi.node_name) >= max_layer_name) else pi.node_name:<30}"
                                                                 f"{str(pi.status):<15}"
                                                                 f"{'layerType: ' + pi.node_type:<30}"
-                                                                f"{'realTime: ' + str(pi.real_time):<20}"
-                                                                f"{'cpu: ' +  str(pi.cpu_time):<20}"
+                                                                f"{'realTime: ' + str(pi.real_time // timedelta(microseconds=1)):<20}"
+                                                                f"{'cpu: ' +  str(pi.cpu_time // timedelta(microseconds=1)):<20}"
                                                                 f"{'execType: ' + pi.exec_type:<20}")
             total_time += pi.real_time
             total_time_cpu += pi.cpu_time
-        print(f'Total time:     {total_time} microseconds')
-        print(f'Total CPU time: {total_time_cpu} microseconds\n')
+        print(f'Total time:     {total_time // timedelta(microseconds=1)} microseconds')
+        print(f'Total CPU time: {total_time_cpu // timedelta(microseconds=1)} microseconds\n')
 
 
 def get_command_line_arguments(argv):

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/utils.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/utils.py
@@ -321,13 +321,13 @@ def print_perf_counters(perf_counts_list):
             print(f"{pi.node_name[:max_layer_name - 4] + '...' if (len(pi.node_name) >= max_layer_name) else pi.node_name:<30}"
                                                                 f"{str(pi.status):<15}"
                                                                 f"{'layerType: ' + pi.node_type:<30}"
-                                                                f"{'realTime: ' + str(pi.real_time // timedelta(microseconds=1)):<20}"
-                                                                f"{'cpu: ' +  str(pi.cpu_time // timedelta(microseconds=1)):<20}"
+                                                                f"{'realTime: ' + str((pi.real_time // timedelta(microseconds=1)) / 1000.0):<20}"
+                                                                f"{'cpu: ' +  str((pi.cpu_time // timedelta(microseconds=1)) / 1000.0):<20}"
                                                                 f"{'execType: ' + pi.exec_type:<20}")
             total_time += pi.real_time
             total_time_cpu += pi.cpu_time
-        print(f'Total time:     {total_time // timedelta(microseconds=1)} microseconds')
-        print(f'Total CPU time: {total_time_cpu // timedelta(microseconds=1)} microseconds\n')
+        print(f'Total time:     {(total_time // timedelta(microseconds=1)) / 1000.0} milliseconds')
+        print(f'Total CPU time: {(total_time_cpu // timedelta(microseconds=1)) / 1000.0} milliseconds\n')
 
 
 def get_command_line_arguments(argv):


### PR DESCRIPTION
When ProfilingInfo was bound by pybind11, those entries turned into
Python timedelta objects. This caused two problems:

1. There was a division by 1000 to go to milliseconds. This caused a lot
   of precision lost, because `timedelta(microseconds=2300)/1000.0 =
   timedelta(2)` and `timedelta(microseconds=33) = timedelta(0)`.
2. When converting those timedelta objects to str, the output is in the
   form of (HH:MM:SS.XXXXXX). This is not very useful microsecond based
   performance counters.

This change simply reverts everything to printing plain microsecond
based integers.