### PR TITLE
Fixing assert when handling iop, iol and ioml in compile tool

### DIFF
--- a/tools/compile_tool/main.cpp
+++ b/tools/compile_tool/main.cpp
@@ -453,7 +453,7 @@ void configurePrePostProcessing(std::shared_ptr<ov::Model>& model,
                     }
                 }
             }
-            OPENVINO_ASSERT(!tensorFound, "Model doesn't have input/output with tensor name: ", tensor_name);
+            OPENVINO_ASSERT(tensorFound, "Model doesn't have input/output with tensor name: ", tensor_name);
         }
     }
     if (!il.empty()) {
@@ -490,7 +490,7 @@ void configurePrePostProcessing(std::shared_ptr<ov::Model>& model,
                     }
                 }
             }
-            OPENVINO_ASSERT(!tensorFound, "Model doesn't have input/output with tensor name: ", tensor_name);
+            OPENVINO_ASSERT(tensorFound, "Model doesn't have input/output with tensor name: ", tensor_name);
         }
     }
 
@@ -528,7 +528,7 @@ void configurePrePostProcessing(std::shared_ptr<ov::Model>& model,
                     }
                 }
             }
-            OPENVINO_ASSERT(!tensorFound, "Model doesn't have input/output with tensor name: ", tensor_name);
+            OPENVINO_ASSERT(tensorFound, "Model doesn't have input/output with tensor name: ", tensor_name);
         }
     }
 


### PR DESCRIPTION
### Details:
 - compile_tool, when using OV API 2.0, should parse the iop, iol and ioml parameters list, read the tensors inputs and outputs, and try to match the user provided list with the tensor information and apply the right precision, layout and model layout
 - this is happening right now, except that there's an assert at the end of every user provided name, to verify whether it was found and applied or not
 - the assert right now seems backwards, and it actually asserts when it finds the name rather than when it doesn't find it
### Tickets:
 - 94496
