### PR TITLE
[Snippets][INT8] Optimized LoadNetwork time

### DIFF
--- a/src/common/snippets/include/snippets/op/convert_saturation.hpp
+++ b/src/common/snippets/include/snippets/op/convert_saturation.hpp
@@ -30,7 +30,7 @@ public:
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
-    bool has_evaluate() const override { return false; }
+    bool has_evaluate() const override;
 };
 
 } // namespace op

--- a/src/common/snippets/include/snippets/op/convert_truncation.hpp
+++ b/src/common/snippets/include/snippets/op/convert_truncation.hpp
@@ -28,8 +28,6 @@ public:
     ConvertTruncation() = default;
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
-
-    bool has_evaluate() const override { return false; }
 };
 
 } // namespace op

--- a/src/common/snippets/include/snippets/op/subgraph.hpp
+++ b/src/common/snippets/include/snippets/op/subgraph.hpp
@@ -82,6 +82,9 @@ public:
 
     void validate_and_infer_types() override;
 
+    // Check for unregistered parameters in body
+    void verify_parameters() const;
+
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& inputs) const override;
 
     // we introduce this method instead of using SubGraphOp::get_function()

--- a/src/common/snippets/include/snippets/pass/constant_convert_folding.hpp
+++ b/src/common/snippets/include/snippets/pass/constant_convert_folding.hpp
@@ -1,0 +1,27 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <ngraph/pass/graph_rewrite.hpp>
+#include <ngraph/pattern/matcher.hpp>
+
+namespace ngraph {
+namespace snippets {
+namespace pass {
+
+/**
+ * @interface ConstantConvertFolding
+ * @brief Constant folding only for branches with Constant and Convert
+ * @ingroup snippets
+ */
+class ConstantConvertFolding: public ngraph::pass::MatcherPass {
+public:
+    ConstantConvertFolding();
+};
+
+
+} // namespace pass
+} // namespace snippets
+} // namespace ngraph

--- a/src/common/snippets/include/snippets/pass/fq_decomposition.hpp
+++ b/src/common/snippets/include/snippets/pass/fq_decomposition.hpp
@@ -61,28 +61,14 @@ public:
                                    std::vector<float>& ish,
                                    std::vector<float>& osc,
                                    std::vector<float>& osh);
-    static std::vector<float> calculateScales(const ngraph::element::Type& out_type,
-                                              const std::vector<float>& cl,
-                                              const std::vector<float>& ch,
-                                              const std::vector<float>& isc,
-                                              const std::vector<float>& ish,
-                                              const std::vector<float>& osc,
-                                              const std::vector<float>& osh);
-};
-
-/**
- * @interface CommonFakeQuantizeDecomposition
- * @ingroup snippets
- * @brief CommonFakeQuantizeDecomposition pass applies all needed transformations for
- *        correct FQ Decomposition:
- *          0. Disable Validate() pass after each transformations
- *          1. FakeQuantization decomposition
- *          2. ConstantFolding
- *          3. Validate
- */
-class CommonFakeQuantizeDecomposition: public ngraph::pass::FunctionPass {
-public:
-    bool run_on_model(const std::shared_ptr<ngraph::Function>& m) override;
+    static bool calculateScales(const ngraph::element::Type& out_type,
+                                const std::vector<float>& cl,
+                                const std::vector<float>& ch,
+                                const std::vector<float>& isc,
+                                const std::vector<float>& ish,
+                                const std::vector<float>& osc,
+                                const std::vector<float>& osh,
+                                std::vector<float>& scales);
 };
 
 }  // namespace pass

--- a/src/common/snippets/src/op/convert_saturation.cpp
+++ b/src/common/snippets/src/op/convert_saturation.cpp
@@ -18,3 +18,12 @@ std::shared_ptr<ngraph::Node> ngraph::snippets::op::ConvertSaturation::clone_wit
     check_new_args_count(this, new_args);
     return std::make_shared<ConvertSaturation>(new_args.at(0), m_destination_type);
 }
