### PR TITLE
[CPU] Fixes for static postops after dynamic convolutions

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -1493,7 +1493,7 @@ void Convolution::redefineOutputMemory(const std::vector<VectorDims> &newOutputS
 
 MemoryDescPtr Convolution::getSumMemDesc(primitive_desc_iterator &primitive_desc_it) {
     if (getOutputShapeAtPort(0).isDynamic()) {
-        return DnnlExtensionUtils::makeUndefinedDesc(primitive_desc_it.dst_desc(0), getInputShapeAtPort(getParentEdges().size() - 1));
+        return DnnlExtensionUtils::makeUndefinedDesc(primitive_desc_it.dst_desc(0), getOutputShapeAtPort(0));
     }
     return DnnlExtensionUtils::makeDescriptor(primitive_desc_it.dst_desc(0));
 }

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -128,7 +128,7 @@ void Reorder::initSupportedPrimitiveDescriptors() {
 }
 
 void Reorder::createPrimitive() {
-    if (inputShapesDefined()) {
+    if (shapesDefined()) {
         if (needPrepareParams())
             prepareParams();
         updateLastInputDims();

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_sum_broadcast.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_sum_broadcast.cpp
@@ -321,7 +321,8 @@ InputShape convInpShape = {
         }
 };
 
-InputShape secondInp = {
+const std::vector<InputShape> secondInp = {
+    {
         //dynamic shapes
         {-1, -1, -1, -1},
         { //target static shapes
@@ -331,12 +332,14 @@ InputShape secondInp = {
             {1, 64, 8, 8},
             {1, 64, 8, 1}
         }
+    },
+    {{1, 64, 8, 8}, {{1, 64, 8, 8}}},
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_Conv_Sum_Broadcast_FP32, ConcatConvSumInPlaceTest,
                          ::testing::Combine(
                                  ::testing::Values(convInpShape),
-                                 ::testing::Values(secondInp),
+                                 ::testing::ValuesIn(secondInp),
                                  ::testing::Values(true, false),
                                  ::testing::ValuesIn(fusingParamsSet),
                                  ::testing::Values(cpuEmptyPluginConfig)),
@@ -345,7 +348,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_Sum_Broadcast_FP32, ConcatConvSumInPlaceTest
 INSTANTIATE_TEST_SUITE_P(smoke_Conv_Sum_Broadcast_BF16, ConcatConvSumInPlaceTest,
                          ::testing::Combine(
                                  ::testing::Values(convInpShape),
-                                 ::testing::Values(secondInp),
+                                 ::testing::ValuesIn(secondInp),
                                  ::testing::Values(true, false),
                                  ::testing::ValuesIn(fusingParamsSetBF16),
                                  ::testing::Values(cpuBF16PluginConfig)),
@@ -354,7 +357,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_Sum_Broadcast_BF16, ConcatConvSumInPlaceTest
 INSTANTIATE_TEST_SUITE_P(smoke_Conv_Sum_Broadcast_INT8, ConcatConvSumInPlaceTestInt8,
                          ::testing::Combine(
                                  ::testing::Values(convInpShape),
-                                 ::testing::Values(secondInp),
+                                 ::testing::ValuesIn(secondInp),
                                  ::testing::Values(true, false),
                                  ::testing::ValuesIn(fusingParamsSet),
                                  ::testing::Values(cpuEmptyPluginConfig)),

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_sum_broadcast.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_sum_broadcast.cpp
@@ -333,7 +333,12 @@ const std::vector<InputShape> secondInp = {
             {1, 64, 8, 1}
         }
     },
-    {{1, 64, 8, 8}, {{1, 64, 8, 8}}},
+    {
+        {1, 64, 8, 8},
+        {
+            {1, 64, 8, 8}
+        }
+    },
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_Conv_Sum_Broadcast_FP32, ConcatConvSumInPlaceTest,


### PR DESCRIPTION
### Details:
 - *Convolution: descriptor creation is fixed for case of static add after dynamic convolution*
 - *Reorder: createPrimitive is fixed for case with static input and dynamic output shapes*

### Tickets:
 - *82665*
