### PR TITLE
[GPU] Update Select Op to use ngraph shape infer

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/select.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/select.hpp
@@ -32,21 +32,21 @@ struct select : public primitive_base<select> {
     /// @param mask Input primitive id with values needed for select computation.
     /// @param input Input primitive id.
     /// @param input2 Second input primitive id.
+    /// @param spec Auto broadcast rule specification
     /// @param output_padding Output data padding information.
-    /// @param broadcast_type String which determines broadcasting type:
     /// "numpy" means that numpy-tyle (ONNX) broadcasting is allowed,
     /// "none" means that all inputs need to have the same shape.
     select(const primitive_id& id,
            const primitive_id& mask,
            const primitive_id& input,
            const primitive_id& input2,
-           const padding& output_padding = padding(),
-           const std::string& broadcast_type = "numpy")
+           const ov::op::AutoBroadcastSpec& spec = ov::op::AutoBroadcastSpec(ov::op::AutoBroadcastType::NUMPY),
+           const padding& output_padding = padding())
         : primitive_base(id, {mask, input, input2}, output_padding),
-          broadcast_type(broadcast_type) {}
+          broadcast_spec(spec.m_type, spec.m_axis) {}
 
-    /// @brief String which determines broadcast type.
-    std::string broadcast_type;
+    /// @brief Define auto broadcast rule specification.
+    ov::op::AutoBroadcastSpec broadcast_spec;
 };
 /// @}
 /// @}

