### PR TITLE
DOCS: Fixing indentation in Build Plugin Using CMake - for 22.2

### DIFF
--- a/docs/IE_PLUGIN_DG/Building.md
+++ b/docs/IE_PLUGIN_DG/Building.md
@@ -57,7 +57,6 @@ A common plugin consists of the following components:
 To build a plugin and its tests, run the following CMake scripts:
 
 - Root `CMakeLists.txt`, which finds the Inference Engine Developer Package using the `find_package` CMake command and adds the `src` and `tests` subdirectories with plugin sources and their tests respectively:
-
 ```cmake
 cmake_minimum_required(VERSION 3.13)
 
@@ -82,21 +81,15 @@ if(ENABLE_TESTS)
     endif()
 endif()
 ```
-
-> **NOTE**: The default values of the `ENABLE_TESTS`, `ENABLE_FUNCTIONAL_TESTS` options are shared via the Inference Engine Developer Package and they are the same as for the main DLDT build tree. You can override them during plugin build using the command below:
-
+   > **NOTE**: The default values of the `ENABLE_TESTS`, `ENABLE_FUNCTIONAL_TESTS` options are shared via the Inference Engine Developer Package and they are the same as for the main DLDT build tree. You can override them during plugin build using the command below:
 ```bash
 $ cmake -DENABLE_FUNCTIONAL_TESTS=OFF -DInferenceEngineDeveloperPackage_DIR=../dldt-release-build ../template-plugin
 ``` 
 
 - `src/CMakeLists.txt` to build a plugin shared library from sources:
-
 @snippet template_plugin/src/CMakeLists.txt cmake:plugin
-
-> **NOTE**: `IE::inference_engine` target is imported from the Inference Engine Developer Package.
+   > **NOTE**: `IE::inference_engine` target is imported from the Inference Engine Developer Package.
 
 - `tests/functional/CMakeLists.txt` to build a set of functional plugin tests:
-
 @snippet template_plugin/tests/functional/CMakeLists.txt cmake:functional_tests
-
-> **NOTE**: The `IE::funcSharedTests` static library with common functional Inference Engine Plugin tests is imported via the Inference Engine Developer Package.
+   > **NOTE**: The `IE::funcSharedTests` static library with common functional Inference Engine Plugin tests is imported via the Inference Engine Developer Package.


### PR DESCRIPTION
Minor fixes that correct indentation of code snippets and note admonitions.
