### PR TITLE
Allow to extra modules by relative path

### DIFF
--- a/cmake/extra_modules.cmake
+++ b/cmake/extra_modules.cmake
@@ -97,6 +97,7 @@ function(register_extra_modules)
     # detect where IE_EXTRA_MODULES contains folders with CMakeLists.txt
     # other folders are supposed to have sub-folders with CMakeLists.txt
     foreach(module_path IN LISTS IE_EXTRA_MODULES)
+        get_filename_component(module_path "${module_path}" ABSOLUTE)
         if(EXISTS "${module_path}/CMakeLists.txt")
             list(APPEND extra_modules "${module_path}")
         elseif(module_path)


### PR DESCRIPTION
### Details:
 - Cmake `if` operator cannot check if file exists using relative paths https://cmake.org/cmake/help/latest/command/if.html#file-operations