### PR TITLE
[GPU] Move device memory allocation from preprocessing stage to runtime for usm memory type

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/infer_request.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/infer_request.hpp
@@ -57,6 +57,8 @@ public:
     void enable_external_queue() { m_useExternalQueue = true; }
 
 private:
+    // This blob is used for outputs processing if output data type convertion or padding handling is needed
+    InferenceEngine::Blob::Ptr intermediate_output_blob = nullptr;
     InferenceEngine::BlobMap _deviceOutputs;
     std::map<std::string, cldnn::primitive_id> inputsMap;
     std::map<std::string, cldnn::primitive_id> outputsMap;
@@ -79,8 +81,6 @@ private:
     InferenceEngine::Blob::Ptr create_host_blob(const InferenceEngine::TensorDesc& desc, bool is_dynamic);
     InferenceEngine::Blob::Ptr create_device_blob(const InferenceEngine::TensorDesc& desc);
 
-    template<typename src_dt, typename dst_dt>
-    void copyResultToOutputBlob(cldnn::memory::ptr src, InferenceEngine::Blob::Ptr dst, bool need_convert = false);
     void copy_output_data(cldnn::memory::ptr outputMemory, InferenceEngine::Blob::Ptr bptr);
     void copy_input_data(std::shared_ptr<cldnn::network> network, const cldnn::primitive_id& inputName,
                          const cldnn::layout& inputLayout, const InferenceEngine::Blob &inputBlob);

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/infer_request.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/infer_request.hpp
@@ -73,12 +73,16 @@ private:
     void prepare_input(const cldnn::primitive_id &inputName, InferenceEngine::Blob::Ptr &inputBlob,
                        std::vector<cldnn::event::ptr>& dependencies);
     void prepare_output(const cldnn::primitive_id& outputName, InferenceEngine::Blob::Ptr& outputBlob);
+    void allocate_dev_mem_if_needed(InferenceEngine::BlobMap& device_mems, InferenceEngine::Blob::Ptr& user_blob,
+                                    const cldnn::primitive_id& blob_name, const cldnn::layout& layout);
 
     InferenceEngine::Blob::Ptr create_host_blob(const InferenceEngine::TensorDesc& desc, bool is_dynamic);
     InferenceEngine::Blob::Ptr create_device_blob(const InferenceEngine::TensorDesc& desc);
 
+    template<typename src_dt, typename dst_dt>
+    void copyResultToOutputBlob(cldnn::memory::ptr src, InferenceEngine::Blob::Ptr dst, bool need_convert = false);
     void copy_output_data(cldnn::memory::ptr outputMemory, InferenceEngine::Blob::Ptr bptr);
