### PR TITLE
[GPU] Fixes for onednn-based impls for dynamic models

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/set_required_layouts.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/set_required_layouts.cpp
@@ -42,7 +42,7 @@ void set_required_layouts::run(program& p) {
 
         // Onednn primitive descriptor creation may fail, for example, due to asymmetric weight.
         try {
-            auto desc = onednn::get_convolution_descriptor(node, dnnl::memory::format_tag::any);
+            auto desc = onednn::get_convolution_descriptor(*node.get_kernel_impl_params(), dnnl::memory::format_tag::any);
             // Note: did not handle attribute properly. especially for zero-point
             dnnl::primitive_desc prim_desc{&desc->data, nullptr, engine.get_onednn_engine(), nullptr};
             auto src_fmt = onednn::find_data_format(prim_desc.src_desc());

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
@@ -78,77 +78,29 @@ public:
 namespace detail {
 
 attach_concatenation_onednn::attach_concatenation_onednn() {
-    implementation_map<concatenation>::add(impl_types::onednn, concatenation_onednn::create, {
-        std::make_tuple(data_types::f32, format::bfyx),
-        std::make_tuple(data_types::f16, format::bfyx),
-        std::make_tuple(data_types::u8, format::bfyx),
-        std::make_tuple(data_types::i8, format::bfyx),
-
-        std::make_tuple(data_types::f32, format::byxf),
-        std::make_tuple(data_types::f16, format::byxf),
-        std::make_tuple(data_types::u8, format::byxf),
-        std::make_tuple(data_types::i8, format::byxf),
-
-        std::make_tuple(data_types::f32, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::f16, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv16),
-
-        std::make_tuple(data_types::f32, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::f16, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv32),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv16_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv32_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv32_fsv32),
-
-        std::make_tuple(data_types::f32, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::f16, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::u8, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::i8, format::b_fs_zyx_fsv16),
-
-        std::make_tuple(data_types::f32, format::b_fs_zyx_fsv32),
-        std::make_tuple(data_types::f16, format::b_fs_zyx_fsv32),
-        std::make_tuple(data_types::u8, format::b_fs_zyx_fsv32),
-        std::make_tuple(data_types::i8, format::b_fs_zyx_fsv32),
-
-        std::make_tuple(data_types::f32, format::bs_fs_zyx_bsv16_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_zyx_bsv16_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_zyx_bsv16_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_zyx_bsv16_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_zyx_bsv32_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_zyx_bsv32_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_zyx_bsv32_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_zyx_bsv32_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_zyx_bsv32_fsv32),
-        std::make_tuple(data_types::f16, format::bs_fs_zyx_bsv32_fsv32),
-        std::make_tuple(data_types::u8, format::bs_fs_zyx_bsv32_fsv32),
-        std::make_tuple(data_types::i8, format::bs_fs_zyx_bsv32_fsv32),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv4_fsv4),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv4_fsv4),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv4_fsv4),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv4_fsv4),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv8_fsv4),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv8_fsv4),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv8_fsv4),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv8_fsv4),
-    });
+    std::vector<data_types> dt = {
+        data_types::f32,
+        data_types::f16,
+        data_types::u8,
+        data_types::i8,
+    };
+    std::vector<format::type> fmt = {
+        format::bfyx,
+        format::byxf,
+        format::b_fs_yx_fsv16,
+        format::b_fs_yx_fsv32,
+        format::bs_fs_yx_bsv16_fsv16,
+        format::bs_fs_yx_bsv32_fsv16,
+        format::bs_fs_yx_bsv32_fsv32,
+        format::b_fs_zyx_fsv16,
+        format::b_fs_zyx_fsv32,
+        format::bs_fs_zyx_bsv16_fsv16,
+        format::bs_fs_zyx_bsv32_fsv16,
+        format::bs_fs_zyx_bsv32_fsv32,
+        format::bs_fs_yx_bsv4_fsv4,
+        format::bs_fs_yx_bsv8_fsv4,
+    };
+    implementation_map<concatenation>::add(impl_types::onednn, concatenation_onednn::create, dt, fmt);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
@@ -45,15 +45,15 @@ protected:
         return args;
     }
 
