### PR TITLE
Docs: Update Benchmark Tool example outputs

### DIFF
--- a/samples/cpp/benchmark_app/README.md
+++ b/samples/cpp/benchmark_app/README.md
@@ -164,7 +164,7 @@ Options:
     -pcseq                    Optional. Report latencies for each shape in -data_shape sequence.
     -dump_config              Optional. Path to JSON file to dump IE parameters, which were set by application.
     -load_config              Optional. Path to JSON file to load custom IE parameters. Please note, command line parameters have higher priority then parameters from configuration file.
-    -infer_precision "<element type>"Optional. Inference precission
+    -infer_precision "<element type>"Optional. Inference precision
     -ip                          <value>     Optional. Specifies precision for all input layers of the network.
     -op                          <value>     Optional. Specifies precision for all output layers of the network.
     -iop                        "<value>"    Optional. Specifies precision for input and output layers by name.

--- a/samples/cpp/benchmark_app/README.md
+++ b/samples/cpp/benchmark_app/README.md
@@ -10,7 +10,7 @@ To use the C++ benchmark_app, you must first build it following the [Build the S
 
 > **NOTE**: If you installed OpenVINO Runtime using PyPI or Anaconda Cloud, only the [Benchmark Python Tool](../../../tools/benchmark_tool/README.md) is available, and you should follow the usage instructions on that page instead.
 
-The benchmarking application works with models in the OpenVINO IR, ONNX, and PaddlePaddle (currently, for a limited list of supported models) formats. Make sure to [convert your models](../../../docs/MO_DG/Deep_Learning_Model_Optimizer_DevGuide.md) if necessary.
+The benchmarking application works with models in the OpenVINO IR (`model.xml` and `model.bin`) and ONNX (`model.onnx`) formats. Make sure to [convert your models](../../../docs/MO_DG/Deep_Learning_Model_Optimizer_DevGuide.md) if necessary.
 
 To run benchmarking with default options on a model, use the following command:
 


### PR DESCRIPTION
This pull request makes a minor update to the Benchmark Tool C++ and Benchmark Tool Python pages. The "sample output from running benchmark_app" is updated with actual output from running the 2022.2 version of benchmark_app.

### Details:
 - see above

### Tickets:
 - NA
