### PR TITLE
[PyOV] Align `pytest` versions

### DIFF
--- a/src/bindings/python/src/compatibility/openvino/requirements-dev.txt
+++ b/src/bindings/python/src/compatibility/openvino/requirements-dev.txt
@@ -1,5 +1,5 @@
 opencv-python>=3.4.4.19
-pytest==4.0.1
+pytest>=5.0,<=7.0.1
 attrs==19.1.0
 pytest-html==1.19.0
 cython>=0.29.22


### PR DESCRIPTION
### Details:
 - `pytest==4.0.1` is incompatible with Python 3.10

### Tickets:
 - none, discussed in internal channels
