### PR TITLE
Add clang-format for target ov_cpu_unit_tests

### DIFF
--- a/src/plugins/intel_cpu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_cpu/tests/unit/CMakeLists.txt
@@ -55,3 +55,5 @@ target_include_directories(${TARGET_NAME} SYSTEM PRIVATE
     $<TARGET_PROPERTY:dnnl,SOURCE_DIR>/src/common
     $<TARGET_PROPERTY:dnnl,SOURCE_DIR>/src/cpu
     $<TARGET_PROPERTY:dnnl,SOURCE_DIR>/include)
+
+add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME})

--- a/src/plugins/intel_cpu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_cpu/tests/unit/CMakeLists.txt
@@ -34,7 +34,6 @@ addIeTargetTest(
             unitTestUtils
             ngraphFunctions
             snippetsNgraphFunctions
-        ADD_CPPLINT
         LABELS
             CPU
 )

--- a/src/plugins/intel_cpu/tests/unit/dnnl_memory_desc_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/dnnl_memory_desc_test.cpp
@@ -2,15 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <utility>
-#include <gtest/gtest.h>
-#include <gmock/gmock-matchers.h>
-
 #include <cpu_memory.h>
-#include "memory_desc/cpu_memory_desc_utils.h"
-#include "nodes/common/blocked_desc_creator.h"
 #include <dnnl_extension_utils.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <utility>
+
+#include "memory_desc/cpu_memory_desc_utils.h"
 #include "memory_desc/dnnl_blocked_memory_desc.h"
+#include "nodes/common/blocked_desc_creator.h"
 
 using namespace ov::intel_cpu;
 using namespace InferenceEngine;
