### PR TITLE
Disable v9 test

### DIFF
--- a/src/frontends/ir/tests/frontend_test_basic.cpp
+++ b/src/frontends/ir/tests/frontend_test_basic.cpp
@@ -137,7 +137,7 @@ TEST_F(IRFrontendTests, elementary_model_reading_v10) {
     EXPECT_TRUE(res.valid) << res.message;
 }
 
-TEST_F(IRFrontendTests, elementary_model_reading_v9) {
+TEST_F(IRFrontendTests, DISABLED_elementary_model_reading_v9) {
     std::string testModelV9 = R"V0G0N(
 <net name="Network" version="9">
     <layers>


### PR DESCRIPTION
### Details:
 - Temporary disable because it fails on CI on ubuntu 18.04

### Tickets:
 - CVS-94211
