### PR TITLE
[GPU] Fix error in calling is_dynamic

### DIFF
--- a/src/plugins/intel_gpu/src/graph/concatenation.cpp
+++ b/src/plugins/intel_gpu/src/graph/concatenation.cpp
@@ -102,8 +102,8 @@ std::string concatenation_inst::to_string(concatenation_node const& node) {
 
 concatenation_inst::typed_primitive_inst(network& network, concatenation_node const& node)
     : parent(network, node) {
+    if (node.is_dynamic()) return;
     auto input_layout = node.input().get_output_layout();
-    if (input_layout.is_dynamic()) return;
 
     auto output_layout = node.get_output_layout();
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/concat_input_order.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/concat_input_order.cpp
@@ -120,7 +120,8 @@ void concat_input_order::run(program& p) {
         // 4. Not already aligned
         // 5. Users can accept shuffled features
         // 6. No fused primitives
-        if (!node->is_type<concatenation>() || node->is_output() || (node->is_valid_output_layout() && node->is_dynamic()))
+        if (!node->is_type<concatenation>() || node->is_output() ||
+            (node->is_valid_output_layout() && node->get_output_layout().is_dynamic()))
             continue;
 
         auto& concat_node = node->as<concatenation>();

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/behavior/ov_infer_request/infer_request_dynamic.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/behavior/ov_infer_request/infer_request_dynamic.cpp
@@ -21,7 +21,6 @@ const std::vector<ov::AnyMap> AutoConfigs = {
 };
 
 const std::vector<ov::AnyMap> AutoNotSupportConfigs = {
-    {ov::device::priorities(CommonTestUtils::DEVICE_GPU)}
 };
 
 std::shared_ptr<ngraph::Function> getFunction1() {


### PR DESCRIPTION
### Details:
 - Error happens when node.is_dynamic() is called but its input nodes' output layouts are not valid yet. 
 - Fixed to check output_layout.is_dynamic() instead of is_dynamic() of the node itself. 
