### PR TITLE
[GNA] Add OV & GNA versions to GNA export file

### DIFF
--- a/src/plugins/intel_gna/gna_model_serial.cpp
+++ b/src/plugins/intel_gna/gna_model_serial.cpp
@@ -92,6 +92,20 @@ inline bool is_little_endian() {
     return LECheck.c[0] == 1;
 }
 
+void GNAVersionSerializer::Export(std::ostream& os) const {
+    writeString(ov::intel_gna::common::get_openvino_version_string(), os);
+    writeString(GNADeviceHelper::GetGnaLibraryVersion(), os);
+}
+
+std::string GNAVersionSerializer::Import(std::istream& is) const {
+    std::string version;
+    if (is.peek() && !is.eof()) {
+        version = "The model was exported with OpenVINO version:\n" + readString(is) + "\n";
+        version += "GNA Library version:\n" + readString(is) + "\n";
+    }
+    return version;
+}
+
 const int gna_header_magic = is_little_endian() ?  0x4d414e47 : 0x474e414d;
 
 GNAPluginNS::HeaderLatest::ModelHeader GNAModelSerial::ReadHeader(std::istream &is) {
@@ -248,7 +262,8 @@ void GNAModelSerial::Import(void *basePointer,
         GNAPluginNS::GnaInputs &inputs,
         GNAPluginNS::GnaOutputs &outputs,
         TranspositionInfoMap &inputsTranspositionInfo,
-        TranspositionInfoMap &outputsTranspositionInfo) {
+        TranspositionInfoMap &outputsTranspositionInfo,
+        std::string & libVersionFromFile) {
     is.exceptions(std::istream::failbit);
     // 2. Read inputs names
     if (model_header_.version.major == 2) {
@@ -377,9 +392,8 @@ void GNAModelSerial::Import(void *basePointer,
     is.read(reinterpret_cast<char*>(basePointer), gnaGraphSize);
 
     // read OV and GNA versions if available in model file
-    if (is.peek() != EOF && log_level_ == ov::log::Level::DEBUG) {     
-        std::cout << "OpenVINO version read form model file:" << std::endl << readString(is) << std::endl;
-        std::cout << "GNA version read from model file:" << std::endl << readString(is) << std::endl;
+    if (model_header_.version.major == 2 && model_header_.version.minor >= 8) {
+        libVersionFromFile = version_.Import(is);
     }
 }
 
@@ -542,10 +556,9 @@ void GNAModelSerial::Export(const GnaAllocations& allocations, std::ostream& os)
     for (const auto& a : allocationsOrdered) {
         os.write(reinterpret_cast<char*>(a.ptr), a.sizeForExport());
     }
-    
-    // write OV & GNA versions 
-    writeString(ov::intel_gna::common::get_openvino_version_string(), os);
-    writeString(GNADeviceHelper::GetGnaLibraryVersion(), os);    
+
+    // write OV & GNA versions
+    version_.Export(os);
 }
 
 void GNAModelSerial::ImportInputs(std::istream &is, void* basePtr, GNAPluginNS::GnaInputs &inputs) {

--- a/src/plugins/intel_gna/gna_model_serial.cpp
+++ b/src/plugins/intel_gna/gna_model_serial.cpp
@@ -27,6 +27,7 @@
 #include "gna_plugin.hpp"
 #include "gna_model_serial.hpp"
 #include "serial/headers/latest/gna_model_header.hpp"
+#include "common/versioning.hpp"
 
 using namespace GNAPluginNS;
 
@@ -374,6 +375,12 @@ void GNAModelSerial::Import(void *basePointer,
 
     // once structure has been read lets read whole gna graph
     is.read(reinterpret_cast<char*>(basePointer), gnaGraphSize);
+
+    // read OV and GNA versions if available in model file
+    if (is.peek() != EOF && log_level_ == ov::log::Level::DEBUG) {     
+        std::cout << "OpenVINO version read form model file:" << std::endl << readString(is) << std::endl;
+        std::cout << "GNA version read from model file:" << std::endl << readString(is) << std::endl;
+    }
 }
 
 void GNAModelSerial::Export(const GnaAllocations& allocations, std::ostream& os) const {
@@ -535,6 +542,10 @@ void GNAModelSerial::Export(const GnaAllocations& allocations, std::ostream& os)
     for (const auto& a : allocationsOrdered) {
         os.write(reinterpret_cast<char*>(a.ptr), a.sizeForExport());
     }
+    
+    // write OV & GNA versions 
+    writeString(ov::intel_gna::common::get_openvino_version_string(), os);
+    writeString(GNADeviceHelper::GetGnaLibraryVersion(), os);    
 }
 
 void GNAModelSerial::ImportInputs(std::istream &is, void* basePtr, GNAPluginNS::GnaInputs &inputs) {

--- a/src/plugins/intel_gna/gna_model_serial.hpp
+++ b/src/plugins/intel_gna/gna_model_serial.hpp
@@ -31,6 +31,7 @@ private:
     TranspositionInfoMap inputs_transpose_info_;
     TranspositionInfoMap outputs_transpose_info_;
     GNAPluginNS::HeaderLatest::ModelHeader model_header_;
+    ov::log::Level log_level_;
 
     void ImportInputs(std::istream &is, void* basePtr, GNAPluginNS::GnaInputs &inputs);
 
@@ -47,12 +48,20 @@ private:
     void AppendTensorNameIfNeeded(GNAPluginNS::GnaDesc& nodeDesc) const;
 
  public:
-    GNAModelSerial(Gna2Model * model, MemoryType & states_holder)
-        : gna2model_(model), pstates_(&states_holder) {
+    GNAModelSerial(Gna2Model* model, MemoryType& states_holder, ov::log::Level log_level = ov::log::Level::NO)
+         : gna2model_(model),
+           pstates_(&states_holder),
+           log_level_(log_level) {
     }
 
-    GNAModelSerial(Gna2Model * model, GNAPluginNS::GnaInputs &inputs, GNAPluginNS::GnaOutputs &outputs)
-        : gna2model_(model), inputs_(inputs), outputs_(outputs) {
+    GNAModelSerial(Gna2Model* model,
+                   GNAPluginNS::GnaInputs& inputs,
+                   GNAPluginNS::GnaOutputs& outputs,
+                   ov::log::Level log_level = ov::log::Level::NO)
+        : gna2model_(model),
+          inputs_(inputs),
+          outputs_(outputs),
+          log_level_(log_level) {
     }
 
     void setHeader(GNAPluginNS::HeaderLatest::ModelHeader header) {

--- a/src/plugins/intel_gna/gna_model_serial.hpp
+++ b/src/plugins/intel_gna/gna_model_serial.hpp
@@ -17,6 +17,15 @@
 #include "gna_device_allocation.hpp"
 
 /**
+ * @brief helper class for GNAGraph serialization tasks
+ */
+class GNAVersionSerializer {
+public:
+    void Export(std::ostream& os) const;
+    std::string Import(std::istream& is) const;
+};
+
+/**
  * @brief implements serialization tasks for GNAGraph
  */
 class GNAModelSerial {
@@ -31,7 +40,7 @@ private:
     TranspositionInfoMap inputs_transpose_info_;
     TranspositionInfoMap outputs_transpose_info_;
     GNAPluginNS::HeaderLatest::ModelHeader model_header_;
-    ov::log::Level log_level_;
+    GNAVersionSerializer version_;
 
     void ImportInputs(std::istream &is, void* basePtr, GNAPluginNS::GnaInputs &inputs);
 
@@ -48,20 +57,17 @@ private:
     void AppendTensorNameIfNeeded(GNAPluginNS::GnaDesc& nodeDesc) const;
 
  public:
-    GNAModelSerial(Gna2Model* model, MemoryType& states_holder, ov::log::Level log_level = ov::log::Level::NO)
+    GNAModelSerial(Gna2Model* model, MemoryType& states_holder)
          : gna2model_(model),
-           pstates_(&states_holder),
-           log_level_(log_level) {
+           pstates_(&states_holder) {
     }
 
     GNAModelSerial(Gna2Model* model,
                    GNAPluginNS::GnaInputs& inputs,
-                   GNAPluginNS::GnaOutputs& outputs,
-                   ov::log::Level log_level = ov::log::Level::NO)
+                   GNAPluginNS::GnaOutputs& outputs)
         : gna2model_(model),
           inputs_(inputs),
-          outputs_(outputs),
-          log_level_(log_level) {
+          outputs_(outputs) {
     }
 
     void setHeader(GNAPluginNS::HeaderLatest::ModelHeader header) {
@@ -112,7 +118,8 @@ private:
                 GNAPluginNS::GnaInputs &inputs,
                 GNAPluginNS::GnaOutputs &outputs,
                 TranspositionInfoMap& inputstranspositionInfo,
-                TranspositionInfoMap& outputstranspositionInfo);
+                TranspositionInfoMap& outputstranspositionInfo,
+                std::string& modelLibVersion);
 
     /**
      * save gna graph to an outpus stream

--- a/src/plugins/intel_gna/gna_plugin.cpp
+++ b/src/plugins/intel_gna/gna_plugin.cpp
@@ -1594,6 +1594,7 @@ InferenceEngine::IExecutableNetworkInternal::Ptr GNAPlugin::ImportNetwork(std::i
     auto header = GNAModelSerial::ReadHeader(networkModel);
 
     void* basePtr = nullptr;
+    std::string modelLibVersion;  //!< OpenVINO and GNA Library versions read from GNA model file
 
     gnamem->getQueue(REGION_SCRATCH)->reserve_ptr(nullptr, &basePtr, header.gnaMemSize);
 
@@ -1601,7 +1602,7 @@ InferenceEngine::IExecutableNetworkInternal::Ptr GNAPlugin::ImportNetwork(std::i
 
     auto model = createModelWrapperForImportNetwork(header.layersCount);
     GNAModelSerial::MemoryType mt;
-    auto serial = GNAModelSerial(&model->object(), mt, gnaFlags->log_level);
+    auto serial = GNAModelSerial(&model->object(), mt);
 
     serial.setHeader(header);
     serial.Import(basePtr,
@@ -1610,7 +1611,18 @@ InferenceEngine::IExecutableNetworkInternal::Ptr GNAPlugin::ImportNetwork(std::i
                   *(inputs_ptr_),
                   outputs_,
                   transpose_inputs_info,
-                  transpose_outputs_info);
+                  transpose_outputs_info,
+                  modelLibVersion);
+
+    // Print OV and GNA Lib versions used for model export
+    if (gnaFlags->log_level >= ov::log::Level::DEBUG) {
+        if (modelLibVersion.length()) {
+            std::cout << modelLibVersion << std::endl;
+        } else {
+            std::cout << "Unable to read OpenVINO or GNA Library version from model file, consider model export with current "
+                    "version of GNA plugin" << std::endl;
+        }
+    }
 
     trivialTopology = (model->object().NumberOfOperations == 0);
 

--- a/src/plugins/intel_gna/gna_plugin.cpp
+++ b/src/plugins/intel_gna/gna_plugin.cpp
@@ -1601,8 +1601,7 @@ InferenceEngine::IExecutableNetworkInternal::Ptr GNAPlugin::ImportNetwork(std::i
 
     auto model = createModelWrapperForImportNetwork(header.layersCount);
     GNAModelSerial::MemoryType mt;
-    auto serial = GNAModelSerial(&model->object(), mt);
-
+    auto serial = GNAModelSerial(&model->object(), mt, gnaFlags->log_level);
 
     serial.setHeader(header);
     serial.Import(basePtr,

--- a/src/tests/unit/gna/gna_model_serial_test.cpp
+++ b/src/tests/unit/gna/gna_model_serial_test.cpp
@@ -8,9 +8,9 @@
 // to suppress deprecated definition errors
 #define IMPLEMENT_INFERENCE_ENGINE_PLUGIN
 #include "gna_model_serial.hpp"
+#include "common/versioning.hpp"
 
-using ::testing::Return;
-using ::testing::_;
+using namespace testing;
 
 class IstreamMock final: public std::streambuf {
 public:
@@ -23,4 +23,27 @@ TEST(GNAModelSerialTest, TestErrorOnTellg) {
     EXPECT_CALL(mock, seekoff(_, _, _)).WillRepeatedly(Return(-1));
     std::istream is(&mock);
     ASSERT_THROW(GNAModelSerial::ReadHeader(is), InferenceEngine::Exception);
+}
+
+TEST(GNAVersionSerializerTest, Export) {
+    std::stringstream sBuf;
+    GNAVersionSerializer verSerializer;
+    verSerializer.Export(sBuf);
+
+    EXPECT_THAT(sBuf.str(), HasSubstr(ov::intel_gna::common::get_openvino_version_string()));
+}
+
+TEST(GNAVersionSerializerTest, ImportWhenVersionIsPresent) {
+    std::stringstream sBuf;
+    GNAVersionSerializer verSerializer;
+    verSerializer.Export(sBuf);
+
+    EXPECT_THAT(verSerializer.Import(sBuf), HasSubstr(ov::intel_gna::common::get_openvino_version_string()));
+}
+
+TEST(GNAVersionSerializerTest, ImportWhenVersionIsNotPresent) {
+    std::stringstream sBuf;
+    GNAVersionSerializer verSerializer;
+
+    EXPECT_EQ(verSerializer.Import(sBuf).length(), 0);
 }


### PR DESCRIPTION
### Details:
 - Add OV version (eg hash commit) to GNA export format file (using wg/rg flag).
 - Add GNA Lib version to GNA export format file (using wg/rg flag).
 - Enable version printing for speech_sample demo only when log mode is set to LOG_DEBUG

### Tickets:
 - 86924