+
+bool ngraph::snippets::op::ConvertSaturation::has_evaluate() const {
+    INTERNAL_OP_SCOPE(ConvertSaturation_has_evaluate);
+    // Original ngraph Convert has truncation algorithm for integer values so we can reuse this implementation
+    // for cases when destination element type is float
+    if (m_destination_type.is_integral())
+        return false;
+    return ov::op::v0::Convert::has_evaluate();
+}

--- a/src/common/snippets/src/pass/common_optimizations.cpp
+++ b/src/common/snippets/src/pass/common_optimizations.cpp
@@ -52,8 +52,9 @@ void ConvertConstantsToParameters(const std::shared_ptr<ngraph::snippets::op::Su
 
     if (new_parameters.size() != 0) {
         body->add_parameters(new_parameters);
-        body->validate_nodes_and_infer_types();
         subgraph->set_arguments(new_external_inputs);
+        // After new parameter addition we should verify body parameters
+        subgraph->verify_parameters();
     }
 }
 
@@ -71,12 +72,13 @@ CommonOptimizations::CommonOptimizations() {
         const auto is_quantized = subgraph->is_quantized();
 
         // Firsly we should transform all original Converts inside body to ConvertTruncation to save original behavior.
-        // Then if Subgraph contains FakeQuantize we enable specific transformation for quantized subgraphs.
+        // Then if Subgraph contains FakeQuantize we enable fq decomposition transformation for quantized subgraphs.
         ngraph::pass::Manager manager;
+        manager.set_per_pass_validation(false);
         manager.register_pass<ngraph::snippets::pass::TransformConvertToConvertTruncation>();
         manager.register_pass<ngraph::snippets::pass::ExplicitTransposeMatMulInputs>();
         if (is_quantized) {
-            manager.register_pass<ngraph::snippets::pass::CommonFakeQuantizeDecomposition>();
+            manager.register_pass<ngraph::snippets::pass::FakeQuantizeDecomposition>();
         }
         manager.register_pass<snippets::pass::SoftmaxReshapeElimination>();
         manager.run_passes(body);
@@ -86,6 +88,7 @@ CommonOptimizations::CommonOptimizations() {
         if (is_quantized) {
             ConvertConstantsToParameters(subgraph);
         }
+
         return true;
     };
 

--- a/src/common/snippets/src/pass/constant_convert_folding.cpp
+++ b/src/common/snippets/src/pass/constant_convert_folding.cpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <snippets/itt.hpp>
+
+#include "snippets/pass/constant_convert_folding.hpp"
+#include "ngraph/pass/constant_folding.hpp"
+
+#include <ngraph/opsets/opset1.hpp>
+#include <ngraph/rt_info.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+
+const auto friendly_name_from = [](const ov::Node& node, const size_t output_count, const size_t idx) {
+    constexpr auto single_output = static_cast<size_t>(1);
+    return single_output == output_count ? node.get_friendly_name() : node.get_friendly_name() + "." + std::to_string(idx);
+};
+
+ngraph::snippets::pass::ConstantConvertFolding::ConstantConvertFolding() {
+    MATCHER_SCOPE(ConstantConvertFolding);
+    auto constant_pattern = ngraph::pattern::wrap_type<ngraph::opset1::Constant>();
+    auto convert_pattern = ngraph::pattern::wrap_type<ngraph::opset1::Convert>({constant_pattern});
+
+    register_matcher(std::make_shared<ngraph::pattern::Matcher>(convert_pattern, matcher_name),
+        [=](ngraph::pattern::Matcher &m) {
+            OV_ITT_SCOPED_TASK(ngraph::pass::itt::domains::SnippetsTransform, "Snippets::op::ConstantConvertFolding")
+            auto root = m.get_match_root();
+
+            const auto &pm = m.get_pattern_value_map();
+            const auto constant = pm.at(constant_pattern).get_node_shared_ptr();
+            const auto convert = pm.at(convert_pattern).get_node_shared_ptr();
+
+            bool rewritten = false;
+            OutputVector replacements(convert->get_output_size());
+            if (convert->constant_fold(replacements, convert->input_values())) {
+                const bool constant_folding_is_disabled = convert->get_rt_info().count(ov::pass::DisableConstantFolding::get_type_info_static());
+                OPENVINO_ASSERT(!constant_folding_is_disabled,
+                                "Node folded but constant folding disabled. Check constant_fold implementation for ",
+                                convert);
+                OPENVINO_ASSERT(replacements.size() == convert->get_output_size(),
+                                "constant_fold_default returned incorrect number of replacements for ",
+                                convert);
+
+                for (size_t i = 0; i < replacements.size(); ++i) {
+                    auto node_output = convert->output(i);
+                    auto replacement = replacements.at(i);
+                    if (replacement.get_node_shared_ptr() && (node_output != replacement)) {
+                        replacement.get_node()->set_friendly_name(friendly_name_from(*convert, replacements.size(), i));
+
+                        node_output.replace(replacement);
+                        // Propagate runtime info attributes to replacement consumer nodes
+                        for (auto& input : replacement.get_target_inputs()) {
+                            auto consumer = input.get_node()->shared_from_this();
+                            copy_runtime_info({convert, consumer}, consumer);
+                        }
+
+                        rewritten = true;
+                    }
+                }
+            }
+            return rewritten;
+        });
+}

--- a/src/common/snippets/src/pass/explicit_transpose_matmul_inputs.cpp
+++ b/src/common/snippets/src/pass/explicit_transpose_matmul_inputs.cpp
@@ -75,6 +75,11 @@ ngraph::snippets::pass::ExplicitTransposeMatMulInputs::ExplicitTransposeMatMulIn
             } else {
                 matmul0->set_transpose_b(false);
             }
