### PR TITLE
[SAMPLES] Remove unneeded GNA clock multiplier in performance counters

### DIFF
--- a/samples/cpp/speech_sample/utils.hpp
+++ b/samples/cpp/speech_sample/utils.hpp
@@ -196,82 +196,6 @@ float std_dev_error(ScoreErrorT error) {
                  (error.sumError / error.numScores) * (error.sumError / error.numScores)));
 }
 
-#if !defined(__arm__) && !defined(_M_ARM) && !defined(__aarch64__) && !defined(_M_ARM64)
-#    ifdef _WIN32
-#        include <intrin.h>
-#        include <windows.h>
-#    else
-
-#        include <cpuid.h>
-
-#    endif
-
-inline void native_cpuid(unsigned int* eax, unsigned int* ebx, unsigned int* ecx, unsigned int* edx) {
-    size_t level = *eax;
-#    ifdef _WIN32
-    int regs[4] = {static_cast<int>(*eax), static_cast<int>(*ebx), static_cast<int>(*ecx), static_cast<int>(*edx)};
-    __cpuid(regs, level);
-    *eax = static_cast<uint32_t>(regs[0]);
-    *ebx = static_cast<uint32_t>(regs[1]);
-    *ecx = static_cast<uint32_t>(regs[2]);
-    *edx = static_cast<uint32_t>(regs[3]);
-#    else
-    __get_cpuid(level, eax, ebx, ecx, edx);
-#    endif
-}
-
-/**
- * @brief Get GNA module frequency
- * @return GNA module frequency in MHz
- */
-float get_gna_frequency_mhz() {
-    uint32_t eax = 1;
-    uint32_t ebx = 0;
-    uint32_t ecx = 0;
-    uint32_t edx = 0;
-    uint32_t family = 0;
-    uint32_t model = 0;
-    const uint8_t sixth_family = 6;
-    const uint8_t cannon_lake_model = 102;
-    const uint8_t gemini_lake_model = 122;
-    const uint8_t ice_lake_model = 126;
-    const uint8_t tgl_model = 140;
-    const uint8_t adl_s_model = 151;
-    const uint8_t adl_p_model = 154;
-
-    native_cpuid(&eax, &ebx, &ecx, &edx);
-    family = (eax >> 8) & 0xF;
-
-    // model is the concatenation of two fields
-    // | extended model | model |
-    // copy extended model data
-    model = (eax >> 16) & 0xF;
-    // shift
-    model <<= 4;
-    // copy model data
-    model += (eax >> 4) & 0xF;
-
-    if (family == sixth_family) {
-        switch (model) {
-        case cannon_lake_model:
-        case ice_lake_model:
-        case tgl_model:
-        case adl_s_model:
-        case adl_p_model:
-            return 400;
-        case gemini_lake_model:
-            return 200;
-        default:
-            return 1;
-        }
-    } else {
-        // counters not supported and we returns just default value
-        return 1;
-    }
-}
-
-#endif  // if not ARM
-
 /**
  * @brief Print a report on the statistical score error
  * @param totalError reference to a total score error struct
@@ -318,11 +242,9 @@ void print_performance_counters(std::map<std::string, ov::ProfilingInfo> const& 
     stream << std::setw(24) << "(us per call)";
     stream << std::endl;
     // if GNA HW counters
-    // get frequency of GNA module
-    float freq = get_gna_frequency_mhz();
     for (const auto& it : utterancePerfMap) {
         std::string const& counter_name = it.first;
-        float current_units_us = static_cast<float>(it.second.real_time.count()) / freq;
+        float current_units_us = static_cast<float>(it.second.real_time.count());
         float call_units_us = 0;
         if (numberOfFrames == 0) {
             throw std::logic_error("Number off frames = 0,  division by zero.");


### PR DESCRIPTION
### Details:
 - Simplify speech_sample to remove `float getGnaFrequencyMHz()` function, since it should no longer be needed when GNA Plugin reports perf counters in time domain instead cycles.
 - GNA library was updated from 1455->1815 (while 1455 was not providing perf counter in time domain, but 1815 does) (https://github.com/openvinotoolkit/openvino/pull/13188)

### Tickets:
 - 58361
