### PR TITLE
[POT] Bump torch version to 1.12

### DIFF
--- a/tools/pot/setup.py
+++ b/tools/pot/setup.py
@@ -101,7 +101,7 @@ version_string = "{}{}".format(sys.version_info[0], sys.version_info[1])
 version_string_with_mem_manager = version_string + 'm' if sys.version_info[1] < 8 else version_string
 os_string = None if sys.platform not in OS_POSTFIXES else OS_POSTFIXES[sys.platform]
 
-TORCH_VERSION = '1.8.1'
+TORCH_VERSION = '1.12.1'
 TORCH_SOURCE_URL_TEMPLATE = 'https://download.pytorch.org/whl/cpu/torch-{tv}%2Bcpu-cp{ver}-cp{' \
                             'ver_m}-{os}.whl'
 


### PR DESCRIPTION
### Details:
 - Bumpy `torch` to 1.12 since lower versions use `onnx.optimizer` which has been deprecated and trying to import it in CIs throws errors.

### Tickets:
 - 95233