+
+            // Update shapes
+            transpose1->validate_and_infer_types();
+            matmul0->validate_and_infer_types();
+
             rewritten |= true;
         }
 

--- a/src/common/snippets/src/pass/softmax_reshape_elimination.cpp
+++ b/src/common/snippets/src/pass/softmax_reshape_elimination.cpp
@@ -63,8 +63,10 @@ ngraph::snippets::pass::SoftmaxReshapeElimination::SoftmaxReshapeElimination() {
             const auto new_axis = input_shape.rank().get_length() - 1;
             if (auto softmax_v8 = ngraph::as_type_ptr<ov::op::v8::Softmax>(softmax)) {
                 softmax_v8->set_axis(new_axis);
+                softmax_v8->validate_and_infer_types();
             } else if (auto softmax_v1 = ngraph::as_type_ptr<ov::op::v1::Softmax>(softmax)) {
                 softmax_v1->set_axis(new_axis);
+                softmax_v1->validate_and_infer_types();
             }
 
             return true;

--- a/src/common/snippets/tests/include/pass/constant_convert_folding.hpp
+++ b/src/common/snippets/tests/include/pass/constant_convert_folding.hpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "lowering_utils.hpp"
+#include "snippets_helpers.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+class ConstantConvertFoldingTests : public TransformationTestsF {
+public:
+    virtual void run();
+};
+
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov

