### PR TITLE
[PyOV] mark pyopenvino as internal

### DIFF
--- a/src/bindings/python/src/pyopenvino/CMakeLists.txt
+++ b/src/bindings/python/src/pyopenvino/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2018-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-project (pyopenvino)
+project (_pyopenvino)
 
 if(NOT DEFINED OpenVINO_SOURCE_DIR)
     find_package(OpenVINODeveloperPackage REQUIRED)

--- a/src/bindings/python/src/pyopenvino/frontend/frontend_module.cmake
+++ b/src/bindings/python/src/pyopenvino/frontend/frontend_module.cmake
@@ -21,7 +21,7 @@ function(frontend_module TARGET FRAMEWORK INSTALL_COMPONENT)
 
     pybind11_add_module(${TARGET_NAME} MODULE NO_EXTRAS ${SOURCES})
 
-    add_dependencies(${TARGET_NAME} pyopenvino)
+    add_dependencies(${TARGET_NAME} _pyopenvino)
     add_dependencies(py_ov_frontends ${TARGET_NAME})
 
     target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"


### PR DESCRIPTION
### Details:
 - Rename openvino.pyopenvino to openvino._pyopenvino module to indicate that this is an internal module and shouldn't be used directly by users.

### Tickets:
 - 92452
