### PR TITLE
fix documentation building including notebooks

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,6 +11,7 @@ idna==2.10
 imagesize==1.2.0
 importlib-metadata==3.10.0
 iniconfig==1.1.1
+ipython==8.5.0
 Jinja2==2.11.3
 lxml>=4.6.5
 MarkupSafe==1.1.1


### PR DESCRIPTION
### Details:
missing ipython component is causing incorrect highlighting for notebook code in sphinx documentation