--- a/src/plugins/intel_gpu/src/graph/include/select_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/select_inst.h
@@ -28,6 +28,8 @@ class typed_primitive_inst<select> : public typed_primitive_inst_base<select> {
     using parent = typed_primitive_inst_base<select>;
 
 public:
+    template<typename ShapeType>
+    static std::vector<layout> calc_output_layouts(const select_node& /*node*/, const kernel_impl_params& impl_param);
     static layout calc_output_layout(select_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(select_node const& node);
     typed_primitive_inst(network& network, select_node const& node);

--- a/src/plugins/intel_gpu/src/graph/select.cpp
+++ b/src/plugins/intel_gpu/src/graph/select.cpp
@@ -9,6 +9,8 @@
 #include "json_object.h"
 #include <string>
 
+#include "select_shape_inference.hpp"
+
 namespace cldnn {
 primitive_type_id select::type_id() {
     static primitive_type_base<select> instance;
@@ -22,13 +24,37 @@ layout select_inst::calc_output_layout(select_node const& node, kernel_impl_para
     auto in_layout = impl_param.get_non_padded_input_layout(1);
     auto output_size = in_layout.get_tensor();
 
-    if (impl_param.typed_desc<select>()->broadcast_type == "numpy") {
+    if (impl_param.typed_desc<select>()->broadcast_spec.m_type == ov::op::AutoBroadcastType::NUMPY) {
         auto input1_size = impl_param.get_input_layout(1).get_tensor();
         auto input2_size = impl_param.get_input_layout(2).get_tensor();
         output_size = tensor::max(input1_size, input2_size);
     }
 
     return layout(in_layout.data_type, in_layout.format, output_size);
+}
+
+template<typename ShapeType>
+std::vector<layout> select_inst::calc_output_layouts(const select_node& /*node*/, const kernel_impl_params& impl_param) {
+    auto input0_layout = impl_param.get_input_layout(0);
+    auto input1_layout = impl_param.get_input_layout(1);
+    auto input2_layout = impl_param.get_input_layout(2);
+
+    auto desc = impl_param.typed_desc<select>();
+    auto dt = desc->output_data_type.value_or(input1_layout.data_type);
+
+    ov::op::v1::Select op;
+    op.set_auto_broadcast(desc->broadcast_spec);
+
+    std::vector<ShapeType> output_shapes = { ShapeType{} };
+    std::vector<ShapeType> input_shapes = {
+        input0_layout.get<ShapeType>(),
+        input1_layout.get<ShapeType>(),
+        input2_layout.get<ShapeType>()
+    };
+
+    ov::op::v1::shape_infer(&op, input_shapes, output_shapes);
+
+    return {{output_shapes[0], dt, format::get_default_format(output_shapes[0].size())}};
 }
 
 std::string select_inst::to_string(select_node const& node) {
@@ -50,6 +76,15 @@ std::string select_inst::to_string(select_node const& node) {
 
 select_inst::typed_primitive_inst(network& network, select_node const& node) : parent(network, node) {
     auto& deps = node.get_dependencies();
+
+    auto dep0_out_layout = deps[0]->get_output_layout();
+    auto dep1_out_layout = deps[1]->get_output_layout();
+    auto dep2_out_layout = deps[2]->get_output_layout();
+
+    if (dep0_out_layout.is_dynamic() ||
+        dep1_out_layout.is_dynamic() ||
+        dep2_out_layout.is_dynamic())
+        return;
 
     CLDNN_ERROR_LESS_THAN(node.id(),
                                 "Number of inputs",
@@ -74,7 +109,7 @@ select_inst::typed_primitive_inst(network& network, select_node const& node) : p
                               deps[2]->get_output_layout().format,
                               "");
 
-    if (node.get_primitive()->broadcast_type == "none") {
+    if (node.get_primitive()->broadcast_spec.m_type == ov::op::AutoBroadcastType::NONE) {
         CLDNN_ERROR_LAYOUT_MISMATCH(node.id(),
                                 "Positive input layout",
                                 deps[1]->get_output_layout(),
@@ -88,7 +123,7 @@ select_inst::typed_primitive_inst(network& network, select_node const& node) : p
                                 "Positive input format",
                                 deps[1]->get_output_layout().get_tensor(),
                                 "");
-    } else if (node.get_primitive()->broadcast_type == "numpy") {
+    } else if (node.get_primitive()->broadcast_spec.m_type == ov::op::AutoBroadcastType::NUMPY) {
         if (deps[1]->get_output_layout().get_tensor() != cldnn::tensor(1) && deps[2]->get_output_layout().get_tensor() != cldnn::tensor(1))
             CLDNN_ERROR_NOT_EQUAL(node.id(),
                                   "Positive input format",
@@ -120,7 +155,7 @@ select_inst::typed_primitive_inst(network& network, select_node const& node) : p
             }
         }
     } else {
-        CLDNN_ERROR_MESSAGE(node.id(), "Unsupported broadcast_type: " + node.get_primitive()->broadcast_type);
+        CLDNN_ERROR_MESSAGE(node.id(), "Unsupported broadcast_type: " + static_cast<int>(node.get_primitive()->broadcast_spec.m_type));
     }
 }
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/plugin/ops/select.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/select.cpp
@@ -33,54 +33,54 @@ static void CreateSelectOp(Program& p, const std::shared_ptr<ngraph::op::v1::Sel
         // Preprocess inputs
         for (size_t i = 0; i < inputPrimitives.size(); ++i) {
             auto input_pshape = op->get_input_partial_shape(i);
-            OPENVINO_ASSERT(input_pshape.is_static(), "Dynamic shapes are not supported for v1::Select with NUMPY mode yet");
-            auto input_shape = input_pshape.to_shape();
-            auto input_rank = input_shape.size();
 
-            // Add reorder if changing number of dimensions requires changing format
-            auto targetFormat = cldnn::format::get_default_format(output_rank);
+            if (input_pshape.is_static() && !p.use_new_shape_infer()) {
+                auto input_shape = input_pshape.to_shape();
+                auto input_rank = input_shape.size();
 
-            if (targetFormat.value != cldnn::format::get_default_format(input_rank).value) {
-                auto reorderName = layerName + "_cldnn_in" + std::to_string(i) + "_reorder";
-                auto targetDatatype = cldnn::element_type_to_data_type(op->get_input_element_type(i));
-                auto reorderPrim = cldnn::reorder(reorderName,
-                                                  inputPrimitives[i],
-                                                  targetFormat,
-                                                  targetDatatype,
-                                                  std::vector<float>(),
-                                                  cldnn::reorder_mean_mode::subtract);
+                // Add reorder if changing number of dimensions requires changing format
+                auto targetFormat = cldnn::format::get_default_format(output_rank);
 
-                p.add_primitive(*op, reorderPrim);
+                if (targetFormat.value != cldnn::format::get_default_format(input_rank).value) {
+                    auto reorderName = layerName + "_cldnn_in" + std::to_string(i) + "_reorder";
+                    auto targetDatatype = cldnn::element_type_to_data_type(op->get_input_element_type(i));
+                    auto reorderPrim = cldnn::reorder(reorderName,
+                                                    inputPrimitives[i],
+                                                    targetFormat,
+                                                    targetDatatype,
+                                                    std::vector<float>(),
+                                                    cldnn::reorder_mean_mode::subtract);
 
-                inputPrimitives[i] = reorderName;
-            }
+                    p.add_primitive(*op, reorderPrim);
 
-            // Reshape input if they differ or select specific shape matches default one
-            if (input_rank != output_rank || input_rank < 4) {
-                auto reshapeName = layerName + "_cldnn_in" + std::to_string(i) + "_reshape";
+                    inputPrimitives[i] = reorderName;
+                }
 
-                // Extend input dimensions to the same size as output dimensions by prepending ones
-                input_shape.insert(input_shape.begin(), output_rank - input_rank, 1ul);
+                // Reshape input if they differ or select specific shape matches default one
+                if (input_rank != output_rank || input_rank < 4) {
+                    auto reshapeName = layerName + "_cldnn_in" + std::to_string(i) + "_reshape";
 
-                auto targetShape = tensor_from_dims(input_shape);
+                    // Extend input dimensions to the same size as output dimensions by prepending ones
+                    input_shape.insert(input_shape.begin(), output_rank - input_rank, 1ul);
 
-                auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape);
+                    auto targetShape = tensor_from_dims(input_shape);
 
-                p.add_primitive(*op, reshapePrim);
+                    auto reshapePrim = cldnn::reshape(reshapeName, inputPrimitives[i], targetShape);
 
-                inputPrimitives[i] = reshapeName;
+                    p.add_primitive(*op, reshapePrim);
+
+                    inputPrimitives[i] = reshapeName;
+                }
             }
         }
     }
-
-    std::string bc_string = broadcast_type.m_type == ngraph::op::AutoBroadcastType::NUMPY ? "numpy" : "none";
 
     auto selectPrim = cldnn::select(layerName,
                                     inputPrimitives[0],
                                     inputPrimitives[1],
                                     inputPrimitives[2],
-                                    cldnn::padding(),
-                                    bc_string);
+                                    broadcast_type,
+                                    cldnn::padding());
 
     p.add_primitive(*op, selectPrim);
 }

--- a/src/plugins/intel_gpu/tests/shape_infer/select_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/shape_infer/select_si_test.cpp
@@ -1,0 +1,171 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils.h"
+
+#include <intel_gpu/primitives/input_layout.hpp>
+#include <intel_gpu/primitives/select.hpp>
+#include <intel_gpu/primitives/data.hpp>
+
+#include "select_inst.h"
+
+#include "program_wrapper.h"
+
+#include <cmath>
+#include <algorithm>
+
+using namespace cldnn;
+using namespace ::tests;
+
+namespace shape_infer_tests {
+
+struct select_test_params {
+    layout mask;
+    layout input1_layout;
+    layout input2_layout;
+    ov::op::AutoBroadcastType broadcast_type;
+    layout expected_layout;
+};
+
+class select_test : public testing::TestWithParam<select_test_params> { };
+
+TEST_P(select_test, shape_infer) {
+    auto p = GetParam();
+
+    auto& engine = get_test_engine();
+
+    auto input0_prim = std::make_shared<input_layout>("input0", p.mask);
+    auto input1_prim = std::make_shared<input_layout>("input1", p.input1_layout);
+    auto input2_prim = std::make_shared<input_layout>("input2", p.input2_layout);
+
+    const ov::op::AutoBroadcastSpec& broadcast_spec = ov::op::AutoBroadcastSpec(p.broadcast_type);
+    auto select_prim = std::make_shared<cldnn::select>("select_output", "input0", "input1", "input2", broadcast_spec);
+
+    cldnn::program prog(engine);
+
+    auto& input0_node = prog.get_or_create(input0_prim);
+    auto& input1_node = prog.get_or_create(input1_prim);
+    auto& input2_node = prog.get_or_create(input2_prim);
+
+    auto& select_node = prog.get_or_create(select_prim);
+    program_wrapper::add_connection(prog, input0_node, select_node);
+    program_wrapper::add_connection(prog, input1_node, select_node);
+    program_wrapper::add_connection(prog, input2_node, select_node);
+
+    auto res = select_inst::calc_output_layouts<ov::PartialShape>(select_node, *select_node.get_kernel_impl_params());
+
+    ASSERT_EQ(res.size(), 1);
+    ASSERT_EQ(res[0], p.expected_layout);
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke, select_test,
+    testing::ValuesIn(std::vector<select_test_params>{
+        {
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx},
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::NONE,
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx},
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::NUMPY,
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape{3, 3, 4}, data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape{3, 1, 4}, data_types::f32, format::bfyx},
+            layout{ov::PartialShape{   3, 4}, data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::NUMPY,
+            layout{ov::PartialShape{3, 3, 4}, data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape{3, 1, 4}, data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape{3, 1, 4}, data_types::f32, format::bfyx},
+            layout{ov::PartialShape{   5, 4}, data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::NUMPY,
+            layout{ov::PartialShape{3, 5, 4}, data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx},
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::PDPD,
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape{2, 3      }, data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape{2, 3, 4, 5}, data_types::f32, format::bfyx},
+            layout{ov::PartialShape{          }, data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::PDPD,
+            layout{ov::PartialShape{2, 3, 4, 5}, data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape{3, -1}, data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx},
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::NONE,
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape{3, -1}, data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape{-1, 2}, data_types::f32, format::bfyx},
+            layout{ov::PartialShape{3, -1}, data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::NONE,
+            layout{ov::PartialShape{3, 2}, data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape::dynamic(3), data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape{3, 2, 4}, data_types::f32, format::bfyx},
+            layout{ov::PartialShape::dynamic(3), data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::NONE,
+            layout{ov::PartialShape{3, 2, 4}, data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx},
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::NONE,
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape{-1, 1, -1}, data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape{3, 1, -1}, data_types::f32, format::bfyx},
+            layout{ov::PartialShape{   5, 4}, data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::NUMPY,
+            layout{ov::PartialShape{3, 5, 4}, data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape::dynamic(3), data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape{3, 2, 4}, data_types::f32, format::bfyx},
+            layout{ov::PartialShape::dynamic(3), data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::NUMPY,
+            layout{ov::PartialShape{3, 2, 4}, data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx},
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::NUMPY,
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape{2, 3      }, data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape{2, 3, 4, 1}, data_types::f32, format::bfyx},
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::PDPD,
+            layout{ov::PartialShape{2, 3, 4, 1}, data_types::f32, format::bfyx}
+        },
+        {
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx}, 
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx},
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx},
+            ov::op::AutoBroadcastType::PDPD,
+            layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx}
+        },
+    }));
+
+}  // shape_infer_tests

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/skip_tests_config.cpp
@@ -109,6 +109,8 @@ std::vector<std::string> disabledTestPatterns() {
             R"(smoke_Basic/SqueezeUnsqueezeLayerTest.CompareWithRefs/OpType=Unsqueeze_IS=\(1.1.1.1\)_Axes=\((0.1.2|0.2.3|1.2.3|0.1.2.3|)\)_.*)",
             // Issue: 90539
             R"(smoke_AutoBatch_BehaviorTests/OVInferRequestIOTensorTest.InferStaticNetworkSetInputTensor/targetDevice=BATCH.*)",
+            // TODO: range input with one element should NOT be regarded as dynamic batch model in Program::IsDynBatchModel().
+            R"(.*smoke_select_CompareWithRefsNumpy_dynamic_range.*)",
             // Issue: 90183
             R"(.*VirtualPlugin.*BehaviorTests.*OVHoldersTestWithConfig.*LoadedTensor.*target_device=MULTI.*)",
             // Currently 1D convolution has an issue

--- a/src/tests/functional/plugin/gpu/single_layer_tests/dynamic/select.cpp
+++ b/src/tests/functional/plugin/gpu/single_layer_tests/dynamic/select.cpp
@@ -1,0 +1,184 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_layer/select.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "ie_precision.hpp"
+#include "ngraph_functions/builders.hpp"
+#include <string>
+
+using namespace ngraph;
+using namespace InferenceEngine;
+using namespace ov::test;
+
+namespace GPULayerTestsDefinitions {
+
+typedef std::tuple<
+    std::vector<InputShape>,    // input shapes
+    ElementType,                // presion of 'then' and 'else' of inputs
+    op::AutoBroadcastSpec,      // broadcast spec
+    TargetDevice                // device name
+> SelectLayerTestParamSet;
+
+class SelectLayerGPUTest : public testing::WithParamInterface<SelectLayerTestParamSet>,
+                           virtual public SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<SelectLayerTestParamSet>& obj) {
+        std::vector<InputShape> inshapes;
+        ElementType netType;
+        op::AutoBroadcastSpec broadcast;
+        TargetDevice targetDevice;
+        std::tie(inshapes, netType, broadcast, targetDevice) = obj.param;
+
+        std::ostringstream result;
+
+        result << "IS=";
+        for (const auto& shape : inshapes) {
+            result << CommonTestUtils::partialShape2str({shape.first}) << "_";
+        }
+        result << "TS=";
+        for (const auto& shape : inshapes) {
+            for (const auto& item : shape.second) {
+                result << CommonTestUtils::vec2str(item) << "_";
+            }
+        }
+        result << "Precision=" << netType << "_";
+        result << "Broadcast=" << broadcast.m_type << "_";
+        result << "trgDev=" << targetDevice;
+
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        std::vector<InputShape> inshapes;
+        ElementType netType;
+        op::AutoBroadcastSpec broadcast;
+        std::tie(inshapes, netType, broadcast, targetDevice) = this->GetParam();
+
+        init_input_shapes(inshapes);
+
+        ParameterVector params = {
+            std::make_shared<opset1::Parameter>(ElementType::boolean, inputDynamicShapes[0]),
+            std::make_shared<opset1::Parameter>(netType, inputDynamicShapes[1]),
+            std::make_shared<opset1::Parameter>(netType, inputDynamicShapes[2]),
+        };
+
+        auto paramOuts = helpers::convert2OutputVector(helpers::castOps2Nodes<op::Parameter>(params));
+        auto select = builder::makeSelect(paramOuts, broadcast);
+
+        auto makeFunction = [](ParameterVector &params, const std::shared_ptr<Node> &lastNode) {
+            ResultVector results;
+
+            for (int i = 0; i < lastNode->get_output_size(); i++)
+                results.push_back(std::make_shared<opset1::Result>(lastNode->output(i)));
+
+            return std::make_shared<Function>(results, params, "SelectLayerGPUTest");
+        };
+        function = makeFunction(params, select);
+    }
+};
+
+TEST_P(SelectLayerGPUTest, CompareWithRefs) {
+   SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+   run();
+}
+
+namespace {
+
+const std::vector<ElementType> netPrecisions = {
+        ElementType::f32,
+        ElementType::f16,
+        ElementType::i32,
+};
+
+namespace Select {
+
+// AutoBroadcastType: NUMPY
+const std::vector<std::vector<InputShape>> inShapesDynamicNumpy = {
+    {
+        { {-1, -1, -1, -1}, {{10, 16, 20, 5}, {2, 1, 7, 1}} },
+        { {-1, -1, -1, -1}, {{10, 16, 20, 5}, {2, 1, 7, 1}} },
+        { {-1, -1, -1, -1}, {{10, 16, 20, 5}, {2, 1, 7, 1}} }
+    },
+    {
+        { {-1, -1, -1, -1}, {{5, 1, 2, 1}, {1, 1, 9, 1}} },
+        { {-1, -1, -1, -1}, {{1, 1, 1, 1}, {1, 1, 1, 1}} },
+        { {-1, -1, -1, -1}, {{5, 1, 2, 1}, {9, 5, 9, 8}} }
+    },
+    {
+        { {        -1, -1}, {{      8, 1}, {      8, 3}} },
+        { {-1, -1, -1, -1}, {{2, 1, 8, 1}, {2, 9, 8, 1}} },
+        { {    -1, -1, -1}, {{   9, 1, 1}, {   9, 1, 3}} }
+    },
+    {
+        { {            -1}, {{         6}, {         3}} },
+        { {-1, -1, -1, -1}, {{2, 1, 8, 1}, {2, 9, 8, 1}} },
+        { {    -1, -1, -1}, {{   9, 1, 1}, {   9, 1, 3}} }
+    },
+    {
+        { {-1, -1, -1, -1}, {{4, 1, 1, 1}, {5, 5, 5, 1}, {3, 4, 5, 6}} },
+        { {-1, -1, -1, -1}, {{1, 8, 1, 1}, {1, 1, 1, 8}, {3, 4, 5, 6}} },
+        { {    -1, -1, -1}, {{   1, 5, 1}, {   5, 5, 8}, {   4, 5, 6}} }
+    },
+    {
+        { {-1, -1, -1, -1}, {{3, 4, 5, 6}} },
+        { {    -1, -1, -1}, {{   4, 5, 6}} },
+        { {        -1, -1}, {{      5, 6}} }
+    },
+};
+
+const auto numpyCases = ::testing::Combine(
+        ::testing::ValuesIn(inShapesDynamicNumpy),
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(op::AutoBroadcastType::NUMPY),
+        ::testing::Values(CommonTestUtils::DEVICE_GPU)
+);
+
+INSTANTIATE_TEST_SUITE_P(smoke_select_CompareWithRefsNumpy_dynamic, SelectLayerGPUTest, numpyCases, SelectLayerGPUTest::getTestCaseName);
+
+const std::vector<std::vector<InputShape>> inShapesDynamicRangeNumpy = {
+    {
+        { {                         {1, 10}}, {{         4}, {          10}, {         1}} },
+        { {{2, 7}, {1, 6}, {5, 12}, {1, 20}}, {{5, 6, 6, 1}, {7, 6, 10, 10}, {5, 4, 5, 3}} },
+        { {                {2, 10}, {1, 16}}, {{      6, 4}, {      10, 10}, {      5, 1}} }
+    },
+};
+
+const auto rangeNumpyCases = ::testing::Combine(
+        ::testing::ValuesIn(inShapesDynamicRangeNumpy),
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(op::AutoBroadcastType::NUMPY),
+        ::testing::Values(CommonTestUtils::DEVICE_GPU)
+);
+
+INSTANTIATE_TEST_SUITE_P(smoke_select_CompareWithRefsNumpy_dynamic_range, SelectLayerGPUTest, rangeNumpyCases, SelectLayerGPUTest::getTestCaseName);
+
+// AutoBroadcastType: NONE
+const std::vector<std::vector<InputShape>> inShapesDynamicNone = {
+    {
+        { {-1, -1, -1, -1}, {{10, 16, 20, 5}, {2, 1, 7, 1}} },
+        { {-1, -1, -1, -1}, {{10, 16, 20, 5}, {2, 1, 7, 1}} },
+        { {-1, -1, -1, -1}, {{10, 16, 20, 5}, {2, 1, 7, 1}} }
+    },
+    {
+        { {{1, 10},       -1, {10, 20}, {1, 5}}, {{3, 16, 15, 5}, {1, 16, 10, 1}, {10, 16, 20, 5}} },
+        { {     -1, {16, 16},       -1,     -1}, {{3, 16, 15, 5}, {1, 16, 10, 1}, {10, 16, 20, 5}} },
+        { {     -1,       -1,       -1,     -1}, {{3, 16, 15, 5}, {1, 16, 10, 1}, {10, 16, 20, 5}} }
+    }
+};
+
+const auto noneCases = ::testing::Combine(
+        ::testing::ValuesIn(inShapesDynamicNone),
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(op::AutoBroadcastType::NONE),
+        ::testing::Values(CommonTestUtils::DEVICE_GPU)
+);
+
+INSTANTIATE_TEST_SUITE_P(smoke_select_CompareWithRefsNone_dynamic, SelectLayerGPUTest, noneCases, SelectLayerGPUTest::getTestCaseName);
+
+} // namespace Select
+} // namespace
+} // namespace GPULayerTestsDefinitions


### PR DESCRIPTION
### Details:
 - *Add calc_output_layouts() using ngraph shape infer for Select OP*
 - *Add unittests to test broadcast_types such as none, numpy, and pdpd*
 - *Modify to get AutoBroadcastSpec instead of getting simple broadcast string in API*
 - *Add gpuFuncTest using dynamic shapes*

### Tickets:
 - *94474*
