### PR TITLE
[GPU] Refactor primitive_impl::create methods and kernel selector

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/common/condition.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/condition.cpp
@@ -47,7 +47,9 @@ struct condition_impl : typed_primitive_impl<condition> {
         return ev;
     }
 
-    static primitive_impl* create(const condition_node& arg, const kernel_impl_params&) { return new condition_impl(arg); }
+    static std::unique_ptr<primitive_impl> create(const condition_node& arg, const kernel_impl_params&) {
+        return make_unique<condition_impl>(arg);
+    }
 
     void init_kernels(const kernels_cache&) override {}
 

--- a/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
@@ -185,7 +185,9 @@ struct loop_impl : typed_primitive_impl<loop> {
         return ev;
     }
 
-    static primitive_impl* create(const loop_node& arg, const kernel_impl_params&) { return new loop_impl(arg); }
+    static std::unique_ptr<primitive_impl> create(const loop_node& arg, const kernel_impl_params&) {
+        return make_unique<loop_impl>(arg);
+    }
 
 private:
     primitive_id _node_id;

--- a/src/plugins/intel_gpu/src/graph/impls/common/wait_for_events.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/wait_for_events.cpp
@@ -45,15 +45,17 @@ public:
 
     bool validate(const primitive_inst&) const override { return true; }
 
