### PR TITLE
Docs: Update "Install OpenVINO Runtime on Linux from Archive File" page

### DIFF
--- a/docs/install_guides/installing-openvino-from-archive-linux.md
+++ b/docs/install_guides/installing-openvino-from-archive-linux.md
@@ -104,7 +104,7 @@ sudo ln -s openvino_2022.2.0.7713 openvino_2022
 ```
 > **NOTE**: If you have already installed a previous release of OpenVINO 2022, a symbolic link to the `openvino_2022` folder may already exist. Remove the previous link with `sudo rm openvino_2022`, then re-issue the previous command.
 
-Congratulations, you finished installation! The `/opt/intel/openvino_2022` folder now contains the core components for OpenVINO™. When other pages in OpenVINO™ documentation refer to the <INSTALL_DIR> directory, this is the folder they're referring to. If you installed OpenVINO™ in a different location (such as `/home/<USER>/Intel/openvino_2022`), make sure to use that instead.
+Congratulations, you finished installation! The `/opt/intel/openvino_2022` folder now contains the core components for OpenVINO™. When other pages in OpenVINO™ documentation refer to the `<INSTALL_DIR>` directory, this is the folder they're referring to. If you installed OpenVINO™ in a different location (such as `/home/<USER>/Intel/openvino_2022`), make sure to use that instead.
 
 ### <a name="set-the-environment-variables"></a>Step 2: Configure the Environment
 
@@ -116,7 +116,7 @@ source /opt/intel/openvino_2022/setupvars.sh
 
 If you have more than one OpenVINO™ version on your machine, you can easily switch its version by sourcing `setupvars.sh` of your choice.
 
-> **NOTE**: You can also run this script every time when you start new terminal session. Open `~/.bashrc` in your favorite editor, and add `source /opt/intel/openvino_2022/setupvars.sh`. Next time when you open a terminal, you will see `[setupvars.sh] OpenVINO™ environment initialized`. Changing `.bashrc` is not recommended when you have many OpenVINO™ versions on your machine and want to switch among them, as each may require different setup.
+> **NOTE**: The above command must be re-run every time the terminal is opened. To set up Linux so it automatically runs the command every time a new terminal is opened, open `~/.bashrc` in your favorite editor and add `source /opt/intel/openvino_2022/setupvars.sh` after the last line. Next time when you open a terminal, you will see `[setupvars.sh] OpenVINO™ environment initialized`. Changing `.bashrc` is not recommended when you have many OpenVINO™ versions on your machine and want to switch among them, as each may require different setup.
 
 The environment variables are set. Next, you can download some additional tools.
 

--- a/docs/install_guides/installing-openvino-from-archive-linux.md
+++ b/docs/install_guides/installing-openvino-from-archive-linux.md
@@ -97,53 +97,33 @@ Next, you'll download the OpenVINO Runtime 2022.2 archive file from the [OpenVIN
      
 @endsphinxdirective
 
-3. Change the directory to where you downloaded the archive files.<br>
-   For example, if you downloaded the files to the current user's `Downloads` directory, use the following command:
-   ```sh
-   cd ~/Downloads/
-   ```
-4. To verify the package by using the `.sha256` file:
-   ```sh
-   sha256sum -с <archive name>.tgz.sha256
-   ```
-   If any error message appears, check your network connections, re-download the correct files, and make sure the download process completes successfully.
-5. Extract OpenVINO files from the `.tgz` file:
-   ```sh
-   tar xf <archive name>.tgz -C <destination_dir>
-   ```
-   where the `<destination_dir>` is the directory that you extract OpenVINO files to. You're recommended to set it as:
-   * For root users or administrators: `/opt/intel/`
-   * For regular users: `/home/<USER>/intel/`
+Finally, create a symbolic link to the folder by issuing:
 
-If you forgot to set the directory in Step 5, you can then use `sudo mv <extracted_folder> /opt/intel` (for root users or administrators), or `mv <extracted_folder> /home/<USER>/intel/` (for regular users) to set that.
-
-For simplicity, it is useful to create a symbolink link:
-```sh
-ln -s /home/<USER>/intel/<extracted_folder> /home/<USER>/intel/openvino_2022
 ```
-If such link already exists, remove the previous link with `rm /home/<USER>/intel/openvino_2022`.
+sudo ln -s openvino_2022.2.0.7713 openvino_2022
+```
+> **NOTE**: If you have already installed a previous release of OpenVINO 2022, a symbolic link to the `openvino_2022` folder may already exist. Remove the previous link with `sudo rm openvino_2022`, then re-issue the previous command.
 
