### PR TITLE
DOCS: Fix doc_string in Eye_9

### DIFF
--- a/docs/ops/generation/Eye_9.md
+++ b/docs/ops/generation/Eye_9.md
@@ -1,4 +1,4 @@
-## Eye <a name="Eye"></a> {#openvino_docs_ops_generation_Eye_9}
+## Eye {#openvino_docs_ops_generation_Eye_9}
 
 **Versioned name**: *Eye-9*
 
@@ -13,7 +13,7 @@
 
 Example 1. *Eye* output with `output_type` = `i32`:
 
-``` 
+```
 num_rows = 3
 
 num_columns = 4
@@ -27,7 +27,7 @@ output  = [[0 0 1 0]
 
 Example 2. *Eye* output with `output_type` = `i32`:
 
-``` 
+```
 num_rows = 3
 
 num_columns = 4
@@ -41,7 +41,7 @@ output  = [[0 0 0 0]
 
 Example 3. *Eye* output with `output_type` = `f16`:
 
-``` 
+```
 num_rows = 2
 
 diagonal_index = 5


### PR DESCRIPTION
### Details:
 - Fix doc_string in Eye_9
  - `Eye <a name=”Eye”></a>` to `Eye`
  - https://docs.openvino.ai/latest/openvino_docs_ops_generation_Eye_9.html
![image](https://user-images.githubusercontent.com/33194443/196826242-0f94bba7-ae19-46cb-84fb-06e7ca17a5ee.png)


### Tickets:
 - None
