### PR TITLE
DOCS: Rewrite "Install OpenVINO Development Tools" page - port to 22.2

### DIFF
--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -1,6 +1,6 @@
 # Install OpenVINO™ Development Tools {#openvino_docs_install_guides_install_dev_tools}
 
-If you want to download, convert, optimize and tune pre-trained deep learning models, install OpenVINO™ Development Tools, which provides the following tools:
+OpenVINO Development Tools is a set of utilities that make it easy to develop and optimize models and applications for OpenVINO. It provides the following tools:
 
 * Model Optimizer
 * Benchmark Tool
@@ -8,19 +8,27 @@ If you want to download, convert, optimize and tune pre-trained deep learning mo
 * Post-Training Optimization Tool
 * Model Downloader and other Open Model Zoo tools
 
+The instructions on this page show how to install OpenVINO Development Tools. If you are a Python developer, it only takes a few simple steps to install the tools with PyPI. If you are developing in C++, OpenVINO Runtime must be installed separately before installing OpenVINO Development Tools.
+
+In both cases, Python 3.6 - 3.10 need be installed on your machine before starting.
+
 > **NOTE**: From the 2022.1 release, the OpenVINO™ Development Tools can only be installed via PyPI. 
 
-## For Python Developers
+## <a name="python-developers"></a>For Python Developers
 
-If you are a Python developer, you can find the main steps below to install OpenVINO Development Tools. For more details, see <https://pypi.org/project/openvino-dev>.
+If you are a Python developer, follow the steps in the <a href="openvino_docs_install_guides_install_dev_tools.html#install-dev-tools">Installing OpenVINO Development Tools</a> section on this page to install it. Installing OpenVINO Development Tools will also install OpenVINO Runtime as a dependency, so you don’t need to install OpenVINO Runtime separately. This option is recommended for new users.
+   
+## <a name="cpp-developers"></a>For C++ Developers
+If you are a C++ developer, you must first install OpenVINO Runtime separately to set up the C++ libraries, sample code, and dependencies for building applications with OpenVINO. These files are not included with the PyPI distribution. See the [Install OpenVINO Runtime](./installing-openvino-runtime.md) page to install OpenVINO Runtime from an archive file for your operating system.
 
-While installing OpenVINO Development Tools, OpenVINO Runtime will also be installed as a dependency, so you don't need to install OpenVINO Runtime separately.
+Once OpenVINO Runtime is installed, you may install OpenVINO Development Tools for access to tools like Model Optimizer, Model Downloader, Benchmark Tool, and other utilities that will help you optimize your model and develop your application. Follow the steps in the <a href="#install-dev-tools">Installing OpenVINO Development Tools</a> section on this page to install it. In Step 4, make sure that you follow the instructions in the "C++" tab.
+
+## <a name="install-dev-tools"></a>Installing OpenVINO™ Development Tools
+Follow these step-by-step instructions to install OpenVINO Development Tools on your computer.
 
 ### Step 1. Set Up Python Virtual Environment
 
-Use a virtual environment to avoid dependency conflicts. 
-
-To create a virtual environment, use the following command:
+Create a virtual Python environment to avoid dependency conflicts. To create a virtual environment, use the following command:
 
 @sphinxdirective
 
@@ -42,6 +50,8 @@ To create a virtual environment, use the following command:
 
 ### Step 2. Activate Virtual Environment
 
+Activate the newly created Python virtual environment by issuing this command:
+
 @sphinxdirective
 
 .. tab:: Linux and macOS
@@ -56,90 +66,131 @@ To create a virtual environment, use the following command:
    
       openvino_env\Scripts\activate
      
-     
+.. important::
+
+  The above command must be re-run every time a new command terminal window is opened.
+  
 @endsphinxdirective
 
 
 ### Step 3. Set Up and Update PIP to the Highest Version
+Make sure `pip` is installed in your environment and upgrade it to the latest version by issuing the following command:
 
-Use the following command:
 ```sh
 python -m pip install --upgrade pip
 ```
 
 ### Step 4. Install the Package
 
