### PR TITLE
[PyOV] Upgrade linter Python version

### DIFF
--- a/.github/workflows/py_checks.yml
+++ b/.github/workflows/py_checks.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.10'
       - name: Install dependencies
         run: python -m pip install -r src/bindings/python/requirements_test.txt
       # samples code-style

--- a/.github/workflows/py_checks.yml
+++ b/.github/workflows/py_checks.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.7'
       - name: Install dependencies
         run: python -m pip install -r src/bindings/python/requirements_test.txt
       # samples code-style

--- a/.github/workflows/py_checks.yml
+++ b/.github/workflows/py_checks.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.9'
       - name: Install dependencies
         run: python -m pip install -r src/bindings/python/requirements_test.txt
       # samples code-style

--- a/src/bindings/python/src/openvino/runtime/ie_api.py
+++ b/src/bindings/python/src/openvino/runtime/ie_api.py
@@ -67,7 +67,7 @@ def _(
         tensor.data[:] = inputs[:]
 
 
-@update_tensor.register(np.number)
+@update_tensor.register(np.number)  # type: ignore
 @update_tensor.register(float)
 @update_tensor.register(int)
 def _(

--- a/src/bindings/python/src/openvino/runtime/utils/types.py
+++ b/src/bindings/python/src/openvino/runtime/utils/types.py
@@ -108,7 +108,7 @@ def get_dtype(openvino_type: Type) -> np.dtype:
 def get_ndarray(data: NumericData) -> np.ndarray:
     """Wrap data into a numpy ndarray."""
     if type(data) == np.ndarray:
-        return data
+        return data  # type: ignore
     return np.array(data)
 
 

--- a/src/bindings/python/tests/test_runtime/test_type.py
+++ b/src/bindings/python/tests/test_runtime/test_type.py
@@ -20,7 +20,7 @@ from openvino.runtime import Type
     ("uint16", np.uint16, Type.u16),
     ("uint32", np.uint32, Type.u32),
     ("uint64", np.uint64, Type.u64),
-    ("bool", np.bool_, Type.boolean),
+    ("bool", bool, Type.boolean),
 ])
 def test_dtype_ovtype_conversion(dtype_string, dtype, ovtype):
     assert ovtype.to_dtype() == dtype


### PR DESCRIPTION
### Details:
 - Python 3.6 is no longer supported. The linter should be ran on a higher version.

### Tickets:
 - 94540
