### PR TITLE
[GNA] enable ncc code naming checker tool for gna plugin

### DIFF
--- a/src/plugins/intel_gna/CMakeLists.txt
+++ b/src/plugins/intel_gna/CMakeLists.txt
@@ -129,6 +129,11 @@ if(NOT BUILD_SHARED_LIBS)
     endif()
 endif()
 
+ov_ncc_naming_style(FOR_TARGET "${TARGET_NAME}"
+                     SOURCE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                     ADDITIONAL_INCLUDE_DIRECTORIES
+                         $<TARGET_PROPERTY:openvino::runtime,INTERFACE_INCLUDE_DIRECTORIES>)
+
 add_subdirectory(tests)
 
 


### PR DESCRIPTION
### Details:
 - added ncc target in CMakeLists.txt for openvino_intel_gna_plugin target