### PR TITLE
OV python: update getting pytorch tensor as input

### DIFF
--- a/src/bindings/python/src/openvino/runtime/ie_api.py
+++ b/src/bindings/python/src/openvino/runtime/ie_api.py
@@ -101,6 +101,8 @@ def normalize_inputs(request: InferRequestBase, inputs: dict) -> dict:
             new_inputs[key] = value
         # If value object has __array__ attribute, load it to Tensor using np.array.
         elif hasattr(value, "__array__"):
+            if hasattr(value, "detach"):
+                value = value.detach().cpu()
             update_tensor(np.array(value, copy=True), request, key)
         # Throw error otherwise.
         else:


### PR DESCRIPTION
### Details:
 - fix for pytorch tensors usage as input . Currently OV failed to infer with pytorch tensor under gradient calculation or offloaded on cuda device, due to inability to get numpy array from it. This fix prevent such behaviour.