@@ -18,30 +19,35 @@ using namespace testing;
 
 TEST(MemDescTest, Conversion) {
     // Check if conversion keep desc structure
-    // dnnl::memory::desc -> DnnlBlockedMemoryDesc -> CpuBlockedMemoryDesc -> DnnlBlockedMemoryDesc -> dnnl::memory::desc
-    auto converted_correctly = [] (dnnl::memory::format_tag fmt, dnnl::memory::dims dims) {
-        dnnl::memory::desc orig_tdesc {dims, dnnl::memory::data_type::u8, fmt};
+    // dnnl::memory::desc -> DnnlBlockedMemoryDesc -> CpuBlockedMemoryDesc -> DnnlBlockedMemoryDesc ->
+    // dnnl::memory::desc
+    auto converted_correctly = [](dnnl::memory::format_tag fmt, dnnl::memory::dims dims) {
+        dnnl::memory::desc orig_tdesc{dims, dnnl::memory::data_type::u8, fmt};
         DnnlMemoryDescPtr plg_tdesc = DnnlExtensionUtils::makeDescriptor(orig_tdesc);
         BlockedMemoryDescPtr blk_tdesc = MemoryDescUtils::convertToBlockedMemoryDesc(plg_tdesc);
-        MemoryDescPtr cpu_blk_tdesc = std::make_shared<CpuBlockedMemoryDesc>(blk_tdesc->getPrecision(), blk_tdesc->getShape(), blk_tdesc->getBlockDims(),
-                                                                  blk_tdesc->getOrder(), blk_tdesc->getOffsetPadding(), blk_tdesc->getOffsetPaddingToData(),
-                                                                  blk_tdesc->getStrides());
+        MemoryDescPtr cpu_blk_tdesc = std::make_shared<CpuBlockedMemoryDesc>(blk_tdesc->getPrecision(),
+                                                                             blk_tdesc->getShape(),
+                                                                             blk_tdesc->getBlockDims(),
+                                                                             blk_tdesc->getOrder(),
+                                                                             blk_tdesc->getOffsetPadding(),
+                                                                             blk_tdesc->getOffsetPaddingToData(),
+                                                                             blk_tdesc->getStrides());
         DnnlMemoryDescPtr plg_tdesc_after = MemoryDescUtils::convertToDnnlMemoryDesc(cpu_blk_tdesc);
         dnnl::memory::desc after_tdesc = plg_tdesc_after->getDnnlDesc();
 
         return orig_tdesc == after_tdesc;
     };
 
-    std::pair<dnnl::memory::format_tag, dnnl::memory::dims> payload[] {
-        { dnnl::memory::format_tag::nChw16c,     {1, 1, 10, 10} },  // auto blocked
-        { dnnl::memory::format_tag::nhwc,        {4, 2, 10, 7 } },  // permuted
-        { dnnl::memory::format_tag::nchw,        {4, 2, 10, 7 } },  // plain
-        { dnnl::memory::format_tag::NChw16n16c,  {4, 2, 10, 7 } },  // blocked for 2 dims
-        { dnnl::memory::format_tag::BAcd16a16b,  {4, 2, 10, 7 } },  // blocked and permuted outer dims
-        { dnnl::memory::format_tag::Acdb16a,     {96, 1, 7, 7 } },  // same strides but not default order
+    std::pair<dnnl::memory::format_tag, dnnl::memory::dims> payload[]{
+        {dnnl::memory::format_tag::nChw16c, {1, 1, 10, 10}},    // auto blocked
+        {dnnl::memory::format_tag::nhwc, {4, 2, 10, 7}},        // permuted
+        {dnnl::memory::format_tag::nchw, {4, 2, 10, 7}},        // plain
+        {dnnl::memory::format_tag::NChw16n16c, {4, 2, 10, 7}},  // blocked for 2 dims
+        {dnnl::memory::format_tag::BAcd16a16b, {4, 2, 10, 7}},  // blocked and permuted outer dims
+        {dnnl::memory::format_tag::Acdb16a, {96, 1, 7, 7}},     // same strides but not default order
     };
 
-    for (const auto &p : payload)
+    for (const auto& p : payload)
         ASSERT_TRUE(converted_correctly(p.first, p.second));
 }
 
@@ -49,23 +55,26 @@ TEST(MemDescTest, UndefinedStateConversion) {
     ngraph::PartialShape ngraphUndefinedShape({{16}, {7, 15}, {-1, -1}, {3}});
     Shape cpuShape(ngraphUndefinedShape);
 
-    const std::vector<dnnl::memory::format_tag> vecTags = {
-            dnnl::memory::format_tag::nChw8c,
-            dnnl::memory::format_tag::nhwc,
-            dnnl::memory::format_tag::nChw16c,
-            dnnl::memory::format_tag::ABcd16a16b,
-            dnnl::memory::format_tag::OIhw4i16o4i
-    };
+    const std::vector<dnnl::memory::format_tag> vecTags = {dnnl::memory::format_tag::nChw8c,
+                                                           dnnl::memory::format_tag::nhwc,
+                                                           dnnl::memory::format_tag::nChw16c,
+                                                           dnnl::memory::format_tag::ABcd16a16b,
+                                                           dnnl::memory::format_tag::OIhw4i16o4i};
 
     for (auto tag : vecTags) {
-        DnnlBlockedMemoryDescPtr dnnlBlockedDesc = std::make_shared<DnnlBlockedMemoryDesc>(cpuShape, dnnl::memory::data_type::f32, tag);
+        DnnlBlockedMemoryDescPtr dnnlBlockedDesc =
+            std::make_shared<DnnlBlockedMemoryDesc>(cpuShape, dnnl::memory::data_type::f32, tag);
 
         ASSERT_FALSE(dnnlBlockedDesc->isDefined());
 
         auto blockedDesc = MemoryDescUtils::convertToBlockedMemoryDesc(dnnlBlockedDesc);
-        MemoryDescPtr cpuBlockedDesc = std::make_shared<CpuBlockedMemoryDesc>(blockedDesc->getPrecision(), blockedDesc->getShape(), blockedDesc->getBlockDims(),
-                                                                    blockedDesc->getOrder(), blockedDesc->getOffsetPadding(),
-                                                                    blockedDesc->getOffsetPaddingToData(), blockedDesc->getStrides());
+        MemoryDescPtr cpuBlockedDesc = std::make_shared<CpuBlockedMemoryDesc>(blockedDesc->getPrecision(),
+                                                                              blockedDesc->getShape(),
+                                                                              blockedDesc->getBlockDims(),
+                                                                              blockedDesc->getOrder(),
+                                                                              blockedDesc->getOffsetPadding(),
+                                                                              blockedDesc->getOffsetPaddingToData(),
+                                                                              blockedDesc->getStrides());
 
         ASSERT_TRUE(dnnlBlockedDesc->isCompatible(*cpuBlockedDesc));
         ASSERT_TRUE(cpuBlockedDesc->isCompatible(*dnnlBlockedDesc));
@@ -88,35 +97,38 @@ TEST(MemDescTest, UndefinedStateConversion) {
 }
 
 TEST(MemDescTest, CompareWithTensorDescRecomputedStrides) {
-    auto converted_correctly = [] (dnnl::memory::format_tag fmt, dnnl::memory::dims dims) {
-        dnnl::memory::desc orig_tdesc {dims, dnnl::memory::data_type::u8, fmt};
+    auto converted_correctly = [](dnnl::memory::format_tag fmt, dnnl::memory::dims dims) {
+        dnnl::memory::desc orig_tdesc{dims, dnnl::memory::data_type::u8, fmt};
         DnnlMemoryDescPtr plg_tdesc = DnnlExtensionUtils::makeDescriptor(orig_tdesc);
         BlockedMemoryDescPtr blk_tdesc = MemoryDescUtils::convertToBlockedMemoryDesc(plg_tdesc);
 
-        CpuBlockedMemoryDesc recomputed_blk_tdesc(blk_tdesc->getPrecision(), blk_tdesc->getShape(), blk_tdesc->getBlockDims(), blk_tdesc->getOrder());
+        CpuBlockedMemoryDesc recomputed_blk_tdesc(blk_tdesc->getPrecision(),
+                                                  blk_tdesc->getShape(),
+                                                  blk_tdesc->getBlockDims(),
+                                                  blk_tdesc->getOrder());
 
-        return  plg_tdesc->isCompatible(recomputed_blk_tdesc);
+        return plg_tdesc->isCompatible(recomputed_blk_tdesc);
     };
 
-    std::pair<dnnl::memory::format_tag, dnnl::memory::dims> payload[] {
-        { dnnl::memory::format_tag::nChw16c,     {1, 1, 10, 10} },  // auto blocked
-        { dnnl::memory::format_tag::nhwc,        {4, 2, 10, 7 } },  // permuted
-        { dnnl::memory::format_tag::nchw,        {4, 2, 10, 7 } },  // plain
-        { dnnl::memory::format_tag::NChw16n16c,  {4, 2, 10, 7 } },  // blocked for 2 dims
-        { dnnl::memory::format_tag::BAcd16a16b,  {4, 2, 10, 7 } },  // blocked and permuted outer dims
-        { dnnl::memory::format_tag::Acdb16a,     {96, 1, 7, 7 } },  // same strides but not default order
+    std::pair<dnnl::memory::format_tag, dnnl::memory::dims> payload[]{
+        {dnnl::memory::format_tag::nChw16c, {1, 1, 10, 10}},    // auto blocked
+        {dnnl::memory::format_tag::nhwc, {4, 2, 10, 7}},        // permuted
+        {dnnl::memory::format_tag::nchw, {4, 2, 10, 7}},        // plain
+        {dnnl::memory::format_tag::NChw16n16c, {4, 2, 10, 7}},  // blocked for 2 dims
+        {dnnl::memory::format_tag::BAcd16a16b, {4, 2, 10, 7}},  // blocked and permuted outer dims
+        {dnnl::memory::format_tag::Acdb16a, {96, 1, 7, 7}},     // same strides but not default order
     };
 
-    for (const auto &p : payload)
+    for (const auto& p : payload)
         ASSERT_TRUE(converted_correctly(p.first, p.second));
 }
 
 TEST(MemDescTest, isPlainCheck) {
-    const auto dims = dnnl::memory::dims {3, 2, 5, 7};
+    const auto dims = dnnl::memory::dims{3, 2, 5, 7};
     const auto type = dnnl::memory::data_type::u8;
-    dnnl::memory::desc plain_tdesc {dims, type, dnnl::memory::format_tag::abcd};
-    dnnl::memory::desc permt_tdesc {dims, type, dnnl::memory::format_tag::acdb};
-    dnnl::memory::desc blckd_tdesc {dims, type, dnnl::memory::format_tag::aBcd8b};
+    dnnl::memory::desc plain_tdesc{dims, type, dnnl::memory::format_tag::abcd};
+    dnnl::memory::desc permt_tdesc{dims, type, dnnl::memory::format_tag::acdb};
+    dnnl::memory::desc blckd_tdesc{dims, type, dnnl::memory::format_tag::aBcd8b};
 
     ASSERT_TRUE(DnnlExtensionUtils::makeDescriptor(plain_tdesc)->hasLayoutType(LayoutType::ncsp));
     ASSERT_FALSE(DnnlExtensionUtils::makeDescriptor(permt_tdesc)->hasLayoutType(LayoutType::ncsp));
@@ -124,13 +136,13 @@ TEST(MemDescTest, isPlainCheck) {
 }
 
 TEST(MemDescTest, isBlockedCCheck) {
-    const auto dims = dnnl::memory::dims {3, 2, 5, 7};
+    const auto dims = dnnl::memory::dims{3, 2, 5, 7};
     const auto type = dnnl::memory::data_type::u8;
 
-    dnnl::memory::desc plain_tdesc {dims, type, dnnl::memory::format_tag::abcd};
-    dnnl::memory::desc tailc_tdesc {dims, type, dnnl::memory::format_tag::acdb};
-    dnnl::memory::desc blck8_tdesc {dims, type, dnnl::memory::format_tag::aBcd8b};
-    dnnl::memory::desc blck8_permCD_tdesc {dims, type, dnnl::memory::format_tag::aBdc16b};
+    dnnl::memory::desc plain_tdesc{dims, type, dnnl::memory::format_tag::abcd};
+    dnnl::memory::desc tailc_tdesc{dims, type, dnnl::memory::format_tag::acdb};
+    dnnl::memory::desc blck8_tdesc{dims, type, dnnl::memory::format_tag::aBcd8b};
+    dnnl::memory::desc blck8_permCD_tdesc{dims, type, dnnl::memory::format_tag::aBdc16b};
     auto plain_mdesc = DnnlExtensionUtils::makeDescriptor(plain_tdesc);
     auto tailc_mdesc = DnnlExtensionUtils::makeDescriptor(tailc_tdesc);
     ASSERT_FALSE(plain_mdesc->hasLayoutType(LayoutType::nCsp8c) || plain_mdesc->hasLayoutType(LayoutType::nCsp16c));
@@ -138,8 +150,8 @@ TEST(MemDescTest, isBlockedCCheck) {
     ASSERT_TRUE(DnnlExtensionUtils::makeDescriptor(blck8_tdesc)->hasLayoutType(LayoutType::nCsp8c));
     ASSERT_FALSE(DnnlExtensionUtils::makeDescriptor(blck8_permCD_tdesc)->hasLayoutType(LayoutType::nCsp16c));
 
-    const auto crop_dims = dnnl::memory::dims {2, 1, 5, 7};
-    const auto crop_off = dnnl::memory::dims {1, 0, 0, 0};
+    const auto crop_dims = dnnl::memory::dims{2, 1, 5, 7};
+    const auto crop_off = dnnl::memory::dims{1, 0, 0, 0};
     dnnl::memory::desc blck8_crop_tdesc = blck8_tdesc.submemory_desc(crop_dims, crop_off);
     dnnl::memory::desc blck8_permCD_crop_tdesc = blck8_permCD_tdesc.submemory_desc(crop_dims, crop_off);
     ASSERT_TRUE(DnnlExtensionUtils::makeDescriptor(blck8_crop_tdesc)->hasLayoutType(LayoutType::nCsp8c));
@@ -147,23 +159,23 @@ TEST(MemDescTest, isBlockedCCheck) {
 }
 
 TEST(MemDescTest, isTailCCheck) {
-    const auto dims = dnnl::memory::dims {3, 2, 5, 7};
+    const auto dims = dnnl::memory::dims{3, 2, 5, 7};
     const auto type = dnnl::memory::data_type::u8;
 
-    dnnl::memory::desc plain_tdesc {dims, type, dnnl::memory::format_tag::abcd};
-    dnnl::memory::desc tailc_tdesc {dims, type, dnnl::memory::format_tag::acdb};
-    dnnl::memory::desc permt_tdesc {dims, type, dnnl::memory::format_tag::bcda};
-    dnnl::memory::desc blck8_tdesc {dims, type, dnnl::memory::format_tag::aBcd8b};
+    dnnl::memory::desc plain_tdesc{dims, type, dnnl::memory::format_tag::abcd};
+    dnnl::memory::desc tailc_tdesc{dims, type, dnnl::memory::format_tag::acdb};
+    dnnl::memory::desc permt_tdesc{dims, type, dnnl::memory::format_tag::bcda};
+    dnnl::memory::desc blck8_tdesc{dims, type, dnnl::memory::format_tag::aBcd8b};
     ASSERT_FALSE(DnnlExtensionUtils::makeDescriptor(plain_tdesc)->hasLayoutType(LayoutType::nspc));
     ASSERT_FALSE(DnnlExtensionUtils::makeDescriptor(permt_tdesc)->hasLayoutType(LayoutType::nspc));
     ASSERT_TRUE(DnnlExtensionUtils::makeDescriptor(tailc_tdesc)->hasLayoutType(LayoutType::nspc));
     ASSERT_FALSE(DnnlExtensionUtils::makeDescriptor(blck8_tdesc)->hasLayoutType(LayoutType::nspc));
 
-    dnnl::memory::desc blck8_permCD_tdesc {dims, type, dnnl::memory::format_tag::aBdc16b};
+    dnnl::memory::desc blck8_permCD_tdesc{dims, type, dnnl::memory::format_tag::aBdc16b};
     ASSERT_FALSE(DnnlExtensionUtils::makeDescriptor(blck8_permCD_tdesc)->hasLayoutType(LayoutType::nspc));
 
-    const auto crop_dims = dnnl::memory::dims {2, 1, 5, 7};
-    const auto crop_off = dnnl::memory::dims {1, 0, 0, 0};
+    const auto crop_dims = dnnl::memory::dims{2, 1, 5, 7};
+    const auto crop_off = dnnl::memory::dims{1, 0, 0, 0};
     dnnl::memory::desc tailc_crop_tdesc = blck8_tdesc.submemory_desc(crop_dims, crop_off);
     ASSERT_FALSE(DnnlExtensionUtils::makeDescriptor(tailc_crop_tdesc)->hasLayoutType(LayoutType::nspc));
 }
@@ -207,16 +219,20 @@ TEST(MemDescTest, KeepOrder) {
     auto dnnDims = DnnlExtensionUtils::convertToDnnlDims(dims.getStaticDims());
 
     memory::desc dnnlDescPlanar(dnnDims, dataType, memory::format_tag::abcd);
-    ASSERT_THAT(DnnlExtensionUtils::makeDescriptor(dnnlDescPlanar)->as<DnnlBlockedMemoryDesc>()->getOrder(), ElementsAre(0, 1, 2, 3));
+    ASSERT_THAT(DnnlExtensionUtils::makeDescriptor(dnnlDescPlanar)->as<DnnlBlockedMemoryDesc>()->getOrder(),
+                ElementsAre(0, 1, 2, 3));
 
     memory::desc dnnlDescTailC(dnnDims, dataType, memory::format_tag::acdb);
-    ASSERT_THAT(DnnlExtensionUtils::makeDescriptor(dnnlDescTailC)->as<DnnlBlockedMemoryDesc>()->getOrder(), ElementsAre(0, 2, 3, 1));
+    ASSERT_THAT(DnnlExtensionUtils::makeDescriptor(dnnlDescTailC)->as<DnnlBlockedMemoryDesc>()->getOrder(),
+                ElementsAre(0, 2, 3, 1));
 
     memory::desc dnnlDescBlockedC(dnnDims, dataType, memory::format_tag::aBcd16b);
-    ASSERT_THAT(DnnlExtensionUtils::makeDescriptor(dnnlDescBlockedC)->as<DnnlBlockedMemoryDesc>()->getOrder(), ElementsAre(0, 1, 2, 3, 1));
+    ASSERT_THAT(DnnlExtensionUtils::makeDescriptor(dnnlDescBlockedC)->as<DnnlBlockedMemoryDesc>()->getOrder(),
+                ElementsAre(0, 1, 2, 3, 1));
 
     memory::desc dnnlDescWeightBlocked(dnnDims, dataType, memory::format_tag::ABcd16b16a2b);
-    ASSERT_THAT(DnnlExtensionUtils::makeDescriptor(dnnlDescWeightBlocked)->as<DnnlBlockedMemoryDesc>()->getOrder(), ElementsAre(0, 1, 2, 3, 1, 0, 1));
+    ASSERT_THAT(DnnlExtensionUtils::makeDescriptor(dnnlDescWeightBlocked)->as<DnnlBlockedMemoryDesc>()->getOrder(),
+                ElementsAre(0, 1, 2, 3, 1, 0, 1));
 }
 
 TEST(MemDescTest, UndefinedState) {
@@ -260,7 +276,6 @@ TEST(MemDescTest, MemSize) {
     static const auto dnnlDataType = dnnl::memory::data_type::f32;
     static const Precision iePrc = Precision::FP32;
 
-
     ngraph::PartialShape ngraphShapeUndef({{16}, {-1, -1}, {20, 30}, {7}});
     ov::intel_cpu::Shape pluginShapeUndef(ngraphShapeUndef);
 
@@ -283,7 +298,8 @@ TEST(MemDescTest, MemSize) {
     ASSERT_EQ(blockedDescDefUpper.getCurrentMemSize(), undefSize);
     auto maxElementsCount = std::accumulate(pluginShapeDefUpperBound.getMaxDims().begin(),
                                             pluginShapeDefUpperBound.getMaxDims().end(),
-                                            1, std::multiplies<size_t>());
+                                            1,
+                                            std::multiplies<size_t>());
     ASSERT_EQ(blockedDescDefUpper.getMaxMemSize(), maxElementsCount * iePrc.size());
 
     DnnlBlockedMemoryDesc memDescDefUpper(pluginShapeDefUpperBound, dnnlDataType, dnnl::memory::format_tag::nhwc);
@@ -318,7 +334,8 @@ TEST(MakeUndefinedDnnlDesc, checkRank) {
     const memory::desc origin({10, 20, 15, 7}, dataType, memory::format_tag::nChw16c);
 
     ov::intel_cpu::Shape pluginShapeWrongRank(ngraph::PartialShape{{-1, -1}, {-1, -1}, {-1, -1}});
-    ASSERT_THROW(DnnlExtensionUtils::makeUndefinedDesc(origin, pluginShapeWrongRank), InferenceEngine::ParameterMismatch);
+    ASSERT_THROW(DnnlExtensionUtils::makeUndefinedDesc(origin, pluginShapeWrongRank),
+                 InferenceEngine::ParameterMismatch);
 
     ov::intel_cpu::Shape pluginShapeRightRank(ngraph::PartialShape{{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}});
     MemoryDescPtr memDesc;
@@ -334,8 +351,9 @@ TEST(MakeUndefinedDnnlDesc, checkDims) {
     ngraph::PartialShape fullyUndef({{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}});
     for (size_t i = 0; i < fullyUndef.size(); ++i) {
         auto partialShape = fullyUndef;
-        partialShape[i] = {3}; // just a number which is not equal to any origin dims
-        ASSERT_THROW(DnnlExtensionUtils::makeUndefinedDesc(origin, ov::intel_cpu::Shape(partialShape)), InferenceEngine::ParameterMismatch);
+        partialShape[i] = {3};  // just a number which is not equal to any origin dims
+        ASSERT_THROW(DnnlExtensionUtils::makeUndefinedDesc(origin, ov::intel_cpu::Shape(partialShape)),
+                     InferenceEngine::ParameterMismatch);
     }
     for (size_t i = 0; i < origin.dims().size(); ++i) {
         auto partialShape = fullyUndef;
@@ -351,13 +369,13 @@ TEST(MakeUndefinedDnnlDesc, checkLayout) {
     using payloadArgs = std::tuple<memory::format_tag, memory::dims, std::string>;
     const memory::data_type dataType = memory::data_type::u8;
 
-    payloadArgs payload[] {
-            payloadArgs{ memory::format_tag::nChw16c,     {1, 1, 10, 10}, "aBcd16b" },  // auto blocked
-            payloadArgs{ memory::format_tag::nhwc,        {4, 2, 10, 7 }, "acdb" },  // permuted
-            payloadArgs{ memory::format_tag::nchw,        {4, 2, 10, 7 }, "abcd" },  // plain
-            payloadArgs{ memory::format_tag::NChw16n16c,  {4, 2, 10, 7 }, "ABcd16a16b" },  // blocked for 2 dims
-            payloadArgs{ memory::format_tag::Acdb16a,     {96, 1, 7, 7 }, "Acdb16a" },  // same strides but not default order
-            payloadArgs{ memory::format_tag::BAcd16a16b,  {17, 2, 10, 7 }, "BAcd16a16b" },  // blocked and permuted outer dims
+    payloadArgs payload[]{
+        payloadArgs{memory::format_tag::nChw16c, {1, 1, 10, 10}, "aBcd16b"},       // auto blocked
+        payloadArgs{memory::format_tag::nhwc, {4, 2, 10, 7}, "acdb"},              // permuted
+        payloadArgs{memory::format_tag::nchw, {4, 2, 10, 7}, "abcd"},              // plain
+        payloadArgs{memory::format_tag::NChw16n16c, {4, 2, 10, 7}, "ABcd16a16b"},  // blocked for 2 dims
+        payloadArgs{memory::format_tag::Acdb16a, {96, 1, 7, 7}, "Acdb16a"},        // same strides but not default order
+        payloadArgs{memory::format_tag::BAcd16a16b, {17, 2, 10, 7}, "BAcd16a16b"},  // blocked and permuted outer dims
     };
 
     ngraph::PartialShape fullyUndef({{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}});
@@ -385,13 +403,13 @@ TEST(MakeUndefinedDnnlDesc, extraData) {
     using payloadArgs = std::tuple<memory::format_tag, memory::dims>;
     const memory::data_type dataType = memory::data_type::u8;
 
-    payloadArgs payload[] {
-            payloadArgs{ memory::format_tag::nChw16c,     {1, 1, 10, 10} },  // auto blocked
-            payloadArgs{ memory::format_tag::nhwc,        {4, 2, 10, 7 } },  // permuted
-            payloadArgs{ memory::format_tag::nchw,        {4, 2, 10, 7 } },  // plain
-            payloadArgs{ memory::format_tag::NChw16n16c,  {4, 2, 10, 7 } },  // blocked for 2 dims
-            payloadArgs{ memory::format_tag::Acdb16a,     {96, 1, 7, 7 } },  // same strides but not default order
-            payloadArgs{ memory::format_tag::BAcd16a16b,  {17, 2, 10, 7 } },  // blocked and permuted outer dims
+    payloadArgs payload[]{
+        payloadArgs{memory::format_tag::nChw16c, {1, 1, 10, 10}},     // auto blocked
+        payloadArgs{memory::format_tag::nhwc, {4, 2, 10, 7}},         // permuted
+        payloadArgs{memory::format_tag::nchw, {4, 2, 10, 7}},         // plain
+        payloadArgs{memory::format_tag::NChw16n16c, {4, 2, 10, 7}},   // blocked for 2 dims
+        payloadArgs{memory::format_tag::Acdb16a, {96, 1, 7, 7}},      // same strides but not default order
+        payloadArgs{memory::format_tag::BAcd16a16b, {17, 2, 10, 7}},  // blocked and permuted outer dims
     };
 
     ngraph::PartialShape fullyUndef({{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}});
@@ -416,25 +434,25 @@ TEST(MakeUndefinedDnnlDesc, extraData) {
     }
 }
 
-
 TEST(isSameMethodTest, CheckTensorWithSameStrides) {
-    auto isSameDataFormat = [] (dnnl::memory::format_tag fmt, dnnl::memory::dims dims) {
-        dnnl::memory::desc oneDnnDesc {dims, dnnl::memory::data_type::u8, fmt};
+    auto isSameDataFormat = [](dnnl::memory::format_tag fmt, dnnl::memory::dims dims) {
+        dnnl::memory::desc oneDnnDesc{dims, dnnl::memory::data_type::u8, fmt};
         auto pluginDesc = DnnlExtensionUtils::makeDescriptor(oneDnnDesc);
         return pluginDesc->isSame(fmt);
     };
 
-    std::pair<dnnl::memory::format_tag, dnnl::memory::dims> testCases[] {
-        { dnnl::memory::format_tag::ntc, {1, 10, 10} },
+    std::pair<dnnl::memory::format_tag, dnnl::memory::dims> testCases[]{
+        {dnnl::memory::format_tag::ntc, {1, 10, 10}},
     };
 
-    for (const auto &tc : testCases)
+    for (const auto& tc : testCases)
         ASSERT_TRUE(isSameDataFormat(tc.first, tc.second));
 }
 
 TEST(makeDummyDesc, LowerBoundMoreThanDummyValue) {
     Shape shape(ngraph::PartialShape{1, 3, 85, {144, 1444}});
-    auto desc = std::make_shared<DnnlBlockedMemoryDesc>(shape, dnnl::memory::data_type::f32, dnnl::memory::format_tag::nchw);
+    auto desc =
+        std::make_shared<DnnlBlockedMemoryDesc>(shape, dnnl::memory::data_type::f32, dnnl::memory::format_tag::nchw);
     ASSERT_FALSE(desc->isDefined());
 
     MemoryDescPtr definedDesc;

--- a/src/plugins/intel_cpu/tests/unit/dnnl_memory_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/dnnl_memory_test.cpp
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <utility>
+#include <cpu_memory.h>
 #include <gtest/gtest.h>
 
-#include <cpu_memory.h>
+#include <utility>
 
 using namespace ov::intel_cpu;
 using namespace InferenceEngine;

--- a/src/plugins/intel_cpu/tests/unit/dnnl_zero_dims_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/dnnl_zero_dims_test.cpp
@@ -2,27 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <cpu_memory.h>
+#include <dnnl_extension_utils.h>
 #include <gtest/gtest.h>
 
-#include <cpu_memory.h>
 #include "memory_desc/cpu_memory_desc_utils.h"
-#include "nodes/common/blocked_desc_creator.h"
-#include <dnnl_extension_utils.h>
 #include "memory_desc/dnnl_blocked_memory_desc.h"
+#include "nodes/common/blocked_desc_creator.h"
 
 using namespace ov::intel_cpu;
 using namespace InferenceEngine;
 using namespace testing;
 
 /* ======================================= BASE ZERO DIM TEST ======================================= */
-class MemDescWithZeroDimsBaseTest: public ::testing::Test {
+class MemDescWithZeroDimsBaseTest : public ::testing::Test {
 protected:
     Shape shape;
     dnnl::memory::format_tag fmt;
     const InferenceEngine::Precision precision = InferenceEngine::Precision::FP32;
 
-    void validate(const BlockedMemoryDesc& desc, const VectorDims& expectedStrieds, size_t offsetSize, size_t offsetPaddingSize,
-                  size_t maxMemSize, bool orderCheckSkip = false) {
+    void validate(const BlockedMemoryDesc& desc,
+                  const VectorDims& expectedStrieds,
+                  size_t offsetSize,
+                  size_t offsetPaddingSize,
+                  size_t maxMemSize,
+                  bool orderCheckSkip = false) {
         VectorDims expectedBlkDims;
         VectorDims expectedOrder;
         {
@@ -81,49 +85,42 @@ protected:
 };
 
 /* ======================================= TEST DATA ======================================= */
-const std::vector<Shape> staticShapes = {
-    Shape(VectorDims{0, 32, 48, 64}),
-    Shape(VectorDims{16, 0, 48, 64}),
-    Shape(VectorDims{16, 32, 0, 64}),
-    Shape(VectorDims{16, 32, 48, 0}),
-    Shape(VectorDims{16, 32, 0, 0}),
-    Shape(VectorDims{0, 0, 48, 64}),
-    Shape(VectorDims{16, 0, 0, 64}),
-    Shape(VectorDims{0, 0, 0, 64}),
-    Shape(VectorDims{16, 0, 0, 0}),
-    Shape(VectorDims{0, 0, 0, 0})
-};
+const std::vector<Shape> staticShapes = {Shape(VectorDims{0, 32, 48, 64}),
+                                         Shape(VectorDims{16, 0, 48, 64}),
+                                         Shape(VectorDims{16, 32, 0, 64}),
+                                         Shape(VectorDims{16, 32, 48, 0}),
+                                         Shape(VectorDims{16, 32, 0, 0}),
+                                         Shape(VectorDims{0, 0, 48, 64}),
+                                         Shape(VectorDims{16, 0, 0, 64}),
+                                         Shape(VectorDims{0, 0, 0, 64}),
+                                         Shape(VectorDims{16, 0, 0, 0}),
+                                         Shape(VectorDims{0, 0, 0, 0})};
 
-const std::vector<Shape> dynamicShapes = {
-    Shape(ngraph::PartialShape{0, -1, {0, 48}, -1}),
-    Shape(ngraph::PartialShape{16, 0, -1, {0, 64}}),
-    Shape(ngraph::PartialShape{-1, -1, 0, -1}),
-    Shape(ngraph::PartialShape{{0, 16}, -1, {0, 48}, 0}),
-    Shape(ngraph::PartialShape{-1, 32, 0, 0}),
-    Shape(ngraph::PartialShape{0, 0, 48, -1}),
-    Shape(ngraph::PartialShape{{0, 16}, 0, 0, 64}),
-    Shape(ngraph::PartialShape{0, 0, 0, -1}),
-    Shape(ngraph::PartialShape{{0, 16}, 0, 0, 0}),
-    Shape(ngraph::PartialShape{0, 0, 0, 0})
-};
+const std::vector<Shape> dynamicShapes = {Shape(ngraph::PartialShape{0, -1, {0, 48}, -1}),
+                                          Shape(ngraph::PartialShape{16, 0, -1, {0, 64}}),
+                                          Shape(ngraph::PartialShape{-1, -1, 0, -1}),
+                                          Shape(ngraph::PartialShape{{0, 16}, -1, {0, 48}, 0}),
+                                          Shape(ngraph::PartialShape{-1, 32, 0, 0}),
+                                          Shape(ngraph::PartialShape{0, 0, 48, -1}),
+                                          Shape(ngraph::PartialShape{{0, 16}, 0, 0, 64}),
+                                          Shape(ngraph::PartialShape{0, 0, 0, -1}),
+                                          Shape(ngraph::PartialShape{{0, 16}, 0, 0, 0}),
+                                          Shape(ngraph::PartialShape{0, 0, 0, 0})};
 
-const std::vector<dnnl::memory::format_tag> fmts = {
-    dnnl::memory::format_tag::nchw,
-    dnnl::memory::format_tag::nhwc,
-    dnnl::memory::format_tag::nChw8c,
-    dnnl::memory::format_tag::nChw16c,
-    dnnl::memory::format_tag::NChw16n16c,
-    dnnl::memory::format_tag::Acdb16a
-};
+const std::vector<dnnl::memory::format_tag> fmts = {dnnl::memory::format_tag::nchw,
+                                                    dnnl::memory::format_tag::nhwc,
+                                                    dnnl::memory::format_tag::nChw8c,
+                                                    dnnl::memory::format_tag::nChw16c,
+                                                    dnnl::memory::format_tag::NChw16n16c,
+                                                    dnnl::memory::format_tag::Acdb16a};
 
 /* ======================================= SPECIFIC TEST CASES ======================================= */
-using MemDescWithZeroDimsParams = std::tuple<dnnl::memory::format_tag,
-                                             Shape>;
+using MemDescWithZeroDimsParams = std::tuple<dnnl::memory::format_tag, Shape>;
 
-class MemDescWithZeroDimsFmtTest: public testing::WithParamInterface<MemDescWithZeroDimsParams>,
-                                  public MemDescWithZeroDimsBaseTest {
+class MemDescWithZeroDimsFmtTest : public testing::WithParamInterface<MemDescWithZeroDimsParams>,
+                                   public MemDescWithZeroDimsBaseTest {
 public:
-    static std::string getTestCaseName(const testing::TestParamInfo<MemDescWithZeroDimsParams> &obj) {
+    static std::string getTestCaseName(const testing::TestParamInfo<MemDescWithZeroDimsParams>& obj) {
         Shape shape;
         dnnl::memory::format_tag fmt;
         std::tie(fmt, shape) = obj.param;
@@ -142,7 +139,8 @@ public:
 protected:
     void SetUp() override {
         std::tie(fmt, shape) = this->GetParam();
-        ASSERT_TRUE(shape.hasZeroDims()) << "Can't run MemDescWithZeroDimsTest, because shape doesn't contain zero dims";
+        ASSERT_TRUE(shape.hasZeroDims())
+            << "Can't run MemDescWithZeroDimsTest, because shape doesn't contain zero dims";
     }
 };
 
@@ -150,31 +148,32 @@ TEST_P(MemDescWithZeroDimsFmtTest, CreateDescWithFmt) {
     Run();
 }
 
-INSTANTIATE_TEST_SUITE_P(smoke_MemDescWithZeroDimsFmtTest_static, MemDescWithZeroDimsFmtTest,
-                         ::testing::Combine(::testing::ValuesIn(fmts),
-                                            ::testing::ValuesIn(staticShapes)),
+INSTANTIATE_TEST_SUITE_P(smoke_MemDescWithZeroDimsFmtTest_static,
+                         MemDescWithZeroDimsFmtTest,
+                         ::testing::Combine(::testing::ValuesIn(fmts), ::testing::ValuesIn(staticShapes)),
                          MemDescWithZeroDimsFmtTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_MemDescWithZeroDimsFmtTest_dynamic, MemDescWithZeroDimsFmtTest,
-                         ::testing::Combine(::testing::ValuesIn(fmts),
-                                            ::testing::ValuesIn(dynamicShapes)),
+INSTANTIATE_TEST_SUITE_P(smoke_MemDescWithZeroDimsFmtTest_dynamic,
+                         MemDescWithZeroDimsFmtTest,
+                         ::testing::Combine(::testing::ValuesIn(fmts), ::testing::ValuesIn(dynamicShapes)),
                          MemDescWithZeroDimsFmtTest::getTestCaseName);
 
-class MemDescWithZeroDimsPlanarTest: public testing::WithParamInterface<Shape>,
-                                     public MemDescWithZeroDimsBaseTest {
+class MemDescWithZeroDimsPlanarTest : public testing::WithParamInterface<Shape>, public MemDescWithZeroDimsBaseTest {
 public:
-    static std::string getTestCaseName(const testing::TestParamInfo<Shape> &obj) {
+    static std::string getTestCaseName(const testing::TestParamInfo<Shape>& obj) {
         Shape shape;
         shape = obj.param;
         std::ostringstream result;
         result << "Shape=" << shape.toString();
         return result.str();
     }
+
 protected:
     void SetUp() override {
         shape = this->GetParam();
         fmt = dnnl::memory::format_tag::nchw;
-        ASSERT_TRUE(shape.hasZeroDims()) << "Can't run MemDescWithZeroDimsTest, because shape doesn't contain zero dims";
+        ASSERT_TRUE(shape.hasZeroDims())
+            << "Can't run MemDescWithZeroDimsTest, because shape doesn't contain zero dims";
     }
 };
 
@@ -182,18 +181,19 @@ TEST_P(MemDescWithZeroDimsPlanarTest, CreateDescPlanar) {
     Run();
 }
 
-INSTANTIATE_TEST_SUITE_P(smoke_MemDescWithZeroDimsPlanarTest, MemDescWithZeroDimsPlanarTest,
+INSTANTIATE_TEST_SUITE_P(smoke_MemDescWithZeroDimsPlanarTest,
+                         MemDescWithZeroDimsPlanarTest,
                          ::testing::ValuesIn(staticShapes),
                          MemDescWithZeroDimsPlanarTest::getTestCaseName);
 
-using MemDescWithZeroDimsCloneNewDimsParams = std::tuple<dnnl::memory::format_tag, // memory format
-                                              Shape,                               // dynamic shapes
-                                              Shape>;                              // static shapes
+using MemDescWithZeroDimsCloneNewDimsParams = std::tuple<dnnl::memory::format_tag,  // memory format
+                                                         Shape,                     // dynamic shapes
+                                                         Shape>;                    // static shapes
 
-class MemDescWithZeroDimsCloneNewDimsTest: public testing::WithParamInterface<MemDescWithZeroDimsCloneNewDimsParams>,
-                                           public MemDescWithZeroDimsBaseTest {
+class MemDescWithZeroDimsCloneNewDimsTest : public testing::WithParamInterface<MemDescWithZeroDimsCloneNewDimsParams>,
+                                            public MemDescWithZeroDimsBaseTest {
 public:
-    static std::string getTestCaseName(const testing::TestParamInfo<MemDescWithZeroDimsCloneNewDimsParams> &obj) {
+    static std::string getTestCaseName(const testing::TestParamInfo<MemDescWithZeroDimsCloneNewDimsParams>& obj) {
         Shape shapeDynamic, shapeClone;
         dnnl::memory::format_tag fmt;
         std::tie(fmt, shapeDynamic, shapeClone) = obj.param;
@@ -203,12 +203,14 @@ public:
         result << "_Fmt=" << dnnl::utils::fmt2str(fmt);
         return result.str();
     }
+
 protected:
     Shape shapeDynamic;
 
     void SetUp() override {
         std::tie(fmt, shapeDynamic, shape) = this->GetParam();
-        ASSERT_TRUE(shape.hasZeroDims()) << "Can't run MemDescWithZeroDimsTest, because shape doesn't contain zero dims";
+        ASSERT_TRUE(shape.hasZeroDims())
+            << "Can't run MemDescWithZeroDimsTest, because shape doesn't contain zero dims";
     }
 };
 
@@ -223,17 +225,18 @@ TEST_P(MemDescWithZeroDimsCloneNewDimsTest, CloneWithNewDims) {
 
     // can't compute order correct since strides equal
     const auto& dims = shape.getDims();
-    bool skipOrderCheck = std::all_of(dims.begin() + 1, dims.end(), [](const size_t& dim) { return dim == 0; });
+    bool skipOrderCheck = std::all_of(dims.begin() + 1, dims.end(), [](const size_t& dim) {
+        return dim == 0;
+    });
     validate(*clonedDescDnnl->as<BlockedMemoryDesc>(), zeroStrides, offset, offsetPadding, 0, skipOrderCheck);
     validate(*clonedDescCpu->as<BlockedMemoryDesc>(), zeroStrides, offset, offsetPadding, 0);
 }
 
-const std::vector<Shape> srcDynShapes = {
-    Shape(ngraph::PartialShape({-1, -1, -1, -1})),
-    Shape(ngraph::PartialShape({{0, 16}, {0, 32}, {0, 48}, {0, 64}}))
-};
+const std::vector<Shape> srcDynShapes = {Shape(ngraph::PartialShape({-1, -1, -1, -1})),
+                                         Shape(ngraph::PartialShape({{0, 16}, {0, 32}, {0, 48}, {0, 64}}))};
 
-INSTANTIATE_TEST_SUITE_P(smoke_MemDescWithZeroDimsCloneNewDimsTest, MemDescWithZeroDimsCloneNewDimsTest,
+INSTANTIATE_TEST_SUITE_P(smoke_MemDescWithZeroDimsCloneNewDimsTest,
+                         MemDescWithZeroDimsCloneNewDimsTest,
                          ::testing::Combine(::testing::ValuesIn(fmts),
                                             ::testing::ValuesIn(srcDynShapes),
                                             ::testing::ValuesIn(staticShapes)),

--- a/src/plugins/intel_cpu/tests/unit/generate_add.cpp
+++ b/src/plugins/intel_cpu/tests/unit/generate_add.cpp
@@ -4,37 +4,30 @@
 
 #include <gtest/gtest.h>
 
-#include <string>
-#include <sstream>
-#include <fstream>
-#include <memory>
-#include <queue>
-#include <map>
 #include <array>
-
-#include <snippets/generator.hpp>
-
+#include <fstream>
+#include <map>
+#include <memory>
 #include <ngraph/function.hpp>
-
 #include <ngraph/opsets/opset1.hpp>
 #include <ngraph/opsets/opset2.hpp>
-
 #include <ngraph/pass/constant_folding.hpp>
 #include <ngraph/pass/visualize_tree.hpp>
-
+#include <ngraph_functions/utils/ngraph_helpers.hpp>
+#include <queue>
+#include <snippets/generator.hpp>
 #include <snippets/op/subgraph.hpp>
-
+#include <sstream>
+#include <string>
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>
-
-#include <ngraph_functions/utils/ngraph_helpers.hpp>
 
 using namespace testing;
 
 inline auto gen_inputs(const ngraph::Shape& shape, size_t n = 2) -> std::vector<std::vector<std::uint8_t>> {
     std::vector<std::vector<std::uint8_t>> referenceInputs(n);
     for (size_t k = 0; k < n; k++) {
-        referenceInputs[k].resize(ngraph::shape_size(shape)*sizeof(float));
+        referenceInputs[k].resize(ngraph::shape_size(shape) * sizeof(float));
         float* in0 = reinterpret_cast<float*>(&referenceInputs[k][0]);
 
         for (size_t i = 0; i < ngraph::shape_size(shape); i++) {
@@ -50,7 +43,9 @@ inline auto gen_inputs(const ngraph::Shape& shape, size_t n = 2) -> std::vector<
     return referenceInputs;
 }
 
-inline auto compare(std::shared_ptr<ngraph::Function>& s, std::shared_ptr<ngraph::Function>& f, std::vector<std::vector<std::uint8_t>>& in) -> bool{
+inline auto compare(std::shared_ptr<ngraph::Function>& s,
+                    std::shared_ptr<ngraph::Function>& f,
+                    std::vector<std::vector<std::uint8_t>>& in) -> bool {
     auto act = ngraph::helpers::interpreterFunction(s, in);
     auto exp = ngraph::helpers::interpreterFunction(f, in);
 
@@ -59,10 +54,11 @@ inline auto compare(std::shared_ptr<ngraph::Function>& s, std::shared_ptr<ngraph
 
     bool isCorrect = true;
     for (int i = 0; i < ngraph::shape_size(f->get_result()->get_shape()); i++) {
-        if (std::abs(pexp[i]-pact[i]) > std::numeric_limits<float>::epsilon()
-            || std::isnan(pexp[i]) != std::isnan(pact[i])) {
+        if (std::abs(pexp[i] - pact[i]) > std::numeric_limits<float>::epsilon() ||
+            std::isnan(pexp[i]) != std::isnan(pact[i])) {
             isCorrect = false;
-            std::cout << i << " expected " << pexp[i] << " actual " << pact[i] << " diff " << std::abs(pexp[i]-pact[i]) << std::endl;
+            std::cout << i << " expected " << pexp[i] << " actual " << pact[i] << " diff "
+                      << std::abs(pexp[i] - pact[i]) << std::endl;
         }
     }
     return isCorrect;
@@ -73,14 +69,16 @@ inline auto wrapAsSnippet(std::shared_ptr<ngraph::Function>& f,
                           const ngraph::Shape& shape1) -> std::shared_ptr<ngraph::Function> {
     auto input0 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape0);
     auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape1);
-    auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input0, input1}, ngraph::clone_function(*f.get()));
+    auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input0, input1},
+                                                                    ngraph::clone_function(*f.get()));
     return std::make_shared<ngraph::Function>(ngraph::NodeVector{snippet}, ngraph::ParameterVector{input0, input1});
 }
 
 inline auto wrapAsSnippet(std::shared_ptr<ngraph::Function>& f, const ngraph::Shape& shape0)
     -> std::shared_ptr<ngraph::Function> {
     auto input0 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape0);
-    auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input0}, ngraph::clone_function(*f.get()));
+    auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input0},
+                                                                    ngraph::clone_function(*f.get()));
     return std::make_shared<ngraph::Function>(ngraph::NodeVector{snippet}, ngraph::ParameterVector{input0});
 }
 
@@ -91,10 +89,10 @@ TEST(SnippetsTests, GenerateAddParams) {
     GTEST_SKIP();
     auto shape = ngraph::Shape{1, 4, 16, 31};
 
-    auto f = ([] (const ngraph::Shape& shape) -> std::shared_ptr<ngraph::Function>{
+    auto f = ([](const ngraph::Shape& shape) -> std::shared_ptr<ngraph::Function> {
         auto input0 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
-        auto add    = std::make_shared<ngraph::opset1::Add>(input0, input1);
+        auto add = std::make_shared<ngraph::opset1::Add>(input0, input1);
 
         return std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input0, input1});
     })(shape);
@@ -109,15 +107,15 @@ TEST(SnippetsTests, GenerateAddConstant) {
     GTEST_SKIP();
     auto shape = ngraph::Shape{1, 4, 16, 31};
 
-    auto f = ([] (const ngraph::Shape& shape) -> std::shared_ptr<ngraph::Function>{
+    auto f = ([](const ngraph::Shape& shape) -> std::shared_ptr<ngraph::Function> {
         auto input0 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
 
         std::vector<float> vals(ngraph::shape_size(shape));
         for (int i = 0; i < ngraph::shape_size(shape); i++) {
-            vals[i] = 1-i/2048.f;
+            vals[i] = 1 - i / 2048.f;
         }
         auto input1 = std::make_shared<ngraph::opset1::Constant>(ngraph::element::f32, shape, vals);
-        auto add    = std::make_shared<ngraph::opset1::Add>(input0, input1);
+        auto add = std::make_shared<ngraph::opset1::Add>(input0, input1);
 
         return std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input0});
     })(shape);
@@ -132,10 +130,12 @@ TEST(SnippetsTests, GenerateAddConstantScalar) {
     GTEST_SKIP();
     auto shape = ngraph::Shape{1, 4, 16, 31};
 
-    auto f = ([] (const ngraph::Shape& shape) -> std::shared_ptr<ngraph::Function>{
+    auto f = ([](const ngraph::Shape& shape) -> std::shared_ptr<ngraph::Function> {
         auto input0 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
-        auto input1 = std::make_shared<ngraph::opset1::Constant>(ngraph::element::f32, ngraph::Shape{1}, std::vector<float>({42.f}));
-        auto add    = std::make_shared<ngraph::opset1::Add>(input0, input1);
+        auto input1 = std::make_shared<ngraph::opset1::Constant>(ngraph::element::f32,
+                                                                 ngraph::Shape{1},
+                                                                 std::vector<float>({42.f}));
+        auto add = std::make_shared<ngraph::opset1::Add>(input0, input1);
 
         return std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input0});
     })(shape);
@@ -150,10 +150,12 @@ TEST(SnippetsTests, GenerateAddConstantScalarEmptySize) {
     GTEST_SKIP();
     auto shape = ngraph::Shape{1, 4, 16, 31};
 
-    auto f = ([] (const ngraph::Shape& shape) -> std::shared_ptr<ngraph::Function>{
+    auto f = ([](const ngraph::Shape& shape) -> std::shared_ptr<ngraph::Function> {
         auto input0 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
-        auto input1 = std::make_shared<ngraph::opset1::Constant>(ngraph::element::f32, ngraph::Shape(), std::vector<float>({42.f}));
-        auto add    = std::make_shared<ngraph::opset1::Add>(input0, input1);
+        auto input1 = std::make_shared<ngraph::opset1::Constant>(ngraph::element::f32,
+                                                                 ngraph::Shape(),
+                                                                 std::vector<float>({42.f}));
+        auto add = std::make_shared<ngraph::opset1::Add>(input0, input1);
 
         return std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input0});
     })(shape);
@@ -169,37 +171,40 @@ TEST(SnippetsTests, GenerateAddBroadcastX2Edges) {
     auto shape0 = ngraph::Shape{1, 4, 16, 31};
     auto shape1 = ngraph::Shape{1, 4, 16, 1};
 
-    auto f = ([] (const ngraph::Shape& shape0, const ngraph::Shape& shape1) -> std::shared_ptr<ngraph::Function>{
+    auto f = ([](const ngraph::Shape& shape0, const ngraph::Shape& shape1) -> std::shared_ptr<ngraph::Function> {
         auto input0 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape0);
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape1);
         auto input2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape1);
 
-        auto add    = std::make_shared<ngraph::opset1::Add>(input0, input1);
-        auto mul    = std::make_shared<ngraph::opset1::Add>(input1, input2);
+        auto add = std::make_shared<ngraph::opset1::Add>(input0, input1);
+        auto mul = std::make_shared<ngraph::opset1::Add>(input1, input2);
 
         auto sub = std::make_shared<ngraph::opset1::Add>(add, mul);
 
-        return std::make_shared<ngraph::Function>(ngraph::NodeVector{sub}, ngraph::ParameterVector{input0, input1, input2});
+        return std::make_shared<ngraph::Function>(ngraph::NodeVector{sub},
+                                                  ngraph::ParameterVector{input0, input1, input2});
     })(shape0, shape1);
 
-    auto s = ([f] (const ngraph::Shape& shape0, const ngraph::Shape& shape1) -> std::shared_ptr<ngraph::Function>{
+    auto s = ([f](const ngraph::Shape& shape0, const ngraph::Shape& shape1) -> std::shared_ptr<ngraph::Function> {
         auto input2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape0);
         auto input3 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape1);
         auto input4 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape1);
-        auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input2, input3, input4}, ngraph::clone_function(*f.get()));
-        return std::make_shared<ngraph::Function>(ngraph::NodeVector{snippet}, ngraph::ParameterVector{input2, input3, input4});
+        auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input2, input3, input4},
+                                                                        ngraph::clone_function(*f.get()));
+        return std::make_shared<ngraph::Function>(ngraph::NodeVector{snippet},
+                                                  ngraph::ParameterVector{input2, input3, input4});
     })(shape0, shape1);
 
     std::vector<std::vector<std::uint8_t>> referenceInputs(3);
-    referenceInputs[0].resize(ngraph::shape_size(shape0)*sizeof(float));
-    referenceInputs[1].resize(ngraph::shape_size(shape1)*sizeof(float));
-    referenceInputs[2].resize(ngraph::shape_size(shape1)*sizeof(float));
+    referenceInputs[0].resize(ngraph::shape_size(shape0) * sizeof(float));
+    referenceInputs[1].resize(ngraph::shape_size(shape1) * sizeof(float));
+    referenceInputs[2].resize(ngraph::shape_size(shape1) * sizeof(float));
 
     float* in0 = reinterpret_cast<float*>(&referenceInputs[0][0]);
     float* in1 = reinterpret_cast<float*>(&referenceInputs[1][0]);
     float* in2 = reinterpret_cast<float*>(&referenceInputs[2][0]);
     for (int i = 0; i < ngraph::shape_size(shape0); i++) {
-        in0[i] = i/2048.f;
+        in0[i] = i / 2048.f;
     }
 
     in1[0] = 1.f;
@@ -225,12 +230,12 @@ TEST(SnippetsTests, GenerateAddBroadcastX2Edges) {
 TEST(SnippetsTests, GenerateAddBroadcastY) {
     GTEST_SKIP();
     auto shape0 = ngraph::Shape{1, 4, 16, 31};
-    auto shape1 = ngraph::Shape{1, 4,  1, 31};
+    auto shape1 = ngraph::Shape{1, 4, 1, 31};
 
-    auto f = ([] (const ngraph::Shape& shape0, const ngraph::Shape& shape1) -> std::shared_ptr<ngraph::Function>{
+    auto f = ([](const ngraph::Shape& shape0, const ngraph::Shape& shape1) -> std::shared_ptr<ngraph::Function> {
         auto input0 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape0);
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape1);
-        auto add    = std::make_shared<ngraph::opset1::Add>(input0, input1);
+        auto add = std::make_shared<ngraph::opset1::Add>(input0, input1);
 
         return std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input0, input1});
     })(shape0, shape1);
@@ -238,8 +243,8 @@ TEST(SnippetsTests, GenerateAddBroadcastY) {
     auto s = wrapAsSnippet(f, shape0, shape1);
 
     std::vector<std::vector<std::uint8_t>> referenceInputs(2);
-    referenceInputs[0].resize(ngraph::shape_size(shape0)*sizeof(float));
-    referenceInputs[1].resize(ngraph::shape_size(shape1)*sizeof(float));
+    referenceInputs[0].resize(ngraph::shape_size(shape0) * sizeof(float));
+    referenceInputs[1].resize(ngraph::shape_size(shape1) * sizeof(float));
 
     float* in0 = reinterpret_cast<float*>(&referenceInputs[0][0]);
     float* in1 = reinterpret_cast<float*>(&referenceInputs[1][0]);
@@ -271,19 +276,20 @@ TEST(SnippetsTests, GenerateAddNegate) {
     GTEST_SKIP();
     auto shape = ngraph::Shape{1, 4, 16, 31};
 
-    auto f = ([] (const ngraph::Shape& shape) -> std::shared_ptr<ngraph::Function>{
+    auto f = ([](const ngraph::Shape& shape) -> std::shared_ptr<ngraph::Function> {
         auto input0 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
-        auto add    = std::make_shared<ngraph::opset1::Add>(input0, input1);
+        auto add = std::make_shared<ngraph::opset1::Add>(input0, input1);
         auto nagate = std::make_shared<ngraph::opset1::Negative>(add);
 
         return std::make_shared<ngraph::Function>(ngraph::NodeVector{nagate}, ngraph::ParameterVector{input0, input1});
     })(shape);
 
-    auto s = ([f] (const ngraph::Shape& shape) -> std::shared_ptr<ngraph::Function>{
+    auto s = ([f](const ngraph::Shape& shape) -> std::shared_ptr<ngraph::Function> {
         auto input2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
         auto input3 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
-        auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input2, input3}, ngraph::clone_function(*f.get()));
+        auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input2, input3},
+                                                                        ngraph::clone_function(*f.get()));
         return std::make_shared<ngraph::Function>(ngraph::NodeVector{snippet}, ngraph::ParameterVector{input2, input3});
     })(shape);
 
@@ -302,13 +308,17 @@ TEST(SnippetsTests, GenerateAddNegateAdd) {
     auto nagate = std::make_shared<ngraph::opset1::Negative>(add);
     auto input3 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
     auto add2 = std::make_shared<ngraph::opset1::Add>(nagate, input3);
-    std::shared_ptr<ngraph::Function> f = std::make_shared<ngraph::Function>(ngraph::NodeVector{add2}, ngraph::ParameterVector{input1, input2, input3});
+    std::shared_ptr<ngraph::Function> f =
+        std::make_shared<ngraph::Function>(ngraph::NodeVector{add2}, ngraph::ParameterVector{input1, input2, input3});
 
     auto input11 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
     auto input21 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
     auto input31 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
-    auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input11, input21, input31}, ngraph::clone_function(*f.get()));
-    std::shared_ptr<ngraph::Function>  s = std::make_shared<ngraph::Function>(ngraph::NodeVector{snippet}, ngraph::ParameterVector{input11, input21, input31});
+    auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input11, input21, input31},
+                                                                    ngraph::clone_function(*f.get()));
+    std::shared_ptr<ngraph::Function> s =
+        std::make_shared<ngraph::Function>(ngraph::NodeVector{snippet},
+                                           ngraph::ParameterVector{input11, input21, input31});
 
     auto referenceInputs = gen_inputs(shape, 3);
     bool isCorrect = compare(s, f, referenceInputs);
@@ -321,10 +331,11 @@ TEST(SnippetsTests, GenerateAddNegateAddMultiEdge) {
     auto shape = ngraph::Shape{1, 4, 16, 31};
     auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
     auto input2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
-    auto add    = std::make_shared<ngraph::opset1::Add>(input1, input2);
+    auto add = std::make_shared<ngraph::opset1::Add>(input1, input2);
     auto nagate = std::make_shared<ngraph::opset1::Negative>(add);
     auto add2 = std::make_shared<ngraph::opset1::Add>(nagate, input1);
-    std::shared_ptr<ngraph::Function> f = std::make_shared<ngraph::Function>(ngraph::NodeVector{add2}, ngraph::ParameterVector{input1, input2});
+    std::shared_ptr<ngraph::Function> f =
+        std::make_shared<ngraph::Function>(ngraph::NodeVector{add2}, ngraph::ParameterVector{input1, input2});
 
     auto s = wrapAsSnippet(f, shape, shape);
     auto referenceInputs = gen_inputs(shape, 2);
@@ -341,11 +352,14 @@ TEST(SnippetsTests, GenerateAddNegateAddMultiEdgeConst) {
     auto add = std::make_shared<ngraph::opset1::Add>(input1, input2);
     auto nagate = std::make_shared<ngraph::opset1::Negative>(add);
     auto add2 = std::make_shared<ngraph::opset1::Add>(nagate, input1);
-    std::shared_ptr<ngraph::Function> f = std::make_shared<ngraph::Function>(ngraph::NodeVector{add2}, ngraph::ParameterVector{input1});
+    std::shared_ptr<ngraph::Function> f =
+        std::make_shared<ngraph::Function>(ngraph::NodeVector{add2}, ngraph::ParameterVector{input1});
 
     auto input11 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
-    auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input11}, ngraph::clone_function(*f.get()));
-    std::shared_ptr<ngraph::Function>  s = std::make_shared<ngraph::Function>(ngraph::NodeVector{snippet}, ngraph::ParameterVector{input11});
+    auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input11},
+                                                                    ngraph::clone_function(*f.get()));
+    std::shared_ptr<ngraph::Function> s =
+        std::make_shared<ngraph::Function>(ngraph::NodeVector{snippet}, ngraph::ParameterVector{input11});
 
     auto referenceInputs = gen_inputs(shape, 1);
     bool isCorrect = compare(s, f, referenceInputs);
@@ -358,12 +372,15 @@ TEST(SnippetsTests, GenerateErf) {
     auto shape = ngraph::Shape{1, 4, 16, 31};
 
     auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
-    auto gelu   = std::make_shared<ngraph::opset1::Erf>(input1);
-    std::shared_ptr<ngraph::Function> f = std::make_shared<ngraph::Function>(ngraph::NodeVector{gelu}, ngraph::ParameterVector{input1});
+    auto gelu = std::make_shared<ngraph::opset1::Erf>(input1);
+    std::shared_ptr<ngraph::Function> f =
+        std::make_shared<ngraph::Function>(ngraph::NodeVector{gelu}, ngraph::ParameterVector{input1});
 
     auto input11 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape);
-    auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input11}, ngraph::clone_function(*f.get()));
-    std::shared_ptr<ngraph::Function> s = std::make_shared<ngraph::Function>(ngraph::NodeVector{snippet}, ngraph::ParameterVector{input11});
+    auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input11},
+                                                                    ngraph::clone_function(*f.get()));
+    std::shared_ptr<ngraph::Function> s =
+        std::make_shared<ngraph::Function>(ngraph::NodeVector{snippet}, ngraph::ParameterVector{input11});
 
     auto referenceInputs = gen_inputs(shape, 1);
     bool isCorrect = compare(s, f, referenceInputs);
@@ -374,13 +391,13 @@ TEST(SnippetsTests, GenerateErf) {
 // ToDO: implement tile selection logic & broadcast emission to make it working. Broadcast substitution works
 TEST(SnippetsTests, GenerateAddBroadcastAutomatic) {
     GTEST_SKIP();
-    std::array<ngraph::Shape, 3> shapes {
-        ngraph::Shape{1, 4, 16, 31},
-        ngraph::Shape{1, 4, 16, 1},
-        ngraph::Shape{1, 4, 16, 1}
-    };
+    std::array<ngraph::Shape, 3> shapes{ngraph::Shape{1, 4, 16, 31},
+                                        ngraph::Shape{1, 4, 16, 1},
+                                        ngraph::Shape{1, 4, 16, 1}};
 
-    auto f = ([] (const ngraph::Shape& shape0, const ngraph::Shape& shape1, const ngraph::Shape& shape2) -> std::shared_ptr<ngraph::Function>{
+    auto f = ([](const ngraph::Shape& shape0,
+                 const ngraph::Shape& shape1,
+                 const ngraph::Shape& shape2) -> std::shared_ptr<ngraph::Function> {
         auto input0 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape0);
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape1);
         auto input2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape2);
@@ -389,15 +406,20 @@ TEST(SnippetsTests, GenerateAddBroadcastAutomatic) {
         auto mul = std::make_shared<ngraph::opset1::Multiply>(input1, input2);
         auto sub = std::make_shared<ngraph::opset1::Subtract>(add, mul);
 
-        return std::make_shared<ngraph::Function>(ngraph::NodeVector{sub}, ngraph::ParameterVector{input0, input1, input2});
+        return std::make_shared<ngraph::Function>(ngraph::NodeVector{sub},
+                                                  ngraph::ParameterVector{input0, input1, input2});
     })(shapes[0], shapes[1], shapes[2]);
 
-    auto s = ([f] (const ngraph::Shape& shape0, const ngraph::Shape& shape1, const ngraph::Shape& shape2) -> std::shared_ptr<ngraph::Function>{
+    auto s = ([f](const ngraph::Shape& shape0,
+                  const ngraph::Shape& shape1,
+                  const ngraph::Shape& shape2) -> std::shared_ptr<ngraph::Function> {
         auto input0 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape0);
         auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape1);
         auto input2 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, shape2);
-        auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input0, input1, input2}, ngraph::clone_function(*f.get()));
-        return std::make_shared<ngraph::Function>(ngraph::NodeVector{snippet}, ngraph::ParameterVector{input0, input1, input2});
+        auto snippet = std::make_shared<ngraph::snippets::op::Subgraph>(ngraph::OutputVector{input0, input1, input2},
+                                                                        ngraph::clone_function(*f.get()));
+        return std::make_shared<ngraph::Function>(ngraph::NodeVector{snippet},
+                                                  ngraph::ParameterVector{input0, input1, input2});
     })(shapes[0], shapes[1], shapes[2]);
 
     std::vector<std::vector<std::uint8_t>> referenceInputs(3);
@@ -406,7 +428,7 @@ TEST(SnippetsTests, GenerateAddBroadcastAutomatic) {
 
         auto in0 = reinterpret_cast<float*>(&referenceInputs[k][0]);
         for (int i = 0; i < ngraph::shape_size(shapes[k]); i++) {
-            in0[i] = k == 0 ? i/2048.f : (k == 1 ? 1.f : 0.42f);
+            in0[i] = k == 0 ? i / 2048.f : (k == 1 ? 1.f : 0.42f);
         }
     }
 

--- a/src/plugins/intel_cpu/tests/unit/jit_kernel_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/jit_kernel_test.cpp
@@ -3,8 +3,9 @@
 //
 
 #include <gtest/gtest.h>
-#include <utils/jit_kernel.hpp>
+
 #include <random>
+#include <utils/jit_kernel.hpp>
 
 using namespace ov::intel_cpu;
 using namespace dnnl::impl::cpu::x64;
@@ -14,11 +15,11 @@ namespace {
 
 #define TEST_JIT_SCALAR_EXPRESSION (c << 5) * b | (a & b - c) | (b - a) >> 2
 
-template<typename Params>
+template <typename Params>
 struct jit_test_kernel : public jit_kernel {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_test_kernel)
 
-    typedef void (*function_t)(const Params *);
+    typedef void (*function_t)(const Params*);
 
     void init() {
         if (create_kernel() != status::success)
@@ -26,7 +27,7 @@ struct jit_test_kernel : public jit_kernel {
         _fn = (function_t)jit_ker();
     }
 
-    void operator()(const Params & args) const {
+    void operator()(const Params& args) const {
         _fn(&args);
     }
 
@@ -34,16 +35,16 @@ private:
     function_t _fn;
 };
 
-template<typename T>
+template <typename T>
 struct jit_scalar_variable_test_kernel {
     struct Params {
         T a;
         T b;
         T c;
-        T *result;
+        T* result;
     };
 
-    void operator()(const Params & args) const {
+    void operator()(const Params& args) const {
         _kernel(args);
     }
 
@@ -70,47 +71,39 @@ private:
     kernel_impl _kernel;
 };
 
-template<typename T>
+template <typename T>
 T scalar_variable_jit_expression(T a, T b, T c) {
     T result = 0;
     jit_scalar_variable_test_kernel<T> kernel;
-    typename jit_scalar_variable_test_kernel<T>::Params args = { a, b, c, &result };
+    typename jit_scalar_variable_test_kernel<T>::Params args = {a, b, c, &result};
     kernel(args);
     return result;
 }
 
-template<typename T>
+template <typename T>
 T scalar_variable_ref_expression(T a, T b, T c) {
     return TEST_JIT_SCALAR_EXPRESSION;
 }
 
 TEST(JitKernel, scalar_variable) {
-    ASSERT_EQ(scalar_variable_jit_expression<uint64_t>(1, 2, 3),
-              scalar_variable_ref_expression<uint64_t>(1, 2, 3));
-    ASSERT_EQ(scalar_variable_jit_expression<int64_t>(1, 2, 3),
-              scalar_variable_ref_expression<int64_t>(1, 2, 3));
-    ASSERT_EQ(scalar_variable_jit_expression<uint32_t>(1, 2, 3),
-              scalar_variable_ref_expression<uint32_t>(1, 2, 3));
-    ASSERT_EQ(scalar_variable_jit_expression<int32_t>(1, 2, 3),
-              scalar_variable_ref_expression<int32_t>(1, 2, 3));
-    ASSERT_EQ(scalar_variable_jit_expression<uint16_t>(1, 2, 3),
-              scalar_variable_ref_expression<uint16_t>(1, 2, 3));
-    ASSERT_EQ(scalar_variable_jit_expression<int16_t>(1, 2, 3),
-              scalar_variable_ref_expression<int16_t>(1, 2, 3));
-    ASSERT_EQ(scalar_variable_jit_expression<uint8_t>(1, 2, 3),
-              scalar_variable_ref_expression<uint8_t>(1, 2, 3));
-    ASSERT_EQ(scalar_variable_jit_expression<int8_t>(1, 2, 3),
-              scalar_variable_ref_expression<int8_t>(1, 2, 3));
+    ASSERT_EQ(scalar_variable_jit_expression<uint64_t>(1, 2, 3), scalar_variable_ref_expression<uint64_t>(1, 2, 3));
+    ASSERT_EQ(scalar_variable_jit_expression<int64_t>(1, 2, 3), scalar_variable_ref_expression<int64_t>(1, 2, 3));
+    ASSERT_EQ(scalar_variable_jit_expression<uint32_t>(1, 2, 3), scalar_variable_ref_expression<uint32_t>(1, 2, 3));
+    ASSERT_EQ(scalar_variable_jit_expression<int32_t>(1, 2, 3), scalar_variable_ref_expression<int32_t>(1, 2, 3));
+    ASSERT_EQ(scalar_variable_jit_expression<uint16_t>(1, 2, 3), scalar_variable_ref_expression<uint16_t>(1, 2, 3));
+    ASSERT_EQ(scalar_variable_jit_expression<int16_t>(1, 2, 3), scalar_variable_ref_expression<int16_t>(1, 2, 3));
+    ASSERT_EQ(scalar_variable_jit_expression<uint8_t>(1, 2, 3), scalar_variable_ref_expression<uint8_t>(1, 2, 3));
+    ASSERT_EQ(scalar_variable_jit_expression<int8_t>(1, 2, 3), scalar_variable_ref_expression<int8_t>(1, 2, 3));
 }
 
 struct jit_variable_test_kernel {
     struct Params {
-        const float *a;
-        const float *b;
-        float *result;
+        const float* a;
+        const float* b;
+        float* result;
     };
 
-    template<size_t N>
+    template <size_t N>
     void test() {
         kernel_impl<N> kernel;
         kernel.init();
@@ -118,7 +111,7 @@ struct jit_variable_test_kernel {
         std::array<float, N> a;
         std::array<float, N> b;
         std::array<float, N> result = {};
-        Params args = { a.data(), b.data(), result.data() };
+        Params args = {a.data(), b.data(), result.data()};
 
         for (size_t i = 0; i < N; ++i) {
             a[i] = static_cast<float>(i);
@@ -141,7 +134,7 @@ struct jit_variable_test_kernel {
     }
 
 private:
-    template<size_t N>
+    template <size_t N>
     class kernel_impl : public jit_test_kernel<Params> {
     public:
         uint8_t order[N];
@@ -198,10 +191,10 @@ struct jit_loop_and_condition_test_kernel {
     struct Params {
         size_t n;
         size_t a;
-        size_t *result;
+        size_t* result;
     };
 
-    void operator()(const Params & args) const {
+    void operator()(const Params& args) const {
         _kernel(args);
     }
 
@@ -220,15 +213,16 @@ private:
 
             auto s = var<size_t>(0);
 
-            foreach(0, n, [&](const variable<size_t> & idx) {
+            foreach (0, n, [&](const variable<size_t>& idx) {
                 _if((idx & 3) != a)
-                ._then([&] {
-                    s += idx + 3;
-                })
-                ._else([&] {
-                    s -= idx - 2;
-                });
-            });
+                    ._then([&] {
+                        s += idx + 3;
+                    })
+                    ._else([&] {
+                        s -= idx - 2;
+                    });
+            })
+                ;
 
             *result = s;
 
@@ -245,7 +239,7 @@ TEST(JitKernel, loop_and_condition) {
     size_t n = 100;
     size_t a = 2;
     size_t result = 0;
-    jit_loop_and_condition_test_kernel::Params args = { n, a, &result };
+    jit_loop_and_condition_test_kernel::Params args = {n, a, &result};
 
     kernel(args);
 
@@ -260,25 +254,25 @@ TEST(JitKernel, loop_and_condition) {
     ASSERT_EQ(result, s);
 }
 
-template<typename SrcT, typename DstT>
+template <typename SrcT, typename DstT>
 struct jit_variable_load_store_test_kernel {
     struct Params {
-        const SrcT *src;
-        DstT *dst;
+        const SrcT* src;
+        DstT* dst;
         size_t size;
     };
 
-    template<size_t N, bool is_src>
+    template <size_t N, bool is_src>
     void test() {
         kernel_impl<N, is_src> kernel;
         kernel.init();
 
         const size_t size = 3;
 
-        std::array<SrcT, N> src {};
-        std::array<DstT, N> result {};
+        std::array<SrcT, N> src{};
+        std::array<DstT, N> result{};
 
-        Params args = { src.data(), result.data(), size };
+        Params args = {src.data(), result.data(), size};
 
         src.fill(static_cast<SrcT>(42));
         for (size_t i = 0; i < size; ++i) {
@@ -287,7 +281,7 @@ struct jit_variable_load_store_test_kernel {
 
         kernel(args);
 
-        std::array<DstT, N> expected_result {};
+        std::array<DstT, N> expected_result{};
 
         for (size_t i = 0; i < size; ++i) {
             expected_result[i] = static_cast<DstT>(i);
@@ -297,7 +291,7 @@ struct jit_variable_load_store_test_kernel {
     }
 
 private:
-    template<size_t N, bool is_src>
+    template <size_t N, bool is_src>
     class kernel_impl : public jit_test_kernel<Params> {
     public:
         void generate() override {
@@ -371,4 +365,4 @@ TEST(JitKernel, variable_load_and_store) {
     }
 }
 
-}   // namespace
+}  // namespace

--- a/src/plugins/intel_cpu/tests/unit/ngraph_transformations/convert_matmul_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/ngraph_transformations/convert_matmul_test.cpp
@@ -4,18 +4,17 @@
 
 #include <gtest/gtest.h>
 
-#include <string>
 #include <memory>
-
 #include <ngraph/function.hpp>
 #include <ngraph/opsets/opset1.hpp>
 #include <ngraph/opsets/opset7.hpp>
-#include <ngraph_transformations/op/fully_connected.hpp>
+#include <ngraph/pass/manager.hpp>
 #include <ngraph_transformations/convert_matmul_to_fc.hpp>
 #include <ngraph_transformations/fc_bias_fusion.hpp>
+#include <ngraph_transformations/op/fully_connected.hpp>
+#include <string>
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>
-#include <ngraph/pass/manager.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
@@ -25,11 +24,11 @@ using namespace ov::intel_cpu;
 TEST(TransformationTests, ConvertMatMulToFCTest1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 3, 2, 2 });
-        auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 2, 2 }, { 1 });
+        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 2, 2});
+        auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 2, 2}, {1});
         auto matmul = std::make_shared<ngraph::opset1::MatMul>(input1, input2, true, false);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ matmul }, ngraph::ParameterVector{ input1 });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{matmul}, ngraph::ParameterVector{input1});
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
         m.register_pass<ConvertMatMulToFC>();
@@ -38,13 +37,13 @@ TEST(TransformationTests, ConvertMatMulToFCTest1) {
     }
 
     {
-        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 3, 2, 2 });
-        auto transpose_constant = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 3 }, { 0, 2, 1 });
+        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3, 2, 2});
+        auto transpose_constant = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{3}, {0, 2, 1});
         auto transpose = std::make_shared<ngraph::opset1::Transpose>(input1, transpose_constant);
-        auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 2, 2 }, { 1 });
+        auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{2, 2}, {1});
         auto matmul = std::make_shared<FullyConnectedNode>(transpose, input2, ngraph::Rank(3));
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ matmul }, ngraph::ParameterVector{ input1 });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{matmul}, ngraph::ParameterVector{input1});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -108,7 +107,8 @@ TEST(TransformationTests, ConvertMatMulToFCTest3) {
 TEST(TransformationTests, ConvertMatMulToFCTest4) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{-1, -1, 2});
+        auto input1 =
+            std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{-1, -1, 2});
         auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{2, 2}, {1});
         auto matmul = std::make_shared<ngraph::opset1::MatMul>(input1, input2, false, true);
 
@@ -121,7 +121,8 @@ TEST(TransformationTests, ConvertMatMulToFCTest4) {
     }
 
     {
-        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{-1, -1, 2});
+        auto input1 =
+            std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{-1, -1, 2});
         auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{2, 2}, {1});
         auto matmul = std::make_shared<FullyConnectedNode>(input1, input2, ngraph::Rank(3));
 
@@ -133,11 +134,11 @@ TEST(TransformationTests, ConvertMatMulToFCTest4) {
 }
 
 TEST(TransformationTests, ConvertMatMulToFCTest5) {
-    auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{ -1, -1, 2 });
-    auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 3, 2, 2 }, { 1 });
+    auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{-1, -1, 2});
+    auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 2, 2}, {1});
     auto matmul = std::make_shared<ngraph::opset1::MatMul>(input1, input2, false, true);
 
-    auto f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ matmul }, ngraph::ParameterVector{ input1 });
+    auto f = std::make_shared<ngraph::Function>(ngraph::NodeVector{matmul}, ngraph::ParameterVector{input1});
 
     ngraph::pass::Manager m;
     m.register_pass<ngraph::pass::InitNodeInfo>();
@@ -146,11 +147,11 @@ TEST(TransformationTests, ConvertMatMulToFCTest5) {
 }
 
 TEST(TransformationTests, ConvertMatMulToFCTest6) {
-    auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{ -1, -1, 2 });
-    auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 3, 1, 2 }, { 1 });
+    auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{-1, -1, 2});
+    auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 1, 2}, {1});
     auto matmul = std::make_shared<ngraph::opset1::MatMul>(input1, input2, false, true);
 
