### PR TITLE
[GPU][DG2] Resolve convolution test failure

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -510,6 +510,11 @@ cldnn::format find_format(dnnl::memory::desc desc, bool is_grouped) {
                 && blk.inner_idxs[0] == 1 && blk.inner_idxs[1] == 2) {
                     if (compare_strides(order, {0, 1, 3, 4, 2}))        return cldnn::format::g_os_yx_is_osv8_isv4;
                     else if (compare_strides(order, {0, 1, 3, 2, 4}))   return cldnn::format::g_os_y_is_x_osv8_isv4;
+            } else if (desc.data.ndims == 6 && blk.inner_nblks == 2
+                && blk.inner_blks[0] == 16 && blk.inner_blks[1] == 8
+                && blk.inner_idxs[0] == 2 && blk.inner_idxs[1] == 1
+                && compare_strides(order, {0, 1, 2, 3, 4, 5})) {
+                    return cldnn::format::g_os_is_zyx_isv16_osv16;
             }
         } else {
             if (desc.data.ndims == 4 && blk.inner_nblks == 4

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights.cl
@@ -81,6 +81,8 @@ inline uint FUNC(get_input_index)(uint g, uint o, uint i, uint z, uint y, uint x
     return GET_FILTER_IS_OS_ZYX_ISA8_OSV8_ISV2_INDEX(INPUT0, o, i, z, y, x);
 #elif defined INPUT0_LAYOUT_IS_OS_ZYX_ISA8_OSV8_ISV4
     return GET_FILTER_IS_OS_ZYX_ISA8_OSV8_ISV4_INDEX(INPUT0, o, i, z, y, x);
+#elif defined INPUT0_LAYOUT_G_OS_IS_ZYX_ISV16_OSV16
+    return GET_FILTER_G_OS_IS_ZYX_ISV16_OSV16_INDEX(INPUT0, g, o, i, z, y, x, SUB_GROUP_SIZE);
 #elif defined INPUT0_LAYOUT_G_OS_IS_YX_ISA8_OSV8_ISV2
     return GET_FILTER_G_OS_IS_YX_ISA8_OSV8_ISV2_INDEX(INPUT0, g, o, i, y, x);
 #elif defined INPUT0_LAYOUT_G_OS_IS_YX_ISA8_OSV8_ISV4

--- a/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
@@ -78,7 +78,6 @@ struct conv_eltw_test_params {
     data_types default_type;
     format default_format;
     size_t expected_fused_primitives;
-    size_t expected_fused_primitives_onednn;
     size_t expected_not_fused_primitives;
 };
 
@@ -153,9 +152,11 @@ public:
         network_fused.set_input_data("input", input_prim);
         network_not_fused.set_input_data("input", input_prim);
 
-        // is DG2 device
-        if (engine.get_device_info().supports_immad)
-            p.expected_fused_primitives = p.expected_fused_primitives_onednn;
+        // WA: grouped convolution test turn off for onednn because fusing behavior is different with cldnn.
+        if (engine.get_device_info().supports_immad && p.groups > 1) {
+            std::cout << "SKIP" << std::endl;
+            return;
+        }
         compare(network_not_fused, network_fused, p);
         auto find_prim = [](primitive_info& p) -> bool {
             // Add more ids when needed
@@ -1524,14 +1525,14 @@ TEST_P(conv_fp32_activation_eltwise_diff_sizes, basic) {
 }
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_fp32_activation_eltwise_diff_sizes, ::testing::ValuesIn(std::vector<conv_eltw_test_params>{
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_1, 2, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_2, 2, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_3, 2, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_4, 2, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_5, 2, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_6, 2, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_7, 3, 3, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_8, 3, 3, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_1, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_2, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_3, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_4, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_5, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_6, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_7, 3, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_8, 3, 4 },
 }));
 
 class conv_scale_activation_eltwise_fp32_quantize_i8 : public ConvEltwTest {};
@@ -1560,14 +1561,14 @@ TEST_P(conv_scale_activation_eltwise_fp32_quantize_i8, basic) {
 }
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_scale_activation_eltwise_fp32_quantize_i8, ::testing::ValuesIn(std::vector<conv_eltw_test_params>{
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_1, 2, 2, 6 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_2, 2, 2, 6 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_3, 2, 2, 6 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_4, 2, 2, 6 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_5, 3, 2, 6 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_6, 3, 2, 6 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_7, 3, 3, 6 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_8, 3, 3, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_1, 2, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_2, 2, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_3, 2, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_4, 2, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_5, 3, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_6, 3, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_7, 3, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_8, 3, 6 },
 }));
 
 /* ----------------------------------------------------------------------------------------------------- */
