### PR TITLE
DOCS: Fix pot best practices for 22.2

### DIFF
--- a/tools/pot/docs/BestPractices.md
+++ b/tools/pot/docs/BestPractices.md
@@ -44,10 +44,14 @@ The Default Quantization algorithm provides multiple hyperparameters which can b
 Below is a list of best practices that can be applied to improve accuracy without a substantial performance reduction with respect to default settings:
 1.  The first recommended option is to change the `preset` from `performance` to `mixed`. This enables asymmetric quantization of 
 activations and can be helpful for models with non-ReLU activation functions, for example, YOLO, EfficientNet, etc.
+
 2.  The next option is `use_fast_bias`. Setting this option to `false` enables a different bias correction method which is more accurate, in general,
 and applied after model quantization as a part of the Default Quantization algorithm.
+
    > **NOTE**: Changing this option can substantially increase quantization time in the POT tool.
+
 3.  Some model architectures require a special approach when being quantized. For example, Transformer-based models need to keep some operations in the original precision to preserve accuracy. That is why POT provides a `model_type` option to specify the model architecture. Now, only `"transformer"` type is available. Use it to quantize Transformer-based models, e.g. BERT.
+
 4.  Another important option is a `range_estimator`. It defines how to calculate the minimum and maximum of quantization range for weights and activations.
 For example, the following `range_estimator` for activations can improve the accuracy for Faster R-CNN based networks:
 ```python
@@ -73,6 +77,7 @@ For example, the following `range_estimator` for activations can improve the acc
 5.  The next option is `stat_subset_size`. It controls the size of the calibration dataset used by POT to collect statistics for quantization parameters initialization.
 It is assumed that this dataset should contain a sufficient number of representative samples. Thus, varying this parameter may affect accuracy (higher is better). 
 However, we empirically found that 300 samples are sufficient to get representative statistics in most cases.
+
 6.  The last option is `ignored_scope`. It allows excluding some layers from the quantization process, i.e. their inputs will not be quantized. It may be helpful for some patterns for which it is known in advance that they drop accuracy when executing in low-precision.
 For example, `DetectionOutput` layer of SSD model expressed as a subgraph should not be quantized to preserve the accuracy of Object Detection models.
 One of the sources for the ignored scope can be the Accuracy-aware algorithm which can revert layers back to the original precision (see details below).

--- a/tools/pot/docs/BestPractices.md
+++ b/tools/pot/docs/BestPractices.md
@@ -42,17 +42,16 @@ There are two alternatives in case of substantial accuracy degradation after app
 ### Tuning Hyperparameters of the Default Quantization
 The Default Quantization algorithm provides multiple hyperparameters which can be used in order to improve accuracy results for the fully-quantized model. 
 Below is a list of best practices that can be applied to improve accuracy without a substantial performance reduction with respect to default settings:
-1.  The first recommended option is to change the `preset` from `performance` to `mixed`. This enables asymmetric quantization of 
+1. The first recommended option is to change the `preset` from `performance` to `mixed`. This enables asymmetric quantization of 
 activations and can be helpful for models with non-ReLU activation functions, for example, YOLO, EfficientNet, etc.
 
-2.  The next option is `use_fast_bias`. Setting this option to `false` enables a different bias correction method which is more accurate, in general,
+2. The next option is `use_fast_bias`. Setting this option to `false` enables a different bias correction method which is more accurate, in general,
 and applied after model quantization as a part of the Default Quantization algorithm.
-
    > **NOTE**: Changing this option can substantially increase quantization time in the POT tool.
 
-3.  Some model architectures require a special approach when being quantized. For example, Transformer-based models need to keep some operations in the original precision to preserve accuracy. That is why POT provides a `model_type` option to specify the model architecture. Now, only `"transformer"` type is available. Use it to quantize Transformer-based models, e.g. BERT.
+3. Some model architectures require a special approach when being quantized. For example, Transformer-based models need to keep some operations in the original precision to preserve accuracy. That is why POT provides a `model_type` option to specify the model architecture. Now, only `"transformer"` type is available. Use it to quantize Transformer-based models, e.g. BERT.
 
-4.  Another important option is a `range_estimator`. It defines how to calculate the minimum and maximum of quantization range for weights and activations.
+4. Another important option is a `range_estimator`. It defines how to calculate the minimum and maximum of quantization range for weights and activations.
 For example, the following `range_estimator` for activations can improve the accuracy for Faster R-CNN based networks:
 ```python
 {
@@ -74,11 +73,11 @@ For example, the following `range_estimator` for activations can improve the acc
 }
 ```
 
-5.  The next option is `stat_subset_size`. It controls the size of the calibration dataset used by POT to collect statistics for quantization parameters initialization.
+5. The next option is `stat_subset_size`. It controls the size of the calibration dataset used by POT to collect statistics for quantization parameters initialization.
 It is assumed that this dataset should contain a sufficient number of representative samples. Thus, varying this parameter may affect accuracy (higher is better). 
 However, we empirically found that 300 samples are sufficient to get representative statistics in most cases.
 
-6.  The last option is `ignored_scope`. It allows excluding some layers from the quantization process, i.e. their inputs will not be quantized. It may be helpful for some patterns for which it is known in advance that they drop accuracy when executing in low-precision.
+6. The last option is `ignored_scope`. It allows excluding some layers from the quantization process, i.e. their inputs will not be quantized. It may be helpful for some patterns for which it is known in advance that they drop accuracy when executing in low-precision.
 For example, `DetectionOutput` layer of SSD model expressed as a subgraph should not be quantized to preserve the accuracy of Object Detection models.
 One of the sources for the ignored scope can be the Accuracy-aware algorithm which can revert layers back to the original precision (see details below).
 


### PR DESCRIPTION
A minor fix that corrects an ordered list in "Tuning Hyperparameters of the Default Quantization" section.
