### PR TITLE
Apply CC to ov::OpSet

### DIFF
--- a/src/core/include/openvino/opsets/opset.hpp
+++ b/src/core/include/openvino/opsets/opset.hpp
@@ -25,6 +25,7 @@ class OPENVINO_API OpSet {
 
 public:
     OpSet() = default;
+    OpSet(const std::string& name);
     virtual ~OpSet() = default;
     std::set<NodeTypeInfo>::size_type size() const {
         std::lock_guard<std::mutex> guard(get_mutex());
@@ -115,6 +116,7 @@ protected:
     }
 
     ngraph::FactoryRegistry<ov::Node> m_factory_registry;
+    std::string m_name;
     std::set<NodeTypeInfo> m_op_types;
     std::map<std::string, NodeTypeInfo> m_name_type_info_map;
     std::map<std::string, NodeTypeInfo> m_case_insensitive_type_info_map;
@@ -171,5 +173,9 @@ const OPENVINO_API OpSet& get_opset7();
  * @ingroup ov_opset_cpp_api
  */
 const OPENVINO_API OpSet& get_opset8();
+/**
+ * @brief Returns opset9
+ * @ingroup ov_opset_cpp_api
+ */
 const OPENVINO_API OpSet& get_opset9();
 }  // namespace ov

--- a/src/core/src/itt.hpp
+++ b/src/core/src/itt.hpp
@@ -25,21 +25,35 @@ OV_ITT_DOMAIN(ov_op, "ov::Op");
 }  // namespace itt
 }  // namespace ov
 OV_CC_DOMAINS(ov_op);
+OV_CC_DOMAINS(ov_opset);
 
+/*
+ * REGISTER_OP registers Operation creation inside OpSet
+ * INSERT_OP macro allows to ignore some Operations inside OpSet if it's creation wasn't registered
+ */
 #if defined(SELECTIVE_BUILD_ANALYZER)
 #    define OV_OP_SCOPE(region) OV_SCOPE(ov_op, region)
 #    define OV_PASS_CALLBACK(matcher)                                   \
         openvino::itt::handle_t m_callback_handle;                      \
         m_callback_handle = openvino::itt::handle(matcher->get_name()); \
         OV_ITT_SCOPED_TASK(SIMPLE_ov_pass, m_callback_handle)
+#    define REGISTER_OP(opset_name, op_name) \
+        OV_ITT_SCOPED_TASK(SIMPLE_ov_opset, openvino::itt::handle(opset_name + "_" + op_name))
+#    define INSERT_OP(opset_name, op_name, op_namespace) opset.insert<op_namespace::op_name>()
 #elif defined(SELECTIVE_BUILD)
 #    define OV_OP_SCOPE(region)                                        \
         if (OV_CC_SCOPE_IS_ENABLED(OV_PP_CAT3(ov_op, _, region)) == 0) \
         throw ngraph::ngraph_error(std::string(OV_PP_TOSTRING(OV_PP_CAT3(ov_op, _, region))) + " is disabled!")
 #    define OV_PASS_CALLBACK(matcher)
+#    define REGISTER_OP(opset_name, op_name)
+#    define INSERT_OP(opset_name, op_name, op_namespace)                                \
+        if (OV_CC_SCOPE_IS_ENABLED(OV_PP_CAT4(ov_opset_, opset_name, _, op_name)) == 1) \
+        opset.insert<op_namespace::op_name>()
 #else
 #    define OV_OP_SCOPE(region) OV_ITT_SCOPED_TASK(ov::itt::domains::ov_op, OV_PP_TOSTRING(region))
 #    define OV_PASS_CALLBACK(matcher)
+#    define REGISTER_OP(opset_name, op_name)
+#    define INSERT_OP(opset_name, op_name, op_namespace) opset.insert<op_namespace::op_name>()
 #endif
 
 #define NGRAPH_TYPE_CASE(region, a, ...)                        \

--- a/src/core/src/opsets/opset.cpp
+++ b/src/core/src/opsets/opset.cpp
@@ -4,10 +4,14 @@
 
 #include "ngraph/opsets/opset.hpp"
 
+#include "../itt.hpp"
+
 #include "ngraph/log.hpp"
 #include "ngraph/ops.hpp"
 
 ngraph::OpSet::OpSet(const ov::OpSet& opset) : ov::OpSet(opset) {}