-To install and configure the components of the development package for working with specific frameworks, use the following command:
-```
-pip install openvino-dev[extras]
-```
-where the `extras` parameter specifies one or more deep learning frameworks via these values: `caffe`, `kaldi`, `mxnet`, `onnx`, `pytorch`, `tensorflow`, `tensorflow2`. Make sure that you install the corresponding frameworks for your models.
+To install and configure the components of the development package for working with specific frameworks, use the commands below.
 
-For example, to install and configure the components for working with TensorFlow 2.x and ONNX, use the following command:
-```
-pip install openvino-dev[tensorflow2,onnx]
-```
-
-> **NOTE**: Model Optimizer support for TensorFlow 1.x environment has been deprecated. Use TensorFlow 2.x environment to convert both TensorFlow 1.x and 2.x models. Use the `tensorflow2` value as much as possible. The `tensorflow` value is provided only for compatibility reasons.
+Note that the commands are different for a Python installation and a C++ installation. If you want to develop with Python only, follow the instructions in the **Python** tab. If you want to develop with C++, first make sure you have installed OpenVINO Runtime using archive files as stated in the <a href="#cpp-developers">For C++ Developers</a> section, then follow the instructions in the **C++** tab.
 
 
-### Step 5. Verify the Installation
+@sphinxdirective
 
-To verify if the package is properly installed, run the command below (this may take a few seconds):
+.. tab:: Python
+
+  To install and configure the components of the development package for working with specific frameworks, use the following command:
+
+   .. code-block:: sh
+   
+      pip install openvino-dev[extras]
+      
+  where the `extras` parameter specifies one or more deep learning frameworks via these values: `caffe`, `kaldi`, `mxnet`, `onnx`, `pytorch`, `tensorflow`, `tensorflow2`. Make sure that you install the corresponding frameworks for your models.
+  
+  For example, to install and configure the components for working with TensorFlow 2.x and ONNX, use the following command:
+  
+   .. code-block:: sh
+   
+      pip install openvino-dev[tensorflow2,onnx]
+   
+   .. note::
+      
+      Model Optimizer support for TensorFlow 1.x environment has been deprecated. Use the `tensorflow2` parameter to install a TensorFlow 2.x environment that can convert both TensorFlow 1.x and 2.x models. If your model isn't compatible with the TensorFlow 2.x environment, use the `tensorflow` parameter to install the TensorFlow 1.x environment. The TF 1.x environment is provided only for legacy compatibility reasons.
+      
+.. tab:: C++
+
+  When using OpenVINO Development Tools for C++ development, it’s important to install the same version as OpenVINO Runtime. Following the instructions below will ensure that you are installing a version that matches that of OpenVINO Runtime.
+  
+  **Recommended: Install Using the Requirements Files**
+  After you have installed OpenVINO Runtime from an archive file, you can find a set of requirements files in the <INSTALL_DIR>\tools\ directory. The requirements files will install the matching version of OpenVINO Development Tools and its dependencies.
+  
+  1. Install the OpenVINO Development Tools mandatory requirements using the following command:
+
+   .. code-block:: sh
+   
+      pip install -r <INSTALL_DIR>\tools\requirements.txt
+      
+  2. If you are using additional frameworks, you must also install the requirements for those frameworks using the corresponding requirements file. For example, if you are using a TensorFlow model, use the following command to install requirements for TensorFlow:
+     
+   .. code-block:: sh
+   
+      pip install -r <INSTALL_DIR>\tools\requirements_tensorflow2.txt
+  
+  **Alternative: Install the openvino-dev Package from PyPI**
+  You can also install OpenVINO Development Tools from PyPI using the following command.
+  
+   .. important::
+    Make sure to specify the `openvino-dev` version that matches your installed version of OpenVINO Runtime. Otherwise, compatibility errors are likely to occur.
+    
+   .. code-block:: sh
+   
+      pip install openvino-dev[EXTRAS]==2022.2
+      
+  where the EXTRAS parameter specifies one or more deep learning frameworks via these values: caffe, kaldi, mxnet, onnx, pytorch, tensorflow, tensorflow2. Make sure that you install the corresponding frameworks for your models. For example: 
+      
+   .. code-block:: sh
+    
+      pip install openvino-dev[tensorflow2,onnx]==2022.2
+   
+   .. note::
+      
+      Model Optimizer support for TensorFlow 1.x environment has been deprecated. Use the `tensorflow2` parameter or to install a TensorFlow 2.x environment that can convert both TensorFlow 1.x and 2.x models. If your model isn't compatible with the TensorFlow 2.x environment, use the `tensorflow` parameter to install the TensorFlow 1.x environment. The TF 1.x environment is provided only for legacy compatibility reasons.
+     
+@endsphinxdirective
+
+For more details on the openvino-dev PyPI package, see https://pypi.org/project/openvino-dev/.
+
+### Step 4. Test the Installation
+
+To verify the package is properly installed, run the command below (this may take a few seconds):
+
 ```sh
 mo -h
 ```
