### PR TITLE
Handle DT_UNKNOWN as DT_REG during file list-up

### DIFF
--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -198,8 +198,9 @@ static void iterate_files_worker(const std::string& path,
                     break;
                 case DT_REG:
                 case DT_UNKNOWN:
-                    // Comment from READDIR(3): only some filesystems have full support for returning the file type in d_type.
-                    //                          All applications must properly handle a return of DT_UNKNOWN.
+                    // Comment from READDIR(3):
+                    //     only some filesystems have full support for returning the file type in d_type.
+                    //     All applications must properly handle a return of DT_UNKNOWN.
                     func(path_name, false);
                     break;
                 default:

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -198,7 +198,8 @@ static void iterate_files_worker(const std::string& path,
                     break;
                 case DT_REG:
                 case DT_UNKNOWN:
-                    // Comment from READDIR(3): only some filesystems have full support for returning the file type in d_type. All applications must properly handle a return of DT_UNKNOWN.
+                    // Comment from READDIR(3): only some filesystems have full support for returning the file type in d_type.
+                    //                          All applications must properly handle a return of DT_UNKNOWN.
                     func(path_name, false);
                     break;
                 default:

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -197,6 +197,8 @@ static void iterate_files_worker(const std::string& path,
                     }
                     break;
                 case DT_REG:
+                case DT_UNKNOWN:
+                    // Comment from READDIR(3): only some filesystems have full support for returning the file type in d_type. All applications must properly handle a return of DT_UNKNOWN.
                     func(path_name, false);
                     break;
                 default:


### PR DESCRIPTION
Some filesystem does not return dt_type properly. (such as sshfs) Without this fix, openvino fails to search frontend when mounted on sshfs.