### PR TITLE
[TF FE] Remove export API for helper transformation

### DIFF
--- a/src/frontends/tensorflow/src/helper_transforms/block_lstm_replacer.hpp
+++ b/src/frontends/tensorflow/src/helper_transforms/block_lstm_replacer.hpp
@@ -18,7 +18,7 @@ namespace pass {
 
 // This transformation replaces BlockLSTM with such outputs as concatenated hidden states
 // and cell state from the last time step.
-class TENSORFLOW_API BlockLSTMReplacer : public ov::pass::MatcherPass {
+class BlockLSTMReplacer : public ov::pass::MatcherPass {
 public:
     OPENVINO_RTTI("ov::frontend::tensorflow::pass::BlockLSTMReplacer");
     BlockLSTMReplacer();

--- a/src/frontends/tensorflow/src/helper_transforms/gru_block_cell_replacer.hpp
+++ b/src/frontends/tensorflow/src/helper_transforms/gru_block_cell_replacer.hpp
@@ -17,7 +17,7 @@ namespace tensorflow {
 namespace pass {
 
 // This transformation handles GRUBlockCell with just one output - hidden state
-class TENSORFLOW_API GRUBlockCellReplacer : public ov::pass::MatcherPass {
+class GRUBlockCellReplacer : public ov::pass::MatcherPass {
 public:
     OPENVINO_RTTI("ov::frontend::tensorflow::pass::GRUBlockCellReplacer");
     GRUBlockCellReplacer();

--- a/src/frontends/tensorflow/src/helper_transforms/unique_replacer.hpp
+++ b/src/frontends/tensorflow/src/helper_transforms/unique_replacer.hpp
@@ -17,7 +17,7 @@ namespace tensorflow {
 namespace pass {
 
 // This transformation expresses Unique with a sub-graph of OpenVINO operations
-class TENSORFLOW_API UniqueReplacer : public ov::pass::MatcherPass {
+class UniqueReplacer : public ov::pass::MatcherPass {
 public:
     OPENVINO_RTTI("ov::frontend::tensorflow::pass::UniqueReplacer");
     UniqueReplacer();

--- a/tests/layer_tests/tensorflow_tests/test_tf_DynamicPartition.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_DynamicPartition.py
@@ -45,10 +45,11 @@ class TestDynamicPartition(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_dynamic_partition_basic(self, params, ie_device, precision, ir_version, temp_dir,
                                      use_new_frontend, use_old_api):
+        if not use_new_frontend:
+            pytest.skip("DynamicPartition operation is not supported via legacy frontend.")
         self._test(*self.create_dynamic_partition_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend, use_old_api=use_old_api)
-
     test_data_other_types = [
         dict(data_shape=[10], partitions_shape=[10], num_partitions=10, data_type=tf.int32),
         dict(data_shape=[7, 3], partitions_shape=[7], num_partitions=8, data_type=tf.int64),
@@ -58,6 +59,8 @@ class TestDynamicPartition(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_dynamic_partition_other_types(self, params, ie_device, precision, ir_version, temp_dir,
                                            use_new_frontend, use_old_api):
+        if not use_new_frontend:
+            pytest.skip("DynamicPartition operation is not supported via legacy frontend.")
         self._test(*self.create_dynamic_partition_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend, use_old_api=use_old_api)

--- a/tests/layer_tests/tensorflow_tests/test_tf_SegmentSum.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SegmentSum.py
@@ -42,6 +42,8 @@ class TestSegmentSum(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_segment_sum_basic(self, params, ie_device, precision, ir_version, temp_dir,
                                use_new_frontend, use_old_api):
+        if not use_new_frontend:
+            pytest.skip("SegmentSum operation is not supported via legacy frontend.")
         self._test(*self.create_segment_sum_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend, use_old_api=use_old_api)
@@ -57,6 +59,8 @@ class TestSegmentSum(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_segment_sum_different_types(self, params, ie_device, precision, ir_version, temp_dir,
                                          use_new_frontend, use_old_api):
+        if not use_new_frontend:
+            pytest.skip("SegmentSum operation is not supported via legacy frontend.")
         self._test(*self.create_segment_sum_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend, use_old_api=use_old_api)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Unique.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Unique.py
@@ -30,6 +30,7 @@ class TestUnique(CommonTFLayerTest):
         return tf_net, None
 
     test_data_basic = [
+        dict(x_shape=[1], data_type=tf.float32, out_idx=tf.int32),
         dict(x_shape=[50], data_type=tf.float32, out_idx=tf.int32),
         dict(x_shape=[100], data_type=tf.float32, out_idx=tf.int64),
     ]


### PR DESCRIPTION
**Details:** Also, it skips layer tests for SegmentSum and DynamicPartition in case legacy frontend

**Ticket:** N/A

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
