### PR TITLE
[C API DOC] fix mac doc build error caused by ov_output_const_port_t

### DIFF
--- a/.ci/azure/mac.yml
+++ b/.ci/azure/mac.yml
@@ -5,7 +5,6 @@ trigger:
     - releases/*
   paths:
     exclude: 
-    - docs/
     - /**/docs/*
     - /**/*.md
     - README.md
@@ -17,7 +16,6 @@ pr:
     - releases/*
   paths:
     exclude: 
-    - docs/
     - /**/docs/*
     - /**/*.md
     - README.md

--- a/.ci/azure/mac.yml
+++ b/.ci/azure/mac.yml
@@ -5,6 +5,7 @@ trigger:
     - releases/*
   paths:
     exclude: 
+    - docs/
     - /**/docs/*
     - /**/*.md
     - README.md
@@ -16,6 +17,7 @@ pr:
     - releases/*
   paths:
     exclude: 
+    - docs/
     - /**/docs/*
     - /**/*.md
     - README.md

--- a/docs/snippets/src/main.c
+++ b/docs/snippets/src/main.c
@@ -48,11 +48,11 @@ ov_compiled_model_create_infer_request(compiled_model, &infer_request);
 void * memory_ptr = NULL;
 //! [part4]
 // Get input port for model with one input
-ov_output_port_t* input_port = NULL;
-ov_model_input(model, &input_port);
+ov_output_const_port_t* input_port = NULL;
+ov_model_const_input(model, &input_port);
 // Get the input shape from input port
 ov_shape_t input_shape;
-ov_port_get_shape(input_port, &input_shape);
+ov_const_port_get_shape(input_port, &input_shape);
 // Get the the type of input
 ov_element_type_e input_type;
 ov_port_get_element_type(input_port, &input_type);
@@ -77,7 +77,7 @@ ov_infer_request_get_output_tensor_by_index(infer_request, 0, &output_tensor);
 //! [part8]
 ov_shape_free(&input_shape);
 ov_tensor_free(output_tensor);
-ov_output_port_free(input_port);
+ov_output_const_port_free(input_port);
 ov_tensor_free(tensor);
 ov_infer_request_free(infer_request);
 ov_compiled_model_free(compiled_model);


### PR DESCRIPTION
### Details:
 - change `ov_output_const_port_t` to `ov_output_port_t`, for fixing mac build error.

### Tickets:
 - 94497