-    auto f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ matmul }, ngraph::ParameterVector{ input1 });
+    auto f = std::make_shared<ngraph::Function>(ngraph::NodeVector{matmul}, ngraph::ParameterVector{input1});
 
     ngraph::pass::Manager m;
     m.register_pass<ngraph::pass::InitNodeInfo>();
@@ -189,7 +190,8 @@ TEST(TransformationTests, ConvertMatMulToFCTest7) {
 TEST(TransformationTests, ConvertMatMulToFCTest8) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{-1, -1, 2});
+        auto input1 =
+            std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{-1, -1, 2});
         auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 2}, {1});
         auto matmul = std::make_shared<ngraph::opset1::MatMul>(input1, input2, false, true);
 
@@ -202,14 +204,15 @@ TEST(TransformationTests, ConvertMatMulToFCTest8) {
     }
 
     {
-        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{-1, -1, 2});
+        auto input1 =
+            std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{-1, -1, 2});
         auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3, 2}, {1});
 
         auto fc = std::make_shared<FullyConnectedNode>(input1, input2, ngraph::Rank(2));
         auto a_shape = std::make_shared<ngraph::opset3::ShapeOf>(input1);
 
         auto I = ngraph::op::util::node_to_get_shape_value_of_indices_from_shape_node(a_shape, {0, 1});
-        auto O = ngraph::opset1::Constant::create(ngraph::element::i64, { 1 }, { 3 });
+        auto O = ngraph::opset1::Constant::create(ngraph::element::i64, {1}, {3});
         auto output_shape = std::make_shared<ngraph::opset1::Concat>(ngraph::OutputVector{I, O}, 0);
 
         f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{fc}, ngraph::ParameterVector{input1});
@@ -250,10 +253,10 @@ TEST(TransformationTests, ConvertMatMulToFCTest9) {
 
 TEST(TransformationTests, ConvertMatMulToFCTest10) {
     auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic());
-    auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 2, 2 }, { 1 });
+    auto input2 = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{2, 2}, {1});
     auto matmul = std::make_shared<ngraph::opset1::MatMul>(input1, input2, false, true);
 
-    auto f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ matmul }, ngraph::ParameterVector{ input1 });
+    auto f = std::make_shared<ngraph::Function>(ngraph::NodeVector{matmul}, ngraph::ParameterVector{input1});
 
     ngraph::pass::Manager m;
     m.register_pass<ngraph::pass::InitNodeInfo>();
@@ -298,7 +301,8 @@ TEST(TransformationTests, FullyConnectedBiasFusionTest1) {
 TEST(TransformationTests, FullyConnectedBiasFusionTest2) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{-1, -1, 3072});
+        auto input1 =
+            std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{-1, -1, 3072});
         auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786, 3072}, {1});
         auto fc = std::make_shared<FullyConnectedNode>(input1, weights, ngraph::Rank(3));
 