+
+ov::OpSet::OpSet(const std::string& name) : m_name(name) {}
 
 std::mutex& ov::OpSet::get_mutex() {
     static std::mutex opset_mutex;
@@ -20,20 +24,25 @@ ov::Node* ov::OpSet::create(const std::string& name) const {
         NGRAPH_WARN << "Couldn't create operator of type: " << name << " . Operation not registered in opset.";
         return nullptr;
     }
+    REGISTER_OP(m_name, name);
     return m_factory_registry.create(type_info_it->second);
 }
 
 ov::Node* ov::OpSet::create_insensitive(const std::string& name) const {
     auto type_info_it = m_case_insensitive_type_info_map.find(to_upper_name(name));
-    return type_info_it == m_case_insensitive_type_info_map.end() ? nullptr
-                                                                  : m_factory_registry.create(type_info_it->second);
+    if (type_info_it == m_case_insensitive_type_info_map.end()) {
+        NGRAPH_WARN << "Couldn't create operator of type: " << name << " . Operation not registered in opset.";
+        return nullptr;
+    }
+    REGISTER_OP(m_name, name);
+    return m_factory_registry.create(type_info_it->second);
 }
 
 const ov::OpSet& ov::get_opset1() {
-    static OpSet opset;
+    static OpSet opset("opset1");
     static std::once_flag flag;
     std::call_once(flag, [&]() {
-#define _OPENVINO_OP_REG(NAME, NAMESPACE) opset.insert<NAMESPACE::NAME>();
+#define _OPENVINO_OP_REG(NAME, NAMESPACE) INSERT_OP(opset1, NAME, NAMESPACE);
 #include "openvino/opsets/opset1_tbl.hpp"
 #undef _OPENVINO_OP_REG
     });
@@ -41,10 +50,10 @@ const ov::OpSet& ov::get_opset1() {
 }
 
 const ov::OpSet& ov::get_opset2() {
-    static OpSet opset;
+    static OpSet opset("opset2");
     static std::once_flag flag;
     std::call_once(flag, [&]() {
-#define _OPENVINO_OP_REG(NAME, NAMESPACE) opset.insert<NAMESPACE::NAME>();
+#define _OPENVINO_OP_REG(NAME, NAMESPACE) INSERT_OP(opset2, NAME, NAMESPACE);
 #include "openvino/opsets/opset2_tbl.hpp"
 #undef _OPENVINO_OP_REG
     });
@@ -52,10 +61,10 @@ const ov::OpSet& ov::get_opset2() {
 }
 
 const ov::OpSet& ov::get_opset3() {
-    static OpSet opset;
+    static OpSet opset("opset3");
     static std::once_flag flag;
     std::call_once(flag, [&]() {
-#define _OPENVINO_OP_REG(NAME, NAMESPACE) opset.insert<NAMESPACE::NAME>();
+#define _OPENVINO_OP_REG(NAME, NAMESPACE) INSERT_OP(opset3, NAME, NAMESPACE);
 #include "openvino/opsets/opset3_tbl.hpp"
 #undef _OPENVINO_OP_REG
     });
@@ -63,10 +72,10 @@ const ov::OpSet& ov::get_opset3() {
 }
 
 const ov::OpSet& ov::get_opset4() {
-    static OpSet opset;
+    static OpSet opset("opset4");
     static std::once_flag flag;
     std::call_once(flag, [&]() {
-#define _OPENVINO_OP_REG(NAME, NAMESPACE) opset.insert<NAMESPACE::NAME>();
+#define _OPENVINO_OP_REG(NAME, NAMESPACE) INSERT_OP(opset4, NAME, NAMESPACE);
 #include "openvino/opsets/opset4_tbl.hpp"
 #undef _OPENVINO_OP_REG
     });
@@ -74,10 +83,10 @@ const ov::OpSet& ov::get_opset4() {
 }
 
 const ov::OpSet& ov::get_opset5() {
-    static OpSet opset;
+    static OpSet opset("opset5");
     static std::once_flag flag;
     std::call_once(flag, [&]() {
-#define _OPENVINO_OP_REG(NAME, NAMESPACE) opset.insert<NAMESPACE::NAME>();
+#define _OPENVINO_OP_REG(NAME, NAMESPACE) INSERT_OP(opset5, NAME, NAMESPACE);
 #include "openvino/opsets/opset5_tbl.hpp"
 #undef _OPENVINO_OP_REG
     });
@@ -85,10 +94,10 @@ const ov::OpSet& ov::get_opset5() {
 }
 
 const ov::OpSet& ov::get_opset6() {
-    static OpSet opset;
+    static OpSet opset("opset6");
     static std::once_flag flag;
     std::call_once(flag, [&]() {
-#define _OPENVINO_OP_REG(NAME, NAMESPACE) opset.insert<NAMESPACE::NAME>();
+#define _OPENVINO_OP_REG(NAME, NAMESPACE) INSERT_OP(opset6, NAME, NAMESPACE);
 #include "openvino/opsets/opset6_tbl.hpp"
 #undef _OPENVINO_OP_REG
     });
@@ -96,10 +105,10 @@ const ov::OpSet& ov::get_opset6() {
 }
 
 const ov::OpSet& ov::get_opset7() {
-    static OpSet opset;
+    static OpSet opset("opset7");
     static std::once_flag flag;
     std::call_once(flag, [&]() {
-#define _OPENVINO_OP_REG(NAME, NAMESPACE) opset.insert<NAMESPACE::NAME>();
+#define _OPENVINO_OP_REG(NAME, NAMESPACE) INSERT_OP(opset7, NAME, NAMESPACE);
 #include "openvino/opsets/opset7_tbl.hpp"
 #undef _OPENVINO_OP_REG
     });
@@ -107,10 +116,10 @@ const ov::OpSet& ov::get_opset7() {
 }
 
 const ov::OpSet& ov::get_opset8() {
-    static OpSet opset;
+    static OpSet opset("opset8");
     static std::once_flag flag;
     std::call_once(flag, [&]() {
-#define _OPENVINO_OP_REG(NAME, NAMESPACE) opset.insert<NAMESPACE::NAME>();
+#define _OPENVINO_OP_REG(NAME, NAMESPACE) INSERT_OP(opset8, NAME, NAMESPACE);
 #include "openvino/opsets/opset8_tbl.hpp"
 #undef _OPENVINO_OP_REG
     });
@@ -118,10 +127,10 @@ const ov::OpSet& ov::get_opset8() {
 }
 
 const ov::OpSet& ov::get_opset9() {
-    static OpSet opset;
+    static OpSet opset("opset9");
     static std::once_flag flag;
     std::call_once(flag, [&]() {
-#define _OPENVINO_OP_REG(NAME, NAMESPACE) opset.insert<NAMESPACE::NAME>();
+#define _OPENVINO_OP_REG(NAME, NAMESPACE) INSERT_OP(opset9, NAME, NAMESPACE);
 #include "openvino/opsets/opset9_tbl.hpp"
 #undef _OPENVINO_OP_REG
     });

--- a/src/core/src/opsets/opset.cpp
+++ b/src/core/src/opsets/opset.cpp
@@ -5,7 +5,6 @@
 #include "ngraph/opsets/opset.hpp"
 
 #include "../itt.hpp"
-
 #include "ngraph/log.hpp"
 #include "ngraph/ops.hpp"
 

--- a/src/core/tests/conditional_compilation/ngraph_cc_collect.cpp
+++ b/src/core/tests/conditional_compilation/ngraph_cc_collect.cpp
@@ -3,6 +3,9 @@
 //
 
 #include <ngraph/except.hpp>
+#include <openvino/opsets/opset.hpp>
+#include <openvino/op/abs.hpp>
+#include <openvino/op/constant.hpp>
 
 #include "gtest/gtest.h"
 
@@ -24,16 +27,27 @@ TEST(conditional_compilation, collect_op_scope) {
 #define ov_op_Scope0 1
     int n = 0;
 
-    // Simple scope is enabled
+    // Simple Scope0 is enabled
     OV_OP_SCOPE(Scope0);
     n = 42;
     EXPECT_EQ(n, 42);
 
-    // Simple scope is disabled
+    // Simple Scope1 is enabled regardless of macros
     OV_OP_SCOPE(Scope1);
     n = 43;
     EXPECT_EQ(n, 43);
 #undef ov_op_Scope0
+}
+
+TEST(conditional_compilation, collect_ops_in_opset) {
+    ov::OpSet opset("test_opset1");
+    INSERT_OP(test_opset1, Abs, ov::op::v0);
+    EXPECT_NE(opset.create("Abs"), nullptr);
+    EXPECT_NE(opset.create_insensitive("Abs"), nullptr);
+
+    INSERT_OP(test_opset1, Constant, ov::op::v0);
+    EXPECT_NE(opset.create("Constant"), nullptr);
+    EXPECT_NE(opset.create_insensitive("Constant"), nullptr);
 }
 
 #undef SELECTIVE_BUILD_ANALYZER

--- a/src/core/tests/conditional_compilation/ngraph_cc_collect.cpp
+++ b/src/core/tests/conditional_compilation/ngraph_cc_collect.cpp
@@ -3,9 +3,9 @@
 //
 
 #include <ngraph/except.hpp>
-#include <openvino/opsets/opset.hpp>
 #include <openvino/op/abs.hpp>
 #include <openvino/op/constant.hpp>
+#include <openvino/opsets/opset.hpp>
 
 #include "gtest/gtest.h"
 

--- a/src/core/tests/conditional_compilation/ngraph_cc_off.cpp
+++ b/src/core/tests/conditional_compilation/ngraph_cc_off.cpp
@@ -3,9 +3,9 @@
 //
 
 #include <ngraph/except.hpp>
-#include <openvino/opsets/opset.hpp>
 #include <openvino/op/abs.hpp>
 #include <openvino/op/constant.hpp>
+#include <openvino/opsets/opset.hpp>
 
 #include "gtest/gtest.h"
 
@@ -40,7 +40,7 @@ TEST(conditional_compilation, all_ops_enabled_in_opset) {
     INSERT_OP(test_opset2, Abs, ov::op::v0);
     EXPECT_NE(opset.create("Abs"), nullptr);
     EXPECT_NE(opset.create_insensitive("Abs"), nullptr);
-    
+
     INSERT_OP(test_opset2, Constant, ov::op::v0);
     EXPECT_NE(opset.create("Constant"), nullptr);
     EXPECT_NE(opset.create_insensitive("Constant"), nullptr);

--- a/src/core/tests/conditional_compilation/ngraph_cc_off.cpp
+++ b/src/core/tests/conditional_compilation/ngraph_cc_off.cpp
@@ -3,6 +3,9 @@
 //
 
 #include <ngraph/except.hpp>
+#include <openvino/opsets/opset.hpp>
+#include <openvino/op/abs.hpp>
+#include <openvino/op/constant.hpp>
 
 #include "gtest/gtest.h"
 
@@ -21,15 +24,26 @@ using namespace std;
 TEST(conditional_compilation, op_scope_with_disabled_cc) {
     int n = 0;
 
-    // Simple scope is enabled
+    // Simple Scope0 is enabled
     OV_OP_SCOPE(Scope0);
     n = 42;
     EXPECT_EQ(n, 42);
 
-    // Simple scope is disabled
+    // Simple Scope1 is enabled regardless of macros
     OV_OP_SCOPE(Scope1);
     n = 43;
     EXPECT_EQ(n, 43);
+}
+
+TEST(conditional_compilation, all_ops_enabled_in_opset) {
+    ov::OpSet opset("test_opset2");
+    INSERT_OP(test_opset2, Abs, ov::op::v0);
+    EXPECT_NE(opset.create("Abs"), nullptr);
+    EXPECT_NE(opset.create_insensitive("Abs"), nullptr);
+    
+    INSERT_OP(test_opset2, Constant, ov::op::v0);
+    EXPECT_NE(opset.create("Constant"), nullptr);
+    EXPECT_NE(opset.create_insensitive("Constant"), nullptr);
 }
 
 #ifdef SELECTIVE_BUILD_ANALYZER_ON

--- a/src/core/tests/conditional_compilation/ngraph_cc_on.cpp
+++ b/src/core/tests/conditional_compilation/ngraph_cc_on.cpp
@@ -3,6 +3,9 @@
 //
 
 #include <ngraph/except.hpp>
+#include <openvino/opsets/opset.hpp>
+#include <openvino/op/abs.hpp>
+#include <openvino/op/constant.hpp>
 
 #include "gtest/gtest.h"
 
@@ -23,16 +26,28 @@ using namespace std;
 TEST(conditional_compilation, disabled_op_scope) {
 #define ov_op_Scope0 1
     int n = 0;
-    const std::string errMsg = "ngraph_op_Scope1 is disabled!";
 
-    // Simple scope is enabled
+    // Simple Scope0 is enabled
     OV_OP_SCOPE(Scope0);
     n = 42;
     EXPECT_EQ(n, 42);
 
-    // Simple scope is disabled
+    // Simple Scope1 is disabled and throws exception
     ASSERT_THROW(OV_OP_SCOPE(Scope1), ngraph::ngraph_error);
 #undef ov_op_Scope0
+}
+
+TEST(conditional_compilation, disabled_Constant_in_opset) {
+    ov::OpSet opset("test_opset3");
+#define ov_opset_test_opset3_Abs 1
+    INSERT_OP(test_opset3, Abs, ov::op::v0);
+    EXPECT_NE(opset.create("Abs"), nullptr);
+    EXPECT_NE(opset.create_insensitive("Abs"), nullptr);
+#undef ov_opset_test_opset3_Abs    
+
+    INSERT_OP(test_opset3, Constant, ov::op::v0);
+    EXPECT_EQ(opset.create("Constant"), nullptr);
+    EXPECT_EQ(opset.create_insensitive("Constant"), nullptr);
 }
 
 #undef SELECTIVE_BUILD

--- a/src/core/tests/conditional_compilation/ngraph_cc_on.cpp
+++ b/src/core/tests/conditional_compilation/ngraph_cc_on.cpp
@@ -3,9 +3,9 @@
 //
 
 #include <ngraph/except.hpp>
-#include <openvino/opsets/opset.hpp>
 #include <openvino/op/abs.hpp>
 #include <openvino/op/constant.hpp>
+#include <openvino/opsets/opset.hpp>
 
 #include "gtest/gtest.h"
 
@@ -43,7 +43,7 @@ TEST(conditional_compilation, disabled_Constant_in_opset) {
     INSERT_OP(test_opset3, Abs, ov::op::v0);
     EXPECT_NE(opset.create("Abs"), nullptr);
     EXPECT_NE(opset.create_insensitive("Abs"), nullptr);
-#undef ov_opset_test_opset3_Abs    
+#undef ov_opset_test_opset3_Abs
 
     INSERT_OP(test_opset3, Constant, ov::op::v0);
     EXPECT_EQ(opset.create("Constant"), nullptr);


### PR DESCRIPTION
### Details:
- for `cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release -DENABLE_CLDNN=OFF -DENABLE_TESTS=OFF -DENABLE_SAMPLES=ON -DENABLE_PYTHON=OFF -DENABLE_IR_V7_READER=OFF -DENABLE_TEMPLATE=OFF -DENABLE_INTEL_VPU=OFF -DENABLE_OV_ONNX_FRONTEND=OFF -DENABLE_OV_PADDLE_FRONTEND=OFF -DENABLE_OV_IR_FRONTEND=ON -DENABLE_OV_TF_FRONTEND=OFF -DENABLE_SSE42=OFF -DENABLE_AVX2=OFF -DENABLE_AVX512F=OFF -DENABLE_INTEL_GNA=ON -DENABLE_INTEL_CPU=OFF -DENABLE_GAPI_PREPROCESSING=OFF -DENABLE_MULTI=OFF -DENABLE_AUTO=OFF -DENABLE_INTEL_MYRIAD=OFF -DENABLE_INTEL_MYRIAD_COMMON=OFF -DENABLE_AUTO_BATCH=OFF -DENABLE_HETERO=OFF -DENABLE_FASTER_BUILD=ON -DENABLE_PROFILING_ITT=OFF -DSELECTIVE_BUILD=ON -DSELECTIVE_BUILD_STAT=<some.csv> -DBUILD_SHARED_LIBS=OFF ..` CMake options there is a binary size **decrease from 6836 KB to 6429 KB** of benchmark_app (static build, LTO disabled)

### Tickets:
 - CVS-71387
