### PR TITLE
[HETERO][nGraph] Fix ConstantFolding fused_names handling

### DIFF
--- a/src/common/offline_transformations/src/compress_quantize_weigths.cpp
+++ b/src/common/offline_transformations/src/compress_quantize_weigths.cpp
@@ -67,7 +67,9 @@ ngraph::pass::CompressQuantizeWeights::CompressQuantizeWeights() {
         if (fq_users.size() == 1 && has_dequantization_subgraph(fq_users[0])) {
             auto& first_convert = fq_users[0];
             if (auto new_weights = ov::get_constant_from_source(first_convert)) {
+                new_weights->set_friendly_name(first_convert->get_friendly_name());
                 replace_node(first_convert, new_weights);
+                copy_runtime_info(first_convert, new_weights);
                 // preserve dequantization subgraph for LP transformations
                 auto weights_users = new_weights->get_users();
                 if (weights_users.size() == 1 && ov::is_type<ngraph::opset8::Convert>(weights_users[0])) {

--- a/src/common/transformations/src/transformations/common_optimizations/align_eltwise_input_ranks.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/align_eltwise_input_ranks.cpp
@@ -5,6 +5,7 @@
 #include "transformations/common_optimizations/align_eltwise_input_ranks.hpp"
 
 #include <ngraph/pattern/op/wrap_type.hpp>
+#include <ngraph/rt_info.hpp>
 #include <openvino/opsets/opset8.hpp>
 
 ov::pass::AlignEltwiseInputRanks::AlignEltwiseInputRanks() {
@@ -50,6 +51,7 @@ ov::pass::AlignEltwiseInputRanks::AlignEltwiseInputRanks() {
                 Shape new_shape = const_shape;
                 new_shape.insert(new_shape.begin(), diff, 1);
                 auto new_const = std::make_shared<opset8::Constant>(*const_node, new_shape);
+                copy_runtime_info(node->get_input_node_shared_ptr(i), new_const);
                 node->input(i).replace_source_output(new_const);
             }
         }

--- a/src/common/transformations/src/transformations/common_optimizations/fold_subgraph_empty_inputs.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fold_subgraph_empty_inputs.cpp
@@ -55,6 +55,7 @@ ov::pass::FoldSubgraphEmptyInputs::FoldSubgraphEmptyInputs() {
                              std::end(multi_subgraph_op_inputs),
                              input,
                              const_empty_replacement);
+                copy_runtime_info(input.get_node_shared_ptr(), const_empty_replacement.get_node_shared_ptr());
             }
             multi_subgraph_op->set_arguments(multi_subgraph_op_inputs);
             return true;

--- a/src/common/transformations/src/transformations/common_optimizations/remove_concat_zero_dim_input.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/remove_concat_zero_dim_input.cpp
@@ -53,6 +53,7 @@ ov::pass::RemoveConcatZeroDimInput::RemoveConcatZeroDimInput() {
                 const auto& empty_constant = opset8::Constant::create(concat->get_output_element_type(0),
                                                                       concat->get_output_partial_shape(0).to_shape(),
                                                                       {});
+                copy_runtime_info(concat, empty_constant);
                 concat->output(0).replace(empty_constant);
                 empty_constant->set_friendly_name(concat->get_friendly_name());
             } else {

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_split.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_split.cpp
@@ -155,6 +155,10 @@ ov::pass::TransposeSinkingSplitBackward::TransposeSinkingSplitBackward() {
                                                                Shape{},
                                                                reversed_transposed_split_axis);
         split->input(1).replace_source_output(new_split_axis_const);
+        copy_runtime_info({split_axis_constant,
+                           output_transpose.transpose->shared_from_this(),
+                           output_transpose.transpose_const->shared_from_this()},
+                          new_split_axis_const);
 
         // remove split output transposes
         for (size_t output_idx = 0; output_idx < split->get_output_size(); ++output_idx) {
@@ -196,6 +200,8 @@ ov::pass::TransposeSinkingSplitForward::TransposeSinkingSplitForward() {
         auto new_split_axis_const =
             std::make_shared<Constant>(split_axis_constant->get_element_type(), Shape{}, transposed_split_axis);
         split_node->input(1).replace_source_output(new_split_axis_const);
+        copy_runtime_info({split_axis_constant, transpose_input_info.transpose, transpose_input_info.transpose_const},
+                          new_split_axis_const);
 
         return true;
     };

--- a/src/common/transformations/src/transformations/smart_reshape/shape_of_const_folding.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/shape_of_const_folding.cpp
@@ -4,6 +4,8 @@
 
 #include "transformations/smart_reshape/shape_of_const_folding.hpp"
 
+#include <openvino/core/rt_info.hpp>
+
 #include "itt.hpp"
 #include "openvino/core/validation_util.hpp"
 #include "openvino/op/shape_of.hpp"
@@ -19,6 +21,7 @@ ov::pass::ShapeOfConstFolding::ShapeOfConstFolding() {
         auto node = m.get_match_root();
         if (auto constant = get_constant_from_source(node)) {
             constant->set_friendly_name(node->get_friendly_name());
+            copy_runtime_info(node, constant);
             replace_node(node, constant);
             return true;
         }

--- a/src/core/include/openvino/core/runtime_attribute.hpp
+++ b/src/core/include/openvino/core/runtime_attribute.hpp
@@ -30,6 +30,7 @@ public:
     using Base = std::tuple<::ov::RuntimeAttribute>;
     virtual ~RuntimeAttribute() = default;
     virtual bool is_copyable() const;
+    virtual bool is_copyable(const std::shared_ptr<Node>& to) const;
     virtual Any init(const std::shared_ptr<Node>& node) const;
     virtual Any merge(const ov::NodeVector& nodes) const;
     virtual Any merge(const ov::OutputVector& outputs) const;

--- a/src/core/include/openvino/op/shape_of.hpp
+++ b/src/core/include/openvino/op/shape_of.hpp
@@ -4,16 +4,16 @@
 
 #pragma once
 
-#include "openvino/op/op.hpp"
+#include "openvino/op/util/shape_of_base.hpp"
 
 namespace ov {
 namespace op {
 namespace v3 {
 /// \brief Operation that returns the shape of its input argument as a tensor.
 /// \ingroup ov_ops_cpp_api
-class OPENVINO_API ShapeOf : public Op {
+class OPENVINO_API ShapeOf : public util::ShapeOfBase {
 public:
-    OPENVINO_OP("ShapeOf", "opset3", op::Op, 3);
+    OPENVINO_OP("ShapeOf", "opset3", util::ShapeOfBase, 3);
     ShapeOf() = default;
     /// \brief Constructs a shape-of operation.
     ShapeOf(const Output<Node>& arg, const element::Type output_type = element::i64);
@@ -51,9 +51,9 @@ private:
 namespace v0 {
 /// \brief Operation that returns the shape of its input argument as a tensor.
 /// \ingroup ov_ops_cpp_api
-class OPENVINO_API ShapeOf : public Op {
+class OPENVINO_API ShapeOf : public util::ShapeOfBase {
 public:
-    OPENVINO_OP("ShapeOf", "opset1");
+    OPENVINO_OP("ShapeOf", "opset1", util::ShapeOfBase);
     ShapeOf() = default;
     /// \brief Constructs a shape-of operation.
     ShapeOf(const Output<Node>& arg);

--- a/src/core/include/openvino/op/util/shape_of_base.hpp
+++ b/src/core/include/openvino/op/util/shape_of_base.hpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/op.hpp"
+
+namespace ov {
+namespace op {
+namespace util {
+class OPENVINO_API ShapeOfBase : public Op {
+public:
+    OPENVINO_OP("ShapeOfBase", "util");
+
+    ShapeOfBase() = default;
+
+    /// \brief Constructs an ShapeOfBase operation.
+    explicit ShapeOfBase(const OutputVector& arguments) : Op(arguments) {}
+};
+}  // namespace util
+}  // namespace op
+}  // namespace ov

--- a/src/core/include/openvino/pass/constant_folding.hpp
+++ b/src/core/include/openvino/pass/constant_folding.hpp
@@ -22,7 +22,7 @@ public:
     bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
 
 protected:
-    void copy_runtime_info_from_input_values(const std::shared_ptr<Node>& node, const Output<Node>& replacement);
+    void copy_runtime_info_from_input_values(const std::shared_ptr<Node>& node);
     /// \brief Folds pre-calculated output tensor values to constants in case lower and
     /// upper estimations are equal. Traverses graph backwards starting from the results.
     bool pre_calculated_values_folding(const std::shared_ptr<ov::Model>& model);

--- a/src/core/include/openvino/pass/constant_folding.hpp
+++ b/src/core/include/openvino/pass/constant_folding.hpp
@@ -22,7 +22,7 @@ public:
     bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
 
 protected:
-    void copy_runtime_info_to_target_inputs(const std::shared_ptr<Node>& node, const Output<Node>& replacement);
+    void copy_runtime_info_from_input_values(const std::shared_ptr<Node>& node, const Output<Node>& replacement);
     /// \brief Folds pre-calculated output tensor values to constants in case lower and
     /// upper estimations are equal. Traverses graph backwards starting from the results.
     bool pre_calculated_values_folding(const std::shared_ptr<ov::Model>& model);

--- a/src/core/src/node.cpp
+++ b/src/core/src/node.cpp
@@ -5,6 +5,7 @@
 #include "ngraph/node.hpp"
 
 #include <memory>
+#include <ngraph/rt_info.hpp>
 #include <ngraph/validation_util.hpp>
 #include <sstream>
 #include <typeindex>
@@ -814,8 +815,10 @@ bool ov::Node::constant_fold(OutputVector& output_values, const OutputVector& in
     if (!all_constants)
         return false;
 
+    NodeVector nodes;
     TensorVector input_tensors;
     for (const auto& input : input_values) {
+        nodes.push_back(input.get_node_shared_ptr());
         auto constant = ov::as_type_ptr<ngraph::op::v0::Constant>(input.get_node_shared_ptr());
         auto tensor = ov::Tensor(input.get_element_type(), input.get_shape());
         std::copy_n(constant->get_data_ptr<uint8_t>(), constant->get_byte_size(), static_cast<uint8_t*>(tensor.data()));
@@ -833,6 +836,7 @@ bool ov::Node::constant_fold(OutputVector& output_values, const OutputVector& in
             output_values[i] = make_shared<ngraph::op::Constant>(output_tensors[i].get_element_type(),
                                                                  output_tensors[i].get_shape(),
                                                                  output_tensors[i].data());
+            copy_runtime_info(nodes, output_values[i].get_node_shared_ptr());
         }
         return true;
     }

--- a/src/core/src/op/shape_of.cpp
+++ b/src/core/src/op/shape_of.cpp
@@ -21,7 +21,9 @@
 using namespace std;
 using namespace ngraph;
 
-op::v3::ShapeOf::ShapeOf(const Output<Node>& arg, element::Type output_type) : Op({arg}), m_output_type(output_type) {
+op::v3::ShapeOf::ShapeOf(const Output<Node>& arg, element::Type output_type)
+    : ShapeOfBase({arg}),
+      m_output_type(output_type) {
     constructor_validate_and_infer_types();
 }
 
@@ -206,7 +208,7 @@ bool op::v3::ShapeOf::constant_fold(OutputVector& output_values, const OutputVec
 }
 
 // op::v0::ShapeOf
-op::v0::ShapeOf::ShapeOf(const Output<Node>& arg) : Op({arg}) {
+op::v0::ShapeOf::ShapeOf(const Output<Node>& arg) : ShapeOfBase({arg}) {
     constructor_validate_and_infer_types();
 }
 

--- a/src/core/src/rt_info.cpp
+++ b/src/core/src/rt_info.cpp
@@ -4,8 +4,7 @@
 
 #include "openvino/core/rt_info.hpp"
 
-#include "ngraph/op/util/op_types.hpp"
-#include "ngraph/variant.hpp"
+#include "openvino/op/util/op_types.hpp"
 
 namespace {
 

--- a/src/core/src/rt_info.cpp
+++ b/src/core/src/rt_info.cpp
@@ -91,7 +91,7 @@ ov::NodeVector list_with_constants(const ov::NodeVector& to) {
         }
         for (auto& input : node->inputs()) {
             auto source_node = input.get_source_output().get_node_shared_ptr();
-            if (ngraph::op::is_constant(source_node) && (0 == source_node->get_rt_info().size())) {
+            if (ov::op::util::is_constant(source_node) && (0 == source_node->get_rt_info().size())) {
                 if (std::find(ops.begin(), ops.end(), source_node) == ops.end()) {
                     ops.push_back(source_node);
                 }

--- a/src/core/src/rt_info.cpp
+++ b/src/core/src/rt_info.cpp
@@ -4,17 +4,19 @@
 
 #include "openvino/core/rt_info.hpp"
 
+#include "ngraph/op/util/op_types.hpp"
 #include "ngraph/variant.hpp"
 
 namespace {
 
-std::unordered_map<std::string, std::vector<ov::Any>> get_copyable_attrs(const ov::OutputVector& outputs) {
+std::unordered_map<std::string, std::vector<ov::Any>> get_copyable_attrs(const ov::OutputVector& outputs,
+                                                                         const ov::Output<ov::Node>& to) {
     std::unordered_map<std::string, std::vector<ov::Any>> attrs;
     for (const auto& output : outputs) {
         for (const auto& item : output.get_rt_info()) {
             bool copy = true;
             if (item.second.is<ov::RuntimeAttribute>()) {
-                copy = item.second.as<ov::RuntimeAttribute>().is_copyable();
+                copy = item.second.as<ov::RuntimeAttribute>().is_copyable(to.get_node_shared_ptr());
             }
             if (copy) {
                 attrs[item.first].push_back(item.second);
@@ -24,13 +26,14 @@ std::unordered_map<std::string, std::vector<ov::Any>> get_copyable_attrs(const o
     return attrs;
 }
 
-std::unordered_map<std::string, std::vector<ov::Any>> get_copyable_attrs(const ov::NodeVector& nodes) {
+std::unordered_map<std::string, std::vector<ov::Any>> get_copyable_attrs(const ov::NodeVector& nodes,
+                                                                         const std::shared_ptr<ov::Node>& to) {
     std::unordered_map<std::string, std::vector<ov::Any>> attrs;
     for (const auto& node : nodes) {
         for (const auto& item : node->get_rt_info()) {
             bool copy = item.first != "opset";
             if (item.second.is<ov::RuntimeAttribute>()) {
-                copy = copy && item.second.as<ov::RuntimeAttribute>().is_copyable();
+                copy = copy && item.second.as<ov::RuntimeAttribute>().is_copyable(to);
             }
             if (copy) {
                 attrs[item.first].push_back(item.second);
@@ -41,8 +44,8 @@ std::unordered_map<std::string, std::vector<ov::Any>> get_copyable_attrs(const o
 }
 
 template <typename T>
-ov::Node::RTMap mergeRuntimeInfo(const T& items) {
-    std::unordered_map<std::string, std::vector<ov::Any>> attrs = get_copyable_attrs(items);
+ov::Node::RTMap mergeRuntimeInfo(const std::vector<T>& items, const T& to) {
+    std::unordered_map<std::string, std::vector<ov::Any>> attrs = get_copyable_attrs(items, to);
 
     ov::Node::RTMap merged_attrs;
     for (auto& item : attrs) {
@@ -80,50 +83,60 @@ void assign_runtime_info(const ov::Node::RTMap& from, ov::Node::RTMap& to) {
     }
 }
 
+ov::NodeVector list_with_constants(const ov::NodeVector& to) {
+    ov::NodeVector ops = to;
+    for (auto& node : to) {
+        if (!node) {
+            continue;
+        }
+        for (auto& input : node->inputs()) {
+            auto source_node = input.get_source_output().get_node_shared_ptr();
+            if (ngraph::op::is_constant(source_node) && (0 == source_node->get_rt_info().size())) {
+                if (std::find(ops.begin(), ops.end(), source_node) == ops.end()) {
+                    ops.push_back(source_node);
+                }
+            }
+        }
+    }
+    return ops;
+}
+
+ov::OutputVector list_with_constants(const ov::OutputVector& to) {
+    ov::OutputVector ops = to;
+    for (auto& node : to) {
+        for (auto& input : node.get_node()->inputs()) {
+            auto source_node = input.get_source_output();
+            if (ngraph::op::is_constant(source_node.get_node_shared_ptr()) && (0 == source_node.get_rt_info().size())) {
+                if (std::find(ops.begin(), ops.end(), source_node) == ops.end()) {
+                    ops.push_back(source_node);
+                }
+            }
+        }
+    }
+    return ops;
+}
 }  // namespace
 
 void ov::copy_runtime_info(const std::shared_ptr<ov::Node>& from, const std::shared_ptr<ov::Node>& to) {
-    auto& attrs = to->get_rt_info();
-    auto opset = get_opset(attrs);
-
-    for (const auto& item : from->get_rt_info()) {
-        bool copy = item.first != "opset";
-        if (item.second.is<ov::RuntimeAttribute>()) {
-            copy = copy && item.second.as<ov::RuntimeAttribute>().is_copyable();
-        }
-        if (copy) {
-            attrs[item.first] = item.second;
-        }
-    }
-
-    if (!opset.empty()) {
-        attrs["opset"] = opset;
-    }
+    return copy_runtime_info(ov::NodeVector{from}, ov::NodeVector{to});
 }
 
 void ov::copy_runtime_info(const std::shared_ptr<ov::Node>& from, ov::NodeVector to) {
-    for (auto& op : to) {
-        copy_runtime_info(from, op);
-    }
+    return copy_runtime_info(ov::NodeVector{from}, to);
 }
 
 void ov::copy_runtime_info(const ov::NodeVector& from, const std::shared_ptr<ov::Node>& to) {
-    auto& rtInfoTo = to->get_rt_info();
-    assign_runtime_info(mergeRuntimeInfo(from), rtInfoTo);
+    return copy_runtime_info(from, ov::NodeVector{to});
 }
 
 void ov::copy_runtime_info(const ov::NodeVector& from, ov::NodeVector to) {
-    auto mergedInfo = mergeRuntimeInfo(from);
-    for (auto& node : to) {
-        auto& rtInfoTo = node->get_rt_info();
-        assign_runtime_info(mergedInfo, rtInfoTo);
+    for (auto& node : list_with_constants(to)) {
+        assign_runtime_info(mergeRuntimeInfo(from, node), node->get_rt_info());
     }
 }
 
 void ov::copy_output_runtime_info(const ov::OutputVector& from, ov::OutputVector to) {
-    auto mergedInfo = mergeRuntimeInfo(from);
-    for (auto& node : to) {
-        auto& rtInfoTo = node.get_rt_info();
-        assign_runtime_info(mergedInfo, rtInfoTo);
+    for (auto& node : list_with_constants(to)) {
+        assign_runtime_info(mergeRuntimeInfo(from, node), node.get_rt_info());
     }
 }

--- a/src/core/src/rt_info.cpp
+++ b/src/core/src/rt_info.cpp
@@ -106,7 +106,7 @@ ov::OutputVector list_with_constants(const ov::OutputVector& to) {
     for (auto& node : to) {
         for (auto& input : node.get_node()->inputs()) {
             auto source_node = input.get_source_output();
-            if (ngraph::op::is_constant(source_node.get_node_shared_ptr()) && (0 == source_node.get_rt_info().size())) {
+            if (ov::op::util::is_constant(source_node.get_node_shared_ptr()) && (0 == source_node.get_rt_info().size())) {
                 if (std::find(ops.begin(), ops.end(), source_node) == ops.end()) {
                     ops.push_back(source_node);
                 }

--- a/src/core/src/rt_info.cpp
+++ b/src/core/src/rt_info.cpp
@@ -106,7 +106,8 @@ ov::OutputVector list_with_constants(const ov::OutputVector& to) {
     for (auto& node : to) {
         for (auto& input : node.get_node()->inputs()) {
             auto source_node = input.get_source_output();
-            if (ov::op::util::is_constant(source_node.get_node_shared_ptr()) && (0 == source_node.get_rt_info().size())) {
+            if (ov::op::util::is_constant(source_node.get_node_shared_ptr()) &&
+                (0 == source_node.get_rt_info().size())) {
                 if (std::find(ops.begin(), ops.end(), source_node) == ops.end()) {
                     ops.push_back(source_node);
                 }

--- a/src/core/src/runtime_attribute.cpp
+++ b/src/core/src/runtime_attribute.cpp
@@ -32,6 +32,10 @@ bool RuntimeAttribute::is_copyable() const {
     return true;
 }
 
+bool RuntimeAttribute::is_copyable(const std::shared_ptr<Node>& to) const {
+    return is_copyable();
+}
+
 std::ostream& operator<<(std::ostream& os, const RuntimeAttribute& attrubute) {
     return os << attrubute.to_string();
 }

--- a/src/core/tests/constant_folding.cpp
+++ b/src/core/tests/constant_folding.cpp
@@ -662,7 +662,7 @@ TEST(constant_folding, shape_of_v0) {
 
     auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    check_names(new_const, {"param", "test"});
+    check_names(new_const, {"test"});
     ASSERT_EQ(new_const->get_output_element_type(0), element::i64);
     auto values_out = new_const->get_vector<int64_t>();
 
@@ -685,7 +685,7 @@ TEST(constant_folding, shape_of_v3) {
 
     auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    check_names(new_const, {"param", "test"});
+    check_names(new_const, {"test"});
     ASSERT_EQ(new_const->get_output_element_type(0), element::i64);
     auto values_out = new_const->get_vector<int64_t>();
 
@@ -708,7 +708,7 @@ TEST(constant_folding, shape_of_i32_v3) {
 
     auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    check_names(new_const, {"param", "test"});
+    check_names(new_const, {"test"});
     ASSERT_EQ(new_const->get_output_element_type(0), element::i32);
     auto values_out = new_const->get_vector<int32_t>();
 

--- a/src/core/tests/constant_folding.cpp
+++ b/src/core/tests/constant_folding.cpp
@@ -18,9 +18,13 @@
 using namespace ngraph;
 using namespace std;
 
+static std::shared_ptr<op::Constant> get_result_constant(std::shared_ptr<Function> f, size_t pos = 0) {
+    return ov::as_type_ptr<op::Constant>(f->get_results().at(pos)->input_value(0).get_node_shared_ptr());
+}
+
 template <typename T>
-static std::vector<T> get_result_constant(std::shared_ptr<Function> f, size_t pos) {
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(pos)->input_value(0).get_node_shared_ptr());
+static std::vector<T> get_result_constant_data(std::shared_ptr<Function> f, size_t pos) {
+    auto new_const = get_result_constant(f, pos);
     return new_const->cast_vector<T>();
 }
 
@@ -38,6 +42,58 @@ typename std::enable_if<std::is_integral<T>::value>::type range_test_check(const
     ASSERT_EQ(values_out, values_expected);
 }
 
+std::ostream& operator<<(std::ostream& os, const std::vector<std::string>& s) {
+    os << "[";
+    for (auto it = s.begin(); it != s.end(); ++it) {
+        if (it != s.begin()) {
+            os << ", " << *it;
+        } else {
+            os << *it;
+        }
+    }
+    os << "]";
+    return os;
+}
+
+void run_constant_folding(std::shared_ptr<ov::Model>& model) {
+    pass::Manager pass_manager;
+    pass_manager.register_pass<pass::InitNodeInfo>();
+    pass_manager.register_pass<pass::ConstantFolding>();
+    pass_manager.run_passes(model);
+}
+
+static void check_names(const std::shared_ptr<ov::Node>& node,
+                        const std::vector<std::string>& expected_fused_names,
+                        const std::string expected_name = "test",
+                        bool exact = true) {
+    EXPECT_TRUE(node);
+
+    // Check node name
+    ASSERT_EQ(node->get_friendly_name(), expected_name);
+
+    // Check fused name
+    ASSERT_TRUE(!expected_fused_names.empty());
+    std::vector<std::string> fused_names = ngraph::getFusedNamesVector(node);
+    if (exact) {
+        std::vector<std::string> expected_sorted = expected_fused_names;
+        std::sort(fused_names.begin(), fused_names.end());
+        std::sort(expected_sorted.begin(), expected_sorted.end());
+        bool is_equal = std::equal(fused_names.begin(), fused_names.end(), expected_sorted.begin());
+        ASSERT_TRUE(is_equal) << "Expected names are not matched to the fused names. Expected '" << expected_fused_names
+                              << "' but actually received '" << fused_names << "'";
+    } else {
+        bool is_expected_name_missed = false;
+        for (auto& name : expected_fused_names) {
+            if (std::find(fused_names.begin(), fused_names.end(), name) == fused_names.end()) {
+                is_expected_name_missed = true;
+            }
+        }
+        ASSERT_FALSE(is_expected_name_missed)
+            << "Not all expected names are found in fused names. Expected '" << expected_fused_names
+            << "' but actually received '" << fused_names << "'";
+    }
+}
+
 TEST(constant_folding, acosh) {
     Shape shape_in{2, 4, 1};
 
@@ -47,21 +103,21 @@ TEST(constant_folding, acosh) {
         expected.push_back(std::acosh(f));
     }
     auto constant = make_shared<op::Constant>(element::f32, shape_in, values_in);
+    constant->set_friendly_name("constant");
     auto acosh = make_shared<op::Acosh>(constant);
     acosh->set_friendly_name("test");
     auto f = make_shared<Function>(acosh, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     EXPECT_EQ(count_ops_of_type<op::Acosh>(f), 0);
     EXPECT_EQ(count_ops_of_type<op::Constant>(f), 1);
     ASSERT_EQ(f->get_results().size(), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results()[0]->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     EXPECT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+
+    check_names(new_const, {"constant", "test"});
 
     auto values_out = new_const->get_vector<float>();
     EXPECT_TRUE(test::all_close_f(expected, values_out, MIN_FLOAT_TOLERANCE_BITS));
@@ -76,21 +132,20 @@ TEST(constant_folding, asinh) {
         expected.push_back(std::asinh(f));
     }
     auto constant = make_shared<op::Constant>(element::f32, shape_in, values_in);
+    constant->set_friendly_name("constant");
     auto asinh = make_shared<op::Asinh>(constant);
     asinh->set_friendly_name("test");
     auto f = make_shared<Function>(asinh, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     EXPECT_EQ(count_ops_of_type<op::Asinh>(f), 0);
     EXPECT_EQ(count_ops_of_type<op::Constant>(f), 1);
     ASSERT_EQ(f->get_results().size(), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results()[0]->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     EXPECT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "test"});
 
     auto values_out = new_const->get_vector<float>();
     EXPECT_TRUE(test::all_close_f(expected, values_out, MIN_FLOAT_TOLERANCE_BITS));
@@ -105,21 +160,20 @@ TEST(constant_folding, atanh) {
         expected.push_back(std::atanh(f));
     }
     auto constant = make_shared<op::Constant>(element::f32, shape_in, values_in);
+    constant->set_friendly_name("constant");
     auto atanh = make_shared<op::Atanh>(constant);
     atanh->set_friendly_name("test");
     auto f = make_shared<Function>(atanh, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     EXPECT_EQ(count_ops_of_type<op::Atanh>(f), 0);
     EXPECT_EQ(count_ops_of_type<op::Constant>(f), 1);
     ASSERT_EQ(f->get_results().size(), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results()[0]->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     EXPECT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "test"});
 
     auto values_out = new_const->get_vector<float>();
     EXPECT_TRUE(test::all_close_f(expected, values_out, MIN_FLOAT_TOLERANCE_BITS));
@@ -132,22 +186,22 @@ TEST(constant_folding, constant_squeeze) {
 
     vector<float> values_in{0, 1, 2, 3, 4, 5, 6, 7};
     auto constant = make_shared<op::Constant>(element::f32, shape_in, values_in);
+    constant->set_friendly_name("constant");
     vector<int64_t> values_axes{2};
     auto constant_axes = op::Constant::create(element::i64, axes_shape, values_axes);
+    constant_axes->set_friendly_name("constant_axes");
     auto squeeze = make_shared<op::Squeeze>(constant, constant_axes);
     squeeze->set_friendly_name("test");
     auto f = make_shared<Function>(squeeze, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Squeeze>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
-    ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    auto new_const = get_result_constant(f);
+    EXPECT_TRUE(new_const);
+    check_names(new_const, {"constant", "constant_axes", "test"});
     ASSERT_EQ(new_const->get_shape(), shape_out);
 
     auto values_out = new_const->get_vector<float>();
@@ -161,22 +215,22 @@ TEST(constant_folding, constant_unsqueeze) {
 
     vector<float> values_in{0, 1, 2, 3, 4, 5, 6, 7};
     auto constant = make_shared<op::Constant>(element::f32, shape_in, values_in);
+    constant->set_friendly_name("constant");
     vector<int64_t> values_axes{2, 3};
     auto constant_axes = op::Constant::create(element::i64, axes_shape, values_axes);
+    constant_axes->set_friendly_name("constant_axes");
     auto unsqueeze = make_shared<op::v0::Unsqueeze>(constant, constant_axes);
     unsqueeze->set_friendly_name("test");
     auto f = make_shared<Function>(unsqueeze, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v0::Unsqueeze>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "constant_axes", "test"});
     ASSERT_EQ(new_const->get_shape(), shape_out);
 
     auto values_out = new_const->get_vector<float>();
@@ -186,24 +240,25 @@ TEST(constant_folding, constant_unsqueeze) {
 TEST(constant_folding, constant_broadcast_v1) {
     vector<int32_t> values_in{0, 1};
     auto constant_in = make_shared<op::Constant>(element::i32, Shape{2}, values_in);
+    constant_in->set_friendly_name("constant_in");
     vector<int64_t> shape_in{2, 4};
     auto constant_shape = make_shared<op::Constant>(element::i64, Shape{2}, shape_in);
+    constant_shape->set_friendly_name("constant_shape");
     vector<int64_t> axes_in{0};
     auto constant_axes = make_shared<op::Constant>(element::i64, Shape{1}, axes_in);
+    constant_axes->set_friendly_name("constant_axes");
     auto broadcast_v1 = make_shared<op::v1::Broadcast>(constant_in, constant_shape, constant_axes);
     broadcast_v1->set_friendly_name("test");
     auto f = make_shared<Function>(broadcast_v1, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Broadcast>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_in", "constant_shape", "constant_axes", "test"});
     auto values_out = new_const->get_vector<int32_t>();
 
     vector<int32_t> values_expected{0, 0, 0, 0, 1, 1, 1, 1};
@@ -213,22 +268,22 @@ TEST(constant_folding, constant_broadcast_v1) {
 TEST(constant_folding, constant_broadcast_v1_with_target_shape) {
     vector<int32_t> values_in{1};
     auto constant_in = make_shared<op::Constant>(element::i32, Shape{1, 1, 1, 1}, values_in);
+    constant_in->set_friendly_name("constant_in");
     vector<int64_t> shape_in{1, 3, 1, 1};
     auto target_shape = make_shared<op::Constant>(element::i64, Shape{4}, shape_in);
+    target_shape->set_friendly_name("target_shape");
     auto broadcast_v1 = make_shared<op::v1::Broadcast>(constant_in, target_shape);
     broadcast_v1->set_friendly_name("test");
     auto f = make_shared<Function>(broadcast_v1, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Broadcast>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_in", "target_shape", "test"}, "test", false);
     auto values_out = new_const->get_vector<int32_t>();
 
     vector<int32_t> values_expected{1, 1, 1};
@@ -238,22 +293,22 @@ TEST(constant_folding, constant_broadcast_v1_with_target_shape) {
 TEST(constant_folding, constant_broadcast_v1_numpy) {
     vector<int32_t> values_in{0, 1};
     auto constant_in = make_shared<op::Constant>(element::i32, Shape{2}, values_in);
+    constant_in->set_friendly_name("constant_in");
     vector<int64_t> shape_in{4, 2};
     auto constant_shape = make_shared<op::Constant>(element::i64, Shape{2}, shape_in);
+    constant_shape->set_friendly_name("constant_shape");
     auto broadcast_v1 = make_shared<op::v1::Broadcast>(constant_in, constant_shape);
     broadcast_v1->set_friendly_name("test");
     auto f = make_shared<Function>(broadcast_v1, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Broadcast>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_in", "constant_shape", "test"}, "test", false);
     auto values_out = new_const->get_vector<int32_t>();
 
     vector<int32_t> values_expected{0, 1, 0, 1, 0, 1, 0, 1};
@@ -273,57 +328,105 @@ TEST(constant_folding, constant_unary_binary) {
     vector<int8_t> values_j{-3, 5};
     vector<uint8_t> values_k{3, 5};
     auto a = make_shared<op::Constant>(element::i32, Shape{2, 2}, values_a);
+    a->set_friendly_name("a");
     auto b = make_shared<op::Constant>(element::i32, Shape{2, 2}, values_b);
+    b->set_friendly_name("b");
     auto c = make_shared<op::Constant>(element::i32, Shape{2, 2}, values_c);
+    c->set_friendly_name("c");
     auto d = make_shared<op::Constant>(element::i32, Shape{2, 2}, values_d);
+    d->set_friendly_name("d");
     auto e = make_shared<op::Constant>(element::i32, Shape{2}, values_e);
+    e->set_friendly_name("e");
     auto f = make_shared<op::Constant>(element::i32, Shape{2}, values_f);
+    f->set_friendly_name("f");
     auto g = make_shared<op::Constant>(element::i32, Shape{2}, values_g);
+    g->set_friendly_name("g");
     auto h = make_shared<op::Constant>(element::boolean, Shape{2, 2}, values_h);
+    h->set_friendly_name("h");
     auto i = make_shared<op::Constant>(element::boolean, Shape{2}, values_i);
+    i->set_friendly_name("i");
     auto j = make_shared<op::Constant>(element::i8, Shape{2}, values_j);
+    j->set_friendly_name("j");
     auto k = make_shared<op::Constant>(element::u8, Shape{2}, values_k);
+    k->set_friendly_name("k");
     auto doubles = make_shared<op::Constant>(element::f64, Shape{2}, std::vector<double>{4.0, 9.0});
+    doubles->set_friendly_name("doubles");
     auto doubles2 = make_shared<op::Constant>(element::f64, Shape{2}, std::vector<double>{4.0, 1.0});
+    doubles2->set_friendly_name("doubles2");
     auto shorts = make_shared<op::Constant>(element::i16, Shape{3}, std::vector<int16_t>{14, -3, -3});
+    shorts->set_friendly_name("shorts");
     auto shorts2 = make_shared<op::Constant>(element::i16, Shape{1}, std::vector<int16_t>{-3});
+    shorts2->set_friendly_name("shorts2");
     auto unsigned_shorts = make_shared<op::Constant>(element::u16, Shape{3}, std::vector<uint16_t>{14, 300, 14});
+    unsigned_shorts->set_friendly_name("unsigned_shorts");
     auto unsigned_shorts2 = make_shared<op::Constant>(element::u16, Shape{1}, std::vector<uint16_t>{300});
+    unsigned_shorts2->set_friendly_name("unsigned_shorts2");
 
     auto add = make_shared<op::v1::Add>(a, b);
+    add->set_friendly_name("add");
     auto sub = make_shared<op::v1::Subtract>(a, b);
+    sub->set_friendly_name("sub");
     auto mul = make_shared<op::v1::Multiply>(a, b);
+    mul->set_friendly_name("mul");
     auto divn = make_shared<op::v1::Divide>(a, b);
+    divn->set_friendly_name("divn");
     auto pow = make_shared<op::v1::Power>(a, b);
+    pow->set_friendly_name("pow");
     auto min = make_shared<op::v1::Minimum>(c, a);
+    min->set_friendly_name("min");
     auto max = make_shared<op::v1::Maximum>(a, c);
+    max->set_friendly_name("max");
     auto absn = make_shared<op::Abs>(c);
+    absn->set_friendly_name("absn");
     auto neg = make_shared<op::Negative>(c);
+    neg->set_friendly_name("neg");
     auto sqrt = make_shared<op::Sqrt>(d);
+    sqrt->set_friendly_name("sqrt");
     auto add_autob_numpy = make_shared<op::v1::Add>(a, e, op::AutoBroadcastType::NUMPY);
+    add_autob_numpy->set_friendly_name("add_autob_numpy");
     auto sub_autob_numpy = make_shared<op::v1::Subtract>(a, e, op::AutoBroadcastType::NUMPY);
+    sub_autob_numpy->set_friendly_name("sub_autob_numpy");
     auto mul_autob_numpy = make_shared<op::v1::Multiply>(a, e, op::AutoBroadcastType::NUMPY);
+    mul_autob_numpy->set_friendly_name("mul_autob_numpy");
     auto div_autob_numpy = make_shared<op::v1::Divide>(a, g, op::AutoBroadcastType::NUMPY);
+    div_autob_numpy->set_friendly_name("div_autob_numpy");
     auto pow_autob_numpy = make_shared<op::v1::Power>(a, g, op::AutoBroadcastType::NUMPY);
+    pow_autob_numpy->set_friendly_name("pow_autob_numpy");
     auto min_autob_numpy = make_shared<op::v1::Minimum>(a, f, op::AutoBroadcastType::NUMPY);
+    min_autob_numpy->set_friendly_name("min_autob_numpy");
     auto max_autob_numpy = make_shared<op::v1::Maximum>(a, f, op::AutoBroadcastType::NUMPY);
+    max_autob_numpy->set_friendly_name("max_autob_numpy");
     auto equal_autob_numpy = make_shared<op::v1::Equal>(a, g, op::AutoBroadcastType::NUMPY);
+    equal_autob_numpy->set_friendly_name("equal_autob_numpy");
     auto not_equal_autob_numpy = make_shared<op::v1::NotEqual>(a, g, op::AutoBroadcastType::NUMPY);
+    not_equal_autob_numpy->set_friendly_name("not_equal_autob_numpy");
     auto greater_autob_numpy = make_shared<op::v1::Greater>(a, g, op::AutoBroadcastType::NUMPY);
+    greater_autob_numpy->set_friendly_name("greater_autob_numpy");
     auto greater_eq_autob_numpy = make_shared<op::v1::GreaterEqual>(a, g, op::AutoBroadcastType::NUMPY);
+    greater_eq_autob_numpy->set_friendly_name("greater_eq_autob_numpy");
     auto less_autob_numpy = make_shared<op::v1::Less>(a, g, op::AutoBroadcastType::NUMPY);
+    less_autob_numpy->set_friendly_name("less_autob_numpy");
     auto less_eq_autob_numpy = make_shared<op::v1::LessEqual>(a, g, op::AutoBroadcastType::NUMPY);
+    less_eq_autob_numpy->set_friendly_name("less_eq_autob_numpy");
     auto logical_or_autob_numpy = make_shared<op::v1::LogicalOr>(h, i, op::AutoBroadcastType::NUMPY);
+    logical_or_autob_numpy->set_friendly_name("logical_or_autob_numpy");
     auto logical_xor_autob_numpy = make_shared<op::Xor>(h, i, op::AutoBroadcastType::NUMPY);
+    logical_xor_autob_numpy->set_friendly_name("logical_xor_autob_numpy");
     auto doubles_sqrt = make_shared<op::Sqrt>(doubles);
+    doubles_sqrt->set_friendly_name("doubles_sqrt");
     auto sub_int8 = make_shared<op::v1::Subtract>(j, j);
+    sub_int8->set_friendly_name("sub_int8");
     auto sub_uint8 = make_shared<op::v1::Subtract>(k, k);
+    sub_uint8->set_friendly_name("sub_uint8");
     auto equal_doubles = make_shared<op::v1::Equal>(doubles, doubles2, op::AutoBroadcastType::NUMPY);
+    equal_doubles->set_friendly_name("equal_doubles");
     auto equal_shorts = make_shared<op::v1::Equal>(shorts, shorts2, op::AutoBroadcastType::NUMPY);
+    equal_shorts->set_friendly_name("equal_shorts");
     auto equal_unsigned_shorts =
         make_shared<op::v1::Equal>(unsigned_shorts, unsigned_shorts2, op::AutoBroadcastType::NUMPY);
-
+    equal_unsigned_shorts->set_friendly_name("equal_unsigned_shorts");
     auto neg_sqrt = make_shared<op::Sqrt>(c);
+    neg_sqrt->set_friendly_name("neg_sqrt");
 
     auto func = make_shared<Function>(NodeVector{add,
                                                  sub,
@@ -359,9 +462,7 @@ TEST(constant_folding, constant_unary_binary) {
                                       ParameterVector{});
     auto func_error = make_shared<Function>(NodeVector{neg_sqrt}, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(func);
+    run_constant_folding(func);
 
     // expected values
     vector<int> add_expected{2, 4, 6, 8};
@@ -395,57 +496,92 @@ TEST(constant_folding, constant_unary_binary) {
     vector<char> equal_shorts_expected{0, 1, 1};
     vector<char> equal_unsigned_shorts_expected{0, 1, 0};
 
-    ASSERT_EQ(get_result_constant<int>(func, 0), add_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 1), sub_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 2), mul_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 3), div_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 4), pow_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 5), min_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 6), max_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 7), abs_neg_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 8), abs_neg_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 9), sqrt_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 10), add_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 11), sub_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 12), mul_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 13), div_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 14), pow_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 15), min_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<int>(func, 16), max_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<char>(func, 17), equal_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<char>(func, 18), not_equal_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<char>(func, 19), greater_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<char>(func, 20), greater_eq_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<char>(func, 21), less_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<char>(func, 22), less_eq_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<char>(func, 23), logical_or_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<char>(func, 24), logical_xor_autob_numpy_expected);
-    ASSERT_EQ(get_result_constant<double>(func, 25), doubles_sqrt_expected);
-    ASSERT_EQ(get_result_constant<int8_t>(func, 26), sub_int8_expected);
-    ASSERT_EQ(get_result_constant<uint8_t>(func, 27), sub_uint8_expected);
-    ASSERT_EQ(get_result_constant<char>(func, 28), equal_doubles_expected);
-    ASSERT_EQ(get_result_constant<char>(func, 29), equal_shorts_expected);
-    ASSERT_EQ(get_result_constant<char>(func, 30), equal_unsigned_shorts_expected);
+    size_t index = 0;
+    ASSERT_EQ(get_result_constant_data<int>(func, index), add_expected);
+    check_names(get_result_constant(func, index++), {"a", "b", "add"}, "add");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), sub_expected);
+    check_names(get_result_constant(func, index++), {"a", "b", "sub"}, "sub");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), mul_expected);
+    check_names(get_result_constant(func, index++), {"a", "b", "mul"}, "mul");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), div_expected);
+    check_names(get_result_constant(func, index++), {"a", "b", "divn"}, "divn");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), pow_expected);
+    check_names(get_result_constant(func, index++), {"a", "b", "pow"}, "pow");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), min_expected);
+    check_names(get_result_constant(func, index++), {"c", "a", "min"}, "min");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), max_expected);
+    check_names(get_result_constant(func, index++), {"a", "c", "max"}, "max");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), abs_neg_expected);
+    check_names(get_result_constant(func, index++), {"c", "absn"}, "absn");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), abs_neg_expected);
+    check_names(get_result_constant(func, index++), {"c", "neg"}, "neg");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), sqrt_expected);
+    check_names(get_result_constant(func, index++), {"d", "sqrt"}, "sqrt");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), add_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"a", "e", "add_autob_numpy"}, "add_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), sub_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"a", "e", "sub_autob_numpy"}, "sub_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), mul_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"a", "e", "mul_autob_numpy"}, "mul_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), div_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"a", "g", "div_autob_numpy"}, "div_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), pow_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"a", "g", "pow_autob_numpy"}, "pow_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), min_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"a", "f", "min_autob_numpy"}, "min_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<int>(func, index), max_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"a", "f", "max_autob_numpy"}, "max_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<char>(func, index), equal_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"a", "g", "equal_autob_numpy"}, "equal_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<char>(func, index), not_equal_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"a", "g", "not_equal_autob_numpy"}, "not_equal_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<char>(func, index), greater_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"a", "g", "greater_autob_numpy"}, "greater_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<char>(func, index), greater_eq_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"a", "g", "greater_eq_autob_numpy"}, "greater_eq_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<char>(func, index), less_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"a", "g", "less_autob_numpy"}, "less_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<char>(func, index), less_eq_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"a", "g", "less_eq_autob_numpy"}, "less_eq_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<char>(func, index), logical_or_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"h", "i", "logical_or_autob_numpy"}, "logical_or_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<char>(func, index), logical_xor_autob_numpy_expected);
+    check_names(get_result_constant(func, index++), {"h", "i", "logical_xor_autob_numpy"}, "logical_xor_autob_numpy");
+    ASSERT_EQ(get_result_constant_data<double>(func, index), doubles_sqrt_expected);
+    check_names(get_result_constant(func, index++), {"doubles", "doubles_sqrt"}, "doubles_sqrt");
+    ASSERT_EQ(get_result_constant_data<int8_t>(func, index), sub_int8_expected);
+    check_names(get_result_constant(func, index++), {"j", "sub_int8"}, "sub_int8");
+    ASSERT_EQ(get_result_constant_data<uint8_t>(func, index), sub_uint8_expected);
+    check_names(get_result_constant(func, index++), {"k", "sub_uint8"}, "sub_uint8");
+    ASSERT_EQ(get_result_constant_data<char>(func, index), equal_doubles_expected);
+    check_names(get_result_constant(func, index++), {"doubles", "doubles2", "equal_doubles"}, "equal_doubles");
+    ASSERT_EQ(get_result_constant_data<char>(func, index), equal_shorts_expected);
+    check_names(get_result_constant(func, index++), {"shorts", "shorts2", "equal_shorts"}, "equal_shorts");
+    ASSERT_EQ(get_result_constant_data<char>(func, index), equal_unsigned_shorts_expected);
+    check_names(get_result_constant(func, index++),
+                {"unsigned_shorts", "unsigned_shorts2", "equal_unsigned_shorts"},
+                "equal_unsigned_shorts");
+
+    pass::Manager pass_manager;
     ASSERT_NO_THROW(pass_manager.run_passes(func_error));
 }
 
 template <element::Type_t from, element::Type_t to, typename T, typename U>
 static void test_const_convert(const vector<T>& values_in, const vector<U>& values_expected) {
     auto constant = op::Constant::create(from, Shape{values_in.size()}, values_in);
+    constant->set_friendly_name("constant");
     auto convert = make_shared<op::Convert>(constant, to);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Convert>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "test"});
     ASSERT_EQ(new_const->get_output_element_type(0), to);
     auto values_out = new_const->template cast_vector<U>();
 
@@ -514,20 +650,19 @@ TEST(constant_folding, shape_of_v0) {
     Shape input_shape{3, 4, 0, 22, 608, 909, 3};
 
     auto param = make_shared<op::Parameter>(element::boolean, input_shape);
+    param->set_friendly_name("param");
     auto shape_of = make_shared<op::v0::ShapeOf>(param);
     shape_of->set_friendly_name("test");
     auto f = make_shared<Function>(shape_of, ParameterVector{param});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v0::ShapeOf>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"param", "test"});
     ASSERT_EQ(new_const->get_output_element_type(0), element::i64);
     auto values_out = new_const->get_vector<int64_t>();
 
@@ -538,20 +673,19 @@ TEST(constant_folding, shape_of_v3) {
     Shape input_shape{3, 4, 0, 22, 608, 909, 3};
 
     auto param = make_shared<op::Parameter>(element::boolean, input_shape);
+    param->set_friendly_name("param");
     auto shape_of = make_shared<op::v3::ShapeOf>(param);
     shape_of->set_friendly_name("test");
     auto f = make_shared<Function>(shape_of, ParameterVector{param});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v3::ShapeOf>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"param", "test"});
     ASSERT_EQ(new_const->get_output_element_type(0), element::i64);
     auto values_out = new_const->get_vector<int64_t>();
 
@@ -562,20 +696,19 @@ TEST(constant_folding, shape_of_i32_v3) {
     Shape input_shape{3, 4, 0, 22, 608, 909, 3};
 
     auto param = make_shared<op::Parameter>(element::boolean, input_shape);
+    param->set_friendly_name("param");
     auto shape_of = make_shared<op::v3::ShapeOf>(param, element::i32);
     shape_of->set_friendly_name("test");
     auto f = make_shared<Function>(shape_of, ParameterVector{param});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v3::ShapeOf>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"param", "test"});
     ASSERT_EQ(new_const->get_output_element_type(0), element::i32);
     auto values_out = new_const->get_vector<int32_t>();
 
@@ -590,15 +723,13 @@ TEST(constant_folding, shape_of_dynamic_v0) {
     shape_of->set_friendly_name("test");
     auto f = make_shared<Function>(shape_of, ParameterVector{param});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(f->get_ops().size(), 3);
 
     auto result_shape_of = f->get_results().at(0)->get_input_node_shared_ptr(0);
     ASSERT_EQ(result_shape_of, shape_of);
-    ASSERT_EQ(result_shape_of->get_friendly_name(), "test");
+    check_names(result_shape_of, {"test"});
 }
 
 TEST(constant_folding, shape_of_dynamic_v3) {
@@ -609,15 +740,13 @@ TEST(constant_folding, shape_of_dynamic_v3) {
     shape_of->set_friendly_name("test");
     auto f = make_shared<Function>(shape_of, ParameterVector{param});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(f->get_ops().size(), 3);
 
     auto result_shape_of = f->get_results().at(0)->get_input_node_shared_ptr(0);
     ASSERT_EQ(result_shape_of, shape_of);
-    ASSERT_EQ(result_shape_of->get_friendly_name(), "test");
+    check_names(result_shape_of, {"test"});
 }
 
 TEST(constant_folding, shape_of_dynamic_i32_v3) {
@@ -628,15 +757,13 @@ TEST(constant_folding, shape_of_dynamic_i32_v3) {
     shape_of->set_friendly_name("test");
     auto f = make_shared<Function>(shape_of, ParameterVector{param});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(f->get_ops().size(), 3);
 
     auto result_shape_of = f->get_results().at(0)->get_input_node_shared_ptr(0);
     ASSERT_EQ(result_shape_of, shape_of);
-    ASSERT_EQ(result_shape_of->get_friendly_name(), "test");
+    check_names(result_shape_of, {"test"});
 }
 
 // We need to be sure that constant folding won't be calculated endlessly.
@@ -648,16 +775,13 @@ TEST(constant_folding, shape_of_dynamic_double_folding_v0) {
     shape_of->set_friendly_name("test");
     auto f = make_shared<Function>(shape_of, ParameterVector{param});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(f->get_ops().size(), 3);
 
     auto result_shape_of = f->get_results().at(0)->get_input_node_shared_ptr(0);
     ASSERT_EQ(result_shape_of, shape_of);
-    ASSERT_EQ(result_shape_of->get_friendly_name(), "test");
+    check_names(result_shape_of, {"test"});
 }
 
 TEST(constant_folding, shape_of_dynamic_double_folding_v3) {
@@ -668,16 +792,13 @@ TEST(constant_folding, shape_of_dynamic_double_folding_v3) {
     shape_of->set_friendly_name("test");
     auto f = make_shared<Function>(shape_of, ParameterVector{param});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(f->get_ops().size(), 3);
 
     auto result_shape_of = f->get_results().at(0)->get_input_node_shared_ptr(0);
     ASSERT_EQ(result_shape_of, shape_of);
-    ASSERT_EQ(result_shape_of->get_friendly_name(), "test");
+    check_names(result_shape_of, {"test"});
 }
 
 // Constant folding will not succeed on ShapeOf if the argument rank is dynamic.
@@ -690,16 +811,14 @@ TEST(constant_folding, shape_of_rank_dynamic_v0) {
     shape_of->set_friendly_name("test");
     auto f = make_shared<Function>(shape_of, ParameterVector{param});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v0::ShapeOf>(f), 1);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 0);
 
     auto result_shape_of = f->get_results().at(0)->get_input_node_shared_ptr(0);
     ASSERT_EQ(result_shape_of, shape_of);
-    ASSERT_EQ(result_shape_of->get_friendly_name(), "test");
+    check_names(result_shape_of, {"test"});
 }
 
 TEST(constant_folding, shape_of_rank_dynamic_v3) {
@@ -710,16 +829,14 @@ TEST(constant_folding, shape_of_rank_dynamic_v3) {
     shape_of->set_friendly_name("test");
     auto f = make_shared<Function>(shape_of, ParameterVector{param});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v3::ShapeOf>(f), 1);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 0);
 
     auto result_shape_of = f->get_results().at(0)->get_input_node_shared_ptr(0);
     ASSERT_EQ(result_shape_of, shape_of);
-    ASSERT_EQ(result_shape_of->get_friendly_name(), "test");
+    check_names(result_shape_of, {"test"});
 }
 
 void const_reverse(const element::Type& axes_elem_type) {
@@ -727,21 +844,21 @@ void const_reverse(const element::Type& axes_elem_type) {
 
     vector<int32_t> values_in{1, 2, 3, 4, 5, 6, 7, 8, 9};
     auto constant = op::Constant::create(element::i32, input_shape, values_in);
+    constant->set_friendly_name("constant");
     auto axes = op::Constant::create(axes_elem_type, {1}, {1});
+    axes->set_friendly_name("axes");
     auto convert = make_shared<op::v1::Reverse>(constant, axes, op::v1::Reverse::Mode::INDEX);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Reverse>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "axes", "test"});
     auto values_out = new_const->get_vector<int32_t>();
 
     vector<int32_t> values_expected{3, 2, 1, 6, 5, 4, 9, 8, 7};
@@ -767,23 +884,23 @@ TEST(constant_folding, const_reduceprod) {
 
     vector<int32_t> values_in{1, 2, 3, 4, 5, 6, 7, 8, 9};
     auto constant = op::Constant::create(element::i32, input_shape, values_in);
+    constant->set_friendly_name("constant");
     Shape axes_shape{1};
     vector<int32_t> values_axes{1};
     auto constant_axes = op::Constant::create(element::i64, axes_shape, values_axes);
+    constant_axes->set_friendly_name("constant_axes");
     auto convert = make_shared<op::v1::ReduceProd>(constant, constant_axes);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ReduceProd>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "constant_axes", "test"});
     ASSERT_EQ(new_const->get_shape(), output_shape);
 
     auto values_out = new_const->get_vector<int32_t>();
@@ -799,23 +916,23 @@ TEST(constant_folding, const_reduceprod_keepdims) {
 
     vector<int32_t> values_in{1, 2, 3, 4, 5, 6, 7, 8, 9};
     auto constant = op::Constant::create(element::i32, input_shape, values_in);
+    constant->set_friendly_name("constant");
     Shape axes_shape{1};
     vector<int32_t> values_axes{1};
     auto constant_axes = op::Constant::create(element::i64, axes_shape, values_axes);
+    constant_axes->set_friendly_name("constant_axes");
     auto convert = make_shared<op::v1::ReduceProd>(constant, constant_axes, true);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ReduceProd>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "constant_axes", "test"});
     ASSERT_EQ(new_const->get_shape(), output_shape);
 
     auto values_out = new_const->get_vector<int32_t>();
@@ -831,23 +948,22 @@ TEST(constant_folding, const_reducesum) {
 
     vector<int32_t> values_in{1, 2, 3, 4, 5, 6, 7, 8, 9};
     auto constant = op::Constant::create(element::i32, input_shape, values_in);
+    constant->set_friendly_name("constant");
     Shape axes_shape{1};
     vector<int32_t> values_axes{1};
     auto constant_axes = op::Constant::create(element::i64, axes_shape, values_axes);
+    constant_axes->set_friendly_name("constant_axes");
     auto convert = make_shared<op::v1::ReduceSum>(constant, constant_axes);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
-
+    run_constant_folding(f);
     ASSERT_EQ(count_ops_of_type<op::v1::ReduceSum>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "constant_axes", "test"});
     ASSERT_EQ(new_const->get_shape(), output_shape);
 
     auto values_out = new_const->get_vector<int32_t>();
@@ -863,23 +979,23 @@ TEST(constant_folding, const_reducesum_keepdims) {
 
     vector<int32_t> values_in{1, 2, 3, 4, 5, 6, 7, 8, 9};
     auto constant = op::Constant::create(element::i32, input_shape, values_in);
+    constant->set_friendly_name("constant");
     Shape axes_shape{1};
     vector<int32_t> values_axes{1};
     auto constant_axes = op::Constant::create(element::i64, axes_shape, values_axes);
+    constant_axes->set_friendly_name("constant_axes");
     auto convert = make_shared<op::v1::ReduceSum>(constant, constant_axes, true);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ReduceSum>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "constant_axes", "test"});
     ASSERT_EQ(new_const->get_shape(), output_shape);
 
     auto values_out = new_const->get_vector<int32_t>();
@@ -895,23 +1011,23 @@ TEST(constant_folding, const_reducemax) {
 
     vector<int32_t> values_in{1, 2, 3, 4, 5, 6};
     auto constant = op::Constant::create(element::i32, input_shape, values_in);
+    constant->set_friendly_name("constant");
     Shape axes_shape{1};
     vector<int32_t> values_axes{1};
     auto constant_axes = op::Constant::create(element::i64, axes_shape, values_axes);
+    constant_axes->set_friendly_name("constant_axes");
     auto convert = make_shared<op::v1::ReduceMax>(constant, constant_axes);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ReduceMax>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "constant_axes", "test"});
     ASSERT_EQ(new_const->get_shape(), output_shape);
 
     auto values_out = new_const->get_vector<int32_t>();
@@ -927,23 +1043,23 @@ TEST(constant_folding, const_reducemax_keepdims) {
 
     vector<int32_t> values_in{1, 2, 3, 4, 5, 6};
     auto constant = op::Constant::create(element::i32, input_shape, values_in);
+    constant->set_friendly_name("constant");
     Shape axes_shape{1};
     vector<int32_t> values_axes{1};
     auto constant_axes = op::Constant::create(element::i64, axes_shape, values_axes);
+    constant_axes->set_friendly_name("constant_axes");
     auto convert = make_shared<op::v1::ReduceMax>(constant, constant_axes, true);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ReduceMax>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "constant_axes", "test"});
     ASSERT_EQ(new_const->get_shape(), output_shape);
 
     auto values_out = new_const->get_vector<int32_t>();
@@ -959,23 +1075,23 @@ TEST(constant_folding, const_reducemin) {
 
     vector<int32_t> values_in{1, 2, 3, 4, 5, 6};
     auto constant = op::Constant::create(element::i32, input_shape, values_in);
+    constant->set_friendly_name("constant");
     Shape axes_shape{1};
     vector<int32_t> values_axes{1};
     auto constant_axes = op::Constant::create(element::i64, axes_shape, values_axes);
+    constant_axes->set_friendly_name("constant_axes");
     auto convert = make_shared<op::v1::ReduceMin>(constant, constant_axes);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ReduceMin>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "constant_axes", "test"});
     ASSERT_EQ(new_const->get_shape(), output_shape);
 
     auto values_out = new_const->get_vector<int32_t>();
@@ -991,23 +1107,23 @@ TEST(constant_folding, const_reducemin_keepdims) {
 
     vector<int32_t> values_in{1, 2, 3, 4, 5, 6};
     auto constant = op::Constant::create(element::i32, input_shape, values_in);
+    constant->set_friendly_name("constant");
     Shape axes_shape{1};
     vector<int32_t> values_axes{1};
     auto constant_axes = op::Constant::create(element::i64, axes_shape, values_axes);
+    constant_axes->set_friendly_name("constant_axes");
     auto convert = make_shared<op::v1::ReduceMin>(constant, constant_axes, true);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ReduceMin>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "constant_axes", "test"});
     ASSERT_EQ(new_const->get_shape(), output_shape);
 
     auto values_out = new_const->get_vector<int32_t>();
@@ -1023,23 +1139,23 @@ TEST(constant_folding, const_reducemean) {
 
     vector<int32_t> values_in{1, 2, 3, 4, 5, 6, 7, 8, 9};
     auto constant = op::Constant::create(element::i32, input_shape, values_in);
+    constant->set_friendly_name("constant");
     Shape axes_shape{1};
     vector<int32_t> values_axes{1};
     auto constant_axes = op::Constant::create(element::i64, axes_shape, values_axes);
+    constant_axes->set_friendly_name("constant_axes");
     auto convert = make_shared<op::v1::ReduceMean>(constant, constant_axes);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ReduceMean>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "constant_axes", "test"});
     ASSERT_EQ(new_const->get_shape(), output_shape);
 
     auto values_out = new_const->get_vector<int32_t>();
@@ -1055,23 +1171,23 @@ TEST(constant_folding, const_reducemean_keepdims) {
 
     vector<int32_t> values_in{1, 2, 3, 4, 5, 6, 7, 8, 9};
     auto constant = op::Constant::create(element::i32, input_shape, values_in);
+    constant->set_friendly_name("constant");
     Shape axes_shape{1};
     vector<int32_t> values_axes{1};
     auto constant_axes = op::Constant::create(element::i64, axes_shape, values_axes);
+    constant_axes->set_friendly_name("constant_axes");
     auto convert = make_shared<op::v1::ReduceMean>(constant, constant_axes, true);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ReduceMean>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "constant_axes", "test"});
     ASSERT_EQ(new_const->get_shape(), output_shape);
 
     auto values_out = new_const->get_vector<int32_t>();
@@ -1086,21 +1202,21 @@ TEST(constant_folding, const_reduce_logical_and__no_keepdims) {
 
     const vector<char> values_in{0, 1, 1, 0, 1, 0, 1, 1, 1};
     const auto data = op::Constant::create(element::boolean, input_shape, values_in);
+    data->set_friendly_name("data");
     const auto axes = op::Constant::create(element::i64, {1}, {1});
+    axes->set_friendly_name("axes");
     const auto convert = make_shared<op::v1::ReduceLogicalAnd>(data, axes, false);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ReduceLogicalAnd>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "axes", "test"});
 
     const Shape expected_out_shape{3};
     ASSERT_EQ(new_const->get_shape(), expected_out_shape);
@@ -1117,21 +1233,21 @@ TEST(constant_folding, const_reduce_logical_and__keepdims) {
 
     const vector<char> values_in{0, 1, 1, 0, 1, 0, 1, 1, 1};
     const auto data = op::Constant::create(element::boolean, input_shape, values_in);
+    data->set_friendly_name("data");
     const auto axes = op::Constant::create(element::i64, {1}, {1});
+    axes->set_friendly_name("axes");
     const auto convert = make_shared<op::v1::ReduceLogicalAnd>(data, axes, true);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ReduceLogicalAnd>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "axes", "test"});
 
     // the output shape is expected to have 'ones' at the positions specified in the reduction axes
     // in case the keep_dims attribute of ReduceLogicalAnd is set to true
@@ -1150,21 +1266,21 @@ TEST(constant_folding, const_reduce_logical_and__keepdims_3d) {
 
     const vector<char> values_in{1, 1, 0, 0, 1, 0, 0, 1};
     const auto data = op::Constant::create(element::boolean, input_shape, values_in);
+    data->set_friendly_name("data");
     const auto axes = op::Constant::create(element::i64, {2}, {0, 2});
+    axes->set_friendly_name("axes");
     const auto convert = make_shared<op::v1::ReduceLogicalAnd>(data, axes, true);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ReduceLogicalAnd>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "axes", "test"});
 
     const Shape expected_out_shape{1, 2, 1};
     ASSERT_EQ(new_const->get_shape(), expected_out_shape);
@@ -1181,21 +1297,21 @@ TEST(constant_folding, const_reduce_logical_or__no_keepdims) {
 
     const vector<char> values_in{1, 0, 0, 1, 0, 1, 0, 0, 0};
     const auto data = op::Constant::create(element::boolean, input_shape, values_in);
+    data->set_friendly_name("data");
     const auto axes = op::Constant::create(element::i64, {1}, {1});
+    axes->set_friendly_name("axes");
     const auto convert = make_shared<op::v1::ReduceLogicalOr>(data, axes, false);
     convert->set_friendly_name("test");
     auto f = make_shared<Function>(convert, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ReduceLogicalAnd>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "axes", "test"});
 
     const Shape expected_out_shape{3};
     ASSERT_EQ(new_const->get_shape(), expected_out_shape);
@@ -1209,21 +1325,21 @@ TEST(constant_folding, const_reduce_logical_or__no_keepdims) {
 
 TEST(constant_folding, const_concat) {
     auto constant0 = op::Constant::create(element::i32, Shape{2, 3}, vector<int32_t>{1, 2, 3, 4, 5, 6});
+    constant0->set_friendly_name("constant0");
     auto constant1 = op::Constant::create(element::i32, Shape{2, 1}, vector<int32_t>{7, 8});
+    constant1->set_friendly_name("constant1");
     auto concat = make_shared<op::Concat>(NodeVector{constant0, constant1}, 1);
     concat->set_friendly_name("test");
     auto f = make_shared<Function>(concat, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant0", "constant1", "test"});
     auto values_out = new_const->get_vector<int32_t>();
 
     vector<int32_t> values_expected{1, 2, 3, 7, 4, 5, 6, 8};
@@ -1233,22 +1349,22 @@ TEST(constant_folding, const_concat) {
 
 TEST(constant_folding, const_concat_3d_single_elem) {
     auto constant_1 = op::Constant::create(element::i32, Shape{1, 1, 1}, vector<int32_t>{1});
+    constant_1->set_friendly_name("constant_1");
     auto constant_2 = op::Constant::create(element::i32, Shape{1, 1, 1}, vector<int32_t>{2});
+    constant_2->set_friendly_name("constant_2");
     auto concat = make_shared<op::Concat>(NodeVector{constant_1, constant_2}, 0);
     concat->set_friendly_name("test");
     auto f = make_shared<Function>(concat, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
 
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_1", "constant_2", "test"});
     ASSERT_EQ(new_const->get_output_shape(0), (Shape{2, 1, 1}));
 
     auto values_out = new_const->get_vector<int32_t>();
@@ -1258,24 +1374,24 @@ TEST(constant_folding, const_concat_3d_single_elem) {
 
 TEST(constant_folding, const_concat_axis_2) {
     auto constant_1 = op::Constant::create(element::i32, Shape{3, 1, 2}, vector<int32_t>{1, 2, 3, 4, 5, 6});
+    constant_1->set_friendly_name("constant_1");
     auto constant_2 = op::Constant::create(element::i32,
                                            Shape{3, 1, 4},
                                            vector<int32_t>{7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18});
+    constant_2->set_friendly_name("constant_2");
     auto concat = make_shared<op::Concat>(NodeVector{constant_1, constant_2}, 2);
     concat->set_friendly_name("test");
     auto f = make_shared<Function>(concat, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
 
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_1", "constant_2", "test"});
     ASSERT_EQ(new_const->get_output_shape(0), (Shape{3, 1, 6}));
 
     auto values_out = new_const->get_vector<int32_t>();
@@ -1285,24 +1401,25 @@ TEST(constant_folding, const_concat_axis_2) {
 
 TEST(constant_folding, const_concat_axis_1_bool_type) {
     auto constant_1 = op::Constant::create(element::boolean, Shape{1, 1, 2}, vector<int32_t>{true, true});
+    constant_1->set_friendly_name("constant_1");
     auto constant_2 = op::Constant::create(element::boolean, Shape{1, 2, 2}, vector<char>{true, false, true, false});
+    constant_2->set_friendly_name("constant_2");
     auto constant_3 =
         op::Constant::create(element::boolean, Shape{1, 3, 2}, vector<char>{true, false, true, false, true, false});
+    constant_3->set_friendly_name("constant_3");
     auto concat = make_shared<op::Concat>(NodeVector{constant_1, constant_2, constant_3}, 1);
     concat->set_friendly_name("test");
     auto f = make_shared<Function>(concat, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
 
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_1", "constant_2", "constant_3", "test"});
     ASSERT_EQ(new_const->get_output_shape(0), (Shape{1, 6, 2}));
 
     auto values_out = new_const->get_vector<char>();
@@ -1312,20 +1429,19 @@ TEST(constant_folding, const_concat_axis_1_bool_type) {
 
 TEST(constant_folding, const_logical_not) {
     auto constant = op::Constant::create(element::boolean, Shape{2, 3}, vector<char>{0, 1, 0, 0, 1, 1});
+    constant->set_friendly_name("constant");
     auto logical_not = make_shared<op::v1::LogicalNot>(constant);
     logical_not->set_friendly_name("test");
     auto f = make_shared<Function>(logical_not, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::LogicalNot>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "test"});
     auto values_out = new_const->get_vector<char>();
 
     vector<char> values_expected{1, 0, 1, 1, 0, 0};
@@ -1335,21 +1451,21 @@ TEST(constant_folding, const_logical_not) {
 
 TEST(constant_folding, const_equal) {
     auto constant0 = op::Constant::create(element::i32, Shape{2, 3}, vector<int32_t>{1, 2, 3, 4, 5, 6});
+    constant0->set_friendly_name("constant0");
     auto constant1 = op::Constant::create(element::i32, Shape{2, 3}, vector<int32_t>{1, 2, 2, 3, 5, 6});
+    constant1->set_friendly_name("constant1");
     auto eq = make_shared<op::v1::Equal>(constant0, constant1);
     eq->set_friendly_name("test");
     auto f = make_shared<Function>(eq, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Equal>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant0", "constant1", "test"});
     auto values_out = new_const->get_vector<char>();
 
     vector<char> values_expected{1, 1, 0, 0, 1, 1};
@@ -1359,21 +1475,21 @@ TEST(constant_folding, const_equal) {
 
 TEST(constant_folding, const_not_equal) {
     auto constant0 = op::Constant::create(element::i32, Shape{2, 3}, vector<int32_t>{1, 2, 3, 4, 5, 6});
+    constant0->set_friendly_name("constant0");
     auto constant1 = op::Constant::create(element::i32, Shape{2, 3}, vector<int32_t>{1, 2, 2, 3, 5, 6});
+    constant1->set_friendly_name("constant1");
     auto eq = make_shared<op::v1::NotEqual>(constant0, constant1);
     eq->set_friendly_name("test");
     auto f = make_shared<Function>(eq, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::NotEqual>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant0", "constant1", "test"});
     auto values_out = new_const->get_vector<char>();
 
     vector<char> values_expected{0, 0, 1, 1, 0, 0};
@@ -1383,21 +1499,21 @@ TEST(constant_folding, const_not_equal) {
 
 TEST(constant_folding, const_greater) {
     auto constant0 = op::Constant::create(element::i32, Shape{2, 3}, vector<int32_t>{1, 2, 3, 4, 5, 6});
+    constant0->set_friendly_name("constant0");
     auto constant1 = op::Constant::create(element::i32, Shape{2, 3}, vector<int32_t>{2, 2, 2, 5, 5, 5});
+    constant1->set_friendly_name("constant1");
     auto eq = make_shared<op::v1::Greater>(constant0, constant1);
     eq->set_friendly_name("test");
     auto f = make_shared<Function>(eq, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Greater>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant0", "constant1", "test"});
     auto values_out = new_const->get_vector<char>();
 
     vector<char> values_expected{0, 0, 1, 0, 0, 1};
@@ -1407,21 +1523,21 @@ TEST(constant_folding, const_greater) {
 
 TEST(constant_folding, const_greater_eq) {
     auto constant0 = op::Constant::create(element::i32, Shape{2, 3}, vector<int32_t>{1, 2, 3, 4, 5, 6});
+    constant0->set_friendly_name("constant0");
     auto constant1 = op::Constant::create(element::i32, Shape{2, 3}, vector<int32_t>{2, 2, 2, 5, 5, 5});
+    constant1->set_friendly_name("constant1");
     auto eq = make_shared<op::v1::GreaterEqual>(constant0, constant1);
     eq->set_friendly_name("test");
     auto f = make_shared<Function>(eq, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::GreaterEqual>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant0", "constant1", "test"});
     auto values_out = new_const->get_vector<char>();
 
     vector<char> values_expected{0, 1, 1, 0, 1, 1};
@@ -1431,21 +1547,21 @@ TEST(constant_folding, const_greater_eq) {
 
 TEST(constant_folding, const_less) {
     auto constant0 = op::Constant::create(element::i32, Shape{2, 3}, vector<int32_t>{1, 2, 3, 4, 5, 6});
+    constant0->set_friendly_name("constant0");
     auto constant1 = op::Constant::create(element::i32, Shape{2, 3}, vector<int32_t>{2, 2, 2, 5, 5, 5});
+    constant1->set_friendly_name("constant1");
     auto eq = make_shared<op::v1::Less>(constant0, constant1);
     eq->set_friendly_name("test");
     auto f = make_shared<Function>(eq, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Less>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant0", "constant1", "test"});
     auto values_out = new_const->get_vector<char>();
 
     vector<char> values_expected{1, 0, 0, 1, 0, 0};
@@ -1455,21 +1571,21 @@ TEST(constant_folding, const_less) {
 
 TEST(constant_folding, const_less_eq) {
     auto constant0 = op::Constant::create(element::i32, Shape{2, 3}, vector<int32_t>{1, 2, 3, 4, 5, 6});
+    constant0->set_friendly_name("constant0");
     auto constant1 = op::Constant::create(element::i32, Shape{2, 3}, vector<int32_t>{2, 2, 2, 5, 5, 5});
+    constant1->set_friendly_name("constant1");
     auto eq = make_shared<op::v1::LessEqual>(constant0, constant1);
     eq->set_friendly_name("test");
     auto f = make_shared<Function>(eq, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::LessEqual>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant0", "constant1", "test"});
     auto values_out = new_const->get_vector<char>();
 
     vector<char> values_expected{1, 1, 0, 1, 1, 0};
@@ -1479,21 +1595,21 @@ TEST(constant_folding, const_less_eq) {
 
 TEST(constant_folding, const_or) {
     auto constant0 = op::Constant::create(element::boolean, Shape{2, 3}, vector<int32_t>{0, 0, 1, 0, 1, 1});
+    constant0->set_friendly_name("constant0");
     auto constant1 = op::Constant::create(element::boolean, Shape{2, 3}, vector<int32_t>{0, 1, 1, 1, 0, 1});
+    constant1->set_friendly_name("constant1");
     auto eq = make_shared<op::v1::LogicalOr>(constant0, constant1);
     eq->set_friendly_name("test");
     auto f = make_shared<Function>(eq, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::LogicalOr>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant0", "constant1", "test"});
     auto values_out = new_const->get_vector<char>();
 
     vector<char> values_expected{0, 1, 1, 1, 1, 1};
@@ -1503,21 +1619,21 @@ TEST(constant_folding, const_or) {
 
 TEST(constant_folding, const_xor) {
     auto constant0 = op::Constant::create(element::boolean, Shape{2, 3}, vector<int32_t>{0, 0, 1, 0, 1, 1});
+    constant0->set_friendly_name("constant0");
     auto constant1 = op::Constant::create(element::boolean, Shape{2, 3}, vector<int32_t>{0, 1, 1, 1, 0, 1});
+    constant1->set_friendly_name("constant1");
     auto eq = make_shared<op::Xor>(constant0, constant1);
     eq->set_friendly_name("test");
     auto f = make_shared<Function>(eq, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Xor>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant0", "constant1", "test"});
     auto values_out = new_const->get_vector<char>();
 
     vector<char> values_expected{0, 1, 0, 1, 1, 0};
@@ -1528,20 +1644,19 @@ TEST(constant_folding, const_xor) {
 TEST(constant_folding, const_ceiling) {
     auto constant =
         op::Constant::create(element::f32, Shape{2, 3}, vector<float>{0.0f, 0.1f, -0.1f, -2.5f, 2.5f, 3.0f});
+    constant->set_friendly_name("constant");
     auto ceil = make_shared<op::Ceiling>(constant);
     ceil->set_friendly_name("test");
     auto f = make_shared<Function>(ceil, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Ceiling>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "test"});
     auto values_out = new_const->get_vector<float>();
 
     vector<float> values_expected{0.0f, 1.0f, 0.0f, -2.0f, 3.0f, 3.0f};
@@ -1552,20 +1667,19 @@ TEST(constant_folding, const_ceiling) {
 TEST(constant_folding, const_floor) {
     auto constant =
         op::Constant::create(element::f32, Shape{2, 3}, vector<float>{0.0f, 0.1f, -0.1f, -2.5f, 2.5f, 3.0f});
+    constant->set_friendly_name("constant");
     auto floor = make_shared<op::Floor>(constant);
     floor->set_friendly_name("test");
     auto f = make_shared<Function>(floor, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Floor>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "test"});
     auto values_out = new_const->get_vector<float>();
 
     vector<float> values_expected{0.0f, 0.0f, -1.0f, -3.0f, 2.0f, 3.0f};
@@ -1578,22 +1692,23 @@ TEST(constant_folding, const_gather_v1) {
         op::Constant::create(element::f32,
                              Shape{2, 5},
                              vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f});
+    constant_data->set_friendly_name("constant_data");
     auto constant_indices = op::Constant::create(element::i64, Shape{4}, vector<int64_t>{0, 3, 2, 2});
+    constant_indices->set_friendly_name("constant_indices");
     auto constant_axis = op::Constant::create(element::i64, Shape{1}, vector<int64_t>{1});
+    constant_axis->set_friendly_name("constant_axis");
     auto gather = make_shared<op::v1::Gather>(constant_data, constant_indices, constant_axis);
     gather->set_friendly_name("test");
     auto f = make_shared<Function>(gather, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Gather>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_data", "constant_indices", "constant_axis", "test"});
     auto values_out = new_const->get_vector<float>();
 
     vector<float> values_expected{1.0f, 4.0f, 3.0f, 3.0f, 6.0f, 9.0f, 8.0f, 8.0f};
@@ -1606,22 +1721,23 @@ TEST(constant_folding, const_gather_v1_scalar) {
         op::Constant::create(element::f32,
                              Shape{2, 5},
                              vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f});
+    constant_data->set_friendly_name("constant_data");
     auto constant_indices = op::Constant::create(element::i64, Shape{4}, vector<int64_t>{0, 3, 2, 2});
+    constant_indices->set_friendly_name("constant_indices");
     auto constant_axis = op::Constant::create(element::i64, Shape{}, vector<int64_t>{1});
+    constant_axis->set_friendly_name("constant_axis");
     auto gather = make_shared<op::v1::Gather>(constant_data, constant_indices, constant_axis);
     gather->set_friendly_name("test");
     auto f = make_shared<Function>(gather, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Gather>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_data", "constant_indices", "constant_axis", "test"});
     auto values_out = new_const->get_vector<float>();
 
     vector<float> values_expected{1.0f, 4.0f, 3.0f, 3.0f, 6.0f, 9.0f, 8.0f, 8.0f};
@@ -1636,26 +1752,27 @@ TEST(constant_folding, const_gather_v1_subgraph) {
     const auto C = make_shared<op::Parameter>(element::f32, Shape{1});
     const int64_t axis = 0;
     const auto axis_const = op::Constant::create(element::i64, {}, {axis});
+    axis_const->set_friendly_name("axis_const");
 
     const auto concat = make_shared<op::Concat>(NodeVector{A, B_const, C}, axis);
+    concat->set_friendly_name("concat");
 
     const vector<int64_t> indices{1};
     const auto indices_const = op::Constant::create(element::i64, {indices.size()}, indices);
+    indices_const->set_friendly_name("indices_const");
     const auto gather = make_shared<op::v1::Gather>(concat, indices_const, axis_const);
     gather->set_friendly_name("test");
     auto f = make_shared<Function>(gather, ParameterVector{A, C});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::v1::Gather>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"axis_const", "concat", "indices_const", "test"});
 
     const auto values_out = new_const->get_vector<float>();
     ASSERT_TRUE(test::all_close_f(values_out, {b_value}, MIN_FLOAT_TOLERANCE_BITS));
@@ -1668,26 +1785,27 @@ TEST(constant_folding, const_gather_v1_subgraph_neg_axis) {
     const auto C_const = op::Constant::create(element::f32, {1}, {b_value});
     const int64_t axis = 0;
     const auto axis_const = op::Constant::create(element::i64, {}, {axis});
+    axis_const->set_friendly_name("axis_const");
 
     const auto concat = make_shared<op::Concat>(NodeVector{A, B, C_const}, axis);
+    concat->set_friendly_name("concat");
 
     const vector<int64_t> indices{-1};
     const auto indices_const = op::Constant::create(element::i64, {indices.size()}, indices);
+    indices_const->set_friendly_name("indices_const");
     const auto gather = make_shared<op::v1::Gather>(concat, indices_const, axis_const);
     gather->set_friendly_name("test");
     auto f = make_shared<Function>(gather, ParameterVector{A, B});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::v1::Gather>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"axis_const", "concat", "indices_const", "test"});
 
     const auto values_out = new_const->get_vector<float>();
     ASSERT_TRUE(test::all_close_f(values_out, {b_value}, MIN_FLOAT_TOLERANCE_BITS));
@@ -1708,9 +1826,7 @@ TEST(constant_folding, const_gather_v1_subgraph_no_constant_input) {
     gather->set_friendly_name("test");
     auto f = make_shared<Function>(gather, ParameterVector{A, B, C});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::v1::Gather>(f), 0);
@@ -1730,9 +1846,7 @@ TEST(constant_folding, const_gather_v1_subgraph_no_constant_input_scalar) {
     const auto gather = make_shared<op::v1::Gather>(concat, indices_const, axis_const);
     auto f = make_shared<Function>(gather, ParameterVector{A, B, C});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::v1::Gather>(f), 0);
@@ -1753,9 +1867,7 @@ TEST(constant_folding, const_gather_v1_subgraph_skip_if_non_zero_axis) {
     const auto gather = make_shared<op::v1::Gather>(concat, indices_const, axis_const);
     auto f = make_shared<Function>(gather, ParameterVector{A, B, C});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 1);
     ASSERT_EQ(count_ops_of_type<op::v1::Gather>(f), 1);
@@ -1775,9 +1887,7 @@ TEST(constant_folding, const_gather_v1_subgraph_skip_if_non_single_indices) {
     const auto gather = make_shared<op::v1::Gather>(concat, indices_const, axis_const);
     auto f = make_shared<Function>(gather, ParameterVector{A, B, C});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 1);
     ASSERT_EQ(count_ops_of_type<op::v1::Gather>(f), 1);
@@ -1797,9 +1907,7 @@ TEST(constant_folding, const_gather_v1_subgraph_skip_if_concat_output_shape_dyna
     const auto gather = make_shared<op::v1::Gather>(concat, indices_const, axis_const);
     auto f = make_shared<Function>(gather, ParameterVector{A, B, C});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 1);
     ASSERT_EQ(count_ops_of_type<op::v1::Gather>(f), 1);
@@ -1819,9 +1927,7 @@ TEST(constant_folding, const_gather_v1_subgraph_skip_if_not_single_input) {
     const auto gather = make_shared<op::v1::Gather>(concat, indices_const, axis_const);
     auto f = make_shared<Function>(gather, ParameterVector{A, B, C});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 1);
     ASSERT_EQ(count_ops_of_type<op::v1::Gather>(f), 1);
@@ -1832,22 +1938,23 @@ TEST(constant_folding, const_gather_v7) {
         op::Constant::create(element::f32,
                              Shape{2, 5},
                              vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f});
+    constant_data->set_friendly_name("constant_data");
     auto constant_indices = op::Constant::create(element::i64, Shape{4}, vector<int64_t>{0, 3, 2, 2});
+    constant_indices->set_friendly_name("constant_indices");
     auto constant_axis = op::Constant::create(element::i64, Shape{1}, vector<int64_t>{1});
+    constant_axis->set_friendly_name("constant_axis");
     auto gather = make_shared<op::v7::Gather>(constant_data, constant_indices, constant_axis);
     gather->set_friendly_name("test");
     auto f = make_shared<Function>(gather, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v7::Gather>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_data", "constant_indices", "constant_axis", "test"});
     auto values_out = new_const->get_vector<float>();
 
     vector<float> values_expected{1.0f, 4.0f, 3.0f, 3.0f, 6.0f, 9.0f, 8.0f, 8.0f};
@@ -1860,22 +1967,23 @@ TEST(constant_folding, const_gather_v7_scalar) {
         op::Constant::create(element::f32,
                              Shape{2, 5},
                              vector<float>{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f});
+    constant_data->set_friendly_name("constant_data");
     auto constant_indices = op::Constant::create(element::i64, Shape{4}, vector<int64_t>{0, 3, 2, 2});
+    constant_indices->set_friendly_name("constant_indices");
     auto constant_axis = op::Constant::create(element::i64, Shape{}, vector<int64_t>{1});
+    constant_axis->set_friendly_name("constant_axis");
     auto gather = make_shared<op::v7::Gather>(constant_data, constant_indices, constant_axis);
     gather->set_friendly_name("test");
     auto f = make_shared<Function>(gather, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v7::Gather>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_data", "constant_indices", "constant_axis", "test"});
     auto values_out = new_const->get_vector<float>();
 
     vector<float> values_expected{1.0f, 4.0f, 3.0f, 3.0f, 6.0f, 9.0f, 8.0f, 8.0f};
@@ -1890,26 +1998,27 @@ TEST(constant_folding, const_gather_v7_subgraph) {
     const auto C = make_shared<op::Parameter>(element::f32, Shape{1});
     const int64_t axis = 0;
     const auto axis_const = op::Constant::create(element::i64, {}, {axis});
+    axis_const->set_friendly_name("axis_const");
 
     const auto concat = make_shared<op::Concat>(NodeVector{A, B_const, C}, axis);
+    concat->set_friendly_name("concat");
 
     const vector<int64_t> indices{1};
     const auto indices_const = op::Constant::create(element::i64, {indices.size()}, indices);
+    indices_const->set_friendly_name("indices_const");
     const auto gather = make_shared<op::v7::Gather>(concat, indices_const, axis_const);
     gather->set_friendly_name("test");
     auto f = make_shared<Function>(gather, ParameterVector{A, C});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::v7::Gather>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"axis_const", "concat", "indices_const", "test"});
 
     const auto values_out = new_const->get_vector<float>();
     ASSERT_TRUE(test::all_close_f(values_out, {b_value}, MIN_FLOAT_TOLERANCE_BITS));
@@ -1922,26 +2031,27 @@ TEST(constant_folding, const_gather_v7_subgraph_neg_axis) {
     const auto C_const = op::Constant::create(element::f32, {1}, {b_value});
     const int64_t axis = 0;
     const auto axis_const = op::Constant::create(element::i64, {}, {axis});
+    axis_const->set_friendly_name("axis_const");
 
     const auto concat = make_shared<op::Concat>(NodeVector{A, B, C_const}, axis);
+    concat->set_friendly_name("concat");
 
     const vector<int64_t> indices{-1};
     const auto indices_const = op::Constant::create(element::i64, {indices.size()}, indices);
+    indices_const->set_friendly_name("indices_const");
     const auto gather = make_shared<op::v7::Gather>(concat, indices_const, axis_const);
     gather->set_friendly_name("test");
     auto f = make_shared<Function>(gather, ParameterVector{A, B});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::v7::Gather>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"axis_const", "concat", "indices_const", "test"});
 
     const auto values_out = new_const->get_vector<float>();
     ASSERT_TRUE(test::all_close_f(values_out, {b_value}, MIN_FLOAT_TOLERANCE_BITS));
@@ -1962,9 +2072,7 @@ TEST(constant_folding, const_gather_v7_subgraph_no_constant_input) {
     gather->set_friendly_name("test");
     auto f = make_shared<Function>(gather, ParameterVector{A, B, C});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::v7::Gather>(f), 0);
@@ -1984,9 +2092,7 @@ TEST(constant_folding, const_gather_v7_subgraph_no_constant_input_scalar) {
     const auto gather = make_shared<op::v7::Gather>(concat, indices_const, axis_const);
     auto f = make_shared<Function>(gather, ParameterVector{A, B, C});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::v7::Gather>(f), 0);
@@ -2007,9 +2113,7 @@ TEST(constant_folding, const_gather_v7_subgraph_skip_if_non_zero_axis) {
     const auto gather = make_shared<op::v7::Gather>(concat, indices_const, axis_const);
     auto f = make_shared<Function>(gather, ParameterVector{A, B, C});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 1);
     ASSERT_EQ(count_ops_of_type<op::v7::Gather>(f), 1);
@@ -2029,9 +2133,7 @@ TEST(constant_folding, const_gather_v7_subgraph_skip_if_non_single_indices) {
     const auto gather = make_shared<op::v7::Gather>(concat, indices_const, axis_const);
     auto f = make_shared<Function>(gather, ParameterVector{A, B, C});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 1);
     ASSERT_EQ(count_ops_of_type<op::v7::Gather>(f), 1);
@@ -2051,9 +2153,7 @@ TEST(constant_folding, const_gather_v7_subgraph_skip_if_concat_output_shape_dyna
     const auto gather = make_shared<op::v7::Gather>(concat, indices_const, axis_const);
     auto f = make_shared<Function>(gather, ParameterVector{A, B, C});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 1);
     ASSERT_EQ(count_ops_of_type<op::v7::Gather>(f), 1);
@@ -2073,9 +2173,7 @@ TEST(constant_folding, const_gather_v7_subgraph_skip_if_not_single_input) {
     const auto gather = make_shared<op::v7::Gather>(concat, indices_const, axis_const);
     auto f = make_shared<Function>(gather, ParameterVector{A, B, C});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Concat>(f), 1);
     ASSERT_EQ(count_ops_of_type<op::v7::Gather>(f), 1);
@@ -2086,9 +2184,13 @@ TEST(constant_folding, const_strided_slice) {
 
     vector<int> values_in{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
     auto constant = make_shared<op::Constant>(element::i32, shape_in, values_in);
+    constant->set_friendly_name("constant");
     auto begin = op::Constant::create(element::i64, {1}, {2});
+    begin->set_friendly_name("begin");
     auto end = op::Constant::create(element::i64, {1}, {15});
+    end->set_friendly_name("end");
     auto stride = op::Constant::create(element::i64, {1}, {3});
+    stride->set_friendly_name("stride");
     auto slice = make_shared<op::v1::StridedSlice>(constant,
                                                    begin,
                                                    end,
@@ -2099,16 +2201,14 @@ TEST(constant_folding, const_strided_slice) {
 
     auto f = make_shared<Function>(slice, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::StridedSlice>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant", "begin", "end", "stride", "test"});
     auto values_out = new_const->get_vector<int>();
 
     vector<int> sliced_values{3, 6, 9, 12, 15};
@@ -2123,21 +2223,21 @@ TEST(constant_folding, constant_dyn_reshape) {
     vector<int64_t> values_shape{2, 4, 1};
 
     auto constant_in = make_shared<op::Constant>(element::f32, shape_in, values_in);
+    constant_in->set_friendly_name("constant_in");
     auto constant_shape = make_shared<op::Constant>(element::i64, shape_shape, values_shape);
+    constant_shape->set_friendly_name("constant_shape");
     auto dyn_reshape = make_shared<op::v1::Reshape>(constant_in, constant_shape, false);
     dyn_reshape->set_friendly_name("test");
     auto f = make_shared<Function>(dyn_reshape, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Reshape>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_in", "constant_shape", "test"});
     auto values_out = new_const->get_vector<float>();
 
     ASSERT_TRUE(test::all_close_f(values_in, values_out, MIN_FLOAT_TOLERANCE_BITS));
@@ -2156,24 +2256,25 @@ TEST(constant_folding, constant_dyn_reshape_shape_not_originally_constant) {
     vector<int64_t> values_shape_b{1, 1, 1};
 
     auto constant_in = make_shared<op::Constant>(element::f32, shape_in, values_in);
+    constant_in->set_friendly_name("constant_in");
     auto constant_shape_a = make_shared<op::Constant>(element::i64, shape_shape, values_shape_a);
+    constant_shape_a->set_friendly_name("constant_shape_a");
     auto constant_shape_b = make_shared<op::Constant>(element::i64, shape_shape, values_shape_b);
-    auto dyn_reshape = make_shared<op::v1::Reshape>(constant_in,
-                                                    std::make_shared<op::v1::Add>(constant_shape_a, constant_shape_b),
-                                                    false);
+    constant_shape_b->set_friendly_name("constant_shape_b");
+    auto add = std::make_shared<op::v1::Add>(constant_shape_a, constant_shape_b);
+    add->set_friendly_name("add");
+    auto dyn_reshape = make_shared<op::v1::Reshape>(constant_in, add, false);
     dyn_reshape->set_friendly_name("test");
     auto f = make_shared<Function>(dyn_reshape, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Reshape>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_in", "constant_shape_a", "constant_shape_b", "add", "test"});
     auto values_out = new_const->get_vector<float>();
 
     ASSERT_TRUE(test::all_close_f(values_in, values_out, MIN_FLOAT_TOLERANCE_BITS));
@@ -2188,9 +2289,7 @@ TEST(constant_folding, const_reshape_no_data_copy) {
 
     auto f = std::make_shared<Function>(NodeVector{consumer1, consumer2}, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     auto const1 = std::dynamic_pointer_cast<op::Constant>(consumer1->input_value(0).get_node_shared_ptr());
     auto const2 = std::dynamic_pointer_cast<op::Constant>(consumer2->input_value(0).get_node_shared_ptr());
@@ -2210,9 +2309,7 @@ TEST(constant_folding, const_squeeze_no_data_copy) {
 
     auto f = std::make_shared<Function>(NodeVector{consumer1, consumer2}, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     auto const1 = std::dynamic_pointer_cast<op::Constant>(consumer1->input_value(0).get_node_shared_ptr());
     auto const2 = std::dynamic_pointer_cast<op::Constant>(consumer2->input_value(0).get_node_shared_ptr());
@@ -2232,9 +2329,7 @@ TEST(constant_folding, const_unsqueeze_no_data_copy) {
 
     auto f = std::make_shared<Function>(NodeVector{consumer1, consumer2}, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     auto const1 = std::dynamic_pointer_cast<op::Constant>(consumer1->input_value(0).get_node_shared_ptr());
     auto const2 = std::dynamic_pointer_cast<op::Constant>(consumer2->input_value(0).get_node_shared_ptr());
@@ -2253,21 +2348,21 @@ TEST(constant_folding, constant_transpose) {
     vector<int64_t> values_perm{1, 0};
 
     auto constant_in = make_shared<op::Constant>(element::f64, shape_in, values_in);
+    constant_in->set_friendly_name("constant_in");
     auto constant_perm = make_shared<op::Constant>(element::i64, shape_perm, values_perm);
+    constant_perm->set_friendly_name("constant_perm");
     auto transpose = make_shared<op::Transpose>(constant_in, constant_perm);
     transpose->set_friendly_name("test");
     auto f = make_shared<Function>(transpose, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Transpose>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_in", "constant_perm", "test"});
     auto values_out = new_const->get_vector<double>();
 
     vector<double> values_permute{0, 4, 1, 5, 2, 6, 3, 7};
@@ -2281,22 +2376,23 @@ void range_test(T start, T stop, T step, const vector<T>& values_expected) {
     vector<T> values_step{step};
 
     auto constant_start = make_shared<op::Constant>(element::from<T>(), Shape{}, values_start);
+    constant_start->set_friendly_name("constant_start");
     auto constant_stop = make_shared<op::Constant>(element::from<T>(), Shape{}, values_stop);
+    constant_stop->set_friendly_name("constant_stop");
     auto constant_step = make_shared<op::Constant>(element::from<T>(), Shape{}, values_step);
+    constant_step->set_friendly_name("constant_step");
     auto range = make_shared<op::Range>(constant_start, constant_stop, constant_step);
     range->set_friendly_name("test");
     auto f = make_shared<Function>(range, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::Range>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_start", "constant_stop", "constant_step", "test"});
 
     auto values_out = new_const->template get_vector<T>();
 
@@ -2322,22 +2418,23 @@ TEST(constant_folding, constant_v1_select) {
     vector<int64_t> values_f{11, 12, 13, 14, 15, 16, 17, 18};
 
     auto constant_selection = make_shared<op::Constant>(element::boolean, Shape{4}, values_selection);
+    constant_selection->set_friendly_name("constant_selection");
     auto constant_t = make_shared<op::Constant>(element::i64, Shape{4}, values_t);
+    constant_t->set_friendly_name("constant_t");
     auto constant_f = make_shared<op::Constant>(element::i64, Shape{2, 4}, values_f);
+    constant_f->set_friendly_name("constant_f");
     auto select = make_shared<op::v1::Select>(constant_selection, constant_t, constant_f);
     select->set_friendly_name("test");
     auto f = make_shared<Function>(select, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Select>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_selection", "constant_t", "constant_f", "test"});
     auto values_out = new_const->get_vector<int64_t>();
 
     vector<int64_t> values_expected{11, 2, 3, 14, 15, 2, 3, 18};
@@ -2353,16 +2450,14 @@ TEST(constant_folding, constant_v1_split) {
     auto split_v1 = make_shared<op::v1::Split>(const_data, const_axis, num_splits);
     auto f = make_shared<Function>(split_v1->outputs(), ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Split>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), num_splits);
 
-    auto res1 = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
-    auto res2 = ov::as_type_ptr<op::Constant>(f->get_results().at(1)->input_value(0).get_node_shared_ptr());
-    auto res3 = ov::as_type_ptr<op::Constant>(f->get_results().at(2)->input_value(0).get_node_shared_ptr());
+    auto res1 = get_result_constant(f);
+    auto res2 = get_result_constant(f, 1);
+    auto res3 = get_result_constant(f, 2);
     ASSERT_TRUE(res1);
     ASSERT_TRUE(res2);
     ASSERT_TRUE(res3);
@@ -2384,16 +2479,14 @@ TEST(constant_folding, constant_v1_split_specialized) {
     auto split_v1 = make_shared<op::v1::Split>(const_data, const_axis, num_splits);
     auto f = make_shared<Function>(split_v1->outputs(), ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Split>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), num_splits);
 
-    auto res1 = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
-    auto res2 = ov::as_type_ptr<op::Constant>(f->get_results().at(1)->input_value(0).get_node_shared_ptr());
-    auto res3 = ov::as_type_ptr<op::Constant>(f->get_results().at(2)->input_value(0).get_node_shared_ptr());
+    auto res1 = get_result_constant(f);
+    auto res2 = get_result_constant(f, 1);
+    auto res3 = get_result_constant(f, 2);
     ASSERT_TRUE(res1);
     ASSERT_TRUE(res2);
     ASSERT_TRUE(res3);
@@ -2416,32 +2509,32 @@ TEST(constant_folding, constant_v1_split_axis_1_4_splits) {
                          48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63};
 
     const auto const_data = op::Constant::create(element::i64, Shape{4, 4, 4}, data);
+    const_data->set_friendly_name("const_data");
     const auto const_axis = op::Constant::create(element::i64, Shape{}, {1});
+    const_axis->set_friendly_name("const_axis");
     const auto num_splits = 4;
 
     auto split_v1 = make_shared<op::v1::Split>(const_data, const_axis, num_splits);
     split_v1->set_friendly_name("test");
     auto f = make_shared<Function>(split_v1->outputs(), ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Split>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), num_splits);
 
-    auto res1 = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
-    auto res2 = ov::as_type_ptr<op::Constant>(f->get_results().at(1)->input_value(0).get_node_shared_ptr());
-    auto res3 = ov::as_type_ptr<op::Constant>(f->get_results().at(2)->input_value(0).get_node_shared_ptr());
-    auto res4 = ov::as_type_ptr<op::Constant>(f->get_results().at(3)->input_value(0).get_node_shared_ptr());
+    auto res1 = get_result_constant(f);
+    auto res2 = get_result_constant(f, 1);
+    auto res3 = get_result_constant(f, 2);
+    auto res4 = get_result_constant(f, 3);
     ASSERT_TRUE(res1);
-    ASSERT_EQ(res1->get_friendly_name(), "test.0");
+    check_names(res1, {"const_data", "const_axis", "test"}, "test.0");
     ASSERT_TRUE(res2);
-    ASSERT_EQ(res2->get_friendly_name(), "test.1");
+    check_names(res2, {"const_data", "const_axis", "test"}, "test.1");
     ASSERT_TRUE(res3);
-    ASSERT_EQ(res3->get_friendly_name(), "test.2");
+    check_names(res3, {"const_data", "const_axis", "test"}, "test.2");
     ASSERT_TRUE(res4);
-    ASSERT_EQ(res4->get_friendly_name(), "test.3");
+    check_names(res4, {"const_data", "const_axis", "test"}, "test.3");
 
     auto res1_values = res1->get_vector<int64_t>();
     ASSERT_EQ(vector<int64_t>({0, 1, 2, 3, 16, 17, 18, 19, 32, 33, 34, 35, 48, 49, 50, 51}), res1_values);
@@ -2469,15 +2562,13 @@ TEST(constant_folding, constant_v1_split_axis_1_2_splits) {
     auto split_v1 = make_shared<op::v1::Split>(const_data, const_axis, num_splits);
     auto f = make_shared<Function>(split_v1->outputs(), ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Split>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), num_splits);
 
-    auto res1 = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
-    auto res2 = ov::as_type_ptr<op::Constant>(f->get_results().at(1)->input_value(0).get_node_shared_ptr());
+    auto res1 = get_result_constant(f);
+    auto res2 = get_result_constant(f, 1);
     ASSERT_TRUE(res1);
     ASSERT_TRUE(res2);
 
@@ -2508,15 +2599,13 @@ TEST(constant_folding, constant_v1_variadic_split_axis_1_2_splits) {
     auto variadic_split_v1 = make_shared<op::v1::VariadicSplit>(const_data, const_axis, constant_lengths);
     auto f = make_shared<Function>(variadic_split_v1->outputs(), ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::VariadicSplit>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), values_lengths.size());
 
-    auto res1 = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
-    auto res2 = ov::as_type_ptr<op::Constant>(f->get_results().at(1)->input_value(0).get_node_shared_ptr());
+    auto res1 = get_result_constant(f);
+    auto res2 = get_result_constant(f, 1);
     ASSERT_TRUE(res1);
     ASSERT_TRUE(res2);
 
@@ -2546,16 +2635,14 @@ TEST(constant_folding, constant_v1_variadic_split_axis_1_3_splits_neg_length) {
     auto variadic_split_v1 = make_shared<op::v1::VariadicSplit>(const_data, const_axis, constant_lengths);
     auto f = make_shared<Function>(variadic_split_v1->outputs(), ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::VariadicSplit>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), values_lengths.size());
 
-    auto res1 = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
-    auto res2 = ov::as_type_ptr<op::Constant>(f->get_results().at(1)->input_value(0).get_node_shared_ptr());
-    auto res3 = ov::as_type_ptr<op::Constant>(f->get_results().at(2)->input_value(0).get_node_shared_ptr());
+    auto res1 = get_result_constant(f);
+    auto res2 = get_result_constant(f, 1);
+    auto res3 = get_result_constant(f, 2);
     ASSERT_TRUE(res1);
     ASSERT_TRUE(res2);
     ASSERT_TRUE(res3);
@@ -2584,14 +2671,12 @@ TEST(constant_folding, constant_v1_one_hot) {
     auto one_hot_v1 = make_shared<op::v1::OneHot>(indices_const, depth_const, on_const, off_const, axis);
     auto f = make_shared<Function>(one_hot_v1, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::OneHot>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto res = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto res = get_result_constant(f);
     ASSERT_TRUE(res);
 
     ASSERT_EQ((Shape{3, 3}), res->get_output_shape(0));
@@ -2614,14 +2699,12 @@ TEST(constant_folding, constant_v1_one_hot_negative_axes) {
     auto one_hot_v1 = make_shared<op::v1::OneHot>(indices_const, depth_const, on_const, off_const, axis);
     auto f = make_shared<Function>(one_hot_v1, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::OneHot>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto res = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto res = get_result_constant(f);
     ASSERT_TRUE(res);
 
     ASSERT_EQ((Shape{4, 3}), res->get_output_shape(0));
@@ -2646,25 +2729,27 @@ TEST(constant_folding, constant_v1_one_hot_negative_axes_2) {
     auto off_value = false;
 
     const auto indices_const = op::Constant::create(element::i64, Shape{2, 2}, indices);
+    indices_const->set_friendly_name("indices_const");
     const auto depth_const = op::Constant::create(element::i64, Shape{}, {3});
+    depth_const->set_friendly_name("depth_const");
     const auto on_const = op::Constant::create(element::boolean, Shape{}, {on_value});
+    on_const->set_friendly_name("on_const");
     const auto off_const = op::Constant::create(element::boolean, Shape{}, {off_value});
+    off_const->set_friendly_name("off_const");
     int64_t axis = -1;
 
     auto one_hot_v1 = make_shared<op::v1::OneHot>(indices_const, depth_const, on_const, off_const, axis);
     one_hot_v1->set_friendly_name("test");
     auto f = make_shared<Function>(one_hot_v1, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::OneHot>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto res = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto res = get_result_constant(f);
     ASSERT_TRUE(res);
-    ASSERT_EQ(res->get_friendly_name(), "test");
+    check_names(res, {"indices_const", "depth_const", "on_const", "off_const", "test"});
 
     ASSERT_EQ((Shape{2, 2, 3}), res->get_output_shape(0));
     ASSERT_EQ(vector<bool>({on_value,
@@ -2689,22 +2774,22 @@ TEST(constant_folding, constant_tile_1d) {
 
     vector<int> values_in{0, 1};
     auto data = make_shared<op::Constant>(element::i32, shape_in, values_in);
+    data->set_friendly_name("data");
     vector<int> values_repeats{2};
     auto repeats = make_shared<op::Constant>(element::i64, shape_repeats, values_repeats);
+    repeats->set_friendly_name("repeats");
     auto tile = make_shared<op::v0::Tile>(data, repeats);
     tile->set_friendly_name("test");
     auto f = make_shared<Function>(tile, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v0::Tile>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "repeats", "test"});
     auto values_out = new_const->get_vector<int>();
 
     vector<int> values_expected{0, 1, 0, 1};
@@ -2718,22 +2803,22 @@ TEST(constant_folding, constant_tile_3d_small_data_rank) {
 
     vector<int> values_in{0, 1};
     auto data = make_shared<op::Constant>(element::i32, shape_in, values_in);
+    data->set_friendly_name("data");
     vector<int> values_repeats{2, 2, 2};
     auto repeats = make_shared<op::Constant>(element::i64, shape_repeats, values_repeats);
+    repeats->set_friendly_name("repeats");
     auto tile = make_shared<op::v0::Tile>(data, repeats);
     tile->set_friendly_name("test");
     auto f = make_shared<Function>(tile, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v0::Tile>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "repeats", "test"});
     auto values_out = new_const->get_vector<int>();
 
     vector<int> values_expected{0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
@@ -2747,22 +2832,22 @@ TEST(constant_folding, constant_tile_3d_few_repeats) {
 
     vector<int> values_in{1, 2, 3, 4, 5, 6};
     auto data = make_shared<op::Constant>(element::i32, shape_in, values_in);
+    data->set_friendly_name("data");
     vector<int> values_repeats{2, 1};
     auto repeats = make_shared<op::Constant>(element::i64, shape_repeats, values_repeats);
+    repeats->set_friendly_name("repeats");
     auto tile = make_shared<op::v0::Tile>(data, repeats);
     tile->set_friendly_name("test");
     auto f = make_shared<Function>(tile, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v0::Tile>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "repeats", "test"});
     auto values_out = new_const->get_vector<int>();
 
     vector<int> values_expected{1, 2, 3, 1, 2, 3, 4, 5, 6, 4, 5, 6};
@@ -2776,22 +2861,22 @@ TEST(constant_folding, constant_tile_1d_0_repeats) {
 
     vector<int> values_in{0, 1};
     auto data = make_shared<op::Constant>(element::i32, shape_in, values_in);
+    data->set_friendly_name("data");
     vector<int> values_repeats{0};
     auto repeats = make_shared<op::Constant>(element::i64, shape_repeats, values_repeats);
+    repeats->set_friendly_name("repeats");
     auto tile = make_shared<op::v0::Tile>(data, repeats);
     tile->set_friendly_name("test");
     auto f = make_shared<Function>(tile, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v0::Tile>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "repeats", "test"});
     auto values_out = new_const->get_vector<int>();
 
     vector<int> values_expected{};
@@ -2805,22 +2890,22 @@ TEST(constant_folding, constant_tile_2d_0_repeats) {
 
     vector<int> values_in{0, 1, 2, 3};
     auto data = make_shared<op::Constant>(element::i32, shape_in, values_in);
+    data->set_friendly_name("data");
     vector<int> values_repeats{0, 0};
     auto repeats = make_shared<op::Constant>(element::i64, shape_repeats, values_repeats);
+    repeats->set_friendly_name("repeats");
     auto tile = make_shared<op::v0::Tile>(data, repeats);
     tile->set_friendly_name("test");
     auto f = make_shared<Function>(tile, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v0::Tile>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "repeats", "test"});
     auto values_out = new_const->get_vector<int>();
 
     vector<int> values_expected{};
@@ -2834,22 +2919,22 @@ TEST(constant_folding, constant_tile_0_rank_data) {
 
     vector<int> values_in{1};
     auto data = make_shared<op::Constant>(element::i32, shape_in, values_in);
+    data->set_friendly_name("data");
     vector<int> values_repeats{4};
     auto repeats = make_shared<op::Constant>(element::i64, shape_repeats, values_repeats);
+    repeats->set_friendly_name("repeats");
     auto tile = make_shared<op::v0::Tile>(data, repeats);
     tile->set_friendly_name("test");
     auto f = make_shared<Function>(tile, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v0::Tile>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "repeats", "test"});
     auto values_out = new_const->get_vector<int>();
 
     vector<int> values_expected{1, 1, 1, 1};
@@ -2858,22 +2943,21 @@ TEST(constant_folding, constant_tile_0_rank_data) {
 
 TEST(constant_folding, constant_non_zero_0D) {
     auto data = op::Constant::create(element::i32, Shape{}, {1});
+    data->set_friendly_name("data");
     auto non_zero = make_shared<op::v3::NonZero>(data);
     non_zero->set_friendly_name("test");
     auto f = make_shared<Function>(non_zero, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     // Fold into constant with shape of {1, 1} for scalar input with
     // non-zero value
     ASSERT_EQ(count_ops_of_type<op::v3::NonZero>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "test"});
     const auto values_out = new_const->get_vector<int64_t>();
 
     const vector<int64_t> values_expected{0};
@@ -2884,20 +2968,19 @@ TEST(constant_folding, constant_non_zero_0D) {
 TEST(constant_folding, constant_non_zero_1D) {
     vector<int> values_in{0, 1, 0, 1};
     auto data = make_shared<op::Constant>(element::i32, Shape{4}, values_in);
+    data->set_friendly_name("data");
     auto non_zero = make_shared<op::v3::NonZero>(data);
     non_zero->set_friendly_name("test");
     auto f = make_shared<Function>(non_zero, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v3::NonZero>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "test"});
     const auto values_out = new_const->get_vector<int64_t>();
 
     const vector<int64_t> values_expected{1, 3};
@@ -2908,20 +2991,19 @@ TEST(constant_folding, constant_non_zero_1D) {
 TEST(constant_folding, constant_non_zero_int32_output_type) {
     vector<int> values_in{0, 1, 0, 1};
     auto data = make_shared<op::Constant>(element::i32, Shape{4}, values_in);
+    data->set_friendly_name("data");
     auto non_zero = make_shared<op::v3::NonZero>(data, element::i32);
     non_zero->set_friendly_name("test");
     auto f = make_shared<Function>(non_zero, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v3::NonZero>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "test"});
     ASSERT_EQ(element::i32, new_const->get_element_type());
     const auto values_out = new_const->get_vector<int32_t>();
 
@@ -2933,20 +3015,19 @@ TEST(constant_folding, constant_non_zero_int32_output_type) {
 TEST(constant_folding, constant_non_zero_1D_all_indices) {
     const vector<float> values_in{1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
     const auto data = make_shared<op::Constant>(element::f32, Shape{values_in.size()}, values_in);
+    data->set_friendly_name("data");
     const auto non_zero = make_shared<op::v3::NonZero>(data);
     non_zero->set_friendly_name("test");
     auto f = make_shared<Function>(non_zero, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v3::NonZero>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "test"});
     const auto values_out = new_const->get_vector<int64_t>();
 
     const vector<int64_t> values_expected{0, 1, 2, 3, 4, 5, 6, 7};
@@ -2957,20 +3038,19 @@ TEST(constant_folding, constant_non_zero_1D_all_indices) {
 TEST(constant_folding, constant_non_zero_2D) {
     vector<int> values_in{1, 0, 0, 0, 1, 0, 1, 1, 0};
     auto data = make_shared<op::Constant>(element::i32, Shape{3, 3}, values_in);
+    data->set_friendly_name("data");
     auto non_zero = make_shared<op::v3::NonZero>(data);
     non_zero->set_friendly_name("test");
     auto f = make_shared<Function>(non_zero, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v3::NonZero>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "test"});
     const auto values_out = new_const->get_vector<int64_t>();
 
     const vector<int64_t> values_expected{0, 1, 2, 2, 0, 1, 0, 1};
@@ -2981,20 +3061,19 @@ TEST(constant_folding, constant_non_zero_2D) {
 TEST(constant_folding, DISABLED_constant_non_zero_2D_all_indices) {
     const vector<int8_t> values_in{1, 1, 1, 1, 1, 1, 1, 1, 1};
     const auto data = make_shared<op::Constant>(element::i8, Shape{3, 3}, values_in);
+    data->set_friendly_name("data");
     const auto non_zero = make_shared<op::v3::NonZero>(data);
     non_zero->set_friendly_name("test");
     auto f = make_shared<Function>(non_zero, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v3::NonZero>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "test"});
     const auto values_out = new_const->get_vector<int64_t>();
 
     const vector<int64_t> values_expected{0, 0, 0, 1, 1, 1, 2, 2, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2};
@@ -3005,41 +3084,39 @@ TEST(constant_folding, DISABLED_constant_non_zero_2D_all_indices) {
 TEST(constant_folding, DISABLED_constant_non_zero_2D_all_zeros) {
     const vector<uint8_t> values_in{0, 0, 0, 0, 0, 0};
     const auto data = make_shared<op::Constant>(element::u8, Shape{2, 3}, values_in);
+    data->set_friendly_name("data");
     const auto non_zero = make_shared<op::v3::NonZero>(data);
     non_zero->set_friendly_name("test");
     auto f = make_shared<Function>(non_zero, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     // fold into Constant with shape of {0}
     ASSERT_EQ(count_ops_of_type<op::v3::NonZero>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "test"});
     ASSERT_EQ(shape_size(new_const->get_shape()), 0);
 }
 
 TEST(constant_folding, constant_non_zero_3D) {
     vector<int> values_in{1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0};
     auto data = make_shared<op::Constant>(element::i32, Shape{2, 3, 3}, values_in);
+    data->set_friendly_name("data");
     auto non_zero = make_shared<op::v3::NonZero>(data);
     non_zero->set_friendly_name("test");
     auto f = make_shared<Function>(non_zero, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v3::NonZero>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    const auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    const auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"data", "test"});
     const auto values_out = new_const->get_vector<int64_t>();
 
     const vector<int64_t> values_expected{0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 1, 2, 2, 2,
@@ -3054,25 +3131,27 @@ TEST(constant_folding, constant_scatter_elements_update_basic) {
 
     const auto data_const =
         op::Constant::create(element::f32, data_shape, std::vector<float>(shape_size(data_shape), 0.f));
+    data_const->set_friendly_name("data_const");
     const auto indices_const = op::Constant::create(element::i32, indices_shape, {1, 0, 2, 0, 2, 1});
+    indices_const->set_friendly_name("indices_const");
     const auto updates_const = op::Constant::create(element::f32, indices_shape, {1.0f, 1.1f, 1.2f, 2.0f, 2.1f, 2.2f});
+    updates_const->set_friendly_name("updates_const");
     const auto axis_const = op::Constant::create(element::i64, Shape{}, {0});
+    axis_const->set_friendly_name("axis_const");
 
     auto scatter_elem_updt =
         make_shared<op::v3::ScatterElementsUpdate>(data_const, indices_const, updates_const, axis_const);
     scatter_elem_updt->set_friendly_name("test");
     auto f = make_shared<Function>(scatter_elem_updt, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v3::ScatterElementsUpdate>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto result_node = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto result_node = get_result_constant(f);
     ASSERT_TRUE(result_node);
-    ASSERT_EQ(result_node->get_friendly_name(), "test");
+    check_names(result_node, {"data_const", "indices_const", "updates_const", "axis_const", "test"});
     ASSERT_EQ(data_shape, result_node->get_output_shape(0));
     std::vector<float> expected{2.f, 1.1f, 0.0f, 1.f, 0.0f, 2.2f, 0.f, 2.1f, 1.2f};
     range_test_check(result_node->cast_vector<float>(), expected);
@@ -3092,14 +3171,12 @@ TEST(constant_folding, constant_scatter_elements_update_negative_axis) {
         make_shared<op::v3::ScatterElementsUpdate>(data_const, indices_const, updates_const, axis_const);
     auto f = make_shared<Function>(scatter_elem_updt, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v3::ScatterElementsUpdate>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto result_node = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto result_node = get_result_constant(f);
     ASSERT_TRUE(result_node);
     ASSERT_EQ(data_shape, result_node->get_output_shape(0));
     std::vector<float> expected{1.1f, 1.0f, 1.2f, 2.0f, 2.2f, 2.1f, 0.0f, 0.0f, 0.0f};
@@ -3120,14 +3197,12 @@ TEST(constant_folding, constant_scatter_elements_update_1d_axis) {
         make_shared<op::v3::ScatterElementsUpdate>(data_const, indices_const, updates_const, axis_const);
     auto f = make_shared<Function>(scatter_elem_updt, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v3::ScatterElementsUpdate>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto result_node = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto result_node = get_result_constant(f);
     ASSERT_TRUE(result_node);
     ASSERT_EQ(data_shape, result_node->get_output_shape(0));
     std::vector<float> expected{2.f, 1.1f, 0.0f, 1.f, 0.0f, 2.2f, 0.f, 2.1f, 1.2f};
@@ -3149,14 +3224,12 @@ TEST(constant_folding, constant_scatter_elements_update_3d_i16) {
         make_shared<op::v3::ScatterElementsUpdate>(data_const, indices_const, updates_const, axis_const);
     auto f = make_shared<Function>(scatter_elem_updt, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v3::ScatterElementsUpdate>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto result_node = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto result_node = get_result_constant(f);
     ASSERT_TRUE(result_node);
     ASSERT_EQ(data_shape, result_node->get_output_shape(0));
     std::vector<int16_t> expected{4, 2, 0, 1, 0, 6, 0, 5, 3, 10, 0, 12, 0, 11, 0, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -3177,14 +3250,12 @@ TEST(constant_folding, constant_scatter_elements_update_one_elem) {
         make_shared<op::v3::ScatterElementsUpdate>(data_const, indices_const, updates_const, axis_const);
     auto f = make_shared<Function>(scatter_elem_updt, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v3::ScatterElementsUpdate>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto result_node = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto result_node = get_result_constant(f);
     ASSERT_TRUE(result_node);
     ASSERT_EQ(data_shape, result_node->get_output_shape(0));
     std::vector<int32_t> expected{input_data};
@@ -3199,21 +3270,21 @@ void test_constant_folding_reshape_v1(Shape& shape_in,
                                       vector<int32_t> values_shape,
                                       bool zero_flag = false) {
     auto constant_in = make_shared<op::Constant>(element::f32, shape_in, values_in);
+    constant_in->set_friendly_name("constant_in");
     auto constant_shape = make_shared<op::Constant>(element::i64, shape_shape, values_shape);
+    constant_shape->set_friendly_name("constant_shape");
     auto dyn_reshape = make_shared<op::v1::Reshape>(constant_in, constant_shape, zero_flag);
     dyn_reshape->set_friendly_name("test");
     auto f = make_shared<Function>(dyn_reshape, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<op::v1::Reshape>(f), 0);
     ASSERT_EQ(count_ops_of_type<op::Constant>(f), 1);
 
-    auto new_const = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto new_const = get_result_constant(f);
     ASSERT_TRUE(new_const);
-    ASSERT_EQ(new_const->get_friendly_name(), "test");
+    check_names(new_const, {"constant_in", "constant_shape", "test"});
     auto values_out = new_const->get_vector<float>();
 
     ASSERT_TRUE(test::all_close_f(values_in, values_out, MIN_FLOAT_TOLERANCE_BITS));
@@ -3270,16 +3341,13 @@ TEST(constant_folding, disable_constant_folding) {
 
     ov::disable_constant_folding(convert);
 
-    pass::Manager m;
-    m.register_pass<pass::ConstantFolding>();
-    m.run_passes(f);
-
+    run_constant_folding(f);
     // Check that sub-graph on second Interpolate input wasn't folded
     ASSERT_EQ(interpolate->input_value(1), convert_after->output(0));
 
     ov::enable_constant_folding(convert);
 
-    m.run_passes(f);
+    run_constant_folding(f);
 
     // After we enabled CF the sub-graph will be folded to Constant
     ASSERT_TRUE(ov::is_type<op::Constant>(interpolate->get_input_node_shared_ptr(1)));
@@ -3302,16 +3370,14 @@ TEST(constant_folding, disable_constant_folding_simple) {
 
     ov::disable_constant_folding(reshape);
 
-    pass::Manager m;
-    m.register_pass<pass::ConstantFolding>();
-    m.run_passes(f);
+    run_constant_folding(f);
 
     // Check that Reshape is not folded
     ASSERT_EQ(divide->input_value(1), reshape->output(0));
 
     ov::enable_constant_folding(reshape);
 
-    m.run_passes(f);
+    run_constant_folding(f);
 
     // After we enabled CF the sub-graph will be folded to Constant
     ASSERT_TRUE(ov::is_type<op::Constant>(divide->get_input_node_shared_ptr(1)));
@@ -3379,15 +3445,13 @@ TEST(constant_folding, constant_loop) {
     auto results = ResultVector{result0, result1};
     auto f = make_shared<Function>(results, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(f);
+    run_constant_folding(f);
 
     ASSERT_EQ(count_ops_of_type<ngraph::opset5::Loop>(f), 0);
     ASSERT_EQ(count_ops_of_type<ngraph::opset5::Constant>(f), 2);
 
-    auto result_node_0 = ov::as_type_ptr<op::Constant>(f->get_results().at(0)->input_value(0).get_node_shared_ptr());
-    auto result_node_1 = ov::as_type_ptr<op::Constant>(f->get_results().at(1)->input_value(0).get_node_shared_ptr());
+    auto result_node_0 = get_result_constant(f);
+    auto result_node_1 = get_result_constant(f, 1);
     ASSERT_TRUE(result_node_0);
     ASSERT_TRUE(result_node_1);
 
@@ -3410,9 +3474,7 @@ TEST(constant_folding, disable_constant_folding_for_shapeof) {
 
     ov::disable_constant_folding(shapeof);
 
-    pass::Manager mgr;
-    mgr.register_pass<pass::ConstantFolding>();
-    mgr.run_passes(model);
+    run_constant_folding(model);
 
     ASSERT_EQ(reshape->input_value(1), shapeof->output(0));
 }
@@ -3430,9 +3492,7 @@ TEST(constant_folding, disable_constant_folding_for_squeeze_unsqueeze) {
     ov::disable_constant_folding(squeeze);
     ov::disable_constant_folding(unsqueeze);
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(model);
+    run_constant_folding(model);
 
     ASSERT_EQ(count_ops_of_type<op::Squeeze>(model), 1);
     ASSERT_EQ(count_ops_of_type<op::Unsqueeze>(model), 1);
@@ -3448,9 +3508,7 @@ TEST(constant_folding, disable_constant_folding_for_convert_like) {
 
     ov::disable_constant_folding(convert_like);
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(model);
+    run_constant_folding(model);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ConvertLike>(model), 1);
 }
@@ -3463,9 +3521,7 @@ TEST(constant_folding, fold_convert_like_node) {
 
     auto model = std::make_shared<ov::Model>(NodeVector{consumer1}, ParameterVector{});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(model);
+    run_constant_folding(model);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ConvertLike>(model), 0);
 }
@@ -3478,9 +3534,7 @@ TEST(constant_folding, fold_convert_like_but_node_is_not_foldable) {
 
     auto model = std::make_shared<ov::Model>(NodeVector{consumer1}, ParameterVector{data});
 
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(model);
+    run_constant_folding(model);
 
     ASSERT_EQ(count_ops_of_type<op::v1::ConvertLike>(model), 1);
 }
@@ -3513,11 +3567,11 @@ TEST(constant_folding, evaluate_on_tensor_vector) {
     EXPECT_CALL(*mock, evaluate).Times(1);
 
     auto model = std::make_shared<ov::Model>(NodeVector{mock}, ParameterVector{});
-    pass::Manager pass_manager;
-    pass_manager.register_pass<pass::ConstantFolding>();
-    pass_manager.run_passes(model);
+
+    run_constant_folding(model);
+
     vector<int> add_expected{2, 4, 6, 8};
-    auto result_node = ov::as_type_ptr<op::Constant>(model->get_results().at(0)->input_value(0).get_node_shared_ptr());
+    auto result_node = get_result_constant(model);
     ASSERT_TRUE(result_node);
     ASSERT_EQ(data_shape, result_node->get_output_shape(0));
     ASSERT_EQ(add_expected, result_node->cast_vector<int>());

--- a/src/core/tests/constant_folding.cpp
+++ b/src/core/tests/constant_folding.cpp
@@ -79,18 +79,26 @@ static void check_names(const std::shared_ptr<ov::Node>& node,
         std::sort(fused_names.begin(), fused_names.end());
         std::sort(expected_sorted.begin(), expected_sorted.end());
         bool is_equal = std::equal(fused_names.begin(), fused_names.end(), expected_sorted.begin());
-        ASSERT_TRUE(is_equal) << "Expected names are not matched to the fused names. Expected '" << expected_fused_names
-                              << "' but actually received '" << fused_names << "'";
+        std::stringstream ss;
+        if (!is_equal) {
+            ss << "Expected names are not matched to the fused names. Expected '" << expected_fused_names
+               << "' but actually received '" << fused_names << "'";
+        }
+        ASSERT_TRUE(is_equal) << ss.str();
     } else {
         bool is_expected_name_missed = false;
         for (auto& name : expected_fused_names) {
             if (std::find(fused_names.begin(), fused_names.end(), name) == fused_names.end()) {
                 is_expected_name_missed = true;
+                break;
             }
         }
-        ASSERT_FALSE(is_expected_name_missed)
-            << "Not all expected names are found in fused names. Expected '" << expected_fused_names
-            << "' but actually received '" << fused_names << "'";
+        std::stringstream ss;
+        if (is_expected_name_missed) {
+            ss << "Not all expected names are found in fused names. Expected '" << expected_fused_names
+               << "' but actually received '" << fused_names << "'";
+        }
+        ASSERT_FALSE(is_expected_name_missed) << ss.str();
     }
 }
 

--- a/src/inference/tests/unit/query_model_test.cpp
+++ b/src/inference/tests/unit/query_model_test.cpp
@@ -416,5 +416,5 @@ TEST_F(GetSupportedNodesTest, ShapeOfNonConstantNode) {
             return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
                    (std::dynamic_pointer_cast<ov::opset9::PRelu>(op) != nullptr);
         },
-        {"input", "slope_compressed", "slope", "prelu"});  // kepp dummy only since it has no unsupported consumers
+        {"input", "slope_compressed", "slope", "prelu"});  // keep dummy only since it has no unsupported consumers
 }

--- a/src/inference/tests/unit/query_model_test.cpp
+++ b/src/inference/tests/unit/query_model_test.cpp
@@ -2,21 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <gtest/gtest.h>
-#include <iostream>
 
+#include <iostream>
 #include <openvino/core/rt_info.hpp>
-#include "openvino/pass/manager.hpp"
+
+#include "cpp_interfaces/interface/ie_iplugin_internal.hpp"
+#include "ngraph/ops.hpp"
+#include "ngraph/pass/constant_folding.hpp"
 #include "openvino/opsets/opset9.hpp"
-#include "transformations/convert_precision.hpp"
+#include "openvino/pass/manager.hpp"
 #include "transformations/common_optimizations/common_optimizations.hpp"
 #include "transformations/common_optimizations/nop_elimination.hpp"
-#include "transformations/op_conversions/log_softmax_decomposition.hpp"
+#include "transformations/convert_precision.hpp"
 #include "transformations/init_node_info.hpp"
+#include "transformations/op_conversions/log_softmax_decomposition.hpp"
 #include "transformations/rt_info/decompression.hpp"
 #include "transformations/rt_info/fused_names_attribute.hpp"
-#include "ngraph/pass/constant_folding.hpp"
-#include "ngraph/ops.hpp"
-#include "cpp_interfaces/interface/ie_iplugin_internal.hpp"
 
 std::ostream& operator<<(std::ostream& os, const std::unordered_set<std::string>& s) {
     for (auto it = s.begin(); it != s.end(); ++it) {
@@ -39,8 +40,11 @@ public:
              std::function<bool(const std::shared_ptr<ngraph::Node>)> is_node_supported,
              const std::unordered_set<std::string>& expected) {
         auto supported = InferenceEngine::GetSupportedNodes(m_function, transform, is_node_supported);
-        auto const is_in_expected = [&expected](const std::string& x){ return expected.find(x) != expected.end(); };
-        bool is_equal = (supported.size() == expected.size()) && std::all_of(supported.begin(), supported.end(), is_in_expected);
+        auto const is_in_expected = [&expected](const std::string& x) {
+            return expected.find(x) != expected.end();
+        };
+        bool is_equal =
+            (supported.size() == expected.size()) && std::all_of(supported.begin(), supported.end(), is_in_expected);
         std::stringstream ss;
         if (!is_equal) {
             ss << "Expected list of supported nodes '" << expected << "' but actually received '" << supported << "'";
@@ -62,18 +66,19 @@ TEST_F(GetSupportedNodesTest, UnsupportedCompressedConstantCF) {
         add->set_friendly_name("add");
         auto result = std::make_shared<ngraph::op::Result>(add);
         result->set_friendly_name("result");
-        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
-                                                 ngraph::ParameterVector{param});
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result}, ngraph::ParameterVector{param});
     }
-    Run([&](std::shared_ptr<ov::Model>& model) {
+    Run(
+        [&](std::shared_ptr<ov::Model>& model) {
             ov::pass::Manager m;
             m.register_pass<ngraph::pass::InitNodeInfo>();
             m.register_pass<ngraph::pass::ConstantFolding>();
             m.run_passes(model);
         },
-    [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op);
-    }, {});
+        [&](const std::shared_ptr<ngraph::Node>& op) {
+            return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op);
+        },
+        {});
 }
 
 TEST_F(GetSupportedNodesTest, ConstantSubgraphCF) {
@@ -96,18 +101,26 @@ TEST_F(GetSupportedNodesTest, ConstantSubgraphCF) {
         reshape->set_friendly_name("reshape");
         auto result = std::make_shared<ngraph::op::Result>(reshape);
         result->set_friendly_name("result");
-        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
-                                                 ngraph::ParameterVector{});
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result}, ngraph::ParameterVector{});
     }
-    Run([&](std::shared_ptr<ov::Model>& model) {
+    Run(
+        [&](std::shared_ptr<ov::Model>& model) {
             ov::pass::Manager m;
             m.register_pass<ngraph::pass::InitNodeInfo>();
             m.register_pass<ngraph::pass::ConstantFolding>();
             m.run_passes(model);
         },
-    [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op);
-    }, {"constant_compressed1", "constant1", "constant_compressed2", "constant2", "add", "const_reshape", "reshape", "result"});
+        [&](const std::shared_ptr<ngraph::Node>& op) {
+            return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op);
+        },
+        {"constant_compressed1",
+         "constant1",
+         "constant_compressed2",
+         "constant2",
+         "add",
+         "const_reshape",
+         "reshape",
+         "result"});
 }
 
 TEST_F(GetSupportedNodesTest, SupportedCompressedConstantNop) {
@@ -122,20 +135,22 @@ TEST_F(GetSupportedNodesTest, SupportedCompressedConstantNop) {
         add->set_friendly_name("add");
         auto result = std::make_shared<ngraph::op::Result>(add);
         result->set_friendly_name("result");
-        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
-                                                 ngraph::ParameterVector{param});
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result}, ngraph::ParameterVector{param});
     }
-    Run([&](std::shared_ptr<ov::Model>& model) {
+    Run(
+        [&](std::shared_ptr<ov::Model>& model) {
             ov::pass::Manager m;
             m.register_pass<ngraph::pass::InitNodeInfo>();
-            m.register_pass<ngraph::pass::ConvertPrecision>(precisions_array{{ngraph::element::f16, ngraph::element::f32}});
+            m.register_pass<ngraph::pass::ConvertPrecision>(
+                precisions_array{{ngraph::element::f16, ngraph::element::f32}});
             m.register_pass<ngraph::pass::NopElimination>();
             m.run_passes(model);
         },
-    [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
-        (std::dynamic_pointer_cast<ov::opset9::Add>(op) != nullptr);
-    }, {"input", "constant_compressed", "constant", "add", "result"});
+        [&](const std::shared_ptr<ngraph::Node>& op) {
+            return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
+                   (std::dynamic_pointer_cast<ov::opset9::Add>(op) != nullptr);
+        },
+        {"input", "constant_compressed", "constant", "add", "result"});
 }
 
 TEST_F(GetSupportedNodesTest, SupportedConstantInsertAdditionalOp) {
@@ -148,10 +163,10 @@ TEST_F(GetSupportedNodesTest, SupportedConstantInsertAdditionalOp) {
         mul->set_friendly_name("output_operation");
         auto result = std::make_shared<ngraph::op::Result>(mul);
         result->set_friendly_name("result");
-        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
-                                                 ngraph::ParameterVector{param});
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result}, ngraph::ParameterVector{param});
     }
-    Run([&](std::shared_ptr<ov::Model>& model) {
+    Run(
+        [&](std::shared_ptr<ov::Model>& model) {
             ov::pass::Manager m;
             m.register_pass<ngraph::pass::InitNodeInfo>();
             m.run_passes(model);
@@ -171,13 +186,13 @@ TEST_F(GetSupportedNodesTest, SupportedConstantInsertAdditionalOp) {
                 }
             }
         },
-    [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
-        (std::dynamic_pointer_cast<ov::opset9::Multiply>(op) != nullptr) ||
-        (std::dynamic_pointer_cast<ov::opset9::Add>(op) != nullptr);
-    }, {"input", "constant", "output_operation", "result"});
+        [&](const std::shared_ptr<ngraph::Node>& op) {
+            return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
+                   (std::dynamic_pointer_cast<ov::opset9::Multiply>(op) != nullptr) ||
+                   (std::dynamic_pointer_cast<ov::opset9::Add>(op) != nullptr);
+        },
+        {"input", "constant", "output_operation", "result"});
 }
-
 
 TEST_F(GetSupportedNodesTest, PartiallySupportedCompressedConstant) {
     {
@@ -202,24 +217,25 @@ TEST_F(GetSupportedNodesTest, PartiallySupportedCompressedConstant) {
         m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result1, result2},
                                                  ngraph::ParameterVector{param1, param2});
     }
-    Run([&](std::shared_ptr<ov::Model>& model) {
+    Run(
+        [&](std::shared_ptr<ov::Model>& model) {
             ov::pass::Manager m;
             m.register_pass<ngraph::pass::InitNodeInfo>();
             m.register_pass<ngraph::pass::ConstantFolding>();
             m.run_passes(model);
         },
-    [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
-        (std::dynamic_pointer_cast<ov::opset9::Multiply>(op) != nullptr);
-    }, {"input2", "constant_compressed", "constant", "mul", "result2"});
+        [&](const std::shared_ptr<ngraph::Node>& op) {
+            return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
+                   (std::dynamic_pointer_cast<ov::opset9::Multiply>(op) != nullptr);
+        },
+        {"input2", "constant_compressed", "constant", "mul", "result2"});
 }
 
 TEST_F(GetSupportedNodesTest, ConstantSubgraphSupported) {
     {
         auto param = std::make_shared<ngraph::op::Parameter>(ov::element::f32, m_shape);
         param->set_friendly_name("input");
-        auto weights =
-                ov::opset9::Constant::create(ov::element::Type_t::f32, {10, 84}, {1});
+        auto weights = ov::opset9::Constant::create(ov::element::Type_t::f32, {10, 84}, {1});
         weights->set_friendly_name("weights");
         auto shapeOf = std::make_shared<ov::opset9::ShapeOf>(weights);
         shapeOf->set_friendly_name("shapeof");
@@ -240,20 +256,31 @@ TEST_F(GetSupportedNodesTest, ConstantSubgraphSupported) {
         auto result = std::make_shared<ngraph::op::Result>(matmul);
         result->set_friendly_name("result");
 
-        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
-                                                 ngraph::ParameterVector{param});
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result}, ngraph::ParameterVector{param});
     }
-        Run([&](std::shared_ptr<ov::Model>& model) {
+    Run(
+        [&](std::shared_ptr<ov::Model>& model) {
             ov::pass::Manager m;
             m.register_pass<ngraph::pass::InitNodeInfo>();
             m.register_pass<ngraph::pass::ConstantFolding>();
             m.register_pass<ngraph::pass::NopElimination>();
             m.run_passes(model);
         },
-    [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
-        (std::dynamic_pointer_cast<ov::opset9::MatMul>(op) != nullptr);
-    }, {"input", "weights", "shapeof", "const1", "const2", "gather", "const3", "concat", "reshape", "matmul", "result"});
+        [&](const std::shared_ptr<ngraph::Node>& op) {
+            return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
+                   (std::dynamic_pointer_cast<ov::opset9::MatMul>(op) != nullptr);
+        },
+        {"input",
+         "weights",
+         "shapeof",
+         "const1",
+         "const2",
+         "gather",
+         "const3",
+         "concat",
+         "reshape",
+         "matmul",
+         "result"});
 }
 
 TEST_F(GetSupportedNodesTest, UnmarkedSupportedInputsOutputs) {
@@ -270,27 +297,27 @@ TEST_F(GetSupportedNodesTest, UnmarkedSupportedInputsOutputs) {
         add->set_friendly_name("add");
         auto result = std::make_shared<ngraph::op::Result>(add);
         result->set_friendly_name("result");
-        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
-                                                 ngraph::ParameterVector{param});
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result}, ngraph::ParameterVector{param});
     }
-        Run([&](std::shared_ptr<ov::Model>& model) {
+    Run(
+        [&](std::shared_ptr<ov::Model>& model) {
             ov::pass::Manager m;
             m.register_pass<ngraph::pass::InitNodeInfo>();
             m.register_pass<ngraph::pass::ConstantFolding>();
             m.run_passes(model);
         },
-    [&](const std::shared_ptr<ngraph::Node>& op) {
-        // Plugin don't mark input, constant and result as supported
-        return (std::dynamic_pointer_cast<ov::opset9::Add>(op) != nullptr);
-    }, {"add"});
+        [&](const std::shared_ptr<ngraph::Node>& op) {
+            // Plugin don't mark input, constant and result as supported
+            return (std::dynamic_pointer_cast<ov::opset9::Add>(op) != nullptr);
+        },
+        {"add"});
 }
 
 TEST_F(GetSupportedNodesTest, WrongFusedNamesInOriginalModel) {
     {
         auto param = std::make_shared<ngraph::op::Parameter>(ov::element::f32, m_shape);
         param->set_friendly_name("input");
-        auto weights =
-                ov::opset9::Constant::create(ov::element::Type_t::f32, {10, 84}, {1});
+        auto weights = ov::opset9::Constant::create(ov::element::Type_t::f32, {10, 84}, {1});
         weights->set_friendly_name("weights");
         auto matmul = std::make_shared<ov::opset9::MatMul>(param, weights, false, true);
         matmul->get_rt_info()[ngraph::FusedNames::get_type_info_static()] = ngraph::FusedNames("add");
@@ -303,16 +330,17 @@ TEST_F(GetSupportedNodesTest, WrongFusedNamesInOriginalModel) {
         auto result = std::make_shared<ngraph::op::Result>(add);
         result->set_friendly_name("result");
 
-        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
-                                                 ngraph::ParameterVector{param});
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result}, ngraph::ParameterVector{param});
     }
-        Run([&](std::shared_ptr<ov::Model>& model) {
+    Run(
+        [&](std::shared_ptr<ov::Model>& model) {
             return;
         },
-    [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
-               (std::dynamic_pointer_cast<ov::opset9::MatMul>(op) != nullptr);
-    }, {"input", "weights", "matmul"});
+        [&](const std::shared_ptr<ngraph::Node>& op) {
+            return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
+                   (std::dynamic_pointer_cast<ov::opset9::MatMul>(op) != nullptr);
+        },
+        {"input", "weights", "matmul"});
 }
 
 TEST_F(GetSupportedNodesTest, FusedNamesSupportedUnsupportedBoth) {
@@ -325,30 +353,32 @@ TEST_F(GetSupportedNodesTest, FusedNamesSupportedUnsupportedBoth) {
         logsoftmax->set_friendly_name("logsoftmax");
         auto result = std::make_shared<ngraph::op::Result>(logsoftmax);
         result->set_friendly_name("result");
-        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
-                                                 ngraph::ParameterVector{param, dummy_param});
+        m_function =
+            std::make_shared<ov::Model>(ngraph::ResultVector{result}, ngraph::ParameterVector{param, dummy_param});
     }
-    Run([&](std::shared_ptr<ov::Model>& model) {
+    Run(
+        [&](std::shared_ptr<ov::Model>& model) {
             ov::pass::Manager m;
             m.register_pass<ngraph::pass::InitNodeInfo>();
             m.register_pass<ngraph::pass::LogSoftmaxDecomposition>();
             m.run_passes(model);
         },
-    [&](const std::shared_ptr<ngraph::Node>& op) {
-        // Exp is not supported and all constants are missing
-        return ov::op::util::is_parameter(op) || ov::op::util::is_output(op) ||
-         (std::dynamic_pointer_cast<ov::opset9::ReduceMax>(op) != nullptr) ||
-         (std::dynamic_pointer_cast<ov::opset9::Subtract>(op) != nullptr) ||
-         (std::dynamic_pointer_cast<ov::opset9::ReduceSum>(op) != nullptr) ||
-         (std::dynamic_pointer_cast<ov::opset9::Log>(op) != nullptr);
-    }, {"dummy_param"}); // kepp dummy only since it has no unsupported consumers
+        [&](const std::shared_ptr<ngraph::Node>& op) {
+            // Exp is not supported and all constants are missing
+            return ov::op::util::is_parameter(op) || ov::op::util::is_output(op) ||
+                   (std::dynamic_pointer_cast<ov::opset9::ReduceMax>(op) != nullptr) ||
+                   (std::dynamic_pointer_cast<ov::opset9::Subtract>(op) != nullptr) ||
+                   (std::dynamic_pointer_cast<ov::opset9::ReduceSum>(op) != nullptr) ||
+                   (std::dynamic_pointer_cast<ov::opset9::Log>(op) != nullptr);
+        },
+        {"dummy_param"});  // kepp dummy only since it has no unsupported consumers
 }
 
 TEST_F(GetSupportedNodesTest, ShapeOfNonConstantNode) {
     {
         auto param = std::make_shared<ngraph::op::Parameter>(ov::element::f32, m_shape);
         param->set_friendly_name("input");
-        auto slope_compressed = ov::opset9::Constant::create(ngraph::element::f16, ngraph::Shape{}, { -2.f });
+        auto slope_compressed = ov::opset9::Constant::create(ngraph::element::f16, ngraph::Shape{}, {-2.f});
         slope_compressed->set_friendly_name("slope_compressed");
         auto convert_slope = std::make_shared<ov::opset9::Convert>(slope_compressed, ov::element::f32);
         convert_slope->set_friendly_name("slope");
@@ -359,27 +389,32 @@ TEST_F(GetSupportedNodesTest, ShapeOfNonConstantNode) {
         shapeOf->set_friendly_name("shapeof");
         auto convert_fp32 = std::make_shared<ov::opset9::Convert>(shapeOf, ov::element::f32);
         convert_fp32->set_friendly_name("convert_fp32");
-        auto scale = ov::opset9::Constant::create(ngraph::element::f32, ngraph::Shape{}, { 2.0f });
+        auto scale = ov::opset9::Constant::create(ngraph::element::f32, ngraph::Shape{}, {2.0f});
         scale->set_friendly_name("scale");
         auto mul_scale = std::make_shared<ov::opset9::Multiply>(convert_fp32, scale);
         mul_scale->set_friendly_name("mul_scale");
         auto convert_i64 = std::make_shared<ov::opset9::Convert>(mul_scale, ov::element::i64);
         convert_i64->set_friendly_name("convert_i64");
-        auto interpolate = std::make_shared<ov::opset9::Interpolate>(prelu, convert_i64, scale, ov::opset9::Interpolate::InterpolateAttrs());
+        auto interpolate = std::make_shared<ov::opset9::Interpolate>(prelu,
+                                                                     convert_i64,
+                                                                     scale,
+                                                                     ov::opset9::Interpolate::InterpolateAttrs());
         interpolate->set_friendly_name("interpolate");
         auto interpolate_result = std::make_shared<ngraph::op::Result>(interpolate);
         interpolate_result->set_friendly_name("interpolate_result");
-        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{interpolate_result},
-                                                 ngraph::ParameterVector{param});
+        m_function =
+            std::make_shared<ov::Model>(ngraph::ResultVector{interpolate_result}, ngraph::ParameterVector{param});
     }
-    Run([&](std::shared_ptr<ov::Model>& model) {
+    Run(
+        [&](std::shared_ptr<ov::Model>& model) {
             ov::pass::Manager m;
             m.register_pass<ngraph::pass::InitNodeInfo>();
             m.register_pass<ngraph::pass::CommonOptimizations>();
             m.run_passes(model);
         },
-    [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
-         (std::dynamic_pointer_cast<ov::opset9::PRelu>(op) != nullptr);
-    }, {"input", "slope_compressed", "slope", "prelu"}); // kepp dummy only since it has no unsupported consumers
+        [&](const std::shared_ptr<ngraph::Node>& op) {
+            return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
+                   (std::dynamic_pointer_cast<ov::opset9::PRelu>(op) != nullptr);
+        },
+        {"input", "slope_compressed", "slope", "prelu"});  // kepp dummy only since it has no unsupported consumers
 }

--- a/src/inference/tests/unit/query_model_test.cpp
+++ b/src/inference/tests/unit/query_model_test.cpp
@@ -41,8 +41,11 @@ public:
         auto supported = InferenceEngine::GetSupportedNodes(m_function, transform, is_node_supported);
         auto const is_in_expected = [&expected](const std::string& x){ return expected.find(x) != expected.end(); };
         bool is_equal = (supported.size() == expected.size()) && std::all_of(supported.begin(), supported.end(), is_in_expected);
-        ASSERT_TRUE(is_equal) << "Expected list of supported nodes '" << expected
-            << "' but actually received '" << supported << "'";
+        std::stringstream ss;
+        if (!is_equal) {
+            ss << "Expected list of supported nodes '" << expected << "' but actually received '" << supported << "'";
+        }
+        ASSERT_TRUE(is_equal) << ss.str();
     }
 };
 

--- a/src/plugins/intel_cpu/src/ngraph_transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_cpu/src/ngraph_transformations/convert_matmul_to_fc.cpp
@@ -102,8 +102,9 @@ ov::intel_cpu::ConvertMatMulToFC::ConvertMatMulToFC() {
          *  sequence starting from 0 and replace last two dimension. For example for length = 4  the
          *  order will be [0, 1, 3, 2] that emulates transpose_a or transpose_b attribute.
          */
+        ngraph::NodeVector new_ops;
 
-        auto create_transpose = [this](const ngraph::Output<ngraph::Node>& node, const std::string& transpose_name) {
+        auto create_transpose = [this, &new_ops ](const ngraph::Output<ngraph::Node>& node, const std::string& transpose_name) {
             auto rank = node.get_partial_shape().rank();
             std::vector<size_t> transpose_order(rank.get_length());
             std::iota(transpose_order.begin(), transpose_order.end(), 0);
@@ -112,13 +113,14 @@ ov::intel_cpu::ConvertMatMulToFC::ConvertMatMulToFC() {
             auto transpose_const = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ transpose_order.size() }, transpose_order);
             auto transpose = ngraph::op::util::make_try_fold<ngraph::opset1::Transpose>(node, transpose_const);
             if (!ngraph::is_type<ngraph::opset1::Constant>(transpose)) {
+                new_ops.push_back(transpose_const);
                 MatcherPass::register_new_node(transpose);
             }
             transpose->set_friendly_name(transpose_name);
+            new_ops.push_back(transpose);
             return transpose;
         };
 
-        ngraph::NodeVector new_ops;
         bool success = true;
         ngraph::PartialShape shape_a_aligned, shape_b_aligned;
         std::tie(success, shape_a_aligned, shape_b_aligned) = get_aligned_shapes();
@@ -137,7 +139,6 @@ ov::intel_cpu::ConvertMatMulToFC::ConvertMatMulToFC() {
         // Weights normalization
         if (!matmul->get_transpose_b()) {
             fc_input_b = create_transpose(fc_input_b, matmul->get_friendly_name() + "/transpose_b");
-            new_ops.push_back(fc_input_b.get_node_shared_ptr());
         }
 
         if (rank_b != 2) {
@@ -146,13 +147,15 @@ ov::intel_cpu::ConvertMatMulToFC::ConvertMatMulToFC() {
             std::vector<int64_t> reshape_shape_values = { -1ll, static_cast<int64_t>(K.get_length()) };
             auto reshape_shape = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 2 }, reshape_shape_values);
             fc_input_b = ngraph::op::util::make_try_fold<ngraph::opset1::Reshape>(fc_input_b, reshape_shape, false);
+            if (!ngraph::is_type<ngraph::opset1::Constant>(fc_input_b.get_node_shared_ptr())) {
+                new_ops.push_back(reshape_shape);
+            }
             new_ops.push_back(fc_input_b.get_node_shared_ptr());
         }
 
         // Input normalization
         if (matmul->get_transpose_a() && rank_a != 1) {
             fc_input_a = create_transpose(fc_input_a, matmul->get_friendly_name() + "/transpose_a");
-            new_ops.push_back(fc_input_a.get_node_shared_ptr());
         }
 
         auto output_rank = matmul->get_output_partial_shape(0).rank();

--- a/src/plugins/intel_cpu/src/ngraph_transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_cpu/src/ngraph_transformations/convert_matmul_to_fc.cpp
@@ -147,7 +147,7 @@ ov::intel_cpu::ConvertMatMulToFC::ConvertMatMulToFC() {
             std::vector<int64_t> reshape_shape_values = { -1ll, static_cast<int64_t>(K.get_length()) };
             auto reshape_shape = ngraph::opset1::Constant::create(ngraph::element::i64, ngraph::Shape{ 2 }, reshape_shape_values);
             fc_input_b = ngraph::op::util::make_try_fold<ngraph::opset1::Reshape>(fc_input_b, reshape_shape, false);
-            if (!ngraph::is_type<ngraph::opset1::Constant>(fc_input_b.get_node_shared_ptr())) {
+            if (!std::dynamic_pointer_cast<ngraph::opset1::Constant>(fc_input_b.get_node_shared_ptr())) {
                 new_ops.push_back(reshape_shape);
             }
             new_ops.push_back(fc_input_b.get_node_shared_ptr());

--- a/src/plugins/intel_cpu/src/ngraph_transformations/move_eltwise_up_data_movement.cpp
+++ b/src/plugins/intel_cpu/src/ngraph_transformations/move_eltwise_up_data_movement.cpp
@@ -89,6 +89,7 @@ ov::intel_cpu::MoveEltwiseUpThroughDataMov::MoveEltwiseUpThroughDataMov() {
         if (is_binary_op && current->get_output_partial_shape(0).rank().get_length() != eltwise->get_input_partial_shape(1).rank().get_length()) {
             auto old_eltwise_const = std::dynamic_pointer_cast<ngraph::opset8::Constant>(eltwise->get_input_node_shared_ptr(1));
             auto new_constant = std::make_shared<ngraph::opset8::Constant>(*old_eltwise_const.get(), ngraph::Shape{});
+            ngraph::copy_runtime_info(old_eltwise_const, new_constant);
             ngraph::replace_node(old_eltwise_const, new_constant);
         }
         ngraph::replace_output_update_name(eltwise->output(0), eltwise->input_value(0));

--- a/src/plugins/intel_cpu/src/utils/rt_info/memory_formats_attribute.hpp
+++ b/src/plugins/intel_cpu/src/utils/rt_info/memory_formats_attribute.hpp
@@ -9,6 +9,7 @@
 
 #include <ngraph/node.hpp>
 #include <ngraph/variant.hpp>
+#include "ngraph/op/util/op_types.hpp"
 
 namespace ov {
 namespace intel_cpu {
@@ -25,6 +26,9 @@ public:
     MemoryFormats() = default;
     explicit MemoryFormats(const std::string &_memory_format) : memory_format(_memory_format) {}
     std::string getMemoryFormats() const { return memory_format; }
+    bool is_copyable(const std::shared_ptr<ov::Node>& to) const override {
+        return (!ngraph::op::is_constant(to));
+    }
 
     ov::Any merge(const ngraph::NodeVector & nodes) const override {
         std::set<std::string> unique_mem_format;

--- a/src/plugins/intel_cpu/src/utils/rt_info/memory_formats_attribute.hpp
+++ b/src/plugins/intel_cpu/src/utils/rt_info/memory_formats_attribute.hpp
@@ -9,7 +9,7 @@
 
 #include <ngraph/node.hpp>
 #include <ngraph/variant.hpp>
-#include "ngraph/op/util/op_types.hpp"
+#include "openvino/op/util/op_types.hpp"
 
 namespace ov {
 namespace intel_cpu {

--- a/src/plugins/intel_cpu/src/utils/rt_info/memory_formats_attribute.hpp
+++ b/src/plugins/intel_cpu/src/utils/rt_info/memory_formats_attribute.hpp
@@ -27,7 +27,7 @@ public:
     explicit MemoryFormats(const std::string &_memory_format) : memory_format(_memory_format) {}
     std::string getMemoryFormats() const { return memory_format; }
     bool is_copyable(const std::shared_ptr<ov::Node>& to) const override {
-        return (!ngraph::op::is_constant(to));
+        return (!ov::op::util::is_constant(to));
     }
 
     ov::Any merge(const ngraph::NodeVector & nodes) const override {

--- a/src/plugins/intel_gna/src/transformations/pwl_approximation.cpp
+++ b/src/plugins/intel_gna/src/transformations/pwl_approximation.cpp
@@ -450,7 +450,7 @@ bool transform_to_pwl(
         m_constant, b_constant, alpha_constant);
     pwl->set_base_node(node);
     pwl->set_friendly_name(node->get_friendly_name());
-    ngraph::copy_runtime_info(node, pwl);
+    ngraph::copy_runtime_info(node, {pwl, m_constant, b_constant, alpha_constant});
     replace_node(node, pwl);
     return true;
 }

--- a/src/tests/ie_test_utils/common_test_utils/graph_comparator.cpp
+++ b/src/tests/ie_test_utils/common_test_utils/graph_comparator.cpp
@@ -837,10 +837,8 @@ void check_rt_info(const std::shared_ptr<ngraph::Function>& f) {
     static const std::vector<std::string> attrs_to_check{"fused_names_0"};
 
     std::ostringstream err_log;
-    for (auto& op : f->get_ops()) {
-        if (ov::op::util::is_constant(op))
-            continue;
 
+    for (auto& op : f->get_ops()) {
         const auto& rt_info = op->get_rt_info();
         for (const auto& attr_name : attrs_to_check) {
             if (!rt_info.count(attr_name)) {

--- a/src/tests/unit/inference_engine/query_model_test.cpp
+++ b/src/tests/unit/inference_engine/query_model_test.cpp
@@ -46,10 +46,10 @@ TEST_F(GetSupportedNodesTest, UnsupportedCompressedConstantCF) {
         param->set_friendly_name("input");
         auto constant_compressed = ngraph::op::Constant::create(ov::element::f16, m_shape, {1});
         constant_compressed->set_friendly_name("constant_compressed");
-        auto convert = std::make_shared<ngraph::opset9::Convert>(constant_compressed, ov::element::f32);
+        auto convert = std::make_shared<ov::opset9::Convert>(constant_compressed, ov::element::f32);
         convert->set_friendly_name("constant");
         ov::mark_as_decompression(convert);
-        auto add = std::make_shared<ngraph::opset9::Add>(param, convert);
+        auto add = std::make_shared<ov::opset9::Add>(param, convert);
         add->set_friendly_name("add");
         auto result = std::make_shared<ngraph::op::Result>(add);
         result->set_friendly_name("result");
@@ -71,19 +71,19 @@ TEST_F(GetSupportedNodesTest, ConstantSubgraphCF) {
     {
         auto constant_compressed1 = ngraph::op::Constant::create(ov::element::f16, m_shape, {1});
         constant_compressed1->set_friendly_name("constant_compressed1");
-        auto convert1 = std::make_shared<ngraph::opset9::Convert>(constant_compressed1, ov::element::f32);
+        auto convert1 = std::make_shared<ov::opset9::Convert>(constant_compressed1, ov::element::f32);
         convert1->set_friendly_name("constant1");
         ov::mark_as_decompression(convert1);
         auto constant_compressed2 = ngraph::op::Constant::create(ov::element::f16, m_shape, {2});
         constant_compressed2->set_friendly_name("constant_compressed2");
-        auto convert2 = std::make_shared<ngraph::opset9::Convert>(constant_compressed2, ov::element::f32);
+        auto convert2 = std::make_shared<ov::opset9::Convert>(constant_compressed2, ov::element::f32);
         convert2->set_friendly_name("constant2");
         ov::mark_as_decompression(convert2);
-        auto add = std::make_shared<ngraph::opset9::Add>(convert1, convert2);
+        auto add = std::make_shared<ov::opset9::Add>(convert1, convert2);
         add->set_friendly_name("add");
-        auto const_reshape = ngraph::opset9::Constant::create(ngraph::element::i64, ov::Shape{1}, {84});
+        auto const_reshape = ov::opset9::Constant::create(ngraph::element::i64, ov::Shape{1}, {84});
         const_reshape->set_friendly_name("const_reshape");
-        auto reshape = std::make_shared<ngraph::opset9::Reshape>(add, const_reshape, false);
+        auto reshape = std::make_shared<ov::opset9::Reshape>(add, const_reshape, false);
         reshape->set_friendly_name("reshape");
         auto result = std::make_shared<ngraph::op::Result>(reshape);
         result->set_friendly_name("result");
@@ -107,9 +107,9 @@ TEST_F(GetSupportedNodesTest, SupportedCompressedConstantNop) {
         param->set_friendly_name("input");
         auto constant_compressed = ngraph::op::Constant::create(ov::element::f16, m_shape, {1});
         constant_compressed->set_friendly_name("constant_compressed");
-        auto convert = std::make_shared<ngraph::opset9::Convert>(constant_compressed, ov::element::f32);
+        auto convert = std::make_shared<ov::opset9::Convert>(constant_compressed, ov::element::f32);
         convert->set_friendly_name("constant");
-        auto add = std::make_shared<ngraph::opset9::Add>(param, convert);
+        auto add = std::make_shared<ov::opset9::Add>(param, convert);
         add->set_friendly_name("add");
         auto result = std::make_shared<ngraph::op::Result>(add);
         result->set_friendly_name("result");
@@ -125,7 +125,7 @@ TEST_F(GetSupportedNodesTest, SupportedCompressedConstantNop) {
         },
     [&](const std::shared_ptr<ngraph::Node>& op) {
         return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
-        (std::dynamic_pointer_cast<ngraph::opset9::Add>(op) != nullptr);
+        (std::dynamic_pointer_cast<ov::opset9::Add>(op) != nullptr);
     }, {"input", "constant_compressed", "constant", "add", "result"});
 }
 
@@ -135,7 +135,7 @@ TEST_F(GetSupportedNodesTest, SupportedConstantInsertAdditionalOp) {
         param->set_friendly_name("input");
         auto mul_const = ngraph::op::Constant::create(ov::element::f32, m_shape, {1});
         mul_const->set_friendly_name("constant");
-        auto mul = std::make_shared<ngraph::opset9::Multiply>(param, mul_const);
+        auto mul = std::make_shared<ov::opset9::Multiply>(param, mul_const);
         mul->set_friendly_name("output_operation");
         auto result = std::make_shared<ngraph::op::Result>(mul);
         result->set_friendly_name("result");
@@ -147,12 +147,12 @@ TEST_F(GetSupportedNodesTest, SupportedConstantInsertAdditionalOp) {
             m.register_pass<ngraph::pass::InitNodeInfo>();
             m.run_passes(model);
             for (auto& op : model->get_ops()) {
-                if (std::dynamic_pointer_cast<ngraph::opset9::Multiply>(op) != nullptr) {
+                if (std::dynamic_pointer_cast<ov::opset9::Multiply>(op) != nullptr) {
                     // Add one more dummy operation
                     auto consumers = op->output(0).get_target_inputs();
                     auto shape = op->get_shape();
                     auto add_const = ngraph::op::Constant::create(ov::element::f32, m_shape, {0});
-                    auto add = std::make_shared<ngraph::opset9::Add>(op, add_const);
+                    auto add = std::make_shared<ov::opset9::Add>(op, add_const);
                     add->set_friendly_name(op->get_friendly_name());
                     op->set_friendly_name(op->get_friendly_name() + "/previous");
                     copy_runtime_info(op, add);
@@ -164,8 +164,8 @@ TEST_F(GetSupportedNodesTest, SupportedConstantInsertAdditionalOp) {
         },
     [&](const std::shared_ptr<ngraph::Node>& op) {
         return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
-        (std::dynamic_pointer_cast<ngraph::opset9::Multiply>(op) != nullptr) ||
-        (std::dynamic_pointer_cast<ngraph::opset9::Add>(op) != nullptr);
+        (std::dynamic_pointer_cast<ov::opset9::Multiply>(op) != nullptr) ||
+        (std::dynamic_pointer_cast<ov::opset9::Add>(op) != nullptr);
     }, {"input", "constant", "output_operation", "result"});
 }
 
@@ -178,14 +178,14 @@ TEST_F(GetSupportedNodesTest, PartiallySupportedCompressedConstant) {
         param2->set_friendly_name("input2");
         auto constant_compressed = ngraph::op::Constant::create(ov::element::f16, m_shape, {1});
         constant_compressed->set_friendly_name("constant_compressed");
-        auto convert = std::make_shared<ngraph::opset9::Convert>(constant_compressed, ov::element::f32);
+        auto convert = std::make_shared<ov::opset9::Convert>(constant_compressed, ov::element::f32);
         convert->set_friendly_name("constant");
         ov::mark_as_decompression(convert);
-        auto add = std::make_shared<ngraph::opset9::Add>(param1, convert);
+        auto add = std::make_shared<ov::opset9::Add>(param1, convert);
         add->set_friendly_name("add");
         auto result1 = std::make_shared<ngraph::op::Result>(add);
         result1->set_friendly_name("result1");
-        auto mul = std::make_shared<ngraph::opset9::Multiply>(param2, convert);
+        auto mul = std::make_shared<ov::opset9::Multiply>(param2, convert);
         mul->set_friendly_name("mul");
         auto result2 = std::make_shared<ngraph::op::Result>(mul);
         result2->set_friendly_name("result2");
@@ -201,7 +201,7 @@ TEST_F(GetSupportedNodesTest, PartiallySupportedCompressedConstant) {
         },
     [&](const std::shared_ptr<ngraph::Node>& op) {
         return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
-        (std::dynamic_pointer_cast<ngraph::opset9::Multiply>(op) != nullptr);
+        (std::dynamic_pointer_cast<ov::opset9::Multiply>(op) != nullptr);
     }, {"input2", "constant_compressed", "constant", "mul", "result2"});
 }
 
@@ -210,23 +210,23 @@ TEST_F(GetSupportedNodesTest, ConstantSubgraphSupported) {
         auto param = std::make_shared<ngraph::op::Parameter>(ov::element::f32, m_shape);
         param->set_friendly_name("input");
         auto weights =
-                ngraph::opset9::Constant::create(ov::element::Type_t::f32, {10, 84}, {1});
+                ov::opset9::Constant::create(ov::element::Type_t::f32, {10, 84}, {1});
         weights->set_friendly_name("weights");
-        auto shapeOf = std::make_shared<ngraph::opset9::ShapeOf>(weights);
+        auto shapeOf = std::make_shared<ov::opset9::ShapeOf>(weights);
         shapeOf->set_friendly_name("shapeof");
-        auto const1 = ngraph::opset9::Constant::create(ov::element::Type_t::i32, {1}, {1});
+        auto const1 = ov::opset9::Constant::create(ov::element::Type_t::i32, {1}, {1});
         const1->set_friendly_name("const1");
-        auto const2 = ngraph::opset9::Constant::create(ov::element::Type_t::i64, {}, {0});
+        auto const2 = ov::opset9::Constant::create(ov::element::Type_t::i64, {}, {0});
         const2->set_friendly_name("const2");
-        auto gather = std::make_shared<ngraph::opset9::Gather>(shapeOf, const1, const2);
+        auto gather = std::make_shared<ov::opset9::Gather>(shapeOf, const1, const2);
         gather->set_friendly_name("gather");
-        auto const3 = ngraph::opset9::Constant::create(ov::element::Type_t::i64, {1}, {1});
+        auto const3 = ov::opset9::Constant::create(ov::element::Type_t::i64, {1}, {1});
         const3->set_friendly_name("const3");
-        auto concat = std::make_shared<ngraph::opset9::Concat>(ov::NodeVector{const3, gather}, 0);
+        auto concat = std::make_shared<ov::opset9::Concat>(ov::NodeVector{const3, gather}, 0);
         concat->set_friendly_name("concat");
-        auto reshape = std::make_shared<ngraph::opset9::Reshape>(param, concat, false);
+        auto reshape = std::make_shared<ov::opset9::Reshape>(param, concat, false);
         reshape->set_friendly_name("reshape");
-        auto matmul = std::make_shared<ngraph::opset9::MatMul>(reshape, weights, false, true);
+        auto matmul = std::make_shared<ov::opset9::MatMul>(reshape, weights, false, true);
         matmul->set_friendly_name("matmul");
         auto result = std::make_shared<ngraph::op::Result>(matmul);
         result->set_friendly_name("result");
@@ -243,7 +243,7 @@ TEST_F(GetSupportedNodesTest, ConstantSubgraphSupported) {
         },
     [&](const std::shared_ptr<ngraph::Node>& op) {
         return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
-        (std::dynamic_pointer_cast<ngraph::opset9::MatMul>(op) != nullptr);
+        (std::dynamic_pointer_cast<ov::opset9::MatMul>(op) != nullptr);
     }, {"input", "weights", "shapeof", "const1", "const2", "gather", "const3", "concat", "reshape", "matmul", "result"});
 }
 
@@ -253,11 +253,11 @@ TEST_F(GetSupportedNodesTest, UnmarkedSupportedInputsOutputs) {
         param->set_friendly_name("input");
         auto constant = ngraph::op::Constant::create(ov::element::f32, ov::Shape{m_shape[1]}, {1});
         constant->set_friendly_name("constant");
-        auto const_reshape = ngraph::opset9::Constant::create(ngraph::element::i64, ov::Shape{2}, m_shape);
+        auto const_reshape = ov::opset9::Constant::create(ngraph::element::i64, ov::Shape{2}, m_shape);
         const_reshape->set_friendly_name("const_reshape");
-        auto reshape = std::make_shared<ngraph::opset9::Reshape>(constant, const_reshape, false);
+        auto reshape = std::make_shared<ov::opset9::Reshape>(constant, const_reshape, false);
         reshape->set_friendly_name("reshape");
-        auto add = std::make_shared<ngraph::opset9::Add>(param, reshape);
+        auto add = std::make_shared<ov::opset9::Add>(param, reshape);
         add->set_friendly_name("add");
         auto result = std::make_shared<ngraph::op::Result>(add);
         result->set_friendly_name("result");
@@ -272,7 +272,7 @@ TEST_F(GetSupportedNodesTest, UnmarkedSupportedInputsOutputs) {
         },
     [&](const std::shared_ptr<ngraph::Node>& op) {
         // Plugin don't mark input, constant and result as supported
-        return (std::dynamic_pointer_cast<ngraph::opset9::Add>(op) != nullptr);
+        return (std::dynamic_pointer_cast<ov::opset9::Add>(op) != nullptr);
     }, {"input", "constant", "const_reshape", "reshape", "add", "result"});
 }
 
@@ -281,14 +281,14 @@ TEST_F(GetSupportedNodesTest, WrongFusedNamesInOriginalModel) {
         auto param = std::make_shared<ngraph::op::Parameter>(ov::element::f32, m_shape);
         param->set_friendly_name("input");
         auto weights =
-                ngraph::opset9::Constant::create(ov::element::Type_t::f32, {10, 84}, {1});
+                ov::opset9::Constant::create(ov::element::Type_t::f32, {10, 84}, {1});
         weights->set_friendly_name("weights");
-        auto matmul = std::make_shared<ngraph::opset9::MatMul>(param, weights, false, true);
+        auto matmul = std::make_shared<ov::opset9::MatMul>(param, weights, false, true);
         matmul->get_rt_info()[ngraph::FusedNames::get_type_info_static()] = ngraph::FusedNames("add");
         matmul->set_friendly_name("matmul");
         auto constant = ngraph::op::Constant::create(ov::element::f32, {1, 10}, {1});
         constant->set_friendly_name("constant");
-        auto add = std::make_shared<ngraph::opset9::Add>(matmul, constant);
+        auto add = std::make_shared<ov::opset9::Add>(matmul, constant);
         add->get_rt_info()[ngraph::FusedNames::get_type_info_static()] = ngraph::FusedNames("matmul");
         add->set_friendly_name("add");
         auto result = std::make_shared<ngraph::op::Result>(add);
@@ -302,6 +302,6 @@ TEST_F(GetSupportedNodesTest, WrongFusedNamesInOriginalModel) {
         },
     [&](const std::shared_ptr<ngraph::Node>& op) {
         return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
-               (std::dynamic_pointer_cast<ngraph::opset9::MatMul>(op) != nullptr);
+               (std::dynamic_pointer_cast<ov::opset9::MatMul>(op) != nullptr);
     }, {"input", "weights", "matmul"});
 }

--- a/src/tests/unit/inference_engine/query_model_test.cpp
+++ b/src/tests/unit/inference_engine/query_model_test.cpp
@@ -35,7 +35,9 @@ public:
              std::function<bool(const std::shared_ptr<ngraph::Node>)> is_node_supported,
              const std::unordered_set<std::string>& expected) {
         auto supported = InferenceEngine::GetSupportedNodes(m_function, transform, is_node_supported);
-        ASSERT_TRUE(supported == expected) << "Expected list of supported nodes '" << expected
+        auto const is_in_expected = [&expected](const std::string& x){ return expected.find(x) !=expected.end(); };
+        ASSERT_TRUE((supported.size() == expected.size()) &&
+            std::all_of(supported.begin(), supported.end(), is_in_expected)) << "Expected list of supported nodes '" << expected
             << "' but actually received '" << supported << "'";
     }
 };

--- a/src/tests/unit/inference_engine/query_model_test.cpp
+++ b/src/tests/unit/inference_engine/query_model_test.cpp
@@ -35,9 +35,9 @@ public:
              std::function<bool(const std::shared_ptr<ngraph::Node>)> is_node_supported,
              const std::unordered_set<std::string>& expected) {
         auto supported = InferenceEngine::GetSupportedNodes(m_function, transform, is_node_supported);
-        auto const is_in_expected = [&expected](const std::string& x){ return expected.find(x) !=expected.end(); };
-        ASSERT_TRUE((supported.size() == expected.size()) &&
-            std::all_of(supported.begin(), supported.end(), is_in_expected)) << "Expected list of supported nodes '" << expected
+        auto const is_in_expected = [&expected](const std::string& x){ return expected.find(x) != expected.end(); };
+        bool is_equal = (supported.size() == expected.size()) && std::all_of(supported.begin(), supported.end(), is_in_expected);
+        ASSERT_TRUE(is_equal) << "Expected list of supported nodes '" << expected
             << "' but actually received '" << supported << "'";
     }
 };
@@ -65,7 +65,7 @@ TEST_F(GetSupportedNodesTest, UnsupportedCompressedConstantCF) {
             m.run_passes(model);
         },
     [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op);
+        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op);
     }, {});
 }
 
@@ -99,7 +99,7 @@ TEST_F(GetSupportedNodesTest, ConstantSubgraphCF) {
             m.run_passes(model);
         },
     [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op);
+        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op);
     }, {"constant_compressed1", "constant1", "constant_compressed2", "constant2", "add", "const_reshape", "reshape", "result"});
 }
 
@@ -126,7 +126,7 @@ TEST_F(GetSupportedNodesTest, SupportedCompressedConstantNop) {
             m.run_passes(model);
         },
     [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
+        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
         (std::dynamic_pointer_cast<ov::opset9::Add>(op) != nullptr);
     }, {"input", "constant_compressed", "constant", "add", "result"});
 }
@@ -165,7 +165,7 @@ TEST_F(GetSupportedNodesTest, SupportedConstantInsertAdditionalOp) {
             }
         },
     [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
+        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
         (std::dynamic_pointer_cast<ov::opset9::Multiply>(op) != nullptr) ||
         (std::dynamic_pointer_cast<ov::opset9::Add>(op) != nullptr);
     }, {"input", "constant", "output_operation", "result"});
@@ -202,7 +202,7 @@ TEST_F(GetSupportedNodesTest, PartiallySupportedCompressedConstant) {
             m.run_passes(model);
         },
     [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
+        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
         (std::dynamic_pointer_cast<ov::opset9::Multiply>(op) != nullptr);
     }, {"input2", "constant_compressed", "constant", "mul", "result2"});
 }
@@ -244,7 +244,7 @@ TEST_F(GetSupportedNodesTest, ConstantSubgraphSupported) {
             m.run_passes(model);
         },
     [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
+        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
         (std::dynamic_pointer_cast<ov::opset9::MatMul>(op) != nullptr);
     }, {"input", "weights", "shapeof", "const1", "const2", "gather", "const3", "concat", "reshape", "matmul", "result"});
 }
@@ -303,7 +303,7 @@ TEST_F(GetSupportedNodesTest, WrongFusedNamesInOriginalModel) {
             return;
         },
     [&](const std::shared_ptr<ngraph::Node>& op) {
-        return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
+        return ov::op::util::is_parameter(op) || ov::op::util::is_constant(op) || ov::op::util::is_output(op) ||
                (std::dynamic_pointer_cast<ov::opset9::MatMul>(op) != nullptr);
     }, {"input", "weights", "matmul"});
 }

--- a/src/tests/unit/inference_engine/query_model_test.cpp
+++ b/src/tests/unit/inference_engine/query_model_test.cpp
@@ -1,0 +1,307 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#include <gtest/gtest.h>
+#include <iostream>
+
+#include <openvino/pass/manager.hpp>
+#include <ngraph/opsets/opset9.hpp>
+#include <transformations/convert_precision.hpp>
+#include <transformations/common_optimizations/nop_elimination.hpp>
+#include <transformations/init_node_info.hpp>
+#include <transformations/rt_info/decompression.hpp>
+#include "transformations/rt_info/fused_names_attribute.hpp"
+#include <ngraph/pass/constant_folding.hpp>
+#include "cpp_interfaces/interface/ie_iplugin_internal.hpp"
+
+std::ostream& operator<<(std::ostream& os, const std::unordered_set<std::string>& s) {
+    for (auto it = s.begin(); it != s.end(); ++it) {
+        if (it != s.begin()) {
+            os << ", " << *it;
+        } else {
+            os << *it;
+        }
+    }
+    return os;
+}
+
+class GetSupportedNodesTest : public ::testing::Test {
+protected:
+    ov::Shape m_shape{1, 84};
+    std::shared_ptr<ov::Model> m_function;
+
+public:
+    void Run(std::function<void(std::shared_ptr<ov::Model>&)> transform,
+             std::function<bool(const std::shared_ptr<ngraph::Node>)> is_node_supported,
+             const std::unordered_set<std::string>& expected) {
+        auto supported = InferenceEngine::GetSupportedNodes(m_function, transform, is_node_supported);
+        ASSERT_TRUE(supported == expected) << "Expected list of supported nodes '" << expected
+            << "' but actually received '" << supported << "'";
+    }
+};
+
+TEST_F(GetSupportedNodesTest, UnsupportedCompressedConstantCF) {
+    {
+        auto param = std::make_shared<ngraph::op::Parameter>(ov::element::f32, m_shape);
+        param->set_friendly_name("input");
+        auto constant_compressed = ngraph::op::Constant::create(ov::element::f16, m_shape, {1});
+        constant_compressed->set_friendly_name("constant_compressed");
+        auto convert = std::make_shared<ngraph::opset9::Convert>(constant_compressed, ov::element::f32);
+        convert->set_friendly_name("constant");
+        ov::mark_as_decompression(convert);
+        auto add = std::make_shared<ngraph::opset9::Add>(param, convert);
+        add->set_friendly_name("add");
+        auto result = std::make_shared<ngraph::op::Result>(add);
+        result->set_friendly_name("result");
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
+                                                 ngraph::ParameterVector{param});
+    }
+    Run([&](std::shared_ptr<ov::Model>& model) {
+            ov::pass::Manager m;
+            m.register_pass<ngraph::pass::InitNodeInfo>();
+            m.register_pass<ngraph::pass::ConstantFolding>();
+            m.run_passes(model);
+        },
+    [&](const std::shared_ptr<ngraph::Node>& op) {
+        return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op);
+    }, {});
+}
+
+TEST_F(GetSupportedNodesTest, ConstantSubgraphCF) {
+    {
+        auto constant_compressed1 = ngraph::op::Constant::create(ov::element::f16, m_shape, {1});
+        constant_compressed1->set_friendly_name("constant_compressed1");
+        auto convert1 = std::make_shared<ngraph::opset9::Convert>(constant_compressed1, ov::element::f32);
+        convert1->set_friendly_name("constant1");
+        ov::mark_as_decompression(convert1);
+        auto constant_compressed2 = ngraph::op::Constant::create(ov::element::f16, m_shape, {2});
+        constant_compressed2->set_friendly_name("constant_compressed2");
+        auto convert2 = std::make_shared<ngraph::opset9::Convert>(constant_compressed2, ov::element::f32);
+        convert2->set_friendly_name("constant2");
+        ov::mark_as_decompression(convert2);
+        auto add = std::make_shared<ngraph::opset9::Add>(convert1, convert2);
+        add->set_friendly_name("add");
+        auto const_reshape = ngraph::opset9::Constant::create(ngraph::element::i64, ov::Shape{1}, {84});
+        const_reshape->set_friendly_name("const_reshape");
+        auto reshape = std::make_shared<ngraph::opset9::Reshape>(add, const_reshape, false);
+        reshape->set_friendly_name("reshape");
+        auto result = std::make_shared<ngraph::op::Result>(reshape);
+        result->set_friendly_name("result");
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
+                                                 ngraph::ParameterVector{});
+    }
+    Run([&](std::shared_ptr<ov::Model>& model) {
+            ov::pass::Manager m;
+            m.register_pass<ngraph::pass::InitNodeInfo>();
+            m.register_pass<ngraph::pass::ConstantFolding>();
+            m.run_passes(model);
+        },
+    [&](const std::shared_ptr<ngraph::Node>& op) {
+        return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op);
+    }, {"constant_compressed1", "constant1", "constant_compressed2", "constant2", "add", "const_reshape", "reshape", "result"});
+}
+
+TEST_F(GetSupportedNodesTest, SupportedCompressedConstantNop) {
+    {
+        auto param = std::make_shared<ngraph::op::Parameter>(ov::element::f32, m_shape);
+        param->set_friendly_name("input");
+        auto constant_compressed = ngraph::op::Constant::create(ov::element::f16, m_shape, {1});
+        constant_compressed->set_friendly_name("constant_compressed");
+        auto convert = std::make_shared<ngraph::opset9::Convert>(constant_compressed, ov::element::f32);
+        convert->set_friendly_name("constant");
+        auto add = std::make_shared<ngraph::opset9::Add>(param, convert);
+        add->set_friendly_name("add");
+        auto result = std::make_shared<ngraph::op::Result>(add);
+        result->set_friendly_name("result");
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
+                                                 ngraph::ParameterVector{param});
+    }
+    Run([&](std::shared_ptr<ov::Model>& model) {
+            ov::pass::Manager m;
+            m.register_pass<ngraph::pass::InitNodeInfo>();
+            m.register_pass<ngraph::pass::ConvertPrecision>(precisions_array{{ngraph::element::f16, ngraph::element::f32}});
+            m.register_pass<ngraph::pass::NopElimination>();
+            m.run_passes(model);
+        },
+    [&](const std::shared_ptr<ngraph::Node>& op) {
+        return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
+        (std::dynamic_pointer_cast<ngraph::opset9::Add>(op) != nullptr);
+    }, {"input", "constant_compressed", "constant", "add", "result"});
+}
+
+TEST_F(GetSupportedNodesTest, SupportedConstantInsertAdditionalOp) {
+    {
+        auto param = std::make_shared<ngraph::op::Parameter>(ov::element::f32, m_shape);
+        param->set_friendly_name("input");
+        auto mul_const = ngraph::op::Constant::create(ov::element::f32, m_shape, {1});
+        mul_const->set_friendly_name("constant");
+        auto mul = std::make_shared<ngraph::opset9::Multiply>(param, mul_const);
+        mul->set_friendly_name("output_operation");
+        auto result = std::make_shared<ngraph::op::Result>(mul);
+        result->set_friendly_name("result");
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
+                                                 ngraph::ParameterVector{param});
+    }
+    Run([&](std::shared_ptr<ov::Model>& model) {
+            ov::pass::Manager m;
+            m.register_pass<ngraph::pass::InitNodeInfo>();
+            m.run_passes(model);
+            for (auto& op : model->get_ops()) {
+                if (std::dynamic_pointer_cast<ngraph::opset9::Multiply>(op) != nullptr) {
+                    // Add one more dummy operation
+                    auto consumers = op->output(0).get_target_inputs();
+                    auto shape = op->get_shape();
+                    auto add_const = ngraph::op::Constant::create(ov::element::f32, m_shape, {0});
+                    auto add = std::make_shared<ngraph::opset9::Add>(op, add_const);
+                    add->set_friendly_name(op->get_friendly_name());
+                    op->set_friendly_name(op->get_friendly_name() + "/previous");
+                    copy_runtime_info(op, add);
+                    for (auto& consumer : consumers) {
+                        consumer.replace_source_output(add);
+                    }
+                }
+            }
+        },
+    [&](const std::shared_ptr<ngraph::Node>& op) {
+        return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
+        (std::dynamic_pointer_cast<ngraph::opset9::Multiply>(op) != nullptr) ||
+        (std::dynamic_pointer_cast<ngraph::opset9::Add>(op) != nullptr);
+    }, {"input", "constant", "output_operation", "result"});
+}
+
+
+TEST_F(GetSupportedNodesTest, PartiallySupportedCompressedConstant) {
+    {
+        auto param1 = std::make_shared<ngraph::op::Parameter>(ov::element::f32, m_shape);
+        param1->set_friendly_name("input1");
+        auto param2 = std::make_shared<ngraph::op::Parameter>(ov::element::f32, m_shape);
+        param2->set_friendly_name("input2");
+        auto constant_compressed = ngraph::op::Constant::create(ov::element::f16, m_shape, {1});
+        constant_compressed->set_friendly_name("constant_compressed");
+        auto convert = std::make_shared<ngraph::opset9::Convert>(constant_compressed, ov::element::f32);
+        convert->set_friendly_name("constant");
+        ov::mark_as_decompression(convert);
+        auto add = std::make_shared<ngraph::opset9::Add>(param1, convert);
+        add->set_friendly_name("add");
+        auto result1 = std::make_shared<ngraph::op::Result>(add);
+        result1->set_friendly_name("result1");
+        auto mul = std::make_shared<ngraph::opset9::Multiply>(param2, convert);
+        mul->set_friendly_name("mul");
+        auto result2 = std::make_shared<ngraph::op::Result>(mul);
+        result2->set_friendly_name("result2");
+
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result1, result2},
+                                                 ngraph::ParameterVector{param1, param2});
+    }
+    Run([&](std::shared_ptr<ov::Model>& model) {
+            ov::pass::Manager m;
+            m.register_pass<ngraph::pass::InitNodeInfo>();
+            m.register_pass<ngraph::pass::ConstantFolding>();
+            m.run_passes(model);
+        },
+    [&](const std::shared_ptr<ngraph::Node>& op) {
+        return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
+        (std::dynamic_pointer_cast<ngraph::opset9::Multiply>(op) != nullptr);
+    }, {"input2", "constant_compressed", "constant", "mul", "result2"});
+}
+
+TEST_F(GetSupportedNodesTest, ConstantSubgraphSupported) {
+    {
+        auto param = std::make_shared<ngraph::op::Parameter>(ov::element::f32, m_shape);
+        param->set_friendly_name("input");
+        auto weights =
+                ngraph::opset9::Constant::create(ov::element::Type_t::f32, {10, 84}, {1});
+        weights->set_friendly_name("weights");
+        auto shapeOf = std::make_shared<ngraph::opset9::ShapeOf>(weights);
+        shapeOf->set_friendly_name("shapeof");
+        auto const1 = ngraph::opset9::Constant::create(ov::element::Type_t::i32, {1}, {1});
+        const1->set_friendly_name("const1");
+        auto const2 = ngraph::opset9::Constant::create(ov::element::Type_t::i64, {}, {0});
+        const2->set_friendly_name("const2");
+        auto gather = std::make_shared<ngraph::opset9::Gather>(shapeOf, const1, const2);
+        gather->set_friendly_name("gather");
+        auto const3 = ngraph::opset9::Constant::create(ov::element::Type_t::i64, {1}, {1});
+        const3->set_friendly_name("const3");
+        auto concat = std::make_shared<ngraph::opset9::Concat>(ov::NodeVector{const3, gather}, 0);
+        concat->set_friendly_name("concat");
+        auto reshape = std::make_shared<ngraph::opset9::Reshape>(param, concat, false);
+        reshape->set_friendly_name("reshape");
+        auto matmul = std::make_shared<ngraph::opset9::MatMul>(reshape, weights, false, true);
+        matmul->set_friendly_name("matmul");
+        auto result = std::make_shared<ngraph::op::Result>(matmul);
+        result->set_friendly_name("result");
+
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
+                                                 ngraph::ParameterVector{param});
+    }
+        Run([&](std::shared_ptr<ov::Model>& model) {
+            ov::pass::Manager m;
+            m.register_pass<ngraph::pass::InitNodeInfo>();
+            m.register_pass<ngraph::pass::ConstantFolding>();
+            m.register_pass<ngraph::pass::NopElimination>();
+            m.run_passes(model);
+        },
+    [&](const std::shared_ptr<ngraph::Node>& op) {
+        return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
+        (std::dynamic_pointer_cast<ngraph::opset9::MatMul>(op) != nullptr);
+    }, {"input", "weights", "shapeof", "const1", "const2", "gather", "const3", "concat", "reshape", "matmul", "result"});
+}
+
+TEST_F(GetSupportedNodesTest, UnmarkedSupportedInputsOutputs) {
+    {
+        auto param = std::make_shared<ngraph::op::Parameter>(ov::element::f32, m_shape);
+        param->set_friendly_name("input");
+        auto constant = ngraph::op::Constant::create(ov::element::f32, ov::Shape{m_shape[1]}, {1});
+        constant->set_friendly_name("constant");
+        auto const_reshape = ngraph::opset9::Constant::create(ngraph::element::i64, ov::Shape{2}, m_shape);
+        const_reshape->set_friendly_name("const_reshape");
+        auto reshape = std::make_shared<ngraph::opset9::Reshape>(constant, const_reshape, false);
+        reshape->set_friendly_name("reshape");
+        auto add = std::make_shared<ngraph::opset9::Add>(param, reshape);
+        add->set_friendly_name("add");
+        auto result = std::make_shared<ngraph::op::Result>(add);
+        result->set_friendly_name("result");
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
+                                                 ngraph::ParameterVector{param});
+    }
+        Run([&](std::shared_ptr<ov::Model>& model) {
+            ov::pass::Manager m;
+            m.register_pass<ngraph::pass::InitNodeInfo>();
+            m.register_pass<ngraph::pass::ConstantFolding>();
+            m.run_passes(model);
+        },
+    [&](const std::shared_ptr<ngraph::Node>& op) {
+        // Plugin don't mark input, constant and result as supported
+        return (std::dynamic_pointer_cast<ngraph::opset9::Add>(op) != nullptr);
+    }, {"input", "constant", "const_reshape", "reshape", "add", "result"});
+}
+
+TEST_F(GetSupportedNodesTest, WrongFusedNamesInOriginalModel) {
+    {
+        auto param = std::make_shared<ngraph::op::Parameter>(ov::element::f32, m_shape);
+        param->set_friendly_name("input");
+        auto weights =
+                ngraph::opset9::Constant::create(ov::element::Type_t::f32, {10, 84}, {1});
+        weights->set_friendly_name("weights");
+        auto matmul = std::make_shared<ngraph::opset9::MatMul>(param, weights, false, true);
+        matmul->get_rt_info()[ngraph::FusedNames::get_type_info_static()] = ngraph::FusedNames("add");
+        matmul->set_friendly_name("matmul");
+        auto constant = ngraph::op::Constant::create(ov::element::f32, {1, 10}, {1});
+        constant->set_friendly_name("constant");
+        auto add = std::make_shared<ngraph::opset9::Add>(matmul, constant);
+        add->get_rt_info()[ngraph::FusedNames::get_type_info_static()] = ngraph::FusedNames("matmul");
+        add->set_friendly_name("add");
+        auto result = std::make_shared<ngraph::op::Result>(add);
+        result->set_friendly_name("result");
+
+        m_function = std::make_shared<ov::Model>(ngraph::ResultVector{result},
+                                                 ngraph::ParameterVector{param});
+    }
+        Run([&](std::shared_ptr<ov::Model>& model) {
+            return;
+        },
+    [&](const std::shared_ptr<ngraph::Node>& op) {
+        return ngraph::op::is_parameter(op) || ngraph::op::is_constant(op) || ngraph::op::is_output(op) ||
+               (std::dynamic_pointer_cast<ngraph::opset9::MatMul>(op) != nullptr);
+    }, {"input", "weights", "matmul"});
+}

--- a/src/tests/unit/inference_engine/query_model_test.cpp
+++ b/src/tests/unit/inference_engine/query_model_test.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 
 #include <openvino/pass/manager.hpp>
-#include <ngraph/opsets/opset9.hpp>
+#include <openvino/opsets/opset9.hpp>
 #include <transformations/convert_precision.hpp>
 #include <transformations/common_optimizations/nop_elimination.hpp>
 #include <transformations/init_node_info.hpp>


### PR DESCRIPTION
### Details:
- *Fix handling of Constants without supported consumers. Previously Constants from original graph was handled, but that's wrong - we should check Constants from transformed graph. And also fused_names of consumers should be checked, not only node name.*
- *Fix handling of case, when additional node is inserted and uses name of previous node.*
- *Fix propogation of RTInfo for ConstantFolding. Previous behaviour leads to situation when Constant names were included into the fused_names of the next functional layer. Instead of it we should copy RTInfo of folded operations into the replacement Constant*
- *Update tests for ConstantFolding in order to verify fused_names attribute*
- *Clean up fused_names if they are present in orignal model in QN*
- *Create tests for GetSupportedNodes function which is used in CPU, GPU and TEMPLATE QN*
- *Update transformation tests to check rt info for Constants*

### Tickets:
 - *95340*
 - *98577

### Notes:
Comments from https://github.com/openvinotoolkit/openvino/pull/2572 from Gleb K.:
```
In this PR ConstantFolding pass was updated to save friendly names and propagate runtime info attribute.
This changes helps to avoid problems with Const->Result sub-graphs where Const used to have random name instead of real output name. Also runtime info propagation inside ConstantFolding pass resolves issue with QueryNetwork where operations on constant sub-graph paths wasn't counted as supported operations.

More detailed, when copying runtime info in CF for particular operation we copy it not to operation replacement (in most cases it is Constant) but to its consumers. Because if we copy it just to replacement node (Constant) this runtime info will be lost during conversion pipeline but if we copy this runtime info to replacement (Constant) consumers this attributes will survive conversion pipeline and QueryNetwork will get all information about function operations and their transformation history.
```

So it seems copying of `fused_names` to consumers was done due to convertion to legacy representation (where weights are presented as part of layer) and not relevant anymore.