### PR TITLE
[MO, Common] Fix SplitConcatPairToInterpolateFusion transformation

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/split_concat_pair_to_interpolate_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/split_concat_pair_to_interpolate_fusion.cpp
@@ -69,6 +69,11 @@ std::pair<std::shared_ptr<ngraph::opset8::Split>, uint64_t> get_split_before_con
 
     // If 'split' node has more than one consumer, then the transformation is not applicable.
     for (const auto& output : split->outputs()) {
+        // if there is 'split' output port with no consumers,
+        // SplitConcatPairToInterpolateFusion is not applicable
+        if (output.get_target_inputs().empty()) {
+            return {};
+        }
         for (const auto& consumer : output.get_target_inputs()) {
             if (consumer.get_node() != concat.get())
                 return {};

--- a/src/tests/functional/inference_engine/transformations/common_optimizations/split_concat_pair_to_interpolate_fusion_test.cpp
+++ b/src/tests/functional/inference_engine/transformations/common_optimizations/split_concat_pair_to_interpolate_fusion_test.cpp
@@ -707,22 +707,4 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSplitWithEmptyPor
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{concat}, ngraph::ParameterVector{input1});
         manager.register_pass<ngraph::pass::SplitConcatPairToInterpolateFusion>();
     }
-    {
-        auto input1 = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 96, 96});
-
-        auto split1_axis = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {axis});
-        auto split1 = std::make_shared<ngraph::opset8::Split>(input1, split1_axis, num_splits);
-
-        auto concat_const1 = ngraph::opset8::Constant::create(ngraph::element::f32,
-                                                              ngraph::Shape{1, 1, 96, 96},
-                                                              std::vector<float>(96 * 96, 0));
-        auto concat_const2 = ngraph::opset8::Constant::create(ngraph::element::f32,
-                                                              ngraph::Shape{1, 1, 96, 96},
-                                                              std::vector<float>(96 * 96, 0));
-
-        ngraph::OutputVector concat_inputs_vec{split1->output(0), concat_const1, concat_const2};
-
-        auto concat = std::make_shared<ngraph::opset8::Concat>(concat_inputs_vec, axis);
-        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{concat}, ngraph::ParameterVector{input1});
-    }
 }

--- a/src/tests/functional/inference_engine/transformations/common_optimizations/split_concat_pair_to_interpolate_fusion_test.cpp
+++ b/src/tests/functional/inference_engine/transformations/common_optimizations/split_concat_pair_to_interpolate_fusion_test.cpp
@@ -682,3 +682,47 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial3D2Dynamic
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ interpolate }, ngraph::ParameterVector{ input });
     }
 }
+
+TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSplitWithEmptyPorts) {
+    // it covers a case with Split node of which some outputs ports are disconnected
+    // in this case the transformation is not applied
+    size_t num_splits = 3;
+    int64_t axis = 1;
+    {
+        auto input1 = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 96, 96});
+
+        auto split1_axis = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {axis});
+        auto split1 = std::make_shared<ngraph::opset8::Split>(input1, split1_axis, num_splits);
+
+        auto concat_const1 = ngraph::opset8::Constant::create(ngraph::element::f32,
+                                                              ngraph::Shape{1, 1, 96, 96},
+                                                              std::vector<float>(96 * 96, 0));
+        auto concat_const2 = ngraph::opset8::Constant::create(ngraph::element::f32,
+                                                              ngraph::Shape{1, 1, 96, 96},
+                                                              std::vector<float>(96 * 96, 0));
+
+        ngraph::OutputVector concat_inputs_vec{split1->output(0), concat_const1, concat_const2};
+
+        auto concat = std::make_shared<ngraph::opset8::Concat>(concat_inputs_vec, axis);
+        function = std::make_shared<ngraph::Function>(ngraph::NodeVector{concat}, ngraph::ParameterVector{input1});
+        manager.register_pass<ngraph::pass::SplitConcatPairToInterpolateFusion>();
+    }
+    {
+        auto input1 = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 96, 96});
+
+        auto split1_axis = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {axis});
+        auto split1 = std::make_shared<ngraph::opset8::Split>(input1, split1_axis, num_splits);
+
+        auto concat_const1 = ngraph::opset8::Constant::create(ngraph::element::f32,
+                                                              ngraph::Shape{1, 1, 96, 96},
+                                                              std::vector<float>(96 * 96, 0));
+        auto concat_const2 = ngraph::opset8::Constant::create(ngraph::element::f32,
+                                                              ngraph::Shape{1, 1, 96, 96},
+                                                              std::vector<float>(96 * 96, 0));
+
+        ngraph::OutputVector concat_inputs_vec{split1->output(0), concat_const1, concat_const2};
+
+        auto concat = std::make_shared<ngraph::opset8::Concat>(concat_inputs_vec, axis);
+        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{concat}, ngraph::ParameterVector{input1});
+    }
+}

--- a/tools/mo/openvino/tools/mo/front/common/partial_infer/utils.py
+++ b/tools/mo/openvino/tools/mo/front/common/partial_infer/utils.py
@@ -329,7 +329,11 @@ def reverse_bypass_infer(node, in_ports: List[int]):
     :param in_ports: input ports for which shape will be updated
     :return:
     """
-    assert node.is_out_port_connected(0)
+    # WA: for cases when terminal Identity node have output control dependency edges
+    # For this case the graph is not correctly build because Identity nodes go
+    # without Result nodes
+    if node.out_port(0).disconnected():
+        return
 
     output_shape = node.out_port(0).data.get_shape()
     if output_shape is not None:

--- a/tools/mo/openvino/tools/mo/front/common/partial_infer/utils.py
+++ b/tools/mo/openvino/tools/mo/front/common/partial_infer/utils.py
@@ -329,9 +329,9 @@ def reverse_bypass_infer(node, in_ports: List[int]):
     :param in_ports: input ports for which shape will be updated
     :return:
     """
-    # WA: for cases when terminal Identity node have output control dependency edges
-    # For this case the graph is not correctly build because Identity nodes go
-    # without Result nodes
+    # WA: for cases when terminal Identity node has only output control dependency edges
+    # For this case the graph is not correctly build because the Identity node goes
+    # without Result node
     if node.out_port(0).disconnected():
         return
 


### PR DESCRIPTION
**Details:** It fixes a case when Split goes with disconnected output port. For this case, this transformation must not be applied.

**Ticket:** 91813

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>

