### PR TITLE
Added post-processing for python wheel platform tags

### DIFF
--- a/src/bindings/python/wheel/CMakeLists.txt
+++ b/src/bindings/python/wheel/CMakeLists.txt
@@ -27,14 +27,59 @@ foreach(_target ie_api constants _pyngraph openvino_c pyopenvino ov_plugins ov_f
     endif()
 endforeach()
 
-execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import wheel.bdist_wheel ; print(f'{wheel.bdist_wheel.get_abi_tag()}')"
-                OUTPUT_VARIABLE PYTHON_ABI OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import wheel.vendored.packaging.tags as tags ; print(f'{tags.interpreter_name()}{tags.interpreter_version()}')"
-                OUTPUT_VARIABLE INTERPRETER OUTPUT_STRIP_TRAILING_WHITESPACE)
+                OUTPUT_VARIABLE PYTHON_TAG OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import wheel.bdist_wheel ; print(f'{wheel.bdist_wheel.get_abi_tag()}')"
+                OUTPUT_VARIABLE ABI_TAG OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import wheel.vendored.packaging.tags as tags ; print(f'{next(tags._platform_tags())}')"
-                OUTPUT_VARIABLE WHEEL_PLATFORM OUTPUT_STRIP_TRAILING_WHITESPACE)
+                OUTPUT_VARIABLE PLATFORM_TAG OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-set(openvino_wheel_name "openvino-${WHEEL_VERSION}-${WHEEL_BUILD}-${INTERPRETER}-${PYTHON_ABI}-${WHEEL_PLATFORM}.whl")
+macro(_ov_platform_arch)
+    if(AARCH64)
+        set(_arch "aarch64")
+    elseif(ARM)
+        set(_arch "armvl7")
+    elseif(X86_64)
+        set(_arch "x86_64")
+    elseif(X86)
+        set(_arch "i686")
+    endif()
+endmacro()
+
+# For macOS and Linux `PLATFORM_TAG` is not always correctly detected
+# So, we need to add our-own post-processing
+if(APPLE AND DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
+    _ov_platform_arch()
+
+    set(_macos_min_version "${CMAKE_OSX_DEPLOYMENT_TARGET}")
+    if(_macos_min_version MATCHES "^1[0-9]$")
+        set(_macos_min_version "${CMAKE_OSX_DEPLOYMENT_TARGET}.0")
+    endif()
+    string(REPLACE "." "_" _macos_min_version "${_macos_min_version}")
+
+    # common platform tag looks like macosx_<macos major>_<macos minor>_<arch>
+    if(_arch AND _macos_min_version)
+        set(PLATFORM_TAG "macosx_${_macos_min_version}_${_arch}")
+    endif()
+elseif(LINUX)
+    _ov_platform_arch()
+
+    execute_process(COMMAND ldd --version
+        OUTPUT_VARIABLE _libc_version
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(_libc_version MATCHES ".*([0-9]+)\\.([0-9]+).*")
+        set(_libc_major "${CMAKE_MATCH_1}")
+        set(_libc_minor "${CMAKE_MATCH_2}")
+    endif()
+
+    # common pattern manylinux_<libc major>_<libc minor>_<arch>
+    if(_libc_version AND _arch)
+        set(PLATFORM_TAG "manylinux_${_libc_major}_${_libc_minor}_${_arch}")
+    endif()
+endif()
+
+set(openvino_wheel_name "openvino-${WHEEL_VERSION}-${WHEEL_BUILD}-${PYTHON_TAG}-${ABI_TAG}-${PLATFORM_TAG}.whl")
 set(openvino_wheels_output_dir "${CMAKE_BINARY_DIR}/wheels")
 set(openvino_wheel_path "${openvino_wheels_output_dir}/${openvino_wheel_name}")
 
@@ -46,7 +91,8 @@ add_custom_command(OUTPUT ${openvino_wheel_path}
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}"
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${OpenVINO_SOURCE_DIR}/licensing" "${CMAKE_BINARY_DIR}/licensing"
     COMMAND ${CMAKE_COMMAND} -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/site-packages"
-    COMMAND ${CMAKE_COMMAND} -E env WHEEL_VERSION=${WHEEL_VERSION}
+    COMMAND ${CMAKE_COMMAND} -E env
+            WHEEL_VERSION=${WHEEL_VERSION}
             WHEEL_BUILD=${WHEEL_BUILD}
             OPENVINO_BUILD_DIR=${OpenVINO_BINARY_DIR}
             OPENVINO_PYTHON_BUILD_DIR=${OpenVINOPython_BINARY_DIR}
@@ -56,8 +102,9 @@ add_custom_command(OUTPUT ${openvino_wheel_path}
             PY_PACKAGES_DIR=${PY_PACKAGES_DIR}
         ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/setup.py" clean bdist_wheel
             --dist-dir ${openvino_wheels_output_dir}
-            --build=${WHEEL_BUILD}
-            --plat-name=${WHEEL_PLATFORM}
+            --build-number=${WHEEL_BUILD}
+            --plat-name=${PLATFORM_TAG}
+            --quiet
     DEPENDS ${openvino_wheel_deps}
            "${CMAKE_CURRENT_SOURCE_DIR}/setup.py"
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/tools/openvino_dev/CMakeLists.txt
+++ b/tools/openvino_dev/CMakeLists.txt
@@ -16,6 +16,7 @@ add_custom_command(OUTPUT ${openvino_wheel_path}
     ${PYTHON_EXECUTABLE} ${SETUP_PY} clean bdist_wheel
         --dist-dir ${openvino_wheels_output_dir}
         --build=${WHEEL_BUILD}
+        --quiet
     DEPENDS ie_wheel
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     COMMENT "Building Python wheel ${openvino_wheel_name}"


### PR DESCRIPTION
### Details:
 - During cross-compilation python uses platform tags from build python, while we need to use from host-python one. In order to fix this, we track libc version as well as architecture and create our own platform tag
 - The same for OSX where can we compile for target macOS (min version) and use different architecture than python one. E.g. default python provides universal2 as architecture, while we need arch64