### PR TITLE
The additional compiler flags were added for CI consistency.

### DIFF
--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 set(TARGET_NAME "openvino_intel_cpu_plugin")
 
 if(CMAKE_COMPILER_IS_GNUCC)
-    ie_add_compiler_flags(-Wno-all)
+    ie_add_compiler_flags(-Wno-all -Werror -Wundef -Wreturn-type -Wunused-variable -Wunused-value -Wswitch -Wformat -Wformat-security)
 endif()
 
 if (WIN32)


### PR DESCRIPTION
The build_macos_release  CI check has additional compiler flags. These flags were added for the GNUCC compiler also. So building errors on this CI check could be detected on the ubuntu environment also.
