### PR TITLE
[GPU] Eltwise adjusted LWS for batch-blocked format

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_base.cpp
@@ -596,7 +596,26 @@ EltwiseKernelBase::DispatchData EltwiseKernelBase::SetDefault(const eltwise_para
     // TODO: can be potentially improved for GPUs with support of LWS > 256
     const size_t optimal_lws_values[] = { 256, 224, 192, 160, 128, 96, 64, 32, 16 };
 
-    if ((params.outputs[0].GetLayout() == DataLayout::b_fs_yx_fsv16 ||
+    if (dispatchData.gws[2] % 16 == 0 &&
+        params.outputs[0].Batch().v % 16 == 0 &&
+        params.outputs[0].Feature().v % 16 == 0 &&
+        dispatchData.gws[1] % 16 == 0 &&
+        (params.outputs[0].GetLayout() == DataLayout::bs_fs_yx_bsv32_fsv16 ||
+        params.outputs[0].GetLayout() == DataLayout::bs_fs_yx_bsv16_fsv16 ||
+        params.outputs[0].GetLayout() == DataLayout::bs_fs_zyx_bsv32_fsv16 ||
+        params.outputs[0].GetLayout() == DataLayout::bs_fs_zyx_bsv16_fsv16 ||
+        params.outputs[0].GetLayout() == DataLayout::bs_fs_zyx_bsv16_fsv32 ||
+        params.outputs[0].GetLayout() == DataLayout::bs_fs_zyx_bsv32_fsv32)) {
+        dispatchData.lws[0] = 1;
+        //dispatchData.gws[1] = ???; calc it below
+        dispatchData.lws[2] = 16;
+        for (auto lws : optimal_lws_values) {
+            if (dispatchData.gws[1] % lws == 0 && lws * dispatchData.lws[2] <= params.engineInfo.maxWorkGroupSize) {
+                dispatchData.lws[1] = lws;
+                break;
+            }
+        }
+    } else if ((params.outputs[0].GetLayout() == DataLayout::b_fs_yx_fsv16 ||
          params.outputs[0].GetLayout() == DataLayout::b_fs_zyx_fsv16 ||
          params.outputs[0].GetLayout() == DataLayout::bs_fs_yx_bsv32_fsv16 ||
          params.outputs[0].GetLayout() == DataLayout::bs_fs_yx_bsv16_fsv16 ||


### PR DESCRIPTION
LWS is adjusted to make items are fetched along batch axes in a workgroup if a layout has bsv32 or bsv16

### Details:
 - added if block for creating LWS for batch blocked layout

### Ticket:
 - 96189