@@ -316,7 +320,8 @@ TEST(TransformationTests, FullyConnectedBiasFusionTest2) {
     }
 
     {
-        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{-1, -1, 3072});
+        auto input1 =
+            std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{-1, -1, 3072});
         auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786, 3072}, {1});
         auto bias = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786}, {1});
         auto fc = std::make_shared<FullyConnectedNode>(input1, weights, bias, ngraph::Rank(3));
@@ -396,13 +401,13 @@ TEST(TransformationTests, FullyConnectedBiasFusionTest4) {
 
 TEST(TransformationTests, FullyConnectedBiasFusionTest5) {
     auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic());
-    auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 786, 128 }, { 1 });
+    auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{786, 128}, {1});
     auto fc = std::make_shared<FullyConnectedNode>(input1, weights, ngraph::Rank(2));
 
-    auto const_bias = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 786 }, { 1 });
+    auto const_bias = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 786}, {1});
     auto add = std::make_shared<ngraph::opset1::Add>(fc, const_bias);
 
-    auto f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input1 });
+    auto f = std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input1});
 
     ngraph::pass::Manager manager;
     manager.register_pass<FullyConnectedBiasFusion>();
@@ -410,14 +415,14 @@ TEST(TransformationTests, FullyConnectedBiasFusionTest5) {
 }
 
 TEST(TransformationTests, FullyConnectedBiasFusionTest6) {
-    auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::u8, ngraph::PartialShape{ -1, -1 });
-    auto weights = ngraph::opset1::Constant::create(ngraph::element::i8, ngraph::Shape{ 786, 128 }, { 1 });
+    auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::u8, ngraph::PartialShape{-1, -1});
+    auto weights = ngraph::opset1::Constant::create(ngraph::element::i8, ngraph::Shape{786, 128}, {1});
     auto fc = std::make_shared<FullyConnectedNode>(input1, weights, ngraph::Rank(2), ngraph::element::f32);
 
-    auto const_bias = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 786 }, { 1 });
+    auto const_bias = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 786}, {1});
     auto add = std::make_shared<ngraph::opset1::Add>(fc, const_bias);
 
-    auto f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input1 });
+    auto f = std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input1});
 
     ngraph::pass::Manager manager;
     manager.register_pass<FullyConnectedBiasFusion>();
@@ -453,11 +458,11 @@ TEST(TransformationTests, ConvertMatMulToFCTest_second_input_rank_adj_1) {
 TEST(TransformationTests, ConvertMatMulToFCTest_second_input_rank_adj_2) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 2, 3 });
-        auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 2, 3 }, { 1 });
+        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{2, 3});
+        auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{2, 3}, {1});
         auto matmul = std::make_shared<ngraph::opset1::MatMul>(input1, weights, false, true);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ matmul }, ngraph::ParameterVector{ input1 });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{matmul}, ngraph::ParameterVector{input1});
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
         m.register_pass<ConvertMatMulToFC>();
@@ -466,10 +471,10 @@ TEST(TransformationTests, ConvertMatMulToFCTest_second_input_rank_adj_2) {
     }
 
     {
-        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 2, 3 });
-        auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 2, 3 }, { 1 });
+        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{2, 3});
+        auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{2, 3}, {1});
         auto matmul = std::make_shared<FullyConnectedNode>(input1, weights, ngraph::Rank(2));
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ matmul }, ngraph::ParameterVector{ input1 });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{matmul}, ngraph::ParameterVector{input1});
     }
 
     auto res = compare_functions(f, f_ref, true);
@@ -479,13 +484,13 @@ TEST(TransformationTests, ConvertMatMulToFCTest_second_input_rank_adj_2) {
 TEST(TransformationTests, ConvertMatMulToFCTest_second_input_rank_adj_3) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 5, 2, 3 });
-        auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 2, 3 }, { 1 });
+        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{5, 2, 3});
+        auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 2, 3}, {1});
         auto matmul = std::make_shared<ngraph::opset1::MatMul>(input1, weights, false, true);
-        auto biases = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 1, 2 }, { 1 });
+        auto biases = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 1, 2}, {1});
         auto add = std::make_shared<ngraph::opset1::Add>(matmul, biases);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ add }, ngraph::ParameterVector{ input1 });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input1});
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
         m.register_pass<ConvertMatMulToFC>();
@@ -495,15 +500,15 @@ TEST(TransformationTests, ConvertMatMulToFCTest_second_input_rank_adj_3) {
     }
 
     {
-        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 5, 2, 3 });
-        auto reshape_before_const = ngraph::opset1::Constant::create(ngraph::element::i64, { 2 }, { -1, 3 });
+        auto input1 = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{5, 2, 3});
+        auto reshape_before_const = ngraph::opset1::Constant::create(ngraph::element::i64, {2}, {-1, 3});
 
-        auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 2, 3 }, { 1 });
-        auto biases = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 2 }, { 1 });
+        auto weights = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{2, 3}, {1});
+        auto biases = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{2}, {1});
         auto matmul = std::make_shared<FullyConnectedNode>(input1, weights, biases, ngraph::Rank(2));
 
-        auto reshape_after_const = ngraph::opset1::Constant::create(ngraph::element::i64, { 4 }, { 1, 5, 2, 2 });
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ matmul }, ngraph::ParameterVector{ input1 });
+        auto reshape_after_const = ngraph::opset1::Constant::create(ngraph::element::i64, {4}, {1, 5, 2, 2});
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{matmul}, ngraph::ParameterVector{input1});
     }
 
     auto res = compare_functions(f, f_ref, true);

--- a/src/plugins/intel_cpu/tests/unit/ngraph_transformations/convert_to_interaction.cpp
+++ b/src/plugins/intel_cpu/tests/unit/ngraph_transformations/convert_to_interaction.cpp
@@ -4,19 +4,18 @@
 
 #include <gtest/gtest.h>
 
-#include <string>
+#include <ie_core.hpp>
 #include <memory>
-
+#include <ngraph_transformations/convert_to_interaction.hpp>
+#include <ngraph_transformations/op/interaction.hpp>
 #include <openvino/opsets/opset1.hpp>
 #include <openvino/opsets/opset8.hpp>
-#include <ngraph_transformations/op/interaction.hpp>
-#include <ngraph_transformations/convert_to_interaction.hpp>
-#include <transformations/common_optimizations/nop_elimination.hpp>
-#include <transformations/smart_reshape/matmul_sr.hpp>
-#include <transformations/init_node_info.hpp>
-#include <transformations/utils/utils.hpp>
 #include <openvino/pass/manager.hpp>
-#include <ie_core.hpp>
+#include <string>
+#include <transformations/common_optimizations/nop_elimination.hpp>
+#include <transformations/init_node_info.hpp>
+#include <transformations/smart_reshape/matmul_sr.hpp>
+#include <transformations/utils/utils.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"
 
@@ -35,12 +34,13 @@ static std::shared_ptr<ov::Model> makeInteraction(const ov::PartialShape& inputS
         inputsParams.push_back(sparse_feat);
     }
     auto shapeof = std::make_shared<opset8::ShapeOf>(dense_feature);
-    auto gather_batch_indices =  std::make_shared<opset1::Constant>(element::i32, ov::Shape{1}, std::vector<int32_t>{0});
-    auto gather_batch_axis =  std::make_shared<opset1::Constant>(element::i32, ov::Shape{}, 0);
+    auto gather_batch_indices = std::make_shared<opset1::Constant>(element::i32, ov::Shape{1}, std::vector<int32_t>{0});
+    auto gather_batch_axis = std::make_shared<opset1::Constant>(element::i32, ov::Shape{}, 0);
     auto gather_batch = std::make_shared<opset8::Gather>(shapeof, gather_batch_indices, gather_batch_axis);
 
-    auto gather_feature_indices =  std::make_shared<opset1::Constant>(element::i32, ov::Shape{1}, std::vector<int32_t>{1});
-    auto gather_feature_axis =  std::make_shared<opset1::Constant>(element::i32, ov::Shape{1}, 0);
+    auto gather_feature_indices =
+        std::make_shared<opset1::Constant>(element::i32, ov::Shape{1}, std::vector<int32_t>{1});
+    auto gather_feature_axis = std::make_shared<opset1::Constant>(element::i32, ov::Shape{1}, 0);
     auto gather_feature = std::make_shared<opset8::Gather>(shapeof, gather_feature_indices, gather_feature_axis);
 
     auto reshape_dim2 = std::make_shared<opset1::Constant>(element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
@@ -49,35 +49,35 @@ static std::shared_ptr<ov::Model> makeInteraction(const ov::PartialShape& inputS
     auto concat1 = std::make_shared<opset1::Concat>(features, 1);
     auto reshape = std::make_shared<opset1::Reshape>(concat1, reshape_shape, true);
     std::vector<int32_t> transpose1_value = {0, 2, 1};
-    auto transpose1_shape =  std::make_shared<opset1::Constant>(element::i32, ov::Shape{3}, transpose1_value);
+    auto transpose1_shape = std::make_shared<opset1::Constant>(element::i32, ov::Shape{3}, transpose1_value);
     auto transpose1 = std::make_shared<opset1::Transpose>(reshape, transpose1_shape);
     auto matmul = std::make_shared<opset1::MatMul>(reshape, transpose1);
     std::vector<int32_t> transpose2_value = {1, 2, 0};
-    auto transpose2_shape =  std::make_shared<opset1::Constant>(element::i32, ov::Shape{3}, transpose2_value);
+    auto transpose2_shape = std::make_shared<opset1::Constant>(element::i32, ov::Shape{3}, transpose2_value);
     auto transpose2 = std::make_shared<opset1::Transpose>(matmul, transpose2_shape);
     std::vector<int32_t> reshape2_value = {729, -1};
-    auto reshape2_shape =  std::make_shared<opset1::Constant>(element::i32, ov::Shape{2}, reshape2_value);
+    auto reshape2_shape = std::make_shared<opset1::Constant>(element::i32, ov::Shape{2}, reshape2_value);
     auto reshape2 = std::make_shared<opset1::Reshape>(transpose2, reshape2_shape, true);
 
     std::vector<int32_t> gather_indices_value;
     for (int i = 1; i < 27; i++) {
-        for (int j = 0; j < i; j ++) {
+        for (int j = 0; j < i; j++) {
             gather_indices_value.push_back(i * 27 + j);
         }
     }
-    auto gather_indices =  std::make_shared<opset1::Constant>(element::i32, ov::Shape{351}, gather_indices_value);
-    auto gather_axis =  std::make_shared<opset1::Constant>(element::i32, ov::Shape{}, 0);
+    auto gather_indices = std::make_shared<opset1::Constant>(element::i32, ov::Shape{351}, gather_indices_value);
+    auto gather_axis = std::make_shared<opset1::Constant>(element::i32, ov::Shape{}, 0);
     auto gather = std::make_shared<opset8::Gather>(reshape2, gather_indices, gather_axis);
     auto reshape3_dim1 = std::make_shared<opset1::Constant>(element::i64, ov::Shape{1}, std::vector<int64_t>{-1});
     auto reshape3_shape = std::make_shared<opset1::Concat>(NodeVector{reshape3_dim1, gather_batch}, 0);
     auto reshape3 = std::make_shared<opset1::Reshape>(gather, reshape3_shape, true);
 
     std::vector<int32_t> transpose3_value = {1, 0};
-    auto transpose3_shape =  std::make_shared<opset1::Constant>(element::i32, ov::Shape{2}, transpose3_value);
+    auto transpose3_shape = std::make_shared<opset1::Constant>(element::i32, ov::Shape{2}, transpose3_value);
     auto transpose3 = std::make_shared<opset1::Transpose>(reshape3, transpose3_shape);
 
     std::vector<int32_t> reshape4_value = {-1, 351};
-    auto reshape4_shape =  std::make_shared<opset1::Constant>(element::i32, ov::Shape{2}, reshape4_value);
+    auto reshape4_shape = std::make_shared<opset1::Constant>(element::i32, ov::Shape{2}, reshape4_value);
     auto reshape4 = std::make_shared<opset1::Reshape>(transpose3, reshape4_shape, true);
     auto concat2 = std::make_shared<opset1::Concat>(NodeVector{dense_feature, reshape4}, 1);
     return std::make_shared<ov::Model>(concat2, inputsParams, "interaction");
@@ -87,7 +87,7 @@ TEST(TransformationTests, ConvertToInteractionTest1) {
     std::shared_ptr<ov::Model> f(nullptr), f_ref(nullptr);
     {
         using namespace ov;
-        //construct interaction graph
+        // construct interaction graph
         auto inputShape = ov::PartialShape{3, 4};
         {
             f = makeInteraction(inputShape);
@@ -98,7 +98,7 @@ TEST(TransformationTests, ConvertToInteractionTest1) {
             m.register_pass<ConvertToInteraction>();
             m.run_passes(f);
         }
-        //construct ref interaction
+        // construct ref interaction
         {
             auto dense_feature = std::make_shared<ngraph::opset1::Parameter>(element::f32, inputShape);
             NodeVector features{dense_feature};

--- a/src/plugins/intel_cpu/tests/unit/ngraph_transformations/convert_to_leaky_relu_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/ngraph_transformations/convert_to_leaky_relu_test.cpp
@@ -4,17 +4,17 @@
 
 #include <gtest/gtest.h>
 
-#include <string>
 #include <memory>
-
 #include <ngraph/function.hpp>
 #include <ngraph/opsets/opset1.hpp>
+#include <ngraph/pass/manager.hpp>
+#include <ngraph_ops/type_relaxed.hpp>
 #include <ngraph_transformations/convert_to_leaky_relu.hpp>
 #include <ngraph_transformations/op/leaky_relu.hpp>
+#include <string>
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>
-#include <ngraph_ops/type_relaxed.hpp>
-#include <ngraph/pass/manager.hpp>
+
 #include "common_test_utils/ngraph_test_utils.hpp"
 
 using namespace testing;
@@ -23,11 +23,11 @@ using namespace ov::intel_cpu;
 TEST(TransformationTests, ConvertToLeakyReluTest1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{}, { -2.f });
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 16, 16});
+        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{}, {-2.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
         m.register_pass<ConvertToLeakyRelu>();
@@ -35,10 +35,10 @@ TEST(TransformationTests, ConvertToLeakyReluTest1) {
     }
 
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 16, 16});
         auto prelu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ngraph::element::f32);
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -48,11 +48,12 @@ TEST(TransformationTests, ConvertToLeakyReluTest1) {
 TEST(TransformationTests, ConvertToLeakyReluTest2) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(4));
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{}, { -2.f });
+        auto input =
+            std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(4));
+        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{}, {-2.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
         m.register_pass<ConvertToLeakyRelu>();
@@ -60,10 +61,11 @@ TEST(TransformationTests, ConvertToLeakyReluTest2) {
     }
 
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(4));
+        auto input =
+            std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(4));
         auto prelu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ngraph::element::f32);
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -74,10 +76,10 @@ TEST(TransformationTests, ConvertToLeakyReluTest3) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic());
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{}, { -2.f });
+        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{}, {-2.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
         m.register_pass<ConvertToLeakyRelu>();
@@ -88,7 +90,7 @@ TEST(TransformationTests, ConvertToLeakyReluTest3) {
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic());
         auto prelu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ngraph::element::f32);
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -98,15 +100,15 @@ TEST(TransformationTests, ConvertToLeakyReluTest3) {
 TEST(TransformationTests, ConvertToLeakyReluTest4) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::u8, ngraph::Shape{ 1, 3, 16, 16 });
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{}, { -2.f });
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::u8, ngraph::Shape{1, 3, 16, 16});
+        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{}, {-2.f});
         auto relaxed_prelu = std::make_shared<ngraph::op::TypeRelaxed<ngraph::opset1::PRelu>>(
-            ngraph::element::TypeVector{ ngraph::element::f32, ngraph::element::f32 },
-            ngraph::element::TypeVector{ ngraph::element::f32 },
+            ngraph::element::TypeVector{ngraph::element::f32, ngraph::element::f32},
+            ngraph::element::TypeVector{ngraph::element::f32},
             ngraph::op::TemporaryReplaceOutputType(input, ngraph::element::f32).get(),
             ngraph::op::TemporaryReplaceOutputType(slope, ngraph::element::f32).get());
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ relaxed_prelu }, ngraph::ParameterVector{ input });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{relaxed_prelu}, ngraph::ParameterVector{input});
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
         m.register_pass<ConvertToLeakyRelu>();
@@ -114,10 +116,10 @@ TEST(TransformationTests, ConvertToLeakyReluTest4) {
     }
 
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::u8, ngraph::Shape{ 1, 3, 16, 16 });
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::u8, ngraph::Shape{1, 3, 16, 16});
         auto prelu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ngraph::element::f32);
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -127,11 +129,11 @@ TEST(TransformationTests, ConvertToLeakyReluTest4) {
 TEST(TransformationTests, ConvertToLeakyReluTest5) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 3 }, { -2.f, -1.f, -2.f });
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 16, 16});
+        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
         f_ref = f;
 
         ngraph::pass::Manager m;

--- a/src/plugins/intel_cpu/tests/unit/ngraph_transformations/move_eltwise_up_data_movement_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/ngraph_transformations/move_eltwise_up_data_movement_test.cpp
@@ -6,16 +6,16 @@
 
 #include <ngraph/function.hpp>
 #include <ngraph/opsets/opset8.hpp>
-#include "ngraph_ops/type_relaxed.hpp"
-#include <transformations/init_node_info.hpp>
 #include <ngraph/pass/manager.hpp>
+#include <ngraph_transformations/move_eltwise_up_data_movement.hpp>
+#include <transformations/init_node_info.hpp>
 
 #include "common_test_utils/ngraph_test_utils.hpp"
-#include <ngraph_transformations/move_eltwise_up_data_movement.hpp>
+#include "ngraph_ops/type_relaxed.hpp"
 
 using namespace testing;
 
-class MoveEltwiseUpThroughDataMovTest: public TransformationTestsF{};
+class MoveEltwiseUpThroughDataMovTest : public TransformationTestsF {};
 
 TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwise) {
     const ngraph::Shape shape{1, 3, 224, 224};
@@ -24,10 +24,12 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwise) {
     {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
 
-        auto transpose_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
+        auto transpose_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
         auto transpose = std::make_shared<ngraph::opset8::Transpose>(input, transpose_const);
 
-        auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
+        auto unsqueeze_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(transpose, unsqueeze_const);
 
         auto sigmoid = std::make_shared<ngraph::opset8::Sigmoid>(unsqueeze);
@@ -40,13 +42,16 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwise) {
 
         auto sigmoid = std::make_shared<ngraph::opset8::Sigmoid>(input);
 
-        auto transpose_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
+        auto transpose_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
         auto transpose = std::make_shared<ngraph::opset8::Transpose>(sigmoid, transpose_const);
 
-        auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
+        auto unsqueeze_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(transpose, unsqueeze_const);
 
-        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
+        function_ref =
+            std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
     }
 }
 
@@ -74,7 +79,8 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, TypeRelaxedEltwise) {
         auto mul_const = ngraph::opset8::Constant::create(ngraph::element::f32, {}, {2.f});
         auto multiply = std::make_shared<ngraph::op::TypeRelaxed<ngraph::opset8::Multiply>>(intermediate_op, mul_const);
 
-        auto transpose_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
+        auto transpose_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
         auto transpose = std::make_shared<ngraph::opset8::Transpose>(multiply, transpose_const);
 
         function_ref =
@@ -92,17 +98,20 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, EltwiseSequence) {
 
         auto matmul = std::make_shared<ngraph::opset8::MatMul>(input_left, input_right);
 
-        auto transpose_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
+        auto transpose_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
         auto transpose = std::make_shared<ngraph::opset8::Transpose>(matmul, transpose_const);
 
         auto relu = std::make_shared<ngraph::opset8::Relu>(transpose);
 
-        auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
+        auto unsqueeze_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(relu, unsqueeze_const);
 
         auto sigmoid = std::make_shared<ngraph::opset8::Sigmoid>(unsqueeze);
 
-        function = std::make_shared<ngraph::Function>(ngraph::NodeVector{sigmoid}, ngraph::ParameterVector{input_left, input_right});
+        function = std::make_shared<ngraph::Function>(ngraph::NodeVector{sigmoid},
+                                                      ngraph::ParameterVector{input_left, input_right});
         manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
     }
     {
@@ -115,13 +124,16 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, EltwiseSequence) {
 
         auto sigmoid = std::make_shared<ngraph::opset8::Sigmoid>(relu);
 
-        auto transpose_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
+        auto transpose_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
         auto transpose = std::make_shared<ngraph::opset8::Transpose>(sigmoid, transpose_const);
 
-        auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
+        auto unsqueeze_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(transpose, unsqueeze_const);
 
-        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input_left, input_right});
+        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze},
+                                                          ngraph::ParameterVector{input_left, input_right});
     }
 }
 
@@ -136,7 +148,8 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, DataMovementTwoConsumers) {
 
     auto matmul = std::make_shared<ngraph::opset8::MatMul>(input_left, input_right);
 
-    auto transpose_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
+    auto transpose_const =
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
     auto transpose = std::make_shared<ngraph::opset8::Transpose>(matmul, transpose_const);
 
     auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
@@ -146,7 +159,8 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, DataMovementTwoConsumers) {
 
     auto relu = std::make_shared<ngraph::opset8::Relu>(transpose);
 
-    function = std::make_shared<ngraph::Function>(ngraph::NodeVector{sigmoid, relu}, ngraph::ParameterVector{input_left, input_right});
+    function = std::make_shared<ngraph::Function>(ngraph::NodeVector{sigmoid, relu},
+                                                  ngraph::ParameterVector{input_left, input_right});
     manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
 }
 
@@ -158,13 +172,17 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleBinaryEltwiseWithScalarOnSecondBra
     {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
 
-        auto transpose_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
+        auto transpose_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
         auto transpose = std::make_shared<ngraph::opset8::Transpose>(input, transpose_const);
 
-        auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
+        auto unsqueeze_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(transpose, unsqueeze_const);
 
-        auto add = std::make_shared<ngraph::opset8::Add>(unsqueeze, ngraph::opset8::Constant::create(ngraph::element::f32, {}, {scalar_value}));
+        auto add = std::make_shared<ngraph::opset8::Add>(
+            unsqueeze,
+            ngraph::opset8::Constant::create(ngraph::element::f32, {}, {scalar_value}));
 
         manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input});
@@ -172,15 +190,20 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleBinaryEltwiseWithScalarOnSecondBra
     {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
 
-        auto add = std::make_shared<ngraph::opset8::Add>(input, ngraph::opset8::Constant::create(ngraph::element::f32, {}, {scalar_value}));
+        auto add = std::make_shared<ngraph::opset8::Add>(
+            input,
+            ngraph::opset8::Constant::create(ngraph::element::f32, {}, {scalar_value}));
 
-        auto transpose_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
+        auto transpose_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
         auto transpose = std::make_shared<ngraph::opset8::Transpose>(add, transpose_const);
 
-        auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
+        auto unsqueeze_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(transpose, unsqueeze_const);
 
-        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
+        function_ref =
+            std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
     }
 }
 
@@ -192,10 +215,13 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleEltwiseWith5ScalarOnSecondBranch) 
     {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
 
-        auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
+        auto unsqueeze_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(input, unsqueeze_const);
 
-        auto add = std::make_shared<ngraph::opset8::Add>(unsqueeze, ngraph::opset8::Constant::create(ngraph::element::f32, {1, 1, 1, 1, 1}, {scalar_value}));
+        auto add = std::make_shared<ngraph::opset8::Add>(
+            unsqueeze,
+            ngraph::opset8::Constant::create(ngraph::element::f32, {1, 1, 1, 1, 1}, {scalar_value}));
 
         manager.register_pass<ov::intel_cpu::MoveEltwiseUpThroughDataMov>();
         function = std::make_shared<ngraph::Function>(ngraph::NodeVector{add}, ngraph::ParameterVector{input});
@@ -203,12 +229,16 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleEltwiseWith5ScalarOnSecondBranch) 
     {
         auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
 
-        auto add = std::make_shared<ngraph::opset8::Add>(input, ngraph::opset8::Constant::create(ngraph::element::f32, {}, {scalar_value}));
+        auto add = std::make_shared<ngraph::opset8::Add>(
+            input,
+            ngraph::opset8::Constant::create(ngraph::element::f32, {}, {scalar_value}));
 
-        auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
+        auto unsqueeze_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(add, unsqueeze_const);
 
-        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
+        function_ref =
+            std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
     }
 }
 
@@ -219,7 +249,8 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleBinaryEltwiseWithNotScalarOnSecond
 
     auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, shape);
 
-    auto transpose_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
+    auto transpose_const =
+        ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{input_order.size()}, input_order);
     auto transpose = std::make_shared<ngraph::opset8::Transpose>(input, transpose_const);
 
     auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
@@ -236,9 +267,11 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwiseDynamicShape) {
     const std::vector<int64_t> input_order = {3, 2, 1, 0};
     const int64_t unsqueeze_axis = 2;
     {
-        auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(3));
+        auto input =
+            std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(3));
 
-        auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
+        auto unsqueeze_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(input, unsqueeze_const);
 
         auto sigmoid = std::make_shared<ngraph::opset8::Sigmoid>(unsqueeze);
@@ -248,14 +281,17 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwiseDynamicShape) {
     }
 
     {
-        auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(3));
+        auto input =
+            std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(3));
 
         auto sigmoid = std::make_shared<ngraph::opset8::Sigmoid>(input);
 
-        auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
+        auto unsqueeze_const =
+            ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(sigmoid, unsqueeze_const);
 
-        function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
+        function_ref =
+            std::make_shared<ngraph::Function>(ngraph::NodeVector{unsqueeze}, ngraph::ParameterVector{input});
     }
 }
 
@@ -263,7 +299,8 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwiseDynamicRank) {
     const std::vector<int64_t> input_order = {3, 2, 1, 0};
     const int64_t unsqueeze_axis = 2;
 
-    auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(ngraph::Rank::dynamic()));
+    auto input = std::make_shared<ngraph::opset8::Parameter>(ngraph::element::f32,
+                                                             ngraph::PartialShape::dynamic(ngraph::Rank::dynamic()));
 
     auto unsqueeze_const = ngraph::opset8::Constant::create(ngraph::element::i64, ngraph::Shape{}, {unsqueeze_axis});
     auto unsqueeze = std::make_shared<ngraph::opset8::Unsqueeze>(input, unsqueeze_const);

--- a/src/plugins/intel_cpu/tests/unit/ngraph_transformations/optimize_sequence_transposes_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/ngraph_transformations/optimize_sequence_transposes_test.cpp
@@ -4,18 +4,18 @@
 
 #include <gtest/gtest.h>
 
-#include <string>
 #include <memory>
-
 #include <ngraph/function.hpp>
 #include <ngraph/opsets/opset1.hpp>
 #include <ngraph/opsets/opset5.hpp>
 #include <ngraph/opsets/opset8.hpp>
+#include <ngraph/pass/manager.hpp>
+#include <ngraph_ops/type_relaxed.hpp>
 #include <ngraph_transformations/rnn_sequences_optimization.hpp>
+#include <string>
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>
-#include <ngraph_ops/type_relaxed.hpp>
-#include <ngraph/pass/manager.hpp>
+
 #include "common_test_utils/ngraph_test_utils.hpp"
 
 using namespace testing;
@@ -24,25 +24,34 @@ using namespace ov::intel_cpu;
 TEST(TransformationTests, OptimizeLSTMSequenceTransposesTest) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 2, 1, 16 });
