### PR TITLE
Added -DDNNL_ENABLE_EXCEPTIONS for Debug build

### DIFF
--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -75,6 +75,7 @@ target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/sr
 
 target_include_directories(${TARGET_NAME} SYSTEM PRIVATE
     $<TARGET_PROPERTY:dnnl,INCLUDE_DIRECTORIES>)
+target_compile_definitions(${TARGET_NAME} PRIVATE $<$<CONFIG:Debug>:DNNL_ENABLE_EXCEPTIONS>)
 
 # Cross compiled function
 # TODO: The same for proposal, proposalONNX, topk


### PR DESCRIPTION
### Details:
Enabled exceptions for Xbyak in Debug build

Depends on [Add support for exceptions during code generation](https://github.com/openvinotoolkit/oneDNN/pull/146)