-You will see the help message for Model Optimizer if installation finished successfully.
 
+You will see the help message for Model Optimizer if installation finished successfully. If you get an error, refer to the [Troubleshooting Guide](./troubleshooting.md) for possible solutions.
 
-## For C++ Developers
-
-Note the following things:
-
-* To install OpenVINO Development Tools, you must have OpenVINO Runtime installed first. You can install OpenVINO Runtime through archive files. See [Install OpenVINO on Linux from Archive](installing-openvino-from-archive-linux.md), [Install OpenVINO on Windows from Archive](installing-openvino-from-archive-windows.md), and [Install OpenVINO on macOS from Archive](installing-openvino-from-archive-macos.md) for more details. 
-* Ensure that the version of OpenVINO Development Tools you are installing matches that of OpenVINO Runtime. 
-
-Use either of the following ways to install OpenVINO Development Tools:
-
-### Recommended: Install Using the Requirements Files
-
-1. After you have installed OpenVINO Runtime from an archive file, you can find a set of requirements files in the `<INSTALL_DIR>\tools\` directory. Select the most suitable ones to use.
-2. Install the same version of OpenVINO Development Tools by using the requirements files. 
-   To install mandatory requirements only, use the following command:
-   ```
-   pip install -r <INSTALL_DIR>\tools\requirements.txt
-   ```
-3. Make sure that you also install your additional frameworks with the corresponding requirements files. For example, if you are using a TensorFlow model, use the following command to install requirements for TensorFlow:  
-```
-pip install -r <INSTALL_DIR>\tools\requirements_tensorflow2.txt
-```
-
-### Alternative: Install from the openvino-dev Package
-
-You can also use the following command to install the latest package version available in the index:
-```
-pip install openvino-dev[EXTRAS]
-```
-where the EXTRAS parameter specifies one or more deep learning frameworks via these values: `caffe`, `kaldi`, `mxnet`, `onnx`, `pytorch`, `tensorflow`, `tensorflow2`. Make sure that you install the corresponding frameworks for your models.
-
-If you have installed OpenVINO Runtime via the installer, to avoid version conflicts, specify your version in the command. For example:
-```
-pip install openvino-dev[tensorflow2,onnx]==2022.1
-```
-    
-> **NOTE**: Model Optimizer support for TensorFlow 1.x environment has been deprecated. Use TensorFlow 2.x environment to convert both TensorFlow 1.x and 2.x models. The `tensorflow` value is provided only for compatibility reasons, use the `tensorflow2` value instead.
-
-For more details, see <https://pypi.org/project/openvino-dev/>.
+Congratulations! You finished installing OpenVINO Development Tools with C++ capability. Now you can start exploring OpenVINO's functionality through example C++ applications. See the "What's Next?" section to learn more!
 
 ## What's Next?
+Learn more about OpenVINO and use it in your own application by trying out some of these examples!
 
-Now you may continue with the following tasks:
+### Get started with Python
+<img src="https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif" width=400>
 
-* To convert models for use with OpenVINO, see [Model Optimizer Developer Guide](../MO_DG/Deep_Learning_Model_Optimizer_DevGuide.md).
-* See pre-trained deep learning models in our [Open Model Zoo](../model_zoo.md).
-* Try out OpenVINO via [OpenVINO Notebooks](https://docs.openvino.ai/latest/notebooks/notebooks.html).
-* To write your own OpenVINO™ applications, see [OpenVINO Runtime User Guide](../OV_Runtime_UG/openvino_intro.md).
-* See sample applications in [OpenVINO™ Toolkit Samples Overview](../OV_Runtime_UG/Samples_Overview.md).
+Try the [Python Quick Start Example](https://docs.openvino.ai/2022.2/notebooks/201-vision-monodepth-with-output.html) to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+
+Visit the [Tutorials](../tutorials.md) page for more Jupyter Notebooks to get you started with OpenVINO, such as:
+* [OpenVINO Python API Tutorial](https://docs.openvino.ai/2022.2/notebooks/002-openvino-api-with-output.html)
+* [Basic image classification program with Hello Image Classification](https://docs.openvino.ai/2022.2/notebooks/001-hello-world-with-output.html)
+* [Convert a PyTorch model and use it for image background removal](https://docs.openvino.ai/2022.2/notebooks/205-vision-background-removal-with-output.html)
+
+### Get started with C++
+<img src="https://user-images.githubusercontent.com/36741649/127170593-86976dc3-e5e4-40be-b0a6-206379cd7df5.jpg" width=400>
+
+Try the [C++ Quick Start Example](@ref openvino_docs_get_started_get_started_demos) for step-by-step instructions on building and running a basic image classification C++ application.
+
+Visit the [Samples](../OV_Runtime_UG/Samples_Overview.md) page for other C++ example applications to get you started with OpenVINO, such as:
+* [Basic object detection with the Hello Reshape SSD C++ sample](@ref openvino_inference_engine_samples_hello_reshape_ssd_README)
+* [Automatic speech recognition C++ sample](@ref openvino_inference_engine_samples_speech_sample_README)
+
+### Learn OpenVINO Development Tools
+* Explore a variety of pre-trained deep learning models in the <a href="model_zoo.html">Open Model Zoo</a> and deploy them in demo applications to see how they work.
+* Want to import a model from another framework and optimize its performance with OpenVINO? Visit the <a href="openvino_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html">Model Optimizer Developer Guide</a>.
+* Accelerate your model's speed even further with quantization and other compression techniques using <a href="pot_introduction.html">Post-Training Optimization Tool</a>.
+* Benchmark your model's inference speed with one simple command using the <a href="openvino_inference_engine_tools_benchmark_tool_README.html">Benchmark Tool</a>.
 
 ## Additional Resources
 

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -10,7 +10,7 @@ OpenVINO Development Tools is a set of utilities that make it easy to develop an
 
 The instructions on this page show how to install OpenVINO Development Tools. If you are a Python developer, it only takes a few simple steps to install the tools with PyPI. If you are developing in C++, OpenVINO Runtime must be installed separately before installing OpenVINO Development Tools.
 
-In both cases, Python 3.6 - 3.10 need be installed on your machine before starting.
+In both cases, Python 3.6 - 3.9 need be installed on your machine before starting.
 
 > **NOTE**: From the 2022.1 release, the OpenVINO™ Development Tools can only be installed via PyPI. 
 

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -164,27 +164,36 @@ You will see the help message for Model Optimizer if installation finished succe
 
 Congratulations! You finished installing OpenVINO Development Tools with C++ capability. Now you can start exploring OpenVINO's functionality through example C++ applications. See the "What's Next?" section to learn more!
 
-## What's Next?
-Learn more about OpenVINO and use it in your own application by trying out some of these examples!
+## <a name="get-started"></a>What's Next?
+Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications! Learn more about how to integrate a model in OpenVINO applications by trying out the following tutorials.
 
-### Get started with Python
-<img src="https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif" width=400>
+@sphinxdirective
+.. tab:: Get started with Python
 
-Try the [Python Quick Start Example](https://docs.openvino.ai/2022.2/notebooks/201-vision-monodepth-with-output.html) to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+   Try the `Python Quick Start Example <https://docs.openvino.ai/2022.2/notebooks/201-vision-monodepth-with-output.html>`_ to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+   
+   .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
+      :width: 400
 
