### PR TITLE
Unbreak LSTMCell-1 conformance test by adding missing descriptor

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -232,8 +232,8 @@ bool RNN::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::s
                 errorMessage = "Node expects constants as W, R, B inputs.";
                 return false;
             }
-            if (ov::is_type<ov::op::v0::LSTMCell>(op) && op->get_input_size() == 7) {
-                errorMessage = "Node does not support 7 inputs";
+            if (ov::is_type<ov::op::v0::LSTMCell>(op) && op->get_input_size() != 6) {
+                errorMessage = "Node expects 6 inputs. Actual: " + std::to_string(op->get_input_size());
                 return false;
             }
         } else if (one_of(op->get_type_info(),

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -232,6 +232,10 @@ bool RNN::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::s
                 errorMessage = "Node expects constants as W, R, B inputs.";
                 return false;
             }
+            if (ov::is_type<ov::op::v0::LSTMCell>(op) && op->get_input_size() == 7) {
+                errorMessage = "Node does not support 7 inputs";
+                return false;
+            }
         } else if (one_of(op->get_type_info(),
                 ov::op::v0::LSTMSequence::get_type_info_static(),
                 ov::op::v5::LSTMSequence::get_type_info_static())) {


### PR DESCRIPTION
### Details:
- Previously this test crashed with 'out-of-bounds' segmentation fault

### Tickets:
 - *92404*
