### PR TITLE
Fix `openvino_mock_py_frontend` target compilation

### DIFF
--- a/src/bindings/python/tests/mock/mock_py_frontend/CMakeLists.txt
+++ b/src/bindings/python/tests/mock/mock_py_frontend/CMakeLists.txt
@@ -26,6 +26,7 @@ target_compile_definitions(${TARGET_NAME} PUBLIC
     $<$<BOOL:${ENABLE_OV_PADDLE_FRONTEND}>:ENABLE_OV_PADDLE_FRONTEND>)
 
 target_link_libraries(${TARGET_NAME} PUBLIC
+    openvino::runtime
     $<$<BOOL:${ENABLE_OV_ONNX_FRONTEND}>:openvino::frontend::onnx>
     $<$<BOOL:${ENABLE_OV_TF_FRONTEND}>:openvino::frontend::tensorflow>
     $<$<BOOL:${ENABLE_OV_PADDLE_FRONTEND}>:openvino::frontend::paddle>)


### PR DESCRIPTION
PR adds missing `openvino::runtime` dependency

### Details:
 - dependency was not added by mistake while refactoring CMake file in https://github.com/openvinotoolkit/openvino/pull/12978
### Tickets:
 - E#54521