-        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 1, 128 });
-        auto Z = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 1, 128 });
+        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{2, 1, 16});
+        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 128});
+        auto Z = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 128});
 
         auto w_val = std::vector<float>(512 * 16, 0);
         auto r_val = std::vector<float>(512 * 128, 0);
         auto b_val = std::vector<float>(512, 0);
-        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 512, 16 }, w_val);
-        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 512, 128 }, r_val);
-        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 512 }, b_val);
+        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 512, 16}, w_val);
+        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 512, 128}, r_val);
+        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 512}, b_val);
 
-        auto transpose_before_const = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 3 }, { 1, 0, 2 });
+        auto transpose_before_const =
+            ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{3}, {1, 0, 2});
         auto transpose_before = std::make_shared<ngraph::opset1::Transpose>(X, transpose_before_const);
 
-        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ngraph::opset5::LSTMSequence>(transpose_before, Y, Z, seq_lengths, W, R, B, 128,
-            ngraph::op::RecurrentSequenceDirection::FORWARD);
+        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {2});
+        auto lstm_seq = std::make_shared<ngraph::opset5::LSTMSequence>(transpose_before,
+                                                                       Y,
+                                                                       Z,
+                                                                       seq_lengths,
+                                                                       W,
+                                                                       R,
+                                                                       B,
+                                                                       128,
+                                                                       ngraph::op::RecurrentSequenceDirection::FORWARD);
 
-        auto transpose_after_const = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 4 }, { 2, 1, 0, 3 });
+        auto transpose_after_const =
+            ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {2, 1, 0, 3});
         auto transpose_after = std::make_shared<ngraph::opset1::Transpose>(lstm_seq->output(0), transpose_after_const);
 
         const auto Y_out = std::make_shared<ngraph::opset1::Result>(transpose_after);
@@ -52,7 +61,7 @@ TEST(TransformationTests, OptimizeLSTMSequenceTransposesTest) {
         Ho->set_friendly_name("Ho");
         Co->set_friendly_name("Co");
 
-        f = std::make_shared<ngraph::Function>(ngraph::ResultVector{ Y_out, Ho, Co }, ngraph::ParameterVector{ X, Y, Z });
+        f = std::make_shared<ngraph::Function>(ngraph::ResultVector{Y_out, Ho, Co}, ngraph::ParameterVector{X, Y, Z});
 
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
@@ -61,25 +70,34 @@ TEST(TransformationTests, OptimizeLSTMSequenceTransposesTest) {
     }
 
     {
-        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 2, 1, 16 });
-        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 1, 128 });
-        auto Z = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 1, 128 });
+        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{2, 1, 16});
+        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 128});
+        auto Z = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 128});
 
         auto w_val = std::vector<float>(512 * 16, 0);
         auto r_val = std::vector<float>(512 * 128, 0);
         auto b_val = std::vector<float>(512, 0);
-        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 512, 16 }, w_val);
-        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 512, 128 }, r_val);
-        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 512 }, b_val);
+        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 512, 16}, w_val);
+        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 512, 128}, r_val);
+        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 512}, b_val);
 
-        auto reshape_before_const  = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 3 }, { 1, 2, 16 });
+        auto reshape_before_const =
+            ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{3}, {1, 2, 16});
         auto reshape_before = std::make_shared<ngraph::opset1::Reshape>(X, reshape_before_const, false);
 
-        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ngraph::opset5::LSTMSequence>(reshape_before, Y, Z, seq_lengths, W, R, B, 128,
-            ngraph::op::RecurrentSequenceDirection::FORWARD);
+        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {2});
+        auto lstm_seq = std::make_shared<ngraph::opset5::LSTMSequence>(reshape_before,
+                                                                       Y,
+                                                                       Z,
+                                                                       seq_lengths,
+                                                                       W,
+                                                                       R,
+                                                                       B,
+                                                                       128,
+                                                                       ngraph::op::RecurrentSequenceDirection::FORWARD);
 
-        auto reshape_after_const = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 4 }, { 2, 1, 1, 128 });
+        auto reshape_after_const =
+            ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {2, 1, 1, 128});
         auto reshape_after = std::make_shared<ngraph::opset1::Reshape>(lstm_seq->output(0), reshape_after_const, false);
 
         const auto Y_out = std::make_shared<ngraph::opset1::Result>(reshape_after);
@@ -89,7 +107,8 @@ TEST(TransformationTests, OptimizeLSTMSequenceTransposesTest) {
         Ho->set_friendly_name("Ho");
         Co->set_friendly_name("Co");
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::ResultVector{ Y_out, Ho, Co }, ngraph::ParameterVector{ X, Y, Z });
+        f_ref =
+            std::make_shared<ngraph::Function>(ngraph::ResultVector{Y_out, Ho, Co}, ngraph::ParameterVector{X, Y, Z});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -99,25 +118,34 @@ TEST(TransformationTests, OptimizeLSTMSequenceTransposesTest) {
 TEST(TransformationTests, OptimizeLSTMSequenceTransposesDynamicTest) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{ 2, -1, -1 });
-        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{ 1, 1, 128 });
-        auto Z = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{ 1, 1, 128 });
+        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{2, -1, -1});
+        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{1, 1, 128});
+        auto Z = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{1, 1, 128});
 
         auto w_val = std::vector<float>(512 * 16, 0);
         auto r_val = std::vector<float>(512 * 128, 0);
         auto b_val = std::vector<float>(512, 0);
-        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 512, 16 }, w_val);
-        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 512, 128 }, r_val);
-        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 512 }, b_val);
+        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 512, 16}, w_val);
+        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 512, 128}, r_val);
+        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 512}, b_val);
 
-        auto transpose_before_const = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 3 }, { 1, 0, 2 });
+        auto transpose_before_const =
+            ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{3}, {1, 0, 2});
         auto transpose_before = std::make_shared<ngraph::opset1::Transpose>(X, transpose_before_const);
 
-        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ngraph::opset5::LSTMSequence>(transpose_before, Y, Z, seq_lengths, W, R, B, 128,
-            ngraph::op::RecurrentSequenceDirection::FORWARD);
+        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {2});
+        auto lstm_seq = std::make_shared<ngraph::opset5::LSTMSequence>(transpose_before,
+                                                                       Y,
+                                                                       Z,
+                                                                       seq_lengths,
+                                                                       W,
+                                                                       R,
+                                                                       B,
+                                                                       128,
+                                                                       ngraph::op::RecurrentSequenceDirection::FORWARD);
 
-        auto transpose_after_const = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 4 }, { 2, 1, 0, 3 });
+        auto transpose_after_const =
+            ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {2, 1, 0, 3});
         auto transpose_after = std::make_shared<ngraph::opset1::Transpose>(lstm_seq->output(0), transpose_after_const);
 
         const auto Y_out = std::make_shared<ngraph::opset1::Result>(transpose_after);
@@ -127,7 +155,7 @@ TEST(TransformationTests, OptimizeLSTMSequenceTransposesDynamicTest) {
         Ho->set_friendly_name("Ho");
         Co->set_friendly_name("Co");
 
-        f = std::make_shared<ngraph::Function>(ngraph::ResultVector{ Y_out, Ho, Co }, ngraph::ParameterVector{ X, Y, Z });
+        f = std::make_shared<ngraph::Function>(ngraph::ResultVector{Y_out, Ho, Co}, ngraph::ParameterVector{X, Y, Z});
 
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
@@ -136,28 +164,37 @@ TEST(TransformationTests, OptimizeLSTMSequenceTransposesDynamicTest) {
     }
 
     {
-        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{ 2, -1, -1 });
-        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{ 1, 1, 128 });
-        auto Z = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{ 1, 1, 128 });
+        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{2, -1, -1});
+        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{1, 1, 128});
+        auto Z = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{1, 1, 128});
 
         auto w_val = std::vector<float>(512 * 16, 0);
         auto r_val = std::vector<float>(512 * 128, 0);
         auto b_val = std::vector<float>(512, 0);
-        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 512, 16 }, w_val);
-        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 512, 128 }, r_val);
-        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 512 }, b_val);
+        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 512, 16}, w_val);
+        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 512, 128}, r_val);
+        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 512}, b_val);
 
         auto data = std::make_shared<ngraph::opset1::ShapeOf>(X);
-        auto reshape_before_pattern = std::make_shared<ngraph::opset8::Gather>(data,
-            ngraph::opset1::Constant::create(ngraph::element::i32, { 3 }, { 1, 0, 2 }),
-            ngraph::opset1::Constant::create(ngraph::element::i32, {}, { 0 }));
+        auto reshape_before_pattern = std::make_shared<ngraph::opset8::Gather>(
+            data,
+            ngraph::opset1::Constant::create(ngraph::element::i32, {3}, {1, 0, 2}),
+            ngraph::opset1::Constant::create(ngraph::element::i32, {}, {0}));
         auto reshape_before = std::make_shared<ngraph::opset1::Reshape>(X, reshape_before_pattern, false);
 
-        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ngraph::opset5::LSTMSequence>(reshape_before, Y, Z, seq_lengths, W, R, B, 128,
-            ngraph::op::RecurrentSequenceDirection::FORWARD);
+        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {2});
+        auto lstm_seq = std::make_shared<ngraph::opset5::LSTMSequence>(reshape_before,
+                                                                       Y,
+                                                                       Z,
+                                                                       seq_lengths,
+                                                                       W,
+                                                                       R,
+                                                                       B,
+                                                                       128,
+                                                                       ngraph::op::RecurrentSequenceDirection::FORWARD);
 
-        auto reshape_after_const = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 4 }, { 2, 1, 1, 128 });
+        auto reshape_after_const =
+            ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {2, 1, 1, 128});
         auto reshape_after = std::make_shared<ngraph::opset1::Reshape>(lstm_seq->output(0), reshape_after_const, false);
 
         const auto Y_out = std::make_shared<ngraph::opset1::Result>(reshape_after);
@@ -167,7 +204,8 @@ TEST(TransformationTests, OptimizeLSTMSequenceTransposesDynamicTest) {
         Ho->set_friendly_name("Ho");
         Co->set_friendly_name("Co");
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::ResultVector{ Y_out, Ho, Co }, ngraph::ParameterVector{ X, Y, Z });
+        f_ref =
+            std::make_shared<ngraph::Function>(ngraph::ResultVector{Y_out, Ho, Co}, ngraph::ParameterVector{X, Y, Z});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -177,24 +215,32 @@ TEST(TransformationTests, OptimizeLSTMSequenceTransposesDynamicTest) {
 TEST(TransformationTests, OptimizeRNNSequenceTransposesTest) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 2, 1, 16 });
-        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 1, 128 });
+        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{2, 1, 16});
+        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 128});
 
         auto w_val = std::vector<float>(128 * 16, 0);
         auto r_val = std::vector<float>(128 * 128, 0);
         auto b_val = std::vector<float>(128, 0);
-        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 128, 16 }, w_val);
-        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 128, 128 }, r_val);
-        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 128 }, b_val);
+        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 128, 16}, w_val);
+        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 128, 128}, r_val);
+        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 128}, b_val);
 
-        auto transpose_before_const = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 3 }, { 1, 0, 2 });
+        auto transpose_before_const =
+            ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{3}, {1, 0, 2});
         auto transpose_before = std::make_shared<ngraph::opset1::Transpose>(X, transpose_before_const);
 
-        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ngraph::opset5::RNNSequence>(transpose_before, Y, seq_lengths, W, R, B, 128,
-            ngraph::op::RecurrentSequenceDirection::FORWARD);
+        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {2});
+        auto lstm_seq = std::make_shared<ngraph::opset5::RNNSequence>(transpose_before,
+                                                                      Y,
+                                                                      seq_lengths,
+                                                                      W,
+                                                                      R,
+                                                                      B,
+                                                                      128,
+                                                                      ngraph::op::RecurrentSequenceDirection::FORWARD);
 
-        auto transpose_after_const = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 4 }, { 2, 1, 0, 3 });
+        auto transpose_after_const =
+            ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {2, 1, 0, 3});
         auto transpose_after = std::make_shared<ngraph::opset1::Transpose>(lstm_seq->output(0), transpose_after_const);
 
         const auto Y_out = std::make_shared<ngraph::opset1::Result>(transpose_after);
@@ -202,7 +248,7 @@ TEST(TransformationTests, OptimizeRNNSequenceTransposesTest) {
         Y_out->set_friendly_name("Y_out");
         Ho->set_friendly_name("Ho");
 
-        f = std::make_shared<ngraph::Function>(ngraph::ResultVector{ Y_out, Ho }, ngraph::ParameterVector{ X, Y });
+        f = std::make_shared<ngraph::Function>(ngraph::ResultVector{Y_out, Ho}, ngraph::ParameterVector{X, Y});
 
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
@@ -211,24 +257,32 @@ TEST(TransformationTests, OptimizeRNNSequenceTransposesTest) {
     }
 
     {
-        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 2, 1, 16 });
-        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 1, 128 });
+        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{2, 1, 16});
+        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 128});
 
         auto w_val = std::vector<float>(128 * 16, 0);
         auto r_val = std::vector<float>(128 * 128, 0);
         auto b_val = std::vector<float>(128, 0);
-        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 128, 16 }, w_val);
-        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 128, 128 }, r_val);
-        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 128 }, b_val);
+        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 128, 16}, w_val);
+        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 128, 128}, r_val);
+        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 128}, b_val);
 
-        auto reshape_before_const = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 3 }, { 1, 2, 16 });
+        auto reshape_before_const =
+            ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{3}, {1, 2, 16});
         auto reshape_before = std::make_shared<ngraph::opset1::Reshape>(X, reshape_before_const, false);
 
-        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ngraph::opset5::RNNSequence>(reshape_before, Y, seq_lengths, W, R, B, 128,
-            ngraph::op::RecurrentSequenceDirection::FORWARD);
+        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {2});
+        auto lstm_seq = std::make_shared<ngraph::opset5::RNNSequence>(reshape_before,
+                                                                      Y,
+                                                                      seq_lengths,
+                                                                      W,
+                                                                      R,
+                                                                      B,
+                                                                      128,
+                                                                      ngraph::op::RecurrentSequenceDirection::FORWARD);
 
-        auto reshape_after_const = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 4 }, { 2, 1, 1, 128 });
+        auto reshape_after_const =
+            ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {2, 1, 1, 128});
         auto reshape_after = std::make_shared<ngraph::opset1::Reshape>(lstm_seq->output(0), reshape_after_const, false);
 
         const auto Y_out = std::make_shared<ngraph::opset1::Result>(reshape_after);
@@ -236,7 +290,7 @@ TEST(TransformationTests, OptimizeRNNSequenceTransposesTest) {
         Y_out->set_friendly_name("Y_out");
         Ho->set_friendly_name("Ho");
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::ResultVector{ Y_out, Ho }, ngraph::ParameterVector{ X, Y });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::ResultVector{Y_out, Ho}, ngraph::ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -246,24 +300,32 @@ TEST(TransformationTests, OptimizeRNNSequenceTransposesTest) {
 TEST(TransformationTests, OptimizeRNNSequenceTransposesDynamicTest) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{ 2, -1, -1 });
-        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 1, 128 });
+        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{2, -1, -1});
+        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 128});
 
         auto w_val = std::vector<float>(128 * 16, 0);
         auto r_val = std::vector<float>(128 * 128, 0);
         auto b_val = std::vector<float>(128, 0);
-        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 128, 16 }, w_val);
-        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 128, 128 }, r_val);
-        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 128 }, b_val);
+        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 128, 16}, w_val);
+        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 128, 128}, r_val);
+        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 128}, b_val);
 
-        auto transpose_before_const = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 3 }, { 1, 0, 2 });
+        auto transpose_before_const =
+            ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{3}, {1, 0, 2});
         auto transpose_before = std::make_shared<ngraph::opset1::Transpose>(X, transpose_before_const);
 
-        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ngraph::opset5::RNNSequence>(transpose_before, Y, seq_lengths, W, R, B, 128,
-            ngraph::op::RecurrentSequenceDirection::FORWARD);
+        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {2});
+        auto lstm_seq = std::make_shared<ngraph::opset5::RNNSequence>(transpose_before,
+                                                                      Y,
+                                                                      seq_lengths,
+                                                                      W,
+                                                                      R,
+                                                                      B,
+                                                                      128,
+                                                                      ngraph::op::RecurrentSequenceDirection::FORWARD);
 
-        auto transpose_after_const = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 4 }, { 2, 1, 0, 3 });
+        auto transpose_after_const =
+            ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {2, 1, 0, 3});
         auto transpose_after = std::make_shared<ngraph::opset1::Transpose>(lstm_seq->output(0), transpose_after_const);
 
         const auto Y_out = std::make_shared<ngraph::opset1::Result>(transpose_after);
@@ -271,7 +333,7 @@ TEST(TransformationTests, OptimizeRNNSequenceTransposesDynamicTest) {
         Y_out->set_friendly_name("Y_out");
         Ho->set_friendly_name("Ho");
 
-        f = std::make_shared<ngraph::Function>(ngraph::ResultVector{ Y_out, Ho }, ngraph::ParameterVector{ X, Y });
+        f = std::make_shared<ngraph::Function>(ngraph::ResultVector{Y_out, Ho}, ngraph::ParameterVector{X, Y});
 
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
@@ -280,27 +342,35 @@ TEST(TransformationTests, OptimizeRNNSequenceTransposesDynamicTest) {
     }
 
     {
-        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{ 2, -1, -1 });
-        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 1, 128 });
+        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{2, -1, -1});
+        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 128});
 
         auto w_val = std::vector<float>(128 * 16, 0);
         auto r_val = std::vector<float>(128 * 128, 0);
         auto b_val = std::vector<float>(128, 0);
-        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 128, 16 }, w_val);
-        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 128, 128 }, r_val);
-        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 128 }, b_val);
+        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 128, 16}, w_val);
+        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 128, 128}, r_val);
+        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 128}, b_val);
 
         auto data = std::make_shared<ngraph::opset1::ShapeOf>(X);
-        auto reshape_before_pattern = std::make_shared<ngraph::opset8::Gather>(data,
-            ngraph::opset1::Constant::create(ngraph::element::i32, { 3 }, { 1, 0, 2 }),
-            ngraph::opset1::Constant::create(ngraph::element::i32, {}, { 0 }));
+        auto reshape_before_pattern = std::make_shared<ngraph::opset8::Gather>(
+            data,
+            ngraph::opset1::Constant::create(ngraph::element::i32, {3}, {1, 0, 2}),
+            ngraph::opset1::Constant::create(ngraph::element::i32, {}, {0}));
         auto reshape_before = std::make_shared<ngraph::opset1::Reshape>(X, reshape_before_pattern, false);
 
-        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ngraph::opset5::RNNSequence>(reshape_before, Y, seq_lengths, W, R, B, 128,
-            ngraph::op::RecurrentSequenceDirection::FORWARD);
+        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {2});
+        auto lstm_seq = std::make_shared<ngraph::opset5::RNNSequence>(reshape_before,
+                                                                      Y,
+                                                                      seq_lengths,
+                                                                      W,
+                                                                      R,
+                                                                      B,
+                                                                      128,
+                                                                      ngraph::op::RecurrentSequenceDirection::FORWARD);
 
-        auto reshape_after_const = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 4 }, { 2, 1, 1, 128 });
+        auto reshape_after_const =
+            ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {2, 1, 1, 128});
         auto reshape_after = std::make_shared<ngraph::opset1::Reshape>(lstm_seq->output(0), reshape_after_const, false);
 
         const auto Y_out = std::make_shared<ngraph::opset1::Result>(reshape_after);
@@ -308,7 +378,7 @@ TEST(TransformationTests, OptimizeRNNSequenceTransposesDynamicTest) {
         Y_out->set_friendly_name("Y_out");
         Ho->set_friendly_name("Ho");
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::ResultVector{ Y_out, Ho }, ngraph::ParameterVector{ X, Y });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::ResultVector{Y_out, Ho}, ngraph::ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -318,24 +388,32 @@ TEST(TransformationTests, OptimizeRNNSequenceTransposesDynamicTest) {
 TEST(TransformationTests, OptimizeGRUSequenceTransposesTest) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 2, 1, 16 });
-        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 1, 128 });
+        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{2, 1, 16});
+        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 128});
 
         auto w_val = std::vector<float>(384 * 16, 0);
         auto r_val = std::vector<float>(384 * 128, 0);
         auto b_val = std::vector<float>(384, 0);
-        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 384, 16 }, w_val);
-        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 384, 128 }, r_val);
-        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 384 }, b_val);
+        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 384, 16}, w_val);
+        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 384, 128}, r_val);
+        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 384}, b_val);
 
-        auto transpose_before_const = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 3 }, { 1, 0, 2 });
+        auto transpose_before_const =
+            ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{3}, {1, 0, 2});
         auto transpose_before = std::make_shared<ngraph::opset1::Transpose>(X, transpose_before_const);
 
-        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ngraph::opset5::GRUSequence>(transpose_before, Y, seq_lengths, W, R, B, 128,
-            ngraph::op::RecurrentSequenceDirection::FORWARD);
+        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {2});
+        auto lstm_seq = std::make_shared<ngraph::opset5::GRUSequence>(transpose_before,
+                                                                      Y,
+                                                                      seq_lengths,
+                                                                      W,
+                                                                      R,
+                                                                      B,
+                                                                      128,
+                                                                      ngraph::op::RecurrentSequenceDirection::FORWARD);
 
-        auto transpose_after_const = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 4 }, { 2, 1, 0, 3 });
+        auto transpose_after_const =
+            ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {2, 1, 0, 3});
         auto transpose_after = std::make_shared<ngraph::opset1::Transpose>(lstm_seq->output(0), transpose_after_const);
 
         const auto Y_out = std::make_shared<ngraph::opset1::Result>(transpose_after);
@@ -343,7 +421,7 @@ TEST(TransformationTests, OptimizeGRUSequenceTransposesTest) {
         Y_out->set_friendly_name("Y_out");
         Ho->set_friendly_name("Ho");
 
-        f = std::make_shared<ngraph::Function>(ngraph::ResultVector{ Y_out, Ho }, ngraph::ParameterVector{ X, Y });
+        f = std::make_shared<ngraph::Function>(ngraph::ResultVector{Y_out, Ho}, ngraph::ParameterVector{X, Y});
 
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
@@ -352,24 +430,32 @@ TEST(TransformationTests, OptimizeGRUSequenceTransposesTest) {
     }
 
     {
-        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 2, 1, 16 });
-        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 1, 128 });
+        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{2, 1, 16});
+        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 128});
 
         auto w_val = std::vector<float>(384 * 16, 0);
         auto r_val = std::vector<float>(384 * 128, 0);
         auto b_val = std::vector<float>(384, 0);
-        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 384, 16 }, w_val);
-        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 384, 128 }, r_val);
-        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 384 }, b_val);
+        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 384, 16}, w_val);
+        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 384, 128}, r_val);
+        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 384}, b_val);
 
-        auto reshape_before_const = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 3 }, { 1, 2, 16 });
+        auto reshape_before_const =
+            ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{3}, {1, 2, 16});
         auto reshape_before = std::make_shared<ngraph::opset1::Reshape>(X, reshape_before_const, false);
 
-        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ngraph::opset5::GRUSequence>(reshape_before, Y, seq_lengths, W, R, B, 128,
-            ngraph::op::RecurrentSequenceDirection::FORWARD);
+        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {2});
+        auto lstm_seq = std::make_shared<ngraph::opset5::GRUSequence>(reshape_before,
+                                                                      Y,
+                                                                      seq_lengths,
+                                                                      W,
+                                                                      R,
+                                                                      B,
+                                                                      128,
+                                                                      ngraph::op::RecurrentSequenceDirection::FORWARD);
 
-        auto reshape_after_const = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 4 }, { 2, 1, 1, 128 });
+        auto reshape_after_const =
+            ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {2, 1, 1, 128});
         auto reshape_after = std::make_shared<ngraph::opset1::Reshape>(lstm_seq->output(0), reshape_after_const, false);
 
         const auto Y_out = std::make_shared<ngraph::opset1::Result>(reshape_after);
@@ -377,7 +463,7 @@ TEST(TransformationTests, OptimizeGRUSequenceTransposesTest) {
         Y_out->set_friendly_name("Y_out");
         Ho->set_friendly_name("Ho");
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::ResultVector{ Y_out, Ho }, ngraph::ParameterVector{ X, Y });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::ResultVector{Y_out, Ho}, ngraph::ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -387,24 +473,32 @@ TEST(TransformationTests, OptimizeGRUSequenceTransposesTest) {
 TEST(TransformationTests, OptimizeGRUSequenceTransposesDynamicTest) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{ 2, -1, -1 });
-        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 1, 128 });
+        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{2, -1, -1});
+        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 128});
 
         auto w_val = std::vector<float>(384 * 16, 0);
         auto r_val = std::vector<float>(384 * 128, 0);
         auto b_val = std::vector<float>(384, 0);
-        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 384, 16 }, w_val);
-        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 384, 128 }, r_val);
-        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 384 }, b_val);
+        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 384, 16}, w_val);
+        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 384, 128}, r_val);
+        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 384}, b_val);
 
-        auto transpose_before_const = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 3 }, { 1, 0, 2 });
+        auto transpose_before_const =
+            ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{3}, {1, 0, 2});
         auto transpose_before = std::make_shared<ngraph::opset1::Transpose>(X, transpose_before_const);
 
-        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ngraph::opset5::GRUSequence>(transpose_before, Y, seq_lengths, W, R, B, 128,
-            ngraph::op::RecurrentSequenceDirection::FORWARD);
+        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {2});
+        auto lstm_seq = std::make_shared<ngraph::opset5::GRUSequence>(transpose_before,
+                                                                      Y,
+                                                                      seq_lengths,
+                                                                      W,
+                                                                      R,
+                                                                      B,
+                                                                      128,
+                                                                      ngraph::op::RecurrentSequenceDirection::FORWARD);
 
-        auto transpose_after_const = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 4 }, { 2, 1, 0, 3 });
+        auto transpose_after_const =
+            ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{4}, {2, 1, 0, 3});
         auto transpose_after = std::make_shared<ngraph::opset1::Transpose>(lstm_seq->output(0), transpose_after_const);
 
         const auto Y_out = std::make_shared<ngraph::opset1::Result>(transpose_after);
@@ -412,7 +506,7 @@ TEST(TransformationTests, OptimizeGRUSequenceTransposesDynamicTest) {
         Y_out->set_friendly_name("Y_out");
         Ho->set_friendly_name("Ho");
 
-        f = std::make_shared<ngraph::Function>(ngraph::ResultVector{ Y_out, Ho }, ngraph::ParameterVector{ X, Y });
+        f = std::make_shared<ngraph::Function>(ngraph::ResultVector{Y_out, Ho}, ngraph::ParameterVector{X, Y});
 
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
@@ -421,27 +515,35 @@ TEST(TransformationTests, OptimizeGRUSequenceTransposesDynamicTest) {
     }
 
     {
-        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{ 2, -1, -1 });
-        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 1, 128 });
+        auto X = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape{2, -1, -1});
+        auto Y = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 1, 128});
 
         auto w_val = std::vector<float>(384 * 16, 0);
         auto r_val = std::vector<float>(384 * 128, 0);
         auto b_val = std::vector<float>(384, 0);
-        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 384, 16 }, w_val);
-        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 384, 128 }, r_val);
-        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 384 }, b_val);
+        auto W = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 384, 16}, w_val);
+        auto R = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 384, 128}, r_val);
+        auto B = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 384}, b_val);
 
         auto data = std::make_shared<ngraph::opset1::ShapeOf>(X);
