### PR TITLE
Skip of 2 failing ONNX CumSum tests

### DIFF
--- a/tests/layer_tests/onnx_tests/test_cumsum.py
+++ b/tests/layer_tests/onnx_tests/test_cumsum.py
@@ -256,6 +256,8 @@ class TestCumSum(OnnxRuntimeLayerTest):
                     use_old_api):
         if 'axis' not in params:
             pytest.skip('No axis cases fail in ONNX')
+        elif 'axis' in params and params['axis'] == -2 and exclusive == 1:
+            pytest.skip('Disabled due to an exception thrown by ONNXRuntime for this use case')
         self._test(
             *self.create_net(**params, exclusive=exclusive, reverse=reverse, ir_version=ir_version),
             ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
@@ -268,6 +270,8 @@ class TestCumSum(OnnxRuntimeLayerTest):
                           temp_dir, use_old_api):
         if 'axis' not in params:
             pytest.skip('No axis cases fail in ONNX')
+        elif 'axis' in params and params['axis'] == -2 and exclusive == 1:
+            pytest.skip('Disabled due to an exception thrown by ONNXRuntime for this use case')
         self._test(*self.create_net_const(**params, precision=precision, exclusive=exclusive,
                                           reverse=reverse,
                                           ir_version=ir_version), ie_device, precision, ir_version,


### PR DESCRIPTION
### Details:
 - 2 tests have been temporarily skipped because the reference framework throws an exception
 - Follow-up by creating an issue in ONNXRT and re-enable those tests when the issue is fixed

### Tickets:
 - 89997
