### PR TITLE
DOCS: Fix for Runtime Inference - 22.2

### DIFF
--- a/docs/OV_Runtime_UG/ShapeInference.md
+++ b/docs/OV_Runtime_UG/ShapeInference.md
@@ -1,6 +1,6 @@
 # Changing Input Shapes {#openvino_docs_OV_UG_ShapeInference}
 
-
+## Introduction (C++)
 
 @sphinxdirective
 .. raw:: html

--- a/docs/OV_Runtime_UG/automatic_batching.md
+++ b/docs/OV_Runtime_UG/automatic_batching.md
@@ -151,4 +151,5 @@ This value also exposed as the final execution statistics on the `benchmark_app`
 This is NOT the actual latency of the batched execution, so you are recommended to refer to other metrics in the same log, for example, "Median" or "Average" execution. 
 
 ### Additional Resources
-[Supported Devices](supported_plugins/Supported_Devices.md)
+
+* [Supported Devices](supported_plugins/Supported_Devices.md)

--- a/docs/OV_Runtime_UG/hetero_execution.md
+++ b/docs/OV_Runtime_UG/hetero_execution.md
@@ -168,4 +168,5 @@ where:
 You can also point to more than two devices: `-d HETERO:MYRIAD,GPU,CPU`
 
 ### See Also
-[Supported Devices](supported_plugins/Supported_Devices.md)
+
+* [Supported Devices](supported_plugins/Supported_Devices.md)

--- a/docs/OV_Runtime_UG/integrate_with_your_application.md
+++ b/docs/OV_Runtime_UG/integrate_with_your_application.md
@@ -253,7 +253,6 @@ cmake --build .
  - See the [OpenVINO Samples](Samples_Overview.md) page or the [Open Model Zoo Demos](https://docs.openvino.ai/2022.2/omz_demos.html) page for specific examples of how OpenVINO pipelines are implemented for applications like image classification, text prediction, and many others.
  - [OpenVINO™ Runtime Preprocessing](./preprocessing_overview.md)
  - [Using Encrypted Models with OpenVINO&trade;](./protecting_model_guide.md)
- - [OpenVINO Samples](Samples_Overview.md)
  - [Open Model Zoo Demos](https://docs.openvino.ai/2022.2/omz_demos.html)
 
 [ie_api_flow_cpp]: img/BASIC_IE_API_workflow_Cpp.svg

--- a/docs/OV_Runtime_UG/multi_device.md
+++ b/docs/OV_Runtime_UG/multi_device.md
@@ -4,8 +4,8 @@
 
 To run inference on multiple devices, you can choose either of the following ways:
 
-   - Use the :ref:`CUMULATIVE_THROUGHPUT option <cumulative throughput>` of the Automatic Device Selection mode. This way, you can use all available devices in the system without the need to specify them. 
-   - Use the Multi-Device execution mode. This page will explain how it works and how to use it.
+- Use the :ref:`CUMULATIVE_THROUGHPUT option <cumulative throughput>` of the Automatic Device Selection mode. This way, you can use all available devices in the system without the need to specify them,
+- Use the Multi-Device execution mode. This page will explain how it works and how to use it.
 
 @endsphinxdirective
 

--- a/docs/OV_Runtime_UG/openvino_intro.md
+++ b/docs/OV_Runtime_UG/openvino_intro.md
@@ -37,7 +37,7 @@ The scheme below illustrates the typical workflow for deploying a trained deep l
 
    * - .. raw:: html
 
-           <iframe allowfullscreen mozallowfullscreen msallowfullscreen oallowfullscreen webkitallowfullscreen height="315" width="100%"
+           <iframe allowfullscreen mozallowfullscreen msallowfullscreen oallowfullscreen webkitallowfullscreen height="315" width="560"
            src="https://www.youtube.com/embed/e6R13V8nbak">
            </iframe>
    * - **OpenVINO Runtime Concept**. Duration: 3:43

--- a/docs/OV_Runtime_UG/performance_hints.md
+++ b/docs/OV_Runtime_UG/performance_hints.md
@@ -132,4 +132,4 @@ The `benchmark_app`, that exists in both  [C++](../../samples/cpp/benchmark_app/
  
 
 ### See Also
-[Supported Devices](./supported_plugins/Supported_Devices.md)
+* [Supported Devices](./supported_plugins/Supported_Devices.md)

--- a/docs/OV_Runtime_UG/preprocessing_details.md
+++ b/docs/OV_Runtime_UG/preprocessing_details.md
@@ -290,7 +290,7 @@ C++ references:
 
 Pre-processing API also allows adding `custom` preprocessing steps into an execution graph. The `custom` function accepts the current `input` node, applies the defined preprocessing operations, and returns a new node.
 
-> **NOTE:** Custom pre-processing function should only insert node(s) after the input. It is done during model compilation. This function will NOT be called during the execution phase. This may appear to be complicated and require knowledge of [OpenVINO™ operations](../ops/opset.md).
+> **NOTE** : Custom pre-processing function should only insert node(s) after the input. It is done during model compilation. This function will NOT be called during the execution phase. This may appear to be complicated and require knowledge of [OpenVINO™ operations](../ops/opset.md).
 
 If there is a need to insert additional operations to the execution graph right after the input, like some specific crops and/or resizes - Pre-processing API can be a good choice to implement this.
 

--- a/docs/OV_Runtime_UG/preprocessing_details.md
+++ b/docs/OV_Runtime_UG/preprocessing_details.md
@@ -290,7 +290,7 @@ C++ references:
 
 Pre-processing API also allows adding `custom` preprocessing steps into an execution graph. The `custom` function accepts the current `input` node, applies the defined preprocessing operations, and returns a new node.
 
-> **Note:** Custom pre-processing function should only insert node(s) after the input. It is done during model compilation. This function will NOT be called during the execution phase. This may appear to be complicated and require knowledge of [OpenVINO™ operations](../ops/opset.md).
+> **NOTE:** Custom pre-processing function should only insert node(s) after the input. It is done during model compilation. This function will NOT be called during the execution phase. This may appear to be complicated and require knowledge of [OpenVINO™ operations](../ops/opset.md).
 
 If there is a need to insert additional operations to the execution graph right after the input, like some specific crops and/or resizes - Pre-processing API can be a good choice to implement this.
 


### PR DESCRIPTION
Fixed following issues:

* Switching between C++ and Python docs for "Shape Inference",
* Removed repetitions,
* Quote background in bullet list at the beginning of "Multi-device execution",
* Broken note directives,
* Fixed video player size in "Inference with OpenVINO Runtime",
* Standardize Additional Resources throughout Runtime Inference.