@@ -2687,11 +2688,11 @@ TEST_P(conv_i8_activation_eltwise_diff_sizes, basic) {
 }
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_i8_activation_eltwise_diff_sizes, ::testing::ValuesIn(std::vector<conv_eltw_test_params>{
-    conv_eltw_test_params{ CASE_CONV_ELTW_i8_1, 3, 3, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_i8_2, 2, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_i8_3, 2, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_i8_4, 2, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_i8_5, 3, 3, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_i8_1, 3, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_i8_2, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_i8_3, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_i8_4, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_i8_5, 3, 4 },
 }));
 
 /* ----------------------------------------------------------------------------------------------------- */

--- a/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
@@ -78,6 +78,7 @@ struct conv_eltw_test_params {
     data_types default_type;
     format default_format;
     size_t expected_fused_primitives;
+    size_t expected_fused_primitives_onednn;
     size_t expected_not_fused_primitives;
 };
 
@@ -152,6 +153,9 @@ public:
         network_fused.set_input_data("input", input_prim);
         network_not_fused.set_input_data("input", input_prim);
 
+        // is DG2 device
+        if (engine.get_device_info().supports_immad)
+            p.expected_fused_primitives = p.expected_fused_primitives_onednn;
         compare(network_not_fused, network_fused, p);
         auto find_prim = [](primitive_info& p) -> bool {
             // Add more ids when needed
@@ -1520,14 +1524,14 @@ TEST_P(conv_fp32_activation_eltwise_diff_sizes, basic) {
 }
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_fp32_activation_eltwise_diff_sizes, ::testing::ValuesIn(std::vector<conv_eltw_test_params>{
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_1, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_2, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_3, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_4, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_5, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_6, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_7, 3, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_8, 3, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_1, 2, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_2, 2, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_3, 2, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_4, 2, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_5, 2, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_6, 2, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_7, 3, 3, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_8, 3, 3, 4 },
 }));
 
 class conv_scale_activation_eltwise_fp32_quantize_i8 : public ConvEltwTest {};
@@ -1556,14 +1560,14 @@ TEST_P(conv_scale_activation_eltwise_fp32_quantize_i8, basic) {
 }
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_scale_activation_eltwise_fp32_quantize_i8, ::testing::ValuesIn(std::vector<conv_eltw_test_params>{
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_1, 2, 6 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_2, 2, 6 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_3, 2, 6 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_4, 2, 6 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_5, 3, 6 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_6, 3, 6 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_7, 3, 6 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_8, 3, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_1, 2, 2, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_2, 2, 2, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_3, 2, 2, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_4, 2, 2, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_5, 3, 2, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_6, 3, 2, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_7, 3, 3, 6 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_FP32_8, 3, 3, 6 },
 }));
 
 /* ----------------------------------------------------------------------------------------------------- */
@@ -2683,11 +2687,11 @@ TEST_P(conv_i8_activation_eltwise_diff_sizes, basic) {
 }
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_i8_activation_eltwise_diff_sizes, ::testing::ValuesIn(std::vector<conv_eltw_test_params>{
-    conv_eltw_test_params{ CASE_CONV_ELTW_i8_1, 3, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_i8_2, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_i8_3, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_i8_4, 2, 4 },
-    conv_eltw_test_params{ CASE_CONV_ELTW_i8_5, 3, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_i8_1, 3, 3, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_i8_2, 2, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_i8_3, 2, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_i8_4, 2, 2, 4 },
+    conv_eltw_test_params{ CASE_CONV_ELTW_i8_5, 3, 3, 4 },
 }));
 
 /* ----------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
### Related Test Cases:
 - fusings_gpu/conv_scale_activation_eltwise_fp32_quantize_i8.basic/4
   - error: reorder_weights.cl: input format - not supported
 - fusings_gpu/conv_scale_activation_eltwise_fp32_quantize_i8.basic/5
   - Unsupported groupedonednn dnnl::memory::desc find_format. ndims: 6, inner_nblks: 2, inner_blks: (blk 16, idx 2) (blk 8, idx 1) , strides_order: 0 1 2 3 4 5

### Details:
 - Each fusing behavior is different for cldnn and onednn.
   - <del>add parameter expected_fused_primitives_onednn</del>
 - <del>Add a few missing cases</del>
 - UPDATE: just disable such testcase (offline discussed)

### Tickets:
 - 67491
