### PR TITLE
[GNA] Introduce CMake flags for building with custom GNA package

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -293,8 +293,16 @@ if(ENABLE_INTEL_GNA)
             GNA_LIB_DIR
             libGNA_INCLUDE_DIRS
             libGNA_LIBRARIES_BASE_PATH)
-        set(GNA_VERSION "03.00.00.1815.1")
-        set(GNA_HASH "682eb01e5a148ea03b90ee12b7fd67afb1479f35ccf2966f83b208e50e91633c")
+        # use default GNA package
+        if(NOT DEFINED GNA_VERSION)
+            set(GNA_VERSION "03.00.00.1815.1")
+            set(GNA_HASH "682eb01e5a148ea03b90ee12b7fd67afb1479f35ccf2966f83b208e50e91633c")
+        # if GNA_VERSION is defined, use custom package; requires custom package hash
+        else()
+            if(NOT DEFINED GNA_HASH)
+                message(FATAL_ERROR "GNA package hash must be provided when using custom GNA version")
+            endif()
+        endif()
 
         set(FILES_TO_EXTRACT_LIST gna_${GNA_VERSION}/include)
         if(WIN32)
@@ -303,6 +311,9 @@ if(ENABLE_INTEL_GNA)
             LIST(APPEND FILES_TO_EXTRACT_LIST gna_${GNA_VERSION}/linux)
         endif()
 
+        if(DEFINED CUSTOM_GNA_LOCATION)
+            set(IE_PATH_TO_DEPS ${CUSTOM_GNA_LOCATION})
+        endif()
         RESOLVE_DEPENDENCY(GNA_EXT_DIR
                 ARCHIVE_UNIFIED "gna/GNA_${GNA_VERSION}.zip"
                 TARGET_PATH "${TEMP}/gna_${GNA_VERSION}"
@@ -310,6 +321,7 @@ if(ENABLE_INTEL_GNA)
                 FILES_TO_EXTRACT FILES_TO_EXTRACT_LIST
                 SHA256 ${GNA_HASH}
                 USE_NEW_LOCATION TRUE)
+        unset(IE_PATH_TO_DEPS)
     update_deps_cache(GNA_EXT_DIR "${GNA_EXT_DIR}" "Path to GNA root folder")
     debug_message(STATUS "gna=" ${GNA_EXT_DIR})
 

--- a/cmake/developer_package/download/download_and_extract.cmake
+++ b/cmake/developer_package/download/download_and_extract.cmake
@@ -35,7 +35,7 @@ function (GetNameAndUrlToDownload name url archive_name_unified archive_name_win
   endif()
 endfunction(GetNameAndUrlToDownload)
 
-#download from paltform specific folder from share server
+#download from platform specific folder from share server
 function (DownloadAndExtractPlatformSpecific
   component
   archive_name_unified


### PR DESCRIPTION
### Details:
Previous behavior: GNA library version was pre-defined in the dependencies.cmake file
New behavior: Three cmake flags were added:
- GNA_VERSION and GNA_HASH, allowing for build with custom GNA version. When GNA_VERSION is provided without GNA_HASH, an error is thrown
- CUSTOM_GNA_LOCATION in case the custom GNA package is not available from the default location. Can be set both to local path and an http server.


### Tickets:
 - 94385
