### PR TITLE
Fixed RDFT under Rosetta

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/kernels/rdft_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/rdft_kernel.cpp
@@ -161,7 +161,7 @@ void jit_dft_kernel_f32<isa>::generate() {
 
             if (kernel_type_ == complex_to_complex) {
                 mov(rdx, 1ULL << 31);
-                vmovq(xmm_neg_mask, rdx);
+                uni_vmovq(xmm_neg_mask, rdx);
                 uni_vbroadcastsd(vmm_neg_mask, xmm_neg_mask);
             }
 


### PR DESCRIPTION
### Details:
 - To fix the issue one should change VEX "vmovq" instruction to universal "uni_vmovq", which will be automatically replaced with "movq" in case of SSE https://github.com/openvinotoolkit/openvino/blob/270051ebcef7639a89e4f5fc73d6c38b5aa120ef/src/plugins/intel_cpu/src/nodes/kernels/rdft_kernel.cpp#L164
BTW, it is better to change all the SIMD mnemonics with uni_* versions to avoid known VEX to nonVEX encoding switch, which has substantial performance penalty on modern platforms.

### Tickets:
 - CVS-93107