-    void copy_input_data(std::shared_ptr<cldnn::network> network, const cldnn::primitive_id &inputName,
+    void copy_input_data(std::shared_ptr<cldnn::network> network, const cldnn::primitive_id& inputName,
                          const cldnn::layout& inputLayout, const InferenceEngine::Blob &inputBlob);
 
     InferenceEngine::Blob::Ptr create_shared_device_blob(const InferenceEngine::TensorDesc& desc, const cldnn::layout& layout, void* usm_host_mem);

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp
@@ -137,6 +137,8 @@ public:
     /// Returns service stream which can be used during program build and optimizations
     virtual stream& get_program_stream() const = 0;
 
+    virtual allocation_type detect_usm_allocation_type(const void* memory) const = 0;
+
 #ifdef ENABLE_ONEDNN_FOR_GPU
     /// Returns onednn engine object which shares device and context with current engine
     virtual dnnl::engine& get_onednn_engine() const = 0;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
@@ -71,6 +71,9 @@ struct memory {
     virtual event::ptr copy_from(stream& /* stream */, const memory& /* other */) = 0;
     virtual event::ptr copy_from(stream& /* stream */, const void* /* host_ptr */) = 0;
 
+    virtual event::ptr copy_to(stream& stream, memory& other) { return other.copy_from(stream, *this); }
+    virtual event::ptr copy_to(stream& /* stream */, void* /* host_ptr */) = 0;
+
 #ifdef ENABLE_ONEDNN_FOR_GPU
     virtual dnnl::memory get_onednn_memory(dnnl::memory::desc /* desc */, int64_t offset = 0) {
         throw std::runtime_error("[CLDNN] Can't convert memory object to onednn");
@@ -107,6 +110,9 @@ struct simple_attached_memory : memory {
 
     event::ptr copy_from(stream& /* stream */, const memory& /* other */) override { return nullptr; };
     event::ptr copy_from(stream& /* stream */, const void* /* host_ptr */) override { return nullptr; }
+
+    event::ptr copy_to(stream& /* stream */, memory& /* other */) override { return nullptr; };
+    event::ptr copy_to(stream& /* stream */, void* /* host_ptr */) override { return nullptr; }
 
 private:
     void* _pointer;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
@@ -89,6 +89,11 @@ const cl::UsmHelper& ocl_engine::get_usm_helper() const {
     return *_usm_helper;
 }
 
+allocation_type ocl_engine::detect_usm_allocation_type(const void* memory) const {
+    return use_unified_shared_memory() ? ocl::gpu_usm::detect_allocation_type(this, memory)
+                                       : allocation_type::unknown;
+}
+
 memory::ptr ocl_engine::allocate_memory(const layout& layout, allocation_type type, bool reset) {
     OPENVINO_ASSERT(!layout.is_dynamic(), "[GPU] Can't allocate memory for dynamic layout");
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.hpp
@@ -32,6 +32,7 @@ public:
     void* get_user_context() const override;
 
     allocation_type get_default_allocation_type() const override { return allocation_type::cl_mem; }
+    allocation_type detect_usm_allocation_type(const void* memory) const override;
 
     const cl::Context& get_cl_context() const;
     const cl::Device& get_cl_device() const;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
@@ -110,6 +110,13 @@ event::ptr gpu_buffer::copy_from(stream& stream, const void* host_ptr) {
     return ev;
 }
 
+event::ptr gpu_buffer::copy_to(stream& stream, void* host_ptr) {
+    auto& cl_stream = downcast<ocl_stream>(stream);
+    cl_stream.get_cl_queue().enqueueReadBuffer(_buffer, true, 0, size(), host_ptr, nullptr, nullptr);
+
+    return stream.create_user_event(true);
+}
+
 #ifdef ENABLE_ONEDNN_FOR_GPU
 dnnl::memory gpu_buffer::get_onednn_memory(dnnl::memory::desc desc, int64_t offset) {
     auto onednn_engine = _engine->get_onednn_engine();
@@ -237,11 +244,19 @@ shared_mem_params gpu_image2d::get_internal_params() const {
 }
 
 event::ptr gpu_image2d::copy_from(stream& /* stream */, const memory& /* other */) {
-    throw std::runtime_error("[clDNN] copy_from is not implemented for gpu_image2d");
+    throw std::runtime_error("[GPU] copy_from is not implemented for gpu_image2d");
 }
 
 event::ptr gpu_image2d::copy_from(stream& /* stream */, const void* /* host_ptr */) {
-    throw std::runtime_error("[clDNN] copy_from is not implemented for gpu_image2d");
+    throw std::runtime_error("[GPU] copy_from is not implemented for gpu_image2d");
+}
+
+event::ptr gpu_image2d::copy_to(stream& /* stream */, memory& /* other */) {
+    throw std::runtime_error("[GPU] copy_to is not implemented for gpu_image2d");
+}
+
+event::ptr gpu_image2d::copy_to(stream& /* stream */, void* /* host_ptr */) {
+    throw std::runtime_error("[GPU] copy_to is not implemented for gpu_image2d");
 }
 
 gpu_media_buffer::gpu_media_buffer(ocl_engine* engine,
@@ -384,15 +399,24 @@ event::ptr gpu_usm::copy_from(stream& stream, const memory& other) {
 
 event::ptr gpu_usm::copy_from(stream& stream, const void* host_ptr) {
     auto& cl_stream = downcast<ocl_stream>(stream);
-    auto ev = stream.create_base_event();
     auto dst_ptr = get_buffer().get();
     cl_stream.get_usm_helper().enqueue_memcpy(cl_stream.get_cl_queue(),
                                               dst_ptr,
                                               host_ptr,
                                               _bytes_count,
                                               true);
+    return stream.create_user_event(true);
+}
 
-    return ev;
+event::ptr gpu_usm::copy_to(stream& stream, void* host_ptr) {
+    auto& cl_stream = downcast<ocl_stream>(stream);
+    auto src_ptr = get_buffer().get();
+    cl_stream.get_usm_helper().enqueue_memcpy(cl_stream.get_cl_queue(),
+                                              host_ptr,
+                                              src_ptr,
+                                              _bytes_count,
+                                              true);
+    return stream.create_user_event(true);
 }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
@@ -420,18 +444,26 @@ shared_mem_params gpu_usm::get_internal_params() const {
     };
 }
 
-allocation_type gpu_usm::detect_allocation_type(ocl_engine* engine, const cl::UsmMemory& buffer) {
-    auto cl_alloc_type = engine->get_usm_helper().get_usm_allocation_type(buffer.get());
+allocation_type gpu_usm::detect_allocation_type(const ocl_engine* engine, const void* mem_ptr) {
+    auto cl_alloc_type = engine->get_usm_helper().get_usm_allocation_type(mem_ptr);
 
-    allocation_type res = allocation_type::unknown;
+    allocation_type res;
     switch (cl_alloc_type) {
         case CL_MEM_TYPE_DEVICE_INTEL: res = allocation_type::usm_device; break;
         case CL_MEM_TYPE_HOST_INTEL: res = allocation_type::usm_host; break;
         case CL_MEM_TYPE_SHARED_INTEL: res = allocation_type::usm_shared; break;
-        default: throw std::runtime_error("[GPU] Unsupported USM alloc type: " + std::to_string(cl_alloc_type));
+        default: res = allocation_type::unknown;
     }
 
     return res;
+}
+
+allocation_type gpu_usm::detect_allocation_type(const ocl_engine* engine, const cl::UsmMemory& buffer) {
+    auto alloc_type = detect_allocation_type(engine, buffer.get());
+    OPENVINO_ASSERT(alloc_type == allocation_type::usm_device ||
+                    alloc_type == allocation_type::usm_host ||
+                    alloc_type == allocation_type::usm_shared, "[GPU] Unsupported USM alloc type: " + to_string(alloc_type));
+    return alloc_type;
 }
 
 std::vector<cl_mem> ocl_surfaces_lock::get_handles(std::vector<memory::ptr> mem) const {

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
@@ -112,9 +112,11 @@ event::ptr gpu_buffer::copy_from(stream& stream, const void* host_ptr) {
 
 event::ptr gpu_buffer::copy_to(stream& stream, void* host_ptr) {
     auto& cl_stream = downcast<ocl_stream>(stream);
-    cl_stream.get_cl_queue().enqueueReadBuffer(_buffer, true, 0, size(), host_ptr, nullptr, nullptr);
+    auto ev = stream.create_base_event();
+    cl::Event ev_ocl = downcast<ocl_event>(ev.get())->get();
+    cl_stream.get_cl_queue().enqueueReadBuffer(_buffer, false, 0, size(), host_ptr, nullptr, &ev_ocl);
 
-    return stream.create_user_event(true);
+    return ev;
 }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.hpp
@@ -42,6 +42,9 @@ struct gpu_buffer : public lockable_gpu_mem, public memory {
 
     event::ptr copy_from(stream& stream, const memory& other) override;
     event::ptr copy_from(stream& stream, const void* host_ptr) override;
+
+    event::ptr copy_to(stream& /* stream */, void* /* other */) override;
+
 #ifdef ENABLE_ONEDNN_FOR_GPU
     dnnl::memory get_onednn_memory(dnnl::memory::desc /* desc */, int64_t offset = 0) override;
 #endif
@@ -66,6 +69,9 @@ struct gpu_image2d : public lockable_gpu_mem, public memory {
 
     event::ptr copy_from(stream& /* stream */, const memory& /* other */) override;
     event::ptr copy_from(stream& /* stream */, const void* /* other */) override;
+
+    event::ptr copy_to(stream& /* stream */, memory& /* other */) override;
+    event::ptr copy_to(stream& /* stream */, void* /* other */) override;
 
 protected:
     cl::Image2D _buffer;
@@ -116,15 +122,18 @@ struct gpu_usm : public lockable_gpu_mem, public memory {
     event::ptr copy_from(stream& stream, const memory& other) override;
     event::ptr copy_from(stream& stream, const void* host_ptr) override;
 
+    event::ptr copy_to(stream& stream, void* host_ptr) override;
 #ifdef ENABLE_ONEDNN_FOR_GPU
     dnnl::memory get_onednn_memory(dnnl::memory::desc /* desc */, int64_t offset = 0) override;
 #endif
+
+    static allocation_type detect_allocation_type(const ocl_engine* engine, const void* mem_ptr);
 
 protected:
     cl::UsmMemory _buffer;
     cl::UsmMemory _host_buffer;
 
-    static allocation_type detect_allocation_type(ocl_engine* engine, const cl::UsmMemory& buffer);
+    static allocation_type detect_allocation_type(const ocl_engine* engine, const cl::UsmMemory& buffer);
 };
 
 struct ocl_surfaces_lock : public surfaces_lock {

--- a/src/tests/functional/plugin/gpu/concurrency/gpu_concurrency_tests.cpp
+++ b/src/tests/functional/plugin/gpu/concurrency/gpu_concurrency_tests.cpp
@@ -108,3 +108,166 @@ INSTANTIATE_TEST_SUITE_P(smoke_RemoteTensor, OVConcurrencyTest,
     ::testing::Combine(::testing::ValuesIn(num_streams),
         ::testing::ValuesIn(num_requests)),
     OVConcurrencyTest::getTestCaseName);
+
+TEST(canSwapTensorsBetweenIRs, inputs) {
+    std::vector<std::vector<uint8_t>> ref;
+    std::vector<ov::Tensor> input_tensors;
+    auto fn = ngraph::builder::subgraph::makeSplitMultiConvConcat();
+
+    auto ie = ov::Core();
+    auto compiled_model = ie.compile_model(fn, CommonTestUtils::DEVICE_GPU);
+
+    const int infer_requests_num = 2;
+    ov::InferRequest infer_request1 = compiled_model.create_infer_request();
+    ov::InferRequest infer_request2 = compiled_model.create_infer_request();
+
+    input_tensors.push_back(infer_request1.get_input_tensor());
+    input_tensors.push_back(infer_request2.get_input_tensor());
+
+    auto calc_ref_results = [&](const ov::Tensor& tensor){
+        const auto tensor_size = tensor.get_byte_size();
+        const auto in_blob_buf = static_cast<uint8_t*>(tensor.data());
+        std::vector<uint8_t> inData(in_blob_buf, in_blob_buf + tensor_size);
+        auto ref_out_data = ngraph::helpers::interpreterFunction(fn, {inData}).front().second;
+        ref.push_back(ref_out_data);
+    };
+
+    auto compare_results = [&](ov::Tensor& result, const uint8_t* refResult) {
+        auto thr = FuncTestUtils::GetComparisonThreshold(InferenceEngine::Precision::FP32);
+        ASSERT_EQ(ov::shape_size(fn->get_output_shape(0)), result.get_size());
+        FuncTestUtils::compareRawBuffers(result.data<float>(),
+                                        reinterpret_cast<const float *>(refResult), ov::shape_size(fn->get_output_shape(0)),
+                                        ov::shape_size(fn->get_output_shape(0)),
+                                        thr);
+    };
+
+    for (size_t i = 0; i < infer_requests_num; i++) {
+        FuncTestUtils::fill_tensor(input_tensors[i], 10, -5, 1, i);
+        calc_ref_results(input_tensors[i]);
+    }
+
+    // Swap tensors between IRs
+    infer_request1.set_input_tensor(input_tensors[1]);
+    infer_request2.set_input_tensor(input_tensors[0]);
+
+    const int niter_limit = 10;
+    int iter1 = 0, iter2 = 0;
+    infer_request1.set_callback([&](std::exception_ptr exception_ptr) mutable {
+        if (exception_ptr) {
+            std::rethrow_exception(exception_ptr);
+        } else {
+            iter1++;
+            ov::Tensor output_tensor = infer_request1.get_output_tensor();
+            compare_results(output_tensor, ref[iter1 % 2].data());
+            if (iter1 < niter_limit) {
+                infer_request1.set_input_tensor(input_tensors[(iter1 + 1) % 2]);
+                infer_request1.start_async();
+            }
+        }
+    });
+
+    infer_request2.set_callback([&](std::exception_ptr exception_ptr) mutable {
+        if (exception_ptr) {
+            std::rethrow_exception(exception_ptr);
+        } else {
+            iter2++;
+            ov::Tensor output_tensor = infer_request2.get_output_tensor();
+            compare_results(output_tensor, ref[(iter2 + 1) % 2].data());
+            if (iter2 < niter_limit) {
+                infer_request2.set_input_tensor(input_tensors[iter2 % 2]);
+                infer_request2.start_async();
+            }
+        }
+    });
+
+    infer_request1.start_async();
+    infer_request2.start_async();
+
+    for (size_t i = 0; i < niter_limit; i++) {
+        infer_request1.wait();
+        infer_request2.wait();
+    }
+}
+
+TEST(canSwapTensorsBetweenIRs, outputs) {
+    std::vector<std::vector<uint8_t>> ref;
+    std::vector<ov::Tensor> input_tensors;
+    std::vector<ov::Tensor> output_tensors;
+    auto fn = ngraph::builder::subgraph::makeSplitMultiConvConcat();
+
+    auto ie = ov::Core();
+    auto compiled_model = ie.compile_model(fn, CommonTestUtils::DEVICE_GPU);
+
+    const int infer_requests_num = 2;
+    ov::InferRequest infer_request1 = compiled_model.create_infer_request();
+    ov::InferRequest infer_request2 = compiled_model.create_infer_request();
+
+    input_tensors.push_back(infer_request1.get_input_tensor());
+    input_tensors.push_back(infer_request2.get_input_tensor());
+    output_tensors.push_back(infer_request1.get_output_tensor());
+    output_tensors.push_back(infer_request2.get_output_tensor());
+
+    auto calc_ref_results = [&](const ov::Tensor& tensor){
+        const auto tensor_size = tensor.get_byte_size();
+        const auto in_blob_buf = static_cast<uint8_t*>(tensor.data());
+        std::vector<uint8_t> inData(in_blob_buf, in_blob_buf + tensor_size);
+        auto ref_out_data = ngraph::helpers::interpreterFunction(fn, {inData}).front().second;
+        ref.push_back(ref_out_data);
+    };
+
+    auto compare_results = [&](ov::Tensor& result, const uint8_t* refResult) {
+        auto thr = FuncTestUtils::GetComparisonThreshold(InferenceEngine::Precision::FP32);
+        ASSERT_EQ(ov::shape_size(fn->get_output_shape(0)), result.get_size());
+        FuncTestUtils::compareRawBuffers(result.data<float>(),
+                                        reinterpret_cast<const float *>(refResult), ov::shape_size(fn->get_output_shape(0)),
+                                        ov::shape_size(fn->get_output_shape(0)),
+                                        thr);
+    };
+
+    for (size_t i = 0; i < infer_requests_num; i++) {
+        FuncTestUtils::fill_tensor(input_tensors[i], 10, -5, 1, i);
+        calc_ref_results(input_tensors[i]);
+    }
+
+    // Swap tensors between IRs
+    infer_request1.set_output_tensor(output_tensors[1]);
+    infer_request2.set_output_tensor(output_tensors[0]);
+
+    const int niter_limit = 10;
+    int iter1 = 0, iter2 = 0;
+    infer_request1.set_callback([&](std::exception_ptr exception_ptr) mutable {
+        if (exception_ptr) {
+            std::rethrow_exception(exception_ptr);
+        } else {
+            iter1++;
+            ov::Tensor output_tensor = infer_request1.get_output_tensor();
+            compare_results(output_tensor, ref[iter1 % 2].data());
+            if (iter1 < niter_limit) {
+                infer_request1.set_output_tensor(output_tensors[(iter1 + 1) % 2]);
+                infer_request1.start_async();
+            }
+        }
+    });
+
+    infer_request2.set_callback([&](std::exception_ptr exception_ptr) mutable {
+        if (exception_ptr) {
+            std::rethrow_exception(exception_ptr);
+        } else {
+            iter2++;
+            ov::Tensor output_tensor = infer_request2.get_output_tensor();
+            compare_results(output_tensor, ref[(iter2 + 1) % 2].data());
+            if (iter2 < niter_limit) {
+                infer_request2.set_output_tensor(output_tensors[iter2 % 2]);
+                infer_request2.start_async();
+            }
+        }
+    });
+
+    infer_request1.start_async();
+    infer_request2.start_async();
+
+    for (size_t i = 0; i < niter_limit; i++) {
+        infer_request1.wait();
+        infer_request2.wait();
+    }
+}

--- a/src/tests/functional/plugin/gpu/concurrency/gpu_concurrency_tests.cpp
+++ b/src/tests/functional/plugin/gpu/concurrency/gpu_concurrency_tests.cpp
@@ -109,7 +109,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_RemoteTensor, OVConcurrencyTest,
         ::testing::ValuesIn(num_requests)),
     OVConcurrencyTest::getTestCaseName);
 
-TEST(canSwapTensorsBetweenIRs, inputs) {
+TEST(canSwapTensorsBetweenInferRequests, inputs) {
     std::vector<std::vector<uint8_t>> ref;
     std::vector<ov::Tensor> input_tensors;
     auto fn = ngraph::builder::subgraph::makeSplitMultiConvConcat();
@@ -189,7 +189,7 @@ TEST(canSwapTensorsBetweenIRs, inputs) {
     }
 }
 
-TEST(canSwapTensorsBetweenIRs, outputs) {
+TEST(canSwapTensorsBetweenInferRequests, outputs) {
     std::vector<std::vector<uint8_t>> ref;
     std::vector<ov::Tensor> input_tensors;
     std::vector<ov::Tensor> output_tensors;

--- a/src/tests/ie_test_utils/functional_test_utils/include/functional_test_utils/blob_utils.hpp
+++ b/src/tests/ie_test_utils/functional_test_utils/include/functional_test_utils/blob_utils.hpp
@@ -572,6 +572,37 @@ inline ov::Tensor create_and_fill_tensor(
     return tensor;
 }
 
+void inline fill_tensor(ov::Tensor& tensor,
+                        uint32_t range = 10,
+                        int32_t start_from = 0,
+                        const int32_t k = 1,
+                        const int seed = 1) {
+    auto element_type = tensor.get_element_type();
+    switch (element_type) {
+#define CASE(X) case X: CommonTestUtils::fill_tensor_random<X>(tensor, range, start_from, k, seed); break;
+#define CASE_FLOAT(X) case X: CommonTestUtils::fill_tensor_random_float<X>(tensor, range, start_from, k, seed); break;
+    CASE_FLOAT(ov::element::f64)
+    CASE_FLOAT(ov::element::f32)
+    CASE_FLOAT(ov::element::f16)
+    CASE_FLOAT(ov::element::bf16)
+    CASE(ov::element::u1)
+    CASE(ov::element::u4)
+    CASE(ov::element::u8)
+    CASE(ov::element::u32)
+    CASE(ov::element::u16)
+    CASE(ov::element::u64)
+    CASE(ov::element::i4)
+    CASE(ov::element::i8)
+    CASE(ov::element::i16)
+    CASE(ov::element::i32)
+    CASE(ov::element::i64)
+#undef CASE
+#undef CASE_FLOAT
+    default:
+        IE_THROW() << "Wrong precision specified: " << element_type;
+    }
+}
+
 inline InferenceEngine::Blob::Ptr createAndFillBlobConsistently(
     const InferenceEngine::TensorDesc &td,
     const uint32_t range,


### PR DESCRIPTION
### Details:
 - The intention of these changes is to avoid incorrect memory re-usage between user's memory (`_inputs` or `_outputs` ) and device's memory (`_deviceInputs` or `_deviceOutputs`) for USM Host type in case of swapping blobs between infer requests. Here is example:

```
...

// If USM memory is supported, then input_tensors(1,2) will be allocated with USM Host type; and device's inputs will
// be allocated on top of this buffers (for avoiding internal memory copy between user's memory and
// device's memory)
auto input_tensor1 = infer_request1.get_input_tensor();
auto input_tensor2 = infer_request2.get_input_tensor();

...
// Fill tensors input_tensor(1,2) with data
...

infer_request1.set_input_tensor(input_tensor2);
infer_request2.set_input_tensor(input_tensor1);

// Buffers swapping will lead to memory copy between user's (input_tensor2) memory and device's memory
// after infer() call. Since infer_reqest1's device memory is the same memory as input_tensor1's, this will lead
// to corruption input_tensor1's memory
infer_request1.infer()
```


### Tickets:
 - 94773