-        auto reshape_before_pattern = std::make_shared<ngraph::opset8::Gather>(data,
-            ngraph::opset1::Constant::create(ngraph::element::i32, { 3 }, { 1, 0, 2 }),
-            ngraph::opset1::Constant::create(ngraph::element::i32, {}, { 0 }));
+        auto reshape_before_pattern = std::make_shared<ngraph::opset8::Gather>(
+            data,
+            ngraph::opset1::Constant::create(ngraph::element::i32, {3}, {1, 0, 2}),
+            ngraph::opset1::Constant::create(ngraph::element::i32, {}, {0}));
         auto reshape_before = std::make_shared<ngraph::opset1::Reshape>(X, reshape_before_pattern, false);
 
-        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{ 1 }, { 2 });
-        auto lstm_seq = std::make_shared<ngraph::opset5::GRUSequence>(reshape_before, Y, seq_lengths, W, R, B, 128,
-            ngraph::op::RecurrentSequenceDirection::FORWARD);
+        auto seq_lengths = ngraph::opset1::Constant::create(ngraph::element::i32, ngraph::Shape{1}, {2});
+        auto lstm_seq = std::make_shared<ngraph::opset5::GRUSequence>(reshape_before,
+                                                                      Y,
+                                                                      seq_lengths,
+                                                                      W,
+                                                                      R,
+                                                                      B,
+                                                                      128,
+                                                                      ngraph::op::RecurrentSequenceDirection::FORWARD);
 
-        auto reshape_after_const = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 4 }, { 2, 1, 1, 128 });
+        auto reshape_after_const =
+            ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{4}, {2, 1, 1, 128});
         auto reshape_after = std::make_shared<ngraph::opset1::Reshape>(lstm_seq->output(0), reshape_after_const, false);
 
         const auto Y_out = std::make_shared<ngraph::opset1::Result>(reshape_after);
@@ -449,7 +551,7 @@ TEST(TransformationTests, OptimizeGRUSequenceTransposesDynamicTest) {
         Y_out->set_friendly_name("Y_out");
         Ho->set_friendly_name("Ho");
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::ResultVector{ Y_out, Ho }, ngraph::ParameterVector{ X, Y });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::ResultVector{Y_out, Ho}, ngraph::ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);

--- a/src/plugins/intel_cpu/tests/unit/ngraph_transformations/reshape_prelu_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/ngraph_transformations/reshape_prelu_test.cpp
@@ -4,16 +4,16 @@
 
 #include <gtest/gtest.h>
 
-#include <string>
 #include <memory>
-
 #include <ngraph/function.hpp>
 #include <ngraph/opsets/opset1.hpp>
+#include <ngraph/pass/manager.hpp>
+#include <ngraph_ops/type_relaxed.hpp>
 #include <ngraph_transformations/reshape_prelu.hpp>
+#include <string>
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>
-#include <ngraph_ops/type_relaxed.hpp>
-#include <ngraph/pass/manager.hpp>
+
 #include "common_test_utils/ngraph_test_utils.hpp"
 
 using namespace testing;
@@ -22,11 +22,11 @@ using namespace ov::intel_cpu;
 TEST(TransformationTests, ReshapePReluTest1) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 3 }, { -2.f, -1.f, -2.f });
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 16, 16});
+        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
         m.register_pass<ReshapePRelu>();
@@ -34,11 +34,12 @@ TEST(TransformationTests, ReshapePReluTest1) {
     }
 
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 3, 1, 1 }, { -2.f, -1.f, -2.f });
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 16, 16});
+        auto slope =
+            ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 3, 1, 1}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -48,12 +49,15 @@ TEST(TransformationTests, ReshapePReluTest1) {
 TEST(TransformationTests, ReshapePReluTest2) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input_pshape = ngraph::PartialShape{ ngraph::Dimension::dynamic(), 3, ngraph::Dimension::dynamic(), ngraph::Dimension::dynamic() };
+        auto input_pshape = ngraph::PartialShape{ngraph::Dimension::dynamic(),
+                                                 3,
+                                                 ngraph::Dimension::dynamic(),
+                                                 ngraph::Dimension::dynamic()};
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, input_pshape);
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 3 }, { -2.f, -1.f, -2.f });
+        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
         m.register_pass<ReshapePRelu>();
@@ -61,12 +65,16 @@ TEST(TransformationTests, ReshapePReluTest2) {
     }
 
     {
-        auto input_pshape = ngraph::PartialShape{ ngraph::Dimension::dynamic(), 3, ngraph::Dimension::dynamic(), ngraph::Dimension::dynamic() };
+        auto input_pshape = ngraph::PartialShape{ngraph::Dimension::dynamic(),
+                                                 3,
+                                                 ngraph::Dimension::dynamic(),
+                                                 ngraph::Dimension::dynamic()};
         auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, input_pshape);
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 3, 1, 1 }, { -2.f, -1.f, -2.f });
+        auto slope =
+            ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 3, 1, 1}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -76,11 +84,12 @@ TEST(TransformationTests, ReshapePReluTest2) {
 TEST(TransformationTests, ReshapePReluTest3) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(4));
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 3 }, { -2.f, -1.f, -2.f });
+        auto input =
+            std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(4));
+        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
         m.register_pass<ReshapePRelu>();
@@ -88,11 +97,13 @@ TEST(TransformationTests, ReshapePReluTest3) {
     }
 
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(4));
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 3, 1, 1 }, { -2.f, -1.f, -2.f });
+        auto input =
+            std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(4));
+        auto slope =
+            ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 3, 1, 1}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -102,11 +113,11 @@ TEST(TransformationTests, ReshapePReluTest3) {
 TEST(TransformationTests, ReshapePReluTest4) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 16, 16 });
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{}, { -2.f });
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 16, 16});
+        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{}, {-2.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
         f_ref = f;
 
         ngraph::pass::Manager m;
@@ -122,11 +133,11 @@ TEST(TransformationTests, ReshapePReluTest4) {
 TEST(TransformationTests, ReshapePReluTest5) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 3 });
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 3 }, { -2.f, -1.f, -2.f });
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{3});
+        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
         f_ref = f;
 
         ngraph::pass::Manager m;
@@ -142,11 +153,11 @@ TEST(TransformationTests, ReshapePReluTest5) {
 TEST(TransformationTests, ReshapePReluTest6) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 1, 3, 4, 4 });
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 4 }, { -2.f, -1.f, -2.f, -1.f });
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{1, 3, 4, 4});
+        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{4}, {-2.f, -1.f, -2.f, -1.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
         f_ref = f;
 
         ngraph::pass::Manager m;
@@ -162,15 +173,15 @@ TEST(TransformationTests, ReshapePReluTest6) {
 TEST(TransformationTests, ReshapePReluTest7) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::u8, ngraph::Shape{ 1, 3, 16, 16 });
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 3 }, { -2.f, -1.f, -2.f });
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::u8, ngraph::Shape{1, 3, 16, 16});
+        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3}, {-2.f, -1.f, -2.f});
         auto relaxed_prelu = std::make_shared<ngraph::op::TypeRelaxed<ngraph::opset1::PRelu>>(
-            ngraph::element::TypeVector{ ngraph::element::f32, ngraph::element::f32 },
-            ngraph::element::TypeVector{ ngraph::element::f32 },
+            ngraph::element::TypeVector{ngraph::element::f32, ngraph::element::f32},
+            ngraph::element::TypeVector{ngraph::element::f32},
             ngraph::op::TemporaryReplaceOutputType(input, ngraph::element::f32).get(),
             ngraph::op::TemporaryReplaceOutputType(slope, ngraph::element::f32).get());
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ relaxed_prelu }, ngraph::ParameterVector{ input });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{relaxed_prelu}, ngraph::ParameterVector{input});
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
         m.register_pass<ReshapePRelu>();
@@ -178,15 +189,16 @@ TEST(TransformationTests, ReshapePReluTest7) {
     }
 
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::u8, ngraph::Shape{ 1, 3, 16, 16 });
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 3, 1, 1 }, { -2.f, -1.f, -2.f });
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::u8, ngraph::Shape{1, 3, 16, 16});
+        auto slope =
+            ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 3, 1, 1}, {-2.f, -1.f, -2.f});
         auto relaxed_prelu = std::make_shared<ngraph::op::TypeRelaxed<ngraph::opset1::PRelu>>(
-            ngraph::element::TypeVector{ ngraph::element::f32, ngraph::element::f32 },
-            ngraph::element::TypeVector{ ngraph::element::f32 },
+            ngraph::element::TypeVector{ngraph::element::f32, ngraph::element::f32},
+            ngraph::element::TypeVector{ngraph::element::f32},
             ngraph::op::TemporaryReplaceOutputType(input, ngraph::element::f32).get(),
             ngraph::op::TemporaryReplaceOutputType(slope, ngraph::element::f32).get());
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ relaxed_prelu }, ngraph::ParameterVector{ input });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{relaxed_prelu}, ngraph::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -196,11 +208,11 @@ TEST(TransformationTests, ReshapePReluTest7) {
 TEST(TransformationTests, ReshapePReluTest8) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 4, 3 });
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 3 }, { -2.f, -1.f, -2.f });
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{4, 3});
+        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{3}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
         m.register_pass<ReshapePRelu>();
@@ -208,11 +220,11 @@ TEST(TransformationTests, ReshapePReluTest8) {
     }
 
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{ 4, 3 });
-        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{ 1, 3 }, { -2.f, -1.f, -2.f });
+        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::Shape{4, 3});
+        auto slope = ngraph::opset1::Constant::create(ngraph::element::f32, ngraph::Shape{1, 3}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -222,11 +234,13 @@ TEST(TransformationTests, ReshapePReluTest8) {
 TEST(TransformationTests, ReshapePReluTest9) {
     std::shared_ptr<ngraph::Function> f(nullptr), f_ref(nullptr);
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(4));
-        auto slope = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(1));
+        auto input =
+            std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(4));
+        auto slope =
+            std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(1));
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input, slope });
+        f = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input, slope});
         ngraph::pass::Manager m;
         m.register_pass<ngraph::pass::InitNodeInfo>();
         m.register_pass<ReshapePRelu>();
@@ -234,15 +248,17 @@ TEST(TransformationTests, ReshapePReluTest9) {
     }
 
     {
-        auto input = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(4));
-        auto slope = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(1));
+        auto input =
+            std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(4));
+        auto slope =
+            std::make_shared<ngraph::opset1::Parameter>(ngraph::element::f32, ngraph::PartialShape::dynamic(1));
 
         auto shape_of = std::make_shared<ngraph::opset1::ShapeOf>(slope);
-        auto reshape_const = ngraph::opset1::Constant::create(ngraph::element::i64, { 4 }, { 1, -1, 1, 1 });
+        auto reshape_const = ngraph::opset1::Constant::create(ngraph::element::i64, {4}, {1, -1, 1, 1});
         auto reshape = std::make_shared<ngraph::opset1::Reshape>(slope, reshape_const, true);
         auto prelu = std::make_shared<ngraph::opset1::PRelu>(input, reshape);
 
-        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{ prelu }, ngraph::ParameterVector{ input, slope });
+        f_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{prelu}, ngraph::ParameterVector{input, slope});
     }
 
     auto res = compare_functions(f, f_ref);

--- a/src/plugins/intel_cpu/tests/unit/ngraph_transformations/snipptes_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/tests/unit/ngraph_transformations/snipptes_mark_skipped.cpp
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <gtest/gtest.h>
-#include <subgraph_simple.hpp>
-#include <subgraph_customizable.hpp>
-#include <snippets_helpers.hpp>
+
 #include <ngraph_transformations/snippets_mark_skipped.hpp>
+#include <snippets_helpers.hpp>
+#include <subgraph_customizable.hpp>
+#include <subgraph_simple.hpp>
+
 #include "snippets/pass/collapse_subgraph.hpp"
 
 namespace ov {
@@ -23,7 +25,7 @@ public:
 };
 
 TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipAfterInputsEltwise) {
-    const auto &f = EltwiseFunction({{2, 3}, {1, 3}});
+    const auto& f = EltwiseFunction({{2, 3}, {1, 3}});
     function = f.getOriginal();
     // None subgraphs are expected, since the whole graph is an eltwise chain after input
     function_ref = f.getOriginal();
@@ -31,7 +33,7 @@ TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipAfterInputsEltwise) {
 }
 
 TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipAfterInputsMatMulEltwise) {
-    const auto &f = MatMulEltwiseBranchesFunction(std::vector<Shape> {{1, 3, 4, 4}, {1, 3, 4, 4}});
+    const auto& f = MatMulEltwiseBranchesFunction(std::vector<Shape>{{1, 3, 4, 4}, {1, 3, 4, 4}});
     function = f.getOriginal();
     // Fully tokenizable, since inputs are followed by MatMul
     function_ref = f.getReference();
@@ -39,11 +41,11 @@ TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipAfterInputsMatMulEltwise) {
 }
 
 TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipConvFused_ConvMulActivation) {
-    std::vector<std::shared_ptr<Node>> eltwiseOps {std::make_shared<ov::op::v1::Multiply>(),
-                                                   std::make_shared<ov::op::v0::Tanh>(),
-                                                   std::make_shared<ov::op::v0::Sqrt>()};
-    std::vector<Shape> inputShapes {{1, 2, 16, 16}, {1, 2, 1, 16}};
-    const auto &f = ConvMulActivationFunction(inputShapes, eltwiseOps);
+    std::vector<std::shared_ptr<Node>> eltwiseOps{std::make_shared<ov::op::v1::Multiply>(),
+                                                  std::make_shared<ov::op::v0::Tanh>(),
+                                                  std::make_shared<ov::op::v0::Sqrt>()};
+    std::vector<Shape> inputShapes{{1, 2, 16, 16}, {1, 2, 1, 16}};
+    const auto& f = ConvMulActivationFunction(inputShapes, eltwiseOps);
     function = f.getOriginal();
     // Fully tokenizable, since Mul with 2 inputs isn't fused into Convolution
     function_ref = f.getReference();
@@ -51,11 +53,11 @@ TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipConvFused_ConvMulActivation)
 }
 
 TEST_F(SnippetsMarkSkippedTests, smoke_SkipConvFused_ConvSumActivation) {
-    std::vector<std::shared_ptr<Node>> eltwiseOps {std::make_shared<ov::op::v1::Add>(),
-                                                   std::make_shared<ov::op::v0::Tanh>(),
-                                                   std::make_shared<ov::op::v0::Sqrt>()};
-    std::vector<Shape> inputShapes {{1, 2, 16, 16}, {1, 2, 1, 16}};
-    const auto &f = ConvMulActivationFunction(inputShapes, eltwiseOps);
+    std::vector<std::shared_ptr<Node>> eltwiseOps{std::make_shared<ov::op::v1::Add>(),
+                                                  std::make_shared<ov::op::v0::Tanh>(),
+                                                  std::make_shared<ov::op::v0::Sqrt>()};
+    std::vector<Shape> inputShapes{{1, 2, 16, 16}, {1, 2, 1, 16}};
+    const auto& f = ConvMulActivationFunction(inputShapes, eltwiseOps);
     function = f.getOriginal();
     // Not tokenizable, since Add + Eltwises can be fused into Convolution
     function_ref = f.getOriginal();

--- a/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
@@ -107,21 +107,21 @@ struct ReorderCPUTestParamSet {
 class ReorderCPUTestGraph {
 public:
     void buildReorderGraph(const ov::intel_cpu::CpuBlockedMemoryDesc& inputDesc,
-                    const ov::intel_cpu::CpuBlockedMemoryDesc& outputDesc) {
+                           const ov::intel_cpu::CpuBlockedMemoryDesc& outputDesc) {
         const dnnl::engine cpuEngine = {dnnl::engine::kind::cpu, 0};
         ov::intel_cpu::WeightsSharing::Ptr weightsCache;
 
         inputNode = std::make_shared<ov::intel_cpu::node::Input>(inputDesc.clone(),
-                                                                      "Reorder_Input",
-                                                                      "Parameter",
-                                                                      cpuEngine,
-                                                                      weightsCache);
+                                                                 "Reorder_Input",
+                                                                 "Parameter",
+                                                                 cpuEngine,
+                                                                 weightsCache);
         reorderNode = std::make_shared<ov::intel_cpu::node::Reorder>("Reorder", cpuEngine, weightsCache);
         outputNode = std::make_shared<ov::intel_cpu::node::Input>(outputDesc.clone(),
-                                                                       "Reorder_Output",
-                                                                       "Result",
-                                                                       cpuEngine,
-                                                                       weightsCache);
+                                                                  "Reorder_Output",
+                                                                  "Result",
+                                                                  cpuEngine,
+                                                                  weightsCache);
 
         parentEdge = std::make_shared<ov::intel_cpu::Edge>(inputNode, reorderNode, 0, 0);
         childEdge = std::make_shared<ov::intel_cpu::Edge>(reorderNode, outputNode, 0, 0);
@@ -162,7 +162,7 @@ protected:
     InferenceEngine::Precision prec;
 };
 
-}// namespace ReorderCPUTest
+}  // namespace ReorderCPUTest
 
 using namespace ReorderCPUTest;
 
@@ -313,8 +313,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_ReorderTestCustomStrideWithFactor,
  * ReorderCPUTest to test the CPU plugin-in dynamism and RT cache
  */
 class ReorderDynamismCPUTest : public ::testing::Test,
-                       public ::testing::WithParamInterface<ReorderCPUTestParamSet>,
-                       public ::ReorderCPUTest::ReorderCPUTestGraph {
+                               public ::testing::WithParamInterface<ReorderCPUTestParamSet>,
+                               public ::ReorderCPUTest::ReorderCPUTestGraph {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ReorderCPUTestParamSet>& obj) {
         ReorderCPUTestParamSet p = obj.param;

--- a/src/plugins/intel_cpu/tests/unit/registers_pool.cpp
+++ b/src/plugins/intel_cpu/tests/unit/registers_pool.cpp
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <gtest/gtest.h>
 #include "nodes/kernels/registers_pool.hpp"
+
+#include <gtest/gtest.h>
+
 #include "common/nstl.hpp"
 
 using namespace ov::intel_cpu;
@@ -12,11 +14,11 @@ template <class T>
 class RegPoolTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        if (typename T::RegT(0).isREG()) { // for general purpose registers Reg8, Reg16, Reg32, Reg64
-            regNumber = 15; // the RSP register excluded by default
+        if (typename T::RegT(0).isREG()) {  // for general purpose registers Reg8, Reg16, Reg32, Reg64
+            regNumber = 15;                 // the RSP register excluded by default
         } else if (typename T::RegT(0).isOPMASK()) {
             regNumber = 8;
-        } else { // SIMD registers
+        } else {  // SIMD registers
             regNumber = x64::cpu_isa_traits<T::IsaParam::isa>::n_vregs;
         }
     }
@@ -32,7 +34,7 @@ TYPED_TEST_P(RegPoolTest, get_return_by_scope) {
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
     {
         RegistersPool::Reg<XbyakRegT> reg{regPool};
-        ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg));
+        ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT&>(reg));
         ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
     }
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
@@ -43,13 +45,13 @@ TYPED_TEST_P(RegPoolTest, get_return_by_method) {
     RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({});
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
     RegistersPool::Reg<XbyakRegT> reg{regPool};
-    ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg));
+    ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT&>(reg));
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
     reg.release();
-    ASSERT_ANY_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg));
+    ASSERT_ANY_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT&>(reg));
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
     reg = RegistersPool::Reg<XbyakRegT>{regPool};
-    ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg));
+    ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT&>(reg));
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
 }
 
@@ -58,7 +60,7 @@ TYPED_TEST_P(RegPoolTest, default_ctor) {
     RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({});
     RegistersPool::Reg<XbyakRegT> reg;
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber);
-    ASSERT_ANY_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg));
+    ASSERT_ANY_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT&>(reg));
 }
 
 TYPED_TEST_P(RegPoolTest, get_all) {
@@ -79,7 +81,7 @@ TYPED_TEST_P(RegPoolTest, move) {
     using XbyakRegT = typename TypeParam::RegT;
     RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({});
     RegistersPool::Reg<XbyakRegT> reg{regPool};
-    ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg));
+    ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT&>(reg));
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
     RegistersPool::Reg<XbyakRegT> reg2{regPool};
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 2);
@@ -87,11 +89,10 @@ TYPED_TEST_P(RegPoolTest, move) {
     reg2 = std::move(reg);
     ASSERT_EQ(reg2.getIdx(), regIdx);
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
-    ASSERT_ANY_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg));
-    ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT &>(reg2));
+    ASSERT_ANY_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT&>(reg));
+    ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<XbyakRegT&>(reg2));
     ASSERT_EQ(regPool->countFree<XbyakRegT>(), this->regNumber - 1);
 }