-    static std::shared_ptr<dnnl::concat::primitive_desc> get_concatenation_descriptor(const concatenation_node& arg) {
-        auto prim = arg.get_primitive();
+    static std::shared_ptr<dnnl::concat::primitive_desc> get_concatenation_descriptor(const kernel_impl_params& impl_params) {
+        auto prim = impl_params.typed_desc<concatenation>();
 
-        auto& engine = arg.get_program().get_engine();
+        auto& engine = impl_params.prog.get_engine();
         std::vector<dnnl::memory::desc> input_mds;
-        for (auto& input : arg.get_dependencies()) {
-            input_mds.push_back(onednn::layout_to_memory_desc(input->get_output_layout()));
+        for (size_t i = 0; i < impl_params.input_layouts.size(); i++) {
+            input_mds.push_back(onednn::layout_to_memory_desc(impl_params.get_input_layout(i)));
         }
-        auto output_md = onednn::layout_to_memory_desc(arg.get_output_layout());
+        auto output_md = onednn::layout_to_memory_desc(impl_params.output_layout);
         return std::make_shared<dnnl::concat::primitive_desc>(
             output_md,
             prim->axis,
@@ -62,15 +62,16 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const concatenation_node& arg, const kernel_impl_params&) {
+    static primitive_impl* create(const concatenation_node& arg, const kernel_impl_params& impl_params) {
+        auto& engine = impl_params.prog.get_engine();
         if (arg.can_be_optimized())
-            return new concatenation_onednn(arg);
-        auto desc = get_concatenation_descriptor(arg);
+            return new concatenation_onednn(engine);
+        auto desc = get_concatenation_descriptor(impl_params);
         auto attr = arg.get_onednn_primitive_attributes();
 
         std::shared_ptr<void> dummy = nullptr;
 
-        return new concatenation_onednn(arg, dummy, attr, *desc);
+        return new concatenation_onednn(engine, dummy, attr, *desc);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
@@ -34,7 +34,7 @@ protected:
     bool validate_impl(const typed_primitive_inst<convolution>& instance) const override {
         bool res = true;
 
-        auto outer_id = _outer.id();
+        auto outer_id = instance.id();
         auto data_type = instance.node.input().get_output_layout().data_type;
 
         // Integer signed/unsigned is ok for convoluiton
@@ -148,23 +148,21 @@ protected:
         return attrs;
     }
 
-    static kernel_selector::WeightsReorderParams get_weights_reorder(const convolution_node& arg, const dnnl::primitive_desc& pd) {
+    static kernel_selector::WeightsReorderParams get_weights_reorder(const kernel_impl_params& impl_params, const dnnl::primitive_desc& pd) {
         kernel_selector::WeightsReorderParams weights_reorder_params;
         auto& reorderKS = kernel_selector::ReorderWeightsKernelSelctor::Instance();
         kernel_selector::reorder_weights_params r_params;
 
-        auto cldnn_prim = arg.get_primitive();
-        auto weights_layout = arg.get_dependency(1).get_output_layout();
-        auto grouped_weights = format::is_grouped(weights_layout.format) || arg.get_primitive()->grouped_weights_shape;
+        auto cldnn_prim = impl_params.typed_desc<convolution>();
+        auto weights_layout = impl_params.get_input_layout(1);
+        auto grouped_weights = format::is_grouped(weights_layout.format) || cldnn_prim->grouped_weights_shape;
         cldnn::format out_fmt = onednn::find_format(pd.weights_desc(0), grouped_weights);
         kernel_selector::WeightsLayout reqLayout = to_weights_layout(out_fmt, cldnn_prim->grouped_weights_shape);
 
-        const auto& param_info = arg.get_kernel_impl_params();
-
-        set_params(*param_info, r_params);
-        r_params.layerID = arg.id() + "_reorder_";
+        set_params(impl_params, r_params);
+        r_params.layerID = cldnn_prim->id + "_reorder_";
         r_params.input = convert_weights_tensor(weights_layout, cldnn_prim->grouped_weights_shape);
-        r_params.output = r_params.input.TransformIgnorePadding(reqLayout, r_params.input.GetDType(), arg.get_groups(), false);
+        r_params.output = r_params.input.TransformIgnorePadding(reqLayout, r_params.input.GetDType(), cldnn_prim->groups, false);
         r_params.rotate_180 = false;
 
         kernel_selector::reorder_optional_params op;
@@ -186,13 +184,13 @@ protected:
 
 
 public:
-    static primitive_impl* create(const convolution_node& arg, const kernel_impl_params&) {
-        auto& engine = arg.get_program().get_engine();
-        auto desc = get_convolution_descriptor(arg);
+    static primitive_impl* create(const convolution_node& arg, const kernel_impl_params& impl_params) {
+        auto& engine = impl_params.prog.get_engine();
+        auto desc = get_convolution_descriptor(impl_params);
         auto attr = get_primitive_attributes(arg);
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return new convolution_onednn(arg, desc, attr, prim_desc, get_weights_reorder(arg, prim_desc));
+        return new convolution_onednn(engine, desc, attr, prim_desc, get_weights_reorder(impl_params, prim_desc));
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
@@ -197,147 +197,43 @@ public:
 namespace detail {
 
 attach_convolution_onednn::attach_convolution_onednn() {
-    implementation_map<convolution>::add(impl_types::onednn, convolution_onednn::create, {
-        std::make_tuple(data_types::f32, format::bfyx),
-        std::make_tuple(data_types::f16, format::bfyx),
-        std::make_tuple(data_types::u8, format::bfyx),
-        std::make_tuple(data_types::i8, format::bfyx),
-
-        std::make_tuple(data_types::f32, format::bfzyx),
-        std::make_tuple(data_types::f16, format::bfzyx),
-        std::make_tuple(data_types::u8, format::bfzyx),
-        std::make_tuple(data_types::i8, format::bfzyx),
-
-        std::make_tuple(data_types::f32, format::byxf),
-        std::make_tuple(data_types::f16, format::byxf),
-        std::make_tuple(data_types::u8, format::byxf),
-        std::make_tuple(data_types::i8, format::byxf),
-
-        std::make_tuple(data_types::f32, format::bzyxf),
-        std::make_tuple(data_types::f16, format::bzyxf),
-        std::make_tuple(data_types::u8, format::bzyxf),
-        std::make_tuple(data_types::i8, format::bzyxf),
-
-        std::make_tuple(data_types::f32, format::b_fs_yx_fsv2),
-        std::make_tuple(data_types::f16, format::b_fs_yx_fsv2),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv2),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv2),
-
-        std::make_tuple(data_types::f32, format::b_fs_zyx_fsv2),
-        std::make_tuple(data_types::f16, format::b_fs_zyx_fsv2),
-        std::make_tuple(data_types::u8, format::b_fs_zyx_fsv2),
-        std::make_tuple(data_types::i8, format::b_fs_zyx_fsv2),
-
-        std::make_tuple(data_types::f32, format::b_fs_yx_fsv4),
-        std::make_tuple(data_types::f16, format::b_fs_yx_fsv4),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv4),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv4),
-
-        std::make_tuple(data_types::f32, format::b_fs_zyx_fsv4),
-        std::make_tuple(data_types::f16, format::b_fs_zyx_fsv4),
-        std::make_tuple(data_types::u8, format::b_fs_zyx_fsv4),
-        std::make_tuple(data_types::i8, format::b_fs_zyx_fsv4),
-
-        std::make_tuple(data_types::f32, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::f16, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv16),
-
-        std::make_tuple(data_types::f32, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::f16, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::u8, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::i8, format::b_fs_zyx_fsv16),
-
-        std::make_tuple(data_types::f32, format::b_fs_zyx_fsv32),
-        std::make_tuple(data_types::f16, format::b_fs_zyx_fsv32),
-        std::make_tuple(data_types::u8, format::b_fs_zyx_fsv32),
-        std::make_tuple(data_types::i8, format::b_fs_zyx_fsv32),
-
-        std::make_tuple(data_types::f32, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::f16, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv32),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv16_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_zyx_bsv16_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_zyx_bsv16_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_zyx_bsv16_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_zyx_bsv16_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv32_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_zyx_bsv32_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_zyx_bsv32_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_zyx_bsv32_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_zyx_bsv32_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv32_fsv32),
-
-        std::make_tuple(data_types::f32, format::bs_fs_zyx_bsv32_fsv32),
-        std::make_tuple(data_types::f16, format::bs_fs_zyx_bsv32_fsv32),
-        std::make_tuple(data_types::u8, format::bs_fs_zyx_bsv32_fsv32),
-        std::make_tuple(data_types::i8, format::bs_fs_zyx_bsv32_fsv32),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv4_fsv4),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv4_fsv4),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv4_fsv4),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv4_fsv4),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv8_fsv4),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv8_fsv4),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv8_fsv4),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv8_fsv4),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv16_fsv4),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv16_fsv4),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv16_fsv4),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv16_fsv4),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv16_fsv2),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv16_fsv2),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv16_fsv2),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv16_fsv2),
-
-        std::make_tuple(data_types::f32, format::bs_fs_zyx_bsv8_fsv4),
-        std::make_tuple(data_types::f16, format::bs_fs_zyx_bsv8_fsv4),
-        std::make_tuple(data_types::u8, format::bs_fs_zyx_bsv8_fsv4),
-        std::make_tuple(data_types::i8, format::bs_fs_zyx_bsv8_fsv4),
-
-        std::make_tuple(data_types::f32, format::bs_fs_zyx_bsv16_fsv4),
-        std::make_tuple(data_types::f16, format::bs_fs_zyx_bsv16_fsv4),
-        std::make_tuple(data_types::u8, format::bs_fs_zyx_bsv16_fsv4),
-        std::make_tuple(data_types::i8, format::bs_fs_zyx_bsv16_fsv4),
-
-        std::make_tuple(data_types::f32, format::bs_fs_zyx_bsv16_fsv2),
-        std::make_tuple(data_types::f16, format::bs_fs_zyx_bsv16_fsv2),
-        std::make_tuple(data_types::u8, format::bs_fs_zyx_bsv16_fsv2),
-        std::make_tuple(data_types::i8, format::bs_fs_zyx_bsv16_fsv2),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv8_fsv2),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv8_fsv2),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv8_fsv2),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv8_fsv2),
-
-        std::make_tuple(data_types::f32, format::bs_fs_zyx_bsv8_fsv2),
-        std::make_tuple(data_types::f16, format::bs_fs_zyx_bsv8_fsv2),
-        std::make_tuple(data_types::u8, format::bs_fs_zyx_bsv8_fsv2),
-        std::make_tuple(data_types::i8, format::bs_fs_zyx_bsv8_fsv2),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv4_fsv2),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv4_fsv2),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv4_fsv2),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv4_fsv2),
-    });
+    std::vector<data_types> dt = {
+        data_types::f32,
+        data_types::f16,
+        data_types::u8,
+        data_types::i8,
+    };
+    std::vector<format::type> fmt = {
+        format::bfyx,
+        format::bfzyx,
+        format::byxf,
+        format::bzyxf,
+        format::b_fs_yx_fsv2,
+        format::b_fs_zyx_fsv2,
+        format::b_fs_yx_fsv4,
+        format::b_fs_zyx_fsv4,
+        format::b_fs_yx_fsv16,
+        format::b_fs_zyx_fsv16,
+        format::b_fs_zyx_fsv32,
+        format::b_fs_yx_fsv32,
+        format::bs_fs_yx_bsv16_fsv16,
+        format::bs_fs_zyx_bsv16_fsv16,
+        format::bs_fs_yx_bsv32_fsv16,
+        format::bs_fs_zyx_bsv32_fsv16,
+        format::bs_fs_yx_bsv32_fsv32,
+        format::bs_fs_zyx_bsv32_fsv32,
+        format::bs_fs_yx_bsv4_fsv4,
+        format::bs_fs_yx_bsv8_fsv4,
+        format::bs_fs_yx_bsv16_fsv4,
+        format::bs_fs_yx_bsv16_fsv2,
+        format::bs_fs_zyx_bsv8_fsv4,
+        format::bs_fs_zyx_bsv16_fsv4,
+        format::bs_fs_zyx_bsv16_fsv2,
+        format::bs_fs_yx_bsv8_fsv2,
+        format::bs_fs_zyx_bsv8_fsv2,
+        format::bs_fs_yx_bsv4_fsv2,
+    };
+    implementation_map<convolution>::add(impl_types::onednn, convolution_onednn::create, dt, fmt);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
@@ -168,62 +168,26 @@ public:
 namespace detail {
 
 attach_deconvolution_onednn::attach_deconvolution_onednn() {
-    implementation_map<deconvolution>::add(impl_types::onednn, deconvolution_onednn::create, {
-        std::make_tuple(data_types::f32, format::bfyx),
-        std::make_tuple(data_types::f16, format::bfyx),
-        std::make_tuple(data_types::u8, format::bfyx),
-        std::make_tuple(data_types::i8, format::bfyx),
-
-        std::make_tuple(data_types::f32, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::f16, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv16),
-
-        std::make_tuple(data_types::f32, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::f16, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv32),
-
-        std::make_tuple(data_types::f32, format::b_fs_zyx_fsv32),
-        std::make_tuple(data_types::f16, format::b_fs_zyx_fsv32),
-        std::make_tuple(data_types::u8, format::b_fs_zyx_fsv32),
-        std::make_tuple(data_types::i8, format::b_fs_zyx_fsv32),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv16_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv32_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv32_fsv32),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv4_fsv4),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv4_fsv4),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv4_fsv4),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv4_fsv4),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv8_fsv4),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv8_fsv4),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv8_fsv4),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv8_fsv4),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv8_fsv2),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv8_fsv2),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv8_fsv2),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv8_fsv2),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv4_fsv2),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv4_fsv2),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv4_fsv2),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv4_fsv2),
-    });
+    std::vector<data_types> dt = {
+        data_types::f32,
+        data_types::f16,
+        data_types::u8,
+        data_types::i8,
+    };
+    std::vector<format::type> fmt = {
+        format::bfyx,
+        format::b_fs_yx_fsv16,
+        format::b_fs_yx_fsv32,
+        format::b_fs_zyx_fsv32,
+        format::bs_fs_yx_bsv16_fsv16,
+        format::bs_fs_yx_bsv32_fsv16,
+        format::bs_fs_yx_bsv32_fsv32,
+        format::bs_fs_yx_bsv4_fsv4,
+        format::bs_fs_yx_bsv8_fsv4,
+        format::bs_fs_yx_bsv8_fsv2,
+        format::bs_fs_yx_bsv4_fsv2,
+    };
+    implementation_map<deconvolution>::add(impl_types::onednn, deconvolution_onednn::create, dt, fmt);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
@@ -29,7 +29,7 @@ protected:
     bool validate_impl(const typed_primitive_inst<deconvolution>& instance) const override {
         bool res = true;
 
-        auto outer_id = _outer.id();
+        auto outer_id = instance.id();
         auto data_type = instance.node.input().get_output_layout().data_type;
 
         // Integer signed/unsigned is ok for convoluiton
@@ -67,23 +67,21 @@ protected:
         return attrs;
     }
 