--- a/src/common/snippets/tests/src/pass/constant_convert_folding.cpp
+++ b/src/common/snippets/tests/src/pass/constant_convert_folding.cpp
@@ -1,0 +1,121 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+#include <pass/constant_convert_folding.hpp>
+#include "snippets/snippets_isa.hpp"
+#include "snippets/pass/constant_convert_folding.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+void ConstantConvertFoldingTests::run() {
+    ASSERT_TRUE(function);
+    std::string name;
+    manager.register_pass<ngraph::snippets::pass::ConstantConvertFolding>();
+}
+
+TEST_F(ConstantConvertFoldingTests, smoke_Snippets_ConstantConvertFolding_oneConvertTruncation) {
+    const auto values = std::vector<float>{1, 2, 3, 4};
+    {
+        const auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4, 10, 10});
+        const auto constant = ngraph::builder::makeConstant(ov::element::i32, {1, 4, 1, 1}, values);
+        const auto convert = std::make_shared<ngraph::snippets::op::ConvertTruncation>(constant, ov::element::f32);
+        const auto add = std::make_shared<ov::op::v1::Add>(data, convert);
+        function = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data});
+    }
+    {
+        const auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4, 10, 10});
+        const auto constant = ngraph::builder::makeConstant(ov::element::f32, {1, 4, 1, 1}, values);
+        const auto add = std::make_shared<ov::op::v1::Add>(data, constant);
+        function_ref = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data});
+    }
+    run();
+}
+
+TEST_F(ConstantConvertFoldingTests, smoke_Snippets_ConstantConvertFolding_oneConvertSaturation) {
+    const auto values = std::vector<float>{1, 2, 3, 4};
+    {
+        const auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4, 10, 10});
+        const auto constant = ngraph::builder::makeConstant(ov::element::i32, {1, 4, 1, 1}, values);
+        const auto convert = std::make_shared<ngraph::snippets::op::ConvertSaturation>(constant, ov::element::f32);
+        const auto add = std::make_shared<ov::op::v1::Add>(data, convert);
+        function = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data});
+    }
+    {
+        const auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4, 10, 10});
+        const auto constant = ngraph::builder::makeConstant(ov::element::f32, {1, 4, 1, 1}, values);
+        const auto add = std::make_shared<ov::op::v1::Add>(data, constant);
+        function_ref = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data});
+    }
+    run();
+}
+
+TEST_F(ConstantConvertFoldingTests, smoke_Snippets_ConstantConvertFolding_twoConvertTruncationSaturation) {
+    const auto values = std::vector<float>{1, 2, 3, 4};
+    {
+        const auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4, 10, 10});
+        const auto constant = ngraph::builder::makeConstant(ov::element::i32, {1, 4, 1, 1}, values);
+        const auto convert0 = std::make_shared<ngraph::snippets::op::ConvertTruncation>(constant, ov::element::i8);
+        const auto convert1 = std::make_shared<ngraph::snippets::op::ConvertSaturation>(convert0, ov::element::f32);
+        const auto add = std::make_shared<ov::op::v1::Add>(data, convert1);
+        function = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data});
+    }
+    {
+        const auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4, 10, 10});
+        const auto constant = ngraph::builder::makeConstant(ov::element::f32, {1, 4, 1, 1}, values);
+        const auto add = std::make_shared<ov::op::v1::Add>(data, constant);
+        function_ref = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data});
+    }
+    run();
+}
+
+TEST_F(ConstantConvertFoldingTests, smoke_Snippets_ConstantConvertFolding_ConstantWithSeveralConsumers_Saturation) {
+    const auto values = std::vector<float>{1, 2, 3, 4};
+    {
+        const auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4, 10, 10});
+        const auto constant = ngraph::builder::makeConstant(ov::element::i32, {1, 4, 1, 1}, values);
+        const auto convert0 = std::make_shared<ngraph::snippets::op::ConvertSaturation>(constant, ov::element::f32);
+        const auto add = std::make_shared<ov::op::v1::Add>(data, convert0);
+        const auto convert1 = std::make_shared<ngraph::snippets::op::ConvertSaturation>(constant, ov::element::f32);
+        const auto mul = std::make_shared<ov::op::v1::Multiply>(add, convert1);
+        function = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{data});
+    }
+    {
+        const auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4, 10, 10});
+        const auto constant0 = ngraph::builder::makeConstant(ov::element::f32, {1, 4, 1, 1}, values);
+        const auto add = std::make_shared<ov::op::v1::Add>(data, constant0);
+        const auto constant1 = ngraph::builder::makeConstant(ov::element::f32, {1, 4, 1, 1}, values);
+        const auto mul = std::make_shared<ov::op::v1::Multiply>(add, constant1);
+        function_ref = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{data});
+    }
+    run();
+}
+
+TEST_F(ConstantConvertFoldingTests, smoke_Snippets_ConstantConvertFolding_ConvertWithSeveralConsumers_Truncation) {
+    const auto values = std::vector<float>{1, 2, 3, 4};
+    {
+        const auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4, 10, 10});
+        const auto constant = ngraph::builder::makeConstant(ov::element::i32, {1, 4, 1, 1}, values);
+        const auto convert = std::make_shared<ngraph::snippets::op::ConvertTruncation>(constant, ov::element::f32);
+        const auto add = std::make_shared<ov::op::v1::Add>(data, convert);
+        const auto mul = std::make_shared<ov::op::v1::Multiply>(add, convert);
+        function = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{data});
+    }
+    {
+        const auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4, 10, 10});
+        const auto constant = ngraph::builder::makeConstant(ov::element::f32, {1, 4, 1, 1}, values);
+        const auto add = std::make_shared<ov::op::v1::Add>(data, constant);
+        const auto mul = std::make_shared<ov::op::v1::Multiply>(add, constant);
+        function_ref = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{data});
+    }
+    run();
+}
+
+
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -541,6 +541,7 @@ bool Snippet::created() const {
 
 void Snippet::generate(const jit_snippets_compile_args* jcp) {
     ov::pass::Manager pre_dialect;
+    pre_dialect.set_per_pass_validation(false);
     pre_dialect.register_pass<ConvertToSwishCPU>();
     if (context->getConfig().enforceBF16 && snippet->has_domain_sensitive_ops()) {
         // enforce BF16 precisions to supported operations
@@ -551,9 +552,11 @@ void Snippet::generate(const jit_snippets_compile_args* jcp) {
     }
 
     ov::pass::Manager post_dialect;
+    post_dialect.set_per_pass_validation(false);
     post_dialect.register_pass<ov::intel_cpu::pass::BrgemmToBrgemmCPU>();
 
     ov::pass::Manager post_precision;
+    post_precision.set_per_pass_validation(false);
     post_precision.register_pass<ov::intel_cpu::pass::RemoveConverts>();
     post_precision.register_pass<ov::intel_cpu::pass::FuseLoadConvert>();
     post_precision.register_pass<ov::intel_cpu::pass::FuseStoreConvert>();

--- a/src/tests/ngraph_helpers/snippets_ngraph_functions/src/fake_quantize_function.cpp
+++ b/src/tests/ngraph_helpers/snippets_ngraph_functions/src/fake_quantize_function.cpp
@@ -220,21 +220,21 @@ std::shared_ptr<ov::Model> FakeQuantizeFunction::getSubgraphWithDecomposedFakeQu
             std::make_shared<ngraph::opset1::Constant>(element::f32, Shape{}, std::vector<float>{13.4211f}));
         multiply->set_friendly_name("multiply");
 
-        const auto subtract = std::make_shared<ngraph::opset1::Subtract>(
+        const auto subtract = std::make_shared<ngraph::opset1::Add>(
             multiply,
-            std::make_shared<ngraph::opset1::Constant>(element::f32, Shape{}, std::vector<float>{13.4211f}));
+            std::make_shared<ngraph::opset1::Constant>(element::f32, Shape{}, std::vector<float>{-13.4211f}));
         subtract->set_friendly_name("subtract");
 
         const auto round = std::make_shared<ngraph::opset5::Round>(subtract, ngraph::opset5::Round::RoundMode::HALF_TO_EVEN);
         round->set_friendly_name("round");
 
-        const auto devide = std::make_shared<ngraph::opset1::Multiply>(
+        const auto divide = std::make_shared<ngraph::opset1::Multiply>(
             round,
             std::make_shared<ngraph::opset1::Constant>(element::f32, Shape{}, std::vector<float>{0.0745098f}));
-        devide->set_friendly_name("devide");
+        divide->set_friendly_name("divide");
 
         const auto add = std::make_shared<ngraph::opset1::Add>(
-            devide,
+            divide,
             std::make_shared<ngraph::opset1::Constant>(element::f32, Shape{}, std::vector<float>{1.f}));
         add->set_friendly_name("add");
 


### PR DESCRIPTION
### Details:
- *Disabled automatic Validate() call and enable after needed transformations*
- *In `ConvertConstantsToParameters` we should check parameters for registration. It's enough for a validation. So now instead of `body->validate_and_type_infer()` we call `verify_parameters()` that verify unregistered parameters*
- *If it's possible now we insert explicitly Constants in FQ decomposition which we have calculated. So after that we can miss `ConstantFolding` pass*
- *After `PrecisionPropagate` pass we call own pass with ConstantFolding for pattern Scalar + Convert. It's covered by tests.*

### Tickets:
 - *93514*