-    static primitive_impl* create_data(const data_node& data, const kernel_impl_params&) { return new wait_for_events_impl(data); }
-
-    static primitive_impl* create_input_layout(const input_layout_node& input, const kernel_impl_params&) {
-        return new wait_for_events_impl(input);
+    static std::unique_ptr<primitive_impl> create_data(const data_node& data, const kernel_impl_params&) {
+        return make_unique<wait_for_events_impl>(data);
     }
 
-    static primitive_impl* create_prior_box(const prior_box_node& prior_box, const kernel_impl_params&) {
+    static std::unique_ptr<primitive_impl> create_input_layout(const input_layout_node& input, const kernel_impl_params&) {
+        return make_unique<wait_for_events_impl>(input);
+    }
+
+    static std::unique_ptr<primitive_impl> create_prior_box(const prior_box_node& prior_box, const kernel_impl_params&) {
         // This primitive is being executed on CPU during network compilation.
-        return new wait_for_events_impl(prior_box);
+        return make_unique<wait_for_events_impl>(prior_box);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/assign.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/assign.cpp
@@ -40,8 +40,8 @@ struct assign_impl : public typed_primitive_impl<assign> {
     void init_kernels(const kernels_cache&) override {}
 
 public:
-    static primitive_impl* create(const assign_node& arg, const kernel_impl_params& impl_param) {
-        return new assign_impl{};
+    static std::unique_ptr<primitive_impl> create(const assign_node& arg, const kernel_impl_params& impl_param) {
+        return make_unique<assign_impl>();
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/detection_output.cpp
@@ -855,7 +855,9 @@ public:
 
     void init_kernels(const kernels_cache&) override {}
 
-    static primitive_impl* create(const detection_output_node& arg, const kernel_impl_params&) { return new detection_output_impl(arg); }
+    static std::unique_ptr<primitive_impl> create(const detection_output_node& arg, const kernel_impl_params&) {
+        return make_unique<detection_output_impl>(arg);
+    }
 };
 
 namespace detail {

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/non_max_suppression.cpp
@@ -405,8 +405,8 @@ struct non_max_suppression_impl : typed_primitive_impl<non_max_suppression> {
         return ev;
     }
 
-    static primitive_impl* create(const non_max_suppression_node&, const kernel_impl_params&) {
-        return new non_max_suppression_impl();
+    static std::unique_ptr<primitive_impl> create(const non_max_suppression_node&, const kernel_impl_params&) {
+        return make_unique<non_max_suppression_impl>();
     }
     void init_kernels(const kernels_cache&) override {}
 };

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/proposal.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/proposal.cpp
@@ -432,7 +432,7 @@ struct proposal_impl : typed_primitive_impl<proposal> {
 
     void init_kernels(const kernels_cache&) override {}
 
-    static primitive_impl* create(const proposal_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const proposal_node& arg, const kernel_impl_params& impl_param) {
         const layout& l = impl_param.input_layouts[2];
         const size_t count = l.feature() == 1 ? static_cast<size_t>(l.batch()) : static_cast<size_t>(l.feature());
 
@@ -444,7 +444,7 @@ struct proposal_impl : typed_primitive_impl<proposal> {
             CLDNN_ERROR_MESSAGE(arg.id(), "image_info must have either 3, 4 or 6 items");
         }
 
-        return new proposal_impl(arg);
+        return make_unique<proposal_impl>(arg);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/read_value.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/read_value.cpp
@@ -41,8 +41,8 @@ struct read_value_impl : public typed_primitive_impl<read_value> {
     void init_kernels(const kernels_cache&) override {}
 
 public:
-    static primitive_impl* create(const read_value_node& arg, const kernel_impl_params& impl_param) {
-        return new read_value_impl{};
+    static std::unique_ptr<primitive_impl> create(const read_value_node& arg, const kernel_impl_params& impl_param) {
+        return make_unique<read_value_impl>();
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/implementation_map.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/implementation_map.hpp
@@ -126,7 +126,7 @@ class implementation_map {
 public:
     using key_builder = implementation_key<primitive_kind>;
     using key_type = typename key_builder::type;
-    using factory_type = std::function<primitive_impl*(const typed_program_node<primitive_kind>&, const kernel_impl_params&)>;
+    using factory_type = std::function<std::unique_ptr<primitive_impl>(const typed_program_node<primitive_kind>&, const kernel_impl_params&)>;
     using map_type = singleton_map<impl_types, std::pair<std::set<key_type>, factory_type>>;
 
     static factory_type get(const kernel_impl_params& impl_params, impl_types preferred_impl_type) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
@@ -84,13 +84,9 @@ struct activation_impl : typed_primitive_impl_ocl<activation> {
         }
 
         auto& kernel_selector = kernel_selector::activation_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(activation_params, activation_optional_params);
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
+        auto best_kernel = kernel_selector.get_best_kernel(activation_params, activation_optional_params);
 
-        auto activation = new activation_impl(arg, best_kernels[0]);
+        auto activation = new activation_impl(arg, best_kernel);
 
         return activation;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
@@ -58,7 +58,7 @@ struct activation_impl : typed_primitive_impl_ocl<activation> {
         ib >> _is_parameterized;
     }
 
-    static primitive_impl* create(const activation_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const activation_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto activation_params = get_default_params<kernel_selector::activation_params>(impl_param);
         auto activation_optional_params =
@@ -86,9 +86,7 @@ struct activation_impl : typed_primitive_impl_ocl<activation> {
         auto& kernel_selector = kernel_selector::activation_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(activation_params, activation_optional_params);
 
-        auto activation = new activation_impl(arg, best_kernel);
-
-        return activation;
+        return make_unique<activation_impl>(arg, best_kernel);
     }
 
 private:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
@@ -82,14 +82,6 @@ struct activation_impl : typed_primitive_impl_ocl<activation> {
         return {params, optional_params};
     }
 
-    static std::unique_ptr<primitive_impl> create(const activation_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<activation_impl>(arg, best_kernel);
-    }
-
 private:
     bool _is_parameterized;
 };
@@ -97,7 +89,7 @@ private:
 namespace detail {
 
 attach_activation_impl::attach_activation_impl() {
-    implementation_map<activation>::add(impl_types::ocl, activation_impl::create, {
+    implementation_map<activation>::add(impl_types::ocl, typed_primitive_impl_ocl<activation>::create<activation_impl>, {
         std::make_tuple(data_types::f32, format::yxfb),
         std::make_tuple(data_types::f16, format::yxfb),
         std::make_tuple(data_types::f32, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
@@ -16,6 +16,8 @@ namespace ocl {
 struct activation_impl : typed_primitive_impl_ocl<activation> {
     using parent = typed_primitive_impl_ocl<activation>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::activation_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::activation_params, kernel_selector::activation_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -58,33 +60,32 @@ struct activation_impl : typed_primitive_impl_ocl<activation> {
         ib >> _is_parameterized;
     }
 
-    static std::unique_ptr<primitive_impl> create(const activation_node& arg, const kernel_impl_params& impl_param) {
-        const auto& prim = arg.get_primitive();
-        auto activation_params = get_default_params<kernel_selector::activation_params>(impl_param);
-        auto activation_optional_params =
-            get_default_optional_params<kernel_selector::activation_optional_params>(arg.get_program());
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<activation>();
+        auto params = get_default_params<kernel_selector::activation_params>(impl_param);
+        auto optional_params = get_default_optional_params<kernel_selector::activation_optional_params>(impl_param.get_program());
 
-        convert_new_activation_func(prim, activation_params.activations);
+        convert_new_activation_func(primitive, params.activations);
 
-        if (arg.is_parameterized()) {
+        bool is_parameterized = !primitive->additional_params_input.empty();
+        if (is_parameterized) {
             const auto& slope_layout = impl_param.input_layouts[1];
             const auto& output_layout = impl_param.output_layout;
 
-            const auto params_num =
-                kernel_selector::GetActivationAdditionalParamsNumber(activation_params.activations[0].function);
+            const auto params_num = kernel_selector::GetActivationAdditionalParamsNumber(params.activations[0].function);
 
-            CLDNN_ERROR_LESS_THAN(arg.id(),
-                                  "Slope layout size count",
-                                  slope_layout.count(),
-                                  "output_layout.feature() * params_num",
-                                  static_cast<size_t>(output_layout.feature() * params_num),
-                                  "Error - not enough data inside additional params buffer");
+            OPENVINO_ASSERT(slope_layout.count() >= static_cast<size_t>(output_layout.feature() * params_num), "[GPU] Invalid slope size in ", primitive->id);
 
-            activation_params.inputActivationParams.push_back(convert_data_tensor(slope_layout));
+            params.inputActivationParams.push_back(convert_data_tensor(slope_layout));
         }
 
-        auto& kernel_selector = kernel_selector::activation_kernel_selector::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(activation_params, activation_optional_params);
+        return {params, optional_params};
+    }
+
+    static std::unique_ptr<primitive_impl> create(const activation_node& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<activation_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
@@ -63,14 +63,9 @@ public:
         }
 
         const auto& kernel_selector = kernel_selector::adaptive_pooling_kernel_selector::Instance();
-        const auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
+        const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "best_kernels.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
-
-        return new adaptive_pooling_impl(arg, best_kernels[0]);
+        return new adaptive_pooling_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
@@ -66,14 +66,6 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const adaptive_pooling_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<adaptive_pooling_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
@@ -95,7 +95,7 @@ attach_adaptive_pooling_impl::attach_adaptive_pooling_impl() {
         format::bs_fs_zyx_bsv32_fsv16
     };
 
-    implementation_map<adaptive_pooling>::add(impl_types::ocl, adaptive_pooling_impl::create, types, formats);
+    implementation_map<adaptive_pooling>::add(impl_types::ocl, typed_primitive_impl_ocl<adaptive_pooling>::create<adaptive_pooling_impl>, types, formats);
 }
 }  // namespace detail
 }  // namespace ocl

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
@@ -36,7 +36,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const adaptive_pooling_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const adaptive_pooling_node& arg, const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::adaptive_pooling_params>(impl_param);
         auto optional_params = get_default_optional_params<kernel_selector::adaptive_pooling_optional_params>(arg.get_program());
 
@@ -65,7 +65,7 @@ public:
         const auto& kernel_selector = kernel_selector::adaptive_pooling_kernel_selector::Instance();
         const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        return new adaptive_pooling_impl(arg, best_kernel);
+        return make_unique<adaptive_pooling_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
@@ -38,7 +38,6 @@ protected:
     }
 
 public:
-
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<adaptive_pooling>();
         auto params = get_default_params<kernel_selector::adaptive_pooling_params>(impl_param);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
@@ -39,6 +39,8 @@ static inline kernel_selector::argm_axis GetArgMaxMinAxis(int64_t axis, size_t r
 struct arg_max_min_impl : typed_primitive_impl_ocl<arg_max_min> {
     using parent = typed_primitive_impl_ocl<arg_max_min>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::arg_max_min_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::arg_max_min_params, kernel_selector::arg_max_min_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -59,7 +61,7 @@ protected:
 
 public:
     static std::unique_ptr<primitive_impl> create(const arg_max_min_node& arg, const kernel_impl_params& impl_param) {
-        const auto& primitive = arg.get_primitive();
+        const auto& primitive = impl_param.typed_desc<arg_max_min>();
         const auto& axis = primitive->axis;
         const auto& top_k = primitive->top_k;
         const auto& mode = primitive->mode;
@@ -69,7 +71,7 @@ public:
 
         auto argm_params = get_default_params<kernel_selector::arg_max_min_params>(impl_param);
         auto argm_optional_params =
-            get_default_optional_params<kernel_selector::arg_max_min_optional_params>(arg.get_program());
+            get_default_optional_params<kernel_selector::arg_max_min_optional_params>(impl_param.get_program());
 
         argm_params.outputs_num = outputs_num;
         argm_params.topK = top_k;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
@@ -58,7 +58,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const arg_max_min_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const arg_max_min_node& arg, const kernel_impl_params& impl_param) {
         const auto& primitive = arg.get_primitive();
         const auto& axis = primitive->axis;
         const auto& top_k = primitive->top_k;
@@ -98,13 +98,9 @@ public:
         argm_params.values_first = values_first;
 
         auto& kernel_selector = kernel_selector::arg_max_min_kernel_selector::Instance();
-
         auto best_kernel = kernel_selector.get_best_kernel(argm_params, argm_optional_params);
 
-
-        auto conv = new arg_max_min_impl(arg, best_kernel);
-
-        return conv;
+        return make_unique<arg_max_min_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
@@ -99,14 +99,10 @@ public:
 
         auto& kernel_selector = kernel_selector::arg_max_min_kernel_selector::Instance();
 
-        kernel_selector::KernelsData best_kernels = kernel_selector.GetBestKernels(argm_params, argm_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(argm_params, argm_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto conv = new arg_max_min_impl(arg, best_kernels[0]);
+        auto conv = new arg_max_min_impl(arg, best_kernel);
 
         return conv;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/average_unpooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/average_unpooling.cpp
@@ -32,7 +32,6 @@ protected:
     }
 
 public:
-
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<average_unpooling>();
         auto params = get_default_params<kernel_selector::average_unpooling_params>(impl_param);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/average_unpooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/average_unpooling.cpp
@@ -47,14 +47,10 @@ public:
         params.unpoolStride = {(uint32_t)stride.spatial[0], (uint32_t)stride.spatial[1]};
 
         auto& kernel_selector = kernel_selector::average_unpooling_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(average_unpooling_params, average_unpooling_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(average_unpooling_params, average_unpooling_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto average_unpool = new average_unpooling_impl(arg, best_kernels[0]);
+        auto average_unpool = new average_unpooling_impl(arg, best_kernel);
 
         return average_unpool;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/average_unpooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/average_unpooling.cpp
@@ -48,20 +48,12 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const average_unpooling_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<average_unpooling_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_average_unpooling_impl::attach_average_unpooling_impl() {
-    implementation_map<average_unpooling>::add(impl_types::ocl, average_unpooling_impl::create, {
+    implementation_map<average_unpooling>::add(impl_types::ocl, typed_primitive_impl_ocl<average_unpooling>::create<average_unpooling_impl>, {
         std::make_tuple(data_types::f32, format::yxfb),
         std::make_tuple(data_types::f16, format::yxfb),
         std::make_tuple(data_types::f32, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/average_unpooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/average_unpooling.cpp
@@ -30,7 +30,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const average_unpooling_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const average_unpooling_node& arg, const kernel_impl_params& impl_param) {
         auto primitive = arg.get_primitive();
         auto average_unpooling_params = get_default_params<kernel_selector::average_unpooling_params>(impl_param);
         auto average_unpooling_optional_params =
@@ -49,10 +49,7 @@ public:
         auto& kernel_selector = kernel_selector::average_unpooling_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(average_unpooling_params, average_unpooling_optional_params);
 
-
-        auto average_unpool = new average_unpooling_impl(arg, best_kernel);
-
-        return average_unpool;
+        return make_unique<average_unpooling_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/batch_to_space.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/batch_to_space.cpp
@@ -38,14 +38,10 @@ public:
         batch_to_space_params.crops_end = convert_dim_vector(primitive->crops_end);
 
         auto& kernel_selector = kernel_selector::batch_to_space_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(batch_to_space_params, batch_to_space_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(batch_to_space_params, batch_to_space_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto batch_to_space = new batch_to_space_impl(arg, best_kernels[0]);
+        auto batch_to_space = new batch_to_space_impl(arg, best_kernel);
 
         return batch_to_space;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/batch_to_space.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/batch_to_space.cpp
@@ -27,7 +27,7 @@ struct batch_to_space_impl : typed_primitive_impl_ocl<batch_to_space> {
     }
 
 public:
-    static primitive_impl* create(const batch_to_space_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const batch_to_space_node& arg, const kernel_impl_params& impl_param) {
         auto primitive = arg.get_primitive();
         auto batch_to_space_params = get_default_params<kernel_selector::batch_to_space_params>(impl_param);
         auto batch_to_space_optional_params =
@@ -40,10 +40,7 @@ public:
         auto& kernel_selector = kernel_selector::batch_to_space_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(batch_to_space_params, batch_to_space_optional_params);
 
-
-        auto batch_to_space = new batch_to_space_impl(arg, best_kernel);
-
-        return batch_to_space;
+        return make_unique<batch_to_space_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/batch_to_space.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/batch_to_space.cpp
@@ -28,8 +28,6 @@ struct batch_to_space_impl : typed_primitive_impl_ocl<batch_to_space> {
         return make_unique<batch_to_space_impl>(*this);
     }
 
-public:
-
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<batch_to_space>();
         auto params = get_default_params<kernel_selector::batch_to_space_params>(impl_param);
@@ -41,20 +39,12 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const batch_to_space_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<batch_to_space_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_batch_to_space_impl::attach_batch_to_space_impl() {
-    implementation_map<batch_to_space>::add(impl_types::ocl, batch_to_space_impl::create, {
+    implementation_map<batch_to_space>::add(impl_types::ocl, typed_primitive_impl_ocl<batch_to_space>::create<batch_to_space_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
         std::make_tuple(data_types::u8, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/binary_convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/binary_convolution.cpp
@@ -85,7 +85,7 @@ public:
         ib >> _split;
     }
 
-    static primitive_impl* create(const binary_convolution_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const binary_convolution_node& arg, const kernel_impl_params& impl_param) {
         const auto& primitive = arg.get_primitive();
         const auto& weights_layout = (*impl_param.weights_layout).convert_to_weights_layout(false);
         const auto& weights_size = weights_layout.get_tensor();
@@ -143,10 +143,7 @@ public:
 
         auto best_kernel = kernel_selector.get_best_kernel(conv_params, conv_optional_params);
 
-
-        auto conv = new binary_convolution_impl(arg, best_kernel);
-
-        return conv;
+        return make_unique<binary_convolution_impl>(arg, best_kernel);
     }
 
 private:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/binary_convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/binary_convolution.cpp
@@ -20,6 +20,8 @@ namespace ocl {
 struct binary_convolution_impl : typed_primitive_impl_ocl<binary_convolution> {
     using parent = typed_primitive_impl_ocl<binary_convolution>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::binary_convolution_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::binary_convolution_params, kernel_selector::binary_convolution_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -85,8 +87,8 @@ public:
         ib >> _split;
     }
 
-    static std::unique_ptr<primitive_impl> create(const binary_convolution_node& arg, const kernel_impl_params& impl_param) {
-        const auto& primitive = arg.get_primitive();
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<binary_convolution>();
         const auto& weights_layout = (*impl_param.weights_layout).convert_to_weights_layout(false);
         const auto& weights_size = weights_layout.get_tensor();
 
@@ -96,21 +98,15 @@ public:
         const auto& dilation = primitive->dilation;
         const auto& pad = primitive->pad;
 
-        const auto depthwise_separable_opt = arg.get_depthwise_sep_opt();
-        const auto actual_split = depthwise_separable_opt ? (decltype(split))1 : split;
+        auto params = get_weights_bias_default_params<kernel_selector::binary_convolution_params>(impl_param, split);
+        auto optional_params = get_default_weights_bias_optional_params<kernel_selector::binary_convolution_optional_params>(impl_param.get_program());
 
-        assert(impl_param.output_layout.feature() / primitive->split() == weights_layout.batch());
-
-        auto conv_params = get_weights_bias_default_params<kernel_selector::binary_convolution_params>(impl_param, actual_split);
-        auto conv_optional_params = get_default_weights_bias_optional_params<kernel_selector::binary_convolution_optional_params>(
-                arg.get_program());
-
-        conv_params.pad_value = primitive->pad_value;
-        conv_params.out_dt = to_data_type(*primitive->output_data_type);
-        conv_params.depthwise_separable_opt = depthwise_separable_opt;
-        conv_params.split = static_cast<uint32_t>(split);
-        conv_params.groups = static_cast<uint32_t>(groups);
-        conv_params.filterSize = {
+        params.pad_value = primitive->pad_value;
+        params.out_dt = to_data_type(*primitive->output_data_type);
+        params.depthwise_separable_opt = false;
+        params.split = static_cast<uint32_t>(split);
+        params.groups = static_cast<uint32_t>(groups);
+        params.filterSize = {
             (uint32_t)weights_size.spatial[0],
             (uint32_t)weights_size.spatial[1],
             (uint32_t)weights_size.spatial[2],
@@ -119,29 +115,35 @@ public:
         uint32_t pad_z = std::max<std::ptrdiff_t>(pad.size() >= 3 ? pad[pad.size() - 3] : 0, 0);
         uint32_t pad_y = std::max<std::ptrdiff_t>(pad.size() >= 2 ? pad[pad.size() - 2] : 0, 0);
         uint32_t pad_x = std::max<std::ptrdiff_t>(pad.size() >= 1 ? pad[pad.size() - 1] : 0, 0);
-        conv_params.padding = {pad_x, pad_y, pad_z};
+        params.padding = {pad_x, pad_y, pad_z};
 
         uint32_t stride_z = stride.size() >= 3 ? stride[stride.size() - 3] : 1;
         uint32_t stride_y = stride.size() >= 2 ? stride[stride.size() - 2] : 1;
         uint32_t stride_x = stride.size() >= 1 ? stride[stride.size() - 1] : 1;
-        conv_params.stride = {stride_x, stride_y, stride_z};
+        params.stride = {stride_x, stride_y, stride_z};
 
         uint32_t dilation_z = dilation.size() >= 3 ? dilation[dilation.size() - 3] : 1;
         uint32_t dilation_y = dilation.size() >= 2 ? dilation[dilation.size() - 2] : 1;
         uint32_t dilation_x = dilation.size() >= 1 ? dilation[dilation.size() - 1] : 1;
-        conv_params.dilation = {dilation_x, dilation_y, dilation_z};
+        params.dilation = {dilation_x, dilation_y, dilation_z};
 
         auto& kernel_selector = kernel_selector::binary_convolution_kernel_selector::Instance();
 
-        const auto& tuning_config = arg.get_program().get_options().get<build_option_type::tuning_config>();
+        const auto& tuning_config = impl_param.get_program().get_options().get<build_option_type::tuning_config>();
 
         if (tuning_config->config.mode == tuning_mode::tuning_tune_and_cache ||
             tuning_config->config.mode == tuning_mode::tuning_retune_and_cache) {
-            conv_optional_params.tuningParams.runner =
-                std::make_shared<gpu::kernel_runner>(arg.get_program().get_engine(), arg.get_program().get_id(), true);
+            optional_params.tuningParams.runner =
+                std::make_shared<gpu::kernel_runner>(impl_param.get_program().get_engine(), impl_param.get_program().get_id(), true);
         }
 
-        auto best_kernel = kernel_selector.get_best_kernel(conv_params, conv_optional_params);
+        return {params, optional_params};
+    }
+
+    static std::unique_ptr<primitive_impl> create(const binary_convolution_node& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<binary_convolution_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/binary_convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/binary_convolution.cpp
@@ -141,14 +141,10 @@ public:
                 std::make_shared<gpu::kernel_runner>(arg.get_program().get_engine(), arg.get_program().get_id(), true);
         }
 
-        kernel_selector::KernelsData best_kernels = kernel_selector.GetBestKernels(conv_params, conv_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(conv_params, conv_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto conv = new binary_convolution_impl(arg, best_kernels[0]);
+        auto conv = new binary_convolution_impl(arg, best_kernel);
 
         return conv;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/binary_convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/binary_convolution.cpp
@@ -127,8 +127,6 @@ public:
         uint32_t dilation_x = dilation.size() >= 1 ? dilation[dilation.size() - 1] : 1;
         params.dilation = {dilation_x, dilation_y, dilation_z};
 
-        auto& kernel_selector = kernel_selector::binary_convolution_kernel_selector::Instance();
-
         const auto& tuning_config = impl_param.get_program().get_options().get<build_option_type::tuning_config>();
 
         if (tuning_config->config.mode == tuning_mode::tuning_tune_and_cache ||
@@ -140,14 +138,6 @@ public:
         return {params, optional_params};
     }
 
-    static std::unique_ptr<primitive_impl> create(const binary_convolution_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<binary_convolution_impl>(arg, best_kernel);
-    }
-
 private:
     int32_t _split;
 };
@@ -155,7 +145,7 @@ private:
 namespace detail {
 
 attach_binary_convolution_impl::attach_binary_convolution_impl() {
-    implementation_map<binary_convolution>::add(impl_types::ocl, binary_convolution_impl::create, {
+    implementation_map<binary_convolution>::add(impl_types::ocl, typed_primitive_impl_ocl<binary_convolution>::create<binary_convolution_impl>, {
         std::make_tuple(data_types::bin, format::b_fs_yx_32fp),
     });
 }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
@@ -58,20 +58,12 @@ struct border_impl : typed_primitive_impl_ocl<border> {
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const border_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<border_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_border_impl::attach_border_impl() {
-    implementation_map<border>::add(impl_types::ocl, border_impl::create, {
+    implementation_map<border>::add(impl_types::ocl, typed_primitive_impl_ocl<border>::create<border_impl>, {
         std::make_tuple(data_types::f32, format::yxfb),
         std::make_tuple(data_types::f16, format::yxfb),
         std::make_tuple(data_types::i32, format::yxfb),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
@@ -59,14 +59,10 @@ struct border_impl : typed_primitive_impl_ocl<border> {
         }
 
         auto& kernel_selector = kernel_selector::border_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(b_params, b_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(b_params, b_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        return new border_impl(arg, best_kernels[0]);
+        return new border_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
@@ -24,7 +24,7 @@ struct border_impl : typed_primitive_impl_ocl<border> {
         return make_unique<border_impl>(*this);
     }
 
-    static primitive_impl* create(const border_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const border_node& arg, const kernel_impl_params& impl_param) {
         auto desc = arg.get_primitive();
 
         auto b_params = get_default_params<kernel_selector::border_params>(impl_param, 1);
@@ -61,8 +61,7 @@ struct border_impl : typed_primitive_impl_ocl<border> {
         auto& kernel_selector = kernel_selector::border_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(b_params, b_optional_params);
 
-
-        return new border_impl(arg, best_kernel);
+        return make_unique<border_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
@@ -51,20 +51,12 @@ struct broadcast_impl : typed_primitive_impl_ocl<broadcast> {
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const broadcast_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<broadcast_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_broadcast_impl::attach_broadcast_impl() {
-    implementation_map<broadcast>::add(impl_types::ocl, broadcast_impl::create, {
+    implementation_map<broadcast>::add(impl_types::ocl, typed_primitive_impl_ocl<broadcast>::create<broadcast_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
         std::make_tuple(data_types::i8, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
@@ -24,7 +24,7 @@ struct broadcast_impl : typed_primitive_impl_ocl<broadcast> {
         return make_unique<broadcast_impl>(*this);
     }
 
-    static primitive_impl* create(const broadcast_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const broadcast_node& arg, const kernel_impl_params& impl_param) {
         const auto& primitive = arg.get_primitive();
         auto bc_params = get_default_params<kernel_selector::broadcast_params>(impl_param, 1);
         auto bc_optional_params =
@@ -51,8 +51,7 @@ struct broadcast_impl : typed_primitive_impl_ocl<broadcast> {
         auto& kernel_selector = kernel_selector::broadcast_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(bc_params, bc_optional_params);
 
-
-        return new broadcast_impl(arg, best_kernel);
+        return make_unique<broadcast_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
@@ -49,14 +49,10 @@ struct broadcast_impl : typed_primitive_impl_ocl<broadcast> {
         }
 
         auto& kernel_selector = kernel_selector::broadcast_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(bc_params, bc_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(bc_params, bc_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        return new broadcast_impl(arg, best_kernels[0]);
+        return new broadcast_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
@@ -21,7 +21,7 @@ struct bucketize_impl : typed_primitive_impl_ocl<bucketize> {
         return make_unique<bucketize_impl>(*this);
     }
 
-    static primitive_impl* create(const bucketize_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const bucketize_node& arg, const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::bucketize_params>(impl_param);
         auto optional_params =
             get_default_optional_params<kernel_selector::bucketize_optional_params>(arg.get_program());
@@ -33,8 +33,7 @@ struct bucketize_impl : typed_primitive_impl_ocl<bucketize> {
         const auto& kernel_selector = kernel_selector::bucketize_kernel_selector::Instance();
         const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-
-        return new bucketize_impl(arg, best_kernel);
+        return make_unique<bucketize_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
@@ -31,14 +31,10 @@ struct bucketize_impl : typed_primitive_impl_ocl<bucketize> {
         params.inputs.push_back(convert_data_tensor(arg.buckets().get_output_layout()));
 
         const auto& kernel_selector = kernel_selector::bucketize_kernel_selector::Instance();
-        const auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
+        const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        return new bucketize_impl(arg, best_kernels.front());
+        return new bucketize_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
@@ -33,14 +33,6 @@ struct bucketize_impl : typed_primitive_impl_ocl<bucketize> {
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const bucketize_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<bucketize_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -71,7 +63,7 @@ attach_bucketize_impl::attach_bucketize_impl() {
             keys.emplace(t, f);
         }
     }
-    implementation_map<bucketize>::add(impl_types::ocl, bucketize_impl::create, keys);
+    implementation_map<bucketize>::add(impl_types::ocl, typed_primitive_impl_ocl<bucketize>::create<bucketize_impl>, keys);
 }
 }  // namespace detail
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
@@ -95,9 +95,9 @@ public:
         ib >> _can_be_optimized;
     }
 
-    static primitive_impl* create(const concatenation_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const concatenation_node& arg, const kernel_impl_params& impl_param) {
         if (arg.can_be_optimized()) {
-            return new concatenation_impl(arg, {});
+            return make_unique<concatenation_impl>(arg, kernel_selector::kernel_data{});
         }
         const auto& primitive = arg.get_primitive();
         auto concat_params = get_default_params<kernel_selector::concatenation_params>(impl_param);
@@ -116,9 +116,7 @@ public:
         auto& kernel_selector = kernel_selector::concatenation_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(concat_params, concat_optional_params);
 
-        auto concat = new concatenation_impl(arg, best_kernel);
-
-        return concat;
+        return make_unique<concatenation_impl>(arg, best_kernel);
     }
 
 private:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
@@ -114,13 +114,9 @@ public:
         concat_optional_params.kernelPerInput = true;
 
         auto& kernel_selector = kernel_selector::concatenation_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(concat_params, concat_optional_params);
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
+        auto best_kernel = kernel_selector.get_best_kernel(concat_params, concat_optional_params);
 
-        auto concat = new concatenation_impl(arg, best_kernels[0]);
+        auto concat = new concatenation_impl(arg, best_kernel);
 
         return concat;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
@@ -116,18 +116,6 @@ public:
         return {params, optional_params};
     }
 
-    static std::unique_ptr<primitive_impl> create(const concatenation_node& arg, const kernel_impl_params& impl_param) {
-        if (arg.can_be_optimized()) {
-            return make_unique<concatenation_impl>(arg, kernel_selector::kernel_data{});
-        }
-
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<concatenation_impl>(arg, best_kernel);
-    }
-
 private:
     bool _can_be_optimized;
 };
@@ -135,7 +123,7 @@ private:
 namespace detail {
 
 attach_concatenation_impl::attach_concatenation_impl() {
-    implementation_map<concatenation>::add(impl_types::ocl, concatenation_impl::create, {
+    implementation_map<concatenation>::add(impl_types::ocl, typed_primitive_impl_ocl<concatenation>::create<concatenation_impl>, {
         std::make_tuple(data_types::f32, format::yxfb),
         std::make_tuple(data_types::f16, format::yxfb),
         std::make_tuple(data_types::i8, format::yxfb),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convert_color.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convert_color.cpp
@@ -49,14 +49,10 @@ public:
         convert_color_params.mem_type = static_cast<kernel_selector::memory_type>(primitive->mem_type);
 
         auto& kernel_selector = kernel_selector::convert_color_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(convert_color_params, convert_color_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(convert_color_params, convert_color_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto convert_color = new convert_color_impl(arg, best_kernels[0]);
+        auto convert_color = new convert_color_impl(arg, best_kernel);
 
         return convert_color;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convert_color.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convert_color.cpp
@@ -33,7 +33,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const convert_color_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const convert_color_node& arg, const kernel_impl_params& impl_param) {
         auto primitive = arg.get_primitive();
 
         auto convert_color_params = get_default_params<kernel_selector::convert_color_params>(impl_param);
@@ -51,10 +51,7 @@ public:
         auto& kernel_selector = kernel_selector::convert_color_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(convert_color_params, convert_color_optional_params);
 
-
-        auto convert_color = new convert_color_impl(arg, best_kernel);
-
-        return convert_color;
+        return make_unique<convert_color_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convert_color.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convert_color.cpp
@@ -19,6 +19,8 @@ namespace ocl {
 struct convert_color_impl : typed_primitive_impl_ocl<convert_color> {
     using parent = typed_primitive_impl_ocl<convert_color>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::convert_color_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::convert_color_params, kernel_selector::convert_color_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -33,23 +35,27 @@ protected:
     }
 
 public:
-    static std::unique_ptr<primitive_impl> create(const convert_color_node& arg, const kernel_impl_params& impl_param) {
-        auto primitive = arg.get_primitive();
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<convert_color>();
 
-        auto convert_color_params = get_default_params<kernel_selector::convert_color_params>(impl_param);
-        auto convert_color_optional_params =
-            get_default_optional_params<kernel_selector::convert_color_optional_params>(arg.get_program());
+        auto params = get_default_params<kernel_selector::convert_color_params>(impl_param);
+        auto optional_params = get_default_optional_params<kernel_selector::convert_color_optional_params>(impl_param.get_program());
 
         for (size_t i = 1; i < impl_param.input_layouts.size(); ++i) {
-            convert_color_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[i]));
+            params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(i)));
         }
 
-        convert_color_params.input_color_format = static_cast<kernel_selector::color_format>(primitive->input_color_format);
-        convert_color_params.output_color_format = static_cast<kernel_selector::color_format>(primitive->output_color_format);
-        convert_color_params.mem_type = static_cast<kernel_selector::memory_type>(primitive->mem_type);
+        params.input_color_format = static_cast<kernel_selector::color_format>(primitive->input_color_format);
+        params.output_color_format = static_cast<kernel_selector::color_format>(primitive->output_color_format);
+        params.mem_type = static_cast<kernel_selector::memory_type>(primitive->mem_type);
 
-        auto& kernel_selector = kernel_selector::convert_color_kernel_selector::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(convert_color_params, convert_color_optional_params);
+        return {params, optional_params};
+    }
+
+    static std::unique_ptr<primitive_impl> create(const convert_color_node& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<convert_color_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convert_color.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convert_color.cpp
@@ -51,20 +51,12 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const convert_color_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<convert_color_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_convert_color_impl::attach_convert_color_impl() {
-    implementation_map<convert_color>::add(impl_types::ocl, convert_color_impl::create, {
+    implementation_map<convert_color>::add(impl_types::ocl, typed_primitive_impl_ocl<convert_color>::create<convert_color_impl>, {
         std::make_tuple(data_types::f32, format::nv12),
         std::make_tuple(data_types::f16, format::nv12),
         std::make_tuple(data_types::u8,  format::nv12),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
@@ -20,6 +20,8 @@ namespace ocl {
 struct convolution_impl : typed_primitive_impl_ocl<convolution> {
     using parent = typed_primitive_impl_ocl<convolution>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::convolution_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::convolution_params, kernel_selector::convolution_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -95,7 +97,7 @@ public:
     }
 
     static std::unique_ptr<primitive_impl> create(const convolution_node& arg, const kernel_impl_params& impl_param) {
-        const auto& primitive = arg.get_primitive();
+        const auto& primitive = impl_param.typed_desc<convolution>();
 
         const auto &split = primitive->split();
         auto stride = primitive->stride;
@@ -108,7 +110,7 @@ public:
         auto conv_params = get_weight_bias_zero_point_default_params<kernel_selector::convolution_params>(
             impl_param, split, 1, primitive->grouped_weights_shape);
         auto conv_optional_params =
-            get_default_weights_bias_optional_params<kernel_selector::convolution_optional_params>(arg.get_program());
+            get_default_weights_bias_optional_params<kernel_selector::convolution_optional_params>(impl_param.get_program());
 
         if (primitive->deformable_mode) {
             conv_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
@@ -94,7 +94,7 @@ public:
         ib >> _depthwise_sep_opt;
     }
 
-    static primitive_impl* create(const convolution_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const convolution_node& arg, const kernel_impl_params& impl_param) {
         const auto& primitive = arg.get_primitive();
 
         const auto &split = primitive->split();
@@ -183,9 +183,7 @@ public:
 
         auto best_kernel = kernel_selector.get_best_kernel(conv_params, conv_optional_params);
 
-        auto conv = new convolution_impl(arg, best_kernel);
-
-        return conv;
+        return make_unique<convolution_impl>(arg, best_kernel);
     }
 
 private:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
@@ -181,13 +181,9 @@ public:
                 std::make_shared<gpu::kernel_runner>(arg.get_program().get_engine(), arg.get_program().get_id(), true, true);
         }
 
-        kernel_selector::KernelsData best_kernels = kernel_selector.GetBestKernels(conv_params, conv_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(conv_params, conv_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with these arguments");
-        auto conv = new convolution_impl(arg, best_kernels[0]);
+        auto conv = new convolution_impl(arg, best_kernel);
 
         return conv;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
@@ -65,6 +65,7 @@ public:
         params.inputs[0] = convert_data_tensor(impl_param.get_input_layout(), 1, impl_param.input_offsets[0]);
         return {params, optional_params};
     }
+
 protected:
     bool optimized_out(crop_inst& instance) const override {
         return parent::optimized_out(instance) || _can_be_optimized;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
@@ -54,7 +54,7 @@ public:
         ib >> _can_be_optimized;
     }
 
-    static primitive_impl* create(const crop_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const crop_node& arg, const kernel_impl_params& impl_param) {
         auto ew_params = get_default_params<kernel_selector::eltwise_params>(impl_param, 1);
         auto ew_optional_params = get_default_optional_params<kernel_selector::eltwise_optional_params>(arg.get_program());
 
@@ -65,10 +65,7 @@ public:
         auto& kernel_selector = kernel_selector::eltwise_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(ew_params, ew_optional_params);
 
-
-        auto crop = new crop_impl(arg, best_kernel);
-
-        return crop;
+        return make_unique<crop_impl>(arg, best_kernel);
     }
 
 private:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
@@ -65,13 +65,9 @@ public:
         params.inputs[0] = convert_data_tensor(impl_param.get_input_layout(), 1, impl_param.input_offsets[0]);
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const crop_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<crop_impl>(arg, best_kernel);
+protected:
+    bool optimized_out(crop_inst& instance) const override {
+        return parent::optimized_out(instance) || _can_be_optimized;
     }
 
 private:
@@ -81,7 +77,7 @@ private:
 namespace detail {
 
 attach_crop_impl::attach_crop_impl() {
-    implementation_map<crop>::add(impl_types::ocl, crop_impl::create, {
+    implementation_map<crop>::add(impl_types::ocl, typed_primitive_impl_ocl<crop>::create<crop_impl>, {
         std::make_tuple(data_types::f32, format::yxfb),
         std::make_tuple(data_types::f16, format::yxfb),
         std::make_tuple(data_types::i64, format::yxfb),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
@@ -66,11 +66,6 @@ public:
         return {params, optional_params};
     }
 
-protected:
-    bool optimized_out(crop_inst& instance) const override {
-        return parent::optimized_out(instance) || _can_be_optimized;
-    }
-
 private:
     bool _can_be_optimized;
 };

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
@@ -63,14 +63,10 @@ public:
         ew_params.inputs[0] = convert_data_tensor(impl_param.get_input_layout(), 1, impl_param.input_offsets[0]);
 
         auto& kernel_selector = kernel_selector::eltwise_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(ew_params, ew_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(ew_params, ew_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto crop = new crop_impl(arg, best_kernels[0]);
+        auto crop = new crop_impl(arg, best_kernel);
 
         return crop;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
@@ -28,7 +28,7 @@ struct ctc_greedy_decoder_impl : typed_primitive_impl_ocl<ctc_greedy_decoder> {
     }
 
 public:
-    static primitive_impl* create(const ctc_greedy_decoder_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const ctc_greedy_decoder_node& arg, const kernel_impl_params& impl_param) {
         auto prim = arg.get_primitive();
 
         auto ctc_gd_params = get_default_params<kernel_selector::ctc_greedy_decoder_params>(impl_param);
@@ -48,10 +48,7 @@ public:
         auto best_kernel = kernel_selector.get_best_kernel(
             ctc_gd_params, ctc_gd_optional_params);
 
-
-        auto grn = new ctc_greedy_decoder_impl(arg, best_kernel);
-
-        return grn;
+        return make_unique<ctc_greedy_decoder_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
@@ -29,7 +29,6 @@ struct ctc_greedy_decoder_impl : typed_primitive_impl_ocl<ctc_greedy_decoder> {
         return make_unique<ctc_greedy_decoder_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<ctc_greedy_decoder>();
         auto params = get_default_params<kernel_selector::ctc_greedy_decoder_params>(impl_param);
@@ -46,20 +45,12 @@ public:
         }
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const ctc_greedy_decoder_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<ctc_greedy_decoder_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_ctc_greedy_decoder_impl::attach_ctc_greedy_decoder_impl() {
-    implementation_map<ctc_greedy_decoder>::add(impl_types::ocl, ctc_greedy_decoder_impl::create, {
+    implementation_map<ctc_greedy_decoder>::add(impl_types::ocl, typed_primitive_impl_ocl<ctc_greedy_decoder>::create<ctc_greedy_decoder_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
         std::make_tuple(data_types::i32, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
@@ -45,15 +45,11 @@ public:
         }
 
         auto& kernel_selector = kernel_selector::ctc_greedy_decoder_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(
+        auto best_kernel = kernel_selector.get_best_kernel(
             ctc_gd_params, ctc_gd_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto grn = new ctc_greedy_decoder_impl(arg, best_kernels[0]);
+        auto grn = new ctc_greedy_decoder_impl(arg, best_kernel);
 
         return grn;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
@@ -20,6 +20,8 @@ namespace ocl {
 struct ctc_greedy_decoder_impl : typed_primitive_impl_ocl<ctc_greedy_decoder> {
     using parent = typed_primitive_impl_ocl<ctc_greedy_decoder>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::ctc_greedy_decoder_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::ctc_greedy_decoder_params, kernel_selector::ctc_greedy_decoder_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -28,25 +30,27 @@ struct ctc_greedy_decoder_impl : typed_primitive_impl_ocl<ctc_greedy_decoder> {
     }
 
 public:
-    static std::unique_ptr<primitive_impl> create(const ctc_greedy_decoder_node& arg, const kernel_impl_params& impl_param) {
-        auto prim = arg.get_primitive();
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<ctc_greedy_decoder>();
+        auto params = get_default_params<kernel_selector::ctc_greedy_decoder_params>(impl_param);
+        auto optional_params = get_default_optional_params<kernel_selector::ctc_greedy_decoder_optional_params>(impl_param.get_program());
 
-        auto ctc_gd_params = get_default_params<kernel_selector::ctc_greedy_decoder_params>(impl_param);
-        auto ctc_gd_optional_params = get_default_optional_params<kernel_selector::ctc_greedy_decoder_optional_params>(arg.get_program());
+        auto has_second_output = !primitive->second_output.empty();
+        params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
+        params.merge_repeated = primitive->ctc_merge_repeated;
+        params.blank_index = primitive->blank_index;
+        params.outputs_num = has_second_output ? 2 : 1;
 
-        ctc_gd_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
-        ctc_gd_params.merge_repeated = prim->ctc_merge_repeated;
-        ctc_gd_params.blank_index = prim->blank_index;
-        ctc_gd_params.outputs_num = arg.has_second_output() ? 2 : 1;
-
-        if (ctc_gd_params.outputs_num == 2) {
-            const auto& second_output_layout = impl_param.input_layouts[1];
-            ctc_gd_params.inputs.push_back(convert_data_tensor(second_output_layout));
+        if (params.outputs_num == 2) {
+            params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(1)));
         }
+        return {params, optional_params};
+    }
 
-        auto& kernel_selector = kernel_selector::ctc_greedy_decoder_kernel_selector::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(
-            ctc_gd_params, ctc_gd_optional_params);
+    static std::unique_ptr<primitive_impl> create(const ctc_greedy_decoder_node& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<ctc_greedy_decoder_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_loss.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_loss.cpp
@@ -36,14 +36,6 @@ struct ctc_loss_impl : typed_primitive_impl_ocl<ctc_loss> {
         }
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const ctc_loss_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<ctc_loss_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -58,7 +50,7 @@ attach_ctc_loss_impl::attach_ctc_loss_impl() {
                     format::bs_fs_yx_bsv32_fsv32,
                     format::bs_fs_yx_bsv32_fsv16};
 
-    implementation_map<ctc_loss>::add(impl_types::ocl, ctc_loss_impl::create, types, formats);
+    implementation_map<ctc_loss>::add(impl_types::ocl, typed_primitive_impl_ocl<ctc_loss>::create<ctc_loss_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_loss.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_loss.cpp
@@ -35,14 +35,10 @@ struct ctc_loss_impl : typed_primitive_impl_ocl<ctc_loss> {
         }
 
         const auto& kernel_selector = kernel_selector::ctc_loss_kernel_selector::Instance();
-        const auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
+        const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        return new ctc_loss_impl(arg, best_kernels.front());
+        return new ctc_loss_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_loss.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_loss.cpp
@@ -21,7 +21,7 @@ struct ctc_loss_impl : typed_primitive_impl_ocl<ctc_loss> {
         return make_unique<ctc_loss_impl>(*this);
     }
 
-    static primitive_impl* create(const ctc_loss_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const ctc_loss_node& arg, const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::ctc_loss_params>(impl_param);
         auto optional_params =
             get_default_optional_params<kernel_selector::ctc_loss_optional_params>(arg.get_program());
@@ -37,8 +37,7 @@ struct ctc_loss_impl : typed_primitive_impl_ocl<ctc_loss> {
         const auto& kernel_selector = kernel_selector::ctc_loss_kernel_selector::Instance();
         const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-
-        return new ctc_loss_impl(arg, best_kernel);
+        return make_unique<ctc_loss_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/cum_sum.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/cum_sum.cpp
@@ -58,7 +58,7 @@ struct cum_sum_impl : typed_primitive_impl_ocl<cum_sum> {
     }
 
 public:
-    static primitive_impl* create(const cum_sum_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const cum_sum_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
 
         auto cum_sum_params = get_default_params<kernel_selector::cum_sum_params>(impl_param);
@@ -73,10 +73,7 @@ public:
         auto& kernel_selector = kernel_selector::cum_sum_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(cum_sum_params, cum_sum_optional_params);
 
-
-        auto cum_sum = new cum_sum_impl(arg, best_kernel);
-
-        return cum_sum;
+        return make_unique<cum_sum_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/cum_sum.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/cum_sum.cpp
@@ -71,14 +71,10 @@ public:
         cum_sum_params.reverse = arg.get_primitive()->reverse;
 
         auto& kernel_selector = kernel_selector::cum_sum_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(cum_sum_params, cum_sum_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(cum_sum_params, cum_sum_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto cum_sum = new cum_sum_impl(arg, best_kernels[0]);
+        auto cum_sum = new cum_sum_impl(arg, best_kernel);
 
         return cum_sum;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/cum_sum.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/cum_sum.cpp
@@ -71,20 +71,12 @@ public:
         params.reverse = primitive->reverse;
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const cum_sum_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<cum_sum_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_cum_sum_impl::attach_cum_sum_impl() {
-    implementation_map<cum_sum>::add(impl_types::ocl, cum_sum_impl::create, {
+    implementation_map<cum_sum>::add(impl_types::ocl, typed_primitive_impl_ocl<cum_sum>::create<cum_sum_impl>, {
         std::make_tuple(data_types::i32, format::bfyx),
         std::make_tuple(data_types::i32, format::bfzyx),
         std::make_tuple(data_types::i32, format::bfwzyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
@@ -245,7 +245,7 @@ static std::unique_ptr<primitive_impl> create(const custom_gpu_primitive_node& a
         cl_kernel->params.arguments.push_back(get_arg(p));
     }
 
-    return make_unique<custom_gpu_primitive_impl>(arg, cl_kernel);
+    return cldnn::make_unique<custom_gpu_primitive_impl>(arg, cl_kernel);
 }
 
 namespace detail {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
@@ -226,7 +226,7 @@ static std::string get_jit_constant(const custom_gpu_primitive_node& outer, cons
     return oss.str();
 }
 
-static primitive_impl* create(const custom_gpu_primitive_node& arg, const kernel_impl_params& impl_param) {
+static std::unique_ptr<primitive_impl> create(const custom_gpu_primitive_node& arg, const kernel_impl_params& impl_param) {
     const auto primitive = arg.get_primitive().get();
 
     auto cl_kernel = std::make_shared<kernel_selector::cl_kernel_data>();
@@ -245,7 +245,7 @@ static primitive_impl* create(const custom_gpu_primitive_node& arg, const kernel
         cl_kernel->params.arguments.push_back(get_arg(p));
     }
 
-    return new custom_gpu_primitive_impl(arg, cl_kernel);
+    return make_unique<custom_gpu_primitive_impl>(arg, cl_kernel);
 }
 
 namespace detail {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
@@ -131,14 +131,6 @@ public:
         return {params, optional_params};
     }
 
-    static std::unique_ptr<primitive_impl> create(const deconvolution_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<deconvolution_impl>(arg, best_kernel);
-    }
-
 private:
     int32_t _split;
     uint32_t _groups;
@@ -168,7 +160,7 @@ attach_deconvolution_impl::attach_deconvolution_impl() {
         format::bs_fs_zyx_bsv32_fsv16,
     };
 
-    implementation_map<deconvolution>::add(impl_types::ocl, deconvolution_impl::create, types, formats);
+    implementation_map<deconvolution>::add(impl_types::ocl, typed_primitive_impl_ocl<deconvolution>::create<deconvolution_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
@@ -17,6 +17,8 @@ namespace ocl {
 struct deconvolution_impl : typed_primitive_impl_ocl<deconvolution> {
     using parent = typed_primitive_impl_ocl<deconvolution>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::deconvolution_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::deconvolution_params, kernel_selector::deconvolution_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -83,8 +85,8 @@ protected:
     uint32_t get_groups() const override { return _groups; }
 
 public:
-    static std::unique_ptr<primitive_impl> create(const deconvolution_node& arg, const kernel_impl_params& impl_param) {
-        const auto& primitive = arg.get_primitive();
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<deconvolution>();
         const auto& split = primitive->split();
         const auto& stride = primitive->stride;
         const ov::Strides dilation(impl_param.output_layout.get_spatial_rank(), 1);
@@ -93,16 +95,15 @@ public:
         const auto& pad = primitive->pad;
         const auto& groups = primitive->groups;
 
-        auto deconv_params = get_weights_bias_default_params<kernel_selector::deconvolution_params>(
+        auto params = get_weights_bias_default_params<kernel_selector::deconvolution_params>(
             impl_param,
             (groups > 1) ? 1 : actual_split,
             1,
             primitive->grouped_weights_shape);
-        auto deconv_optional_params =
-            get_default_weights_bias_optional_params<kernel_selector::deconvolution_optional_params>(arg.get_program());
+        auto optional_params = get_default_weights_bias_optional_params<kernel_selector::deconvolution_optional_params>(impl_param.get_program());
 
-        deconv_params.split = split;
-        deconv_params.groups = groups;
+        params.split = split;
+        params.groups = groups;
 
         const auto weights_idx = 1 + 0;
         const auto& weights_layout = impl_param.input_layouts[weights_idx].convert_to_weights_layout(primitive->grouped_weights_shape);
@@ -110,25 +111,30 @@ public:
         uint32_t ky = weights_layout.spatial(1);
         uint32_t kz = weights_layout.spatial(2);
 
-        deconv_params.filterSize = { kx, ky, kz };
+        params.filterSize = { kx, ky, kz };
 
         uint32_t pad_z = std::max<std::ptrdiff_t>(pad.size() >= 3 ? pad[pad.size() - 3] : 0, 0);
         uint32_t pad_y = std::max<std::ptrdiff_t>(pad.size() >= 2 ? pad[pad.size() - 2] : 0, 0);
         uint32_t pad_x = std::max<std::ptrdiff_t>(pad.size() >= 1 ? pad[pad.size() - 1] : 0, 0);
-        deconv_params.padding = {pad_x, pad_y, pad_z};
+        params.padding = {pad_x, pad_y, pad_z};
 
         uint32_t stride_z = stride.size() >= 3 ? stride[stride.size() - 3] : 1;
         uint32_t stride_y = stride.size() >= 2 ? stride[stride.size() - 2] : 1;
         uint32_t stride_x = stride.size() >= 1 ? stride[stride.size() - 1] : 1;
-        deconv_params.stride = {stride_x, stride_y, stride_z};
+        params.stride = {stride_x, stride_y, stride_z};
 
         uint32_t dilation_z = dilation.size() >= 3 ? dilation[dilation.size() - 3] : 1;
         uint32_t dilation_y = dilation.size() >= 2 ? dilation[dilation.size() - 2] : 1;
         uint32_t dilation_x = dilation.size() >= 1 ? dilation[dilation.size() - 1] : 1;
-        deconv_params.dilation = {dilation_x, dilation_y, dilation_z};
+        params.dilation = {dilation_x, dilation_y, dilation_z};
 
-        auto& kernel_selector = kernel_selector::deconvolution_kernel_selector::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(deconv_params, deconv_optional_params);
+        return {params, optional_params};
+    }
+
+    static std::unique_ptr<primitive_impl> create(const deconvolution_node& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<deconvolution_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
@@ -127,14 +127,10 @@ public:
         deconv_params.dilation = {dilation_x, dilation_y, dilation_z};
 
         auto& kernel_selector = kernel_selector::deconvolution_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(deconv_params, deconv_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(deconv_params, deconv_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with these arguments");
-        auto deconv = new deconvolution_impl(arg, best_kernels[0]);
-        deconv->can_reuse_memory = best_kernels[0].can_reuse_memory;
+        auto deconv = new deconvolution_impl(arg, best_kernel);
+        deconv->can_reuse_memory = best_kernel.can_reuse_memory;
 
         return deconv;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deformable_convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deformable_convolution.cpp
@@ -97,14 +97,6 @@ public:
         return {params, optional_params};
     }
 
-    static std::unique_ptr<primitive_impl> create(const deformable_conv_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<deformable_conv_impl>(arg, best_kernel);
-    }
-
 private:
     int32_t _split;
     uint32_t _groups;
@@ -178,27 +170,19 @@ public:
                               (uint32_t)kernel_size.spatial[2] };
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const deformable_interp_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<deformable_interp_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_deformable_conv_impl::attach_deformable_conv_impl() {
-    implementation_map<deformable_conv>::add(impl_types::ocl, deformable_conv_impl::create, {
+    implementation_map<deformable_conv>::add(impl_types::ocl, typed_primitive_impl_ocl<deformable_conv>::create<deformable_conv_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
     });
 }
 
 attach_deformable_interp_impl::attach_deformable_interp_impl() {
-    implementation_map<deformable_interp>::add(impl_types::ocl, deformable_interp_impl::create, {
+    implementation_map<deformable_interp>::add(impl_types::ocl, typed_primitive_impl_ocl<deformable_interp>::create<deformable_interp_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
     });

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deformable_convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deformable_convolution.cpp
@@ -97,13 +97,9 @@ public:
         };
 
         auto& kernel_selector = kernel_selector::deformable_conv_kernel_selector::Instance();
-        kernel_selector::KernelsData best_kernels = kernel_selector.GetBestKernels(conv_params, conv_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(conv_params, conv_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with these arguments");
-        auto conv = new deformable_conv_impl(arg, best_kernels[0]);
+        auto conv = new deformable_conv_impl(arg, best_kernel);
 
         return conv;
     }
@@ -180,13 +176,9 @@ public:
                                    (uint32_t)kernel_size.spatial[2] };
 
         auto& kernel_selector = kernel_selector::deformable_interp_kernel_selector::Instance();
-        kernel_selector::KernelsData best_kernels = kernel_selector.GetBestKernels(conv_params, conv_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(conv_params, conv_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with these arguments");
-        auto conv = new deformable_interp_impl(arg, best_kernels[0]);
+        auto conv = new deformable_interp_impl(arg, best_kernel);
 
         return conv;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deformable_convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deformable_convolution.cpp
@@ -68,7 +68,7 @@ protected:
     uint32_t get_groups() const override { return _groups; }
 
 public:
-    static primitive_impl* create(const deformable_conv_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const deformable_conv_node& arg, const kernel_impl_params& impl_param) {
         const auto& primitive = arg.get_primitive();
         const auto& split = primitive->split();
         const auto& groups = primitive->groups;
@@ -99,9 +99,7 @@ public:
         auto& kernel_selector = kernel_selector::deformable_conv_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(conv_params, conv_optional_params);
 
-        auto conv = new deformable_conv_impl(arg, best_kernel);
-
-        return conv;
+        return make_unique<deformable_conv_impl>(arg, best_kernel);
     }
 
 private:
@@ -125,7 +123,7 @@ protected:
     uint32_t get_groups() const override { return 1; }
 
 public:
-    static primitive_impl* create(const deformable_interp_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const deformable_interp_node& arg, const kernel_impl_params& impl_param) {
         const auto input_idx = 0;
         const auto trans_idx = 1;
         const auto mask_idx = 2;
@@ -178,9 +176,7 @@ public:
         auto& kernel_selector = kernel_selector::deformable_interp_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(conv_params, conv_optional_params);
 
-        auto conv = new deformable_interp_impl(arg, best_kernel);
-
-        return conv;
+        return make_unique<deformable_interp_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/depth_to_space.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/depth_to_space.cpp
@@ -26,7 +26,7 @@ struct depth_to_space_impl : typed_primitive_impl_ocl<depth_to_space> {
     }
 
 public:
-    static primitive_impl* create(const depth_to_space_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const depth_to_space_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
 
         auto depth_to_space_params = get_default_params<kernel_selector::depth_to_space_params>(impl_param);
@@ -40,10 +40,7 @@ public:
         auto& kernel_selector = kernel_selector::depth_to_space_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(depth_to_space_params, depth_to_space_optional_params);
 
-
-        auto depth_to_space = new depth_to_space_impl(arg, best_kernel);
-
-        return depth_to_space;
+        return make_unique<depth_to_space_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/depth_to_space.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/depth_to_space.cpp
@@ -38,14 +38,10 @@ public:
                                                                                                     : kernel_selector::depth_to_space_mode::DEPTH_FIRST;
 
         auto& kernel_selector = kernel_selector::depth_to_space_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(depth_to_space_params, depth_to_space_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(depth_to_space_params, depth_to_space_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto depth_to_space = new depth_to_space_impl(arg, best_kernels[0]);
+        auto depth_to_space = new depth_to_space_impl(arg, best_kernel);
 
         return depth_to_space;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/depth_to_space.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/depth_to_space.cpp
@@ -27,7 +27,6 @@ struct depth_to_space_impl : typed_primitive_impl_ocl<depth_to_space> {
         return make_unique<depth_to_space_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<depth_to_space>();
         auto params = get_default_params<kernel_selector::depth_to_space_params>(impl_param);
@@ -37,14 +36,6 @@ public:
         params.mode = primitive->mode == depth_to_space_mode::blocks_first ? kernel_selector::depth_to_space_mode::BLOCKS_FIRST
                                                                            : kernel_selector::depth_to_space_mode::DEPTH_FIRST;
         return {params, optional_params};
-    }
-
-    static std::unique_ptr<primitive_impl> create(const depth_to_space_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<depth_to_space_impl>(arg, best_kernel);
     }
 };
 
@@ -66,7 +57,7 @@ attach_depth_to_space_impl::attach_depth_to_space_impl() {
         format::bs_fs_yx_bsv32_fsv16,
         format::bs_fs_yx_bsv32_fsv32,
     };
-    implementation_map<depth_to_space>::add(impl_types::ocl, depth_to_space_impl::create, dt, fmt);
+    implementation_map<depth_to_space>::add(impl_types::ocl, typed_primitive_impl_ocl<depth_to_space>::create<depth_to_space_impl>, dt, fmt);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/detection_output.cpp
@@ -26,13 +26,6 @@ struct detection_output_impl : typed_primitive_impl_ocl<detection_output> {
         return make_unique<detection_output_impl>(*this);
     }
 
-private:
-    static void set_detection_output_specific_params(kernel_selector::detection_output_params::DedicatedParams& detectOutParams,
-                                                     const detection_output_node& arg) {
-        auto primitive = arg.get_primitive();
-
-    }
-
 protected:
     bool optimized_out(detection_output_inst& instance) const override {
         /// purpose: To optimize out detection_output for perf measurement.

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/detection_output.cpp
@@ -78,14 +78,6 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const detection_output_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<detection_output_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -100,7 +92,7 @@ attach_detection_output_impl::attach_detection_output_impl() {
         format::bs_fs_yx_bsv16_fsv32,
         format::bs_fs_zyx_bsv16_fsv32,
     };
-    implementation_map<detection_output>::add(impl_types::ocl, detection_output_impl::create, dt, fmt);
+    implementation_map<detection_output>::add(impl_types::ocl, typed_primitive_impl_ocl<detection_output>::create<detection_output_impl>, dt, fmt);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/detection_output.cpp
@@ -60,7 +60,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const detection_output_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const detection_output_node& arg, const kernel_impl_params& impl_param) {
         auto detect_out_params = get_default_params<kernel_selector::detection_output_params>(impl_param);
         auto detect_out_optional_params =
             get_default_optional_params<kernel_selector::detection_output_optional_params>(arg.get_program());
@@ -74,10 +74,7 @@ public:
         auto& kernel_selector = kernel_selector::detection_output_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(detect_out_params, detect_out_optional_params);
 
-
-        auto detection_output = new detection_output_impl(arg, best_kernel);
-
-        return detection_output;
+        return make_unique<detection_output_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/detection_output.cpp
@@ -72,14 +72,10 @@ public:
         set_detection_output_specific_params(detect_out_params.detectOutParams, arg);
 
         auto& kernel_selector = kernel_selector::detection_output_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(detect_out_params, detect_out_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(detect_out_params, detect_out_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto detection_output = new detection_output_impl(arg, best_kernels[0]);
+        auto detection_output = new detection_output_impl(arg, best_kernel);
 
         return detection_output;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
@@ -73,14 +73,6 @@ struct dft_impl : typed_primitive_impl_ocl<dft> {
         auto optional_params = get_default_optional_params<kernel_selector::dft_optional_params>(impl_param.get_program());
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const dft_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<dft_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -106,7 +98,7 @@ attach_dft_impl::attach_dft_impl() {
         // 6d
         format::bfwzyx,
     };
-    implementation_map<dft>::add(impl_types::ocl, dft_impl::create, types, formats);
+    implementation_map<dft>::add(impl_types::ocl, typed_primitive_impl_ocl<dft>::create<dft_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
@@ -71,14 +71,9 @@ struct dft_impl : typed_primitive_impl_ocl<dft> {
         auto optional_params = get_default_optional_params<kernel_selector::dft_optional_params>(arg.get_program());
 
         auto& kernel_selector = kernel_selector::dft_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
-
-        return new dft_impl{arg, best_kernels.front()};
+        return new dft_impl{arg, best_kernel};
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
@@ -24,7 +24,7 @@ struct dft_impl : typed_primitive_impl_ocl<dft> {
         return make_unique<dft_impl>(*this);
     }
 
-    static primitive_impl* create(const dft_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const dft_node& arg, const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::dft_params>(impl_param);
         const auto primitive = impl_param.typed_desc<dft>();
         params.axes = primitive->axes;
@@ -73,7 +73,7 @@ struct dft_impl : typed_primitive_impl_ocl<dft> {
         auto& kernel_selector = kernel_selector::dft_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        return new dft_impl{arg, best_kernel};
+        return make_unique<dft_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
@@ -17,6 +17,8 @@ namespace ocl {
 
 struct dft_impl : typed_primitive_impl_ocl<dft> {
     using typed_primitive_impl_ocl::typed_primitive_impl_ocl;
+    using kernel_selector_t = kernel_selector::dft_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::dft_params, kernel_selector::dft_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -24,9 +26,9 @@ struct dft_impl : typed_primitive_impl_ocl<dft> {
         return make_unique<dft_impl>(*this);
     }
 
-    static std::unique_ptr<primitive_impl> create(const dft_node& arg, const kernel_impl_params& impl_param) {
-        auto params = get_default_params<kernel_selector::dft_params>(impl_param);
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto primitive = impl_param.typed_desc<dft>();
+        auto params = get_default_params<kernel_selector::dft_params>(impl_param);
         params.axes = primitive->axes;
 
         if (primitive->signal_size.empty()) {
@@ -68,10 +70,14 @@ struct dft_impl : typed_primitive_impl_ocl<dft> {
             }
         }
 
-        auto optional_params = get_default_optional_params<kernel_selector::dft_optional_params>(arg.get_program());
+        auto optional_params = get_default_optional_params<kernel_selector::dft_optional_params>(impl_param.get_program());
+        return {params, optional_params};
+    }
 
-        auto& kernel_selector = kernel_selector::dft_kernel_selector::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
+    static std::unique_ptr<primitive_impl> create(const dft_node& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<dft_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -110,20 +110,12 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const eltwise_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<eltwise_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_eltwise_impl::attach_eltwise_impl() {
-    implementation_map<eltwise>::add(impl_types::ocl, eltwise_impl::create, {
+    implementation_map<eltwise>::add(impl_types::ocl, typed_primitive_impl_ocl<eltwise>::create<eltwise_impl>, {
         std::make_tuple(data_types::f32, format::yxfb),
         std::make_tuple(data_types::f16, format::yxfb),
         std::make_tuple(data_types::i8, format::yxfb),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -17,6 +17,8 @@ namespace ocl {
 struct eltwise_impl : typed_primitive_impl_ocl<eltwise> {
     using parent = typed_primitive_impl_ocl<eltwise>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::eltwise_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::eltwise_params, kernel_selector::eltwise_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -31,34 +33,32 @@ protected:
     }
 
 public:
-    static std::unique_ptr<primitive_impl> create(const eltwise_node& arg, const kernel_impl_params& impl_param) {
-        const auto& primitive = arg.get_primitive();
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<eltwise>();
+        auto inputs_count = primitive->input.size();
 
-        auto ew_params = get_default_params<kernel_selector::eltwise_params>(impl_param);
-        auto ew_optional_params =
-            get_default_optional_params<kernel_selector::eltwise_optional_params>(arg.get_program());
+        auto params = get_default_params<kernel_selector::eltwise_params>(impl_param);
+        auto optional_params = get_default_optional_params<kernel_selector::eltwise_optional_params>(impl_param.get_program());
 
-        for (size_t i = 1; i < arg.inputs_count(); i++) {
-            ew_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[i]));
+        for (size_t i = 1; i < inputs_count; i++) {
+            params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[i]));
         }
 
+        params.operations.push_back({{kernel_selector::eltwise_params::InputType::Buffer(0), kernel_selector::eltwise_params::InputType::Buffer(1)},
+                                     convert_to_eltwise_mode(primitive->mode)});
 
-        ew_params.operations.push_back({{kernel_selector::eltwise_params::InputType::Buffer(0),
-                                         kernel_selector::eltwise_params::InputType::Buffer(1)},
-                                        convert_to_eltwise_mode(primitive->mode)});
-
-        for (uint32_t i = 2; i < static_cast<uint32_t>(arg.inputs_count()); i++) {
-            ew_params.operations.push_back({{kernel_selector::eltwise_params::InputType::Intermediate(i - 2),
-                                             kernel_selector::eltwise_params::InputType::Buffer(i)},
-                                            convert_to_eltwise_mode(primitive->mode)});
+        for (uint32_t i = 2; i < static_cast<uint32_t>(inputs_count); i++) {
+            params.operations.push_back({{kernel_selector::eltwise_params::InputType::Intermediate(i - 2),
+                                          kernel_selector::eltwise_params::InputType::Buffer(i)},
+                                          convert_to_eltwise_mode(primitive->mode)});
         }
 
         if (primitive->mode == eltwise_mode::sum) {
-            ew_params.coefficients = primitive->coefficients;
+            params.coefficients = primitive->coefficients;
         }
 
-        for (size_t i = 0; i < ew_params.inputs.size(); i++) {
-            if (!ew_params.inputs[i].SameDims(ew_params.outputs[0])) {
+        for (size_t i = 0; i < params.inputs.size(); i++) {
+            if (!params.inputs[i].SameDims(params.outputs[0])) {
                 std::vector<int32_t> input_size = impl_param.input_layouts[i].get_tensor().raw.vector();
                 std::vector<int32_t> output_size = impl_param.output_layout.get_tensor().raw.vector();
                 bool broadcast = false;
@@ -67,10 +67,10 @@ public:
                         broadcast = true;
                 }
                 if (broadcast) {
-                    ew_params.broadcast = true;
+                    params.broadcast = true;
                     break;
                 } else {
-                    ew_params.layoutBased = true;
+                    params.layoutBased = true;
                     break;
                 }
             }
@@ -79,37 +79,42 @@ public:
         // stride
         if (!primitive->stride.empty()) {
             const auto& stride = primitive->stride;
-            ew_params.stride.resize(stride.size());
+            params.stride.resize(stride.size());
             for (size_t i = 0; i < primitive->stride.size(); i++) {
-                ew_params.stride[i] = {(uint32_t)stride[i].spatial[0],
-                                       (uint32_t)stride[i].spatial[1],
-                                       (uint32_t)stride[i].spatial[2]};
+                params.stride[i] = {(uint32_t)stride[i].spatial[0],
+                                    (uint32_t)stride[i].spatial[1],
+                                    (uint32_t)stride[i].spatial[2]};
             }
         }
 
         // check if strides are the same
-        if (!ew_params.stride.empty()) {
-            const auto& stride = ew_params.stride[0];
-            for (size_t i = 1; i < ew_params.stride.size(); i++) {
-                if (stride.x != ew_params.stride[i].x || stride.y != ew_params.stride[i].y)
-                    ew_params.layoutBased = true;
+        if (!params.stride.empty()) {
+            const auto& stride = params.stride[0];
+            for (size_t i = 1; i < params.stride.size(); i++) {
+                if (stride.x != params.stride[i].x || stride.y != params.stride[i].y)
+                    params.layoutBased = true;
             }
-        } else if (!ew_params.inputs[0].SameDimsSizes(ew_params.inputs[1])) {
-            ew_params.broadcast = true;
+        } else if (!params.inputs[0].SameDimsSizes(params.inputs[1])) {
+            params.broadcast = true;
         }
 
         // TODO [LOW PRECISION]: check if this parameter's really needed. Maybe data types are enough
         bool quantization = true;
-        for (size_t i = 0; i < arg.inputs_count(); i++) {
+        for (size_t i = 0; i < inputs_count; i++) {
             if (impl_param.input_layouts[i].data_type != data_types::u8 &&
                 impl_param.input_layouts[i].data_type != data_types::i8) {
                 quantization = false;
             }
         }
-        ew_params.int8_quantization = quantization;
+        params.int8_quantization = quantization;
 
-        auto& kernel_selector = kernel_selector::eltwise_kernel_selector::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(ew_params, ew_optional_params);
+        return {params, optional_params};
+    }
+
+    static std::unique_ptr<primitive_impl> create(const eltwise_node& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<eltwise_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -31,7 +31,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const eltwise_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const eltwise_node& arg, const kernel_impl_params& impl_param) {
         const auto& primitive = arg.get_primitive();
 
         auto ew_params = get_default_params<kernel_selector::eltwise_params>(impl_param);
@@ -111,10 +111,7 @@ public:
         auto& kernel_selector = kernel_selector::eltwise_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(ew_params, ew_optional_params);
 
-
-        auto eltwise = new eltwise_impl(arg, best_kernel);
-
-        return eltwise;
+        return make_unique<eltwise_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -109,14 +109,10 @@ public:
         ew_params.int8_quantization = quantization;
 
         auto& kernel_selector = kernel_selector::eltwise_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(ew_params, ew_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(ew_params, ew_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto eltwise = new eltwise_impl(arg, best_kernels[0]);
+        auto eltwise = new eltwise_impl(arg, best_kernel);
 
         return eltwise;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/embedding_bag.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/embedding_bag.cpp
@@ -27,7 +27,6 @@ struct embedding_bag_impl : typed_primitive_impl_ocl<embedding_bag> {
         return make_unique<embedding_bag_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<embedding_bag>();
         auto params = get_default_params<kernel_selector::embedding_bag_params>(impl_param);
@@ -55,20 +54,12 @@ public:
         params.default_index = primitive->default_index;
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const embedding_bag_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<embedding_bag_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_embedding_bag_impl::attach_embedding_bag_impl() {
-    implementation_map<embedding_bag>::add(impl_types::ocl, embedding_bag_impl::create, {
+    implementation_map<embedding_bag>::add(impl_types::ocl, typed_primitive_impl_ocl<embedding_bag>::create<embedding_bag_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
     });

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/embedding_bag.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/embedding_bag.cpp
@@ -54,14 +54,10 @@ public:
         embedding_bag_params.default_index = arg.get_primitive()->default_index;
 
         auto& kernel_selector = kernel_selector::embedding_bag_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(embedding_bag_params, embedding_bag_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(embedding_bag_params, embedding_bag_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto embedding_bag = new embedding_bag_impl(arg, best_kernels[0]);
+        auto embedding_bag = new embedding_bag_impl(arg, best_kernel);
 
         return embedding_bag;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/embedding_bag.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/embedding_bag.cpp
@@ -26,7 +26,7 @@ struct embedding_bag_impl : typed_primitive_impl_ocl<embedding_bag> {
     }
 
 public:
-    static primitive_impl* create(const embedding_bag_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const embedding_bag_node& arg, const kernel_impl_params& impl_param) {
         const auto& primitive = arg.get_primitive();
         auto embedding_bag_params = get_default_params<kernel_selector::embedding_bag_params>(impl_param);
         auto embedding_bag_optional_params =
@@ -56,10 +56,7 @@ public:
         auto& kernel_selector = kernel_selector::embedding_bag_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(embedding_bag_params, embedding_bag_optional_params);
 
-
-        auto embedding_bag = new embedding_bag_impl(arg, best_kernel);
-
-        return embedding_bag;
+        return make_unique<embedding_bag_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_detection_output.cpp
@@ -33,7 +33,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const experimental_detectron_detection_output_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const experimental_detectron_detection_output_node& arg, const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::experimental_detectron_detection_output_params>(impl_param);
         auto optional_params =
             get_default_optional_params<kernel_selector::experimental_detectron_detection_output_optional_params>(
@@ -60,7 +60,7 @@ public:
         const auto& kernel_selector = kernel_selector::experimental_detectron_detection_output_kernel_selector::Instance();
         const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        return new experimental_detectron_detection_output_impl(arg, best_kernel);
+        return make_unique<experimental_detectron_detection_output_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_detection_output.cpp
@@ -56,29 +56,22 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const experimental_detectron_detection_output_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<experimental_detectron_detection_output_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 attach_experimental_detectron_detection_output_impl::attach_experimental_detectron_detection_output_impl() {
-  const std::vector<data_types> types {data_types::f16, data_types::f32};
-  const std::vector<format::type> formats = {format::bfyx,
+    const std::vector<data_types> types {data_types::f16, data_types::f32};
+    const std::vector<format::type> formats = {format::bfyx,
                         format::b_fs_yx_fsv16,
                         format::b_fs_yx_fsv32,
                         format::bs_fs_yx_bsv16_fsv16,
                         format::bs_fs_yx_bsv32_fsv32,
                         format::bs_fs_yx_bsv32_fsv16};
 
-  implementation_map<experimental_detectron_detection_output>::add(
-      impl_types::ocl, experimental_detectron_detection_output_impl::create,
-      types, formats);
+    implementation_map<experimental_detectron_detection_output>::add(
+        impl_types::ocl,
+        typed_primitive_impl_ocl<experimental_detectron_detection_output>::create<experimental_detectron_detection_output_impl>,
+        types, formats);
 }
 }  // namespace detail
 }  // namespace ocl

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_detection_output.cpp
@@ -57,16 +57,10 @@ public:
         params.inputs.push_back(convert_data_tensor(arg.output_classes_node().get_output_layout()));
         params.inputs.push_back(convert_data_tensor(arg.output_scores_node().get_output_layout()));
 
-        const auto& kernel_selector =
-            kernel_selector::experimental_detectron_detection_output_kernel_selector::Instance();
-        const auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
+        const auto& kernel_selector = kernel_selector::experimental_detectron_detection_output_kernel_selector::Instance();
+        const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "best_kernels.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
-
-        return new experimental_detectron_detection_output_impl(arg, best_kernels[0]);
+        return new experimental_detectron_detection_output_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_generate_proposals_single_image.cpp
@@ -39,7 +39,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const experimental_detectron_generate_proposals_single_image_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const experimental_detectron_generate_proposals_single_image_node& arg, const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::experimental_detectron_generate_proposals_single_image_params>(impl_param);
         auto optional_params = get_default_optional_params<
                 kernel_selector::experimental_detectron_generate_proposals_single_image_optional_params>(arg.get_program());
@@ -60,7 +60,7 @@ public:
         const auto& kernel_selector = kernel_selector::experimental_detectron_generate_proposals_single_image_kernel_selector::Instance();
         const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        return new experimental_detectron_generate_proposals_single_image_impl(arg, best_kernel);
+        return make_unique<experimental_detectron_generate_proposals_single_image_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_generate_proposals_single_image.cpp
@@ -45,7 +45,8 @@ public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<experimental_detectron_generate_proposals_single_image>();
         auto params = get_default_params<kernel_selector::experimental_detectron_generate_proposals_single_image_params>(impl_param);
-        auto optional_params = get_default_optional_params<kernel_selector::experimental_detectron_generate_proposals_single_image_optional_params>(impl_param.get_program());
+        auto optional_params =
+            get_default_optional_params<kernel_selector::experimental_detectron_generate_proposals_single_image_optional_params>(impl_param.get_program());
 
         params.min_size = primitive->min_size;
         params.nms_threshold  = primitive->nms_threshold;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_generate_proposals_single_image.cpp
@@ -58,14 +58,6 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const experimental_detectron_generate_proposals_single_image_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<experimental_detectron_generate_proposals_single_image_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -81,8 +73,10 @@ attach_experimental_detectron_generate_proposals_single_image_impl::attach_exper
         format::bs_fs_yx_bsv32_fsv32
     };
 
-    implementation_map<experimental_detectron_generate_proposals_single_image>::add(impl_types::ocl,
-        experimental_detectron_generate_proposals_single_image_impl::create, types, formats);
+    implementation_map<experimental_detectron_generate_proposals_single_image>::add(
+        impl_types::ocl,
+        typed_primitive_impl_ocl<experimental_detectron_generate_proposals_single_image>::create<experimental_detectron_generate_proposals_single_image_impl>,
+        types, formats);
 }
 }  // namespace detail
 }  // namespace ocl

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_generate_proposals_single_image.cpp
@@ -58,14 +58,9 @@ public:
         params.inputs.push_back(convert_data_tensor(arg.output_roi_scores_node().get_output_layout()));
 
         const auto& kernel_selector = kernel_selector::experimental_detectron_generate_proposals_single_image_kernel_selector::Instance();
-        const auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
+        const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "best_kernels.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
-
-        return new experimental_detectron_generate_proposals_single_image_impl(arg, best_kernels[0]);
+        return new experimental_detectron_generate_proposals_single_image_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_generate_proposals_single_image.cpp
@@ -16,6 +16,9 @@ struct experimental_detectron_generate_proposals_single_image_impl
         : public typed_primitive_impl_ocl<experimental_detectron_generate_proposals_single_image> {
     using parent = typed_primitive_impl_ocl<experimental_detectron_generate_proposals_single_image>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::experimental_detectron_generate_proposals_single_image_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::experimental_detectron_generate_proposals_single_image_params,
+                                      kernel_selector::experimental_detectron_generate_proposals_single_image_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -39,26 +42,27 @@ protected:
     }
 
 public:
-    static std::unique_ptr<primitive_impl> create(const experimental_detectron_generate_proposals_single_image_node& arg, const kernel_impl_params& impl_param) {
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<experimental_detectron_generate_proposals_single_image>();
         auto params = get_default_params<kernel_selector::experimental_detectron_generate_proposals_single_image_params>(impl_param);
-        auto optional_params = get_default_optional_params<
-                kernel_selector::experimental_detectron_generate_proposals_single_image_optional_params>(arg.get_program());
-
-        const auto& primitive = arg.get_primitive();
+        auto optional_params = get_default_optional_params<kernel_selector::experimental_detectron_generate_proposals_single_image_optional_params>(impl_param.get_program());
 
         params.min_size = primitive->min_size;
         params.nms_threshold  = primitive->nms_threshold;
         params.pre_nms_count = primitive->pre_nms_count;
         params.post_nms_count = primitive->post_nms_count;
 
-        params.inputs.push_back(convert_data_tensor(arg.anchors().get_output_layout()));
-        params.inputs.push_back(convert_data_tensor(arg.deltas().get_output_layout()));
-        params.inputs.push_back(convert_data_tensor(arg.scores().get_output_layout()));
+        for (size_t i = 1; i < impl_param.input_layouts.size(); i++) {
+            params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(i)));
+        }
 
-        params.inputs.push_back(convert_data_tensor(arg.output_roi_scores_node().get_output_layout()));
+        return {params, optional_params};
+    }
 
-        const auto& kernel_selector = kernel_selector::experimental_detectron_generate_proposals_single_image_kernel_selector::Instance();
-        const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
+    static std::unique_ptr<primitive_impl> create(const experimental_detectron_generate_proposals_single_image_node& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<experimental_detectron_generate_proposals_single_image_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_prior_grid_generator.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_prior_grid_generator.cpp
@@ -28,7 +28,7 @@ struct experimental_detectron_prior_grid_generator_impl
         return make_unique<experimental_detectron_prior_grid_generator_impl>(*this);
     }
 
-    static primitive_impl* create(const experimental_detectron_prior_grid_generator_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const experimental_detectron_prior_grid_generator_node& arg, const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::experimental_detectron_prior_grid_generator_params>(impl_param);
         auto primPtr = arg.get_primitive();
         auto& prim = *primPtr;
@@ -46,7 +46,7 @@ struct experimental_detectron_prior_grid_generator_impl
         auto& kernel_selector = kernel_selector::experimental_detectron_prior_grid_generator_instance();
         auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        return new experimental_detectron_prior_grid_generator_impl{arg, best_kernel};
+        return make_unique<experimental_detectron_prior_grid_generator_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_prior_grid_generator.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_prior_grid_generator.cpp
@@ -46,14 +46,6 @@ struct experimental_detectron_prior_grid_generator_impl
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const experimental_detectron_prior_grid_generator_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<experimental_detectron_prior_grid_generator_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -61,7 +53,7 @@ namespace detail {
 attach_experimental_detectron_prior_grid_generator_impl::attach_experimental_detectron_prior_grid_generator_impl() {
     implementation_map<experimental_detectron_prior_grid_generator>::add(
         impl_types::ocl,
-        experimental_detectron_prior_grid_generator_impl::create,
+        typed_primitive_impl_ocl<experimental_detectron_prior_grid_generator>::create<experimental_detectron_prior_grid_generator_impl>,
         {
             std::make_tuple(data_types::f16, format::bfyx),
             std::make_tuple(data_types::f32, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_prior_grid_generator.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_prior_grid_generator.cpp
@@ -44,14 +44,9 @@ struct experimental_detectron_prior_grid_generator_impl
                 arg.get_program());
 
         auto& kernel_selector = kernel_selector::experimental_detectron_prior_grid_generator_instance();
-        auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
-
-        return new experimental_detectron_prior_grid_generator_impl{arg, best_kernels.front()};
+        return new experimental_detectron_prior_grid_generator_impl{arg, best_kernel};
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_roi_feature_extractor.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_roi_feature_extractor.cpp
@@ -46,8 +46,6 @@ protected:
 public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<experimental_detectron_roi_feature_extractor>();
-        const auto output_layout = impl_param.output_layout;
-        const auto padding_filling_value = output_layout.data_padding.filling_value();
         auto params = get_default_params<kernel_selector::experimental_detectron_roi_feature_extractor_params>(impl_param);
         auto optional_params = get_default_optional_params<kernel_selector::experimental_detectron_roi_feature_extractor_optional_params>(
             impl_param.get_program());
@@ -67,23 +65,17 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const experimental_detectron_roi_feature_extractor_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<experimental_detectron_roi_feature_extractor_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 attach_experimental_detectron_roi_feature_extractor_impl::attach_experimental_detectron_roi_feature_extractor_impl() {
-    implementation_map<experimental_detectron_roi_feature_extractor>::add(impl_types::ocl,
-                                                                            experimental_detectron_roi_feature_extractor_impl::create, {
-                                                                                std::make_tuple(data_types::f16, format::bfyx),
-                                                                                std::make_tuple(data_types::f32, format::bfyx)
-                                                                                });
+    implementation_map<experimental_detectron_roi_feature_extractor>::add(
+        impl_types::ocl,
+        typed_primitive_impl_ocl<experimental_detectron_roi_feature_extractor>::create<experimental_detectron_roi_feature_extractor_impl>,
+        {
+            std::make_tuple(data_types::f16, format::bfyx),
+            std::make_tuple(data_types::f32, format::bfyx)
+        });
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_roi_feature_extractor.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_roi_feature_extractor.cpp
@@ -41,7 +41,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const experimental_detectron_roi_feature_extractor_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const experimental_detectron_roi_feature_extractor_node& arg, const kernel_impl_params& impl_param) {
         const auto& primitive = arg.get_primitive();
         const auto output_layout = impl_param.output_layout;
         const auto padding_filling_value = output_layout.data_padding.filling_value();
@@ -70,7 +70,7 @@ public:
         auto& kernel_selector = kernel_selector::experimental_detectron_roi_feature_extractor_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        return new experimental_detectron_roi_feature_extractor_impl(arg, best_kernel);
+        return make_unique<experimental_detectron_roi_feature_extractor_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_roi_feature_extractor.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_roi_feature_extractor.cpp
@@ -68,10 +68,9 @@ public:
         params.number_of_inputs = number_of_inputs;
 
         auto& kernel_selector = kernel_selector::experimental_detectron_roi_feature_extractor_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(), "best_kernels.empty()", best_kernels.empty(), "Cannot find a proper kernel with this arguments");
-        return new experimental_detectron_roi_feature_extractor_impl(arg, best_kernels.front());
+        return new experimental_detectron_roi_feature_extractor_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_topk_rois.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_topk_rois.cpp
@@ -34,14 +34,6 @@ struct experimental_detectron_topk_rois_impl : typed_primitive_impl_ocl<experime
 
         return {params, {}};
     }
-
-    static std::unique_ptr<primitive_impl> create(const experimental_detectron_topk_rois_node &arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<experimental_detectron_topk_rois_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -54,10 +46,11 @@ attach_experimental_detectron_topk_rois_impl::attach_experimental_detectron_topk
                     format::bs_fs_yx_bsv16_fsv16,
                     format::bs_fs_yx_bsv32_fsv16,
                     format::bs_fs_yx_bsv32_fsv32};
-    implementation_map<experimental_detectron_topk_rois>::add(impl_types::ocl,
-                                                              experimental_detectron_topk_rois_impl::create,
-                                                              types,
-                                                              formats);
+    implementation_map<experimental_detectron_topk_rois>::add(
+        impl_types::ocl,
+        typed_primitive_impl_ocl<experimental_detectron_topk_rois>::create<experimental_detectron_topk_rois_impl>,
+        types,
+        formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_topk_rois.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_topk_rois.cpp
@@ -23,7 +23,7 @@ struct experimental_detectron_topk_rois_impl : typed_primitive_impl_ocl<experime
         return make_unique<experimental_detectron_topk_rois_impl>(*this);
     }
 
-    static primitive_impl *create(const experimental_detectron_topk_rois_node &arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const experimental_detectron_topk_rois_node &arg, const kernel_impl_params& impl_param) {
         const auto& primitive = arg.get_primitive();
         auto params = get_default_params<kernel_selector::experimental_detectron_topk_roi_params>(impl_param);
         const auto& kernel_selector =
@@ -31,7 +31,8 @@ struct experimental_detectron_topk_rois_impl : typed_primitive_impl_ocl<experime
         params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
         params.max_rois = primitive->max_rois;
         auto best_kernel = kernel_selector.get_best_kernel(params, kernel_selector::experimental_detectron_topk_roi_optional_params());
-        return new experimental_detectron_topk_rois_impl(arg, best_kernel);
+
+        return make_unique<experimental_detectron_topk_rois_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_topk_rois.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_topk_rois.cpp
@@ -26,17 +26,12 @@ struct experimental_detectron_topk_rois_impl : typed_primitive_impl_ocl<experime
     static primitive_impl *create(const experimental_detectron_topk_rois_node &arg, const kernel_impl_params& impl_param) {
         const auto& primitive = arg.get_primitive();
         auto params = get_default_params<kernel_selector::experimental_detectron_topk_roi_params>(impl_param);
-        const auto& experimental_detectron_topk_rois_kernel_selector =
+        const auto& kernel_selector =
                 kernel_selector::experimental_detectron_topk_rois_kernel_selector::Instance();
         params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
         params.max_rois = primitive->max_rois;
-        auto best_kernels = experimental_detectron_topk_rois_kernel_selector.GetBestKernels(params,
-                                                                                            kernel_selector::experimental_detectron_topk_roi_optional_params());
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
-        return new experimental_detectron_topk_rois_impl(arg, best_kernels[0]);
+        auto best_kernel = kernel_selector.get_best_kernel(params, kernel_selector::experimental_detectron_topk_roi_optional_params());
+        return new experimental_detectron_topk_rois_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/extract_image_patches.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/extract_image_patches.cpp
@@ -29,7 +29,7 @@ struct extract_image_patches_impl : typed_primitive_impl_ocl<extract_image_patch
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<extract_image_patches>();
         auto params = get_default_params<kernel_selector::extract_image_patches_params>(impl_param);
-        auto optional_params =get_default_optional_params<kernel_selector::extract_image_patches_optional_params>(impl_param.get_program());
+        auto optional_params = get_default_optional_params<kernel_selector::extract_image_patches_optional_params>(impl_param.get_program());
 
         params.sizes = primitive->sizes;
         params.strides = primitive->strides;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/extract_image_patches.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/extract_image_patches.cpp
@@ -25,7 +25,7 @@ struct extract_image_patches_impl : typed_primitive_impl_ocl<extract_image_patch
     }
 
 public:
-    static primitive_impl* create(const extract_image_patches_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const extract_image_patches_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto params = get_default_params<kernel_selector::extract_image_patches_params>(impl_param);
         auto optional_params =
@@ -39,10 +39,7 @@ public:
         auto& kernel_selector = kernel_selector::extract_image_patches_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-
-        auto extract_image_patches = new extract_image_patches_impl(arg, best_kernel);
-
-        return extract_image_patches;
+        return make_unique<extract_image_patches_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/extract_image_patches.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/extract_image_patches.cpp
@@ -37,14 +37,10 @@ public:
         params.auto_pad = prim->auto_pad;
 
         auto& kernel_selector = kernel_selector::extract_image_patches_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto extract_image_patches = new extract_image_patches_impl(arg, best_kernels[0]);
+        auto extract_image_patches = new extract_image_patches_impl(arg, best_kernel);
 
         return extract_image_patches;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/extract_image_patches.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/extract_image_patches.cpp
@@ -26,7 +26,6 @@ struct extract_image_patches_impl : typed_primitive_impl_ocl<extract_image_patch
         return make_unique<extract_image_patches_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<extract_image_patches>();
         auto params = get_default_params<kernel_selector::extract_image_patches_params>(impl_param);
@@ -39,20 +38,12 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const extract_image_patches_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<extract_image_patches_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_extract_image_patches_impl::attach_extract_image_patches_impl() {
-    implementation_map<extract_image_patches>::add(impl_types::ocl, extract_image_patches_impl::create, {
+    implementation_map<extract_image_patches>::add(impl_types::ocl, typed_primitive_impl_ocl<extract_image_patches>::create<extract_image_patches_impl>, {
         std::make_tuple(data_types::i32, format::bfyx),
         std::make_tuple(data_types::i64, format::bfyx),
         std::make_tuple(data_types::i8, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eye.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eye.cpp
@@ -28,7 +28,7 @@ struct eye_impl : typed_primitive_impl_ocl<eye> {
         return make_unique<eye_impl>(*this);
     }
 
-    static primitive_impl* create(const eye_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const eye_node& arg, const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::eye_params>(impl_param);
         auto op_params = get_default_optional_params<kernel_selector::eye_optional_params>(arg.get_program());
 
@@ -38,8 +38,7 @@ struct eye_impl : typed_primitive_impl_ocl<eye> {
         auto& kernel_selector = kernel_selector::eye_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(params, op_params);
 
-
-        return new eye_impl(arg, best_kernel);
+        return make_unique<eye_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eye.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eye.cpp
@@ -39,14 +39,6 @@ struct eye_impl : typed_primitive_impl_ocl<eye> {
 
         return {params, {}};
     }
-
-    static std::unique_ptr<primitive_impl> create(const eye_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<eye_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -74,7 +66,7 @@ attach_eye_impl::attach_eye_impl() {
         format::bs_fs_zyx_bsv32_fsv32,
         format::bs_fs_zyx_bsv32_fsv16,
     };
-    implementation_map<eye>::add(impl_types::ocl, eye_impl::create, types, formats);
+    implementation_map<eye>::add(impl_types::ocl, typed_primitive_impl_ocl<eye>::create<eye_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eye.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eye.cpp
@@ -36,14 +36,10 @@ struct eye_impl : typed_primitive_impl_ocl<eye> {
         params.diagonal_index = primitive->shift;
 
         auto& kernel_selector = kernel_selector::eye_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(params, op_params);
+        auto best_kernel = kernel_selector.get_best_kernel(params, op_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        return new eye_impl(arg, best_kernels[0]);
+        return new eye_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
@@ -120,14 +120,10 @@ public:
             std::make_shared<gpu::kernel_runner>(arg.get_program().get_engine(), arg.get_program().get_id(), true);
 
         auto& kernel_selector = kernel_selector::fully_connected_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(fc_params, fc_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(fc_params, fc_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto fc = new fully_connected_impl(arg, best_kernels[0]);
+        auto fc = new fully_connected_impl(arg, best_kernel);
 
         return fc;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
@@ -120,20 +120,12 @@ public:
         optional_params.tuningParams.runner = std::make_shared<gpu::kernel_runner>(progam.get_engine(), progam.get_id(), true);
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const fully_connected_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<fully_connected_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_fully_connected_impl::attach_fully_connected_impl() {
-    implementation_map<fully_connected>::add(impl_types::ocl, fully_connected_impl::create, {
+    implementation_map<fully_connected>::add(impl_types::ocl, typed_primitive_impl_ocl<fully_connected>::create<fully_connected_impl>, {
         std::make_tuple(data_types::f32, format::yxfb),
         std::make_tuple(data_types::f16, format::yxfb),
         std::make_tuple(data_types::f32, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
@@ -43,7 +43,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const fully_connected_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const fully_connected_node& arg, const kernel_impl_params& impl_param) {
         const auto primitive = arg.get_primitive();
 
         auto get_fc_input_layouts = [primitive](const std::vector<layout>& input_layouts) {
@@ -122,10 +122,7 @@ public:
         auto& kernel_selector = kernel_selector::fully_connected_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(fc_params, fc_optional_params);
 
-
-        auto fc = new fully_connected_impl(arg, best_kernel);
-
-        return fc;
+        return make_unique<fully_connected_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
@@ -84,14 +84,10 @@ public:
         gather_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
 
         auto& kernel_selector = kernel_selector::gather_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(gather_params, gather_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(gather_params, gather_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto gather = new gather_impl(arg, best_kernels[0]);
+        auto gather = new gather_impl(arg, best_kernel);
 
         return gather;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
@@ -85,20 +85,12 @@ public:
         params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(1)));
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const gather_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<gather_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_gather_impl::attach_gather_impl() {
-    implementation_map<gather>::add(impl_types::ocl, gather_impl::create, {
+    implementation_map<gather>::add(impl_types::ocl, typed_primitive_impl_ocl<gather>::create<gather_impl>, {
         std::make_tuple(data_types::f32, format::fyxb),
         std::make_tuple(data_types::f16, format::fyxb),
         std::make_tuple(data_types::i32, format::fyxb),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
@@ -70,7 +70,7 @@ struct gather_impl : typed_primitive_impl_ocl<gather> {
     }
 
 public:
-    static primitive_impl* create(const gather_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const gather_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto gather_params = get_default_params<kernel_selector::gather_params>(impl_param);
         auto gather_optional_params =
@@ -86,10 +86,7 @@ public:
         auto& kernel_selector = kernel_selector::gather_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(gather_params, gather_optional_params);
 
-
-        auto gather = new gather_impl(arg, best_kernel);
-
-        return gather;
+        return make_unique<gather_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_elements.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_elements.cpp
@@ -69,14 +69,10 @@ public:
         gather_elements_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
 
         auto& kernel_selector = kernel_selector::gather_elements_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(gather_elements_params, gather_elements_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(gather_elements_params, gather_elements_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto gather_elements = new gather_elements_impl(arg, best_kernels[0]);
+        auto gather_elements = new gather_elements_impl(arg, best_kernel);
 
         return gather_elements;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_elements.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_elements.cpp
@@ -58,7 +58,6 @@ struct gather_elements_impl : typed_primitive_impl_ocl<gather_elements> {
         return make_unique<gather_elements_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<gather_elements>();
         auto params = get_default_params<kernel_selector::gather_elements_params>(impl_param);
@@ -70,20 +69,12 @@ public:
         params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(1)));
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const gather_elements_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<gather_elements_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_gather_elements_impl::attach_gather_elements_impl() {
-    implementation_map<gather_elements>::add(impl_types::ocl, gather_elements_impl::create, {
+    implementation_map<gather_elements>::add(impl_types::ocl, typed_primitive_impl_ocl<gather_elements>::create<gather_elements_impl>, {
         std::make_tuple(data_types::i8, format::bfyx),
         std::make_tuple(data_types::u8, format::bfyx),
         std::make_tuple(data_types::f32, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_elements.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_elements.cpp
@@ -57,7 +57,7 @@ struct gather_elements_impl : typed_primitive_impl_ocl<gather_elements> {
     }
 
 public:
-    static primitive_impl* create(const gather_elements_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const gather_elements_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto gather_elements_params = get_default_params<kernel_selector::gather_elements_params>(impl_param);
         auto gather_elements_optional_params =
@@ -71,10 +71,7 @@ public:
         auto& kernel_selector = kernel_selector::gather_elements_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(gather_elements_params, gather_elements_optional_params);
 
-
-        auto gather_elements = new gather_elements_impl(arg, best_kernel);
-
-        return gather_elements;
+        return make_unique<gather_elements_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_nd.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_nd.cpp
@@ -37,14 +37,10 @@ struct gather_nd_impl : typed_primitive_impl_ocl<gather_nd> {
         gather_nd_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
 
         auto& kernel_selector = kernel_selector::gather_nd_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(gather_nd_params, gather_nd_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(gather_nd_params, gather_nd_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto gather_nd = new gather_nd_impl(arg, best_kernels[0]);
+        auto gather_nd = new gather_nd_impl(arg, best_kernel);
 
         return gather_nd;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_nd.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_nd.cpp
@@ -24,7 +24,7 @@ struct gather_nd_impl : typed_primitive_impl_ocl<gather_nd> {
         return make_unique<gather_nd_impl>(*this);
     }
 
-    static primitive_impl* create(const gather_nd_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const gather_nd_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto gather_nd_params = get_default_params<kernel_selector::gather_nd_params>(impl_param);
         auto gather_nd_optional_params =
@@ -39,10 +39,7 @@ struct gather_nd_impl : typed_primitive_impl_ocl<gather_nd> {
         auto& kernel_selector = kernel_selector::gather_nd_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(gather_nd_params, gather_nd_optional_params);
 
-
-        auto gather_nd = new gather_nd_impl(arg, best_kernel);
-
-        return gather_nd;
+        return make_unique<gather_nd_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_nd.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_nd.cpp
@@ -38,20 +38,12 @@ struct gather_nd_impl : typed_primitive_impl_ocl<gather_nd> {
         params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(1)));
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const gather_nd_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<gather_nd_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_gather_nd_impl::attach_gather_nd_impl() {
-    implementation_map<gather_nd>::add(impl_types::ocl, gather_nd_impl::create, {
+    implementation_map<gather_nd>::add(impl_types::ocl, typed_primitive_impl_ocl<gather_nd>::create<gather_nd_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
         std::make_tuple(data_types::i32, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_tree.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_tree.cpp
@@ -36,15 +36,8 @@ struct gather_tree_impl : typed_primitive_impl_ocl<gather_tree> {
         }
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const gather_tree_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<gather_tree_impl>(arg, best_kernel);
-    }
 };
+
 namespace detail {
 attach_gather_tree_impl::attach_gather_tree_impl() {
     auto types = {data_types::i32, data_types::f32};
@@ -63,7 +56,7 @@ attach_gather_tree_impl::attach_gather_tree_impl() {
         format::bs_fs_yx_bsv32_fsv32,
     };
 
-    implementation_map<gather_tree>::add(impl_types::ocl, gather_tree_impl::create, types, formats);
+    implementation_map<gather_tree>::add(impl_types::ocl, typed_primitive_impl_ocl<gather_tree>::create<gather_tree_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_tree.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_tree.cpp
@@ -34,14 +34,9 @@ struct gather_tree_impl : typed_primitive_impl_ocl<gather_tree> {
         }
 
         auto& kernel_selector = kernel_selector::gather_tree_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(b_params, b_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(b_params, b_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-            "Best_kernel.empty()",
-            best_kernels.empty(),
-            "Cannot find a proper kernel with this arguments");
-
-        return new gather_tree_impl(arg, best_kernels[0]);
+        return new gather_tree_impl(arg, best_kernel);
     }
 };
 namespace detail {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_tree.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_tree.cpp
@@ -24,7 +24,7 @@ struct gather_tree_impl : typed_primitive_impl_ocl<gather_tree> {
         return make_unique<gather_tree_impl>(*this);
     }
 
-    static primitive_impl* create(const gather_tree_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const gather_tree_node& arg, const kernel_impl_params& impl_param) {
         auto desc = arg.get_primitive();
         auto b_params = get_default_params<kernel_selector::gather_tree_params>(impl_param, 1);
         auto b_optional_params = get_default_optional_params<kernel_selector::gather_tree_optional_params>(arg.get_program());
@@ -36,7 +36,7 @@ struct gather_tree_impl : typed_primitive_impl_ocl<gather_tree> {
         auto& kernel_selector = kernel_selector::gather_tree_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(b_params, b_optional_params);
 
-        return new gather_tree_impl(arg, best_kernel);
+        return make_unique<gather_tree_impl>(arg, best_kernel);
     }
 };
 namespace detail {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -130,14 +130,6 @@ public:
         }
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const gemm_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<gemm_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -166,7 +158,7 @@ attach_gemm_impl::attach_gemm_impl() {
         format::bfwzyx,
     };
 
-    implementation_map<gemm>::add(impl_types::ocl, gemm_impl::create, types, formats);
+    implementation_map<gemm>::add(impl_types::ocl, typed_primitive_impl_ocl<gemm>::create<gemm_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -129,14 +129,10 @@ public:
         }
 
         auto& kernel_selector = kernel_selector::gemm_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(gemm_params, gemm_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(gemm_params, gemm_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        return new gemm_impl(arg, best_kernels[0]);
+        return new gemm_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -17,6 +17,8 @@ namespace ocl {
 struct gemm_impl : typed_primitive_impl_ocl<gemm> {
     using parent = typed_primitive_impl_ocl<gemm>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::gemm_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::gemm_params, kernel_selector::gemm_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -25,9 +27,9 @@ struct gemm_impl : typed_primitive_impl_ocl<gemm> {
     }
 
 public:
-    static std::unique_ptr<primitive_impl> create(const gemm_node& arg, const kernel_impl_params& impl_param) {
-        auto desc = arg.get_primitive();
-        auto get_gemm_input_layouts = [desc](const std::vector<layout>& input_layouts, const layout& output_layout) {
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<gemm>();
+        auto get_gemm_input_layouts = [primitive](const std::vector<layout>& input_layouts, const layout& output_layout) {
             auto get_updated_input_shape = [&](const ov::Shape& input_shape, size_t input_rank, bool transpose, bool first_input) {
                 ov::Shape updated_input_shape;
 
@@ -54,8 +56,8 @@ public:
             auto input0_shape = input_layouts[0].get_shape();
             auto input1_shape = input_layouts[1].get_shape();
 
-            auto updated_input0_shape = get_updated_input_shape(input0_shape, desc->input_rank, desc->transpose_input0, true);
-            auto updated_input1_shape = get_updated_input_shape(input1_shape, desc->weight_rank, desc->transpose_input1, false);
+            auto updated_input0_shape = get_updated_input_shape(input0_shape, primitive->input_rank, primitive->transpose_input0, true);
+            auto updated_input1_shape = get_updated_input_shape(input1_shape, primitive->weight_rank, primitive->transpose_input1, false);
 
             std::vector<layout> layouts = input_layouts;
             layouts[0].set_partial_shape(updated_input0_shape);
@@ -63,22 +65,22 @@ public:
 
             if (input_layouts.size() == 3) {
                 auto bias_shape = input_layouts[2].get_shape();
-                auto updated_bias_shape = get_updated_input_shape(bias_shape, desc->weight_rank, desc->transpose_input1, false);
+                auto updated_bias_shape = get_updated_input_shape(bias_shape, primitive->weight_rank, primitive->transpose_input1, false);
                 layouts[2].set_partial_shape(updated_bias_shape);
             }
 
             return layouts;
         };
 
-        auto get_gemm_output_layout = [desc](const std::vector<layout>& input_layouts, const layout& output_layout) {
+        auto get_gemm_output_layout = [primitive](const std::vector<layout>& input_layouts, const layout& output_layout) {
             auto updated_output_layout = output_layout;
             auto output_rank = output_layout.get_shape().size();
             if (output_rank < 4) {
                 const auto& input0_layout = input_layouts[0];
                 const auto& input1_layout = input_layouts[1];
 
-                auto M = !desc->transpose_input0 ? input0_layout.spatial(1) : input0_layout.spatial(0);
-                auto N = !desc->transpose_input1 ? input1_layout.spatial(0) : input1_layout.spatial(1);
+                auto M = !primitive->transpose_input0 ? input0_layout.spatial(1) : input0_layout.spatial(0);
+                auto N = !primitive->transpose_input1 ? input1_layout.spatial(0) : input1_layout.spatial(1);
 
                 auto output_shape = input0_layout.get_shape();
                 for (const auto& input_layout : input_layouts) {
@@ -103,33 +105,36 @@ public:
         const auto input_layouts = get_gemm_input_layouts(impl_param.input_layouts, impl_param.output_layout);
         const auto output_layout = get_gemm_output_layout(input_layouts, impl_param.output_layout);
 
-        auto gemm_params = get_default_params<kernel_selector::gemm_params>(impl_param, 1);
-        auto gemm_optional_params =
-            get_default_optional_params<kernel_selector::gemm_optional_params>(arg.get_program());
+        auto params = get_default_params<kernel_selector::gemm_params>(impl_param, 1);
+        auto optional_params = get_default_optional_params<kernel_selector::gemm_optional_params>(impl_param.get_program());
 
-        gemm_params.inputs.clear();
-        for (size_t i = 0; i < desc->input_size(); ++i) {
-            gemm_params.inputs.push_back(convert_data_tensor(input_layouts[i]));
+        params.inputs.clear();
+        for (size_t i = 0; i < primitive->input_size(); ++i) {
+            params.inputs.push_back(convert_data_tensor(input_layouts[i]));
         }
-        gemm_params.outputs[0] = convert_data_tensor(output_layout);
+        params.outputs[0] = convert_data_tensor(output_layout);
 
-        gemm_params.alpha = desc->alpha;
-        gemm_params.beta = desc->beta;
-        gemm_params.transpose_input0 = desc->transpose_input0;
-        gemm_params.transpose_input1 = desc->transpose_input1;
+        params.alpha = primitive->alpha;
+        params.beta = primitive->beta;
+        params.transpose_input0 = primitive->transpose_input0;
+        params.transpose_input1 = primitive->transpose_input1;
 
         bool is_quantized = true;
         for (auto& input : impl_param.input_layouts)
             is_quantized &= data_type_traits::is_quantized(input.data_type);
 
         if (is_quantized) {
-            gemm_params.quantization = kernel_selector::QuantizationType::SYMMETRIC;
+            params.quantization = kernel_selector::QuantizationType::SYMMETRIC;
         } else {
-            gemm_params.quantization = kernel_selector::QuantizationType::NONE;
+            params.quantization = kernel_selector::QuantizationType::NONE;
         }
+        return {params, optional_params};
+    }
 
-        auto& kernel_selector = kernel_selector::gemm_kernel_selector::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(gemm_params, gemm_optional_params);
+    static std::unique_ptr<primitive_impl> create(const gemm_node& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<gemm_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -25,7 +25,7 @@ struct gemm_impl : typed_primitive_impl_ocl<gemm> {
     }
 
 public:
-    static primitive_impl* create(const gemm_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const gemm_node& arg, const kernel_impl_params& impl_param) {
         auto desc = arg.get_primitive();
         auto get_gemm_input_layouts = [desc](const std::vector<layout>& input_layouts, const layout& output_layout) {
             auto get_updated_input_shape = [&](const ov::Shape& input_shape, size_t input_rank, bool transpose, bool first_input) {
@@ -131,8 +131,7 @@ public:
         auto& kernel_selector = kernel_selector::gemm_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(gemm_params, gemm_optional_params);
 
-
-        return new gemm_impl(arg, best_kernel);
+        return make_unique<gemm_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/generate_proposals.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/generate_proposals.cpp
@@ -57,14 +57,9 @@ public:
         params.inputs.push_back(convert_data_tensor(arg.output_rois_nums_node().get_output_layout()));
 
         const auto& kernel_selector = kernel_selector::generate_proposals_kernel_selector::Instance();
-        const auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
+        const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "best_kernels.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
-
-        return new generate_proposals_impl(arg, best_kernels[0]);
+        return new generate_proposals_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/generate_proposals.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/generate_proposals.cpp
@@ -33,7 +33,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const generate_proposals_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const generate_proposals_node& arg, const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::generate_proposals_params>(impl_param);
         auto optional_params = get_default_optional_params<
                 kernel_selector::generate_proposals_optional_params>(arg.get_program());
@@ -59,7 +59,7 @@ public:
         const auto& kernel_selector = kernel_selector::generate_proposals_kernel_selector::Instance();
         const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        return new generate_proposals_impl(arg, best_kernel);
+        return make_unique<generate_proposals_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/generate_proposals.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/generate_proposals.cpp
@@ -54,20 +54,12 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const generate_proposals_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<generate_proposals_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
     attach_generate_proposals_impl::attach_generate_proposals_impl() {
         implementation_map<generate_proposals>::add(impl_types::ocl,
-                                                    generate_proposals_impl::create, {
+                                                    typed_primitive_impl_ocl<generate_proposals>::create<generate_proposals_impl>, {
                                                             std::make_tuple(data_types::f16, format::bfyx),
                                                             std::make_tuple(data_types::f16, format::b_fs_yx_fsv16),
                                                             std::make_tuple(data_types::f16, format::b_fs_yx_fsv32),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/generate_proposals.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/generate_proposals.cpp
@@ -17,6 +17,8 @@ struct generate_proposals_impl
         : public typed_primitive_impl_ocl<generate_proposals> {
     using parent = typed_primitive_impl_ocl<generate_proposals>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::generate_proposals_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::generate_proposals_params, kernel_selector::generate_proposals_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -33,12 +35,10 @@ protected:
     }
 
 public:
-    static std::unique_ptr<primitive_impl> create(const generate_proposals_node& arg, const kernel_impl_params& impl_param) {
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<generate_proposals>();
         auto params = get_default_params<kernel_selector::generate_proposals_params>(impl_param);
-        auto optional_params = get_default_optional_params<
-                kernel_selector::generate_proposals_optional_params>(arg.get_program());
-
-        const auto& primitive = arg.get_primitive();
+        auto optional_params = get_default_optional_params<kernel_selector::generate_proposals_optional_params>(impl_param.get_program());
 
         params.min_size = primitive->min_size;
         params.nms_threshold  = primitive->nms_threshold;
@@ -46,18 +46,19 @@ public:
         params.post_nms_count = primitive->post_nms_count;
         params.normalized = primitive->normalized;
         params.nms_eta = primitive->nms_eta;
-        params.roi_num_type = primitive->roi_num_type == cldnn::data_types::i32 ?
-                kernel_selector::Datatype::INT32 : kernel_selector::Datatype::INT64;
+        params.roi_num_type = primitive->roi_num_type == cldnn::data_types::i32 ? kernel_selector::Datatype::INT32 : kernel_selector::Datatype::INT64;
 
-        params.inputs.push_back(convert_data_tensor(arg.anchors().get_output_layout()));
-        params.inputs.push_back(convert_data_tensor(arg.deltas().get_output_layout()));
-        params.inputs.push_back(convert_data_tensor(arg.scores().get_output_layout()));
+        for (size_t i = 1; i < impl_param.input_layouts.size(); i++) {
+            params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(i)));
+        }
 
-        params.inputs.push_back(convert_data_tensor(arg.output_rois_scores_node().get_output_layout()));
-        params.inputs.push_back(convert_data_tensor(arg.output_rois_nums_node().get_output_layout()));
+        return {params, optional_params};
+    }
 
-        const auto& kernel_selector = kernel_selector::generate_proposals_kernel_selector::Instance();
-        const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
+    static std::unique_ptr<primitive_impl> create(const generate_proposals_node& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<generate_proposals_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/generic_layer.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/generic_layer.cpp
@@ -119,11 +119,11 @@ struct generic_layer_cpu : typed_primitive_impl<generic_layer> {
     void init_kernels(const kernels_cache&) override {}
 };
 
-static primitive_impl* create(const generic_layer_node& arg, const kernel_impl_params&) {
+static std::unique_ptr<primitive_impl> create(const generic_layer_node& arg, const kernel_impl_params&) {
     if (arg.get_primitive()->generic_params.engine == kernel_selector::generic_kernel_params::Engine::GPU) {
-        return new generic_layer_impl(arg);
+        return make_unique<generic_layer_impl>(arg);
     } else {
-        return new generic_layer_cpu(arg);
+        return make_unique<generic_layer_cpu>(arg);
     }
 }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/grid_sample.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/grid_sample.cpp
@@ -42,6 +42,9 @@ kernel_selector::grid_sample_params::PaddingMode from(GridSampleOp::PaddingMode 
 struct grid_sample_impl : public typed_primitive_impl_ocl<grid_sample> {
     using parent = typed_primitive_impl_ocl<grid_sample>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::grid_sample_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::grid_sample_params, kernel_selector::grid_sample_optional_params>;
+
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -49,28 +52,19 @@ struct grid_sample_impl : public typed_primitive_impl_ocl<grid_sample> {
         return make_unique<grid_sample_impl>(*this);
     }
 
-    static primitive_impl* create(const grid_sample_node& arg, const kernel_impl_params& impl_param) {
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<grid_sample>();
         auto params = get_default_params<kernel_selector::grid_sample_params>(impl_param);
-        auto optional_params =
-            get_default_optional_params<kernel_selector::grid_sample_optional_params>(arg.get_program());
+        auto optional_params = get_default_optional_params<kernel_selector::grid_sample_optional_params>(impl_param.get_program());
 
         const auto grid_layout = impl_param.get_input_layout(1);
         params.inputs.push_back(convert_data_tensor(grid_layout));
 
-        const auto primitive = impl_param.typed_desc<grid_sample>();
         params.align_corners = primitive->attributes.align_corners;
         params.interpolation_mode = from(primitive->attributes.mode);
         params.padding_mode = from(primitive->attributes.padding_mode);
 
-        const auto& kernel_selector = kernel_selector::grid_sample_kernel_selector::Instance();
-        const auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
-
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
-
-        return new grid_sample_impl(arg, best_kernels.front());
+        return {params, optional_params};
     }
 };
 
@@ -86,7 +80,7 @@ attach_grid_sample_impl::attach_grid_sample_impl() {
                     format::bs_fs_yx_bsv32_fsv32,
                     format::bs_fs_yx_bsv32_fsv16};
 
-    implementation_map<grid_sample>::add(impl_types::ocl, grid_sample_impl::create, types, formats);
+    implementation_map<grid_sample>::add(impl_types::ocl, typed_primitive_impl_ocl<grid_sample>::create<grid_sample_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/grn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/grn.cpp
@@ -20,6 +20,8 @@ namespace ocl {
 struct grn_impl : typed_primitive_impl_ocl<grn> {
     using parent = typed_primitive_impl_ocl<grn>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::grn_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::grn_params, kernel_selector::grn_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -28,15 +30,20 @@ struct grn_impl : typed_primitive_impl_ocl<grn> {
     }
 
 public:
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<grn>();
+        auto params = get_default_params<kernel_selector::grn_params>(impl_param);
+        auto optional_params = get_default_optional_params<kernel_selector::grn_optional_params>(impl_param.get_program());
+
+        params.bias = primitive->bias;
+
+        return {params, optional_params};
+    }
+
     static std::unique_ptr<primitive_impl> create(const grn_node& arg, const kernel_impl_params& impl_param) {
-        const auto& prim = arg.get_primitive();
-        auto grn_params = get_default_params<kernel_selector::grn_params>(impl_param);
-        auto grn_optional_params = get_default_optional_params<kernel_selector::grn_optional_params>(arg.get_program());
-
-        grn_params.bias = prim->bias;
-
-        auto& kernel_selector = kernel_selector::grn_kernel_selector::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(grn_params, grn_optional_params);
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<grn_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/grn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/grn.cpp
@@ -36,14 +36,10 @@ public:
         grn_params.bias = prim->bias;
 
         auto& kernel_selector = kernel_selector::grn_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(grn_params, grn_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(grn_params, grn_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto grn = new grn_impl(arg, best_kernels[0]);
+        auto grn = new grn_impl(arg, best_kernel);
 
         return grn;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/grn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/grn.cpp
@@ -39,20 +39,12 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const grn_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<grn_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_grn_impl::attach_grn_impl() {
-    implementation_map<grn>::add(impl_types::ocl, grn_impl::create, {
+    implementation_map<grn>::add(impl_types::ocl, typed_primitive_impl_ocl<grn>::create<grn_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
     });

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/grn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/grn.cpp
@@ -28,7 +28,7 @@ struct grn_impl : typed_primitive_impl_ocl<grn> {
     }
 
 public:
-    static primitive_impl* create(const grn_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const grn_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto grn_params = get_default_params<kernel_selector::grn_params>(impl_param);
         auto grn_optional_params = get_default_optional_params<kernel_selector::grn_optional_params>(arg.get_program());
@@ -38,10 +38,7 @@ public:
         auto& kernel_selector = kernel_selector::grn_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(grn_params, grn_optional_params);
 
-
-        auto grn = new grn_impl(arg, best_kernel);
-
-        return grn;
+        return make_unique<grn_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lrn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lrn.cpp
@@ -23,7 +23,7 @@ struct lrn_impl : typed_primitive_impl_ocl<lrn> {
         return make_unique<lrn_impl>(*this);
     }
 
-    static primitive_impl* create(const lrn_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const lrn_node& arg, const kernel_impl_params& impl_param) {
         const auto& primitive = arg.get_primitive();
         auto lrn_params = get_default_params<kernel_selector::lrn_params>(impl_param);
         auto lrn_optional_params = get_default_optional_params<kernel_selector::lrn_optional_params>(arg.get_program());
@@ -40,10 +40,7 @@ struct lrn_impl : typed_primitive_impl_ocl<lrn> {
         auto& kernel_selector = kernel_selector::lrn_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(lrn_params, lrn_optional_params);
 
-
-        auto lrn = new lrn_impl(arg, best_kernel);
-
-        return lrn;
+        return make_unique<lrn_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lrn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lrn.cpp
@@ -41,20 +41,12 @@ struct lrn_impl : typed_primitive_impl_ocl<lrn> {
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const lrn_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<lrn_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_lrn_impl::attach_lrn_impl() {
-    implementation_map<lrn>::add(impl_types::ocl, lrn_impl::create, {
+    implementation_map<lrn>::add(impl_types::ocl, typed_primitive_impl_ocl<lrn>::create<lrn_impl>, {
         std::make_tuple(data_types::f32, format::yxfb),
         std::make_tuple(data_types::f16, format::yxfb),
         std::make_tuple(data_types::u8, format::yxfb),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lrn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lrn.cpp
@@ -38,14 +38,10 @@ struct lrn_impl : typed_primitive_impl_ocl<lrn> {
                                   : kernel_selector::lrn_mode::ACROSS_CHANNEL;
 
         auto& kernel_selector = kernel_selector::lrn_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(lrn_params, lrn_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(lrn_params, lrn_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto lrn = new lrn_impl(arg, best_kernels[0]);
+        auto lrn = new lrn_impl(arg, best_kernel);
 
         return lrn;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_input.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_input.cpp
@@ -62,14 +62,10 @@ public:
             get_default_weights_bias_optional_params<kernel_selector::lstm_dynamic_input_optional_params>(arg.get_program());
 
         auto& kernel_selector = kernel_selector::lstm_dynamic_input_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(dlstm_input_params, lstm_dynamic_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(dlstm_input_params, lstm_dynamic_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto lstm_dynamic = new lstm_dynamic_input_impl(arg, best_kernels[0]);
+        auto lstm_dynamic = new lstm_dynamic_input_impl(arg, best_kernel);
 
         return lstm_dynamic;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_input.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_input.cpp
@@ -63,20 +63,12 @@ public:
         auto optional_params = get_default_weights_bias_optional_params<kernel_selector::lstm_dynamic_input_optional_params>(impl_param.get_program());
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const lstm_dynamic_input_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<lstm_dynamic_input_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_lstm_dynamic_input_impl::attach_lstm_dynamic_input_impl() {
-    implementation_map<lstm_dynamic_input>::add(impl_types::ocl, lstm_dynamic_input_impl::create, {
+    implementation_map<lstm_dynamic_input>::add(impl_types::ocl, typed_primitive_impl_ocl<lstm_dynamic_input>::create<lstm_dynamic_input_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
     });

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_input.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_input.cpp
@@ -36,7 +36,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const lstm_dynamic_input_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const lstm_dynamic_input_node& arg, const kernel_impl_params& impl_param) {
         auto dlstm_input_params = get_default_params<kernel_selector::lstm_dynamic_input_params>(impl_param);
 
         const auto dyn_len_idx = 1;
@@ -64,10 +64,7 @@ public:
         auto& kernel_selector = kernel_selector::lstm_dynamic_input_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(dlstm_input_params, lstm_dynamic_optional_params);
 
-
-        auto lstm_dynamic = new lstm_dynamic_input_impl(arg, best_kernel);
-
-        return lstm_dynamic;
+        return make_unique<lstm_dynamic_input_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_timeloop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_timeloop.cpp
@@ -18,6 +18,8 @@ namespace ocl {
 struct lstm_dynamic_timeloop_impl : typed_primitive_impl_ocl<lstm_dynamic_timeloop> {
     using parent = typed_primitive_impl_ocl<lstm_dynamic_timeloop>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::lstm_dynamic_timeloop_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::lstm_dynamic_timeloop_params, kernel_selector::lstm_dynamic_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -76,7 +78,7 @@ public:
 
         // finially get best kernel
         auto dlstm_timeloop_optional_params =
-            get_default_optional_params<kernel_selector::lstm_dynamic_optional_params>(arg.get_program());
+            get_default_optional_params<kernel_selector::lstm_dynamic_optional_params>(impl_param.get_program());
 
         auto& kernel_selector = kernel_selector::lstm_dynamic_timeloop_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(dlstm_timeloop_params, dlstm_timeloop_optional_params);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_timeloop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_timeloop.cpp
@@ -79,14 +79,10 @@ public:
             get_default_optional_params<kernel_selector::lstm_dynamic_optional_params>(arg.get_program());
 
         auto& kernel_selector = kernel_selector::lstm_dynamic_timeloop_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(dlstm_timeloop_params, dlstm_timeloop_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(dlstm_timeloop_params, dlstm_timeloop_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto lstm_dynamic = new lstm_dynamic_timeloop_impl(arg, best_kernels[0]);
+        auto lstm_dynamic = new lstm_dynamic_timeloop_impl(arg, best_kernel);
 
         return lstm_dynamic;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_timeloop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_dynamic_timeloop.cpp
@@ -41,7 +41,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const lstm_dynamic_timeloop_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const lstm_dynamic_timeloop_node& arg, const kernel_impl_params& impl_param) {
         auto dlstm_timeloop_params = get_default_params<kernel_selector::lstm_dynamic_timeloop_params>(impl_param);
 
         // dyn length
@@ -81,10 +81,7 @@ public:
         auto& kernel_selector = kernel_selector::lstm_dynamic_timeloop_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(dlstm_timeloop_params, dlstm_timeloop_optional_params);
 
-
-        auto lstm_dynamic = new lstm_dynamic_timeloop_impl(arg, best_kernel);
-
-        return lstm_dynamic;
+        return make_unique<lstm_dynamic_timeloop_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_elt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_elt.cpp
@@ -18,6 +18,8 @@ namespace ocl {
 struct lstm_elt_impl : typed_primitive_impl_ocl<lstm_elt> {
     using parent = typed_primitive_impl_ocl<lstm_elt>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::lstm_elt_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::lstm_elt_params, kernel_selector::lstm_elt_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_elt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_elt.cpp
@@ -80,14 +80,10 @@ public:
         lstm_elt_params.direction = arg.direction();
 
         auto& kernel_selector = kernel_selector::lstm_elt_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(lstm_elt_params, lstm_elt_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(lstm_elt_params, lstm_elt_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto lstm_elt = new lstm_elt_impl(arg, best_kernels[0]);
+        auto lstm_elt = new lstm_elt_impl(arg, best_kernel);
 
         return lstm_elt;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_elt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_elt.cpp
@@ -36,7 +36,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const lstm_elt_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const lstm_elt_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto lstm_elt_params = get_default_params<kernel_selector::lstm_elt_params>(impl_param);
         auto lstm_elt_optional_params =
@@ -82,10 +82,7 @@ public:
         auto& kernel_selector = kernel_selector::lstm_elt_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(lstm_elt_params, lstm_elt_optional_params);
 
-
-        auto lstm_elt = new lstm_elt_impl(arg, best_kernel);
-
-        return lstm_elt;
+        return make_unique<lstm_elt_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_gemm.cpp
@@ -81,14 +81,10 @@ public:
             get_default_optional_params<kernel_selector::lstm_gemm_optional_params>(arg.get_program());
 
         auto& kernel_selector = kernel_selector::lstm_gemm_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(lstm_gemm_params, lstm_gemm_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(lstm_gemm_params, lstm_gemm_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto lstm_gemm = new lstm_gemm_impl(arg, best_kernels[0]);
+        auto lstm_gemm = new lstm_gemm_impl(arg, best_kernel);
 
         return lstm_gemm;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_gemm.cpp
@@ -18,6 +18,8 @@ namespace ocl {
 struct lstm_gemm_impl : typed_primitive_impl_ocl<lstm_gemm> {
     using parent = typed_primitive_impl_ocl<lstm_gemm>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::lstm_gemm_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::lstm_gemm_params, kernel_selector::lstm_gemm_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -78,7 +80,7 @@ public:
         }
 
         auto lstm_gemm_optional_params =
-            get_default_optional_params<kernel_selector::lstm_gemm_optional_params>(arg.get_program());
+            get_default_optional_params<kernel_selector::lstm_gemm_optional_params>(impl_param.get_program());
 
         auto& kernel_selector = kernel_selector::lstm_gemm_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(lstm_gemm_params, lstm_gemm_optional_params);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_gemm.cpp
@@ -39,7 +39,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const lstm_gemm_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const lstm_gemm_node& arg, const kernel_impl_params& impl_param) {
         const auto input_idx = 0;
         const auto weight_idx = 1;
         const auto recurrent_idx = 2;
@@ -83,10 +83,7 @@ public:
         auto& kernel_selector = kernel_selector::lstm_gemm_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(lstm_gemm_params, lstm_gemm_optional_params);
 
-
-        auto lstm_gemm = new lstm_gemm_impl(arg, best_kernel);
-
-        return lstm_gemm;
+        return make_unique<lstm_gemm_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/matrix_nms.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/matrix_nms.cpp
@@ -40,6 +40,8 @@ kernel_selector::matrix_nms_params::sort_result_type from(matrix_nms::sort_resul
 struct matrix_nms_impl : typed_primitive_impl_ocl<matrix_nms> {
     using parent = typed_primitive_impl_ocl<matrix_nms>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::matrix_nms_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::matrix_nms_params, kernel_selector::matrix_nms_optional_params>;
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<matrix_nms_impl>(*this);
@@ -58,10 +60,10 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const matrix_nms_node& node, const kernel_impl_params& impl_param) {
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<matrix_nms>();
         auto params = get_default_params<kernel_selector::matrix_nms_params>(impl_param);
-        auto optional_params =
-            get_default_optional_params<kernel_selector::matrix_nms_optional_params>(node.get_program());
+        auto optional_params = get_default_optional_params<kernel_selector::matrix_nms_optional_params>(impl_param.get_program());
 
         const auto& scores_layout = impl_param.get_input_layout(1);
         const auto& second_output_layout = impl_param.get_input_layout(2);
@@ -71,7 +73,6 @@ public:
         params.inputs.push_back(convert_data_tensor(second_output_layout));
         params.inputs.push_back(convert_data_tensor(third_output_layout));
 
-        const auto& primitive = node.get_primitive();
         params.sort_type = from(primitive->attribs.sort_type);
         params.sort_result_across_batch = primitive->attribs.sort_result_across_batch;
         params.score_threshold = primitive->attribs.score_threshold;
@@ -83,17 +84,7 @@ public:
         params.post_threshold = primitive->attribs.post_threshold;
         params.normalized = primitive->attribs.normalized;
 
-        auto& kernel_selector = kernel_selector::matrix_nms_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
-
-        CLDNN_ERROR_BOOL(node.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this nodeuments");
-
-        auto matrix_nms_node = new matrix_nms_impl(node, best_kernels[0]);
-
-        return matrix_nms_node;
+        return {params, optional_params};
     }
 };
 
@@ -109,7 +100,7 @@ attach_matrix_nms_impl::attach_matrix_nms_impl() {
                     format::bs_fs_yx_bsv32_fsv16,
                     format::bs_fs_yx_bsv32_fsv32};
 
-    implementation_map<matrix_nms>::add(impl_types::ocl, matrix_nms_impl::create, types, formats);
+    implementation_map<matrix_nms>::add(impl_types::ocl, typed_primitive_impl_ocl<matrix_nms>::create<matrix_nms_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/mutable_data.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/mutable_data.cpp
@@ -20,7 +20,9 @@ struct mutable_data_impl : public typed_primitive_impl_ocl<mutable_data> {
     }
 
 public:
-    static primitive_impl* create(mutable_data_node const& arg, const kernel_impl_params&) { return new mutable_data_impl(arg, {}); }
+    static std::unique_ptr<primitive_impl> create(mutable_data_node const& arg, const kernel_impl_params&) {
+        return make_unique<mutable_data_impl>(arg, kernel_selector::kernel_data{});
+    }
 };
 
 namespace detail {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
@@ -28,7 +28,7 @@ struct mvn_impl : typed_primitive_impl_ocl<mvn> {
     }
 
 public:
-    static primitive_impl* create(const mvn_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const mvn_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto mvn_params = get_default_params<kernel_selector::mvn_params>(impl_param);
         auto mvn_optional_params = get_default_optional_params<kernel_selector::mvn_optional_params>(arg.get_program());
@@ -44,10 +44,7 @@ public:
         auto& kernel_selector = kernel_selector::mvn_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(mvn_params, mvn_optional_params);
 
-
-        auto mvn = new mvn_impl(arg, best_kernel);
-
-        return mvn;
+        return make_unique<mvn_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
@@ -29,7 +29,6 @@ struct mvn_impl : typed_primitive_impl_ocl<mvn> {
         return make_unique<mvn_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<mvn>();
         auto params = get_default_params<kernel_selector::mvn_params>(impl_param);
@@ -44,20 +43,12 @@ public:
                                                        : kernel_selector::mvn_eps_mode::OUTSIDE_SQRT;
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const mvn_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<mvn_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_mvn_impl::attach_mvn_impl() {
-    implementation_map<mvn>::add(impl_types::ocl, mvn_impl::create, {
+    implementation_map<mvn>::add(impl_types::ocl, typed_primitive_impl_ocl<mvn>::create<mvn_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
         std::make_tuple(data_types::u8, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
@@ -42,14 +42,10 @@ public:
                                                                      : kernel_selector::mvn_eps_mode::OUTSIDE_SQRT;
 
         auto& kernel_selector = kernel_selector::mvn_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(mvn_params, mvn_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(mvn_params, mvn_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto mvn = new mvn_impl(arg, best_kernels[0]);
+        auto mvn = new mvn_impl(arg, best_kernel);
 
         return mvn;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_max_suppression.cpp
@@ -15,6 +15,8 @@ namespace ocl {
 struct non_max_suppression_impl : typed_primitive_impl_ocl<non_max_suppression> {
     using parent = typed_primitive_impl_ocl<non_max_suppression>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::non_max_suppression_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::non_max_suppression_params, kernel_selector::non_max_suppression_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -56,10 +58,10 @@ protected:
 
 public:
     static std::unique_ptr<primitive_impl> create(const non_max_suppression_node& arg, const kernel_impl_params& impl_param) {
-        const auto& primitive = arg.get_primitive();
+        const auto& primitive = impl_param.typed_desc<non_max_suppression>();
         auto params = get_default_params<kernel_selector::non_max_suppression_params>(impl_param);
         auto optional_params =
-            get_default_optional_params<kernel_selector::non_max_suppression_optional_params>(arg.get_program());
+            get_default_optional_params<kernel_selector::non_max_suppression_optional_params>(impl_param.get_program());
 
         const auto input_scores_idx = 1;
         params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[input_scores_idx]));

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_max_suppression.cpp
@@ -133,14 +133,10 @@ public:
         params.box_encoding = primitive->center_point_box ? kernel_selector::BoxEncodingType::BOX_ENCODING_CENTER
                                                           : kernel_selector::BoxEncodingType::BOX_ENCODING_CORNER;
         auto& kernel_selector = kernel_selector::non_max_suppression_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto non_max_suppression_node = new non_max_suppression_impl(arg, best_kernels[0]);
+        auto non_max_suppression_node = new non_max_suppression_impl(arg, best_kernel);
 
         return non_max_suppression_node;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_max_suppression.cpp
@@ -55,7 +55,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const non_max_suppression_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const non_max_suppression_node& arg, const kernel_impl_params& impl_param) {
         const auto& primitive = arg.get_primitive();
         auto params = get_default_params<kernel_selector::non_max_suppression_params>(impl_param);
         auto optional_params =
@@ -135,10 +135,7 @@ public:
         auto& kernel_selector = kernel_selector::non_max_suppression_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-
-        auto non_max_suppression_node = new non_max_suppression_impl(arg, best_kernel);
-
-        return non_max_suppression_node;
+        return make_unique<non_max_suppression_impl>(arg, best_kernel);
     }
 
 private:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
@@ -27,7 +27,7 @@ struct count_nonzero_impl : typed_primitive_impl_ocl<count_nonzero> {
         return make_unique<count_nonzero_impl>(*this);
     }
 
-    static primitive_impl* create(const count_nonzero_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const count_nonzero_node& arg, const kernel_impl_params& impl_param) {
         auto nonzero_params = get_default_params<kernel_selector::count_nonzero_params>(impl_param);
         auto nonzero_optional_params =
             get_default_optional_params<kernel_selector::count_nonzero_optional_params>(arg.get_program());
@@ -35,9 +35,7 @@ struct count_nonzero_impl : typed_primitive_impl_ocl<count_nonzero> {
         auto& kernel_selector = kernel_selector::count_nonzero_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(nonzero_params, nonzero_optional_params);
 
-        auto count_nonzero = new count_nonzero_impl(arg, best_kernel);
-
-        return count_nonzero;
+        return make_unique<count_nonzero_impl>(arg, best_kernel);
     }
 };
 
@@ -52,7 +50,7 @@ struct gather_nonzero_impl : typed_primitive_impl_ocl<gather_nonzero> {
     }
 
 public:
-    static primitive_impl* create(const gather_nonzero_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const gather_nonzero_node& arg, const kernel_impl_params& impl_param) {
         auto nonzero_params = get_default_params<kernel_selector::gather_nonzero_params>(impl_param);
         auto nonzero_optional_params =
             get_default_optional_params<kernel_selector::gather_nonzero_optional_params>(arg.get_program());
@@ -63,9 +61,7 @@ public:
         auto& kernel_selector = kernel_selector::gather_nonzero_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(nonzero_params, nonzero_optional_params);
 
-        auto gather_nonzero = new gather_nonzero_impl(arg, best_kernel);
-
-        return gather_nonzero;
+        return make_unique<gather_nonzero_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
@@ -33,11 +33,9 @@ struct count_nonzero_impl : typed_primitive_impl_ocl<count_nonzero> {
             get_default_optional_params<kernel_selector::count_nonzero_optional_params>(arg.get_program());
 
         auto& kernel_selector = kernel_selector::count_nonzero_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(nonzero_params, nonzero_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(nonzero_params, nonzero_optional_params);
 
-        OPENVINO_ASSERT(!best_kernels.empty(), "Cannot find a proper kernel for ", arg.id());
-
-        auto count_nonzero = new count_nonzero_impl(arg, best_kernels[0]);
+        auto count_nonzero = new count_nonzero_impl(arg, best_kernel);
 
         return count_nonzero;
     }
@@ -63,11 +61,9 @@ public:
         nonzero_params.ov_input_rank = impl_param.get_input_layout().get_shape().size();
 
         auto& kernel_selector = kernel_selector::gather_nonzero_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(nonzero_params, nonzero_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(nonzero_params, nonzero_optional_params);
 
-        OPENVINO_ASSERT(!best_kernels.empty(), "Cannot find a proper kernel for ", arg.id());
-
-        auto gather_nonzero = new gather_nonzero_impl(arg, best_kernels[0]);
+        auto gather_nonzero = new gather_nonzero_impl(arg, best_kernel);
 
         return gather_nonzero;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
@@ -34,14 +34,6 @@ struct count_nonzero_impl : typed_primitive_impl_ocl<count_nonzero> {
         auto optional_params = get_default_optional_params<kernel_selector::count_nonzero_optional_params>(impl_param.get_program());
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const count_nonzero_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<count_nonzero_impl>(arg, best_kernel);
-    }
 };
 
 struct gather_nonzero_impl : typed_primitive_impl_ocl<gather_nonzero> {
@@ -56,7 +48,6 @@ struct gather_nonzero_impl : typed_primitive_impl_ocl<gather_nonzero> {
         return make_unique<gather_nonzero_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::gather_nonzero_params>(impl_param);
         auto optional_params = get_default_optional_params<kernel_selector::gather_nonzero_optional_params>(impl_param.get_program());
@@ -65,20 +56,12 @@ public:
         params.ov_input_rank = impl_param.get_input_layout().get_shape().size();
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const gather_nonzero_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<gather_nonzero_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_count_nonzero_impl::attach_count_nonzero_impl() {
-    implementation_map<count_nonzero>::add(impl_types::ocl, count_nonzero_impl::create, {
+    implementation_map<count_nonzero>::add(impl_types::ocl, typed_primitive_impl_ocl<count_nonzero>::create<count_nonzero_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
         std::make_tuple(data_types::i32, format::bfyx),
@@ -100,7 +83,7 @@ attach_count_nonzero_impl::attach_count_nonzero_impl() {
 }
 
 attach_gather_nonzero_impl::attach_gather_nonzero_impl() {
-    implementation_map<gather_nonzero>::add(impl_types::ocl, gather_nonzero_impl::create, {
+    implementation_map<gather_nonzero>::add(impl_types::ocl, typed_primitive_impl_ocl<gather_nonzero>::create<gather_nonzero_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
         std::make_tuple(data_types::i32, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/normalize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/normalize.cpp
@@ -53,14 +53,10 @@ public:
         }
 
         auto& kernel_selector = kernel_selector::normalize_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(norm_params, norm_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(norm_params, norm_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto lrn = new normalize_impl(arg, best_kernels[0]);
+        auto lrn = new normalize_impl(arg, best_kernel);
 
         return lrn;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/normalize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/normalize.cpp
@@ -54,14 +54,6 @@ public:
         }
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const normalize_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<normalize_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -78,7 +70,7 @@ attach_normalize_impl::attach_normalize_impl() {
         format::bs_fs_yx_bsv32_fsv32,
         format::bs_fs_yx_bsv32_fsv16,
     };
-    implementation_map<normalize>::add(impl_types::ocl, normalize_impl::create, types, formats);
+    implementation_map<normalize>::add(impl_types::ocl, typed_primitive_impl_ocl<normalize>::create<normalize_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/normalize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/normalize.cpp
@@ -35,7 +35,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const normalize_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const normalize_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto norm_params = get_default_params<kernel_selector::normalize_params>(impl_param);
         auto norm_optional_params =
@@ -55,10 +55,7 @@ public:
         auto& kernel_selector = kernel_selector::normalize_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(norm_params, norm_optional_params);
 
-
-        auto lrn = new normalize_impl(arg, best_kernel);
-
-        return lrn;
+        return make_unique<normalize_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/one_hot.cpp
@@ -40,14 +40,9 @@ struct one_hot_impl : typed_primitive_impl_ocl<one_hot> {
         oh_params.one_hot_limit = output_sizes[oh_params.one_hot_axis];
 
         auto& kernel_selector = kernel_selector::one_hot_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(oh_params, oh_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(oh_params, oh_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with these arguments");
-
-        return new one_hot_impl(arg, best_kernels[0]);
+        return new one_hot_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/one_hot.cpp
@@ -41,20 +41,12 @@ struct one_hot_impl : typed_primitive_impl_ocl<one_hot> {
         params.one_hot_limit = output_sizes[params.one_hot_axis];
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const one_hot_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<one_hot_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_one_hot_impl::attach_one_hot_impl() {
-    implementation_map<one_hot>::add(impl_types::ocl, one_hot_impl::create, {
+    implementation_map<one_hot>::add(impl_types::ocl, typed_primitive_impl_ocl<one_hot>::create<one_hot_impl>, {
         std::make_tuple(data_types::i8, format::bfyx),
         std::make_tuple(data_types::u8, format::bfyx),
         std::make_tuple(data_types::i32, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/one_hot.cpp
@@ -25,7 +25,7 @@ struct one_hot_impl : typed_primitive_impl_ocl<one_hot> {
         return make_unique<one_hot_impl>(*this);
     }
 
-    static primitive_impl* create(const one_hot_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const one_hot_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto oh_params = get_default_params<kernel_selector::one_hot_params>(impl_param, 1);
         auto oh_optional_params =
@@ -42,7 +42,7 @@ struct one_hot_impl : typed_primitive_impl_ocl<one_hot> {
         auto& kernel_selector = kernel_selector::one_hot_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(oh_params, oh_optional_params);
 
-        return new one_hot_impl(arg, best_kernel);
+        return make_unique<one_hot_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
@@ -62,14 +62,9 @@ struct permute_impl : typed_primitive_impl_ocl<permute> {
         auto permute_order = convert_permute_order(prim->permute_order, in_rank);
         permute_params.order = permute_order;
         auto& kernel_selector = kernel_selector::permute_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(permute_params, permute_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(permute_params, permute_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
-
-        auto permute = new permute_impl(arg, best_kernels[0]);
+        auto permute = new permute_impl(arg, best_kernel);
 
         return permute;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
@@ -52,7 +52,7 @@ struct permute_impl : typed_primitive_impl_ocl<permute> {
         return make_unique<permute_impl>(*this);
     }
 
-    static primitive_impl* create(const permute_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const permute_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto permute_params = get_default_params<kernel_selector::permute_params>(impl_param);
         auto permute_optional_params =
@@ -64,9 +64,7 @@ struct permute_impl : typed_primitive_impl_ocl<permute> {
         auto& kernel_selector = kernel_selector::permute_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(permute_params, permute_optional_params);
 
-        auto permute = new permute_impl(arg, best_kernel);
-
-        return permute;
+        return make_unique<permute_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
@@ -65,20 +65,12 @@ struct permute_impl : typed_primitive_impl_ocl<permute> {
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const permute_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<permute_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_permute_impl::attach_permute_impl() {
-    implementation_map<permute>::add(impl_types::ocl, permute_impl::create, {});
+    implementation_map<permute>::add(impl_types::ocl, typed_primitive_impl_ocl<permute>::create<permute_impl>, {});
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/pooling.cpp
@@ -172,14 +172,10 @@ public:
         pp.poolDilation = {dilation_x, dilation_y, dilation_z};
 
         auto& kernel_selector = kernel_selector::pooling_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(pool_params, pool_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(pool_params, pool_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto pool = new pooling_impl(arg, best_kernels[0]);
+        auto pool = new pooling_impl(arg, best_kernel);
 
         return pool;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/pooling.cpp
@@ -72,7 +72,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const pooling_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const pooling_node& arg, const kernel_impl_params& impl_param) {
         validate_args(arg);
         const auto primitive = arg.get_primitive();
         auto pool_params = get_default_params<kernel_selector::pooling_params>(impl_param);
@@ -174,10 +174,7 @@ public:
         auto& kernel_selector = kernel_selector::pooling_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(pool_params, pool_optional_params);
 
-
-        auto pool = new pooling_impl(arg, best_kernel);
-
-        return pool;
+        return make_unique<pooling_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
@@ -85,6 +85,9 @@ struct typed_primitive_impl_ocl : public typed_primitive_impl<PType> {
 
     template<typename ImplType>
     static std::unique_ptr<primitive_impl> create(const typed_program_node<PType>& arg, const kernel_impl_params& impl_param) {
+        if (arg.can_be_optimized()) {
+            return make_unique<ImplType>(arg, kernel_selector::kernel_data{});
+        }
         auto kernel_params = ImplType::get_kernel_params(impl_param);
         auto& kernel_selector = ImplType::kernel_selector_t::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
@@ -83,6 +83,15 @@ struct typed_primitive_impl_ocl : public typed_primitive_impl<PType> {
         ib >> _kernel_args;
     }
 
+    template<typename ImplType>
+    static std::unique_ptr<primitive_impl> create(const typed_program_node<PType>& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = ImplType::get_kernel_params(impl_param);
+        auto& kernel_selector = ImplType::kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
+
+        return make_unique<ImplType>(arg, best_kernel);
+    }
+
 protected:
     virtual bool optimized_out(typed_primitive_inst<PType>&) const { return false; }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/prior_box.cpp
@@ -25,7 +25,7 @@ struct prior_box_impl : typed_primitive_impl_ocl<prior_box> {
         return make_unique<prior_box_impl>(*this);
     }
 
-    static primitive_impl* create(const prior_box_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const prior_box_node& arg, const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::prior_box_params>(impl_param);
         const auto& kernel_selector = kernel_selector::prior_box_kernel_selector::Instance();
         const auto& primitive = arg.get_primitive();
@@ -78,7 +78,8 @@ struct prior_box_impl : typed_primitive_impl_ocl<prior_box> {
 
         params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
         const auto best_kernel = kernel_selector.get_best_kernel(params, kernel_selector::prior_box_optional_params());
-        return new prior_box_impl(arg, best_kernel);
+
+        return make_unique<prior_box_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/prior_box.cpp
@@ -30,7 +30,6 @@ struct prior_box_impl : typed_primitive_impl_ocl<prior_box> {
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<prior_box>();
         auto params = get_default_params<kernel_selector::prior_box_params>(impl_param);
-        const auto& kernel_selector = kernel_selector::prior_box_kernel_selector::Instance();
 
         const auto width = primitive->output_size.spatial[0];
         const auto height = primitive->output_size.spatial[1];
@@ -81,14 +80,6 @@ struct prior_box_impl : typed_primitive_impl_ocl<prior_box> {
         params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(1)));
         return {params, {}};
     }
-
-    static std::unique_ptr<primitive_impl> create(const prior_box_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<prior_box_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -101,7 +92,7 @@ attach_prior_box_impl::attach_prior_box_impl() {
                     format::bs_fs_yx_bsv16_fsv16,
                     format::bs_fs_yx_bsv32_fsv16,
                     format::bs_fs_yx_bsv32_fsv32};
-    implementation_map<prior_box>::add(impl_types::ocl, prior_box_impl::create, types, formats);
+    implementation_map<prior_box>::add(impl_types::ocl, typed_primitive_impl_ocl<prior_box>::create<prior_box_impl>, types, formats);
 }
 }  // namespace detail
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/prior_box.cpp
@@ -77,12 +77,8 @@ struct prior_box_impl : typed_primitive_impl_ocl<prior_box> {
         params.num_priors_4 = output_shape[1] / (params.width * params.height);
 
         params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
-        const auto best_kernels = kernel_selector.GetBestKernels(params, kernel_selector::prior_box_optional_params());
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
-        return new prior_box_impl(arg, best_kernels[0]);
+        const auto best_kernel = kernel_selector.get_best_kernel(params, kernel_selector::prior_box_optional_params());
+        return new prior_box_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/pyramid_roi_align.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/pyramid_roi_align.cpp
@@ -18,6 +18,8 @@ namespace ocl {
 struct pyramid_roi_align_impl : typed_primitive_impl_ocl<pyramid_roi_align> {
     using parent = typed_primitive_impl_ocl<pyramid_roi_align>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::PyramidROIAlign_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::PyramidROIAlign_params, kernel_selector::PyramidROIAlign_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -25,34 +27,38 @@ struct pyramid_roi_align_impl : typed_primitive_impl_ocl<pyramid_roi_align> {
         return make_unique<pyramid_roi_align_impl>(*this);
     }
 
-    static std::unique_ptr<primitive_impl> create(const pyramid_roi_align_node& arg, const kernel_impl_params& impl_param) {
-        auto prim = arg.get_primitive();
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<pyramid_roi_align>();
         auto params = get_default_params<kernel_selector::PyramidROIAlign_params>(impl_param, 1);
-        auto optional_params =
-            get_default_optional_params<kernel_selector::PyramidROIAlign_optional_params>(arg.get_program());
+        auto optional_params = get_default_optional_params<kernel_selector::PyramidROIAlign_optional_params>(impl_param.get_program());
 
         const auto P2_idx = 1;
         const auto P3_idx = 2;
         const auto P4_idx = 3;
         const auto P5_idx = 4;
-        params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[P2_idx]));
-        params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[P3_idx]));
-        params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[P4_idx]));
-        params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[P5_idx]));
+        params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(P2_idx)));
+        params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(P3_idx)));
+        params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(P4_idx)));
+        params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(P5_idx)));
 
-        params.sampling_ratio_x = prim->sampling_ratio;
-        params.sampling_ratio_y = prim->sampling_ratio;
+        params.sampling_ratio_x = primitive->sampling_ratio;
+        params.sampling_ratio_y = primitive->sampling_ratio;
 
-        auto first_layer_scale = prim->pyramid_scales[0];
-        auto image_size_x = impl_param.input_layouts[P2_idx].spatial(0) * first_layer_scale;
-        auto image_size_y = impl_param.input_layouts[P2_idx].spatial(1) * first_layer_scale;
+        auto first_layer_scale = primitive->pyramid_scales[0];
+        auto image_size_x = impl_param.get_input_layout(P2_idx).spatial(0) * first_layer_scale;
+        auto image_size_y = impl_param.get_input_layout(P2_idx).spatial(1) * first_layer_scale;
         params.image_size_x = image_size_x;
         params.image_size_y = image_size_y;
 
-        params.pyramid_starting_level = prim->pyramid_starting_level;
+        params.pyramid_starting_level = primitive->pyramid_starting_level;
 
-        auto& kernel_selector = kernel_selector::PyramidROIAlign_kernel_selector::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
+        return {params, optional_params};
+    }
+
+    static std::unique_ptr<primitive_impl> create(const pyramid_roi_align_node& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<pyramid_roi_align_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/pyramid_roi_align.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/pyramid_roi_align.cpp
@@ -52,14 +52,10 @@ struct pyramid_roi_align_impl : typed_primitive_impl_ocl<pyramid_roi_align> {
         params.pyramid_starting_level = prim->pyramid_starting_level;
 
         auto& kernel_selector = kernel_selector::PyramidROIAlign_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        return new pyramid_roi_align_impl(arg, best_kernels[0]);
+        return new pyramid_roi_align_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/pyramid_roi_align.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/pyramid_roi_align.cpp
@@ -25,7 +25,7 @@ struct pyramid_roi_align_impl : typed_primitive_impl_ocl<pyramid_roi_align> {
         return make_unique<pyramid_roi_align_impl>(*this);
     }
 
-    static primitive_impl* create(const pyramid_roi_align_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const pyramid_roi_align_node& arg, const kernel_impl_params& impl_param) {
         auto prim = arg.get_primitive();
         auto params = get_default_params<kernel_selector::PyramidROIAlign_params>(impl_param, 1);
         auto optional_params =
@@ -54,8 +54,7 @@ struct pyramid_roi_align_impl : typed_primitive_impl_ocl<pyramid_roi_align> {
         auto& kernel_selector = kernel_selector::PyramidROIAlign_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-
-        return new pyramid_roi_align_impl(arg, best_kernel);
+        return make_unique<pyramid_roi_align_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/pyramid_roi_align.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/pyramid_roi_align.cpp
@@ -54,20 +54,12 @@ struct pyramid_roi_align_impl : typed_primitive_impl_ocl<pyramid_roi_align> {
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const pyramid_roi_align_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<pyramid_roi_align_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_pyramid_roi_align_impl::attach_pyramid_roi_align_impl() {
-    implementation_map<pyramid_roi_align>::add(impl_types::ocl, pyramid_roi_align_impl::create, {
+    implementation_map<pyramid_roi_align>::add(impl_types::ocl, typed_primitive_impl_ocl<pyramid_roi_align>::create<pyramid_roi_align_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f32, format::yxfb),
         std::make_tuple(data_types::f32, format::byxf),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
@@ -83,14 +83,10 @@ public:
         quantize_params.outputs = { convert_data_tensor(output_layout) };
 
         auto& kernel_selector = kernel_selector::quantize_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(quantize_params, quantize_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(quantize_params, quantize_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto quantize = new quantize_impl(arg, best_kernels[0]);
+        auto quantize = new quantize_impl(arg, best_kernel);
 
         return quantize;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
@@ -45,7 +45,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const quantize_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const quantize_node& arg, const kernel_impl_params& impl_param) {
         auto quantize_params = get_default_params<kernel_selector::quantize_params>(impl_param);
         auto quantize_optional_params =
             get_default_optional_params<kernel_selector::quantize_optional_params>(arg.get_program());
@@ -85,10 +85,7 @@ public:
         auto& kernel_selector = kernel_selector::quantize_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(quantize_params, quantize_optional_params);
 
-
-        auto quantize = new quantize_impl(arg, best_kernel);
-
-        return quantize;
+        return make_unique<quantize_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
@@ -18,6 +18,8 @@ namespace ocl {
 struct quantize_impl : typed_primitive_impl_ocl<quantize> {
     using parent = typed_primitive_impl_ocl<quantize>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::quantize_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::quantize_params, kernel_selector::quantize_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -48,7 +50,7 @@ public:
     static std::unique_ptr<primitive_impl> create(const quantize_node& arg, const kernel_impl_params& impl_param) {
         auto quantize_params = get_default_params<kernel_selector::quantize_params>(impl_param);
         auto quantize_optional_params =
-            get_default_optional_params<kernel_selector::quantize_optional_params>(arg.get_program());
+            get_default_optional_params<kernel_selector::quantize_optional_params>(impl_param.get_program());
 
         quantize_params.levels = arg.get_levels();
         quantize_params.packed_binary_output = arg.get_packed_binary_output();

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/random_uniform.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/random_uniform.cpp
@@ -26,19 +26,13 @@ struct random_uniform_impl : typed_primitive_impl_ocl<random_uniform> {
     static primitive_impl *create(const random_uniform_node &arg, const kernel_impl_params& impl_param) {
         const auto &primitive = arg.get_primitive();
         auto params = get_default_params<kernel_selector::random_uniform_params>(impl_param);
-        auto &random_uniform_kernel_selector =
-                kernel_selector::random_uniform_kernel_selector::Instance();
+        auto& kernel_selector = kernel_selector::random_uniform_kernel_selector::Instance();
         params.global_seed = primitive->global_seed;
         params.op_seed = primitive->op_seed;
         params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
         params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[2]));
-        auto best_kernels = random_uniform_kernel_selector.GetBestKernels(params,
-                                                                          kernel_selector::random_uniform_optional_params());
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
-        return new random_uniform_impl(arg, best_kernels[0]);
+        auto best_kernel = kernel_selector.get_best_kernel(params, kernel_selector::random_uniform_optional_params());
+        return new random_uniform_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/random_uniform.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/random_uniform.cpp
@@ -23,7 +23,7 @@ struct random_uniform_impl : typed_primitive_impl_ocl<random_uniform> {
         return make_unique<random_uniform_impl>(*this);
     }
 
-    static primitive_impl *create(const random_uniform_node &arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const random_uniform_node &arg, const kernel_impl_params& impl_param) {
         const auto &primitive = arg.get_primitive();
         auto params = get_default_params<kernel_selector::random_uniform_params>(impl_param);
         auto& kernel_selector = kernel_selector::random_uniform_kernel_selector::Instance();
@@ -32,7 +32,8 @@ struct random_uniform_impl : typed_primitive_impl_ocl<random_uniform> {
         params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
         params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[2]));
         auto best_kernel = kernel_selector.get_best_kernel(params, kernel_selector::random_uniform_optional_params());
-        return new random_uniform_impl(arg, best_kernel);
+
+        return make_unique<random_uniform_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/random_uniform.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/random_uniform.cpp
@@ -35,20 +35,12 @@ struct random_uniform_impl : typed_primitive_impl_ocl<random_uniform> {
 
         return {params, {}};
     }
-
-    static std::unique_ptr<primitive_impl> create(const random_uniform_node &arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<random_uniform_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_random_uniform_impl::attach_random_uniform_impl() {
-    implementation_map<random_uniform>::add(impl_types::ocl, random_uniform_impl::create, {
+    implementation_map<random_uniform>::add(impl_types::ocl, typed_primitive_impl_ocl<random_uniform>::create<random_uniform_impl>, {
             std::make_tuple(data_types::f16, format::bfyx),
             std::make_tuple(data_types::f16, format::bfzyx),
             std::make_tuple(data_types::f16, format::bfwzyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
@@ -30,14 +30,9 @@ struct range_impl : typed_primitive_impl_ocl<range> {
             get_default_optional_params<kernel_selector::range_optional_params>(arg.get_program());
 
         auto& kernel_selector = kernel_selector::range_instance();
-        auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
-
-        return new range_impl{arg, best_kernels.front()};
+        return new range_impl{arg, best_kernel};
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
@@ -14,7 +14,10 @@ namespace cldnn {
 namespace ocl {
 
 struct range_impl : typed_primitive_impl_ocl<range> {
-    using typed_primitive_impl_ocl::typed_primitive_impl_ocl;
+    using parent = typed_primitive_impl_ocl<range>;
+    using parent::parent;
+    using kernel_selector_t = kernel_selector::range_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::range_params, kernel_selector::range_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -22,15 +25,20 @@ struct range_impl : typed_primitive_impl_ocl<range> {
         return make_unique<range_impl>(*this);
     }
 
-    static std::unique_ptr<primitive_impl> create(const range_node& arg, const kernel_impl_params& impl_param) {
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<range>();
         auto params = get_default_params<kernel_selector::range_params>(impl_param);
         for (int i : {1, 2})
-            params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[i]));
-        auto optional_params =
-            get_default_optional_params<kernel_selector::range_optional_params>(arg.get_program());
+            params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(i)));
+        auto optional_params = get_default_optional_params<kernel_selector::range_optional_params>(impl_param.get_program());
 
-        auto& kernel_selector = kernel_selector::range_instance();
-        auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
+        return {params, optional_params};
+    }
+
+    static std::unique_ptr<primitive_impl> create(const range_node& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<range_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
@@ -22,7 +22,7 @@ struct range_impl : typed_primitive_impl_ocl<range> {
         return make_unique<range_impl>(*this);
     }
 
-    static primitive_impl* create(const range_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const range_node& arg, const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::range_params>(impl_param);
         for (int i : {1, 2})
             params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[i]));
@@ -32,7 +32,7 @@ struct range_impl : typed_primitive_impl_ocl<range> {
         auto& kernel_selector = kernel_selector::range_instance();
         auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        return new range_impl{arg, best_kernel};
+        return make_unique<range_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
@@ -34,14 +34,6 @@ struct range_impl : typed_primitive_impl_ocl<range> {
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const range_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<range_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -49,7 +41,7 @@ namespace detail {
 attach_range_impl::attach_range_impl() {
     implementation_map<range>::add(
         impl_types::ocl,
-        range_impl::create,
+        typed_primitive_impl_ocl<range>::create<range_impl>,
         {
             std::make_tuple(data_types::u8, format::bfyx),
             std::make_tuple(data_types::i8, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reduce.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reduce.cpp
@@ -78,7 +78,6 @@ struct reduce_impl : typed_primitive_impl_ocl<reduce> {
         return make_unique<reduce_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<reduce>();
         auto params = get_default_params<kernel_selector::reduce_params>(impl_param);
@@ -90,20 +89,12 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const reduce_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<reduce_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_reduce_impl::attach_reduce_impl() {
-    implementation_map<reduce>::add(impl_types::ocl, reduce_impl::create, {
+    implementation_map<reduce>::add(impl_types::ocl, typed_primitive_impl_ocl<reduce>::create<reduce_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
         std::make_tuple(data_types::i32, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reduce.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reduce.cpp
@@ -87,12 +87,10 @@ public:
         reduce_params.reduceMode = cldnn_2_reduce_mode(prim->mode);
 
         auto& kernel_selector = kernel_selector::reduce_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(reduce_params, reduce_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(reduce_params, reduce_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(), "Best_kernel.empty()", best_kernels.empty(), "Cannot find a proper kernel with this arguments");
-
-        auto reduce = new reduce_impl(arg, best_kernels[0]);
-        reduce->can_reuse_memory = best_kernels[0].can_reuse_memory;
+        auto reduce = new reduce_impl(arg, best_kernel);
+        reduce->can_reuse_memory = best_kernel.can_reuse_memory;
 
         return reduce;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reduce.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reduce.cpp
@@ -77,7 +77,7 @@ struct reduce_impl : typed_primitive_impl_ocl<reduce> {
     }
 
 public:
-    static primitive_impl* create(const reduce_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const reduce_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto reduce_params = get_default_params<kernel_selector::reduce_params>(impl_param);
         auto reduce_optional_params = get_default_optional_params<kernel_selector::reduce_optional_params>(arg.get_program());
@@ -89,10 +89,7 @@ public:
         auto& kernel_selector = kernel_selector::reduce_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(reduce_params, reduce_optional_params);
 
-        auto reduce = new reduce_impl(arg, best_kernel);
-        reduce->can_reuse_memory = best_kernel.can_reuse_memory;
-
-        return reduce;
+        return make_unique<reduce_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/region_yolo.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/region_yolo.cpp
@@ -38,20 +38,12 @@ struct region_yolo_impl : typed_primitive_impl_ocl<region_yolo> {
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const region_yolo_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<region_yolo_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_region_yolo_impl::attach_region_yolo_impl() {
-    implementation_map<region_yolo>::add(impl_types::ocl, region_yolo_impl::create, {
+    implementation_map<region_yolo>::add(impl_types::ocl, typed_primitive_impl_ocl<region_yolo>::create<region_yolo_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
         std::make_tuple(data_types::f32, format::byxf),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/region_yolo.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/region_yolo.cpp
@@ -36,14 +36,10 @@ struct region_yolo_impl : typed_primitive_impl_ocl<region_yolo> {
         ry_params.mask_size = primitive->mask_size;
 
         auto& kernel_selector = kernel_selector::region_yolo_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(ry_params, ry_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(ry_params, ry_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto region_yolo_node = new region_yolo_impl(arg, best_kernels[0]);
+        auto region_yolo_node = new region_yolo_impl(arg, best_kernel);
 
         return region_yolo_node;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/region_yolo.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/region_yolo.cpp
@@ -23,7 +23,7 @@ struct region_yolo_impl : typed_primitive_impl_ocl<region_yolo> {
         return make_unique<region_yolo_impl>(*this);
     }
 
-    static primitive_impl* create(const region_yolo_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const region_yolo_node& arg, const kernel_impl_params& impl_param) {
         auto ry_params = get_default_params<kernel_selector::region_yolo_params>(impl_param);
         auto ry_optional_params =
             get_default_optional_params<kernel_selector::region_yolo_optional_params>(arg.get_program());
@@ -38,10 +38,7 @@ struct region_yolo_impl : typed_primitive_impl_ocl<region_yolo> {
         auto& kernel_selector = kernel_selector::region_yolo_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(ry_params, ry_optional_params);
 
-
-        auto region_yolo_node = new region_yolo_impl(arg, best_kernel);
-
-        return region_yolo_node;
+        return make_unique<region_yolo_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
@@ -135,14 +135,6 @@ public:
         return {params, optional_params};
     }
 
-    static std::unique_ptr<primitive_impl> create(const reorder_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<reorder_impl>(arg, best_kernel);
-    }
-
 private:
     bool _can_be_optimized;
     bool _has_mean;
@@ -151,7 +143,7 @@ private:
 namespace detail {
 
 attach_reorder_impl::attach_reorder_impl() {
-    implementation_map<reorder>::add(impl_types::ocl, reorder_impl::create, {});
+    implementation_map<reorder>::add(impl_types::ocl, typed_primitive_impl_ocl<reorder>::create<reorder_impl>, {});
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
@@ -72,7 +72,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const reorder_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const reorder_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto&& output_layout = impl_param.output_layout;
         auto reorder_params = get_default_params<kernel_selector::reorder_params>(impl_param);
@@ -134,10 +134,7 @@ public:
         auto& kernel_selector = kernel_selector::reorder_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(reorder_params, reorder_optional_params);
 
-
-        auto reorder = new reorder_impl(arg, best_kernel);
-
-        return reorder;
+        return make_unique<reorder_impl>(arg, best_kernel);
     }
 
 private:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
@@ -16,6 +16,8 @@ namespace ocl {
 struct reorder_impl : typed_primitive_impl_ocl<reorder> {
     using parent = typed_primitive_impl_ocl<reorder>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::reorder_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::reorder_params, kernel_selector::reorder_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -72,67 +74,71 @@ protected:
     }
 
 public:
-    static std::unique_ptr<primitive_impl> create(const reorder_node& arg, const kernel_impl_params& impl_param) {
-        const auto& prim = arg.get_primitive();
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<reorder>();
         auto&& output_layout = impl_param.output_layout;
-        auto reorder_params = get_default_params<kernel_selector::reorder_params>(impl_param);
-        auto reorder_optional_params =
-            get_default_optional_params<kernel_selector::reorder_optional_params>(arg.get_program());
+        auto params = get_default_params<kernel_selector::reorder_params>(impl_param);
+        auto optional_params = get_default_optional_params<kernel_selector::reorder_optional_params>(impl_param.get_program());
 
-        for (size_t i = 1; i < arg.inputs_count(); i++) {
-            reorder_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[i]));
+        auto inputs_count = primitive->input.size();
+        bool has_mean = !primitive->mean.empty();
+        for (size_t i = 1; i < inputs_count; i++) {
+            params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(i)));
         }
         if (impl_param.output_layout.data_padding) {
-            reorder_params.has_padded_output = true;
+            params.has_padded_output = true;
         }
 
-        if (arg.has_mean()) {
-            if (impl_param.input_layouts[0].format == cldnn::format::nv12) {
-                const auto& mean_layout = arg.mean_nv12().get_output_layout();
-                reorder_params.mean = convert_data_tensor(mean_layout);
-                reorder_params.mode = kernel_selector::mean_subtruct_mode::IN_BUFFER;
+        if (has_mean) {
+            if (impl_param.get_input_layout(0).format == cldnn::format::nv12) {
+                const auto& mean_layout = impl_param.get_input_layout(2);
+                params.mean = convert_data_tensor(mean_layout);
+                params.mode = kernel_selector::mean_subtruct_mode::IN_BUFFER;
             } else {
                 const auto mean_idx = 1;
-                const auto& mean_layout = impl_param.input_layouts[mean_idx];
-                reorder_params.mean = convert_data_tensor(mean_layout);
-                reorder_params.mode = kernel_selector::mean_subtruct_mode::IN_BUFFER;
+                const auto& mean_layout = impl_param.get_input_layout(mean_idx);
+                params.mean = convert_data_tensor(mean_layout);
+                params.mode = kernel_selector::mean_subtruct_mode::IN_BUFFER;
             }
-        } else if (prim->subtract_per_feature.empty() == false) {
-            reorder_params.mode = kernel_selector::mean_subtruct_mode::INSIDE_PARAMS;
-            reorder_params.meanValues = prim->subtract_per_feature;
+        } else if (primitive->subtract_per_feature.empty() == false) {
+            params.mode = kernel_selector::mean_subtruct_mode::INSIDE_PARAMS;
+            params.meanValues = primitive->subtract_per_feature;
         } else {
-            reorder_params.mode = kernel_selector::mean_subtruct_mode::NONE;
+            params.mode = kernel_selector::mean_subtruct_mode::NONE;
         }
 
-        if (reorder_params.mode != kernel_selector::mean_subtruct_mode::NONE) {
-            switch (prim->mean_mode) {
+        if (params.mode != kernel_selector::mean_subtruct_mode::NONE) {
+            switch (primitive->mean_mode) {
                 case reorder_mean_mode::none:
-                    reorder_params.mean_op = kernel_selector::mean_op::NONE;
+                    params.mean_op = kernel_selector::mean_op::NONE;
                     break;
                 case reorder_mean_mode::mul:
-                    reorder_params.mean_op = kernel_selector::mean_op::MUL;
+                    params.mean_op = kernel_selector::mean_op::MUL;
                     break;
                 case reorder_mean_mode::subtract:
-                    reorder_params.mean_op = kernel_selector::mean_op::SUB;
+                    params.mean_op = kernel_selector::mean_op::SUB;
                     break;
                 case reorder_mean_mode::div:
-                    reorder_params.mean_op = kernel_selector::mean_op::DIV;
+                    params.mean_op = kernel_selector::mean_op::DIV;
                     break;
-                default:
-                    throw std::out_of_range(arg.id() + ": unsupported mean_mode value.");
+                default: OPENVINO_ASSERT(false, "[GPU] Unsupported mean_mode value in primitive ", primitive->id);
             }
         }
 
         if (output_layout.format == format::winograd_2x3_s1_data) {
-            reorder_params.winograd_input_offset_x = 0;
-            reorder_params.winograd_input_offset_y = 0;
-            reorder_params.winograd_nr_tiles_x = ceil_div(output_layout.spatial(0), 4);
+            params.winograd_input_offset_x = 0;
+            params.winograd_input_offset_y = 0;
+            params.winograd_nr_tiles_x = ceil_div(output_layout.spatial(0), 4);
         }
 
-        reorder_params.winograd = impl_param.input_layouts[0].format.is_winograd() || output_layout.format.is_winograd();
+        params.winograd = impl_param.input_layouts[0].format.is_winograd() || output_layout.format.is_winograd();
+        return {params, optional_params};
+    }
 
-        auto& kernel_selector = kernel_selector::reorder_kernel_selector::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(reorder_params, reorder_optional_params);
+    static std::unique_ptr<primitive_impl> create(const reorder_node& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<reorder_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
@@ -132,14 +132,10 @@ public:
         reorder_params.winograd = impl_param.input_layouts[0].format.is_winograd() || output_layout.format.is_winograd();
 
         auto& kernel_selector = kernel_selector::reorder_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(reorder_params, reorder_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(reorder_params, reorder_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto reorder = new reorder_impl(arg, best_kernels[0]);
+        auto reorder = new reorder_impl(arg, best_kernel);
 
         return reorder;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorg_yolo.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorg_yolo.cpp
@@ -32,14 +32,10 @@ struct reorg_yolo_impl : typed_primitive_impl_ocl<reorg_yolo> {
         ry_params.stride = primitive->stride;
 
         auto& kernel_selector = kernel_selector::reorg_yolo_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(ry_params, ry_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(ry_params, ry_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto reorg_yolo_node = new reorg_yolo_impl(arg, best_kernels[0]);
+        auto reorg_yolo_node = new reorg_yolo_impl(arg, best_kernel);
 
         return reorg_yolo_node;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorg_yolo.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorg_yolo.cpp
@@ -16,6 +16,8 @@ namespace ocl {
 struct reorg_yolo_impl : typed_primitive_impl_ocl<reorg_yolo> {
     using parent = typed_primitive_impl_ocl<reorg_yolo>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::reorg_yolo_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::reorg_yolo_params, kernel_selector::reorg_yolo_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -23,16 +25,19 @@ struct reorg_yolo_impl : typed_primitive_impl_ocl<reorg_yolo> {
         return make_unique<reorg_yolo_impl>(*this);
     }
 
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<reorg_yolo>();
+        auto params = get_default_params<kernel_selector::reorg_yolo_params>(impl_param);
+        auto optional_params = get_default_optional_params<kernel_selector::reorg_yolo_optional_params>(impl_param.get_program());
+
+        params.stride = primitive->stride;
+        return {params, optional_params};
+    }
+
     static std::unique_ptr<primitive_impl> create(const reorg_yolo_node& arg, const kernel_impl_params& impl_param) {
-        const auto& primitive = arg.get_primitive();
-        auto ry_params = get_default_params<kernel_selector::reorg_yolo_params>(impl_param);
-        auto ry_optional_params =
-            get_default_optional_params<kernel_selector::reorg_yolo_optional_params>(arg.get_program());
-
-        ry_params.stride = primitive->stride;
-
-        auto& kernel_selector = kernel_selector::reorg_yolo_kernel_selector::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(ry_params, ry_optional_params);
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<reorg_yolo_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorg_yolo.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorg_yolo.cpp
@@ -33,14 +33,6 @@ struct reorg_yolo_impl : typed_primitive_impl_ocl<reorg_yolo> {
         params.stride = primitive->stride;
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const reorg_yolo_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<reorg_yolo_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -58,7 +50,7 @@ attach_reorg_yolo_impl::attach_reorg_yolo_impl() {
         format::bs_fs_yx_bsv32_fsv32,
     };
 
-    implementation_map<reorg_yolo>::add(impl_types::ocl, reorg_yolo_impl::create, types, formats);
+    implementation_map<reorg_yolo>::add(impl_types::ocl, typed_primitive_impl_ocl<reorg_yolo>::create<reorg_yolo_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorg_yolo.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorg_yolo.cpp
@@ -23,7 +23,7 @@ struct reorg_yolo_impl : typed_primitive_impl_ocl<reorg_yolo> {
         return make_unique<reorg_yolo_impl>(*this);
     }
 
-    static primitive_impl* create(const reorg_yolo_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const reorg_yolo_node& arg, const kernel_impl_params& impl_param) {
         const auto& primitive = arg.get_primitive();
         auto ry_params = get_default_params<kernel_selector::reorg_yolo_params>(impl_param);
         auto ry_optional_params =
@@ -34,10 +34,7 @@ struct reorg_yolo_impl : typed_primitive_impl_ocl<reorg_yolo> {
         auto& kernel_selector = kernel_selector::reorg_yolo_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(ry_params, ry_optional_params);
 
-
-        auto reorg_yolo_node = new reorg_yolo_impl(arg, best_kernel);
-
-        return reorg_yolo_node;
+        return make_unique<reorg_yolo_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
@@ -165,14 +165,10 @@ struct resample_impl : typed_primitive_impl_ocl<resample> {
         }
 
         auto& kernel_selector = kernel_selector::resample_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(us_params, us_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(us_params, us_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto resample = new resample_impl(arg, best_kernels[0]);
+        auto resample = new resample_impl(arg, best_kernel);
 
         return resample;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
@@ -135,7 +135,7 @@ struct resample_impl : typed_primitive_impl_ocl<resample> {
         return make_unique<resample_impl>(*this);
     }
 
-    static primitive_impl* create(const resample_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const resample_node& arg, const kernel_impl_params& impl_param) {
         const auto& primitive = arg.get_primitive();
         auto us_params = get_default_params<kernel_selector::resample_params>(impl_param);
         auto us_optional_params =
@@ -167,10 +167,7 @@ struct resample_impl : typed_primitive_impl_ocl<resample> {
         auto& kernel_selector = kernel_selector::resample_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(us_params, us_optional_params);
 
-
-        auto resample = new resample_impl(arg, best_kernel);
-
-        return resample;
+        return make_unique<resample_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
@@ -167,14 +167,6 @@ struct resample_impl : typed_primitive_impl_ocl<resample> {
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const resample_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<resample_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -209,7 +201,7 @@ attach_resample_impl::attach_resample_impl() {
     keys.emplace(data_types::f16, format::yxfb);
     keys.emplace(data_types::f16, format::fs_b_yx_fsv32);
 
-    implementation_map<resample>::add(impl_types::ocl, resample_impl::create, keys);
+    implementation_map<resample>::add(impl_types::ocl, typed_primitive_impl_ocl<resample>::create<resample_impl>, keys);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reshape.cpp
@@ -33,14 +33,10 @@ public:
             get_default_optional_params<kernel_selector::reshape_optional_params>(arg.get_program());
 
         auto& kernel_selector = kernel_selector::reshape_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(reorder_params, reorder_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(reorder_params, reorder_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto reshape = new reshape_impl(arg, best_kernels[0]);
+        auto reshape = new reshape_impl(arg, best_kernel);
 
         return reshape;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reshape.cpp
@@ -24,9 +24,9 @@ struct reshape_impl : public typed_primitive_impl_ocl<reshape> {
     }
 
 public:
-    static primitive_impl* create(reshape_node const& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(reshape_node const& arg, const kernel_impl_params& impl_param) {
         if (arg.can_be_optimized()) {
-            return new reshape_impl(arg, {});
+            return make_unique<reshape_impl>(arg, kernel_selector::kernel_data{});
         }
         auto reorder_params = get_default_params<kernel_selector::reshape_params>(impl_param);
         auto reorder_optional_params =
@@ -35,10 +35,7 @@ public:
         auto& kernel_selector = kernel_selector::reshape_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(reorder_params, reorder_optional_params);
 
-
-        auto reshape = new reshape_impl(arg, best_kernel);
-
-        return reshape;
+        return make_unique<reshape_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reshape.cpp
@@ -25,31 +25,18 @@ struct reshape_impl : public typed_primitive_impl_ocl<reshape> {
         return make_unique<reshape_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::reshape_params>(impl_param);
         auto optional_params = get_default_optional_params<kernel_selector::reshape_optional_params>(impl_param.get_program());
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(reshape_node const& arg, const kernel_impl_params& impl_param) {
-        if (arg.can_be_optimized()) {
-            return make_unique<reshape_impl>(arg, kernel_selector::kernel_data{});
-        }
-
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<reshape_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_reshape_impl::attach_reshape_impl() {
-    implementation_map<reshape>::add(impl_types::ocl, reshape_impl::create, {});
+    implementation_map<reshape>::add(impl_types::ocl, typed_primitive_impl_ocl<reshape>::create<reshape_impl>, {});
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reverse.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reverse.cpp
@@ -27,7 +27,6 @@ struct reverse_impl : typed_primitive_impl_ocl<reverse> {
         return make_unique<reverse_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<reverse>();
         auto params = get_default_params<kernel_selector::reverse_params>(impl_param);
@@ -37,14 +36,6 @@ public:
         params.reverseMode = primitive->mode == reverse_mode::index ? kernel_selector::reverse_mode::index
                                                                     : kernel_selector::reverse_mode::mask;
         return {params, optional_params};
-    }
-
-    static std::unique_ptr<primitive_impl> create(const reverse_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<reverse_impl>(arg, best_kernel);
     }
 };
 
@@ -77,7 +68,7 @@ attach_reverse_impl::attach_reverse_impl() {
             keys.emplace(t, f);
         }
     }
-    implementation_map<reverse>::add(impl_types::ocl, reverse_impl::create, keys);
+    implementation_map<reverse>::add(impl_types::ocl, typed_primitive_impl_ocl<reverse>::create<reverse_impl>, keys);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reverse.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reverse.cpp
@@ -26,7 +26,7 @@ struct reverse_impl : typed_primitive_impl_ocl<reverse> {
     }
 
 public:
-    static primitive_impl* create(const reverse_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const reverse_node& arg, const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::reverse_params>(impl_param);
         const auto optional_params =
             get_default_optional_params<kernel_selector::reverse_optional_params>(arg.get_program());
@@ -38,10 +38,7 @@ public:
         const auto& kernel_selector = kernel_selector::reverse_kernel_selector::Instance();
         const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-
-        auto reverse = new reverse_impl(arg, best_kernel);
-
-        return reverse;
+        return make_unique<reverse_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reverse.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reverse.cpp
@@ -36,14 +36,10 @@ public:
                                                                               : kernel_selector::reverse_mode::mask;
 
         const auto& kernel_selector = kernel_selector::reverse_kernel_selector::Instance();
-        const auto best_kernels = kernel_selector.GetBestKernels(params, optional_params);
+        const auto best_kernel = kernel_selector.get_best_kernel(params, optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto reverse = new reverse_impl(arg, best_kernels[0]);
+        auto reverse = new reverse_impl(arg, best_kernel);
 
         return reverse;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reverse_sequence.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reverse_sequence.cpp
@@ -25,7 +25,7 @@ struct reverse_sequence_impl : typed_primitive_impl_ocl<reverse_sequence> {
     }
 
 public:
-    static primitive_impl* create(const reverse_sequence_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const reverse_sequence_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto reverse_sequence_params = get_default_params<kernel_selector::reverse_sequence_params>(impl_param);
         auto reverse_sequence_optional_params =
@@ -39,10 +39,7 @@ public:
         auto& kernel_selector = kernel_selector::reverse_sequence_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(reverse_sequence_params, reverse_sequence_optional_params);
 
-
-        auto reverse_sequence = new reverse_sequence_impl(arg, best_kernel);
-
-        return reverse_sequence;
+        return make_unique<reverse_sequence_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reverse_sequence.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reverse_sequence.cpp
@@ -26,7 +26,6 @@ struct reverse_sequence_impl : typed_primitive_impl_ocl<reverse_sequence> {
         return make_unique<reverse_sequence_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<reverse_sequence>();
         auto params = get_default_params<kernel_selector::reverse_sequence_params>(impl_param);
@@ -39,20 +38,12 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const reverse_sequence_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<reverse_sequence_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_reverse_sequence_impl::attach_reverse_sequence_impl() {
-    implementation_map<reverse_sequence>::add(impl_types::ocl, reverse_sequence_impl::create, {
+    implementation_map<reverse_sequence>::add(impl_types::ocl, typed_primitive_impl_ocl<reverse_sequence>::create<reverse_sequence_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
         std::make_tuple(data_types::i32, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reverse_sequence.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reverse_sequence.cpp
@@ -37,14 +37,10 @@ public:
         reverse_sequence_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
 
         auto& kernel_selector = kernel_selector::reverse_sequence_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(reverse_sequence_params, reverse_sequence_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(reverse_sequence_params, reverse_sequence_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto reverse_sequence = new reverse_sequence_impl(arg, best_kernels[0]);
+        auto reverse_sequence = new reverse_sequence_impl(arg, best_kernel);
 
         return reverse_sequence;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roi_align.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roi_align.cpp
@@ -89,14 +89,10 @@ public:
         roi_align_params.spatial_scale = primitive->spatial_scale;
 
         auto& kernel_selector = kernel_selector::roi_align_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(roi_align_params, roi_align_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(roi_align_params, roi_align_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto roi_align = new roi_align_impl(arg, best_kernels[0]);
+        auto roi_align = new roi_align_impl(arg, best_kernel);
 
         return roi_align;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roi_align.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roi_align.cpp
@@ -64,9 +64,6 @@ public:
         const auto& input_layout = impl_param.get_input_layout(0);
         const auto& rois_layout = impl_param.get_input_layout(1);
         const auto& batches_layout = impl_param.get_input_layout(2);
-        const auto& output_layout = impl_param.output_layout;
-
-        const auto padding_filling_value = output_layout.data_padding.filling_value();
 
         auto params = get_default_params<kernel_selector::roi_align_params>(impl_param);
         auto optional_params = get_default_optional_params<kernel_selector::roi_align_optional_params>(impl_param.get_program());
@@ -79,14 +76,6 @@ public:
         params.spatial_scale = primitive->spatial_scale;
 
         return {params, optional_params};
-    }
-
-    static std::unique_ptr<primitive_impl> create(const roi_align_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<roi_align_impl>(arg, best_kernel);
     }
 };
 
@@ -102,7 +91,7 @@ attach_roi_align_impl::attach_roi_align_impl() {
                     format::bs_fs_yx_bsv32_fsv16,
                     format::bs_fs_yx_bsv32_fsv32};
 
-    implementation_map<roi_align>::add(impl_types::ocl, roi_align_impl::create, types, formats);
+    implementation_map<roi_align>::add(impl_types::ocl, typed_primitive_impl_ocl<roi_align>::create<roi_align_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roi_align.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roi_align.cpp
@@ -57,7 +57,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const roi_align_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const roi_align_node& arg, const kernel_impl_params& impl_param) {
         const auto& input_layout = impl_param.input_layouts[0];
         const auto& output_layout = impl_param.output_layout;
         const auto& rois_layout = impl_param.input_layouts[1];
@@ -91,10 +91,7 @@ public:
         auto& kernel_selector = kernel_selector::roi_align_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(roi_align_params, roi_align_optional_params);
 
-
-        auto roi_align = new roi_align_impl(arg, best_kernel);
-
-        return roi_align;
+        return make_unique<roi_align_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roi_pooling.cpp
@@ -61,7 +61,7 @@ protected:
     }
 
 public:
-    static primitive_impl* create(const roi_pooling_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const roi_pooling_node& arg, const kernel_impl_params& impl_param) {
         const auto& input_layout = impl_param.input_layouts[0];
         const auto& output_layout = impl_param.output_layout;
         const auto& rois_layout = impl_param.input_layouts[1];
@@ -102,10 +102,7 @@ public:
         auto& kernel_selector = kernel_selector::roi_pooling_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(roi_params, roi_optional_params);
 
-
-        auto roi_pool = new roi_pooling_impl(arg, best_kernel);
-
-        return roi_pool;
+        return make_unique<roi_pooling_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roi_pooling.cpp
@@ -36,6 +36,8 @@ kernel_selector::pool_type cldnn_2_pool_type(pooling_mode mode) {
 struct roi_pooling_impl : typed_primitive_impl_ocl<roi_pooling> {
     using parent = typed_primitive_impl_ocl<roi_pooling>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::roi_pooling_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::roi_pooling_params, kernel_selector::roi_pooling_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -61,46 +63,39 @@ protected:
     }
 
 public:
-    static std::unique_ptr<primitive_impl> create(const roi_pooling_node& arg, const kernel_impl_params& impl_param) {
-        const auto& input_layout = impl_param.input_layouts[0];
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<roi_pooling>();
+        const auto& input_layout = impl_param.get_input_layout(0);
+        const auto& rois_layout = impl_param.get_input_layout(1);
         const auto& output_layout = impl_param.output_layout;
-        const auto& rois_layout = impl_param.input_layouts[1];
-        const auto& primitive = arg.get_primitive();
 
         const auto padding_filling_value = output_layout.data_padding.filling_value();
 
-        CLDNN_ERROR_NOT_EQUAL(arg.id(),
-                              "roi_pooling padding filling value",
-                              padding_filling_value,
-                              "padding mode",
-                              0.0f,
-                              "Unknown padding mode in roi_pooling.");
-        CLDNN_ERROR_NOT_PROPER_FORMAT(arg.id(),
-                                      "Input_layout.format",
-                                      input_layout.format.value,
-                                      "output_layout.format",
-                                      output_layout.format);
-        auto roi_params = get_default_params<kernel_selector::roi_pooling_params>(impl_param);
-        auto roi_optional_params =
-            get_default_optional_params<kernel_selector::roi_pooling_optional_params>(arg.get_program());
+        auto params = get_default_params<kernel_selector::roi_pooling_params>(impl_param);
+        auto optional_params = get_default_optional_params<kernel_selector::roi_pooling_optional_params>(impl_param.get_program());
 
-        roi_params.inputs.push_back(convert_data_tensor(rois_layout));
+        params.inputs.push_back(convert_data_tensor(rois_layout));
         if (primitive->mode == pooling_mode::deformable_bilinear && !primitive->no_trans)
-            roi_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[2]));
-        roi_params.mode = cldnn_2_pool_type(primitive->mode);
-        roi_params.position_sensitive = primitive->position_sensitive;
-        roi_params.pooled_width = primitive->pooled_width;
-        roi_params.pooled_height = primitive->pooled_height;
-        roi_params.spatial_scale = primitive->spatial_scale;
-        roi_params.spatial_bins_x = primitive->spatial_bins_x;
-        roi_params.spatial_bins_y = primitive->spatial_bins_y;
-        roi_params.trans_std = primitive->trans_std;
-        roi_params.no_trans = primitive->no_trans;
-        roi_params.part_size = primitive->part_size;
-        roi_params.group_size = primitive->group_size;
+            params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(2)));
+        params.mode = cldnn_2_pool_type(primitive->mode);
+        params.position_sensitive = primitive->position_sensitive;
+        params.pooled_width = primitive->pooled_width;
+        params.pooled_height = primitive->pooled_height;
+        params.spatial_scale = primitive->spatial_scale;
+        params.spatial_bins_x = primitive->spatial_bins_x;
+        params.spatial_bins_y = primitive->spatial_bins_y;
+        params.trans_std = primitive->trans_std;
+        params.no_trans = primitive->no_trans;
+        params.part_size = primitive->part_size;
+        params.group_size = primitive->group_size;
 
-        auto& kernel_selector = kernel_selector::roi_pooling_kernel_selector::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(roi_params, roi_optional_params);
+        return {params, optional_params};
+    }
+
+    static std::unique_ptr<primitive_impl> create(const roi_pooling_node& arg, const kernel_impl_params& impl_param) {
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<roi_pooling_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roi_pooling.cpp
@@ -67,9 +67,6 @@ public:
         const auto& primitive = impl_param.typed_desc<roi_pooling>();
         const auto& input_layout = impl_param.get_input_layout(0);
         const auto& rois_layout = impl_param.get_input_layout(1);
-        const auto& output_layout = impl_param.output_layout;
-
-        const auto padding_filling_value = output_layout.data_padding.filling_value();
 
         auto params = get_default_params<kernel_selector::roi_pooling_params>(impl_param);
         auto optional_params = get_default_optional_params<kernel_selector::roi_pooling_optional_params>(impl_param.get_program());

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roi_pooling.cpp
@@ -91,14 +91,6 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const roi_pooling_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<roi_pooling_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -113,7 +105,7 @@ attach_roi_pooling_impl::attach_roi_pooling_impl() {
 
     auto types = {data_types::f16, data_types::f32};
 
-    implementation_map<roi_pooling>::add(impl_types::ocl, roi_pooling_impl::create, types, formats);
+    implementation_map<roi_pooling>::add(impl_types::ocl, typed_primitive_impl_ocl<roi_pooling>::create<roi_pooling_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roi_pooling.cpp
@@ -100,14 +100,10 @@ public:
         roi_params.group_size = primitive->group_size;
 
         auto& kernel_selector = kernel_selector::roi_pooling_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(roi_params, roi_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(roi_params, roi_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto roi_pool = new roi_pooling_impl(arg, best_kernels[0]);
+        auto roi_pool = new roi_pooling_impl(arg, best_kernel);
 
         return roi_pool;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
@@ -31,14 +31,6 @@ struct roll_impl : typed_primitive_impl_ocl<roll> {
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const roll_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<roll_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -69,7 +61,7 @@ attach_roll_impl::attach_roll_impl() {
             keys.emplace(t, f);
         }
     }
-    implementation_map<roll>::add(impl_types::ocl, roll_impl::create, keys);
+    implementation_map<roll>::add(impl_types::ocl, typed_primitive_impl_ocl<roll>::create<roll_impl>, keys);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
@@ -13,6 +13,8 @@ namespace ocl {
 struct roll_impl : typed_primitive_impl_ocl<roll> {
     using parent = typed_primitive_impl_ocl<roll>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::roll_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::roll_params, kernel_selector::roll_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -20,16 +22,20 @@ struct roll_impl : typed_primitive_impl_ocl<roll> {
         return make_unique<roll_impl>(*this);
     }
 
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<roll>();
+        auto params = get_default_params<kernel_selector::roll_params>(impl_param);
+        auto optional_params = get_default_optional_params<kernel_selector::roll_optional_params>(impl_param.get_program());
+
+        params.shift = convert_dim_vector(primitive->shift);
+
+        return {params, optional_params};
+    }
+
     static std::unique_ptr<primitive_impl> create(const roll_node& arg, const kernel_impl_params& impl_param) {
-        auto roll_params = get_default_params<kernel_selector::roll_params>(impl_param);
-        auto roll_optional_params =
-            get_default_optional_params<kernel_selector::roll_optional_params>(arg.get_program());
-
-        auto primitive = arg.get_primitive();
-        roll_params.shift = convert_dim_vector(primitive->shift);
-
-        const auto& kernel_selector = kernel_selector::roll_kernel_selector::Instance();
-        const auto best_kernel = kernel_selector.get_best_kernel(roll_params, roll_optional_params);
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<roll_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
@@ -20,7 +20,7 @@ struct roll_impl : typed_primitive_impl_ocl<roll> {
         return make_unique<roll_impl>(*this);
     }
 
-    static primitive_impl* create(const roll_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const roll_node& arg, const kernel_impl_params& impl_param) {
         auto roll_params = get_default_params<kernel_selector::roll_params>(impl_param);
         auto roll_optional_params =
             get_default_optional_params<kernel_selector::roll_optional_params>(arg.get_program());
@@ -31,8 +31,7 @@ struct roll_impl : typed_primitive_impl_ocl<roll> {
         const auto& kernel_selector = kernel_selector::roll_kernel_selector::Instance();
         const auto best_kernel = kernel_selector.get_best_kernel(roll_params, roll_optional_params);
 
-
-        return new roll_impl(arg, best_kernel);
+        return make_unique<roll_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
@@ -29,14 +29,10 @@ struct roll_impl : typed_primitive_impl_ocl<roll> {
         roll_params.shift = convert_dim_vector(primitive->shift);
 
         const auto& kernel_selector = kernel_selector::roll_kernel_selector::Instance();
-        const auto best_kernels = kernel_selector.GetBestKernels(roll_params, roll_optional_params);
+        const auto best_kernel = kernel_selector.get_best_kernel(roll_params, roll_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        return new roll_impl(arg, best_kernels.front());
+        return new roll_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
@@ -53,7 +53,6 @@ struct scatter_elements_update_impl : typed_primitive_impl_ocl<scatter_elements_
         return make_unique<scatter_elements_update_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<scatter_elements_update>();
         auto params = get_default_params<kernel_selector::scatter_elements_update_params>(impl_param);
@@ -66,13 +65,6 @@ public:
         return {params, optional_params};
     }
 
-    static std::unique_ptr<primitive_impl> create(const scatter_elements_update_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<scatter_elements_update_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -97,7 +89,11 @@ attach_scatter_elements_update_impl::attach_scatter_elements_update_impl() {
             format::bfwzyx
     };
 
-    implementation_map<scatter_elements_update>::add(impl_types::ocl, scatter_elements_update_impl::create, types, formats);
+    implementation_map<scatter_elements_update>::add(
+        impl_types::ocl,
+        typed_primitive_impl_ocl<scatter_elements_update>::create<scatter_elements_update_impl>,
+        types,
+        formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
@@ -16,8 +16,7 @@ namespace cldnn {
 namespace ocl {
 
 namespace {
-kernel_selector::scatter_update_axis convert_axis(int64_t axis, const scatter_elements_update_node& arg) {
-    auto rank = arg.input(0).get_output_layout().get_rank();
+kernel_selector::scatter_update_axis convert_axis(int64_t axis, size_t rank) {
     if (axis < 0) {
         axis += rank;
     }
@@ -36,7 +35,7 @@ kernel_selector::scatter_update_axis convert_axis(int64_t axis, const scatter_el
         case 3: return kernel_selector::scatter_update_axis::Y;
         case 4: return kernel_selector::scatter_update_axis::Z;
         case 5: return kernel_selector::scatter_update_axis::W;
-        default: CLDNN_ERROR_MESSAGE(arg.id(), "Unsupported Axis");
+        default: OPENVINO_ASSERT(false, "[GPU] Unsupported scatter update axis");
     }
     return kernel_selector::scatter_update_axis::X;
 }
@@ -45,6 +44,8 @@ kernel_selector::scatter_update_axis convert_axis(int64_t axis, const scatter_el
 struct scatter_elements_update_impl : typed_primitive_impl_ocl<scatter_elements_update> {
     using parent = typed_primitive_impl_ocl<scatter_elements_update>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::scatter_elements_update_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::scatter_elements_update_params, kernel_selector::scatter_elements_update_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -53,19 +54,22 @@ struct scatter_elements_update_impl : typed_primitive_impl_ocl<scatter_elements_
     }
 
 public:
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<scatter_elements_update>();
+        auto params = get_default_params<kernel_selector::scatter_elements_update_params>(impl_param);
+        auto optional_params = get_default_optional_params<kernel_selector::scatter_elements_update_optional_params>(impl_param.get_program());
+
+        params.axis = convert_axis(primitive->axis, impl_param.get_input_layout(0).get_rank());
+
+        params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(1)));
+        params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(2)));
+        return {params, optional_params};
+    }
+
     static std::unique_ptr<primitive_impl> create(const scatter_elements_update_node& arg, const kernel_impl_params& impl_param) {
-        const auto& prim = arg.get_primitive();
-        auto scatter_elements_update_params = get_default_params<kernel_selector::scatter_elements_update_params>(impl_param);
-        auto scatter_elements_update_optional_params =
-            get_default_optional_params<kernel_selector::scatter_elements_update_optional_params>(arg.get_program());
-
-        scatter_elements_update_params.axis = convert_axis(prim->axis, arg);
-
-        scatter_elements_update_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[1]));
-        scatter_elements_update_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[2]));
-
-        auto& kernel_selector = kernel_selector::scatter_elements_update_kernel_selector::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(scatter_elements_update_params, scatter_elements_update_optional_params);
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<scatter_elements_update_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
@@ -65,14 +65,10 @@ public:
         scatter_elements_update_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[2]));
 
         auto& kernel_selector = kernel_selector::scatter_elements_update_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(scatter_elements_update_params, scatter_elements_update_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(scatter_elements_update_params, scatter_elements_update_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto scatter_elements_update = new scatter_elements_update_impl(arg, best_kernels[0]);
+        auto scatter_elements_update = new scatter_elements_update_impl(arg, best_kernel);
 
         return scatter_elements_update;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
@@ -53,7 +53,7 @@ struct scatter_elements_update_impl : typed_primitive_impl_ocl<scatter_elements_
     }
 
 public:
-    static primitive_impl* create(const scatter_elements_update_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const scatter_elements_update_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto scatter_elements_update_params = get_default_params<kernel_selector::scatter_elements_update_params>(impl_param);
         auto scatter_elements_update_optional_params =
@@ -67,10 +67,7 @@ public:
         auto& kernel_selector = kernel_selector::scatter_elements_update_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(scatter_elements_update_params, scatter_elements_update_optional_params);
 
-
-        auto scatter_elements_update = new scatter_elements_update_impl(arg, best_kernel);
-
-        return scatter_elements_update;
+        return make_unique<scatter_elements_update_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
@@ -64,7 +64,6 @@ struct scatter_elements_update_impl : typed_primitive_impl_ocl<scatter_elements_
         params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(2)));
         return {params, optional_params};
     }
-
 };
 
 namespace detail {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_nd_update.cpp
@@ -37,14 +37,10 @@ public:
         scatter_nd_update_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[2]));
 
         auto& kernel_selector = kernel_selector::scatter_nd_update_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(scatter_nd_update_params, scatter_nd_update_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(scatter_nd_update_params, scatter_nd_update_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto scatter_nd_update = new scatter_nd_update_impl(arg, best_kernels[0]);
+        auto scatter_nd_update = new scatter_nd_update_impl(arg, best_kernel);
 
         return scatter_nd_update;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_nd_update.cpp
@@ -39,7 +39,6 @@ struct scatter_nd_update_impl : typed_primitive_impl_ocl<scatter_nd_update> {
 
         return {params, optional_params};
     }
-
 };
 
 namespace detail {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_nd_update.cpp
@@ -27,7 +27,6 @@ struct scatter_nd_update_impl : typed_primitive_impl_ocl<scatter_nd_update> {
         return make_unique<scatter_nd_update_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<scatter_nd_update>();
         auto params = get_default_params<kernel_selector::scatter_nd_update_params>(impl_param);
@@ -41,19 +40,12 @@ public:
         return {params, optional_params};
     }
 
-    static std::unique_ptr<primitive_impl> create(const scatter_nd_update_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<scatter_nd_update_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_scatter_nd_update_impl::attach_scatter_nd_update_impl() {
-    implementation_map<scatter_nd_update>::add(impl_types::ocl, scatter_nd_update_impl::create, {
+    implementation_map<scatter_nd_update>::add(impl_types::ocl, typed_primitive_impl_ocl<scatter_nd_update>::create<scatter_nd_update_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
         std::make_tuple(data_types::i32, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_nd_update.cpp
@@ -26,7 +26,7 @@ struct scatter_nd_update_impl : typed_primitive_impl_ocl<scatter_nd_update> {
     }
 
 public:
-    static primitive_impl* create(const scatter_nd_update_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const scatter_nd_update_node& arg, const kernel_impl_params& impl_param) {
         auto scatter_nd_update_params = get_default_params<kernel_selector::scatter_nd_update_params>(impl_param);
         auto scatter_nd_update_optional_params =
             get_default_optional_params<kernel_selector::scatter_nd_update_optional_params>(arg.get_program());
@@ -39,10 +39,7 @@ public:
         auto& kernel_selector = kernel_selector::scatter_nd_update_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(scatter_nd_update_params, scatter_nd_update_optional_params);
 
-
-        auto scatter_nd_update = new scatter_nd_update_impl(arg, best_kernel);
-
-        return scatter_nd_update;
+        return make_unique<scatter_nd_update_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.cpp
@@ -63,14 +63,10 @@ public:
         scatter_update_params.inputs.push_back(convert_data_tensor(impl_param.input_layouts[2]));
 
         auto& kernel_selector = kernel_selector::scatter_update_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(scatter_update_params, scatter_update_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(scatter_update_params, scatter_update_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto scatter_update = new scatter_update_impl(arg, best_kernels[0]);
+        auto scatter_update = new scatter_update_impl(arg, best_kernel);
 
         return scatter_update;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.cpp
@@ -52,7 +52,7 @@ struct scatter_update_impl : typed_primitive_impl_ocl<scatter_update> {
     }
 
 public:
-    static primitive_impl* create(const scatter_update_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const scatter_update_node& arg, const kernel_impl_params& impl_param) {
         auto scatter_update_params = get_default_params<kernel_selector::scatter_update_params>(impl_param);
         auto scatter_update_optional_params =
             get_default_optional_params<kernel_selector::scatter_update_optional_params>(arg.get_program());
@@ -65,10 +65,7 @@ public:
         auto& kernel_selector = kernel_selector::scatter_update_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(scatter_update_params, scatter_update_optional_params);
 
-
-        auto scatter_update = new scatter_update_impl(arg, best_kernel);
-
-        return scatter_update;
+        return make_unique<scatter_update_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.cpp
@@ -64,14 +64,6 @@ public:
         params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(2)));
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const scatter_update_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<scatter_update_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -95,7 +87,7 @@ attach_scatter_update_impl::attach_scatter_update_impl() {
         format::bfwzyx
     };
 
-    implementation_map<scatter_update>::add(impl_types::ocl, scatter_update_impl::create, types, formats);
+    implementation_map<scatter_update>::add(impl_types::ocl, typed_primitive_impl_ocl<scatter_update>::create<scatter_update_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/select.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/select.cpp
@@ -61,14 +61,10 @@ public:
         }
 
         auto& kernel_selector = kernel_selector::select_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(select_params, select_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(select_params, select_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto select = new select_impl(arg, best_kernels[0]);
+        auto select = new select_impl(arg, best_kernel);
 
         return select;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/select.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/select.cpp
@@ -25,7 +25,6 @@ struct select_impl : typed_primitive_impl_ocl<select> {
         return make_unique<select_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<select>();
         auto params = get_default_params<kernel_selector::select_params>(impl_param);
@@ -63,20 +62,12 @@ public:
         }
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const select_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<select_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_select_impl::attach_select_impl() {
-    implementation_map<select>::add(impl_types::ocl, select_impl::create, {
+    implementation_map<select>::add(impl_types::ocl, typed_primitive_impl_ocl<select>::create<select_impl>, {
         std::make_tuple(data_types::f32, format::yxfb),
         std::make_tuple(data_types::f16, format::yxfb),
         std::make_tuple(data_types::i8, format::yxfb),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/select.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/select.cpp
@@ -24,7 +24,7 @@ struct select_impl : typed_primitive_impl_ocl<select> {
     }
 
 public:
-    static primitive_impl* create(const select_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const select_node& arg, const kernel_impl_params& impl_param) {
         auto select_params = get_default_params<kernel_selector::select_params>(impl_param);
         auto select_optional_params =
             get_default_optional_params<kernel_selector::select_optional_params>(arg.get_program());
@@ -63,10 +63,7 @@ public:
         auto& kernel_selector = kernel_selector::select_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(select_params, select_optional_params);
 
-
-        auto select = new select_impl(arg, best_kernel);
-
-        return select;
+        return make_unique<select_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/shape_of.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/shape_of.cpp
@@ -23,7 +23,7 @@ struct shape_of_impl : typed_primitive_impl_ocl<shape_of> {
         return make_unique<shape_of_impl>(*this);
     }
 
-    static primitive_impl* create(const shape_of_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const shape_of_node& arg, const kernel_impl_params& impl_param) {
         auto shape_of_params = get_default_params<kernel_selector::shape_of_params>(impl_param);
         auto shape_of_optional_params =
             get_default_optional_params<kernel_selector::shape_of_optional_params>(arg.get_program());
@@ -35,9 +35,7 @@ struct shape_of_impl : typed_primitive_impl_ocl<shape_of> {
         auto& kernel_selector = kernel_selector::shape_of_instance();
         auto best_kernel = kernel_selector.get_best_kernel(shape_of_params, shape_of_optional_params);
 
-        auto shape_of = new shape_of_impl(arg, best_kernel);
-
-        return shape_of;
+        return make_unique<shape_of_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/shape_of.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/shape_of.cpp
@@ -33,13 +33,9 @@ struct shape_of_impl : typed_primitive_impl_ocl<shape_of> {
         shape_of_params.input_dims = input_layout.get_dims();
 
         auto& kernel_selector = kernel_selector::shape_of_instance();
-        auto best_kernels = kernel_selector.GetBestKernels(shape_of_params, shape_of_optional_params);
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
+        auto best_kernel = kernel_selector.get_best_kernel(shape_of_params, shape_of_optional_params);
 
-        auto shape_of = new shape_of_impl(arg, best_kernels[0]);
+        auto shape_of = new shape_of_impl(arg, best_kernel);
 
         return shape_of;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/shape_of.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/shape_of.cpp
@@ -35,20 +35,12 @@ struct shape_of_impl : typed_primitive_impl_ocl<shape_of> {
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const shape_of_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<shape_of_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_shape_of_impl::attach_shape_of_impl() {
-    implementation_map<shape_of>::add(impl_types::ocl, shape_of_impl::create, {});
+    implementation_map<shape_of>::add(impl_types::ocl, typed_primitive_impl_ocl<shape_of>::create<shape_of_impl>, {});
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/shuffle_channels.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/shuffle_channels.cpp
@@ -43,7 +43,6 @@ struct shuffle_channels_impl : typed_primitive_impl_ocl<shuffle_channels> {
 
         return {params, optional_params};
     }
-
 };
 
 namespace detail {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/shuffle_channels.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/shuffle_channels.cpp
@@ -42,14 +42,10 @@ public:
         shuffle_channels_params.axis = axis;
 
         auto& kernel_selector = kernel_selector::shuffle_channels_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(shuffle_channels_params, shuffle_channels_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(shuffle_channels_params, shuffle_channels_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto shuffle_channels = new shuffle_channels_impl(arg, best_kernels[0]);
+        auto shuffle_channels = new shuffle_channels_impl(arg, best_kernel);
 
         return shuffle_channels;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/shuffle_channels.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/shuffle_channels.cpp
@@ -27,7 +27,6 @@ struct shuffle_channels_impl : typed_primitive_impl_ocl<shuffle_channels> {
         return make_unique<shuffle_channels_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<shuffle_channels>();
         auto params = get_default_params<kernel_selector::shuffle_channels_params>(impl_param);
@@ -45,19 +44,12 @@ public:
         return {params, optional_params};
     }
 
-    static std::unique_ptr<primitive_impl> create(const shuffle_channels_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<shuffle_channels_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_shuffle_channels_impl::attach_shuffle_channels_impl() {
-    implementation_map<shuffle_channels>::add(impl_types::ocl, shuffle_channels_impl::create, {
+    implementation_map<shuffle_channels>::add(impl_types::ocl, typed_primitive_impl_ocl<shuffle_channels>::create<shuffle_channels_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
         std::make_tuple(data_types::u8, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/shuffle_channels.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/shuffle_channels.cpp
@@ -26,7 +26,7 @@ struct shuffle_channels_impl : typed_primitive_impl_ocl<shuffle_channels> {
     }
 
 public:
-    static primitive_impl* create(const shuffle_channels_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const shuffle_channels_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto shuffle_channels_params = get_default_params<kernel_selector::shuffle_channels_params>(impl_param);
         auto shuffle_channels_optional_params =
@@ -44,10 +44,7 @@ public:
         auto& kernel_selector = kernel_selector::shuffle_channels_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(shuffle_channels_params, shuffle_channels_optional_params);
 
-
-        auto shuffle_channels = new shuffle_channels_impl(arg, best_kernel);
-
-        return shuffle_channels;
+        return make_unique<shuffle_channels_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
@@ -74,7 +74,7 @@ struct slice_impl : typed_primitive_impl_ocl<slice> {
         return make_unique<slice_impl>(*this);
     }
 
-    static primitive_impl* create(const slice_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const slice_node& arg, const kernel_impl_params& impl_param) {
         auto params = get_default_params<kernel_selector::slice_params>(impl_param);
         auto op_params = get_default_optional_params<kernel_selector::slice_optional_params>(arg.get_program());
         const auto& inputs = arg.get_dependencies();
@@ -107,7 +107,7 @@ struct slice_impl : typed_primitive_impl_ocl<slice> {
                 kernel_selector::slice_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(params, op_params);
 
-        return new slice_impl(arg, best_kernel);
+        return make_unique<slice_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
@@ -105,12 +105,9 @@ struct slice_impl : typed_primitive_impl_ocl<slice> {
         params.step = std::move(selected_step);
         auto &kernel_selector =
                 kernel_selector::slice_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(params, op_params);
+        auto best_kernel = kernel_selector.get_best_kernel(params, op_params);
 
-        CLDNN_ERROR_BOOL(arg.id(), "Best_kernel.empty()", best_kernels.empty(),
-                "Cannot find a proper kernel with this arguments");
-
-        return new slice_impl(arg, best_kernels[0]);
+        return new slice_impl(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
@@ -58,6 +58,8 @@ std::vector<std::int32_t> extractShape(kernel_selector::Tensor::DataTensor& tens
 struct slice_impl : typed_primitive_impl_ocl<slice> {
     using parent = typed_primitive_impl_ocl<slice>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::slice_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::slice_params, kernel_selector::slice_optional_params>;
 
     enum InputIndices {
         kData,

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
@@ -57,14 +57,6 @@ struct softmax_impl : typed_primitive_impl_ocl<softmax> {
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const softmax_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<softmax_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -78,7 +70,7 @@ attach_softmax_impl::attach_softmax_impl() {
             format::bfzyx
     };
 
-    implementation_map<softmax>::add(impl_types::ocl, softmax_impl::create, types, formats);
+    implementation_map<softmax>::add(impl_types::ocl, typed_primitive_impl_ocl<softmax>::create<softmax_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
@@ -45,7 +45,7 @@ struct softmax_impl : typed_primitive_impl_ocl<softmax> {
         return make_unique<softmax_impl>(*this);
     }
 
-    static primitive_impl* create(const softmax_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const softmax_node& arg, const kernel_impl_params& impl_param) {
         const auto primitive = arg.get_primitive();
         auto sm_params = get_default_params<kernel_selector::softmax_params>(impl_param);
         auto sm_optional_params =
@@ -57,10 +57,7 @@ struct softmax_impl : typed_primitive_impl_ocl<softmax> {
         auto& kernel_selector = kernel_selector::softmax_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(sm_params, sm_optional_params);
 
-
-        auto softmax_node = new softmax_impl(arg, best_kernel);
-
-        return softmax_node;
+        return make_unique<softmax_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
@@ -55,14 +55,10 @@ struct softmax_impl : typed_primitive_impl_ocl<softmax> {
         sm_params.dim = get_softmax_dim(primitive->dimension, rank);
 
         auto& kernel_selector = kernel_selector::softmax_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(sm_params, sm_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(sm_params, sm_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto softmax_node = new softmax_impl(arg, best_kernels[0]);
+        auto softmax_node = new softmax_impl(arg, best_kernel);
 
         return softmax_node;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
@@ -38,6 +38,8 @@ static inline kernel_selector::softmax_dim get_softmax_dim(int64_t axis, size_t 
 struct softmax_impl : typed_primitive_impl_ocl<softmax> {
     using parent = typed_primitive_impl_ocl<softmax>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::softmax_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::softmax_params, kernel_selector::softmax_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -45,17 +47,21 @@ struct softmax_impl : typed_primitive_impl_ocl<softmax> {
         return make_unique<softmax_impl>(*this);
     }
 
+    static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
+        const auto& primitive = impl_param.typed_desc<softmax>();
+        auto params = get_default_params<kernel_selector::softmax_params>(impl_param);
+        auto optional_params = get_default_optional_params<kernel_selector::softmax_optional_params>(impl_param.get_program());
+
+        size_t rank = impl_param.output_layout.get_rank();
+        params.dim = get_softmax_dim(primitive->dimension, rank);
+
+        return {params, optional_params};
+    }
+
     static std::unique_ptr<primitive_impl> create(const softmax_node& arg, const kernel_impl_params& impl_param) {
-        const auto primitive = arg.get_primitive();
-        auto sm_params = get_default_params<kernel_selector::softmax_params>(impl_param);
-        auto sm_optional_params =
-            get_default_optional_params<kernel_selector::softmax_optional_params>(arg.get_program());
-
-        size_t rank = arg.get_output_layout().get_rank();
-        sm_params.dim = get_softmax_dim(primitive->dimension, rank);
-
-        auto& kernel_selector = kernel_selector::softmax_kernel_selector::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(sm_params, sm_optional_params);
+        auto kernel_params = get_kernel_params(impl_param);
+        auto& kernel_selector = kernel_selector_t::Instance();
+        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
 
         return make_unique<softmax_impl>(arg, best_kernel);
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_batch.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_batch.cpp
@@ -38,14 +38,10 @@ public:
         space_to_batch_params.pads_end = convert_dim_vector(primitive->pads_end);
 
         auto& kernel_selector = kernel_selector::space_to_batch_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(space_to_batch_params, space_to_batch_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(space_to_batch_params, space_to_batch_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto space_to_batch = new space_to_batch_impl(arg, best_kernels[0]);
+        auto space_to_batch = new space_to_batch_impl(arg, best_kernel);
 
         return space_to_batch;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_batch.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_batch.cpp
@@ -28,7 +28,6 @@ struct space_to_batch_impl : typed_primitive_impl_ocl<space_to_batch> {
         return make_unique<space_to_batch_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<space_to_batch>();
         auto params = get_default_params<kernel_selector::space_to_batch_params>(impl_param);
@@ -40,20 +39,12 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const space_to_batch_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<space_to_batch_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_space_to_batch_impl::attach_space_to_batch_impl() {
-    implementation_map<space_to_batch>::add(impl_types::ocl, space_to_batch_impl::create, {
+    implementation_map<space_to_batch>::add(impl_types::ocl, typed_primitive_impl_ocl<space_to_batch>::create<space_to_batch_impl>, {
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
         std::make_tuple(data_types::u8, format::bfyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_batch.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_batch.cpp
@@ -27,7 +27,7 @@ struct space_to_batch_impl : typed_primitive_impl_ocl<space_to_batch> {
     }
 
 public:
-    static primitive_impl* create(const space_to_batch_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const space_to_batch_node& arg, const kernel_impl_params& impl_param) {
         auto primitive = arg.get_primitive();
         auto space_to_batch_params = get_default_params<kernel_selector::space_to_batch_params>(impl_param);
         auto space_to_batch_optional_params =
@@ -40,10 +40,7 @@ public:
         auto& kernel_selector = kernel_selector::space_to_batch_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(space_to_batch_params, space_to_batch_optional_params);
 
-
-        auto space_to_batch = new space_to_batch_impl(arg, best_kernel);
-
-        return space_to_batch;
+        return make_unique<space_to_batch_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_depth.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_depth.cpp
@@ -38,14 +38,10 @@ public:
         space_to_depth_params.block_size = prim->block_size;
 
         auto& kernel_selector = kernel_selector::space_to_depth_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(space_to_depth_params, space_to_depth_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(space_to_depth_params, space_to_depth_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto space_to_depth = new space_to_depth_impl(arg, best_kernels[0]);
+        auto space_to_depth = new space_to_depth_impl(arg, best_kernel);
 
         return space_to_depth;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_depth.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_depth.cpp
@@ -25,7 +25,7 @@ struct space_to_depth_impl : typed_primitive_impl_ocl<space_to_depth> {
     }
 
 public:
-    static primitive_impl* create(const space_to_depth_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const space_to_depth_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = arg.get_primitive();
         auto space_to_depth_params = get_default_params<kernel_selector::space_to_depth_params>(impl_param);
         auto space_to_depth_optional_params =
@@ -40,10 +40,7 @@ public:
         auto& kernel_selector = kernel_selector::space_to_depth_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(space_to_depth_params, space_to_depth_optional_params);
 
-
-        auto space_to_depth = new space_to_depth_impl(arg, best_kernel);
-
-        return space_to_depth;
+        return make_unique<space_to_depth_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_depth.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_depth.cpp
@@ -26,7 +26,6 @@ struct space_to_depth_impl : typed_primitive_impl_ocl<space_to_depth> {
         return make_unique<space_to_depth_impl>(*this);
     }
 
-public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<space_to_depth>();
         auto params = get_default_params<kernel_selector::space_to_depth_params>(impl_param);
@@ -40,20 +39,12 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const space_to_depth_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<space_to_depth_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
 
 attach_space_to_depth_impl::attach_space_to_depth_impl() {
-    implementation_map<space_to_depth>::add(impl_types::ocl, space_to_depth_impl::create, {
+    implementation_map<space_to_depth>::add(impl_types::ocl, typed_primitive_impl_ocl<space_to_depth>::create<space_to_depth_impl>, {
         std::make_tuple(data_types::f32, format::bfzyx),
         std::make_tuple(data_types::f16, format::bfzyx),
         std::make_tuple(data_types::u8, format::bfzyx),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
@@ -133,14 +133,10 @@ public:
         }
 
         auto& kernel_selector = kernel_selector::strided_slice_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(params, op_params);
+        auto best_kernel = kernel_selector.get_best_kernel(params, op_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto strided_slice = new strided_slice_impl(arg, best_kernels[0]);
+        auto strided_slice = new strided_slice_impl(arg, best_kernel);
 
         return strided_slice;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
@@ -48,6 +48,8 @@ namespace ocl {
 struct strided_slice_impl : typed_primitive_impl_ocl<strided_slice> {
     using parent = typed_primitive_impl_ocl<strided_slice>;
     using parent::parent;
+    using kernel_selector_t = kernel_selector::strided_slice_kernel_selector;
+    using kernel_params_t = std::pair<kernel_selector::strided_slice_params, kernel_selector::strided_slice_optional_params>;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION
 
@@ -59,7 +61,7 @@ public:
     static std::unique_ptr<primitive_impl> create(const strided_slice_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = impl_param.typed_desc<strided_slice>();
         auto params = get_default_params<kernel_selector::strided_slice_params>(impl_param);
-        auto op_params = get_default_optional_params<kernel_selector::strided_slice_optional_params>(arg.get_program());
+        auto op_params = get_default_optional_params<kernel_selector::strided_slice_optional_params>(impl_param.get_program());
         const size_t dims_num = params.inputs[0].Dimentions();
 
         // Getting data from constant inputs. There are 3 args: Begin, End, Stride

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
@@ -56,7 +56,7 @@ struct strided_slice_impl : typed_primitive_impl_ocl<strided_slice> {
     }
 
 public:
-    static primitive_impl* create(const strided_slice_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const strided_slice_node& arg, const kernel_impl_params& impl_param) {
         const auto& prim = impl_param.typed_desc<strided_slice>();
         auto params = get_default_params<kernel_selector::strided_slice_params>(impl_param);
         auto op_params = get_default_optional_params<kernel_selector::strided_slice_optional_params>(arg.get_program());
@@ -135,10 +135,7 @@ public:
         auto& kernel_selector = kernel_selector::strided_slice_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(params, op_params);
 
-
-        auto strided_slice = new strided_slice_impl(arg, best_kernel);
-
-        return strided_slice;
+        return make_unique<strided_slice_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
@@ -43,14 +43,10 @@ public:
         }
 
         auto& kernel_selector = kernel_selector::tile_kernel_selector::Instance();
-        auto best_kernels = kernel_selector.GetBestKernels(tile_params, tile_optional_params);
+        auto best_kernel = kernel_selector.get_best_kernel(tile_params, tile_optional_params);
 
-        CLDNN_ERROR_BOOL(arg.id(),
-                         "Best_kernel.empty()",
-                         best_kernels.empty(),
-                         "Cannot find a proper kernel with this arguments");
 
-        auto tile = new tile_impl(arg, best_kernels[0]);
+        auto tile = new tile_impl(arg, best_kernel);
 
         return tile;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
@@ -26,7 +26,7 @@ struct tile_impl : typed_primitive_impl_ocl<tile> {
     }
 
 public:
-    static primitive_impl* create(const tile_node& arg, const kernel_impl_params& impl_param) {
+    static std::unique_ptr<primitive_impl> create(const tile_node& arg, const kernel_impl_params& impl_param) {
         auto tile_params = get_default_params<kernel_selector::tile_params>(impl_param);
         auto tile_optional_params =
             get_default_optional_params<kernel_selector::tile_optional_params>(arg.get_program());
@@ -45,10 +45,7 @@ public:
         auto& kernel_selector = kernel_selector::tile_kernel_selector::Instance();
         auto best_kernel = kernel_selector.get_best_kernel(tile_params, tile_optional_params);
 
-
-        auto tile = new tile_impl(arg, best_kernel);
-
-        return tile;
+        return make_unique<tile_impl>(arg, best_kernel);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
@@ -46,14 +46,6 @@ public:
 
         return {params, optional_params};
     }
-
-    static std::unique_ptr<primitive_impl> create(const tile_node& arg, const kernel_impl_params& impl_param) {
-        auto kernel_params = get_kernel_params(impl_param);
-        auto& kernel_selector = kernel_selector_t::Instance();
-        auto best_kernel = kernel_selector.get_best_kernel(kernel_params.first, kernel_params.second);
-
-        return make_unique<tile_impl>(arg, best_kernel);
-    }
 };
 
 namespace detail {
@@ -77,7 +69,7 @@ attach_tile_impl::attach_tile_impl() {
         format::bs_fs_zyx_bsv32_fsv16
     };
 
-    implementation_map<tile>::add(impl_types::ocl, tile_impl::create, types, formats);
+    implementation_map<tile>::add(impl_types::ocl, typed_primitive_impl_ocl<tile>::create<tile_impl>, types, formats);
 }
 
 }  // namespace detail

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
@@ -104,17 +104,17 @@ public:
         _prim = dnnl::concat(_pd, prim_cache);
     }
 
-    static primitive_impl* create(const concatenation_node& arg, const kernel_impl_params& impl_params) {
+    static std::unique_ptr<primitive_impl> create(const concatenation_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
         if (arg.can_be_optimized())
-            return new concatenation_onednn(engine);
+            return make_unique<concatenation_onednn>(engine);
         auto prim = impl_params.typed_desc<concatenation>();
         auto desc = get_concatenation_descriptor(impl_params, prim->axis, impl_params.prog->get_engine());
         auto attr = arg.get_onednn_primitive_attributes();
 
         std::shared_ptr<void> dummy = nullptr;
 
-        return new concatenation_onednn(engine, dummy, attr, *desc);
+        return make_unique<concatenation_onednn>(engine, dummy, attr, *desc);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
@@ -114,7 +114,7 @@ public:
 
         std::shared_ptr<void> dummy = nullptr;
 
-        return make_unique<concatenation_onednn>(engine, dummy, attr, *desc);
+        return cldnn::make_unique<concatenation_onednn>(engine, dummy, attr, *desc);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
@@ -208,13 +208,13 @@ public:
         _prim = dnnl::primitive(_pd, prim_cache);
     }
 
-    static primitive_impl* create(const convolution_node& arg, const kernel_impl_params& impl_params) {
+    static std::unique_ptr<primitive_impl> create(const convolution_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
         auto desc = get_convolution_descriptor(impl_params);
         auto attr = get_primitive_attributes(arg);
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return new convolution_onednn(engine, desc, attr, prim_desc, get_weights_reorder(impl_params, prim_desc, arg.get_transposed()));
+        return make_unique<convolution_onednn>(engine, desc, attr, prim_desc, get_weights_reorder(impl_params, prim_desc, arg.get_transposed()));
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
@@ -214,7 +214,7 @@ public:
         auto attr = get_primitive_attributes(arg);
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return make_unique<convolution_onednn>(engine, desc, attr, prim_desc, get_weights_reorder(impl_params, prim_desc, arg.get_transposed()));
+        return cldnn::make_unique<convolution_onednn>(engine, desc, attr, prim_desc, get_weights_reorder(impl_params, prim_desc, arg.get_transposed()));
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
@@ -127,13 +127,13 @@ public:
         _prim = dnnl::primitive(_pd, prim_cache);
     }
 
-    static primitive_impl* create(const deconvolution_node& arg, const kernel_impl_params& impl_params) {
+    static std::unique_ptr<primitive_impl> create(const deconvolution_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
         auto desc = get_deconvolution_descriptor(impl_params);
         auto attr = get_primitive_attributes(arg);
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return new deconvolution_onednn(engine, desc, attr, prim_desc, get_weights_reorder(impl_params, prim_desc));
+        return make_unique<deconvolution_onednn>(engine, desc, attr, prim_desc, get_weights_reorder(impl_params, prim_desc));
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
@@ -133,7 +133,7 @@ public:
         auto attr = get_primitive_attributes(arg);
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return make_unique<deconvolution_onednn>(engine, desc, attr, prim_desc, get_weights_reorder(impl_params, prim_desc));
+        return cldnn::make_unique<deconvolution_onednn>(engine, desc, attr, prim_desc, get_weights_reorder(impl_params, prim_desc));
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -195,7 +195,7 @@ public:
         auto attr = arg.get_onednn_primitive_attributes();
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return make_unique<fully_connected_onednn>(engine, desc, attr, prim_desc, get_weights_reorder(impl_params, prim_desc));
+        return cldnn::make_unique<fully_connected_onednn>(engine, desc, attr, prim_desc, get_weights_reorder(impl_params, prim_desc));
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -189,13 +189,13 @@ public:
         _prim = dnnl::primitive(_pd, prim_cache);
     }
 
-    static primitive_impl* create(const fully_connected_node& arg, const kernel_impl_params& impl_params) {
+    static std::unique_ptr<primitive_impl> create(const fully_connected_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
         auto desc = get_fully_connected_descriptor(impl_params);
         auto attr = arg.get_onednn_primitive_attributes();
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return new fully_connected_onednn(engine, desc, attr, prim_desc, get_weights_reorder(impl_params, prim_desc));
+        return make_unique<fully_connected_onednn>(engine, desc, attr, prim_desc, get_weights_reorder(impl_params, prim_desc));
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
@@ -232,13 +232,13 @@ public:
         _prim = dnnl::primitive(_pd, prim_cache);
     }
 
-    static primitive_impl* create(const gemm_node& arg, const kernel_impl_params& impl_params) {
+    static std::unique_ptr<primitive_impl> create(const gemm_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
         auto desc = get_gemm_descriptor(impl_params);
         auto attr = arg.get_onednn_primitive_attributes();
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return new gemm_onednn(engine, desc, attr, prim_desc);
+        return make_unique<gemm_onednn>(engine, desc, attr, prim_desc);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
@@ -238,7 +238,7 @@ public:
         auto attr = arg.get_onednn_primitive_attributes();
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return make_unique<gemm_onednn>(engine, desc, attr, prim_desc);
+        return cldnn::make_unique<gemm_onednn>(engine, desc, attr, prim_desc);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.cpp
@@ -93,7 +93,7 @@ public:
         auto attr = arg.get_onednn_primitive_attributes();
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return make_unique<pooling_onednn>(engine, desc, attr, prim_desc);
+        return cldnn::make_unique<pooling_onednn>(engine, desc, attr, prim_desc);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.cpp
@@ -87,13 +87,13 @@ public:
         _prim = dnnl::primitive(_pd, prim_cache);
     }
 
-    static primitive_impl* create(const pooling_node& arg, const kernel_impl_params& impl_params) {
+    static std::unique_ptr<primitive_impl> create(const pooling_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
         auto desc = get_pooling_descriptor(impl_params);
         auto attr = arg.get_onednn_primitive_attributes();
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return new pooling_onednn(engine, desc, attr, prim_desc);
+        return make_unique<pooling_onednn>(engine, desc, attr, prim_desc);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reduction_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reduction_onednn.cpp
@@ -122,7 +122,7 @@ public:
         auto attr = arg.get_onednn_primitive_attributes();
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return make_unique<reduction_onednn>(engine, desc, attr, prim_desc);
+        return cldnn::make_unique<reduction_onednn>(engine, desc, attr, prim_desc);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reduction_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reduction_onednn.cpp
@@ -116,13 +116,13 @@ public:
         _prim = dnnl::primitive(_pd, prim_cache);
     }
 
-    static primitive_impl* create(const reduce_node& arg, const kernel_impl_params& impl_params) {
+    static std::unique_ptr<primitive_impl> create(const reduce_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
         auto desc = get_reduction_descriptor(impl_params);
         auto attr = arg.get_onednn_primitive_attributes();
         dnnl::primitive_desc prim_desc{&desc->data, attr.get(), engine.get_onednn_engine(), nullptr};
 
-        return new reduction_onednn(engine, desc, attr, prim_desc);
+        return make_unique<reduction_onednn>(engine, desc, attr, prim_desc);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
@@ -84,14 +84,14 @@ public:
         _prim = dnnl::reorder(_pd, prim_cache);
     }
 
-    static primitive_impl* create(const reorder_node& arg, const kernel_impl_params& impl_params) {
+    static std::unique_ptr<primitive_impl> create(const reorder_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
         auto attr = arg.get_onednn_primitive_attributes();
         auto desc = get_reorder_descriptor(impl_params, *attr, impl_params.prog->get_engine());
 
         std::shared_ptr<void> dummy = nullptr;
 
-        return new reorder_onednn(engine, dummy, attr, *desc);
+        return make_unique<reorder_onednn>(engine, dummy, attr, *desc);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
@@ -91,7 +91,7 @@ public:
 
         std::shared_ptr<void> dummy = nullptr;
 
-        return make_unique<reorder_onednn>(engine, dummy, attr, *desc);
+        return cldnn::make_unique<reorder_onednn>(engine, dummy, attr, *desc);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/include/kernel_selector_helper.h
+++ b/src/plugins/intel_gpu/src/graph/include/kernel_selector_helper.h
@@ -183,6 +183,10 @@ struct kernel_impl_params {
 
     void save(BinaryOutputBuffer& ob) const;
     void load(BinaryInputBuffer& ib);
+    const program& get_program() const {
+        OPENVINO_ASSERT(prog != nullptr, "[GPU] Program pointer in kernel_impl_params in not initialized");
+        return *prog;
+    }
 };
 
 template <typename T = std::uint32_t>

--- a/src/plugins/intel_gpu/src/graph/include/primitive_type_base.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_type_base.h
@@ -44,7 +44,7 @@ struct primitive_type_base : primitive_type {
     std::unique_ptr<primitive_impl> choose_impl(const cldnn::program_node& node, const kernel_impl_params& runtime_params) const override {
         OPENVINO_ASSERT(node.type() == this, "[GPU] primitive_type_base::choose_impl: primitive type mismatch");
         auto factory = implementation_map<PType>::get(runtime_params, node.get_preferred_impl_type());
-        return std::unique_ptr<primitive_impl>(factory(node, runtime_params));
+        return factory(node, runtime_params);
     }
 
     bool does_an_implementation_exist(const cldnn::program_node& node) const override {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector.cpp
@@ -65,6 +65,12 @@ kernel_selector_base::kernel_selector_base() {
 #endif
 }
 
+KernelData kernel_selector_base::get_best_kernel(const Params& params, const optional_params& options) const {
+    auto kernels = GetBestKernels(params, options);
+    OPENVINO_ASSERT(!kernels.empty(), "[GPU] Couldn't find a suitable kernel for ", params.layerID, " params: ", params.to_cache_string_v2());
+    return kernels[0];
+}
+
 KernelsData kernel_selector_base::GetNaiveBestKernel(const Params& params,
                                                      const optional_params& options,
                                                      KernelType kType) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector.cpp
@@ -67,7 +67,7 @@ kernel_selector_base::kernel_selector_base() {
 
 KernelData kernel_selector_base::get_best_kernel(const Params& params, const optional_params& options) const {
     auto kernels = GetBestKernels(params, options);
-    OPENVINO_ASSERT(!kernels.empty(), "[GPU] Couldn't find a suitable kernel for ", params.layerID, " params: ", params.to_cache_string_v2());
+    OPENVINO_ASSERT(!kernels.empty(), "[GPU] Couldn't find a suitable kernel for ", params.layerID, " params raw string: ", params.to_cache_string_v2());
     return kernels[0];
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector.h
@@ -23,13 +23,14 @@ public:
     kernel_selector_base();
     virtual ~kernel_selector_base() {}
 
-    virtual KernelsData GetBestKernels(const Params& params, const optional_params& options) const = 0;
+    KernelData get_best_kernel(const Params& params, const optional_params& options) const;
 
 protected:
     template <typename T>
     inline void Attach() {
         implementations.push_back(std::make_shared<T>());
     }
+    virtual KernelsData GetBestKernels(const Params& params, const optional_params& options) const = 0;
 
     virtual KernelsData GetNaiveBestKernel(const Params& params,
                                            const optional_params& options,

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/ed_pgg/prior_grid_generator_kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/ed_pgg/prior_grid_generator_kernel_selector.cpp
@@ -6,23 +6,12 @@
 #include "prior_grid_generator_kernel_ref.h"
 
 namespace kernel_selector {
-namespace {
 
-class experimental_detectron_prior_grid_generator_kernel_selector : public kernel_selector_base {
-    KernelsData GetBestKernels(const Params &params, const optional_params &options) const override {
-        return GetNaiveBestKernel(params, options, KernelType::EXPERIMENTAL_DETECTRON_PRIOR_GRID_GENERATOR);
-    }
-public:
-    experimental_detectron_prior_grid_generator_kernel_selector() {
-        Attach<ExperimentalDetectronPriorGridGeneratorKernelRef>();
-    }
-};
-
-}  // namespace
-
-kernel_selector_base& experimental_detectron_prior_grid_generator_instance() {
-    static experimental_detectron_prior_grid_generator_kernel_selector instance;
-    return instance;
+experimental_detectron_prior_grid_generator_kernel_selector::experimental_detectron_prior_grid_generator_kernel_selector() {
+    Attach<ExperimentalDetectronPriorGridGeneratorKernelRef>();
 }
 
+KernelsData experimental_detectron_prior_grid_generator_kernel_selector::GetBestKernels(const Params& params, const optional_params& options) const {
+    return GetNaiveBestKernel(params, options, KernelType::EXPERIMENTAL_DETECTRON_PRIOR_GRID_GENERATOR);
+}
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/ed_pgg/prior_grid_generator_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/ed_pgg/prior_grid_generator_kernel_selector.h
@@ -7,10 +7,17 @@
 #include <kernel_selector.h>
 
 namespace kernel_selector {
+class experimental_detectron_prior_grid_generator_kernel_selector : public kernel_selector_base {
+public:
+    static experimental_detectron_prior_grid_generator_kernel_selector& Instance() {
+        static experimental_detectron_prior_grid_generator_kernel_selector instance_;
+        return instance_;
+    }
 
-/*
- * ExperimentalDetectronPriorGridGenerator kernel selector
- */
-kernel_selector_base& experimental_detectron_prior_grid_generator_instance();
+    experimental_detectron_prior_grid_generator_kernel_selector();
 
+    virtual ~experimental_detectron_prior_grid_generator_kernel_selector() {}
+
+    KernelsData GetBestKernels(const Params& params, const optional_params& options) const override;
+};
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/range/range_kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/range/range_kernel_selector.cpp
@@ -6,23 +6,12 @@
 #include "range_kernel_ref.h"
 
 namespace kernel_selector {
-namespace {
 
-class range_kernel_selector: public kernel_selector_base {
-    KernelsData GetBestKernels(const Params &params, const optional_params &options) const override {
-        return GetNaiveBestKernel(params, options, KernelType::RANGE);
-    }
-public:
-    range_kernel_selector() {
-        Attach<RangeKernelRef>();
-    }
-};
-
-}  // namespace
-
-kernel_selector_base& range_instance() {
-    static range_kernel_selector instance;
-    return instance;
+range_kernel_selector::range_kernel_selector() {
+    Attach<RangeKernelRef>();
 }
 
+KernelsData range_kernel_selector::GetBestKernels(const Params& params, const optional_params& options) const {
+    return GetNaiveBestKernel(params, options, KernelType::RANGE);
+}
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/range/range_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/range/range_kernel_selector.h
@@ -7,7 +7,17 @@
 #include "kernel_selector.h"
 
 namespace kernel_selector {
+class range_kernel_selector : public kernel_selector_base {
+public:
+    static range_kernel_selector& Instance() {
+        static range_kernel_selector instance_;
+        return instance_;
+    }
 
-kernel_selector_base& range_instance();
+    range_kernel_selector();
 
+    virtual ~range_kernel_selector() {}
+
+    KernelsData GetBestKernels(const Params& params, const optional_params& options) const override;
+};
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/shape_of/shape_of_kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/shape_of/shape_of_kernel_selector.cpp
@@ -6,23 +6,12 @@
 #include "shape_of_kernel_ref.h"
 
 namespace kernel_selector {
-namespace {
 
-class shape_of_kernel_selector: public kernel_selector_base {
-    KernelsData GetBestKernels(const Params &params, const optional_params &options) const override {
-        return GetNaiveBestKernel(params, options, KernelType::SHAPE_OF);
-    }
-public:
-    shape_of_kernel_selector() {
-        Attach<ShapeOfKernelRef>();
-    }
-};
-
-}  // namespace
-
-kernel_selector_base& shape_of_instance() {
-    static shape_of_kernel_selector instance;
-    return instance;
+shape_of_kernel_selector::shape_of_kernel_selector() {
+    Attach<ShapeOfKernelRef>();
 }
 
+KernelsData shape_of_kernel_selector::GetBestKernels(const Params& params, const optional_params& options) const {
+    return GetNaiveBestKernel(params, options, KernelType::SHAPE_OF);
+}
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/shape_of/shape_of_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/shape_of/shape_of_kernel_selector.h
@@ -7,7 +7,17 @@
 #include "kernel_selector.h"
 
 namespace kernel_selector {
+class shape_of_kernel_selector : public kernel_selector_base {
+public:
+    static shape_of_kernel_selector& Instance() {
+        static shape_of_kernel_selector instance_;
+        return instance_;
+    }
 
-kernel_selector_base& shape_of_instance();
+    shape_of_kernel_selector();
 
+    virtual ~shape_of_kernel_selector() {}
+
+    KernelsData GetBestKernels(const Params& params, const optional_params& options) const override;
+};
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/tests/test_cases/reorg_yolo_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reorg_yolo_gpu_test.cpp
@@ -297,7 +297,7 @@ public:
         std::tie(params, target_format, should_fail) = this->GetParam();
 
         if (should_fail) {
-            ASSERT_THROW(run_test(params, target_format), std::invalid_argument);
+            ASSERT_ANY_THROW(run_test(params, target_format));
         } else {
             ASSERT_NO_FATAL_FAILURE(run_test(params, target_format));
         }


### PR DESCRIPTION
### Details:
 - Add `kernel_selector::get_best_kernel()` method instead of `GetBestKernels()` to avoid emptiness check copy-paste
 - `GetBestKernels()` is made protected
 - primitive_impl::create methods now return `unique_ptr`
 - Extracted `primitive_impl::get_kernel_params()` functions from `primitive_impl::create()` for further reuse in `primitive_impl::update_dispatch_data()` (Several primitives are not changed as we need to handle those carefully to get rid of program_node dependency)
 - Added common impl of create() function which can be used in primitive impls which has `get_kernel_params()` implemented