-Visit the [Tutorials](../tutorials.md) page for more Jupyter Notebooks to get you started with OpenVINO, such as:
-* [OpenVINO Python API Tutorial](https://docs.openvino.ai/2022.2/notebooks/002-openvino-api-with-output.html)
-* [Basic image classification program with Hello Image Classification](https://docs.openvino.ai/2022.2/notebooks/001-hello-world-with-output.html)
-* [Convert a PyTorch model and use it for image background removal](https://docs.openvino.ai/2022.2/notebooks/205-vision-background-removal-with-output.html)
+   Visit the :ref:`Tutorials <notebook tutorials>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
+   
+   * `OpenVINO Python API Tutorial <https://docs.openvino.ai/2022.2/notebooks/002-openvino-api-with-output.html>`_
+   * `Basic image classification program with Hello Image Classification <https://docs.openvino.ai/2022.2/notebooks/001-hello-world-with-output.html>`_
+   * `Convert a PyTorch model and use it for image background removal <https://docs.openvino.ai/2022.2/notebooks/205-vision-background-removal-with-output.html>`_
 
-### Get started with C++
-<img src="https://user-images.githubusercontent.com/36741649/127170593-86976dc3-e5e4-40be-b0a6-206379cd7df5.jpg" width=400>
+.. tab:: Get started with C++
 
-Try the [C++ Quick Start Example](@ref openvino_docs_get_started_get_started_demos) for step-by-step instructions on building and running a basic image classification C++ application.
+   Try the `C++ Quick Start Example <openvino_docs_get_started_get_started_demos.html>`_ for step-by-step instructions on building and running a basic image classification C++ application.
+   
+   .. image:: https://user-images.githubusercontent.com/36741649/127170593-86976dc3-e5e4-40be-b0a6-206379cd7df5.jpg
+      :width: 400
 
-Visit the [Samples](../OV_Runtime_UG/Samples_Overview.md) page for other C++ example applications to get you started with OpenVINO, such as:
-* [Basic object detection with the Hello Reshape SSD C++ sample](@ref openvino_inference_engine_samples_hello_reshape_ssd_README)
-* [Automatic speech recognition C++ sample](@ref openvino_inference_engine_samples_speech_sample_README)
+   Visit the :ref:`Samples <code samples>` page for other C++ example applications to get you started with OpenVINO, such as:
+   
+   * `Basic object detection with the Hello Reshape SSD C++ sample <openvino_inference_engine_samples_hello_reshape_ssd_README.html>`_
+   * `Automatic speech recognition C++ sample <openvino_inference_engine_samples_speech_sample_README.html>`_
+
+@endsphinxdirective
 
 ### Learn OpenVINO Development Tools
 * Explore a variety of pre-trained deep learning models in the <a href="model_zoo.html">Open Model Zoo</a> and deploy them in demo applications to see how they work.


### PR DESCRIPTION
Port of changes from https://github.com/openvinotoolkit/openvino/pull/13348 to 22.2.

Details:

* Rewrote the introductory section to give more explanation of what OpenVINO Dev Tools is
* Added "For Python Developers" and "For C++ Developers" sections in the introduction to explain the difference in the install process
* Changed the existing "For Python Developers" section to "Installing OpenVINO Development Tools"
* In Step 4, added a Sphinx tab to provide different instructions for Python and C++ users. Python users install using pip install openvino-dev, while C++ install using requirements.txt files. (C++ can alternatively install using pip install openvino-dev, but must be careful to use the right version.)
* In Step 5, added a sentence to tell users to visit the Troubleshooting page if they encountered errors
* Removed the old "For C++ Developers" section
* Changed the "What's Next?" section to add more enticing links, similar to https://github.com/openvinotoolkit/openvino/pull/13219