-The `/opt/intel/openvino_<version>/` or `/home/<USER>/intel/openvino_<version>/` will be referred as the standard OpenVINO `<INSTALL_DIR>` in this document.
-
-The core components are now installed. Continue to the next section to install components.
+Congratulations, you finished installation! The `/opt/intel/openvino_2022` folder now contains the core components for OpenVINO™. When other pages in OpenVINO™ documentation refer to the <INSTALL_DIR> directory, this is the folder they're referring to. If you installed OpenVINO™ in a different location (such as `/home/<USER>/Intel/openvino_2022`), make sure to use that instead.
 
 ### <a name="set-the-environment-variables"></a>Step 2: Configure the Environment
 
-You must update several environment variables before you can compile and run OpenVINO™ applications. Set environment variables as follows:
+You must update several environment variables before you can compile and run OpenVINO™ applications. Open a terminal (if it isn't already open) and run the setupvars.bat batch file as shown below to temporarily set your environment variables. Again, if you installed OpenVINO™ in a folder other than `/opt/intel/openvino_2022`, use that location instead.
 
 ```sh
-source <INSTALL_DIR>/setupvars.sh
+source /opt/intel/openvino_2022/setupvars.sh
 ```  
 
 If you have more than one OpenVINO™ version on your machine, you can easily switch its version by sourcing `setupvars.sh` of your choice.
 
-> **NOTE**: You can also run this script every time when you start new terminal session. Open `~/.bashrc` in your favorite editor, and add `source <INSTALL_DIR>/setupvars.sh`. Next time when you open a terminal, you will see `[setupvars.sh] OpenVINO™ environment initialized`. Changing `.bashrc` is not recommended when you have many OpenVINO™ versions on your machine and want to switch among them, as each may require different setup.
+> **NOTE**: You can also run this script every time when you start new terminal session. Open `~/.bashrc` in your favorite editor, and add `source /opt/intel/openvino_2022/setupvars.sh`. Next time when you open a terminal, you will see `[setupvars.sh] OpenVINO™ environment initialized`. Changing `.bashrc` is not recommended when you have many OpenVINO™ versions on your machine and want to switch among them, as each may require different setup.
 
 The environment variables are set. Next, you can download some additional tools.
 
 ### <a name="model-optimizer">Step 3 (Optional): Install Additional Components
+OpenVINO Development Tools adds even more functionality to OpenVINO. It provides tools like Model Optimizer, Benchmark Tool, Post-Training Optimization Tool, and Open Model Zoo Downloader. If you install OpenVINO Development Tools, OpenVINO Runtime will also be installed as a dependency, so you don't need to install OpenVINO Runtime separately. 
 
-Since the OpenVINO™ 2022.1 release, the following development tools: Model Optimizer, Post-Training Optimization Tool, Model Downloader and other Open Model Zoo tools, Accuracy Checker, and Annotation Converter can only be installed via PyPI. See [Install OpenVINO™ Development Tools](installing-model-dev-tools.md) for detailed steps.
+See the [Install OpenVINO Development Tools](installing-model-dev-tools.md) page for step-by-step installation instructions.
 
 OpenCV is necessary to run demos from Open Model Zoo (OMZ). Some OpenVINO samples can also extend their capabilities when compiled with OpenCV as a dependency. To install OpenCV for OpenVINO, see the [instructions on Github](https://github.com/opencv/opencv/wiki/BuildOpenCV4OpenVINO).
 

--- a/docs/install_guides/installing-openvino-from-archive-linux.md
+++ b/docs/install_guides/installing-openvino-from-archive-linux.md
@@ -11,6 +11,8 @@ With the OpenVINO™ 2022.2 release, you can download and use archive files to i
 
   * Ubuntu 18.04 long-term support (LTS), 64-bit
   * Ubuntu 20.04 long-term support (LTS), 64-bit
+  * Red Hat Enterprise Linux 8, 64-bit
+  * Debian 9 armhf
 
   .. note::
      Since the OpenVINO™ 2022.1 release, CentOS 7.6, 64-bit is not longer supported.
@@ -48,13 +50,53 @@ With the OpenVINO™ 2022.2 release, you can download and use archive files to i
 
 ### <a name="install-openvino"></a>Step 1: Download and Install the OpenVINO Core Components
 
-1. Select and download the OpenVINO™ archive files from [Intel® Distribution of OpenVINO™ toolkit download page](https://software.intel.com/en-us/openvino-toolkit/choose-download). There are typically two files for you to download: 
-   ```sh
-   l_openvino_toolkit_<operating system>_<release version>_<package ID>_x86_64.tgz
-   l_openvino_toolkit_<operating system>_<release version>_<package ID>_x86_64.tgz.sha256
-   ``` 
-   where the `.sha256` file is used to verify the success of the download process.
-2. Open a command prompt terminal window. You can use the keyboard shortcut: Ctrl+Alt+T
+First, open a terminal using Ctrl + Alt + T. Create a folder for OpenVINO and move into it by issuing the following commands. If the `/opt/intel` folder already exists, skip the `mkdir` command.
+
+```sh
+sudo mkdir /opt/intel
+cd /opt/intel
+```
+
+> **NOTE**: The `/opt/intel` path is the recommended folder path for administrators or root users. If you prefer to install OpenVINO in regular userspace, the recommended path is `/home/<USER>/Intel`. You may use a different path if desired.
+
+Next, you'll download the OpenVINO Runtime 2022.2 archive file from the [OpenVINO archives](https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.2/windows) site. Issue the following command to download the archive file, unpack it, and rename the folder to `openvino_2022.2.0.7713`:
+
+@sphinxdirective
+
+.. tab:: Ubuntu 18.04
+
+   .. code-block:: sh
+   
+      sudo wget https://github.com/openvinotoolkit/openvino/releases/download/2022.2.0/l_openvino_toolkit_ubuntu18_2022.2.0.7713.af16ea1d79a_x86_64.tgz -O openvino_2022.2.0.7713.tgz
+      sudo tar -xf openvino_2022.2.0.7713.tgz
+      sudo mv l_openvino_toolkit_ubuntu18_2022.2.0.7713.af16ea1d79a_x86_64 openvino_2022.2.0.7713
+      
+.. tab:: Ubuntu 20.04
+
+   .. code-block:: sh
+   
+      sudo wget https://github.com/openvinotoolkit/openvino/releases/download/2022.2.0/l_openvino_toolkit_ubuntu20_2022.2.0.7713.af16ea1d79a_x86_64.tgz -O openvino_2022.2.0.7713.tgz
+      sudo tar -xf openvino_2022.2.0.7713.tgz
+      sudo mv l_openvino_toolkit_ubuntu20_2022.2.0.7713.af16ea1d79a_x86_64 openvino_2022.2.0.7713
+      
+.. tab:: Red Hat
+
+   .. code-block:: sh
+   
+      sudo wget https://github.com/openvinotoolkit/openvino/releases/download/2022.2.0/l_openvino_toolkit_rhel8_2022.2.0.7713.af16ea1d79a_x86_64.tgz -O openvino_2022.2.0.7713.tgz
+      sudo tar -xf openvino_2022.2.0.7713.tgz
+      sudo mv l_openvino_toolkit_rhel8_2022.2.0.7713.af16ea1d79a_x86_64 openvino_2022.2.0.7713
+      
+.. tab:: Debian
+
+   .. code-block:: sh
+   
+      sudo wget https://github.com/openvinotoolkit/openvino/releases/download/2022.2.0/l_openvino_toolkit_debian9_arm_2022.2.0.7713.af16ea1d79a_armhf.tgz -O openvino_2022.2.0.7713.tgz
+      sudo tar -xf openvino_2022.2.0.7713.tgz
+      sudo mv l_openvino_toolkit_debian9_arm_2022.2.0.7713.af16ea1d79a_armhf openvino_2022.2.0.7713
+     
+@endsphinxdirective
+
 3. Change the directory to where you downloaded the archive files.<br>
    For example, if you downloaded the files to the current user's `Downloads` directory, use the following command:
    ```sh

--- a/docs/install_guides/installing-openvino-from-archive-linux.md
+++ b/docs/install_guides/installing-openvino-from-archive-linux.md
@@ -1,8 +1,6 @@
 # Install OpenVINO™ Runtime on Linux from an Archive File {#openvino_docs_install_guides_installing_openvino_from_archive_linux}
 
-With the OpenVINO™ 2022.2 release, you can download and use archive files to install OpenVINO Runtime. 
-
-You can also check the [Release Notes](https://software.intel.com/en-us/articles/OpenVINO-RelNotes) for more information on updates in this release.
+With the OpenVINO™ 2022.2 release, you can download and use archive files to install OpenVINO Runtime. The archive files contain pre-built binaries and library files needed for OpenVINO Runtime, as well as sample code for running demos. This page provides instructions showing how to install OpenVINO Runtime using archive files. Check the Release Notes for more information on updates in the 2022.2 release.
 
 > **NOTE**: Since the OpenVINO™ 2022.1 release, the following development tools: Model Optimizer, Post-Training Optimization Tool, Model Downloader and other Open Model Zoo tools, Accuracy Checker, and Annotation Converter can be installed via [pypi.org](https://pypi.org/project/openvino-dev/) only.
 
@@ -42,20 +40,13 @@ You can also check the [Release Notes](https://software.intel.com/en-us/articles
   * `CMake 3.13 or higher, 64-bit <https://cmake.org/download/>`_
   * GCC 7.5.0 (for Ubuntu 18.04) or GCC 9.3.0 (for Ubuntu 20.04)
   * `Python 3.6 - 3.9, 64-bit <https://www.python.org/downloads/windows/>`_
-     * Note that OpenVINO is gradually stopping the support for Python 3.6. Python 3.7 - 3.9 are recommended. 
+     * Note that OpenVINO is gradually phasing out support for Python 3.6. Python 3.7 - 3.9 are recommended. 
 
 @endsphinxdirective
 
 ## Installing OpenVINO Runtime
 
-@sphinxdirective
-
-.. important::
-   Before you start your journey with installation of the Intel® Distribution of OpenVINO™ toolkit, we encourage you to check the :ref:`code samples <code samples>` in C, C++, Python and :ref:`notebook tutorials <notebook tutorials>`, so you could see all the amazing things that you can achieve with our tool.
-
-@endsphinxdirective
-
-### <a name="install-openvino"></a>Step 1: Download and Install the OpenVINO Package
+### <a name="install-openvino"></a>Step 1: Download and Install the OpenVINO Core Components
 
 1. Select and download the OpenVINO™ archive files from [Intel® Distribution of OpenVINO™ toolkit download page](https://software.intel.com/en-us/openvino-toolkit/choose-download). There are typically two files for you to download: 
    ```sh

--- a/docs/install_guides/installing-openvino-from-archive-linux.md
+++ b/docs/install_guides/installing-openvino-from-archive-linux.md
@@ -128,7 +128,8 @@ See the [Install OpenVINO Development Tools](installing-model-dev-tools.md) page
 OpenCV is necessary to run demos from Open Model Zoo (OMZ). Some OpenVINO samples can also extend their capabilities when compiled with OpenCV as a dependency. To install OpenCV for OpenVINO, see the [instructions on Github](https://github.com/opencv/opencv/wiki/BuildOpenCV4OpenVINO).
 
 ### <a name="optional-steps"></a>Step 4 (Optional): Configure Inference on Non-CPU Devices
-
+OpenVINO Runtime has a plugin architecture that enables you to run inference on multiple devices without rewriting your code. Supported devices include integrated GPUs, discrete GPUs, NCS2, VPUs, and GNAs. See the instructions below to set up OpenVINO on these devices.
+ 
 @sphinxdirective 
 .. tab:: GPU
 
@@ -154,18 +155,26 @@ OpenCV is necessary to run demos from Open Model Zoo (OMZ). Some OpenVINO sample
 @endsphinxdirective
 
 ## <a name="get-started"></a>What's Next?
+Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications! Learn more about how to integrate a model in OpenVINO applications by trying out the following tutorials.
 
-Now you are ready to try out the toolkit.
+### Get started with Python
+<img src="https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif" width=400>
 
-Start with some Python tutorials:
-   * [Hello Image Classification](https://docs.openvino.ai/latest/notebooks/001-hello-world-with-output.html)
-   * [Convert TensorFlow models with OpenVINO™](https://docs.openvino.ai/latest/notebooks/101-tensorflow-to-openvino-with-output.html)
-   * [Convert a PyTorch model and remove the image background](https://docs.openvino.ai/latest/notebooks/205-vision-background-removal-with-output.html)
+Try the [Python Quick Start Example](https://docs.openvino.ai/2022.2/notebooks/201-vision-monodepth-with-output.html) to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
-To start with C++ samples, see <a href="openvino_docs_OV_UG_Samples_Overview.html#build-samples-linux">Build Sample Applications on Linux</a> first, and then you can try the following samples:
-   * [Hello Classification C++ Sample](@ref openvino_inference_engine_samples_hello_classification_README)
-   * [Hello Reshape SSD C++ Sample](@ref openvino_inference_engine_samples_hello_reshape_ssd_README)
-   * [Image Classification Async C++ Sample](@ref openvino_inference_engine_samples_classification_sample_async_README)
+Visit the [Tutorials](../tutorials.md) page for more Jupyter Notebooks to get you started with OpenVINO, such as:
+* [OpenVINO Python API Tutorial](https://docs.openvino.ai/2022.2/notebooks/002-openvino-api-with-output.html)
+* [Basic image classification program with Hello Image Classification](https://docs.openvino.ai/2022.2/notebooks/001-hello-world-with-output.html)
+* [Convert a PyTorch model and use it for image background removal](https://docs.openvino.ai/2022.2/notebooks/205-vision-background-removal-with-output.html)
+
+### Get started with C++
+<img src="https://user-images.githubusercontent.com/36741649/127170593-86976dc3-e5e4-40be-b0a6-206379cd7df5.jpg" width=400>
+
+Try the [C++ Quick Start Example](@ref openvino_docs_get_started_get_started_demos) for step-by-step instructions on building and running a basic image classification C++ application.
+
+Visit the [Samples](../OV_Runtime_UG/Samples_Overview.md) page for other C++ example applications to get you started with OpenVINO, such as:
+* [Basic object detection with the Hello Reshape SSD C++ sample](@ref openvino_inference_engine_samples_hello_reshape_ssd_README)
+* [Automatic speech recognition C++ sample](@ref openvino_inference_engine_samples_speech_sample_README)
 
 ## <a name="uninstall"></a>Uninstalling the Intel® Distribution of OpenVINO™ Toolkit
 


### PR DESCRIPTION
Significant changes to the "Install OpenVINO Runtime on Linux from Archive File" page! These changes are similar to PR #13332. If we decide on any changes to that PR while it is being reviewed, I will make the same changes to this PR.

### Details:
1. After discussing with @ryanloney, I rewrote the Step 1 and Step 2 installation instructions to be more specific. The user can now copy+paste the commands step-by-step into the terminal. This helps prevent users from being confused on where the archive folders should be unpacked.

The rewrite includes instructions for Ubuntu 18.04, Ubuntu 20.04, Red Hat 8, and Debian 9. I tested the instructions on my Ubuntu 20.04 PC, and they work. I removed the `.sha256` checksum verification step, because it seems very low risk and adds complexity to the install process. Please do a close review of the new instructions to make sure you agree with the changes. 

2. Added some introductory sentences on Step 3 and Step 4 sections to provide a little more context.

3. Changed the "What's Next?" section to add more enticing links, similar to #13219 .

### Tickets:
N/A