-
 
 TYPED_TEST_P(RegPoolTest, fixed_idx) {
     using XbyakRegT = typename TypeParam::RegT;
@@ -99,7 +100,8 @@ TYPED_TEST_P(RegPoolTest, fixed_idx) {
     using Ptr = std::shared_ptr<RegistersPool::Reg<XbyakRegT>>;
     std::vector<Ptr> regs(this->regNumber);
     for (int c = 0; c < this->regNumber; ++c) {
-        if (c == Xbyak::Operand::RSP) continue;
+        if (c == Xbyak::Operand::RSP)
+            continue;
         regs[c] = std::make_shared<RegistersPool::Reg<XbyakRegT>>(regPool, c);
         ASSERT_EQ(regs[c]->getIdx(), c);
     }
@@ -111,9 +113,7 @@ TYPED_TEST_P(RegPoolTest, fixed_idx) {
 TYPED_TEST_P(RegPoolTest, exclude) {
     using XbyakRegT = typename TypeParam::RegT;
     static constexpr int excludedIdx = 0;
-    RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({
-                                                                                         XbyakRegT(excludedIdx)
-                                                                                 });
+    RegistersPool::Ptr regPool = RegistersPool::create<TypeParam::IsaParam::isa>({XbyakRegT(excludedIdx)});
     using Ptr = std::shared_ptr<RegistersPool::Reg<XbyakRegT>>;
     std::vector<Ptr> regs(this->regNumber - 1);
     std::set<int> idxsInUse;
@@ -127,68 +127,73 @@ TYPED_TEST_P(RegPoolTest, exclude) {
 
 namespace combiner {
 
-template<class Reg, class Isa>
+template <class Reg, class Isa>
 struct Case {
     using RegT = Reg;
     using IsaParam = Isa;
 };
 
-template<class TupleType, class TupleParam, std::size_t I>
+template <class TupleType, class TupleParam, std::size_t I>
 struct make_case {
     static constexpr std::size_t N = std::tuple_size<TupleParam>::value;
 
-    using type = Case<typename std::tuple_element<I / N, TupleType>::type,
-            typename std::tuple_element<I % N, TupleParam>::type>;
+    using type =
+        Case<typename std::tuple_element<I / N, TupleType>::type, typename std::tuple_element<I % N, TupleParam>::type>;
 };
 
-template<class T1, class T2, class Is>
+template <class T1, class T2, class Is>
 struct make_combinations;
 
-template<size_t ...> struct index_sequence  { };
-template<size_t N, size_t ...S> struct make_index_sequence_impl : make_index_sequence_impl <N - 1, N - 1, S...> { };
-template<size_t ...S> struct make_index_sequence_impl <0, S...> { using type = index_sequence<S...>; };
-template<size_t N> using make_index_sequence = typename make_index_sequence_impl<N>::type;
+template <size_t...>
+struct index_sequence {};
+template <size_t N, size_t... S>
+struct make_index_sequence_impl : make_index_sequence_impl<N - 1, N - 1, S...> {};
+template <size_t... S>
+struct make_index_sequence_impl<0, S...> {
+    using type = index_sequence<S...>;
+};
+template <size_t N>
+using make_index_sequence = typename make_index_sequence_impl<N>::type;
 
-template<class TupleType, class TupleParam, std::size_t... Is>
+template <class TupleType, class TupleParam, std::size_t... Is>
 struct make_combinations<TupleType, TupleParam, index_sequence<Is...>> {
     using tuples = std::tuple<typename make_case<TupleType, TupleParam, Is>::type...>;
 };
 
-template<class TupleTypes, class... Params>
-using Combinations_t = typename make_combinations
-        <TupleTypes,
-                std::tuple<Params...>,
-                make_index_sequence<(std::tuple_size<TupleTypes>::value) *(sizeof...(Params))>>::tuples;
+template <class TupleTypes, class... Params>
+using Combinations_t =
+    typename make_combinations<TupleTypes,
+                               std::tuple<Params...>,
+                               make_index_sequence<(std::tuple_size<TupleTypes>::value) * (sizeof...(Params))>>::tuples;
 
-template<class T>
+template <class T>
 struct TestTypesCombiner;
 
-template<class ...T>
+template <class... T>
 struct TestTypesCombiner<std::tuple<T...>> {
     using Types = ::testing::Types<T...>;
 };
 
-} // namespace combiner
+}  // namespace combiner
 
-template<x64::cpu_isa_t Isa>
-struct IsaParam { static constexpr x64::cpu_isa_t isa = Isa; };
+template <x64::cpu_isa_t Isa>
+struct IsaParam {
+    static constexpr x64::cpu_isa_t isa = Isa;
+};
 
 using TestTypes = combiner::TestTypesCombiner<combiner::Combinations_t<
-        std::tuple<
-                Xbyak::Reg8, Xbyak::Reg16, Xbyak::Reg32, Xbyak::Reg64, Xbyak::Xmm, Xbyak::Ymm, Xbyak::Zmm
-        >,
-        IsaParam<x64::sse41>,
-        IsaParam<x64::avx>,
-        IsaParam<x64::avx2>,
-        IsaParam<x64::avx2_vnni> >>::Types;
+    std::tuple<Xbyak::Reg8, Xbyak::Reg16, Xbyak::Reg32, Xbyak::Reg64, Xbyak::Xmm, Xbyak::Ymm, Xbyak::Zmm>,
+    IsaParam<x64::sse41>,
+    IsaParam<x64::avx>,
+    IsaParam<x64::avx2>,
+    IsaParam<x64::avx2_vnni>>>::Types;
 
 using TestTypesAvx512 = combiner::TestTypesCombiner<combiner::Combinations_t<
-        std::tuple<
-                Xbyak::Reg8, Xbyak::Reg16, Xbyak::Reg32, Xbyak::Reg64, Xbyak::Xmm, Xbyak::Ymm, Xbyak::Zmm, Xbyak::Opmask
-        >,
-        IsaParam<x64::avx512_core>,
-        IsaParam<x64::avx512_core_vnni>,
-        IsaParam<x64::avx512_core_bf16> >>::Types;
+    std::
+        tuple<Xbyak::Reg8, Xbyak::Reg16, Xbyak::Reg32, Xbyak::Reg64, Xbyak::Xmm, Xbyak::Ymm, Xbyak::Zmm, Xbyak::Opmask>,
+    IsaParam<x64::avx512_core>,
+    IsaParam<x64::avx512_core_vnni>,
+    IsaParam<x64::avx512_core_bf16>>>::Types;
 
 REGISTER_TYPED_TEST_SUITE_P(RegPoolTest,
                             get_return_by_scope,
@@ -202,7 +207,6 @@ REGISTER_TYPED_TEST_SUITE_P(RegPoolTest,
 INSTANTIATE_TYPED_TEST_SUITE_P(testIsaAndRegTypes, RegPoolTest, TestTypes);
 INSTANTIATE_TYPED_TEST_SUITE_P(testIsaAndRegTypesAvx512, RegPoolTest, TestTypesAvx512);
 
-
 const int simdRegNumber = x64::cpu_isa_traits<x64::avx2>::n_vregs;
 const int freeGeneralRegNumber = 15;
 
@@ -212,7 +216,7 @@ TEST(RegistersPoolTests, simd_and_general) {
     ASSERT_EQ(regPool->countFree<Xbyak::Reg64>(), freeGeneralRegNumber);
     {
         RegistersPool::Reg<Xbyak::Xmm> reg{regPool};
-        ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<Xbyak::Xmm &>(reg));
+        ASSERT_NO_THROW([[maybe_unused]] auto val = static_cast<Xbyak::Xmm&>(reg));
         ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber - 1);
         ASSERT_EQ(regPool->countFree<Xbyak::Ymm>(), simdRegNumber - 1);
         ASSERT_EQ(regPool->countFree<Xbyak::Reg64>(), freeGeneralRegNumber);
@@ -244,4 +248,3 @@ TEST(RegistersPoolTests, get_all) {
     regs.clear();
     ASSERT_EQ(regPool->countFree<Xbyak::Xmm>(), simdRegNumber);
 }
-

--- a/src/plugins/intel_cpu/tests/unit/rt_cache.cpp
+++ b/src/plugins/intel_cpu/tests/unit/rt_cache.cpp
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <thread>
-
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <thread>
 
 #include "cache/lru_cache.h"
 #include "cache/multi_cache.h"
@@ -23,7 +23,7 @@ struct IntKey {
 
     int data;
 };
-} // namespace
+}  // namespace
 
 TEST(LruCacheTests, Evict) {
     constexpr size_t capacity = 10;
@@ -97,12 +97,12 @@ TEST(LruCacheTests, Empty) {
     }
 }
 namespace {
-template<typename T, typename K>
+template <typename T, typename K>
 class mockBuilder {
 public:
     MOCK_METHOD(T, build, (const K&));
 };
-}// namespace
+}  // namespace
 
 TEST(CacheEntryTests, GetOrCreate) {
     using testing::_;
@@ -111,15 +111,17 @@ TEST(CacheEntryTests, GetOrCreate) {
     constexpr size_t capacity = 10;
 
     mockBuilder<ValueType::element_type, IntKey> builderMock;
-    EXPECT_CALL(builderMock, build(_))
-            .Times(3 * capacity)
-            .WillRepeatedly([](const IntKey& key){return key.data;});
+    EXPECT_CALL(builderMock, build(_)).Times(3 * capacity).WillRepeatedly([](const IntKey& key) {
+        return key.data;
+    });
 
-    auto builder = [&](const IntKey& key) { return std::make_shared<int>(builderMock.build(key)); };
+    auto builder = [&](const IntKey& key) {
+        return std::make_shared<int>(builderMock.build(key));
+    };
 
     CacheEntry<IntKey, ValueType> entry(capacity);
 
-    //creating so we miss everytime
+    // creating so we miss everytime
     for (int i = 0; i < capacity; ++i) {
         auto result = entry.getOrCreate({i}, builder);
         ASSERT_NE(result.first, ValueType());
@@ -127,7 +129,7 @@ TEST(CacheEntryTests, GetOrCreate) {
         ASSERT_EQ(result.second, CacheEntryBase::LookUpStatus::Miss);
     }
 
-    //always hit
+    // always hit
     for (int i = 0; i < capacity; ++i) {
         auto result = entry.getOrCreate({i}, builder);
         ASSERT_NE(result.first, ValueType());
@@ -135,7 +137,7 @@ TEST(CacheEntryTests, GetOrCreate) {
         ASSERT_EQ(result.second, CacheEntryBase::LookUpStatus::Hit);
     }
 
-    //new values displace old ones
+    // new values displace old ones
     for (int i = capacity; i < 2 * capacity; ++i) {
         auto result = entry.getOrCreate({i}, builder);
         ASSERT_NE(result.first, ValueType());
@@ -143,7 +145,7 @@ TEST(CacheEntryTests, GetOrCreate) {
         ASSERT_EQ(result.second, CacheEntryBase::LookUpStatus::Miss);
     }
 
-    //can not hit the old ones
+    // can not hit the old ones
     for (int i = 0; i < capacity; ++i) {
         auto result = entry.getOrCreate({i}, builder);
         ASSERT_NE(result.first, ValueType());
@@ -160,15 +162,17 @@ TEST(CacheEntryTests, Empty) {
     constexpr size_t attempts = 10;
 
     mockBuilder<ValueType::element_type, IntKey> builderMock;
-    EXPECT_CALL(builderMock, build(_))
-            .Times(2 * attempts)
-            .WillRepeatedly([](const IntKey& key){return key.data;});
+    EXPECT_CALL(builderMock, build(_)).Times(2 * attempts).WillRepeatedly([](const IntKey& key) {
+        return key.data;
+    });
 
-    auto builder = [&](const IntKey& key) { return std::make_shared<int>(builderMock.build(key)); };
+    auto builder = [&](const IntKey& key) {
+        return std::make_shared<int>(builderMock.build(key));
+    };
 
     CacheEntry<IntKey, ValueType> entry(capacity);
 
-    //creating so we miss everytime
+    // creating so we miss everytime
     for (int i = 0; i < attempts; ++i) {
         auto result = entry.getOrCreate({i}, builder);
         ASSERT_NE(result.first, ValueType());
@@ -176,7 +180,7 @@ TEST(CacheEntryTests, Empty) {
         ASSERT_EQ(result.second, CacheEntryBase::LookUpStatus::Miss);
     }
 
-    //since the capacity is 0 we will always miss
+    // since the capacity is 0 we will always miss
     for (int i = 0; i < attempts; ++i) {
         auto result = entry.getOrCreate({i}, builder);
         ASSERT_NE(result.first, ValueType());
@@ -196,7 +200,7 @@ struct StringKey {
 
     std::string data;
 };
-} // namespace
+}  // namespace
 
 TEST(MultiCacheTests, GetOrCreate) {
     using testing::_;
@@ -206,21 +210,25 @@ TEST(MultiCacheTests, GetOrCreate) {
     constexpr size_t capacity = 10;
 
     mockBuilder<IntValueType::element_type, IntKey> intBuilderMock;
-    EXPECT_CALL(intBuilderMock, build(_))
-            .Times(3 * capacity)
-            .WillRepeatedly([](const IntKey& key){return key.data;});
+    EXPECT_CALL(intBuilderMock, build(_)).Times(3 * capacity).WillRepeatedly([](const IntKey& key) {
+        return key.data;
+    });
 
     mockBuilder<StrValueType::element_type, StringKey> strBuilderMock;
-    EXPECT_CALL(strBuilderMock, build(_))
-            .Times(3 * capacity)
-            .WillRepeatedly([](const StringKey& key){return key.data;});
+    EXPECT_CALL(strBuilderMock, build(_)).Times(3 * capacity).WillRepeatedly([](const StringKey& key) {
+        return key.data;
+    });
 
-    auto intBuilder = [&](const IntKey& key) { return std::make_shared<int>(intBuilderMock.build(key)); };
-    auto strBuilder = [&](const StringKey& key) { return std::make_shared<std::string>(strBuilderMock.build(key)); };
+    auto intBuilder = [&](const IntKey& key) {
+        return std::make_shared<int>(intBuilderMock.build(key));
+    };
+    auto strBuilder = [&](const StringKey& key) {
+        return std::make_shared<std::string>(strBuilderMock.build(key));
+    };
 
     MultiCache cache(capacity);
 
-    //creating so we miss everytime
+    // creating so we miss everytime
     for (int i = 0; i < capacity; ++i) {
         auto intResult = cache.getOrCreate(IntKey{i}, intBuilder);
         ASSERT_NE(intResult.first, IntValueType());
@@ -232,7 +240,7 @@ TEST(MultiCacheTests, GetOrCreate) {
         ASSERT_EQ(strResult.second, CacheEntryBase::LookUpStatus::Miss);
     }
 
-    //always hit
+    // always hit
     for (int i = 0; i < capacity; ++i) {
         auto intResult = cache.getOrCreate(IntKey{i}, intBuilder);
         ASSERT_NE(intResult.first, IntValueType());
@@ -244,7 +252,7 @@ TEST(MultiCacheTests, GetOrCreate) {
         ASSERT_EQ(strResult.second, CacheEntryBase::LookUpStatus::Hit);
     }
 
-    //new values displace old ones
+    // new values displace old ones
     for (int i = capacity; i < 2 * capacity; ++i) {
         auto intResult = cache.getOrCreate(IntKey{i}, intBuilder);
         ASSERT_NE(intResult.first, IntValueType());
@@ -256,7 +264,7 @@ TEST(MultiCacheTests, GetOrCreate) {
         ASSERT_EQ(strResult.second, CacheEntryBase::LookUpStatus::Miss);
     }
 
-    //can not hit the old ones
+    // can not hit the old ones
     for (int i = 0; i < capacity; ++i) {
         auto intResult = cache.getOrCreate(IntKey{i}, intBuilder);
         ASSERT_NE(intResult.first, IntValueType());
@@ -278,21 +286,25 @@ TEST(MultiCacheTests, Empty) {
     constexpr size_t attempts = 10;
 
     mockBuilder<IntValueType::element_type, IntKey> intBuilderMock;
-    EXPECT_CALL(intBuilderMock, build(_))
-            .Times(2 * attempts)
-            .WillRepeatedly([](const IntKey& key){return key.data;});
+    EXPECT_CALL(intBuilderMock, build(_)).Times(2 * attempts).WillRepeatedly([](const IntKey& key) {
+        return key.data;
+    });
 
     mockBuilder<StrValueType::element_type, StringKey> strBuilderMock;
-    EXPECT_CALL(strBuilderMock, build(_))
-            .Times(2 * attempts)
-            .WillRepeatedly([](const StringKey& key){return key.data;});
+    EXPECT_CALL(strBuilderMock, build(_)).Times(2 * attempts).WillRepeatedly([](const StringKey& key) {
+        return key.data;
+    });
 
-    auto intBuilder = [&](const IntKey& key) { return std::make_shared<int>(intBuilderMock.build(key)); };
-    auto strBuilder = [&](const StringKey& key) { return std::make_shared<std::string>(strBuilderMock.build(key)); };
+    auto intBuilder = [&](const IntKey& key) {
+        return std::make_shared<int>(intBuilderMock.build(key));
+    };
+    auto strBuilder = [&](const StringKey& key) {
+        return std::make_shared<std::string>(strBuilderMock.build(key));
+    };
 
     MultiCache cache(capacity);
 
-    //creating so we miss everytime
+    // creating so we miss everytime
     for (int i = 0; i < attempts; ++i) {
         auto intResult = cache.getOrCreate(IntKey{i}, intBuilder);
         ASSERT_NE(intResult.first, IntValueType());
@@ -304,7 +316,7 @@ TEST(MultiCacheTests, Empty) {
         ASSERT_EQ(strResult.second, CacheEntryBase::LookUpStatus::Miss);
     }
 
-    //since the capacity is 0 we will always miss
+    // since the capacity is 0 we will always miss
     for (int i = 0; i < attempts; ++i) {
         auto intResult = cache.getOrCreate(IntKey{i}, intBuilder);
         ASSERT_NE(intResult.first, IntValueType());
@@ -329,11 +341,11 @@ public:
         _t.join();
     }
     ScopedThread(ScopedThread&& rhs) noexcept = default;
+
 private:
     std::thread _t;
 };
-}// namespace
-
+}  // namespace
 
 TEST(MultiCacheTests, SmokeTypeIdSync) {
     using IntValueType = std::shared_ptr<int>;
@@ -342,13 +354,17 @@ TEST(MultiCacheTests, SmokeTypeIdSync) {
     constexpr size_t capacity = 10;
     constexpr size_t numThreads = 30;
 
-    auto intBuilder = [&](const IntKey& key) { return std::make_shared<int>(key.data); };
-    auto strBuilder = [&](const StringKey& key) { return std::make_shared<std::string>(key.data); };
+    auto intBuilder = [&](const IntKey& key) {
+        return std::make_shared<int>(key.data);
+    };
+    auto strBuilder = [&](const StringKey& key) {
+        return std::make_shared<std::string>(key.data);
+    };
 
     std::vector<MultiCache> vecCache(numThreads, MultiCache(capacity));
 
     auto testRoutine = [&](MultiCache& cache) {
-        //creating so we miss everytime
+        // creating so we miss everytime
         for (int i = 0; i < capacity; ++i) {
             auto intResult = cache.getOrCreate(IntKey{i}, intBuilder);
             ASSERT_NE(intResult.first, IntValueType());
@@ -360,7 +376,7 @@ TEST(MultiCacheTests, SmokeTypeIdSync) {
             ASSERT_EQ(strResult.second, CacheEntryBase::LookUpStatus::Miss);
         }
 
-        //always hit
+        // always hit
         for (int i = 0; i < capacity; ++i) {
             auto intResult = cache.getOrCreate(IntKey{i}, intBuilder);
             ASSERT_NE(intResult.first, IntValueType());

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/batch_to_space_shape_inference.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/batch_to_space_shape_inference.cpp
@@ -6,8 +6,8 @@
 
 #include <openvino/core/coordinate_diff.hpp>
 #include <openvino/op/batch_to_space.hpp>
-#include <openvino/op/parameter.hpp>
 #include <openvino/op/constant.hpp>
+#include <openvino/op/parameter.hpp>
 #include <utils/shape_inference/shape_inference.hpp>
 #include <utils/shape_inference/static_shape.hpp>
 
@@ -63,14 +63,18 @@ TEST(StaticShapeInferenceTest, BatchToSpaceWithMissingTensorData) {
     constant_data[1] = block;
     constant_data[3] = crops_end;
 
-    EXPECT_THROW(shape_inference(batch_to_space.get(), input_shapes, output_shapes, constant_data), NodeValidationFailure);
+    EXPECT_THROW(shape_inference(batch_to_space.get(), input_shapes, output_shapes, constant_data),
+                 NodeValidationFailure);
 }
 
 TEST(StaticShapeInferenceTest, batch_to_space_output_with_const_inputs) {
     auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, ov::PartialShape{-1, -1, -1, -1});
-    auto block_shape = std::make_shared<ov::op::v0::Constant>(element::i64, ov::Shape{4}, std::vector<int64_t>{1, 10, 5, 1});
-    auto crops_begin = std::make_shared<ov::op::v0::Constant>(element::i64, ov::Shape{4}, std::vector<int64_t>{0, 3, 1, 0});
-    auto crops_end = std::make_shared<ov::op::v0::Constant>(element::i64, ov::Shape{4}, std::vector<int64_t>{0, 3, 0, 0});
+    auto block_shape =
+        std::make_shared<ov::op::v0::Constant>(element::i64, ov::Shape{4}, std::vector<int64_t>{1, 10, 5, 1});
+    auto crops_begin =
+        std::make_shared<ov::op::v0::Constant>(element::i64, ov::Shape{4}, std::vector<int64_t>{0, 3, 1, 0});
+    auto crops_end =
+        std::make_shared<ov::op::v0::Constant>(element::i64, ov::Shape{4}, std::vector<int64_t>{0, 3, 0, 0});
     const auto batch_to_space = std::make_shared<ov::op::v1::BatchToSpace>(data, block_shape, crops_begin, crops_end);
     std::vector<StaticShape> input_shapes = {{100, 7, 13, 3}, {4}, {4}, {4}};
     std::vector<StaticShape> output_shapes = {{}};

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/broadcast_shape_inference.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/broadcast_shape_inference.cpp
@@ -31,12 +31,14 @@ TEST(StaticShapeInferenceTest, BroadcastBidirectionalTest) {
 
     static_input_shapes = {StaticShape{16, 1, 1}, StaticShape{4}};
     static_output_shapes = {StaticShape{}};
-    EXPECT_THROW(shape_inference(broadcast_v3.get(), static_input_shapes, static_output_shapes, {}), NodeValidationFailure);
+    EXPECT_THROW(shape_inference(broadcast_v3.get(), static_input_shapes, static_output_shapes, {}),
+                 NodeValidationFailure);
 }
 
 TEST(StaticShapeInferenceTest, BroadcastBidirectionalConstantTest) {
     auto input = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{-1, -1, -1, -1});
-    auto target_shape = std::make_shared<ov::op::v0::Constant>(element::i32, ov::Shape{3}, std::vector<int32_t>{16, 1, 40});
+    auto target_shape =
+        std::make_shared<ov::op::v0::Constant>(element::i32, ov::Shape{3}, std::vector<int32_t>{16, 1, 40});
     auto broadcast_v3 = std::make_shared<op::v3::Broadcast>(input, target_shape, op::BroadcastType::BIDIRECTIONAL);
 
     std::vector<StaticShape> static_input_shapes = {StaticShape{1, 16, 50, 1}, StaticShape{3}},
@@ -63,12 +65,14 @@ TEST(StaticShapeInferenceTest, BroadcastPDPDTest) {
 
     static_input_shapes = {StaticShape{3, 1}, StaticShape{3}};
     static_output_shapes = {StaticShape{}};
-    EXPECT_THROW(shape_inference(broadcast_v3.get(), static_input_shapes, static_output_shapes, {}), NodeValidationFailure);
+    EXPECT_THROW(shape_inference(broadcast_v3.get(), static_input_shapes, static_output_shapes, {}),
+                 NodeValidationFailure);
 }
 
 TEST(StaticShapeInferenceTest, BroadcastPDPDConstantTest) {
     auto input = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{-1, -1});
-    auto target_shape = std::make_shared<ov::op::v0::Constant>(element::i32, ov::Shape{3}, std::vector<int32_t>{2, 3, 6});
+    auto target_shape =
+        std::make_shared<ov::op::v0::Constant>(element::i32, ov::Shape{3}, std::vector<int32_t>{2, 3, 6});
     auto broadcast_v3 =
         std::make_shared<op::v3::Broadcast>(input, target_shape, op::BroadcastModeSpec(op::BroadcastType::PDPD, 1));
 
@@ -95,7 +99,8 @@ TEST(StaticShapeInferenceTest, BroadcastNumpyTest) {
 
     static_input_shapes = {StaticShape{16, 1, 1}, StaticShape{4}};
     static_output_shapes = {StaticShape{}};
-    EXPECT_THROW(shape_inference(broadcast_v3.get(), static_input_shapes, static_output_shapes, {}), NodeValidationFailure);
+    EXPECT_THROW(shape_inference(broadcast_v3.get(), static_input_shapes, static_output_shapes, {}),
+                 NodeValidationFailure);
 }
 
 TEST(StaticShapeInferenceTest, BroadcastNumpyConstantTest) {
@@ -133,7 +138,8 @@ TEST(StaticShapeInferenceTest, BroadcastExplicitTest) {
     constant_data.erase(1);
     EXPECT_THROW(shape_inference(broadcast_v3.get(), static_input_shapes, static_output_shapes, constant_data),
                  NodeValidationFailure);
-    EXPECT_THROW(shape_inference(broadcast_v3.get(), static_input_shapes, static_output_shapes, {}), NodeValidationFailure);
+    EXPECT_THROW(shape_inference(broadcast_v3.get(), static_input_shapes, static_output_shapes, {}),
+                 NodeValidationFailure);
 }
 
 TEST(StaticShapeInferenceTest, BroadcastExplicitConstantTest) {
@@ -170,7 +176,8 @@ TEST(StaticShapeInferenceTest, BroadcastV1PDPDTest) {
 
     static_input_shapes = {StaticShape{3, 1}, StaticShape{3}};
     static_output_shapes = {StaticShape{}};
-    EXPECT_THROW(shape_inference(broadcast_v1.get(), static_input_shapes, static_output_shapes, {}), NodeValidationFailure);
+    EXPECT_THROW(shape_inference(broadcast_v1.get(), static_input_shapes, static_output_shapes, {}),
+                 NodeValidationFailure);
 }
 
 TEST(StaticShapeInferenceTest, BroadcastV1NumpyTest) {
@@ -190,7 +197,8 @@ TEST(StaticShapeInferenceTest, BroadcastV1NumpyTest) {
 
     static_input_shapes = {StaticShape{3, 1}, StaticShape{3}};
     static_output_shapes = {StaticShape{}};
-    EXPECT_THROW(shape_inference(broadcast_v1.get(), static_input_shapes, static_output_shapes, {}), NodeValidationFailure);
+    EXPECT_THROW(shape_inference(broadcast_v1.get(), static_input_shapes, static_output_shapes, {}),
+                 NodeValidationFailure);
 }
 
 TEST(StaticShapeInferenceTest, BroadcastV1ExplicitTest) {
@@ -214,5 +222,6 @@ TEST(StaticShapeInferenceTest, BroadcastV1ExplicitTest) {
 
     static_input_shapes = {StaticShape{3, 1}, StaticShape{3}, StaticShape{2}};
     static_output_shapes = {StaticShape{}};
-    EXPECT_THROW(shape_inference(broadcast_v1.get(), static_input_shapes, static_output_shapes, {}), NodeValidationFailure);
+    EXPECT_THROW(shape_inference(broadcast_v1.get(), static_input_shapes, static_output_shapes, {}),
+                 NodeValidationFailure);
 }

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/concat_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/concat_shape_inference_test.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "concat_shape_inference.hpp"
+
 #include "gtest/gtest.h"
 #include "openvino/op/parameter.hpp"
 #include "openvino/pass/graph_rewrite.hpp"

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/convolution_shape_inference.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/convolution_shape_inference.cpp
@@ -5,11 +5,11 @@
 #include <gtest/gtest.h>
 
 #include <openvino/core/coordinate_diff.hpp>
+#include <openvino/op/constant.hpp>
 #include <openvino/op/convolution.hpp>
 #include <openvino/op/group_conv.hpp>
 #include <openvino/op/parameter.hpp>
 #include <openvino/op/relu.hpp>
-#include <openvino/op/constant.hpp>
 #include <utils/shape_inference/shape_inference.hpp>
 #include <utils/shape_inference/static_shape.hpp>
 
@@ -35,7 +35,6 @@ TEST(StaticShapeInferenceTest, ConvolutionTest) {
 
     ASSERT_EQ(static_output_shapes[0], StaticShape({3, 7, 5, 5}));
 }
-
 
 TEST(StaticShapeInferenceTest, GroupConvolutionTest) {
     Strides strides{1, 1};
@@ -68,8 +67,8 @@ TEST(StaticShapeInferenceTest, ConvolutionBackPropDataTest) {
     const CoordinateDiff output_padding{1, 1};
     const op::PadType auto_pad = op::PadType::SAME_LOWER;
 
-    auto output_shape = std::make_shared<op::v0::Constant>(
-            ov::element::i64, ov::Shape{2}, std::vector<int64_t>({3, 3}));
+    auto output_shape =
+        std::make_shared<op::v0::Constant>(ov::element::i64, ov::Shape{2}, std::vector<int64_t>({3, 3}));
     auto conv = std::make_shared<op::v1::ConvolutionBackpropData>(data,
                                                                   filters,
                                                                   output_shape,
@@ -98,25 +97,26 @@ TEST(StaticShapeInferenceTest, GroupConvolutionBackPropDataTest) {
     const CoordinateDiff output_padding{1, 1};
     const op::PadType auto_pad = op::PadType::SAME_LOWER;
 
-    auto output_shape = std::make_shared<op::v0::Constant>(
-            ov::element::i64, ov::Shape{2}, std::vector<int64_t>({3, 3}));
+    auto output_shape =
+        std::make_shared<op::v0::Constant>(ov::element::i64, ov::Shape{2}, std::vector<int64_t>({3, 3}));
     auto conv = std::make_shared<op::v1::GroupConvolutionBackpropData>(data,
-                                                                  filters,
-                                                                  output_shape,
-                                                                  strides,
-                                                                  padding_begin,
-                                                                  padding_end,
-                                                                  dilations,
-                                                                  auto_pad,
-                                                                  output_padding);
+                                                                       filters,
+                                                                       output_shape,
+                                                                       strides,
+                                                                       padding_begin,
+                                                                       padding_end,
+                                                                       dilations,
+                                                                       auto_pad,
+                                                                       output_padding);
 
-    std::vector<StaticShape> static_input_shapes = {StaticShape{1, 16, 2, 2}, StaticShape{4, 4, 6, 3, 3}, StaticShape{2}},
+    std::vector<StaticShape> static_input_shapes = {StaticShape{1, 16, 2, 2},
+                                                    StaticShape{4, 4, 6, 3, 3},
+                                                    StaticShape{2}},
                              static_output_shapes = {StaticShape{}};
     shape_inference(conv.get(), static_input_shapes, static_output_shapes);
 
     ASSERT_EQ(static_output_shapes[0], StaticShape({1, 24, 3, 3}));
 }
-
 
 #if 0
 TEST(StaticShapeInferenceTest, ConvolutionTimeTest) {

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/einsum_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/einsum_test.cpp
@@ -45,7 +45,5 @@ TEST(StaticShapeInferenceTest, Einsum5) {
     auto I3 = std::make_shared<op::v0::Parameter>(element::i32, ov::PartialShape::dynamic());
     auto O = std::make_shared<op::v7::Einsum>(OutputVector{I1, I2, I3}, "ab,bcd,bc->ca");
 
-    check_static_shape(O.get(),
-                       {StaticShape{2, 5}, StaticShape{5, 3, 6}, StaticShape{5, 3}},
-                       {StaticShape{3, 2}});
+    check_static_shape(O.get(), {StaticShape{2, 5}, StaticShape{5, 3, 6}, StaticShape{5, 3}}, {StaticShape{3, 2}});
 }

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/elementwises.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/elementwises.cpp
@@ -5,10 +5,10 @@
 #include <gtest/gtest.h>
 
 #include <openvino/core/coordinate_diff.hpp>
-#include <openvino/op/parameter.hpp>
 #include <openvino/op/add.hpp>
-#include <openvino/op/relu.hpp>
 #include <openvino/op/fake_quantize.hpp>
+#include <openvino/op/parameter.hpp>
+#include <openvino/op/relu.hpp>
 #include <utils/shape_inference/shape_inference.hpp>
 #include <utils/shape_inference/static_shape.hpp>
 
@@ -19,8 +19,7 @@ TEST(StaticShapeInferenceTest, UnaryEltwiseTest) {
     auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{-1, -1, -1, -1});
     auto node = std::make_shared<op::v0::Relu>(data);
 
-    std::vector<StaticShape> static_input_shapes = {StaticShape{3, 6, 5, 5}},
-        static_output_shapes = {StaticShape{}};
+    std::vector<StaticShape> static_input_shapes = {StaticShape{3, 6, 5, 5}}, static_output_shapes = {StaticShape{}};
     shape_inference(node.get(), static_input_shapes, static_output_shapes);
 
     ASSERT_EQ(static_output_shapes[0], StaticShape({3, 6, 5, 5}));
@@ -33,7 +32,7 @@ TEST(StaticShapeInferenceTest, BinaryEltwiseTest) {
     auto node = std::make_shared<op::v1::Add>(data, data_1);
 
     std::vector<StaticShape> static_input_shapes = {StaticShape{3, 6, 1, 5}, StaticShape{1, 3, 5}},
-            static_output_shapes = {StaticShape{}};
+                             static_output_shapes = {StaticShape{}};
     shape_inference(node.get(), static_input_shapes, static_output_shapes);
 
     ASSERT_EQ(static_output_shapes[0], StaticShape({3, 6, 3, 5}));
@@ -48,14 +47,12 @@ TEST(StaticShapeInferenceTest, FakeQuantizeTest) {
 
     auto node = std::make_shared<op::v0::FakeQuantize>(data, il, ih, ol, oh, 256);
 
-    std::vector<StaticShape> static_input_shapes = {
-                StaticShape{3, 6, 3, 5},
-                StaticShape{1, 3, 1},
-                StaticShape{1},
-                StaticShape{5},
-                StaticShape{1, 1, 1, 1}
-            },
-            static_output_shapes = {StaticShape{}};
+    std::vector<StaticShape> static_input_shapes = {StaticShape{3, 6, 3, 5},
+                                                    StaticShape{1, 3, 1},
+                                                    StaticShape{1},
+                                                    StaticShape{5},
+                                                    StaticShape{1, 1, 1, 1}},
+                             static_output_shapes = {StaticShape{}};
 
     shape_inference(node.get(), static_input_shapes, static_output_shapes);
     ASSERT_EQ(static_output_shapes[0], StaticShape({3, 6, 3, 5}));

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/embeddingbag_offsets_sum_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/embeddingbag_offsets_sum_test.cpp
@@ -20,8 +20,7 @@ TEST(StaticShapeInferenceTest, EmbeddingBagOffsetsSumV3) {
     auto ebos =
         make_shared<op::v3::EmbeddingBagOffsetsSum>(emb_table, indices, offsets, default_index, per_sample_weights);
 
-    check_static_shape(
-        ebos.get(),
-        {StaticShape{5, 2}, StaticShape{4}, StaticShape{3}, StaticShape{}, StaticShape{4}},
-        {StaticShape{3, 2}});
+    check_static_shape(ebos.get(),
+                       {StaticShape{5, 2}, StaticShape{4}, StaticShape{3}, StaticShape{}, StaticShape{4}},
+                       {StaticShape{3, 2}});
 }

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/experimental_detectron_topkrois_shape_inference.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/experimental_detectron_topkrois_shape_inference.cpp
@@ -26,7 +26,8 @@ TEST(StaticShapeInferenceTest, ExperimentalDetectronTopKROIsTest) {
 
     ASSERT_EQ(output_shapes[0], PartialShape({5, 4}));
 
-    std::vector<StaticShape> static_input_shapes = {StaticShape{10, 4}, StaticShape{10}}, static_output_shapes = {StaticShape{}};
+    std::vector<StaticShape> static_input_shapes = {StaticShape{10, 4}, StaticShape{10}},
+                             static_output_shapes = {StaticShape{}};
     shape_infer(rois.get(), static_input_shapes, static_output_shapes);
 
     ASSERT_EQ(static_output_shapes[0], StaticShape({5, 4}));

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/make_shape_inference.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/make_shape_inference.cpp
@@ -3,15 +3,16 @@
 //
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <ngraph_ops/type_relaxed.hpp>
 #include <openvino/core/coordinate_diff.hpp>
 #include <openvino/op/ops.hpp>
 #include <openvino/op/parameter.hpp>
+#include <thread>
 #include <utils/shape_inference/shape_inference.hpp>
 #include <utils/shape_inference/static_shape.hpp>
+
 #include "ngraph_functions/builders.hpp"
-#include <thread>
-#include <atomic>
-#include <ngraph_ops/type_relaxed.hpp>
 
 using namespace ov;
 using namespace ov::intel_cpu;
@@ -24,8 +25,8 @@ TEST(StaticShapeInferenceTest, MakeShapeInference) {
     auto inp2 = std::make_shared<op::v0::Parameter>(element::i8, PartialShape{-1, -1, -1, -1});
 
     auto matMulRelaxed = std::make_shared<ngraph::op::TypeRelaxed<ngraph::opset3::MatMul>>(
-            *as_type_ptr<ngraph::opset3::MatMul>(ngraph::builder::makeMatMul(inp1_f32, inp2_f32, false, false)),
-            element::f32);
+        *as_type_ptr<ngraph::opset3::MatMul>(ngraph::builder::makeMatMul(inp1_f32, inp2_f32, false, false)),
+        element::f32);
 
     auto matMul = matMulRelaxed->clone_with_new_inputs({inp1, inp2});
 

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/pad_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/pad_test.cpp
@@ -19,9 +19,6 @@ TEST(StaticShapeInferenceTest, Padv1) {
     const auto pad = std::make_shared<ov::op::v1::Pad>(data, pads_begin, pads_end, pad_val, op::PadMode::CONSTANT);
 
     check_static_shape(pad.get(),
-                       {StaticShape{3, 6, 5, 5},
-                        StaticShape{4},
-                        StaticShape{4},
-                        StaticShape()},
+                       {StaticShape{3, 6, 5, 5}, StaticShape{4}, StaticShape{4}, StaticShape()},
                        {StaticShape({6, 9, 8, 8})});
 }

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/reduce_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/reduce_test.cpp
@@ -5,9 +5,9 @@
 #include <gtest/gtest.h>
 
 #include <openvino/core/coordinate_diff.hpp>
-#include <openvino/op/reduce_mean.hpp>
-#include <openvino/op/parameter.hpp>
 #include <openvino/op/constant.hpp>
+#include <openvino/op/parameter.hpp>
+#include <openvino/op/reduce_mean.hpp>
 #include <utils/shape_inference/shape_inference.hpp>
 #include <utils/shape_inference/static_shape.hpp>
 
@@ -18,11 +18,10 @@ TEST(StaticShapeInferenceTest, ReduceTest) {
     auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{-1, -1, -1, -1});
     auto axes = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{2}, std::vector<int32_t>{1, 3});
 
-    auto reduce =
-            std::make_shared<op::v1::ReduceMean>(data, axes, true);
+    auto reduce = std::make_shared<op::v1::ReduceMean>(data, axes, true);
 
     std::vector<StaticShape> static_input_shapes = {StaticShape{3, 6, 5, 5}, StaticShape{2}},
-            static_output_shapes = {StaticShape{}};
+                             static_output_shapes = {StaticShape{}};
     shape_inference(reduce.get(), static_input_shapes, static_output_shapes);
 
     ASSERT_EQ(static_output_shapes[0], StaticShape({3, 1, 5, 1}));

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/roi_align_shape_inference.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/roi_align_shape_inference.cpp
@@ -17,9 +17,7 @@ TEST(StaticShapeInferenceTest, ROIAlignTest) {
     const auto rois = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, -1});
     const auto batch_indices = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
     const auto op = std::make_shared<op::v3::ROIAlign>(data, rois, batch_indices, 2, 2, 1, 1.0f, "avg");
-    const std::vector<StaticShape> input_shapes = {StaticShape{2, 3, 5, 5},
-                                                   StaticShape{7, 4},
-                                                   StaticShape{7}};
+    const std::vector<StaticShape> input_shapes = {StaticShape{2, 3, 5, 5}, StaticShape{7, 4}, StaticShape{7}};
     std::vector<StaticShape> output_shapes = {StaticShape{}};
     shape_inference(op.get(), input_shapes, output_shapes);
 

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/roll_shape_inference.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/roll_shape_inference.cpp
@@ -27,9 +27,7 @@ TEST(StaticShapeInferenceTest, RollTest) {
     std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>> constant_data;
     constant_data[2] = axes_tensor;
 
-    const std::vector<StaticShape> input_shapes = {StaticShape{3, 3, 3},
-                                                   StaticShape{3},
-                                                   StaticShape{3}};
+    const std::vector<StaticShape> input_shapes = {StaticShape{3, 3, 3}, StaticShape{3}, StaticShape{3}};
     std::vector<StaticShape> output_shapes = {StaticShape{}};
     shape_inference(roll.get(), input_shapes, output_shapes, constant_data);
     ASSERT_EQ(output_shapes[0], input_shapes[0]);
@@ -43,9 +41,7 @@ TEST(StaticShapeInferenceTest, RollTestWithConstAxis) {
     auto axes = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int32_t>{0, 1, -1});
     auto roll = std::make_shared<ov::op::v7::Roll>(arg, shift, axes);
 
-    const std::vector<StaticShape> input_shapes = {StaticShape{3, 3, 3},
-                                                   StaticShape{3},
-                                                   StaticShape{3}};
+    const std::vector<StaticShape> input_shapes = {StaticShape{3, 3, 3}, StaticShape{3}, StaticShape{3}};
     std::vector<StaticShape> output_shapes = {StaticShape{}};
     shape_inference(roll.get(), input_shapes, output_shapes);
     ASSERT_EQ(output_shapes[0], input_shapes[0]);

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/shape_node_tests.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/shape_node_tests.cpp
@@ -5,12 +5,12 @@
 #include <gtest/gtest.h>
 
 #include <openvino/core/coordinate_diff.hpp>
+#include <openvino/op/constant.hpp>
+#include <openvino/op/parameter.hpp>
 #include <openvino/op/reshape.hpp>
+#include <openvino/op/shape_of.hpp>
 #include <openvino/op/squeeze.hpp>
 #include <openvino/op/unsqueeze.hpp>
-#include <openvino/op/parameter.hpp>
-#include <openvino/op/constant.hpp>
-#include <openvino/op/shape_of.hpp>
 #include <utils/shape_inference/shape_inference.hpp>
 #include <utils/shape_inference/static_shape.hpp>
 
@@ -21,11 +21,10 @@ TEST(StaticShapeInferenceTest, ReshapeTest) {
     auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{-1, -1, -1, -1});
     auto pattern = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{2}, std::vector<int32_t>{0, -1});
 
-    auto reduce =
-            std::make_shared<op::v1::Reshape>(data, pattern, true);
+    auto reduce = std::make_shared<op::v1::Reshape>(data, pattern, true);
 
     std::vector<StaticShape> static_input_shapes = {StaticShape{3, 6, 5, 5}, StaticShape{2}},
-            static_output_shapes = {StaticShape{}};
+                             static_output_shapes = {StaticShape{}};
     shape_inference(reduce.get(), static_input_shapes, static_output_shapes);
 
     ASSERT_EQ(static_output_shapes[0], StaticShape({3, 150}));
@@ -35,11 +34,10 @@ TEST(StaticShapeInferenceTest, SqueezeTest) {
     auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{-1, -1, -1, -1});
     auto pattern = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{2}, std::vector<int32_t>{-3, 0});
 
-    auto reduce =
-            std::make_shared<op::v0::Squeeze>(data, pattern);
+    auto reduce = std::make_shared<op::v0::Squeeze>(data, pattern);
 
     std::vector<StaticShape> static_input_shapes = {StaticShape{1, 6, 1, 7, 1}, StaticShape{2}},
-            static_output_shapes = {StaticShape{}};
+                             static_output_shapes = {StaticShape{}};
     shape_inference(reduce.get(), static_input_shapes, static_output_shapes);
 
     ASSERT_EQ(static_output_shapes[0], StaticShape({6, 7, 1}));
@@ -49,11 +47,10 @@ TEST(StaticShapeInferenceTest, UnsqueezeTest) {
     auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{-1, -1, -1, -1});
     auto pattern = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{2}, std::vector<int32_t>{-3, 0});
 
-    auto reduce =
-            std::make_shared<op::v0::Unsqueeze>(data, pattern);
+    auto reduce = std::make_shared<op::v0::Unsqueeze>(data, pattern);
 
     std::vector<StaticShape> static_input_shapes = {StaticShape{2, 3, 4, 5, 6}, StaticShape{2}},
-            static_output_shapes = {StaticShape{}};
+                             static_output_shapes = {StaticShape{}};
     shape_inference(reduce.get(), static_input_shapes, static_output_shapes);
 
     ASSERT_EQ(static_output_shapes[0], StaticShape({1, 2, 3, 4, 1, 5, 6}));
@@ -62,11 +59,9 @@ TEST(StaticShapeInferenceTest, UnsqueezeTest) {
 TEST(StaticShapeInferenceTest, ShapeOf5DTest) {
     auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{-1, -1, -1, -1});
 
-    auto shapeof =
-            std::make_shared<op::v0::ShapeOf>(data);
+    auto shapeof = std::make_shared<op::v0::ShapeOf>(data);
 
-    std::vector<StaticShape> static_input_shapes = {StaticShape{2, 3, 4, 5, 6}},
-            static_output_shapes = {StaticShape{}};
+    std::vector<StaticShape> static_input_shapes = {StaticShape{2, 3, 4, 5, 6}}, static_output_shapes = {StaticShape{}};
     shape_inference(shapeof.get(), static_input_shapes, static_output_shapes);
 
     ASSERT_EQ(static_output_shapes[0], StaticShape({5}));
@@ -75,11 +70,9 @@ TEST(StaticShapeInferenceTest, ShapeOf5DTest) {
 TEST(StaticShapeInferenceTest, ShapeOf0DTest) {
     auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{});
 
-    auto shapeof =
-            std::make_shared<op::v3::ShapeOf>(data);
+    auto shapeof = std::make_shared<op::v3::ShapeOf>(data);
 
-    std::vector<StaticShape> static_input_shapes = {StaticShape{}},
-            static_output_shapes = {StaticShape{}};
+    std::vector<StaticShape> static_input_shapes = {StaticShape{}}, static_output_shapes = {StaticShape{}};
     shape_inference(shapeof.get(), static_input_shapes, static_output_shapes);
 
     ASSERT_EQ(static_output_shapes[0], StaticShape({}));

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/space_to_batch_shape_inference.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/space_to_batch_shape_inference.cpp
@@ -76,13 +76,17 @@ TEST(StaticShapeInferenceTest, SpaceToBatchThrowExceptionWithMissingPadsHostTens
 
 TEST(StaticShapeInferenceTest, space_to_batch_output_with_const_inputs) {
     auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, ov::PartialShape{-1, -1, -1, -1});
-    auto block_shape = std::make_shared<ov::op::v0::Constant>(element::i64, ov::Shape{4}, std::vector<int64_t>{1, 12, 100, 2});
-    auto pads_begin = std::make_shared<ov::op::v0::Constant>(element::i64, ov::Shape{4}, std::vector<int64_t>{0, 3, 38, 1});
-    auto pads_end = std::make_shared<ov::op::v0::Constant>(element::i64, ov::Shape{4}, std::vector<int64_t>{0, 5, 38, 0});
+    auto block_shape =
+        std::make_shared<ov::op::v0::Constant>(element::i64, ov::Shape{4}, std::vector<int64_t>{1, 12, 100, 2});
+    auto pads_begin =
+        std::make_shared<ov::op::v0::Constant>(element::i64, ov::Shape{4}, std::vector<int64_t>{0, 3, 38, 1});
+    auto pads_end =
+        std::make_shared<ov::op::v0::Constant>(element::i64, ov::Shape{4}, std::vector<int64_t>{0, 5, 38, 0});
     const auto space_to_batch = std::make_shared<ov::op::v1::SpaceToBatch>(data, block_shape, pads_begin, pads_end);
     std::vector<StaticShape> input_shapes = {{2, 100, 1024, 3}, {4}, {4}, {4}};
     std::vector<StaticShape> output_shapes = {{}};
     shape_inference(space_to_batch.get(), input_shapes, output_shapes);
 
-    ASSERT_EQ(output_shapes[0], (StaticShape{2 * 12 * 100 * 2, (100 + 3 + 5) / 12, (1024 + 38 + 38) / 100, (3 + 1) / 2}));
+    ASSERT_EQ(output_shapes[0],
+              (StaticShape{2 * 12 * 100 * 2, (100 + 3 + 5) / 12, (1024 + 38 + 38) / 100, (3 + 1) / 2}));
 }

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/strided_slice_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/strided_slice_test.cpp
@@ -36,17 +36,11 @@ TEST(StaticShapeInferenceTest, StridedSlice2) {
 
     auto ss = std::make_shared<op::v1::StridedSlice>(data, begin, end, stride, begin_mask, end_mask);
 
-    check_static_shape(ss.get(),
-                       {StaticShape{3, 2, 3}, {1, 0, 0}, {2, 1, 3}, {1, 1, 1}},
-                       {StaticShape{1, 1, 3}});
+    check_static_shape(ss.get(), {StaticShape{3, 2, 3}, {1, 0, 0}, {2, 1, 3}, {1, 1, 1}}, {StaticShape{1, 1, 3}});
 
-    check_static_shape(ss.get(),
-                       {StaticShape{3, 2, 3}, {1, 0, 0}, {2, 2, 3}, {1, 1, 1}},
-                       {StaticShape{1, 2, 3}});
+    check_static_shape(ss.get(), {StaticShape{3, 2, 3}, {1, 0, 0}, {2, 2, 3}, {1, 1, 1}}, {StaticShape{1, 2, 3}});
 
-    check_static_shape(ss.get(),
-                       {StaticShape{3, 2, 3}, {2, 0, 0}, {3, 2, 3}, {1, 1, 2}},
-                       {StaticShape{1, 2, 2}});
+    check_static_shape(ss.get(), {StaticShape{3, 2, 3}, {2, 0, 0}, {3, 2, 3}, {1, 1, 2}}, {StaticShape{1, 2, 2}});
 }
 
 TEST(StaticShapeInferenceTest, StridedSlice3) {
@@ -60,9 +54,7 @@ TEST(StaticShapeInferenceTest, StridedSlice3) {
 
     auto ss = std::make_shared<op::v1::StridedSlice>(data, begin, end, stride, begin_mask, end_mask);
 
-    check_static_shape(ss.get(),
-                       {StaticShape{3, 2, 3}, {1, 0, 0}, {0, 0, 0}, {1, 1, 1}},
-                       {StaticShape{2, 2, 3}});
+    check_static_shape(ss.get(), {StaticShape{3, 2, 3}, {1, 0, 0}, {0, 0, 0}, {1, 1, 1}}, {StaticShape{2, 2, 3}});
 }
 
 TEST(StaticShapeInferenceTest, StridedSlice4) {
@@ -76,9 +68,7 @@ TEST(StaticShapeInferenceTest, StridedSlice4) {
 
     auto ss = std::make_shared<op::v1::StridedSlice>(data, begin, end, stride, begin_mask, end_mask);
 
-    check_static_shape(ss.get(),
-                       {StaticShape{3, 2, 3}, {0, 1, 0}, {2, 0, 0}, {1, 1, 2}},
-                       {StaticShape{2, 1, 2}});
+    check_static_shape(ss.get(), {StaticShape{3, 2, 3}, {0, 1, 0}, {2, 0, 0}, {1, 1, 2}}, {StaticShape{2, 1, 2}});
 }
 
 TEST(StaticShapeInferenceTest, StridedSlice5) {
@@ -92,7 +82,5 @@ TEST(StaticShapeInferenceTest, StridedSlice5) {
 
     auto ss = std::make_shared<op::v1::StridedSlice>(data, begin, end, stride, begin_mask, end_mask);
 
-    check_static_shape(ss.get(),
-                       {StaticShape{3, 2, 3}, {0, 0, 0}, {1, 0, 0}, {1, 1, -1}},
-                       {StaticShape{1, 2, 3}});
+    check_static_shape(ss.get(), {StaticShape{3, 2, 3}, {0, 0, 0}, {1, 0, 0}, {1, 1, -1}}, {StaticShape{1, 2, 3}});
 }

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/variadic_split_tests.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/variadic_split_tests.cpp
@@ -32,15 +32,9 @@ static std::shared_ptr<op::v1::VariadicSplit> build_variadic_split(PartialShape 
 TEST(StaticShapeInferenceTest, VariadicSplitV1) {
     const auto split = build_variadic_split(ov::PartialShape::dynamic(), {}, {});
 
-    check_static_shape(split.get(),
-                       {StaticShape{12, 6}, {-2}, {7, -1, 2}},
-                       {{7, 6}, {3, 6}, {2, 6}});
-    check_static_shape(split.get(),
-                       {StaticShape{12, 6}, {-2}, {-1, 7, 2}},
-                       {{3, 6}, {7, 6}, {2, 6}});
-    check_static_shape(split.get(),
-                       {StaticShape{12, 1, 6}, {2}, {3, 1, 2}},
-                       {{12, 1, 3}, {12, 1, 1}, {12, 1, 2}});
+    check_static_shape(split.get(), {StaticShape{12, 6}, {-2}, {7, -1, 2}}, {{7, 6}, {3, 6}, {2, 6}});
+    check_static_shape(split.get(), {StaticShape{12, 6}, {-2}, {-1, 7, 2}}, {{3, 6}, {7, 6}, {2, 6}});
+    check_static_shape(split.get(), {StaticShape{12, 1, 6}, {2}, {3, 1, 2}}, {{12, 1, 3}, {12, 1, 1}, {12, 1, 2}});
     check_static_shape(split.get(), {StaticShape{12, 6}, {1}, {6, 0}}, {{12, 6}, {12, 0}});
 }
 

--- a/src/plugins/intel_cpu/tests/unit/snippets/fake_quantize_tokenization_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets/fake_quantize_tokenization_test.cpp
@@ -5,12 +5,12 @@
 #include <gtest/gtest.h>
 
 #include "common_test_utils/ngraph_test_utils.hpp"
-#include "snippets/pass/fq_decomposition.hpp"
-#include "snippets/pass/collapse_subgraph.hpp"
 #include "fake_quantize_function.hpp"
-#include "snippets/op/subgraph.hpp"
-#include "ngraph_transformations/snippets_mark_skipped.hpp"
 #include "function_helper.hpp"
+#include "ngraph_transformations/snippets_mark_skipped.hpp"
+#include "snippets/op/subgraph.hpp"
+#include "snippets/pass/collapse_subgraph.hpp"
+#include "snippets/pass/fq_decomposition.hpp"
 
 namespace ov {
 namespace test {
@@ -22,19 +22,24 @@ public:
         manager.register_pass<ov::intel_cpu::SnippetsMarkSkipped>();
         manager.register_pass<ngraph::snippets::pass::EnumerateNodes>();
         manager.register_pass<ngraph::snippets::pass::TokenizeSnippets>();
-        manager.get_pass_config()->set_callback<ngraph::snippets::pass::TokenizeSnippets>([](const std::shared_ptr<const ov::Node>& n) -> bool {
-            return false;
-        });
+        manager.get_pass_config()->set_callback<ngraph::snippets::pass::TokenizeSnippets>(
+            [](const std::shared_ptr<const ov::Node>& n) -> bool {
+                return false;
+            });
     }
 
     void TearDown() override {
         TransformationTestsF::TearDown();
 
         auto subgraph = FunctionHelper::getSubgraph(function);
-        auto body = subgraph == nullptr ? nullptr : std::dynamic_pointer_cast<ngraph::snippets::op::Subgraph>(subgraph)->get_body();
+        auto body = subgraph == nullptr
+                        ? nullptr
+                        : std::dynamic_pointer_cast<ngraph::snippets::op::Subgraph>(subgraph)->get_body();
 
         auto subgraph_ref = FunctionHelper::getSubgraph(function_ref);
-        auto body_ref = subgraph_ref == nullptr ? nullptr : std::dynamic_pointer_cast<ngraph::snippets::op::Subgraph>(subgraph_ref)->get_body();
+        auto body_ref = subgraph_ref == nullptr
+                            ? nullptr
+                            : std::dynamic_pointer_cast<ngraph::snippets::op::Subgraph>(subgraph_ref)->get_body();
 
         if ((body != nullptr) && (body_ref != nullptr)) {
             auto res = comparator.compare(body, body_ref);
@@ -47,57 +52,53 @@ public:
 };
 
 TEST_F(FakeQuantizeTokenizationTest, smoke_Snippets_FakeQuantize_PerTensor) {
-    function = FakeQuantizeFunction::getOperationAndFakeQuantize(
-        { {1, 3, 16, 16} },
-        element::f32,
-        { {}, {}, {}, {} },
-        true,
-        FunctionHelper::makePrerequisitesOriginal());
+    function = FakeQuantizeFunction::getOperationAndFakeQuantize({{1, 3, 16, 16}},
+                                                                 element::f32,
+                                                                 {{}, {}, {}, {}},
+                                                                 true,
+                                                                 FunctionHelper::makePrerequisitesOriginal());
 
-    function_ref = FakeQuantizeFunction::getSubgraphWithFakeQuantize(
-        { {1, 3, 16, 16} },
-        element::f32,
-        { {}, {}, {}, {} },
-        true,
-        FunctionHelper::makePrerequisitesOriginal());
+    function_ref = FakeQuantizeFunction::getSubgraphWithFakeQuantize({{1, 3, 16, 16}},
+                                                                     element::f32,
+                                                                     {{}, {}, {}, {}},
+                                                                     true,
+                                                                     FunctionHelper::makePrerequisitesOriginal());
 
     register_passes();
 }
 
 TEST_F(FakeQuantizeTokenizationTest, smoke_Snippets_FakeQuantize_PerChannels) {
-    function = FakeQuantizeFunction::getOperationAndFakeQuantize(
-        { {1, 3, 16, 16} },
-        element::f32,
-        { {1, 3, 1, 1}, {1, 3, 1, 1}, {1, 3, 1, 1}, {1, 3, 1, 1} },
-        true,
-        FunctionHelper::makePrerequisitesOriginal());
+    function =
+        FakeQuantizeFunction::getOperationAndFakeQuantize({{1, 3, 16, 16}},
+                                                          element::f32,
+                                                          {{1, 3, 1, 1}, {1, 3, 1, 1}, {1, 3, 1, 1}, {1, 3, 1, 1}},
+                                                          true,
+                                                          FunctionHelper::makePrerequisitesOriginal());
 
-    function_ref = FakeQuantizeFunction::getSubgraphWithFakeQuantize(
-        { {1, 3, 16, 16} },
-        element::f32,
-        { {1, 3, 1, 1}, {1, 3, 1, 1}, {1, 3, 1, 1}, {1, 3, 1, 1} },
-        true,
-        FunctionHelper::makePrerequisitesOriginal());
+    function_ref =
+        FakeQuantizeFunction::getSubgraphWithFakeQuantize({{1, 3, 16, 16}},
+                                                          element::f32,
+                                                          {{1, 3, 1, 1}, {1, 3, 1, 1}, {1, 3, 1, 1}, {1, 3, 1, 1}},
+                                                          true,
+                                                          FunctionHelper::makePrerequisitesOriginal());
 
     register_passes();
 }
 
 TEST_F(FakeQuantizeTokenizationTest, smoke_Snippets_ConvolutionWithFakeQuantize) {
-    function = FakeQuantizeFunction::getOperationAndFakeQuantize(
-        {{1, 3, 16, 16}},
-        element::f32,
-        {{}, {}, {}, {}},
-        true,
-        FunctionHelper::makePrerequisitesOriginal(),
-        std::make_shared<ngraph::opset1::Convolution>());
+    function = FakeQuantizeFunction::getOperationAndFakeQuantize({{1, 3, 16, 16}},
+                                                                 element::f32,
+                                                                 {{}, {}, {}, {}},
+                                                                 true,
+                                                                 FunctionHelper::makePrerequisitesOriginal(),
+                                                                 std::make_shared<ngraph::opset1::Convolution>());
 
-    function_ref = FakeQuantizeFunction::getOperationAndFakeQuantize(
-        {{1, 3, 16, 16}},
-        element::f32,
-        {{}, {}, {}, {}},
-        true,
-        FunctionHelper::makePrerequisitesOriginal(),
-        std::make_shared<ngraph::opset1::Convolution>());
+    function_ref = FakeQuantizeFunction::getOperationAndFakeQuantize({{1, 3, 16, 16}},
+                                                                     element::f32,
+                                                                     {{}, {}, {}, {}},
+                                                                     true,
+                                                                     FunctionHelper::makePrerequisitesOriginal(),
+                                                                     std::make_shared<ngraph::opset1::Convolution>());
 
     register_passes();
 }


### PR DESCRIPTION
### Details:
 - Add clang-format target to ov_cpu_unit_tests target
 - Apply formatter to ov_cpu_unit_tests  target source files
