### PR TITLE
DOCS: Fixing indentation in Plugin Testing - for 22.2

### DIFF
--- a/docs/IE_PLUGIN_DG/PluginTesting.md
+++ b/docs/IE_PLUGIN_DG/PluginTesting.md
@@ -14,15 +14,12 @@ Engine concepts: plugin creation, multiple executable networks support, multiple
 2. **Single layer tests** (`single_layer_tests` sub-folder). This groups of tests checks that a particular single layer can be inferenced on a device. An example of test instantiation based on test definition from `IE::funcSharedTests` library:
 
     - From the declaration of convolution test class we can see that it's a parametrized GoogleTest based class with the `convLayerTestParamsSet` tuple of parameters:
-
     @snippet single_layer/convolution.hpp test_convolution:definition
 
     - Based on that, define a set of parameters for `Template` plugin functional test instantiation:
-
     @snippet single_layer_tests/convolution.cpp test_convolution:declare_parameters
 
     - Instantiate the test itself using standard GoogleTest macro `INSTANTIATE_TEST_SUITE_P`:
-
     @snippet single_layer_tests/convolution.cpp test_convolution:instantiate
 
 3. **Sub-graph tests** (`subgraph_tests` sub-folder). This group of tests is designed to tests small patterns or combination of layers. E.g. when a particular topology is being enabled in a plugin e.g. TF ResNet-50, there is no need to add the whole topology to test tests. In opposite way, a particular repetitive subgraph or pattern can be extracted from `ResNet-50` and added to the tests. The instantiation of the sub-graph tests is done in the same way as for single layer tests.


### PR DESCRIPTION
A minor fix that corrects indentation of snippets.