### PR TITLE
[GPU] Reduce overhead in device_query

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
@@ -254,6 +254,8 @@ public:
     std::pair<int64_t/*const alloc*/, int64_t/*general alloc*/> get_estimated_device_mem_usage();
 
     void remove_kernel(kernel_id id);
+    bool is_local_block_io_supported() const;
+    void query_local_block_io_supported();
 
 private:
     uint32_t prog_id = 0;
@@ -273,6 +275,7 @@ private:
     std::unique_ptr<pass_manager> pm;
     std::shared_ptr<kernel_selector::TuningCache> tuning_cache;
     bool is_body_program;
+    int8_t is_subgroup_local_block_io_supported;
 
     std::map<primitive_id, std::shared_ptr<program_node>> nodes_map;
     std::list<primitive_id> optimized_out;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
@@ -58,7 +58,7 @@ struct device_info {
     bool supports_subgroups;                    ///< Does engine support cl_intel_subgroups extension.
     bool supports_subgroups_short;              ///< Does engine support cl_intel_subgroups_short extension.
     bool supports_subgroups_char;               ///< Does engine support cl_intel_subgroups_char extension.
-    bool supports_local_block_io;               ///< Does engine support cl_intel_subgroup_local_block_io extension.
+    bool supports_local_block_io;               ///< Does engine support cl_intel_subgroup_local_block_io extension. Check program build with this option.
     bool supports_queue_families;               ///< Does engine support cl_intel_command_queue_families extension.
     bool supports_image;                        ///< Does engine support images (CL_DEVICE_IMAGE_SUPPORT cap).
 

--- a/src/plugins/intel_gpu/src/graph/kernel_selector_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/kernel_selector_helper.cpp
@@ -1006,7 +1006,8 @@ void set_params(const kernel_impl_params& param_info, kernel_selector::params& p
     params.engineInfo.bIMMADSupport = device_info.supports_immad != 0;
     params.engineInfo.bImageSupport = device_info.supports_image != 0;
     params.engineInfo.bOptHintsSupport = false;
-    params.engineInfo.bLocalBlockIOSupport = device_info.supports_local_block_io;
+
+    params.engineInfo.bLocalBlockIOSupport = device_info.supports_local_block_io && program->is_local_block_io_supported();
     params.engineInfo.deviceType = get_device_type(device_info.dev_type);
     params.engineInfo.maxWorkGroupSize = device_info.max_work_group_size;
     params.engineInfo.maxLocalMemSize = device_info.max_local_mem_size;

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -107,9 +107,12 @@ program::program(engine& engine_ref,
       options(options),
       processing_order(),
       tuning_cache(nullptr),
-      is_body_program(is_body_program) {
+      is_body_program(is_body_program),
+      is_subgroup_local_block_io_supported(-1) {
     init_primitives();
     set_options();
+    query_local_block_io_supported();
+
     pm = std::unique_ptr<pass_manager>(new pass_manager(*this));
     prepare_nodes(topology);
     _kernels_cache = std::unique_ptr<kernels_cache>(new kernels_cache(_engine, prog_id,
@@ -117,6 +120,7 @@ program::program(engine& engine_ref,
     _impls_cache = std::unique_ptr<ImplementationsCache>(new ImplementationsCache(_impls_cache_capacity));
     _in_mem_kernels_cache = std::unique_ptr<KernelsCache>(new KernelsCache(_in_mem_kernels_cache_capacity));
     program_node::reset_unique_id();
+
     if (no_optimizations) {
         init_graph();
     } else {
@@ -132,9 +136,12 @@ program::program(engine& engine_ref,
       _stream(_engine.create_stream()),
       options(options),
       processing_order(),
-      tuning_cache(nullptr) {
+      tuning_cache(nullptr),
+      is_subgroup_local_block_io_supported(-1) {
     init_primitives();
     set_options();
+    query_local_block_io_supported();
+
     _kernels_cache = std::unique_ptr<kernels_cache>(new kernels_cache(_engine, prog_id,
                                                                       kernel_selector::KernelBase::get_db().get_batch_header_str()));
     _impls_cache = std::unique_ptr<ImplementationsCache>(new ImplementationsCache(_impls_cache_capacity));
@@ -149,9 +156,10 @@ program::program(engine& engine)
       _stream(_engine.create_stream()),
       options(build_options()),
       processing_order(),
-      tuning_cache(nullptr) { }
-
+      tuning_cache(nullptr),
+      is_subgroup_local_block_io_supported(-1) { }
 program::~program() {
+    query_local_block_io_supported();
 }
 
 void program::init_primitives() {
@@ -463,6 +471,59 @@ void program::set_options() {
 
     if (!options.get<build_option_type::force_implementations>()->forcing.empty()) {
         options.set_option(build_option::optimize_data(true));
+    }
+}
+
+bool program::is_local_block_io_supported() const {
+    if (is_subgroup_local_block_io_supported == -1)
+        throw std::invalid_argument("subgroup_local_block_io_supported has NOT been initialized!");
+
+    return  static_cast<bool>(is_subgroup_local_block_io_supported);
+}
+
+void program::query_local_block_io_supported() {
+    auto& device = _engine.get_device();
+    auto device_info = device->get_info();
+    if (device_info.supports_local_block_io == false)
+        is_subgroup_local_block_io_supported = static_cast<int8_t>(false);
+
+    if (is_subgroup_local_block_io_supported != -1)
+        return;
+
+    std::shared_ptr<kernel_selector::KernelString> kernel_string = std::make_shared<kernel_selector::KernelString>();
+    std::string kernel_code =
+        "__attribute__((intel_reqd_sub_group_size(8)))"
+        "__attribute__((reqd_work_group_size(8, 1, 1)))"
+        "void kernel is_local_block_io_supported(global uchar* dst) {"
+        "    uint lid = get_sub_group_local_id();"
+        "    uchar val = (uchar)lid * 2;"
+        "    __local uchar tmp_slm[8];"
+        "    intel_sub_group_block_write_uc2(tmp_slm, (uchar2)(val));"
+        "    barrier(CLK_LOCAL_MEM_FENCE);"
+        "    uchar2 read = intel_sub_group_block_read_uc2(tmp_slm);"
+        "    dst[lid] = read.s0 + 1;"
+        "}";
+
+    kernel_string->str = kernel_code;
+    kernel_string->options = "-Dcl_intel_subgroup_local_block_io -DLOCAL_BLOCK_IO_SUPPORTED=1";
+    kernel_string->entry_point = "is_local_block_io_supported";
+    kernel_string->batch_compilation = true;
+
+    try {
+        auto _kernels_cache_device_query = std::unique_ptr<kernels_cache>(new kernels_cache(_engine, prog_id,
+                                                                    kernel_selector::KernelBase::get_db().get_batch_header_str()));
+        auto id = _kernels_cache_device_query->set_kernel_source(kernel_string, false);
+        _kernels_cache_device_query->build_all();
+
+        auto kernel = _kernels_cache_device_query->get_kernel(id);
+        bool is_valid = _kernels_cache_device_query->validate_simple_kernel_execution(kernel);
+        is_subgroup_local_block_io_supported = static_cast<int8_t>(is_valid);
+
+        _kernels_cache_device_query->remove_kernel(id);
+        return;
+    } catch (...) {
+        is_subgroup_local_block_io_supported = static_cast<int8_t>(false);
+        return;
     }
 }
 

--- a/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
@@ -4,7 +4,9 @@
 
 #include "kernels_factory.hpp"
 #include "kernels_cache.hpp"
+#include "ocl/ocl_kernel.hpp"
 #include "ocl/ocl_engine.hpp"
+#include "ocl/ocl_common.hpp"
 #include "intel_gpu/runtime/debug_configuration.hpp"
 #include "openvino/util/file_util.hpp"
 
@@ -134,8 +136,10 @@ void kernels_cache::get_program_source(const kernels_code& kernels_source_code, 
         auto& batches = std::get<1>(c.second);
         for (auto& b : batches) {
             std::string full_code = options + " " + _engine.get_device_info().driver_version;
+            full_code += _engine.get_device_info().dev_name;
             for (auto& ss : b.source)
                 full_code += ss;
+
             b.hash_value = std::hash<std::string>()(full_code);
             all_batches->push_back(b);
         }
@@ -236,7 +240,8 @@ void kernels_cache::build_batch(const engine& build_engine, const batch_program&
             cl::Program program(cl_build_engine.get_cl_context(), batch.source);
             {
                 OV_ITT_SCOPED_TASK(itt::domains::CLDNN, "KernelsCache::BuildProgram::RunCompilation");
-                program.build(cl_build_engine.get_cl_device(), batch.options.c_str());
+                if (program.build(cl_build_engine.get_cl_device(), batch.options.c_str()) != CL_SUCCESS)
+                    throw std::runtime_error("Failed in building program.");
             }
 
             if (dump_sources && dump_file.good()) {
@@ -259,9 +264,12 @@ void kernels_cache::build_batch(const engine& build_engine, const batch_program&
             }
         } else {
             cl::Program program(cl_build_engine.get_cl_context(), {cl_build_engine.get_cl_device()}, precompiled_kernels);
-            program.build(cl_build_engine.get_cl_device(), batch.options.c_str());
+            if (program.build(cl_build_engine.get_cl_device(), batch.options.c_str()) != CL_SUCCESS)
+                throw std::runtime_error("Failed in building program with a precompiled kernel.");
+
             program.createKernels(&kernels);
         }
+
         {
             std::lock_guard<std::mutex> lock(_mutex);
             for (auto& k : kernels) {
@@ -325,6 +333,40 @@ kernel::ptr kernels_cache::get_kernel(kernel_id id) const {
     if (_kernels.end() == res)
         throw std::runtime_error("Kernel " + id + " not found in the kernel cache!");
     return res->second;
+}
+
+bool kernels_cache::validate_simple_kernel_execution(kernel::ptr krl) {
+    auto casted = downcast<ocl::ocl_kernel>(krl.get());
+    auto kernel = casted->get_handle();
+    try {
+        auto casted_dev = dynamic_cast<ocl::ocl_device*>(_engine.get_device().get());
+        auto device = casted_dev->get_device();
+        cl::Context ctx(device);
+
+        cl::Buffer buffer(ctx, CL_MEM_READ_WRITE, sizeof(uint8_t) * 8);
+        if (kernel.setArg(0, buffer) != CL_SUCCESS)
+            return false;
+
+        cl::Event ev;
+        cl::CommandQueue queue(ctx, device);
+        if (queue.enqueueNDRangeKernel(kernel, cl::NDRange(), cl::NDRange(8), cl::NDRange(8), nullptr, &ev) != CL_SUCCESS)
+            return false;
+
+        uint8_t result[8];
+        uint8_t expected[8] = { 1, 3, 5, 7, 9, 11, 13, 15 };
+        if (queue.enqueueReadBuffer(buffer, CL_TRUE, 0, sizeof(uint8_t) * 8, &result) != CL_SUCCESS)
+            return false;
+
+        for (int i = 0; i < 8; ++i) {
+            if (result[i] != expected[i])
+                return false;
+        }
+
+        ev.wait();
+        return true;
+    } catch (...) {
+        return false;
+    }
 }
 
 void kernels_cache::build_all() {

--- a/src/plugins/intel_gpu/src/runtime/kernels_cache.hpp
+++ b/src/plugins/intel_gpu/src/runtime/kernels_cache.hpp
@@ -95,6 +95,9 @@ public:
     void set_batch_header_str(const std::vector<std::string> &batch_headers) {
         batch_header_str = std::move(batch_headers);
     }
+
+    bool validate_simple_kernel_execution(kernel::ptr kernel);
+
     // forces compilation of all pending kernels/programs
     void build_all();
     void reset();

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
@@ -33,6 +33,7 @@
 #include <dlfcn.h>
 #endif
 
+
 namespace cldnn {
 namespace ocl {
 
@@ -147,54 +148,6 @@ bool get_imad_support(const cl::Device& device) {
     return false;
 }
 
-bool is_local_block_io_supported(const cl::Device& device) {
-    try {
-        cl_int status = CL_SUCCESS;
-        cl::Context ctx(device);
-        std::string kernel_code =
-            "__attribute__((intel_reqd_sub_group_size(8)))"
-            "__attribute__((reqd_work_group_size(8, 1, 1)))"
-            "void kernel is_local_block_io_supported(global uchar* dst) {"
-            "    uint lid = get_sub_group_local_id();"
-            "    uchar val = (uchar)lid * 2;"
-            "    __local uchar tmp_slm[8];"
-            "    intel_sub_group_block_write_uc2(tmp_slm, (uchar2)(val));"
-            "    barrier(CLK_LOCAL_MEM_FENCE);"
-            "    uchar2 read = intel_sub_group_block_read_uc2(tmp_slm);"
-            "    dst[lid] = read.s0 + 1;"
-            "}";
-        cl::Program program(ctx, kernel_code);
-        if (program.build(device, "-Dcl_intel_subgroup_local_block_io") != CL_SUCCESS)
-            return false;
-        cl::Buffer buffer(ctx, CL_MEM_READ_WRITE, sizeof(uint8_t) * 8);
-        cl::Kernel kernel(program, "is_local_block_io_supported");
-        status = kernel.setArg(0, buffer);
-
-        if (status != CL_SUCCESS)
-            return false;
-
-        cl::Event ev;
-        cl::CommandQueue queue(ctx, device);
-        status = queue.enqueueNDRangeKernel(kernel, cl::NDRange(), cl::NDRange(8), cl::NDRange(8), nullptr, &ev);
-        if (status != CL_SUCCESS)
-            return false;
-        ev.wait();
-
-        uint8_t result[8];
-        uint8_t expected[8] = { 1, 3, 5, 7, 9, 11, 13, 15 };
-        status = queue.enqueueReadBuffer(buffer, CL_TRUE, 0, sizeof(uint8_t) * 8, &result);
-        if (status != CL_SUCCESS)
-            return false;
-        for (int i = 0; i < 8; ++i) {
-            if (result[i] != expected[i])
-                return false;
-        }
-        return true;
-    } catch (...) {
-        return false;
-    }
-}
-
 device_info init_device_info(const cl::Device& device) {
     device_info info = {};
     info.vendor_id = static_cast<uint32_t>(device.getInfo<CL_DEVICE_VENDOR_ID>());
@@ -233,8 +186,7 @@ device_info init_device_info(const cl::Device& device) {
 
     info.supports_usm = extensions.find("cl_intel_unified_shared_memory") != std::string::npos;
 
-    info.supports_local_block_io = extensions.find("cl_intel_subgroup_local_block_io") != std::string::npos &&
-                                   is_local_block_io_supported(device);
+    info.supports_local_block_io = extensions.find("cl_intel_subgroup_local_block_io") != std::string::npos;
 
     info.supports_queue_families = extensions.find("cl_intel_command_queue_families") != std::string::npos;
 


### PR DESCRIPTION
Signed-off-by: Min, Byungil <byungil.min@intel.com>

### Details:
 - remove overhead of is_local_block_io_supported by using cache_dir
 - Add device name to hash_value generation in kernel cache
 - query a device supports is_local_block_io_supported while set_option in program


### Tickets:
 - 92893
