### PR TITLE
[GPU] Fix reshape shape calculation for MatMul operation

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
@@ -129,7 +129,7 @@ static void CreateMatMulOp(Program& p, const std::shared_ptr<ngraph::op::v0::Mat
         };
 
         if (reshape_fc) {
-            inputName = reshape_to_2d(shape_a, inputName, shape_a.back(), "_cldnn_reshape_in");
+            inputName = reshape_to_2d(shape_a, inputName, K, "_cldnn_reshape_in");
         }
 
         if (shape_b.size() != 2) {

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/mat_mul.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/mat_mul.cpp
@@ -17,6 +17,7 @@ const std::vector<InferenceEngine::Precision> inputPrecisions = {
 
 const std::vector<ShapeRelatedParams> shapeRelatedParams = {
         { { {2, 1, 1, 5, 6}, false }, { {1, 1, 6, 4}, false } },
+        { { {2, 2, 4, 16}, true }, { {1, 1, 1, 4}, true } },
         { { {2, 1, 2, 3, 5, 6}, false }, { {1, 1, 6, 4}, false } },
         { { {1, 4, 5, 6}, false }, { {1, 4, 6, 4}, false } },
         { { {1, 16, 128}, false }, { {1, 64, 128}, true } },


### PR DESCRIPTION
### Details:
 - This patch fixes incorrect feature's dimension size selection in case of transposed `shape_a`

### Tickets:
 - 92959
