### PR TITLE
[GPU] Fix the perf regression from not working crop opt out.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -347,7 +347,7 @@ void prepare_buffer_fusing::run(program& p) {
                 }
             }
 
-            if (node.get_dependencies().size() == 1 && node.get_users().size() > 0) {
+            if (node.get_users().size() > 0) {
                 if (p.is_loop_body() && node.get_dependency(0).is_type<lstm_elt>()) {
                     return;
                 }


### PR DESCRIPTION
Crop from split has multiple intput +axis, +splits_length(variadic-split) So always failed opt out.

Signed-off-by: hyunback <hyunback.kim@intel.com>

### Tickets:
 - *94429*
