### PR TITLE
[CAPI]Remove unreasonable assert in test cases

### DIFF
--- a/src/bindings/c/tests/ov_compiled_model_test.cpp
+++ b/src/bindings/c/tests/ov_compiled_model_test.cpp
@@ -9,7 +9,7 @@ TEST_P(ov_compiled_model, ov_compiled_model_inputs_size) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
@@ -21,7 +21,7 @@ TEST_P(ov_compiled_model, ov_compiled_model_inputs_size) {
 
     size_t input_size;
     OV_EXPECT_OK(ov_compiled_model_inputs_size(compiled_model, &input_size));
-    ASSERT_NE(0, input_size);
+    EXPECT_NE(0, input_size);
 
     ov_compiled_model_free(compiled_model);
     ov_model_free(model);
@@ -32,7 +32,7 @@ TEST_P(ov_compiled_model, ov_compiled_model_input) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
@@ -44,7 +44,7 @@ TEST_P(ov_compiled_model, ov_compiled_model_input) {
 
     ov_output_const_port_t* input_port = nullptr;
     OV_EXPECT_OK(ov_compiled_model_input(compiled_model, &input_port));
-    ASSERT_NE(nullptr, input_port);
+    EXPECT_NE(nullptr, input_port);
 
     ov_output_const_port_free(input_port);
     ov_compiled_model_free(compiled_model);
@@ -56,11 +56,11 @@ TEST_P(ov_compiled_model, ov_compiled_model_input_by_index) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_compiled_model_t* compiled_model = nullptr;
     OV_EXPECT_OK(ov_core_compile_model(core, model, device_name.c_str(), 0, &compiled_model));
@@ -68,10 +68,10 @@ TEST_P(ov_compiled_model, ov_compiled_model_input_by_index) {
 
     ov_output_const_port_t* input_port = nullptr;
     OV_EXPECT_OK(ov_compiled_model_input_by_index(compiled_model, 0, &input_port));
-    ASSERT_NE(nullptr, input_port);
+    EXPECT_NE(nullptr, input_port);
 
     ov_shape_t shape;
-    OV_EXPECT_OK(ov_const_port_get_shape(input_port, &shape));
+    OV_ASSERT_OK(ov_const_port_get_shape(input_port, &shape));
     ov_shape_free(&shape);
 
     ov_output_const_port_free(input_port);
@@ -84,11 +84,11 @@ TEST_P(ov_compiled_model, ov_compiled_model_input_by_name) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_compiled_model_t* compiled_model = nullptr;
     OV_EXPECT_OK(ov_core_compile_model(core, model, device_name.c_str(), 0, &compiled_model));
@@ -96,10 +96,10 @@ TEST_P(ov_compiled_model, ov_compiled_model_input_by_name) {
 
     ov_output_const_port_t* input_port = nullptr;
     OV_EXPECT_OK(ov_compiled_model_input_by_name(compiled_model, "data", &input_port));
-    ASSERT_NE(nullptr, input_port);
+    EXPECT_NE(nullptr, input_port);
 
     ov_shape_t shape;
-    OV_EXPECT_OK(ov_const_port_get_shape(input_port, &shape));
+    OV_ASSERT_OK(ov_const_port_get_shape(input_port, &shape));
     ov_shape_free(&shape);
 
     ov_output_const_port_free(input_port);
@@ -113,7 +113,7 @@ TEST_P(ov_compiled_model, set_and_get_property) {
     auto device_name = "MULTI:GPU,CPU";
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     char* info = nullptr;
     const char* key_0 = ov_property_key_available_devices;
@@ -151,7 +151,7 @@ TEST_P(ov_compiled_model, get_property) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
@@ -175,7 +175,7 @@ TEST_P(ov_compiled_model, create_compiled_model_with_property) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
@@ -200,7 +200,7 @@ TEST_P(ov_compiled_model, ov_compiled_model_outputs_size) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
@@ -212,7 +212,7 @@ TEST_P(ov_compiled_model, ov_compiled_model_outputs_size) {
 
     size_t output_size;
     OV_EXPECT_OK(ov_compiled_model_outputs_size(compiled_model, &output_size));
-    ASSERT_NE(0, output_size);
+    EXPECT_NE(0, output_size);
 
     ov_compiled_model_free(compiled_model);
     ov_model_free(model);
@@ -223,7 +223,7 @@ TEST_P(ov_compiled_model, ov_compiled_model_output) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
@@ -235,7 +235,7 @@ TEST_P(ov_compiled_model, ov_compiled_model_output) {
 
     ov_output_const_port_t* output_port = nullptr;
     OV_EXPECT_OK(ov_compiled_model_output(compiled_model, &output_port));
-    ASSERT_NE(nullptr, output_port);
+    EXPECT_NE(nullptr, output_port);
 
     ov_output_const_port_free(output_port);
     ov_compiled_model_free(compiled_model);
@@ -247,11 +247,11 @@ TEST_P(ov_compiled_model, ov_compiled_model_output_by_index) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_compiled_model_t* compiled_model = nullptr;
     OV_EXPECT_OK(ov_core_compile_model(core, model, device_name.c_str(), 0, &compiled_model));
@@ -259,10 +259,10 @@ TEST_P(ov_compiled_model, ov_compiled_model_output_by_index) {
 
     ov_output_const_port_t* output_port = nullptr;
     OV_EXPECT_OK(ov_compiled_model_output_by_index(compiled_model, 0, &output_port));
-    ASSERT_NE(nullptr, output_port);
+    EXPECT_NE(nullptr, output_port);
 
     ov_shape_t shape;
-    OV_EXPECT_OK(ov_const_port_get_shape(output_port, &shape));
+    OV_ASSERT_OK(ov_const_port_get_shape(output_port, &shape));
     ov_shape_free(&shape);
 
     ov_output_const_port_free(output_port);
@@ -275,11 +275,11 @@ TEST_P(ov_compiled_model, ov_compiled_model_output_by_name) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_compiled_model_t* compiled_model = nullptr;
     OV_EXPECT_OK(ov_core_compile_model(core, model, device_name.c_str(), 0, &compiled_model));
@@ -287,10 +287,10 @@ TEST_P(ov_compiled_model, ov_compiled_model_output_by_name) {
 
     ov_output_const_port_t* output_port = nullptr;
     OV_EXPECT_OK(ov_compiled_model_output_by_name(compiled_model, "fc_out", &output_port));
-    ASSERT_NE(nullptr, output_port);
+    EXPECT_NE(nullptr, output_port);
 
     ov_shape_t shape;
-    OV_EXPECT_OK(ov_const_port_get_shape(output_port, &shape));
+    OV_ASSERT_OK(ov_const_port_get_shape(output_port, &shape));
     ov_shape_free(&shape);
 
     ov_output_const_port_free(output_port);
@@ -303,7 +303,7 @@ TEST_P(ov_compiled_model, get_runtime_model) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
@@ -327,7 +327,7 @@ TEST_P(ov_compiled_model, get_runtime_model_error_handling) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
@@ -351,7 +351,7 @@ TEST_P(ov_compiled_model, create_infer_request) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
@@ -375,7 +375,7 @@ TEST_P(ov_compiled_model, create_infer_request_error_handling) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));

--- a/src/bindings/c/tests/ov_core_test.cpp
+++ b/src/bindings/c/tests/ov_core_test.cpp
@@ -25,25 +25,25 @@ INSTANTIATE_TEST_SUITE_P(device_name, ov_core, ::testing::Values("CPU"));
 TEST(ov_core, ov_core_create_with_config) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create_with_config(plugins_xml, &core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
     ov_core_free(core);
 }
 
 TEST(ov_core, ov_core_create_with_no_config) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
     ov_core_free(core);
 }
 
 TEST(ov_core, ov_core_read_model) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_model_free(model);
     ov_core_free(core);
@@ -52,11 +52,11 @@ TEST(ov_core, ov_core_read_model) {
 TEST(ov_core, ov_core_read_model_no_bin) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, nullptr, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_model_free(model);
     ov_core_free(core);
@@ -65,7 +65,7 @@ TEST(ov_core, ov_core_read_model_no_bin) {
 TEST(ov_core, ov_core_read_model_from_memory) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     std::vector<uint8_t> weights_content(content_from_file(bin, true));
 
@@ -74,13 +74,13 @@ TEST(ov_core, ov_core_read_model_from_memory) {
     int64_t dims[2] = {1, (int64_t)weights_content.size()};
     ov_shape_create(2, dims, &shape);
     OV_EXPECT_OK(ov_tensor_create_from_host_ptr(ov_element_type_e::U8, shape, weights_content.data(), &tensor));
-    ASSERT_NE(nullptr, tensor);
+    EXPECT_NE(nullptr, tensor);
 
     std::vector<uint8_t> xml_content(content_from_file(xml, false));
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(
         ov_core_read_model_from_memory(core, reinterpret_cast<const char*>(xml_content.data()), tensor, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_shape_free(&shape);
     ov_tensor_free(tensor);
@@ -92,15 +92,15 @@ TEST_P(ov_core, ov_core_compile_model) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, nullptr, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_compiled_model_t* compiled_model = nullptr;
     OV_EXPECT_OK(ov_core_compile_model(core, model, device_name.c_str(), 0, &compiled_model));
-    ASSERT_NE(nullptr, compiled_model);
+    EXPECT_NE(nullptr, compiled_model);
 
     ov_compiled_model_free(compiled_model);
     ov_model_free(model);
@@ -111,17 +111,17 @@ TEST_P(ov_core, ov_core_compile_model_with_property) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, nullptr, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_compiled_model_t* compiled_model = nullptr;
     const char* key = ov_property_key_num_streams;
     const char* num = "11";
     OV_EXPECT_OK(ov_core_compile_model(core, model, device_name.c_str(), 2, &compiled_model, key, num));
-    ASSERT_NE(nullptr, compiled_model);
+    EXPECT_NE(nullptr, compiled_model);
 
     char* property_value = nullptr;
     OV_EXPECT_OK(ov_compiled_model_get_property(compiled_model, key, &property_value));
@@ -137,11 +137,11 @@ TEST_P(ov_core, ov_core_compile_model_with_property_invalid) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, nullptr, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_compiled_model_t* compiled_model = nullptr;
     const char* key = ov_property_key_num_streams;
@@ -158,11 +158,11 @@ TEST_P(ov_core, ov_core_compile_model_from_file) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_compiled_model_t* compiled_model = nullptr;
     OV_EXPECT_OK(ov_core_compile_model_from_file(core, xml, device_name.c_str(), 0, &compiled_model));
-    ASSERT_NE(nullptr, compiled_model);
+    EXPECT_NE(nullptr, compiled_model);
 
     ov_compiled_model_free(compiled_model);
     ov_core_free(core);
@@ -172,7 +172,7 @@ TEST_P(ov_core, ov_core_set_property_enum) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     const char* key = ov_property_key_log_level;
     const char* mode = "WARNING";
@@ -185,7 +185,7 @@ TEST_P(ov_core, ov_core_set_property_invalid_number_property_arguments) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     const char* key_1 = ov_property_key_inference_num_threads;
     const char* value_1 = "12";
@@ -208,7 +208,7 @@ TEST_P(ov_core, ov_core_set_property_enum_invalid) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     const char* key = ov_property_key_hint_performance_mode;
     const char* mode = "LATENCY";
@@ -231,7 +231,7 @@ TEST_P(ov_core, ov_core_set_and_get_property_enum) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     const char* key = ov_property_key_affinity;
     const char* affinity = "HYBRID_AWARE";
@@ -256,7 +256,7 @@ TEST_P(ov_core, ov_core_set_and_get_property_bool) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     const char* key = ov_property_key_enable_profiling;
     const char* enable = "YES";
@@ -273,7 +273,7 @@ TEST_P(ov_core, ov_core_set_and_get_property_bool_invalid) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     const char* key = ov_property_key_enable_profiling;
     const char* enable = "TEST";
@@ -291,7 +291,7 @@ TEST_P(ov_core, ov_core_get_property) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     char* property_value;
     OV_EXPECT_OK(
@@ -304,7 +304,7 @@ TEST_P(ov_core, ov_core_set_get_property_str) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     const char* key = ov_property_key_cache_dir;
     const char cache_dir[] = "./cache_dir";
@@ -323,7 +323,7 @@ TEST_P(ov_core, ov_core_set_get_property_int) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     const char* key = ov_property_key_inference_num_threads;
     const char* num = "8";
@@ -341,7 +341,7 @@ TEST_P(ov_core, ov_core_set_property_int_invalid) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     const char* key = ov_property_key_inference_num_threads;
     OV_EXPECT_OK(ov_core_set_property(core, device_name.c_str(), key, "abc"));
@@ -357,7 +357,7 @@ TEST_P(ov_core, ov_core_set_multiple_common_properties) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     // Test enum
     const char* key_1 = ov_property_key_hint_performance_mode;
@@ -404,7 +404,7 @@ TEST_P(ov_core, ov_core_set_multiple_common_properties) {
 TEST(ov_core, ov_core_get_available_devices) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_available_devices_t devices;
     OV_EXPECT_OK(ov_core_get_available_devices(core, &devices));
@@ -417,11 +417,11 @@ TEST_P(ov_core, ov_compiled_model_export_model) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_compiled_model_t* compiled_model = nullptr;
     OV_EXPECT_OK(ov_core_compile_model_from_file(core, xml, device_name.c_str(), 0, &compiled_model));
-    ASSERT_NE(nullptr, compiled_model);
+    EXPECT_NE(nullptr, compiled_model);
 
     std::string export_path = TestDataHelpers::generate_model_path("test_model", "exported_model.blob");
     OV_EXPECT_OK(ov_compiled_model_export_model(compiled_model, export_path.c_str()));
@@ -435,11 +435,11 @@ TEST_P(ov_core, ov_core_import_model) {
     ov_core_t* core = nullptr;
 
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_compiled_model_t* compiled_model = nullptr;
     OV_EXPECT_OK(ov_core_compile_model_from_file(core, xml, device_name.c_str(), 0, &compiled_model));
-    ASSERT_NE(nullptr, compiled_model);
+    EXPECT_NE(nullptr, compiled_model);
 
     std::string export_path = TestDataHelpers::generate_model_path("test_model", "exported_model.blob");
     OV_EXPECT_OK(ov_compiled_model_export_model(compiled_model, export_path.c_str()));
@@ -452,7 +452,7 @@ TEST_P(ov_core, ov_core_import_model) {
                                       buffer.size(),
                                       device_name.c_str(),
                                       &compiled_model_imported));
-    ASSERT_NE(nullptr, compiled_model_imported);
+    EXPECT_NE(nullptr, compiled_model_imported);
     ov_compiled_model_free(compiled_model_imported);
     ov_core_free(core);
 }
@@ -461,7 +461,7 @@ TEST_P(ov_core, ov_core_get_versions_by_device_name) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_core_version_list_t version_list;
     OV_EXPECT_OK(ov_core_get_versions_by_device_name(core, device_name.c_str(), &version_list));
@@ -480,8 +480,8 @@ TEST(ov_core, ov_core_create_with_config_unicode) {
         std::wstring plugins_xml_ws = add_unicode_postfix_to_path(plugins_xml, postfix);
         ASSERT_EQ(true, copy_file(plugins_xml, plugins_xml_ws));
 
-        OV_ASSERT_OK(ov_core_create_with_config_unicode(plugins_xml_ws.c_str(), &core));
-        ASSERT_NE(nullptr, core);
+        OV_EXPECT_OK(ov_core_create_with_config_unicode(plugins_xml_ws.c_str(), &core));
+        EXPECT_NE(nullptr, core);
         remove_file_ws(plugins_xml_ws);
         ov_core_free(core);
     }
@@ -489,8 +489,8 @@ TEST(ov_core, ov_core_create_with_config_unicode) {
 
 TEST(ov_core, ov_core_read_model_unicode) {
     ov_core_t* core = nullptr;
-    OV_ASSERT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    OV_EXPECT_OK(ov_core_create(&core));
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     for (std::size_t index = 0; index < test_unicode_postfix_vector.size(); index++) {
@@ -501,8 +501,8 @@ TEST(ov_core, ov_core_read_model_unicode) {
         ASSERT_EQ(true, copy_file(xml, xml_ws));
         ASSERT_EQ(true, copy_file(bin, bin_ws));
 
-        OV_ASSERT_OK(ov_core_read_model_unicode(core, xml_ws.c_str(), bin_ws.c_str(), &model));
-        ASSERT_NE(nullptr, model);
+        OV_EXPECT_OK(ov_core_read_model_unicode(core, xml_ws.c_str(), bin_ws.c_str(), &model));
+        EXPECT_NE(nullptr, model);
         remove_file_ws(xml_ws);
         remove_file_ws(bin_ws);
 
@@ -515,8 +515,8 @@ TEST(ov_core, ov_core_read_model_unicode) {
 TEST_P(ov_core, ov_core_compile_model_from_file_unicode) {
     auto device_name = GetParam();
     ov_core_t* core = nullptr;
-    OV_ASSERT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    OV_EXPECT_OK(ov_core_create(&core));
+    EXPECT_NE(nullptr, core);
 
     ov_compiled_model_t* compiled_model = nullptr;
     for (std::size_t index = 0; index < test_unicode_postfix_vector.size(); index++) {
@@ -526,9 +526,9 @@ TEST_P(ov_core, ov_core_compile_model_from_file_unicode) {
         ASSERT_EQ(true, copy_file(xml, xml_ws));
         ASSERT_EQ(true, copy_file(bin, bin_ws));
 
-        OV_ASSERT_OK(
+        OV_EXPECT_OK(
             ov_core_compile_model_from_file_unicode(core, xml_ws.c_str(), device_name.c_str(), 0, &compiled_model));
-        ASSERT_NE(nullptr, compiled_model);
+        EXPECT_NE(nullptr, compiled_model);
         remove_file_ws(xml_ws);
         remove_file_ws(bin_ws);
         ov_compiled_model_free(compiled_model);

--- a/src/bindings/c/tests/ov_infer_request_test.cpp
+++ b/src/bindings/c/tests/ov_infer_request_test.cpp
@@ -17,7 +17,7 @@ inline void get_tensor_info(ov_model_t* model, bool input, char** name, ov_shape
     OV_EXPECT_OK(ov_port_get_any_name(port, name));
     EXPECT_NE(nullptr, *name);
 
-    OV_EXPECT_OK(ov_const_port_get_shape(port, shape));
+    OV_ASSERT_OK(ov_const_port_get_shape(port, shape));
     OV_EXPECT_OK(ov_port_get_element_type(port, type));
 
     ov_partial_shape_t p_shape;
@@ -41,7 +41,7 @@ protected:
         infer_request = nullptr;
 
         OV_EXPECT_OK(ov_core_create(&core));
-        ASSERT_NE(nullptr, core);
+        EXPECT_NE(nullptr, core);
 
         OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
         EXPECT_NE(nullptr, model);
@@ -106,18 +106,18 @@ protected:
         infer_request = nullptr;
 
         OV_EXPECT_OK(ov_core_create(&core));
-        ASSERT_NE(nullptr, core);
+        EXPECT_NE(nullptr, core);
 
         OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
         EXPECT_NE(nullptr, model);
 
-        OV_ASSERT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
+        OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
         EXPECT_NE(nullptr, preprocess);
 
-        OV_ASSERT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
+        OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
         EXPECT_NE(nullptr, input_info);
 
-        OV_ASSERT_OK(ov_preprocess_input_info_get_tensor_info(input_info, &input_tensor_info));
+        OV_EXPECT_OK(ov_preprocess_input_info_get_tensor_info(input_info, &input_tensor_info));
         EXPECT_NE(nullptr, input_tensor_info);
 
         ov_shape_t shape = {0, nullptr};
@@ -134,13 +134,13 @@ protected:
         OV_EXPECT_OK(ov_preprocess_input_tensor_info_set_layout(input_tensor_info, layout));
         ov_layout_free(layout);
 
-        OV_ASSERT_OK(ov_preprocess_input_info_get_preprocess_steps(input_info, &input_process));
-        ASSERT_NE(nullptr, input_process);
+        OV_EXPECT_OK(ov_preprocess_input_info_get_preprocess_steps(input_info, &input_process));
+        EXPECT_NE(nullptr, input_process);
         OV_EXPECT_OK(
             ov_preprocess_preprocess_steps_resize(input_process, ov_preprocess_resize_algorithm_e::RESIZE_LINEAR));
 
         OV_EXPECT_OK(ov_preprocess_input_info_get_model_info(input_info, &input_model));
-        ASSERT_NE(nullptr, input_model);
+        EXPECT_NE(nullptr, input_model);
 
         const char* model_layout_desc = "NCHW";
         OV_EXPECT_OK(ov_layout_create(model_layout_desc, &model_layout));

--- a/src/bindings/c/tests/ov_model_test.cpp
+++ b/src/bindings/c/tests/ov_model_test.cpp
@@ -6,15 +6,15 @@
 TEST(ov_model, ov_model_const_input) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_output_const_port_t* input_port = nullptr;
     OV_EXPECT_OK(ov_model_const_input(model, &input_port));
-    ASSERT_NE(nullptr, input_port);
+    EXPECT_NE(nullptr, input_port);
 
     ov_output_const_port_free(input_port);
     ov_model_free(model);
@@ -24,18 +24,18 @@ TEST(ov_model, ov_model_const_input) {
 TEST(ov_model, ov_model_const_input_by_name) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_output_const_port_t* input_port = nullptr;
     OV_EXPECT_OK(ov_model_const_input_by_name(model, "data", &input_port));
-    ASSERT_NE(nullptr, input_port);
+    EXPECT_NE(nullptr, input_port);
 
     ov_shape_t shape;
-    OV_EXPECT_OK(ov_const_port_get_shape(input_port, &shape));
+    OV_ASSERT_OK(ov_const_port_get_shape(input_port, &shape));
     ov_shape_free(&shape);
 
     ov_output_const_port_free(input_port);
@@ -46,18 +46,18 @@ TEST(ov_model, ov_model_const_input_by_name) {
 TEST(ov_model, ov_model_const_input_by_index) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_output_const_port_t* input_port = nullptr;
     OV_EXPECT_OK(ov_model_const_input_by_index(model, 0, &input_port));
-    ASSERT_NE(nullptr, input_port);
+    EXPECT_NE(nullptr, input_port);
 
     ov_shape_t shape;
-    OV_EXPECT_OK(ov_const_port_get_shape(input_port, &shape));
+    OV_ASSERT_OK(ov_const_port_get_shape(input_port, &shape));
     ov_shape_free(&shape);
 
     ov_output_const_port_free(input_port);
@@ -68,15 +68,15 @@ TEST(ov_model, ov_model_const_input_by_index) {
 TEST(ov_model, ov_model_input) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_output_port_t* input_port = nullptr;
     OV_EXPECT_OK(ov_model_input(model, &input_port));
-    ASSERT_NE(nullptr, input_port);
+    EXPECT_NE(nullptr, input_port);
 
     ov_output_port_free(input_port);
     ov_model_free(model);
@@ -86,18 +86,18 @@ TEST(ov_model, ov_model_input) {
 TEST(ov_model, ov_model_input_by_name) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_output_port_t* input_port = nullptr;
     OV_EXPECT_OK(ov_model_input_by_name(model, "data", &input_port));
-    ASSERT_NE(nullptr, input_port);
+    EXPECT_NE(nullptr, input_port);
 
     ov_shape_t shape;
-    OV_EXPECT_OK(ov_port_get_shape(input_port, &shape));
+    OV_ASSERT_OK(ov_port_get_shape(input_port, &shape));
     ov_shape_free(&shape);
 
     ov_output_port_free(input_port);
@@ -108,18 +108,18 @@ TEST(ov_model, ov_model_input_by_name) {
 TEST(ov_model, ov_model_input_by_index) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_output_port_t* input_port = nullptr;
     OV_EXPECT_OK(ov_model_input_by_index(model, 0, &input_port));
-    ASSERT_NE(nullptr, input_port);
+    EXPECT_NE(nullptr, input_port);
 
     ov_shape_t shape;
-    OV_EXPECT_OK(ov_port_get_shape(input_port, &shape));
+    OV_ASSERT_OK(ov_port_get_shape(input_port, &shape));
     ov_shape_free(&shape);
 
     ov_output_port_free(input_port);
@@ -130,15 +130,15 @@ TEST(ov_model, ov_model_input_by_index) {
 TEST(ov_model, ov_model_const_output) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_output_const_port_t* output_port = nullptr;
     OV_EXPECT_OK(ov_model_const_output(model, &output_port));
-    ASSERT_NE(nullptr, output_port);
+    EXPECT_NE(nullptr, output_port);
 
     ov_output_const_port_free(output_port);
     ov_model_free(model);
@@ -148,18 +148,18 @@ TEST(ov_model, ov_model_const_output) {
 TEST(ov_model, ov_model_const_output_by_index) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_output_const_port_t* output_port = nullptr;
     OV_EXPECT_OK(ov_model_const_output_by_index(model, 0, &output_port));
-    ASSERT_NE(nullptr, output_port);
+    EXPECT_NE(nullptr, output_port);
 
     ov_shape_t shape;
-    OV_EXPECT_OK(ov_const_port_get_shape(output_port, &shape));
+    OV_ASSERT_OK(ov_const_port_get_shape(output_port, &shape));
     ov_shape_free(&shape);
 
     ov_output_const_port_free(output_port);
@@ -170,18 +170,18 @@ TEST(ov_model, ov_model_const_output_by_index) {
 TEST(ov_model, ov_model_const_output_by_name) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_output_const_port_t* output_port = nullptr;
     OV_EXPECT_OK(ov_model_const_output_by_name(model, "fc_out", &output_port));
-    ASSERT_NE(nullptr, output_port);
+    EXPECT_NE(nullptr, output_port);
 
     ov_shape_t shape;
-    OV_EXPECT_OK(ov_const_port_get_shape(output_port, &shape));
+    OV_ASSERT_OK(ov_const_port_get_shape(output_port, &shape));
     ov_shape_free(&shape);
 
     ov_output_const_port_free(output_port);
@@ -192,15 +192,15 @@ TEST(ov_model, ov_model_const_output_by_name) {
 TEST(ov_model, ov_model_output) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_output_port_t* output_port = nullptr;
     OV_EXPECT_OK(ov_model_output(model, &output_port));
-    ASSERT_NE(nullptr, output_port);
+    EXPECT_NE(nullptr, output_port);
 
     ov_output_port_free(output_port);
     ov_model_free(model);
@@ -210,18 +210,18 @@ TEST(ov_model, ov_model_output) {
 TEST(ov_model, ov_model_output_by_index) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_output_port_t* output_port = nullptr;
     OV_EXPECT_OK(ov_model_output_by_index(model, 0, &output_port));
-    ASSERT_NE(nullptr, output_port);
+    EXPECT_NE(nullptr, output_port);
 
     ov_shape_t shape;
-    OV_EXPECT_OK(ov_port_get_shape(output_port, &shape));
+    OV_ASSERT_OK(ov_port_get_shape(output_port, &shape));
     ov_shape_free(&shape);
 
     ov_output_port_free(output_port);
@@ -232,18 +232,18 @@ TEST(ov_model, ov_model_output_by_index) {
 TEST(ov_model, ov_model_output_by_name) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_output_port_t* output_port = nullptr;
     OV_EXPECT_OK(ov_model_output_by_name(model, "fc_out", &output_port));
-    ASSERT_NE(nullptr, output_port);
+    EXPECT_NE(nullptr, output_port);
 
     ov_shape_t shape;
-    OV_EXPECT_OK(ov_port_get_shape(output_port, &shape));
+    OV_ASSERT_OK(ov_port_get_shape(output_port, &shape));
     ov_shape_free(&shape);
 
     ov_output_port_free(output_port);
@@ -254,15 +254,15 @@ TEST(ov_model, ov_model_output_by_name) {
 TEST(ov_model, ov_model_inputs_size) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     size_t input_size;
     OV_EXPECT_OK(ov_model_inputs_size(model, &input_size));
-    ASSERT_NE(0, input_size);
+    EXPECT_NE(0, input_size);
 
     ov_model_free(model);
     ov_core_free(core);
@@ -271,15 +271,15 @@ TEST(ov_model, ov_model_inputs_size) {
 TEST(ov_model, ov_model_outputs_size) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     size_t output_size;
     OV_EXPECT_OK(ov_model_outputs_size(model, &output_size));
-    ASSERT_NE(0, output_size);
+    EXPECT_NE(0, output_size);
 
     ov_model_free(model);
     ov_core_free(core);
@@ -288,13 +288,13 @@ TEST(ov_model, ov_model_outputs_size) {
 TEST(ov_model, ov_model_is_dynamic) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
-    ASSERT_NO_THROW(ov_model_is_dynamic(model));
+    EXPECT_NO_THROW(ov_model_is_dynamic(model));
 
     ov_model_free(model);
     ov_core_free(core);
@@ -303,15 +303,15 @@ TEST(ov_model, ov_model_is_dynamic) {
 TEST(ov_model, ov_model_reshape_input_by_name) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_output_const_port_t* input_port_1 = nullptr;
     OV_EXPECT_OK(ov_model_const_input(model, &input_port_1));
-    ASSERT_NE(nullptr, input_port_1);
+    EXPECT_NE(nullptr, input_port_1);
 
     char* tensor_name = nullptr;
     OV_EXPECT_OK(ov_port_get_any_name(input_port_1, &tensor_name));
@@ -326,7 +326,7 @@ TEST(ov_model, ov_model_reshape_input_by_name) {
 
     ov_output_const_port_t* input_port_2 = nullptr;
     OV_EXPECT_OK(ov_model_const_input(model, &input_port_2));
-    ASSERT_NE(nullptr, input_port_2);
+    EXPECT_NE(nullptr, input_port_2);
 
     EXPECT_NE(input_port_1, input_port_2);
 
@@ -342,15 +342,15 @@ TEST(ov_model, ov_model_reshape_input_by_name) {
 TEST(ov_model, ov_model_get_friendly_name) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     char* friendly_name = nullptr;
     OV_EXPECT_OK(ov_model_get_friendly_name(model, &friendly_name));
-    ASSERT_NE(nullptr, friendly_name);
+    EXPECT_NE(nullptr, friendly_name);
 
     ov_free(friendly_name);
     ov_model_free(model);

--- a/src/bindings/c/tests/ov_preprocess_test.cpp
+++ b/src/bindings/c/tests/ov_preprocess_test.cpp
@@ -6,15 +6,15 @@
 TEST(ov_preprocess, ov_preprocess_prepostprocessor_create) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_prepostprocessor_free(preprocess);
     ov_model_free(model);
@@ -24,19 +24,19 @@ TEST(ov_preprocess, ov_preprocess_prepostprocessor_create) {
 TEST(ov_preprocess, ov_preprocess_prepostprocessor_get_input_info) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info(preprocess, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_input_info_free(input_info);
     ov_preprocess_prepostprocessor_free(preprocess);
@@ -47,19 +47,19 @@ TEST(ov_preprocess, ov_preprocess_prepostprocessor_get_input_info) {
 TEST(ov_preprocess, ov_preprocess_prepostprocessor_get_input_info_by_name) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_name(preprocess, "data", &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_input_info_free(input_info);
     ov_preprocess_prepostprocessor_free(preprocess);
@@ -70,19 +70,19 @@ TEST(ov_preprocess, ov_preprocess_prepostprocessor_get_input_info_by_name) {
 TEST(ov_preprocess, ov_preprocess_prepostprocessor_get_input_info_by_index) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_input_info_free(input_info);
     ov_preprocess_prepostprocessor_free(preprocess);
@@ -93,23 +93,23 @@ TEST(ov_preprocess, ov_preprocess_prepostprocessor_get_input_info_by_index) {
 TEST(ov_preprocess, ov_preprocess_input_info_get_tensor_info) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_input_tensor_info_t* input_tensor_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_tensor_info(input_info, &input_tensor_info));
-    ASSERT_NE(nullptr, input_tensor_info);
+    EXPECT_NE(nullptr, input_tensor_info);
 
     ov_preprocess_input_tensor_info_free(input_tensor_info);
     ov_preprocess_input_info_free(input_info);
@@ -121,23 +121,23 @@ TEST(ov_preprocess, ov_preprocess_input_info_get_tensor_info) {
 TEST(ov_preprocess, ov_preprocess_input_info_get_preprocess_steps) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_preprocess_steps_t* input_process = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_preprocess_steps(input_info, &input_process));
-    ASSERT_NE(nullptr, input_process);
+    EXPECT_NE(nullptr, input_process);
 
     ov_preprocess_preprocess_steps_free(input_process);
     ov_preprocess_input_info_free(input_info);
@@ -149,23 +149,23 @@ TEST(ov_preprocess, ov_preprocess_input_info_get_preprocess_steps) {
 TEST(ov_preprocess, ov_preprocess_preprocess_steps_resize) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_preprocess_steps_t* input_process = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_preprocess_steps(input_info, &input_process));
-    ASSERT_NE(nullptr, input_process);
+    EXPECT_NE(nullptr, input_process);
 
     OV_EXPECT_OK(ov_preprocess_preprocess_steps_resize(input_process, ov_preprocess_resize_algorithm_e::RESIZE_LINEAR));
 
@@ -179,23 +179,23 @@ TEST(ov_preprocess, ov_preprocess_preprocess_steps_resize) {
 TEST(ov_preprocess, ov_preprocess_input_tensor_info_set_element_type) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_input_tensor_info_t* input_tensor_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_tensor_info(input_info, &input_tensor_info));
-    ASSERT_NE(nullptr, input_tensor_info);
+    EXPECT_NE(nullptr, input_tensor_info);
 
     OV_EXPECT_OK(ov_preprocess_input_tensor_info_set_element_type(input_tensor_info, ov_element_type_e::F32));
 
@@ -209,23 +209,23 @@ TEST(ov_preprocess, ov_preprocess_input_tensor_info_set_element_type) {
 TEST(ov_preprocess, ov_preprocess_input_tensor_info_set_from) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_input_tensor_info_t* input_tensor_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_tensor_info(input_info, &input_tensor_info));
-    ASSERT_NE(nullptr, input_tensor_info);
+    EXPECT_NE(nullptr, input_tensor_info);
 
     ov_tensor_t* tensor = nullptr;
     ov_shape_t shape;
@@ -246,23 +246,23 @@ TEST(ov_preprocess, ov_preprocess_input_tensor_info_set_from) {
 TEST(ov_preprocess, ov_preprocess_input_tensor_info_set_layout) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_input_tensor_info_t* input_tensor_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_tensor_info(input_info, &input_tensor_info));
-    ASSERT_NE(nullptr, input_tensor_info);
+    EXPECT_NE(nullptr, input_tensor_info);
 
     ov_layout_t* layout = nullptr;
     const char* input_layout_desc = "NCHW";
@@ -280,23 +280,23 @@ TEST(ov_preprocess, ov_preprocess_input_tensor_info_set_layout) {
 TEST(ov_preprocess, ov_preprocess_input_tensor_info_set_color_format) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_input_tensor_info_t* input_tensor_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_tensor_info(input_info, &input_tensor_info));
-    ASSERT_NE(nullptr, input_tensor_info);
+    EXPECT_NE(nullptr, input_tensor_info);
 
     OV_EXPECT_OK(
         ov_preprocess_input_tensor_info_set_color_format(input_tensor_info, ov_color_format_e::NV12_SINGLE_PLANE));
@@ -311,23 +311,23 @@ TEST(ov_preprocess, ov_preprocess_input_tensor_info_set_color_format) {
 TEST(ov_preprocess, ov_preprocess_input_tensor_info_set_spatial_static_shape) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_input_tensor_info_t* input_tensor_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_tensor_info(input_info, &input_tensor_info));
-    ASSERT_NE(nullptr, input_tensor_info);
+    EXPECT_NE(nullptr, input_tensor_info);
 
     size_t input_height = 500;
     size_t input_width = 500;
@@ -344,27 +344,27 @@ TEST(ov_preprocess, ov_preprocess_input_tensor_info_set_spatial_static_shape) {
 TEST(ov_preprocess, ov_preprocess_preprocess_steps_convert_element_type) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_preprocess_steps_t* input_process = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_preprocess_steps(input_info, &input_process));
-    ASSERT_NE(nullptr, input_process);
+    EXPECT_NE(nullptr, input_process);
 
     ov_preprocess_input_tensor_info_t* input_tensor_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_tensor_info(input_info, &input_tensor_info));
-    ASSERT_NE(nullptr, input_tensor_info);
+    EXPECT_NE(nullptr, input_tensor_info);
 
     OV_EXPECT_OK(ov_preprocess_input_tensor_info_set_element_type(input_tensor_info, ov_element_type_e::U8));
     OV_EXPECT_OK(ov_preprocess_preprocess_steps_convert_element_type(input_process, ov_element_type_e::F32));
@@ -380,27 +380,27 @@ TEST(ov_preprocess, ov_preprocess_preprocess_steps_convert_element_type) {
 TEST(ov_preprocess, ov_preprocess_preprocess_steps_convert_color) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_preprocess_steps_t* input_process = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_preprocess_steps(input_info, &input_process));
-    ASSERT_NE(nullptr, input_process);
+    EXPECT_NE(nullptr, input_process);
 
     ov_preprocess_input_tensor_info_t* input_tensor_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_tensor_info(input_info, &input_tensor_info));
-    ASSERT_NE(nullptr, input_tensor_info);
+    EXPECT_NE(nullptr, input_tensor_info);
 
     OV_EXPECT_OK(
         ov_preprocess_input_tensor_info_set_color_format(input_tensor_info, ov_color_format_e::NV12_SINGLE_PLANE));
@@ -417,19 +417,19 @@ TEST(ov_preprocess, ov_preprocess_preprocess_steps_convert_color) {
 TEST(ov_preprocess, ov_preprocess_prepostprocessor_get_output_info) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_output_info_t* output_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_output_info(preprocess, &output_info));
-    ASSERT_NE(nullptr, output_info);
+    EXPECT_NE(nullptr, output_info);
 
     ov_preprocess_output_info_free(output_info);
     ov_preprocess_prepostprocessor_free(preprocess);
@@ -440,19 +440,19 @@ TEST(ov_preprocess, ov_preprocess_prepostprocessor_get_output_info) {
 TEST(ov_preprocess, ov_preprocess_prepostprocessor_get_output_info_by_index) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_output_info_t* output_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_output_info_by_index(preprocess, 0, &output_info));
-    ASSERT_NE(nullptr, output_info);
+    EXPECT_NE(nullptr, output_info);
 
     ov_preprocess_output_info_free(output_info);
     ov_preprocess_prepostprocessor_free(preprocess);
@@ -463,19 +463,19 @@ TEST(ov_preprocess, ov_preprocess_prepostprocessor_get_output_info_by_index) {
 TEST(ov_preprocess, ov_preprocess_prepostprocessor_get_output_info_by_name) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_output_info_t* output_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_output_info_by_name(preprocess, "fc_out", &output_info));
-    ASSERT_NE(nullptr, output_info);
+    EXPECT_NE(nullptr, output_info);
 
     ov_preprocess_output_info_free(output_info);
     ov_preprocess_prepostprocessor_free(preprocess);
@@ -486,23 +486,23 @@ TEST(ov_preprocess, ov_preprocess_prepostprocessor_get_output_info_by_name) {
 TEST(ov_preprocess, ov_preprocess_output_info_get_tensor_info) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_output_info_t* output_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_output_info_by_index(preprocess, 0, &output_info));
-    ASSERT_NE(nullptr, output_info);
+    EXPECT_NE(nullptr, output_info);
 
     ov_preprocess_output_tensor_info_t* output_tensor_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_output_info_get_tensor_info(output_info, &output_tensor_info));
-    ASSERT_NE(nullptr, output_tensor_info);
+    EXPECT_NE(nullptr, output_tensor_info);
 
     ov_preprocess_output_tensor_info_free(output_tensor_info);
     ov_preprocess_output_info_free(output_info);
@@ -514,23 +514,23 @@ TEST(ov_preprocess, ov_preprocess_output_info_get_tensor_info) {
 TEST(ov_preprocess, ov_preprocess_output_set_element_type) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_output_info_t* output_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_output_info_by_index(preprocess, 0, &output_info));
-    ASSERT_NE(nullptr, output_info);
+    EXPECT_NE(nullptr, output_info);
 
     ov_preprocess_output_tensor_info_t* output_tensor_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_output_info_get_tensor_info(output_info, &output_tensor_info));
-    ASSERT_NE(nullptr, output_tensor_info);
+    EXPECT_NE(nullptr, output_tensor_info);
 
     OV_EXPECT_OK(ov_preprocess_output_set_element_type(output_tensor_info, ov_element_type_e::F32));
 
@@ -544,23 +544,23 @@ TEST(ov_preprocess, ov_preprocess_output_set_element_type) {
 TEST(ov_preprocess, ov_preprocess_input_info_get_model_info) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_input_model_info_t* input_model = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_model_info(input_info, &input_model));
-    ASSERT_NE(nullptr, input_model);
+    EXPECT_NE(nullptr, input_model);
 
     ov_preprocess_input_model_info_free(input_model);
     ov_preprocess_input_info_free(input_info);
@@ -572,23 +572,23 @@ TEST(ov_preprocess, ov_preprocess_input_info_get_model_info) {
 TEST(ov_preprocess, ov_preprocess_input_model_info_set_layout) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_input_model_info_t* input_model = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_model_info(input_info, &input_model));
-    ASSERT_NE(nullptr, input_model);
+    EXPECT_NE(nullptr, input_model);
 
     ov_layout_t* layout = nullptr;
     const char* layout_desc = "NCHW";
@@ -606,19 +606,19 @@ TEST(ov_preprocess, ov_preprocess_input_model_info_set_layout) {
 TEST(ov_preprocess, ov_preprocess_prepostprocessor_build) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_model_t* new_model = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_build(preprocess, &new_model));
-    ASSERT_NE(nullptr, new_model);
+    EXPECT_NE(nullptr, new_model);
 
     ov_model_free(new_model);
     ov_preprocess_prepostprocessor_free(preprocess);
@@ -629,23 +629,23 @@ TEST(ov_preprocess, ov_preprocess_prepostprocessor_build) {
 TEST(ov_preprocess, ov_preprocess_prepostprocessor_build_apply) {
     ov_core_t* core = nullptr;
     OV_EXPECT_OK(ov_core_create(&core));
-    ASSERT_NE(nullptr, core);
+    EXPECT_NE(nullptr, core);
 
     ov_model_t* model = nullptr;
     OV_EXPECT_OK(ov_core_read_model(core, xml, bin, &model));
-    ASSERT_NE(nullptr, model);
+    EXPECT_NE(nullptr, model);
 
     ov_preprocess_prepostprocessor_t* preprocess = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_create(model, &preprocess));
-    ASSERT_NE(nullptr, preprocess);
+    EXPECT_NE(nullptr, preprocess);
 
     ov_preprocess_input_info_t* input_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_input_info_by_index(preprocess, 0, &input_info));
-    ASSERT_NE(nullptr, input_info);
+    EXPECT_NE(nullptr, input_info);
 
     ov_preprocess_input_tensor_info_t* input_tensor_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_tensor_info(input_info, &input_tensor_info));
-    ASSERT_NE(nullptr, input_tensor_info);
+    EXPECT_NE(nullptr, input_tensor_info);
     ov_tensor_t* tensor = nullptr;
     ov_shape_t shape;
     int64_t dims[4] = {1, 416, 416, 3};
@@ -662,12 +662,12 @@ TEST(ov_preprocess, ov_preprocess_prepostprocessor_build_apply) {
 
     ov_preprocess_preprocess_steps_t* input_process = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_preprocess_steps(input_info, &input_process));
-    ASSERT_NE(nullptr, input_process);
+    EXPECT_NE(nullptr, input_process);
     OV_EXPECT_OK(ov_preprocess_preprocess_steps_resize(input_process, ov_preprocess_resize_algorithm_e::RESIZE_LINEAR));
 
     ov_preprocess_input_model_info_t* input_model = nullptr;
     OV_EXPECT_OK(ov_preprocess_input_info_get_model_info(input_info, &input_model));
-    ASSERT_NE(nullptr, input_model);
+    EXPECT_NE(nullptr, input_model);
 
     const char* model_layout_desc = "NCHW";
     ov_layout_t* model_layout = nullptr;
@@ -677,15 +677,15 @@ TEST(ov_preprocess, ov_preprocess_prepostprocessor_build_apply) {
 
     ov_preprocess_output_info_t* output_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_get_output_info_by_index(preprocess, 0, &output_info));
-    ASSERT_NE(nullptr, output_info);
+    EXPECT_NE(nullptr, output_info);
     ov_preprocess_output_tensor_info_t* output_tensor_info = nullptr;
     OV_EXPECT_OK(ov_preprocess_output_info_get_tensor_info(output_info, &output_tensor_info));
-    ASSERT_NE(nullptr, output_tensor_info);
+    EXPECT_NE(nullptr, output_tensor_info);
     OV_EXPECT_OK(ov_preprocess_output_set_element_type(output_tensor_info, ov_element_type_e::F32));
 
     ov_model_t* new_model = nullptr;
     OV_EXPECT_OK(ov_preprocess_prepostprocessor_build(preprocess, &new_model));
-    ASSERT_NE(nullptr, new_model);
+    EXPECT_NE(nullptr, new_model);
 
     ov_preprocess_input_tensor_info_free(input_tensor_info);
     ov_tensor_free(tensor);


### PR DESCRIPTION
### Details:
 - Remove unnecessary assert to keep test going on even it reports failure 
 - Keep reasonable assert to avoid segment fault

### Tickets:
 - *ticket-id*
