### PR TITLE
check if ncc is enabled before looking for ncc.py

### DIFF
--- a/cmake/developer_package/ncc_naming_style/ncc_naming_style.cmake
+++ b/cmake/developer_package/ncc_naming_style/ncc_naming_style.cmake
@@ -77,12 +77,13 @@ if(ENABLE_NCC_STYLE)
 endif()
 
 # check python requirements_dev.txt
+if(ENABLE_NCC_STYLE)
+    set(ncc_script_py "${ncc_style_dir}/ncc/ncc.py")
 
-set(ncc_script_py "${ncc_style_dir}/ncc/ncc.py")
-
-if(NOT EXISTS ${ncc_script_py})
-    message(WARNING "ncc.py is not downloaded via submodule")
-    set(ENABLE_NCC_STYLE OFF)
+    if(NOT EXISTS ${ncc_script_py})
+        message(WARNING "ncc.py is not downloaded via submodule")
+        set(ENABLE_NCC_STYLE OFF)
+    endif()
 endif()
 
 if(ENABLE_NCC_STYLE)


### PR DESCRIPTION
If ENABLE_NCC_STYLE=OFF, the check for ncc.py still happens. A confusing warning is reported and a redundant setting of ENABLE_NCC_STYLE to OFF is done.

Check that ENABLE_NCC_STYLE is enabled before looking for ncc.py

Signed-off-by: Tom Rix <trix@redhat.com>

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