-    static kernel_selector::WeightsReorderParams get_weights_reorder(const deconvolution_node& arg, const dnnl::primitive_desc& pd) {
+    static kernel_selector::WeightsReorderParams get_weights_reorder(const kernel_impl_params& impl_params, const dnnl::primitive_desc& pd) {
         kernel_selector::WeightsReorderParams weights_reorder_params;
         auto& reorderKS = kernel_selector::ReorderWeightsKernelSelctor::Instance();
         kernel_selector::reorder_weights_params r_params;
 
-        auto cldnn_prim = arg.get_primitive();
-        auto weights_layout = arg.get_dependency(1).get_output_layout();
-        auto grouped_weights = format::is_grouped(weights_layout.format) || arg.get_primitive()->grouped_weights_shape;
+        auto cldnn_prim = impl_params.typed_desc<deconvolution>();
+        auto weights_layout = impl_params.get_input_layout(1);
+        auto grouped_weights = format::is_grouped(weights_layout.format) || cldnn_prim->grouped_weights_shape;
         cldnn::format out_fmt = onednn::find_format(pd.weights_desc(0), grouped_weights);
         kernel_selector::WeightsLayout reqLayout = to_weights_layout(out_fmt, cldnn_prim->grouped_weights_shape);
 
-        const auto& param_info = arg.get_kernel_impl_params();
-
-        set_params(*param_info, r_params);
-        r_params.layerID = arg.id() + "_reorder_";
+        set_params(impl_params, r_params);
+        r_params.layerID = cldnn_prim->id + "_reorder_";
         r_params.input = convert_weights_tensor(weights_layout, cldnn_prim->grouped_weights_shape);
-        r_params.output = r_params.input.TransformIgnorePadding(reqLayout, r_params.input.GetDType(), arg.get_groups(), false);
+        r_params.output = r_params.input.TransformIgnorePadding(reqLayout, r_params.input.GetDType(), cldnn_prim->groups, false);
         r_params.rotate_180 = false;
 
         kernel_selector::reorder_optional_params op;
@@ -102,21 +100,22 @@ protected:
         return weights_reorder_params;
     }
 
-    static std::shared_ptr<dnnl::deconvolution_forward::desc> get_deconvolution_descriptor(const deconvolution_node& arg) {
-        auto prim = arg.get_primitive();
+    static std::shared_ptr<dnnl::deconvolution_forward::desc> get_deconvolution_descriptor(const kernel_impl_params& impl_params) {
+        auto prim = impl_params.typed_desc<deconvolution>();
 
-        auto& input = arg.get_dependency(0);
-        auto& weights = arg.get_dependency(1);
+        auto input_layout = impl_params.get_input_layout(0);
+        auto weights_layout = impl_params.get_input_layout(1);
+        auto output_layout = impl_params.output_layout;
 
         dnnl::memory::dims stride(prim->stride.begin(), prim->stride.end());
-        dnnl::memory::dims dilation(input.get_output_layout().get_spatial_rank(), 1);
+        dnnl::memory::dims dilation(input_layout.get_spatial_rank(), 1);
         dnnl::memory::dims pad_l(prim->pad.begin(), prim->pad.end());
         dnnl::memory::dims pad_r(prim->pad.begin(), prim->pad.end());
 
-        auto input_md = onednn::layout_to_memory_desc(input.get_output_layout());
-        auto weights_md = onednn::layout_to_memory_desc(weights.get_output_layout(), dnnl::memory::format_tag::any);
-        auto output_md = onednn::layout_to_memory_desc(arg.get_output_layout());
-        auto grouped_weights = format::is_grouped(weights.get_output_layout().format) || prim->grouped_weights_shape;
+        auto input_md = onednn::layout_to_memory_desc(input_layout);
+        auto weights_md = onednn::layout_to_memory_desc(weights_layout, dnnl::memory::format_tag::any);
+        auto output_md = onednn::layout_to_memory_desc(output_layout);
+        auto grouped_weights = format::is_grouped(weights_layout.format) || prim->grouped_weights_shape;
 
         for (size_t i = 0; i < dilation.size(); i++) {
             dilation[i]--;
@@ -128,8 +127,8 @@ protected:
             pad_r[i] = (is - 1) * stride[i] - os + kernel_range - pad_l[i];
         }
 
-        if (arg.bias_term()) {
-            auto bias_md = onednn::layout_to_memory_desc(arg.get_dependency(2).get_output_layout(), dnnl::memory::format_tag::any, true);
+        if (!prim->bias.empty()) {
+            auto bias_md = onednn::layout_to_memory_desc(impl_params.get_input_layout(2), dnnl::memory::format_tag::any, true);
             return std::make_shared<dnnl::deconvolution_forward::desc>(
                 dnnl::prop_kind::forward_inference,
                 dnnl::algorithm::deconvolution_direct,
@@ -156,13 +155,13 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const deconvolution_node& arg, const kernel_impl_params&) {
-        auto& engine = arg.get_program().get_engine();
-        auto desc = get_deconvolution_descriptor(arg);
+    static primitive_impl* create(const deconvolution_node& arg, const kernel_impl_params& impl_params) {
+        auto& engine = impl_params.prog.get_engine();
+        auto desc = get_deconvolution_descriptor(impl_params);
         auto attr = get_primitive_attributes(arg);
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return new deconvolution_onednn(arg, desc, attr, prim_desc, get_weights_reorder(arg, prim_desc));
+        return new deconvolution_onednn(engine, desc, attr, prim_desc, get_weights_reorder(impl_params, prim_desc));
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -91,7 +91,7 @@ protected:
         return weights_reorder_params;
     }
 
-    static std::shared_ptr<dnnl::inner_product_forward::desc> get_fully_connected_descriptor( const kernel_impl_params& impl_params) {
+    static std::shared_ptr<dnnl::inner_product_forward::desc> get_fully_connected_descriptor(const kernel_impl_params& impl_params) {
         auto prim = impl_params.typed_desc<fully_connected>();
 
         auto input_layout = impl_params.get_input_layout(0);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -138,17 +138,17 @@ public:
 namespace detail {
 
 attach_fully_connected_onednn::attach_fully_connected_onednn() {
-    implementation_map<fully_connected>::add(impl_types::onednn, fully_connected_onednn::create, {
-        std::make_tuple(data_types::f32, format::bfyx),
-        std::make_tuple(data_types::f16, format::bfyx),
-        std::make_tuple(data_types::u8, format::bfyx),
-        std::make_tuple(data_types::i8, format::bfyx),
-
-        std::make_tuple(data_types::f32, format::bfzyx),
-        std::make_tuple(data_types::f16, format::bfzyx),
-        std::make_tuple(data_types::u8, format::bfzyx),
-        std::make_tuple(data_types::i8, format::bfzyx),
-    });
+    std::vector<data_types> dt = {
+        data_types::f32,
+        data_types::f16,
+        data_types::u8,
+        data_types::i8,
+    };
+    std::vector<format::type> fmt = {
+        format::bfyx,
+        format::bfzyx,
+    };
+    implementation_map<fully_connected>::add(impl_types::onednn, fully_connected_onednn::create, dt, fmt);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
@@ -51,16 +51,13 @@ protected:
         }
     }
 
-    static std::shared_ptr<dnnl::matmul::desc> get_gemm_descriptor(const gemm_node& arg) {
-        auto prim = arg.get_primitive();
+    static std::shared_ptr<dnnl::matmul::desc> get_gemm_descriptor(const kernel_impl_params& impl_params) {
+        auto prim = impl_params.typed_desc<gemm>();
         auto gemm_with_bias = prim->dependencies().size() == 3;
 
-        auto& input0 = arg.get_dependency(0);
-        auto& input1 = arg.get_dependency(1);
-
-        auto in0_l = input0.get_output_layout();
-        auto in1_l = input1.get_output_layout();
-        auto out_l = arg.get_output_layout();
+        auto in0_l = impl_params.get_input_layout(0);
+        auto in1_l = impl_params.get_input_layout(1);
+        auto out_l = impl_params.output_layout;
 
         size_t in0_batched_size = in0_l.count() / (in0_l.spatial(0) * in0_l.spatial(1));
         size_t in1_batched_size = in1_l.count() / (in1_l.spatial(0) * in1_l.spatial(1));
@@ -68,7 +65,7 @@ protected:
 
         auto batched_dims_can_be_removed = in0_batched_size == 1 && in1_batched_size == 1 && out_batched_size == 1;
         if (gemm_with_bias) {
-            auto bias_l = arg.get_dependency(2).get_output_layout();
+            auto bias_l = impl_params.get_input_layout(2);
             size_t bias_batched_size = bias_l.count() / (bias_l.spatial(0) * bias_l.spatial(1));
             batched_dims_can_be_removed &= bias_batched_size == 1;
         }
@@ -102,7 +99,7 @@ protected:
         dnnl::memory::desc out_md(out_dims, out_dt, out_fmt);
 
         if (gemm_with_bias) {
-            auto bias_l = arg.get_dependency(2).get_output_layout();
+            auto bias_l = impl_params.get_input_layout(2);
             auto bias_rank = cldnn::format::dimension(bias_l.format);
             dnnl::memory::data_type bias_dt = onednn::convert_data_type(bias_l.data_type);
             dnnl::memory::dims bias_dims = onednn::convert_gemm_tensor(bias_l.get_tensor(), bias_rank, batched_dims_can_be_removed);
@@ -123,13 +120,13 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const gemm_node& arg, const kernel_impl_params&) {
-        auto& engine = arg.get_program().get_engine();
-        auto desc = get_gemm_descriptor(arg);
+    static primitive_impl* create(const gemm_node& arg, const kernel_impl_params& impl_params) {
+        auto& engine = impl_params.prog.get_engine();
+        auto desc = get_gemm_descriptor(impl_params);
         auto attr = arg.get_onednn_primitive_attributes();
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return new gemm_onednn(arg, desc, attr, prim_desc);
+        return new gemm_onednn(engine, desc, attr, prim_desc);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
@@ -133,22 +133,18 @@ public:
 namespace detail {
 
 attach_gemm_onednn::attach_gemm_onednn() {
-    implementation_map<gemm>::add(impl_types::onednn, gemm_onednn::create, {
-        std::make_tuple(data_types::f32, format::bfyx),
-        std::make_tuple(data_types::f16, format::bfyx),
-        std::make_tuple(data_types::u8, format::bfyx),
-        std::make_tuple(data_types::i8, format::bfyx),
-
-        std::make_tuple(data_types::f32, format::bfzyx),
-        std::make_tuple(data_types::f16, format::bfzyx),
-        std::make_tuple(data_types::u8, format::bfzyx),
-        std::make_tuple(data_types::i8, format::bfzyx),
-
-        std::make_tuple(data_types::f32, format::bfwzyx),
-        std::make_tuple(data_types::f16, format::bfwzyx),
-        std::make_tuple(data_types::u8, format::bfwzyx),
-        std::make_tuple(data_types::i8, format::bfwzyx),
-    });
+    std::vector<data_types> dt = {
+        data_types::f32,
+        data_types::f16,
+        data_types::u8,
+        data_types::i8,
+    };
+    std::vector<format::type> fmt = {
+        format::bfyx,
+        format::bfzyx,
+        format::bfwzyx,
+    };
+    implementation_map<gemm>::add(impl_types::onednn, gemm_onednn::create, dt, fmt);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.cpp
@@ -24,18 +24,19 @@ protected:
         return make_unique<pooling_onednn>(*this);
     }
 
-    static std::shared_ptr<dnnl::pooling_forward::desc> get_pooling_descriptor(const pooling_node& arg) {
-        auto prim = arg.get_primitive();
+    static std::shared_ptr<dnnl::pooling_forward::desc> get_pooling_descriptor(const kernel_impl_params& impl_params) {
+        auto prim = impl_params.typed_desc<pooling>();
 
-        auto& input = arg.get_dependency(0);
+        auto input_layout = impl_params.get_input_layout(0);
+        auto output_layout = impl_params.output_layout;
 
         dnnl::memory::dims stride(prim->stride.begin(), prim->stride.end());
         dnnl::memory::dims kernel(prim->size.begin(), prim->size.end());
         dnnl::memory::dims pad_l(prim->pad.begin(), prim->pad.end());
         dnnl::memory::dims pad_r(prim->pad_end.begin(), prim->pad_end.end());
 
-        auto input_md = onednn::layout_to_memory_desc(input.get_output_layout());
-        auto output_md = onednn::layout_to_memory_desc(arg.get_output_layout());
+        auto input_md = onednn::layout_to_memory_desc(input_layout);
+        auto output_md = onednn::layout_to_memory_desc(output_layout);
 
         if (prim->global_pooling) {
             for (size_t i = 0; i < kernel.size(); i++)
@@ -66,13 +67,13 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const pooling_node& arg, const kernel_impl_params&) {
-        auto& engine = arg.get_program().get_engine();
-        auto desc = get_pooling_descriptor(arg);
+    static primitive_impl* create(const pooling_node& arg, const kernel_impl_params& impl_params) {
+        auto& engine = impl_params.prog.get_engine();
+        auto desc = get_pooling_descriptor(impl_params);
         auto attr = arg.get_onednn_primitive_attributes();
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return new pooling_onednn(arg, desc, attr, prim_desc);
+        return new pooling_onednn(engine, desc, attr, prim_desc);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.cpp
@@ -80,62 +80,27 @@ public:
 namespace detail {
 
 attach_pooling_onednn::attach_pooling_onednn() {
-    implementation_map<pooling>::add(impl_types::onednn, pooling_onednn::create, {
-        std::make_tuple(data_types::f32, format::bfyx),
-        std::make_tuple(data_types::f16, format::bfyx),
-        std::make_tuple(data_types::u8, format::bfyx),
-        std::make_tuple(data_types::i8, format::bfyx),
+    std::vector<data_types> dt = {
+        data_types::f32,
+        data_types::f16,
+        data_types::u8,
+        data_types::i8,
+    };
+    std::vector<format::type> fmt = {
+        format::bfyx,
+        format::b_fs_yx_fsv16,
+        format::b_fs_zyx_fsv16,
+        format::b_fs_yx_fsv32,
+        format::b_fs_zyx_fsv32,
+        format::bs_fs_yx_bsv16_fsv16,
+        format::bs_fs_yx_bsv32_fsv16,
+        format::bs_fs_yx_bsv32_fsv32,
+        format::bs_fs_zyx_bsv16_fsv16,
+        format::bs_fs_zyx_bsv32_fsv16,
+        format::bs_fs_zyx_bsv32_fsv32,
+    };
 
-        std::make_tuple(data_types::f32, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::f16, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv16),
-
-        std::make_tuple(data_types::f32, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::f16, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::u8, format::b_fs_zyx_fsv16),
-        std::make_tuple(data_types::i8, format::b_fs_zyx_fsv16),
-
-        std::make_tuple(data_types::f32, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::f16, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv32),
-
-        std::make_tuple(data_types::f32, format::b_fs_zyx_fsv32),
-        std::make_tuple(data_types::f16, format::b_fs_zyx_fsv32),
-        std::make_tuple(data_types::u8, format::b_fs_zyx_fsv32),
-        std::make_tuple(data_types::i8, format::b_fs_zyx_fsv32),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv16_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv32_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv32_fsv32),
-
-        std::make_tuple(data_types::f32, format::bs_fs_zyx_bsv16_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_zyx_bsv16_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_zyx_bsv16_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_zyx_bsv16_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_zyx_bsv32_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_zyx_bsv32_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_zyx_bsv32_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_zyx_bsv32_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_zyx_bsv32_fsv32),
-        std::make_tuple(data_types::f16, format::bs_fs_zyx_bsv32_fsv32),
-        std::make_tuple(data_types::u8, format::bs_fs_zyx_bsv32_fsv32),
-        std::make_tuple(data_types::i8, format::bs_fs_zyx_bsv32_fsv32),
-    });
+    implementation_map<pooling>::add(impl_types::onednn, pooling_onednn::create, dt, fmt);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
@@ -31,29 +31,29 @@ static std::mutex cacheAccessMutex;
 
 template <class PType, class DescType, class PrimDescType = dnnl::primitive_desc, class PrimType = dnnl::primitive>
 struct typed_primitive_onednn_impl : public typed_primitive_impl<PType> {
-    const typed_program_node<PType>& _outer;
+    const engine& _engine;
     std::shared_ptr<DescType> _desc;
     std::shared_ptr<dnnl::primitive_attr> _attrs;
     PrimDescType _pd;
     PrimType _prim;
     std::unordered_map<uint32_t, std::unordered_map<int, dnnl::memory>> _args;
 
-    typed_primitive_onednn_impl(const typed_program_node<PType>& arg,
+    typed_primitive_onednn_impl(const engine& engine,
                                 std::shared_ptr<DescType> desc,
                                 std::shared_ptr<dnnl::primitive_attr> attrs,
                                 const PrimDescType& pd,
                                 kernel_selector::WeightsReorderParams weights_reorder = {})
         : typed_primitive_impl<PType>(weights_reorder, pd.impl_info_str()),
-          _outer(arg),
+          _engine(engine),
           _desc(desc),
           _attrs(attrs),
           _pd(pd) {
             build_primitive();
         }
 
-    typed_primitive_onednn_impl(const typed_program_node<PType>& arg)
+    typed_primitive_onednn_impl(const engine& engine)
         : typed_primitive_impl<PType>({}, "undef"),
-          _outer(arg),
+          _engine(engine),
           _pd(),
           _prim() {
         assert(arg.can_be_optimized());
@@ -63,7 +63,7 @@ struct typed_primitive_onednn_impl : public typed_primitive_impl<PType> {
 
 private:
     std::string get_cache_directory() const {
-        auto path = _outer.get_program().get_engine().configuration().kernels_cache_path;
+        auto path = _engine.configuration().kernels_cache_path;
         if (path.empty()) {
             return {};
         }

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
@@ -56,7 +56,6 @@ struct typed_primitive_onednn_impl : public typed_primitive_impl<PType> {
           _engine(engine),
           _pd(),
           _prim() {
-        assert(arg.can_be_optimized());
     }
 
     bool is_cpu() const override { return false; }

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reduction_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reduction_onednn.cpp
@@ -98,37 +98,21 @@ public:
 namespace detail {
 
 attach_reduction_onednn::attach_reduction_onednn() {
-    implementation_map<reduce>::add(impl_types::onednn, reduction_onednn::create, {
-        std::make_tuple(data_types::f32, format::bfyx),
-        std::make_tuple(data_types::f16, format::bfyx),
-        std::make_tuple(data_types::u8, format::bfyx),
-        std::make_tuple(data_types::i8, format::bfyx),
+    std::vector<data_types> dt = {
+        data_types::f32,
+        data_types::f16,
+        data_types::u8,
+        data_types::i8,
+    };
+    std::vector<format::type> fmt = {
+        format::b_fs_yx_fsv16,
+        format::b_fs_yx_fsv32,
+        format::bs_fs_yx_bsv16_fsv16,
+        format::bs_fs_yx_bsv32_fsv16,
+        format::bs_fs_yx_bsv32_fsv32,
+    };
 
-        std::make_tuple(data_types::f32, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::f16, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv16),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv16),
-
-        std::make_tuple(data_types::f32, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::f16, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::u8, format::b_fs_yx_fsv32),
-        std::make_tuple(data_types::i8, format::b_fs_yx_fsv32),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv16_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv16_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv32_fsv16),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv32_fsv16),
-
-        std::make_tuple(data_types::f32, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::f16, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::u8, format::bs_fs_yx_bsv32_fsv32),
-        std::make_tuple(data_types::i8, format::bs_fs_yx_bsv32_fsv32),
-    });
+    implementation_map<reduce>::add(impl_types::onednn, reduction_onednn::create, dt, fmt);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
@@ -41,31 +41,33 @@ protected:
         return args;
     }
 
-    static std::shared_ptr<dnnl::reorder::primitive_desc> get_reorder_descriptor(const reorder_node& arg) {
-        auto prim = arg.get_primitive();
+    static std::shared_ptr<dnnl::reorder::primitive_desc> get_reorder_descriptor(const kernel_impl_params& impl_params, const dnnl::primitive_attr& attr) {
+        auto prim = impl_params.typed_desc<reorder>();
 
-        auto& input = arg.get_dependency(0);
-        auto& engine = arg.get_program().get_engine();
+        auto input_layout = impl_params.get_input_layout(0);
+        auto output_layout = impl_params.output_layout;
+        auto& engine = impl_params.prog.get_engine();
 
-        auto input_md = onednn::layout_to_memory_desc(input.get_output_layout());
-        auto output_md = onednn::layout_to_memory_desc(arg.get_output_layout());
+        auto input_md = onednn::layout_to_memory_desc(input_layout);
+        auto output_md = onednn::layout_to_memory_desc(output_layout);
 
         return std::make_shared<dnnl::reorder::primitive_desc>(
             engine.get_onednn_engine(),
             input_md,
             engine.get_onednn_engine(),
             output_md,
-            *(arg.get_onednn_primitive_attributes()));
+            attr);
     }
 
 public:
-    static primitive_impl* create(const reorder_node& arg, const kernel_impl_params&) {
-        auto desc = get_reorder_descriptor(arg);
+    static primitive_impl* create(const reorder_node& arg, const kernel_impl_params& impl_params) {
+        auto& engine = impl_params.prog.get_engine();
         auto attr = arg.get_onednn_primitive_attributes();
+        auto desc = get_reorder_descriptor(impl_params, *attr);
 
         std::shared_ptr<void> dummy = nullptr;
 
-        return new reorder_onednn(arg, dummy, attr, *desc);
+        return new reorder_onednn(engine, dummy, attr, *desc);
     }
 };
 


### PR DESCRIPTION
### Details:
 - Use impl_params instead of program_node in some parts
 - Simplified impls registration
 - Removed program_node reference from onednn base impl class and replaced with engine ref
 - Some fixes in layout optimizer for dynamic bert base via onednn
 - Fixed primitives synchronization for in-order queues before shape inference

### Tickets:
 - *85556*
