### PR TITLE
TensorFlow TopK layer test extended to use TopKV2

### DIFF
--- a/tests/layer_tests/tensorflow_tests/test_tf_TopK.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TopK.py
@@ -12,20 +12,20 @@ from unit_tests.utils.graph import build_graph
 
 class Test_TopK(CommonTFLayerTest):
     @staticmethod
-    def create_topK_net(shape, k, ir_version, use_new_frontend):
+    def create_topK_net(shape, k, op_type, ir_version, use_new_frontend):
         """
             Tensorflow net:
 
-                          |-> Values
-            Input -> TopK |
-                          |-> Indices
+                             |-> Values
+            Input -> TopK/V2 |
+                             |-> Indices
 
 
             IR net:
 
-                          |-> Values
-            Input -> TopK |
-                          |-> Indices
+                             |-> Values
+            Input -> TopK/V2 |
+                             |-> Indices
 
         """
 
@@ -35,10 +35,14 @@ class Test_TopK(CommonTFLayerTest):
 
         # Create the graph and model
         with tf.compat.v1.Session() as sess:
-            shape_net = permute_nchw_to_nhwc(shape)
-
-            input_tensor = tf.compat.v1.placeholder(tf.int32, shape=shape_net, name='Input')
-            values, indices = tf.nn.top_k(input_tensor, k=k, sorted=True, name='Operation')
+            input_tensor = tf.compat.v1.placeholder(tf.float32, shape=shape, name='Input')
+            if op_type == 'TopK':
+                values, indices = tf.nn.top_k(input=input_tensor, k=k, sorted=True, name='Operation')
+            elif op_type == 'TopKV2':
+                k_tensor = tf.compat.v1.placeholder(tf.float32, shape=shape, name='Input_k')
+                values, indices = tf.raw_ops.TopKV2(input=input_tensor, k=k, sorted=True, name='Operation')
+            else:
+                raise RuntimeError("Unsupported operation")
 
             tf.compat.v1.global_variables_initializer()
             tf_net = sess.graph_def
@@ -46,15 +50,15 @@ class Test_TopK(CommonTFLayerTest):
         #
         #   Create reference IR net
         #
-        topk_output_shape = shape.copy()
-        inverse_nhwc_nchw = PermuteAttrs.get_nhwc_to_nchw_permutation(len(topk_output_shape)).inv
-        topk_axis = permute_axis(len(topk_output_shape) - 1,
-                                 inverse_nhwc_nchw)  # we need to permute axis attribute
-        topk_output_shape[topk_axis] = k
-
         ref_net = None
 
         if check_ir_version(10, None, ir_version) and not use_new_frontend:
+            topk_output_shape = shape.copy()
+            inverse_nhwc_nchw = PermuteAttrs.get_nhwc_to_nchw_permutation(len(topk_output_shape)).inv
+            topk_axis = permute_axis(len(topk_output_shape) - 1,
+                                     inverse_nhwc_nchw)  # we need to permute axis attribute
+            topk_output_shape[topk_axis] = k
+
             nodes_attributes = {
                 'input': {'kind': 'op', 'type': 'Parameter'},
                 'input_data': {'shape': shape, 'kind': 'data'},
@@ -85,16 +89,19 @@ class Test_TopK(CommonTFLayerTest):
 
         return tf_net, ref_net
 
+    test_ops = ['TopK', 'TopKV2']
+
     test_data_1D = [
         dict(shape=[15], k=10),
         dict(shape=[15], k=5),
     ]
 
     @pytest.mark.parametrize("params", test_data_1D)
+    @pytest.mark.parametrize("op_type", test_ops)
     @pytest.mark.nightly
-    def test_TopK_1D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
+    def test_TopK_1D(self, params, op_type, ie_device, precision, ir_version, temp_dir, use_new_frontend,
                      use_old_api):
-        self._test(*self.create_topK_net(**params, ir_version=ir_version,
+        self._test(*self.create_topK_net(**params, op_type=op_type, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend, use_old_api=use_old_api)
@@ -105,10 +112,11 @@ class Test_TopK(CommonTFLayerTest):
     ]
 
     @pytest.mark.parametrize("params", test_data_2D)
+    @pytest.mark.parametrize("op_type", test_ops)
     @pytest.mark.nightly
-    def test_TopK_2D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
+    def test_TopK_2D(self, params, op_type, ie_device, precision, ir_version, temp_dir, use_new_frontend,
                      use_old_api):
-        self._test(*self.create_topK_net(**params, ir_version=ir_version,
+        self._test(*self.create_topK_net(**params, op_type=op_type, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend, use_old_api=use_old_api)
@@ -119,10 +127,11 @@ class Test_TopK(CommonTFLayerTest):
     ]
 
     @pytest.mark.parametrize("params", test_data_3D)
+    @pytest.mark.parametrize("op_type", test_ops)
     @pytest.mark.nightly
-    def test_TopK_3D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
+    def test_TopK_3D(self, params, op_type, ie_device, precision, ir_version, temp_dir, use_new_frontend,
                      use_old_api):
-        self._test(*self.create_topK_net(**params, ir_version=ir_version,
+        self._test(*self.create_topK_net(**params, op_type=op_type, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend, use_old_api=use_old_api)
@@ -133,10 +142,11 @@ class Test_TopK(CommonTFLayerTest):
     ]
 
     @pytest.mark.parametrize("params", test_data_4D)
+    @pytest.mark.parametrize("op_type", test_ops)
     @pytest.mark.nightly
-    def test_TopK_4D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
+    def test_TopK_4D(self, params, op_type, ie_device, precision, ir_version, temp_dir, use_new_frontend,
                      use_old_api):
-        self._test(*self.create_topK_net(**params, ir_version=ir_version,
+        self._test(*self.create_topK_net(**params, op_type=op_type, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend, use_old_api=use_old_api)
@@ -147,10 +157,11 @@ class Test_TopK(CommonTFLayerTest):
     ]
 
     @pytest.mark.parametrize("params", test_data_5D)
+    @pytest.mark.parametrize("op_type", test_ops)
     @pytest.mark.nightly
-    def test_TopK_5D(self, params, ie_device, precision, ir_version, temp_dir, use_new_frontend,
+    def test_TopK_5D(self, params, op_type, ie_device, precision, ir_version, temp_dir, use_new_frontend,
                      use_old_api):
-        self._test(*self.create_topK_net(**params, ir_version=ir_version,
+        self._test(*self.create_topK_net(**params, op_type=op_type, ir_version=ir_version,
                                          use_new_frontend=use_new_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_new_frontend=use_new_frontend, use_old_api=use_old_api)


### PR DESCRIPTION
### Details:
 - Extended TensorFlow TopK layer test to use for TopKV2

### Tickets:
 - 92849, 92880
