### PR TITLE
[CPU] The Gather JIT kernel improvement. Part 1.

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/gather.h
+++ b/src/plugins/intel_cpu/src/nodes/gather.h
@@ -27,60 +27,27 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ngraph::Node>& op, std::string& errorMessage) noexcept;
 
-    struct threadExecParams {
-        std::vector<int> specIdxInBytes;
-        std::vector<int> permIdxMask;
-        std::vector<int> srcBeforeAxisDiff;
-        std::vector<int> idxBatchSumInBytes;
-        std::vector<int> dataBeforeAxisSumInBytes;
-
-        std::vector<int> afterAxIdxInBytes;
-        std::vector<int> specIdxDiff;
-        std::vector<int> beforeAxPermMask;
-        std::vector<int> afterAxPermMask;
-        int betweenBatchAndAxisIter = 0;
-        int specIdxAndAfterAxIterB = 0;
-
-        uint64_t workAmount = 0;
-        uint64_t dstStart = 0;
-    };
-
 protected:
     void createOrUpdateJitKernelIfNeeded();
+    void initializePerThreadParams();
     void executeDynamicImpl(dnnl::stream strm) override;
     bool needPrepareParams() const override;
     void prepareParams() override;
     std::vector<VectorDims> shapeInfer() const override;
 
 private:
-    void initShortParams(threadExecParams& p, uint64_t start);
     void execReference();
 
     bool isDataShapeStat = false;
     bool isIdxShapeStat = false;
     bool isAxisInputConst = false;
-
     bool reverseIndexing = false;
-
-    uint64_t dataTypeSize = 1lu;
-    static constexpr uint64_t idxTypeSize = sizeof(int);
-
     int axis = 0;
-    int axisDim = 0;
     int batchDims = 0;
     int dataSrcRank = 1;
-    uint64_t specIndicesSize = 0lu;
-    uint64_t beforeBatchSize = 0lu;
-    uint64_t beforeAxisSize = 0lu;
-    uint64_t betweenBatchAndAxisSize = 0lu;
-    uint64_t afterAxisSize = 0lu;
-    uint64_t afterAxisSizeInBytes = 0lu;
-    uint64_t axisAndAfterAxisSizeInBytes = 0lu;
-    uint64_t srcAfterBatchSizeInBytes = 0lu;
-    uint64_t specIdxAndAfterAxSizeB = 0lu;
-    uint64_t totalWork = 0lu;
+    GatherShapeParameters shapeParameters;
 
-    std::vector<threadExecParams> execParamsPerThread;
+    std::vector<GatherShapeParameters::PerThread> execParamsPerThread;
 
     static constexpr size_t GATHER_DATA = 0;
     static constexpr size_t GATHER_INDICES = 1;

--- a/src/plugins/intel_cpu/src/nodes/gather.h
+++ b/src/plugins/intel_cpu/src/nodes/gather.h
@@ -46,6 +46,7 @@ public:
     };
 
 protected:
+    void createOrUpdateJitKernelIfNeeded();
     void executeDynamicImpl(dnnl::stream strm) override;
     bool needPrepareParams() const override;
     void prepareParams() override;
@@ -85,7 +86,7 @@ private:
     static constexpr size_t GATHER_INDICES = 1;
     static constexpr size_t GATHER_AXIS = 2;
 
-    std::shared_ptr<jitGatherKernelBase> jitKernel;
+    std::shared_ptr<jitGatherKernelInterface> jitKernel;
 };
 
 }   // namespace node

--- a/src/plugins/intel_cpu/src/nodes/kernels/gather_uni_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/gather_uni_kernel.cpp
@@ -10,42 +10,28 @@ using namespace dnnl::impl::cpu;
 namespace ov {
 namespace intel_cpu {
 
-const unsigned jitGatherKernelBase::shufMask8bitUni[16]  = {0x0C080400, 0x80808080, 0x80808080, 0x80808080, 0x0C080400, 0x80808080, 0x80808080, 0x80808080,
-                                                            0x0C080400, 0x80808080, 0x80808080, 0x80808080, 0x0C080400, 0x80808080, 0x80808080, 0x80808080};
-const unsigned jitGatherKernelBase::permMask8bitA2[8]    = {0, 4, 1, 5, 2, 6, 3, 7};
-const unsigned jitGatherKernelBase::permMask8bitA5[16]   = {0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15};
-
-const unsigned jitGatherKernelBase::shufMask16bitUni[16] = {0x05040100, 0x0D0C0908, 0x80808080, 0x80808080, 0x05040100, 0x0D0C0908, 0x80808080, 0x80808080,
-                                                            0x05040100, 0x0D0C0908, 0x80808080, 0x80808080, 0x05040100, 0x0D0C0908, 0x80808080, 0x80808080};
-const unsigned jitGatherKernelBase::permMask16bitA2[8]   = {0, 1, 4, 5, 2, 3, 6, 7};
-const unsigned jitGatherKernelBase::permMask16bitA5[16]  = {0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15};
-
-const unsigned jitGatherKernelBase::incVec[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
-
 #define GET_OFF(field) offsetof(gatherJitExecArgs, field)
 
-template <x64::cpu_isa_t isa>
-jitUniGatherKernel<isa>::jitUniGatherKernel(const jGatherConfParams& jcp) :
-        jitGatherKernelBase(jcp), x64::jit_generator(jit_name()) {
-    vlen = x64::cpu_isa_traits<isa>::vlen;
-    dataElPerVec = vlen / jcp.dataTypeSize;
-    idxElPerVec = vlen / indicesTypeSize;
-    if (jcp.dataTypeSize == 2)
-        dataTypeShift = 1;
-    else if (jcp.dataTypeSize == 4)
-        dataTypeShift = 2;
 
-    if (isa == x64::avx2) {
-        permMask8bitUni = permMask8bitA2;
-        permMask16bitUni = permMask16bitA2;
-    } else if (isa == x64::avx512_core) {
-        permMask8bitUni = permMask8bitA5;
-        permMask16bitUni = permMask16bitA5;
-    }
+template<x64::cpu_isa_t isa>
+void jitGatherKernelBase<isa>::initialize(const jGatherConfParams& jcp) {
+    this->beforeAxisSize = jcp.beforeAxisSize;
+    this->specIdxSize = jcp.specIdxSize;
+    this->batchDims = jcp.batchDims;
+    this->reverseIndexing = jcp.reverseIndexing;
+    this->afterAxisSize = jcp.afterAxisSize;
+    this->dynamicShapes = jcp.dynamicShapes;
 }
 
-template <x64::cpu_isa_t isa>
-void jitUniGatherKernel<isa>::create_ker() {
+template<x64::cpu_isa_t isa>
+bool jitGatherKernelBase<isa>::isSameParams(const jGatherConfParams& jcp) {
+    return beforeAxisSize == jcp.beforeAxisSize && specIdxSize == jcp.specIdxSize && batchDims == jcp.batchDims &&
+            reverseIndexing == jcp.reverseIndexing && afterAxisSize == jcp.afterAxisSize && dynamicShapes && jcp.dynamicShapes &&
+            getDataTypeSize() == jcp.dataTypeSize;
+}
+
+template<x64::cpu_isa_t isa>
+void jitGatherKernelBase<isa>::create_ker() {
     auto code = x64::jit_generator::create_kernel();
     if (code != dnnl::impl::status::success)
         IE_THROW() << "Could not create Gather kernel. Error code: " << std::to_string(code);
@@ -53,928 +39,181 @@ void jitUniGatherKernel<isa>::create_ker() {
 }
 
 template <x64::cpu_isa_t isa>
-void jitUniGatherKernel<isa>::generate() {
+void jitGatherKernelBase<isa>::generate() {
     this->preamble();
-
     mov(regSrc, ptr[regParams + GET_OFF(src)]);
     mov(regDst, ptr[regParams + GET_OFF(dst)]);
     mov(regIndices, ptr[regParams + GET_OFF(indices)]);
-
     mov(regWorkAmount, ptr[regParams + GET_OFF(workAmount)]);
-
-    auto& vAux0 = vmmAuxContainer[0];
-    auto& vAux1 = vmmAuxContainer[1];
-    auto& xAux0 = xmmAuxContainer[0];
-    auto& xAux1 = xmmAuxContainer[1];
-
     uni_vpxor(vmmZeros, vmmZeros, vmmZeros);
-    mov(regAux1, ptr[regParams + GET_OFF(axisDim)]);
-    uni_vpbroadcastd(vmmAxisDim, ptr[regAux1]);
-
-    if (!jcp.dynamicShapes) {
-        mov(regAux1, ptr[regParams + GET_OFF(specIndicesSize)]);
-        uni_vpbroadcastd(vmmSpecIdxSizeB, ptr[regAux1]);
-        uni_vpslld(vmmSpecIdxSizeB, vmmSpecIdxSizeB, idxTypeShift); // multiply by indices type size.
-
-        mov(regAux1, ptr[regParams + GET_OFF(specIdxB)]);
-        uni_vmovups(vmmSpecIdxB, ptr[regAux1]);
-
-        if (jcp.beforeAxisSize != 1lu) {
-            mov(regAux1, ptr[regParams + GET_OFF(dataBeforeAxisSumB)]);
-            uni_vmovups(vmmSrcBeforeAxisSumB, ptr[regAux1]);
-        }
-
-        if (jcp.afterAxisSize == 1lu) { // Elementwise case.
-            uni_vmovd(reg32SpecIdxSizeB, xmmSpecIdxSizeB);
-            if (jcp.beforeAxisSize != 1lu) {
-                mov(regAux1, ptr[regParams + GET_OFF(axisAndAfterAxisSizeB)]);
-                uni_vpbroadcastd(vmmAxisAndAfterAxisSizeB, ptr[regAux1]);
-            }
-
-            mov(regAux1, ptr[regParams + GET_OFF(idxBatchSumB)]);
-            uni_vmovups(vmmIdxBatchSumB, ptr[regAux1]);
-
-            mov(regAux1, ptr[regParams + GET_OFF(betweenBatchAndAxisSize)]);
-            mov(regBetweenBatchAndAxisSize, ptr[regAux1]);
-            mov(regBetweenBatchAndAxisIter, ptr[regParams + GET_OFF(betweenBatchAndAxisIter)]);
-
-            if (jcp.specIdxSize < idxElPerVec) { // Short case.
-                if (jcp.specIdxSize != 1 && jcp.specIdxSize != 2 && jcp.specIdxSize != 4 && jcp.specIdxSize != 8 && jcp.specIdxSize != 16) {
-                    mov(regAux1, ptr[regParams + GET_OFF(permIdxMask)]);
-                    uni_vmovups(vmmPermIdxMask, ptr[regAux1]);
-                }
-                if (jcp.beforeAxisSize != 1lu) {
-                    mov(regAux1, ptr[regParams + GET_OFF(beforeAxisDiff)]);
-                    uni_vmovups(vmmBeforeAxDiffB, ptr[regAux1]);
-                    if (jcp.dataTypeSize != 1)
-                        uni_vpslld(vmmBeforeAxDiffB, vmmBeforeAxDiffB, dataTypeShift); // multiply by data type size
-                }
-                if (jcp.batchDims > 0lu) {
-                    mov(regAux1, ptr[regParams + GET_OFF(srcAfterBatchSizeB)]);
-                    uni_vpbroadcastd(vmmSrcAfterBatchSizeB, ptr[regAux1]);
-                }
-
-                process(true, false);
-            } else { // Long case.
-                uni_vmovd(reg32IdxIter, xmmSpecIdxB);
-                fillVlenVector();
-
-                process(false, false);
-            }
-        } else { // Blocked case.
-            if (jcp.afterAxisSize <= idxElPerVec) { // Short case.
-                mov(regAux1, ptr[regParams + GET_OFF(afterAxIdxB)]);
-                uni_vmovups(vmmAfterAxisIdxB, ptr[regAux1]);
-                mov(regAux1, ptr[regParams + GET_OFF(afterAxisPermMask)]);
-                uni_vmovups(vmmAfterAxisPermMask, ptr[regAux1]);
-                mov(regAux1, ptr[regParams + GET_OFF(specIdxDiff)]);
-                uni_vmovups(vmmSpecIdxDiff, ptr[regAux1]);
-                mov(regAux1, ptr[regParams + GET_OFF(srcAfterBatchSizeB)]);
-                uni_vpbroadcastd(vmmSrcAfterBatchSizeB, ptr[regAux1]);
-                mov(regAux1, ptr[regParams + GET_OFF(afterAxisSize)]);
-                uni_vpbroadcastd(vmmAfterAxisSize, ptr[regAux1]);
-
-                if (jcp.beforeAxisSize != 1lu) {
-                    mov(rSpecIdxAndAfterAxIterB, ptr[regParams + GET_OFF(specIdxAndAfterAxIterB)]);
-                    mov(rSpecIdxAndAfterAxSizeB, ptr[regParams + GET_OFF(specIdxAndAfterAxSizeB)]);
-                    if (jcp.specIdxSize * jcp.afterAxisSize < idxElPerVec) {
-                        mov(regAux1, ptr[regParams + GET_OFF(beforeAxisDiff)]);
-                        uni_vmovups(vmmBeforeAxDiffB, ptr[regAux1]);
-                    } else {
-                        mov(regAux1, ptr[regParams + GET_OFF(axisAndAfterAxisSizeB)]);
-                        uni_vpbroadcastd(vmmAxisAndAfterAxisSizeB, ptr[regAux1]);
-                    }
-                    const uint64_t specIdxAndAfterAxisSize = jcp.specIdxSize * jcp.afterAxisSize;
-                    if (specIdxAndAfterAxisSize != 1 && specIdxAndAfterAxisSize != 2 && specIdxAndAfterAxisSize != 4 &&
-                            specIdxAndAfterAxisSize != 8 && specIdxAndAfterAxisSize != 16) {
-                        mov(regAux1, ptr[regParams + GET_OFF(beforeAxisPermMask)]);
-                        uni_vmovups(vmmBeforeAxPermMask, ptr[regAux1]);
-                    }
-                }
-
-                process(true, true);
-            } else { // Long case.
-                IE_THROW() << "Gather kernel does not support static shape with after axis size greater than elements in vector.";
-            }
-        }
-    } else { // Dynamic shapes.
-        mov(regAux1, ptr[regParams + GET_OFF(start)]);
-        uni_vpbroadcastd(vmmSpecIdxB, ptr[regAux1]);
-        mov(regAux1, reinterpret_cast<uintptr_t>(incVec));
-        uni_vpaddd(vmmSpecIdxB, vmmSpecIdxB, ptr[regAux1]);
-        vcvtdq2ps(vmmSpecIdxB, vmmSpecIdxB);
-
-        // Formula: specIndices = (start % specIndicesSize) * idxTypeSize
-        mov(regAux1, ptr[regParams + GET_OFF(specIndicesSize)]);
-        uni_vpbroadcastd(vmmSpecIdxSizeB, ptr[regAux1]);
-        uni_vcvtdq2ps(vAux1, vmmSpecIdxSizeB);
-        uni_vdivps(vmmSrcBeforeAxisSumB, vmmSpecIdxB, vAux1);
-        uni_vroundps(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, 0x1);
-        uni_vfnmadd231ps(vmmSpecIdxB, vmmSrcBeforeAxisSumB, vAux1);
-        uni_vcvtps2dq(vmmSpecIdxB, vmmSpecIdxB);
-        uni_vpslld(vmmSpecIdxB, vmmSpecIdxB, idxTypeShift); // multiply by indices type size.
-        uni_vpslld(vmmSpecIdxSizeB, vmmSpecIdxSizeB, idxTypeShift); // multiply by indices type size.
-        uni_vmovd(reg32SpecIdxSizeB, xmmSpecIdxSizeB);
-
-        mov(regAux1, ptr[regParams + GET_OFF(betweenBatchAndAxisSize)]);
-        uni_vpbroadcastd(vAux1, ptr[regAux1]);
-        uni_vmovd(reg32BetweenBatchAndAxisSize, xAux1);
-        uni_vcvtdq2ps(vAux1, vAux1);
-        uni_vdivps(vmmIdxBatchSumB, vmmSrcBeforeAxisSumB, vAux1);
-        uni_vroundps(vmmIdxBatchSumB, vmmIdxBatchSumB, 0x1);
-        uni_vfnmadd231ps(vmmSrcBeforeAxisSumB, vmmIdxBatchSumB, vAux1);
-        uni_vcvtps2dq(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB);
-        uni_vmovd(reg32BetweenBatchAndAxisIter, xmmSrcBeforeAxisSum);
-        uni_vcvtps2dq(vmmIdxBatchSumB, vmmIdxBatchSumB);
-
-        mov(regAux1, ptr[regParams + GET_OFF(axisAndAfterAxisSizeB)]);
-        uni_vpbroadcastd(vmmAxisAndAfterAxisSizeB, ptr[regAux1]);
-        // Formula: srcBeforeAxisSum = ((start / specIndicesSize) % betweenBatchAndAxis) * axisAndAfterAxisSize + srcAfterBatchSize * idxBatchSum
-        if (jcp.beforeAxisSize != 1lu) {
-            uni_vpmulld(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, vmmAxisAndAfterAxisSizeB);
-            mov(regAux1, ptr[regParams + GET_OFF(srcAfterBatchSizeB)]);
-            uni_vpbroadcastd(vAux0, ptr[regAux1]);
-            uni_vpmulld(vAux0, vAux0, vmmIdxBatchSumB);
-            uni_vpaddd(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, vAux0);
-        }
-
-        // Formula: idxBatchSum = specIdxSize * (start / afterBatchSize)
-        uni_vpmulld(vmmIdxBatchSumB, vmmIdxBatchSumB, vmmSpecIdxSizeB);
-
-        Xbyak::Label lBlock, lEnd;
-        mov(regAux2, ptr[regParams + GET_OFF(afterAxSize)]);
-        cmp(regAux2, 1);
-        jg(lBlock, T_NEAR);
-        {
-            Xbyak::Label lLessThanVector1, lTail1, lTail2, lE1;
-
-            cmp(regSpecIdxSizeB, vlen);
-            jl(lLessThanVector1, T_NEAR);
-                uni_vmovd(reg32IdxIter, xmmSpecIdxB);
-                fillVlenVector();
-
-                process(false, false);
-                jmp(lE1, T_NEAR);
-            L(lLessThanVector1);
-                mov(regAux1, ptr[regParams + GET_OFF(permIdxMask)]);
-                uni_vmovups(vmmPermIdxMask, ptr[regAux1]);
-                if (jcp.beforeAxisSize != 1lu) {
-                    mov(regAux1, ptr[regParams + GET_OFF(beforeAxisDiff)]);
-                    uni_vmovups(vmmBeforeAxDiffB, ptr[regAux1]);
-                    if (jcp.dataTypeSize != 1)
-                        uni_vpslld(vmmBeforeAxDiffB, vmmBeforeAxDiffB, dataTypeShift); // multiply by data type size
-                }
-                mov(regAux1, ptr[regParams + GET_OFF(srcAfterBatchSizeB)]);
-                uni_vpbroadcastd(vmmSrcAfterBatchSizeB, ptr[regAux1]);
-
-                process(true, false);
-            L(lE1);
-            jmp(lEnd, T_NEAR);
-        }
-        L(lBlock); {
-            mov(regAux1, ptr[regParams + GET_OFF(start)]);
-            uni_vpbroadcastd(vmmAfterAxisIdxB, ptr[regAux1]);
-            mov(regAux1, reinterpret_cast<uintptr_t>(incVec));
-            uni_vpaddd(vmmAfterAxisIdxB, vmmAfterAxisIdxB, ptr[regAux1]);
-            uni_vcvtdq2ps(vmmAfterAxisIdxB, vmmAfterAxisIdxB);
-
-            // afterAxIdxB = (start % afterAxSize) * idxTypeSize
-            movd(xAux0, reg32Aux1);
-            uni_vpbroadcastd(vAux1, xAux0);
-            uni_vcvtdq2ps(vAux1, vAux1);
-            uni_vdivps(vmmSrcBeforeAxisSumB, vmmAfterAxisIdxB, vAux1);
-            uni_vroundps(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, 0x1);
-            uni_vfnmadd231ps(vmmAfterAxisIdxB, vmmSrcBeforeAxisSumB, vAux1);
-            uni_vcvtps2dq(vmmAfterAxisIdxB, vmmAfterAxisIdxB);
-            uni_vpslld(vmmAfterAxisIdxB, vmmAfterAxisIdxB, idxTypeShift); // multiply by indices type size.
-
-            Xbyak::Label lLessThanVector2, lTail3, lTail4, lE2;
-
-            cmp(regAux2, dataElPerVec);
-            jl(lLessThanVector2, T_NEAR);
-                uni_vmovd(reg32IdxIter, xmmSpecIdxB);
-                fillVlenVector();
-
-//                process(false, true);
-                jmp(lE2, T_NEAR);
-            L(lLessThanVector2);
-                auto& vAux2 = vmmAuxContainer[2];
-                // Calculate permute mask
-                uni_vmovd(xAux0, reg32Aux2);
-                uni_vpbroadcastd(vAux1, xAux0);
-                mov(regAux1, reinterpret_cast<uintptr_t>(&idxElPerVec));
-                uni_vpbroadcastd(vAux0, ptr[regAux1]);
-                uni_vpsubd(vmmAfterAxisPermMask, vAux0, vAux1);
-                mov(regAux1, reinterpret_cast<uintptr_t>(incVec));
-                uni_vpaddd(vmmAfterAxisPermMask, vmmAfterAxisPermMask, ptr[regAux1]);
-                for (int i = 0; i < 6; i++) {
-                    if (isa == x64::avx512_core) {
-                        Xbyak::Opmask kMask2 = Xbyak::Opmask(vAux2.getIdx());
-                        vpcmpgtd(kMask2, vAux0, vmmAfterAxisPermMask);
-                        uni_vpsubd(vmmAfterAxisPermMask | kMask2, vmmAfterAxisPermMask, vAux1);
-                    } else {
-                        vpcmpgtd(vAux2, vAux0, vmmAfterAxisPermMask);
-                        vpandn(vAux2, vAux2, vAux1);
-                        uni_vpsubd(vmmAfterAxisPermMask, vmmAfterAxisPermMask, vAux2);
-                    }
-                }
-
-                process(true, true);
-            L(lE2);
-        }
-        L(lEnd);
-    }
-
+    uploadParamPtrWithVpbroadcastd(vmmAxisDim, GET_OFF(axisDim));
+    generateDynamicitySpecific();
     this->postamble();
 }
 
-template <>
-void jitUniGatherKernel<x64::avx2>::uniVpGatherDd(Vmm& vDst, const Xbyak::Address& srcAddr, Vmask& kMask) {
-    vpgatherdd(vDst, srcAddr, kMask);
-}
-template <>
-void jitUniGatherKernel<x64::avx512_core>::uniVpGatherDd(Vmm& vDst, const Xbyak::Address& srcAddr, Vmask& kMask) {
-    vpgatherdd(vDst | kMask, srcAddr);
-}
-
-template <>
-void jitUniGatherKernel<x64::avx2>::normalizeRawIndices(Vmm& vRawIndices, Vmask& kDstMask, Vmask& kAuxMask) {
-    // Compensate negative indices.
-    if (jcp.reverseIndexing) {
-        vpcmpgtd(kAuxMask, vmmZeros, vRawIndices);
-        vpand(kAuxMask, kAuxMask, vmmAxisDim);
-        uni_vpaddd(vRawIndices, vRawIndices, kAuxMask);
-    }
-    // Check boundaries.
-    vpcmpgtd(kDstMask, vmmAxisDim, vRawIndices);
-    vpcmpgtd(kAuxMask, vmmZeros, vRawIndices);
-    vpandn(kDstMask, kAuxMask, kDstMask);
-    // Multiply by type size.
-    if (jcp.dataTypeSize > 1)
-        uni_vpslld(vRawIndices, vRawIndices, dataTypeShift);
-}
-
-template <>
-void jitUniGatherKernel<x64::avx512_core>::normalizeRawIndices(Vmm& vRawIndices, Vmask& kDstMask, Vmask& kAuxMask) {
-    // Compensate negative indices.
-    if (jcp.reverseIndexing) {
-        vpcmpgtd(kAuxMask, vmmZeros, vRawIndices);
-        uni_vpaddd(vRawIndices | kAuxMask, vRawIndices, vmmAxisDim);
-    }
-    // Check boundaries.
-    vpcmpgtd(kAuxMask, vmmAxisDim, vRawIndices);
-    vpcmpd(kDstMask | kAuxMask, vmmZeros, vRawIndices, 2); // 2 - LE
-    // Multiply by type size.
-    if (jcp.dataTypeSize > 1)
-        uni_vpslld(vRawIndices, vRawIndices, dataTypeShift);
-}
-
-template <>
-void jitUniGatherKernel<x64::avx2>::normWithUpperBound(Vmm& vTarget, Vmm& vMax, Vmask& kAuxMask) {
-    vpcmpgtd(kAuxMask, vMax, vTarget);
-    vpandn(kAuxMask, kAuxMask, vMax);
-    uni_vpsubd(vTarget, vTarget, kAuxMask);
-}
-
-template <>
-void jitUniGatherKernel<x64::avx512_core>::normWithUpperBound(Vmm& vTarget, Vmm& vMax, Vmask& kAuxMask) {
-    vpcmpd(kAuxMask, vMax, vTarget, 2); // 2 -> LE
-    uni_vpsubd(vTarget | kAuxMask, vTarget, vMax);
-}
-
-// Requires vAuxPool length 4.
-// Returns calculated shifts in vAuxPool[0] and mask in vAuxPool[1].
-template <>
-void jitUniGatherKernel<x64::avx2>::calcSrcShiftLong(Vmm* vAuxPool, bool shiftFirst) {
-    auto& vDstShifts = vAuxPool[0];
-    auto& kDstMask = masksContainer[vAuxPool[1].getIdx()];
-    auto& vAux0 = vAuxPool[2];
-    auto& vAux1 = vAuxPool[3];
-    auto& kAuxMask0 = masksContainer[vAux1.getIdx()];
-
-    Xbyak::Label lIdxStride, lExit;
-    if (shiftFirst)
-        uni_vpaddd(vmmSpecIdxB, vmmSpecIdxB, vmmVecLenB);
-
-    add(regIdxIter, vlen);
-    cmp(regIdxIter, regSpecIdxSizeB);
-    jge(lIdxStride, T_NEAR);
-        if (jcp.batchDims > 0lu) {
-            uni_vpaddd(vDstShifts, vmmIdxBatchSumB, vmmSpecIdxB);
-            uni_vmovd(reg32Aux1, xmmAuxContainer[vDstShifts.getIdx()]);
-        } else {
-            uni_vmovd(reg32Aux1, xmmSpecIdxB);
-        }
-        vmovdqu(vDstShifts, ptr[regIndices + regAux1]);
-        normalizeRawIndices(vDstShifts, kDstMask, kAuxMask0);
-        if (jcp.beforeAxisSize != 1lu)
-            uni_vpaddd(vDstShifts, vDstShifts, vmmSrcBeforeAxisSumB);
-    jmp(lExit, T_NEAR);
-    L(lIdxStride);
-        sub(regIdxIter, regSpecIdxSizeB);
-        vpcmpeqd(kDstMask, vAux0, vAux0);
-        if (shiftFirst) {
-            vpcmpgtd(vAux0, vmmSpecIdxSizeB, vmmSpecIdxB);
-            vpandn(vAux1, vAux0, vmmSpecIdxSizeB);
-            uni_vpsubd(vAux1, vmmSpecIdxB, vAux1);
-            if (jcp.batchDims > 0lu)
-                uni_vpaddd(vAux1, vmmIdxBatchSumB, vAux1);
-            uni_vpsubd(vmmSpecIdxB, vmmSpecIdxB, vmmSpecIdxSizeB);
-        } else {
-            if (jcp.batchDims > 0lu) {
-                uni_vpaddd(vAux0, vmmIdxBatchSumB, vmmSpecIdxB);
-                uniVpGatherDd(vDstShifts, ptr[regIndices + vAux0], kDstMask);
-            } else {
-                uniVpGatherDd(vDstShifts, ptr[regIndices + vmmSpecIdxB], kDstMask);
-            }
-            normalizeRawIndices(vDstShifts, kDstMask, kAuxMask0);
-
-            uni_vpbroadcastd(vAux0, xmmSpecIdxB);
-            vpcmpgtd(vAux1, vAux0, vmmSpecIdxB);
-            vpandn(vAux0, vAux1, vmmSpecIdxSizeB);
-            uni_vpsubd(vmmSpecIdxB, vmmSpecIdxB, vAux0);
-
-            if (jcp.beforeAxisSize != 1lu) {
-                uni_vpaddd(vDstShifts, vDstShifts, vmmSrcBeforeAxisSumB);
-                vpandn(vAux0, vAux1, vmmAxisAndAfterAxisSizeB);
-                uni_vpaddd(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, vAux0);
-            }
-        }
-
-        if (jcp.batchDims > 0lu) {
-            Xbyak::Label l1;
-            inc(regBetweenBatchAndAxisIter);
-            cmp(regBetweenBatchAndAxisIter, regBetweenBatchAndAxisSize);
-            jl(l1, T_NEAR);
-                mov(regBetweenBatchAndAxisIter, 0);
-                if (shiftFirst) {
-                    uni_vpaddd(vmmIdxBatchSumB, vmmIdxBatchSumB, vmmSpecIdxSizeB);
-                    vpandn(vDstShifts, vAux0, vmmSpecIdxSizeB);
-                    uni_vpaddd(vAux1, vAux1, vDstShifts);
-                } else {
-                    vpandn(vAux0, vAux1, vmmSpecIdxSizeB);
-                    uni_vpaddd(vmmIdxBatchSumB, vmmIdxBatchSumB, vAux0);
-                }
-            L(l1);
-        }
-
-        if (shiftFirst) {
-            uniVpGatherDd(vDstShifts, ptr[regIndices + vAux1], kDstMask);
-            normalizeRawIndices(vDstShifts, kDstMask, kAuxMask0);
-
-            if (jcp.beforeAxisSize != 1lu) {
-                vpandn(vAux0, vAux0, vmmAxisAndAfterAxisSizeB);
-                uni_vpaddd(vAux0, vAux0, vmmSrcBeforeAxisSumB);
-                uni_vpaddd(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, vmmAxisAndAfterAxisSizeB);
-
-                uni_vpaddd(vDstShifts, vDstShifts, vAux0);
-            }
-        }
-    L(lExit);
-}
-
-// Requires vAuxPool length 4.
-// Returns calculated shifts in vAuxPool[0] and mask in vAuxPool[1].
-template <>
-void jitUniGatherKernel<x64::avx512_core>::calcSrcShiftLong(Vmm* vAuxPool, bool shiftFirst) {
-    auto& vDstShifts = vAuxPool[0];
-    auto& kDstMask = masksContainer[vAuxPool[1].getIdx()];
-    auto& vAux0 = vAuxPool[2];
-    auto& vAux1 = vAuxPool[3];
-    auto& kAuxMask0 = masksContainer[vAux1.getIdx()];
-    auto& kAuxMask1 = masksContainer[vAux1.getIdx() + 1];
-
-    Xbyak::Label lIdxStride, lExit;
-    if (shiftFirst)
-        uni_vpaddd(vmmSpecIdxB, vmmSpecIdxB, vmmVecLenB);
-
-    add(regIdxIter, vlen);
-    cmp(regIdxIter, regSpecIdxSizeB);
-    jge(lIdxStride, T_NEAR);
-        if (jcp.batchDims > 0lu) {
-            uni_vpaddd(vDstShifts, vmmIdxBatchSumB, vmmSpecIdxB);
-            uni_vmovd(reg32Aux1, xmmAuxContainer[vDstShifts.getIdx()]);
-        } else {
-            uni_vmovd(reg32Aux1, xmmSpecIdxB);
-        }
-        vmovdqu64(vDstShifts, ptr[regIndices + regAux1]);
-        normalizeRawIndices(vDstShifts, kDstMask, kAuxMask0);
-        if (jcp.beforeAxisSize != 1lu)
-            uni_vpaddd(vDstShifts, vDstShifts, vmmSrcBeforeAxisSumB);
-    jmp(lExit, T_NEAR);
-    L(lIdxStride);
-        sub(regIdxIter, regSpecIdxSizeB);
-        vpcmpeqd(kDstMask, vDstShifts, vDstShifts);
-        if (shiftFirst) {
-            vpcmpd(kAuxMask1, vmmSpecIdxSizeB, vmmSpecIdxB, 2); // 2 -> LE
-            if (jcp.batchDims > 0lu) {
-                uni_vpaddd(vAux1, vmmIdxBatchSumB, vmmSpecIdxB);
-                uni_vpsubd(vAux1 | kAuxMask1, vAux1, vmmSpecIdxSizeB);
-            } else {
-                uni_vmovups(vAux1, vmmSpecIdxB);
-                uni_vpsubd(vAux1 | kAuxMask1, vmmSpecIdxB, vmmSpecIdxSizeB);
-            }
-            uni_vpsubd(vmmSpecIdxB, vmmSpecIdxB, vmmSpecIdxSizeB);
-        } else {
-            if (jcp.batchDims > 0lu) {
-                uni_vpaddd(vAux0, vmmIdxBatchSumB, vmmSpecIdxB);
-                uniVpGatherDd(vDstShifts, ptr[regIndices + vAux0], kDstMask);
-            } else {
-                uniVpGatherDd(vDstShifts, ptr[regIndices + vmmSpecIdxB], kDstMask);
-            }
-            normalizeRawIndices(vDstShifts, kDstMask, kAuxMask0);
-
-            uni_vpbroadcastd(vAux0, xmmSpecIdxB);
-            vpcmpd(kAuxMask1, vAux0, vmmSpecIdxB, 2); // 2 -> LE
-            uni_vpsubd(vmmSpecIdxB | kAuxMask1, vmmSpecIdxB, vmmSpecIdxSizeB);
-
-            if (jcp.beforeAxisSize != 1lu) {
-                uni_vpaddd(vDstShifts, vDstShifts, vmmSrcBeforeAxisSumB);
-                uni_vpaddd(vmmSrcBeforeAxisSumB | kAuxMask1, vmmSrcBeforeAxisSumB, vmmAxisAndAfterAxisSizeB);
-            }
-        }
-
-        if (jcp.batchDims > 0lu) {
-            Xbyak::Label l1;
-            inc(regBetweenBatchAndAxisIter);
-            cmp(regBetweenBatchAndAxisIter, regBetweenBatchAndAxisSize);
-            jl(l1, T_NEAR);
-                mov(regBetweenBatchAndAxisIter, 0);
-                if (shiftFirst) {
-                    uni_vpaddd(vmmIdxBatchSumB, vmmIdxBatchSumB, vmmSpecIdxSizeB);
-                    uni_vpaddd(vAux1 | kAuxMask1, vAux1, vmmSpecIdxSizeB);
-                } else {
-                    uni_vpaddd(vmmIdxBatchSumB | kAuxMask1, vmmIdxBatchSumB, vmmSpecIdxSizeB);
-                }
-            L(l1);
-        }
-
-        if (shiftFirst) {
-            uniVpGatherDd(vDstShifts, ptr[regIndices + vAux1], kDstMask);
-            normalizeRawIndices(vDstShifts, kDstMask, kAuxMask0);
-
-            if (jcp.beforeAxisSize != 1lu) {
-                uni_vpaddd(vDstShifts, vDstShifts, vmmSrcBeforeAxisSumB);
-                uni_vpaddd(vDstShifts | kAuxMask1, vDstShifts, vmmAxisAndAfterAxisSizeB);
-                uni_vpaddd(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, vmmAxisAndAfterAxisSizeB);
-            }
-        }
-    L(lExit);
+template <x64::cpu_isa_t isa>
+void jitGatherKernelBase<isa>::uploadParamPtrWithVpbroadcastd(const Vmm& vmmDest, size_t offset) {
+    RegistersPool::Reg<Xbyak::Reg64> regAux {regPool};
+    mov(regAux, ptr[regParams + offset]);
+    uni_vpbroadcastd(vmmDest, ptr[regAux]);
 }
 
 template <x64::cpu_isa_t isa>
-void jitUniGatherKernel<isa>::calcSrcShiftLongBlock(Vmm* vAuxPool, bool shiftFirst) {
-    // Most likely there will no significant performance gain vs memcpy in reference implementation on big blocks after axis,
-    // therefore no time was invested to this case yet.
-    IE_THROW() << "Unsupported case.";
+void jitGatherKernelBase<isa>::uploadParamPtrWithVmovups(const Vmm& vmmDest, size_t offset) {
+    RegistersPool::Reg<Xbyak::Reg64> regAux {regPool};
+    mov(regAux, ptr[regParams + offset]);
+    uni_vmovups(vmmDest, ptr[regAux]);
 }
 
-// Requires vAuxPool length 3.
-// Returns calculated shifts in vAuxPool[0] and mask in vAuxPool[1].
-template <x64::cpu_isa_t isa>
-void jitUniGatherKernel<isa>::calcSrcShiftShort(Vmm* vAuxPool, bool shiftFirst) {
-    auto& vDstShifts = vAuxPool[0];
-    auto& kDstMask = masksContainer[vAuxPool[1].getIdx()];
-    auto& vAux0 = vAuxPool[2];
-
-    if (shiftFirst) {
-        if (jcp.beforeAxisSize != 1lu)
-            uni_vpaddd(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, vmmBeforeAxDiffB);
-        // No sense to permute if specIdxSize is one of {1, 2, 4, 8, 16}. 0 is reserved for dynamic case.
-        if (jcp.specIdxSize != 1 && jcp.specIdxSize != 2 && jcp.specIdxSize != 4 && jcp.specIdxSize != 8 && jcp.specIdxSize != 16) {
-            vpermd(vmmSpecIdxB, vmmPermIdxMask, vmmSpecIdxB);
-            if (jcp.beforeAxisSize != 1lu)
-                vpermd(vmmBeforeAxDiffB, vmmPermIdxMask, vmmBeforeAxDiffB);
-        }
-    }
-
-    vpcmpeqd(kDstMask, vAux0, vAux0);
-    if (jcp.batchDims > 0lu) {
-        // Calculate indices batch sum.
-        uni_vcvtdq2ps(vAux0, vmmSrcBeforeAxisSumB);
-        uni_vcvtdq2ps(vDstShifts, vmmSrcAfterBatchSizeB);
-        uni_vdivps(vAux0, vAux0, vDstShifts);
-        uni_vroundps(vAux0, vAux0, 0x1);
-        uni_vcvtps2dq(vAux0, vAux0);
-
-        uni_vpmulld(vAux0, vAux0, vmmSpecIdxSizeB);
-        uni_vpaddd(vAux0, vAux0, vmmSpecIdxB);
-
-        uniVpGatherDd(vDstShifts, ptr[regIndices + vAux0], kDstMask);
-    } else {
-        uniVpGatherDd(vDstShifts, ptr[regIndices + vmmSpecIdxB], kDstMask);
-    }
-
-    auto& kAuxMask0 = masksContainer[vAux0.getIdx()];
-    normalizeRawIndices(vDstShifts, kDstMask, kAuxMask0);
-    if (jcp.beforeAxisSize != 1lu)
-        uni_vpaddd(vDstShifts, vDstShifts, vmmSrcBeforeAxisSumB);
-}
-
-// Requires vAuxPool length 4.
-// Returns calculated shifts in vAuxPool[0] and mask in vAuxPool[1].
-template <x64::cpu_isa_t isa>
-void jitUniGatherKernel<isa>::calcSrcShiftShortBlock(Vmm* vAuxPool, bool shiftFirst) {
-    auto& vDstShifts = vAuxPool[0];
-    auto& kDstMask = masksContainer[vAuxPool[1].getIdx()];
-    auto& vAux0 = vAuxPool[2];
-    auto& vAux1 = vAuxPool[3];
-    auto& kAuxMask0 = masksContainer[vAux0.getIdx()];
-    const uint64_t specIdxAndAfterAxisSize = jcp.specIdxSize * jcp.afterAxisSize;
-
-    if (shiftFirst) {
-        if (jcp.specIdxSize != 1) {
-            uni_vpaddd(vmmSpecIdxB, vmmSpecIdxB, vmmSpecIdxDiff);
-            normWithUpperBound(vmmSpecIdxB, vmmSpecIdxSizeB, kAuxMask0);
-        }
-        // No sense to permute if afterAxisSize is one of {1, 2, 4, 8, 16}. 0 is reserved for dynamic case.
-        if (jcp.afterAxisSize != 1 && jcp.afterAxisSize != 2 && jcp.afterAxisSize != 4 && jcp.afterAxisSize != 8 && jcp.afterAxisSize != 16) {
-            vpermd(vmmAfterAxisIdxB, vmmAfterAxisPermMask, vmmAfterAxisIdxB);
-            if (jcp.specIdxSize != 1)
-                vpermd(vmmSpecIdxDiff, vmmAfterAxisPermMask, vmmSpecIdxDiff);
-        }
-
-        if (jcp.beforeAxisSize != 1lu) {
-            if (!jcp.dynamicShapes) {
-                if (specIdxAndAfterAxisSize > 0lu && specIdxAndAfterAxisSize <= idxElPerVec) {
-                    uni_vpaddd(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, vmmBeforeAxDiffB);
-                    uni_vmovups(vAux1, vmmSrcBeforeAxisSumB);
-                    if (specIdxAndAfterAxisSize != 1 && specIdxAndAfterAxisSize != 2 && specIdxAndAfterAxisSize != 4 &&
-                            specIdxAndAfterAxisSize != 8 && specIdxAndAfterAxisSize != 16)
-                        vpermd(vmmBeforeAxDiffB, vmmBeforeAxPermMask, vmmBeforeAxDiffB);
-                } else {
-                    Xbyak::Label lBeforeAxStep, lBeforeAxStepEnd;
-                    add(rSpecIdxAndAfterAxIterB, idxElPerVec * jcp.dataTypeSize);
-                    cmp(rSpecIdxAndAfterAxIterB, rSpecIdxAndAfterAxSizeB);
-                    jl(lBeforeAxStep, T_NEAR);
-                        sub(rSpecIdxAndAfterAxIterB, rSpecIdxAndAfterAxSizeB);
-
-                        vpmulld(vAux0, vmmSpecIdxB, vmmAfterAxisSize);
-                        uni_vpaddd(vAux0, vAux0, vmmAfterAxisIdxB);
-                        Xbyak::Xmm& xAux0 = xmmAuxContainer[vAux0.getIdx()];
-                        uni_vpbroadcastd(vAux1, xAux0);
-                        if (isa == x64::avx512_core) {
-                            Xbyak::Opmask kMask0 = Xbyak::Opmask(kAuxMask0.getIdx());
-                            vpcmpgtd(kMask0, vAux1, vAux0);
-                            uni_vmovups(vAux1, vmmSrcBeforeAxisSumB);
-                            uni_vpaddd(vAux1 | kMask0, vmmSrcBeforeAxisSumB, vmmAxisAndAfterAxisSizeB);
-                        } else {
-                            vpcmpgtd(vAux1, vAux1, vAux0);
-                            vpand(vAux1, vAux1, vmmAxisAndAfterAxisSizeB);
-                            uni_vpaddd(vAux1, vmmSrcBeforeAxisSumB, vAux1);
-                        }
-                        uni_vpaddd(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, vmmAxisAndAfterAxisSizeB);
-                        jmp(lBeforeAxStepEnd);
-                    L(lBeforeAxStep);
-                        uni_vmovups(vAux1, vmmSrcBeforeAxisSumB);
-                    L(lBeforeAxStepEnd);
-                }
-            } else {
-            }
-        }
-    } else {
-        if (jcp.beforeAxisSize != 1lu) {
-            uni_vmovups(vAux1, vmmSrcBeforeAxisSumB);
-            if (specIdxAndAfterAxisSize > idxElPerVec) {
-                // Broadcast the last element.
-                if (isa == x64::avx512_core) {
-                    vshuff64x2(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, 0xFF);
-                } else {
-                    vpermq(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, 0xFF);
-                }
-                vpshufd(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, 0xFF);
-
-                Xbyak::Label lBeforeAxStepEnd1;
-                add(rSpecIdxAndAfterAxIterB, idxElPerVec * jcp.dataTypeSize);
-                cmp(rSpecIdxAndAfterAxIterB, rSpecIdxAndAfterAxSizeB);
-                jl(lBeforeAxStepEnd1, T_NEAR);
-                    sub(rSpecIdxAndAfterAxIterB, rSpecIdxAndAfterAxSizeB);
-                cmp(rSpecIdxAndAfterAxIterB, 0);
-                jne(lBeforeAxStepEnd1, T_NEAR);
-                    uni_vpaddd(vmmSrcBeforeAxisSumB, vmmSrcBeforeAxisSumB, vmmAxisAndAfterAxisSizeB);
-                L(lBeforeAxStepEnd1);
-            }
-        }
-    }
-
-    vpcmpeqd(kDstMask, vAux0, vAux0);
-    if (jcp.batchDims > 0lu) {
-        // Calculate indices batch sum.
-        uni_vcvtdq2ps(vAux0, vAux1);
-        uni_vcvtdq2ps(vDstShifts, vmmSrcAfterBatchSizeB);
-        uni_vdivps(vAux0, vAux0, vDstShifts);
-        uni_vroundps(vAux0, vAux0, 0x1);
-        uni_vcvtps2dq(vAux0, vAux0);
-
-        uni_vpmulld(vAux0, vAux0, vmmSpecIdxSizeB);
-        uni_vpaddd(vAux0, vAux0, vmmSpecIdxB);
-
-        uniVpGatherDd(vDstShifts, ptr[regIndices + vAux0], kDstMask);
-    } else {
-        uniVpGatherDd(vDstShifts, ptr[regIndices + vmmSpecIdxB], kDstMask);
-    }
-
-    normalizeRawIndices(vDstShifts, kDstMask, kAuxMask0);
-
-    if (jcp.afterAxisSize != 1lu) {
-        vpmulld(vDstShifts, vDstShifts, vmmAfterAxisSize);
-        uni_vpaddd(vDstShifts, vDstShifts, vmmAfterAxisIdxB);
-    }
-    if (jcp.beforeAxisSize != 1lu)
-        uni_vpaddd(vDstShifts, vDstShifts, vAux1);
-}
 
 template <x64::cpu_isa_t isa>
-void jitUniGatherKernel<isa>::process(bool isShortIdx, bool blocked) {
+void jitGatherKernelBase<isa>::process(ShiftCalculator& shiftCalculator) {
     Xbyak::Label lTailProc, lEndProc;
-    cmp(regWorkAmount, dataElPerVec);
+    cmp(regWorkAmount, getDataElPerVec());
     jl(lTailProc, T_NEAR);
-        if (jcp.dataTypeSize == 4)
-            process32b(isShortIdx, blocked);
-        else if (jcp.dataTypeSize == 2)
-            process16b(isShortIdx, blocked);
-        else if (jcp.dataTypeSize == 1)
-            process8b(isShortIdx, blocked);
+    processDataTypeSpecific(shiftCalculator);
     jmp(lEndProc, T_NEAR);
     L(lTailProc);
-        tail(isShortIdx, false, blocked);
+    tail(shiftCalculator, false);
     L(lEndProc);
 }
 
-template <x64::cpu_isa_t isa>
-void jitUniGatherKernel<isa>::process32b(bool isShortIdx, bool blocked) {
-    Xbyak::Label lDstIdxLoop, lTail;
-
-    // First iteration
-    shiftIdxAndGather(vmmAuxContainer, isShortIdx, false, blocked);
-    uni_vmovups(ptr[regDst], vmmAuxContainer[2]);
-
-    // Main loop
-    L(lDstIdxLoop);
-    {
-        add(regDst, vlen);
-        sub(regWorkAmount, dataElPerVec);
-        cmp(regWorkAmount, dataElPerVec);
-        jl(lTail, T_NEAR);
-
-        shiftIdxAndGather(vmmAuxContainer, isShortIdx, true, blocked);
-        uni_vmovups(ptr[regDst], vmmAuxContainer[2]);
-
-        jmp(lDstIdxLoop, T_NEAR);
-    }
-
-    L(lTail);
-    tail(isShortIdx, true, blocked);
+template <>
+void jitGatherKernelBase<x64::avx2>::combineMasks(Vmask& maskA, const Vmask& maskB) {
+    vpand(maskA, maskA, maskB);
+}
+template <>
+void jitGatherKernelBase<x64::avx512_core>::combineMasks(Vmask& maskA, const Vmask& maskB) {
+    kandd(maskA, maskA, maskB);
 }
 
 template <x64::cpu_isa_t isa>
-void jitUniGatherKernel<isa>::process16b(bool isShortIdx, bool blocked) {
-    Xbyak::Label lDstIdxLoop1, lTail;
-
-    Vmm vShufMask, vPermMask, vBuff0;
-    if (isa == x64::avx512_core) {
-        vPermMask = vmmAuxContainer[7];
-        vShufMask = vmmAuxContainer[8];
-        vBuff0    = vmmAuxContainer[9];
-    } else {
-        vPermMask = vmmAuxContainer[1];
-        vShufMask = vmmAuxContainer[4];
-        vBuff0    = vmmAuxContainer[5];
-    }
-
-    mov(regAux1, reinterpret_cast<uintptr_t>(shufMask16bitUni));
-    uni_vmovups(vShufMask, ptr[regAux1]);
-    mov(regAux1, reinterpret_cast<uintptr_t>(permMask16bitUni));
-    uni_vmovups(vPermMask, ptr[regAux1]);
-
-    // First iteration
-    shiftIdxAndGather(vmmAuxContainer, isShortIdx, false, blocked);
-    vpshufb(vBuff0, vmmAuxContainer[2], vShufMask);
-
-    shiftIdxAndGather(vmmAuxContainer, isShortIdx, true, blocked);
-    vpshufb(vmmAuxContainer[0], vmmAuxContainer[2], vShufMask);
-
-    vshufps(vmmAuxContainer[0], vBuff0, vmmAuxContainer[0], 0x44);
-    vpermd(vmmAuxContainer[0], vPermMask, vmmAuxContainer[0]);
-
-    uni_vmovups(ptr[regDst], vmmAuxContainer[0]);
-
-    // Main loop.
-    L(lDstIdxLoop1);
-    {
-        add(regDst, vlen);
-        sub(regWorkAmount, dataElPerVec);
-        cmp(regWorkAmount, dataElPerVec);
-        jl(lTail, T_NEAR);
-
-        shiftIdxAndGather(vmmAuxContainer, isShortIdx, true, blocked);
-        vpshufb(vBuff0, vmmAuxContainer[2], vShufMask);
-
-        shiftIdxAndGather(vmmAuxContainer, isShortIdx, true, blocked);
-        vpshufb(vmmAuxContainer[0], vmmAuxContainer[2], vShufMask);
-
-        vshufps(vmmAuxContainer[0], vBuff0, vmmAuxContainer[0], 0x44);
-        vpermd(vmmAuxContainer[0], vPermMask, vmmAuxContainer[0]);
-
-        uni_vmovups(ptr[regDst], vmmAuxContainer[0]);
-
-        jmp(lDstIdxLoop1, T_NEAR);
-    }
-
-    L(lTail);
-    tail(isShortIdx, true, blocked);
-}
-
-template <x64::cpu_isa_t isa>
-void jitUniGatherKernel<isa>::process8b(bool isShortIdx, bool blocked) {
-    Xbyak::Label lDstIdxLoop1, lTail;
-
-    Vmm vShufMask, vPermMask, vBuff0, vBuff1;
-    if (isa == x64::avx512_core) {
-        vPermMask = vmmAuxContainer[7];
-        vShufMask = vmmAuxContainer[8];
-        vBuff0    = vmmAuxContainer[9];
-        vBuff1    = vmmAuxContainer[10];
-    } else {
-        vPermMask = vmmAuxContainer[1];
-        vShufMask = vmmAuxContainer[4];
-        vBuff0    = vmmAuxContainer[5];
-        vBuff1    = vmmAuxContainer[6];
-    }
-    mov(regAux1, reinterpret_cast<uintptr_t>(shufMask8bitUni));
-    uni_vmovups(vShufMask, ptr[regAux1]);
-
-    // First iteration
-    shiftIdxAndGather(vmmAuxContainer, isShortIdx, false, blocked);
-    vpshufb(vBuff0, vmmAuxContainer[2], vShufMask);
-
-    shiftIdxAndGather(vmmAuxContainer, isShortIdx, true, blocked);
-    vpshufb(vmmAuxContainer[0], vmmAuxContainer[2], vShufMask);
-
-    vshufps(vBuff0, vBuff0, vmmAuxContainer[0], 0x0);
-
-    shiftIdxAndGather(vmmAuxContainer, isShortIdx, true, blocked);
-    vpshufb(vBuff1, vmmAuxContainer[2], vShufMask);
-
-    shiftIdxAndGather(vmmAuxContainer, isShortIdx, true, blocked);
-    vpshufb(vmmAuxContainer[0], vmmAuxContainer[2], vShufMask);
-
-    vshufps(vBuff1, vBuff1, vmmAuxContainer[0], 0x0);
-    vshufps(vmmAuxContainer[0], vBuff0, vBuff1, 0x88);
-
-    mov(regAux1, reinterpret_cast<uintptr_t>(permMask8bitUni));
-    uni_vmovups(vPermMask, ptr[regAux1]);
-
-    vpermd(vmmAuxContainer[0], vPermMask, vmmAuxContainer[0]);
-
-    uni_vmovups(ptr[regDst], vmmAuxContainer[0]);
-
-    // Main loop.
-    L(lDstIdxLoop1);
-    {
-        add(regDst, vlen);
-        sub(regWorkAmount, dataElPerVec);
-        cmp(regWorkAmount, dataElPerVec);
-        jl(lTail, T_NEAR);
-
-        shiftIdxAndGather(vmmAuxContainer, isShortIdx, true, blocked);
-        vpshufb(vBuff0, vmmAuxContainer[2], vShufMask);
-
-        shiftIdxAndGather(vmmAuxContainer, isShortIdx, true, blocked);
-        vpshufb(vmmAuxContainer[0], vmmAuxContainer[2], vShufMask);
-
-        vshufps(vBuff0, vBuff0, vmmAuxContainer[0], 0x0);
-
-        shiftIdxAndGather(vmmAuxContainer, isShortIdx, true, blocked);
-        vpshufb(vBuff1, vmmAuxContainer[2], vShufMask);
-
-        shiftIdxAndGather(vmmAuxContainer, isShortIdx, true, blocked);
-        vpshufb(vmmAuxContainer[0], vmmAuxContainer[2], vShufMask);
-
-        vshufps(vmmAuxContainer[0], vBuff1, vmmAuxContainer[0], 0x0);
-        vshufps(vmmAuxContainer[0], vBuff0, vmmAuxContainer[0], 0x88);
-
-        if (isa == x64::avx2) {
-            // Register vPermMask is invalidated by shiftIdxAndGather and must be initialized again.
-            mov(regAux1, reinterpret_cast<uintptr_t>(permMask8bitUni));
-            uni_vmovups(vPermMask, ptr[regAux1]);
-        }
-        vpermd(vmmAuxContainer[0], vPermMask, vmmAuxContainer[0]);
-
-        uni_vmovups(ptr[regDst], vmmAuxContainer[0]);
-
-        jmp(lDstIdxLoop1, T_NEAR);
-    }
-
-    L(lTail);
-    tail(isShortIdx, true, blocked);
-}
-
-// Requires vAuxPool length 4.
-// Returns gathered data in vAuxPool[2].
-template <x64::cpu_isa_t isa>
-void jitUniGatherKernel<isa>::shiftIdxAndGather(Vmm* vAuxPool, bool isShortIdx, bool shiftFirst, bool blocked) {
-    if (blocked) {
-        if (isShortIdx) {
-            calcSrcShiftShortBlock(vAuxPool, shiftFirst);
-        } else {
-            calcSrcShiftLongBlock(vAuxPool, shiftFirst);
-        }
-    } else {
-        if (isShortIdx) {
-            calcSrcShiftShort(vAuxPool, shiftFirst);
-        } else {
-            calcSrcShiftLong(vAuxPool, shiftFirst);
-        }
-    }
-    auto& kGatherMask = masksContainer[vAuxPool[1].getIdx()];
-    uni_vmovups(vAuxPool[2], vmmZeros);
-    uniVpGatherDd(vAuxPool[2], ptr[regSrc + vAuxPool[0]], kGatherMask);
-}
-
-template <x64::cpu_isa_t isa>
-void jitUniGatherKernel<isa>::tail(bool isShortIdx, bool shiftFirst, bool blocked) {
-    auto& vSrcShift = vmmAuxContainer[0];
-    auto& kGatherMask = masksContainer[vmmAuxContainer[1].getIdx()];
-    auto& vAux0 = vmmAuxContainer[2];
-    auto& vAux1 = vmmAuxContainer[3];
-    auto& kAuxMask1 = masksContainer[vAux1.getIdx()];
+void jitGatherKernelBase<isa>::tail(ShiftCalculator& shiftCalculator, bool shiftFirst) {
     Xbyak::Label lEnd;
 
-    const int secondStepCycles = 4 / jcp.dataTypeSize;
+    const int secondStepCycles = 4 / getDataTypeSize();
     for (int p = 0; p < secondStepCycles; p++) {
         cmp(regWorkAmount, 0);
         jle(lEnd, T_NEAR);
 
-        if (isShortIdx) {
-            if (blocked) {
-                calcSrcShiftShortBlock(vmmAuxContainer, p > 0 || shiftFirst);
-            } else {
-                calcSrcShiftShort(vmmAuxContainer, p > 0 || shiftFirst);
-            }
+        RegistersPool::Reg<Vmm> vSrcShift;
+        RegistersPool::Reg<Vmask> kGatherMask;
+        std::tie(kGatherMask, vSrcShift) = shiftCalculator.calcSrcShift(*this, p > 0 || shiftFirst);
+
+        RegistersPool::Reg<Vmask> kAuxMask1 {regPool};
+        fillRestWorkMask(kAuxMask1, regWorkAmount);
+        combineMasks(kGatherMask, kAuxMask1);
+        RegistersPool::Reg<Vmm> vmmSrc {regPool};
+        uni_vmovups(vmmSrc, vmmZeros);
+        uniVpGatherDd(vmmSrc, ptr[regSrc + vSrcShift], kGatherMask);
+        if (getDataTypeSize() == 4) {
+            uni_vmovups_tail(ptr[regDst], kAuxMask1, vmmSrc);
+            sub(regWorkAmount, getDataElPerVec());
         } else {
-            if (blocked) {
-                calcSrcShiftLongBlock(vmmAuxContainer, p > 0 || shiftFirst);
-            } else {
-                calcSrcShiftLong(vmmAuxContainer, p > 0 || shiftFirst);
-            }
-        }
-
-        fillRestWorkMask(kAuxMask1, vAux0, regWorkAmount, regAux1, rdx);
-
-        // Combining masks.
-        if (isa == x64::avx512_core) {
-            auto kMask1 = Xbyak::Opmask(kAuxMask1.getIdx());
-            auto kMaskG = Xbyak::Opmask(kGatherMask.getIdx());
-            kandd(kMaskG, kMaskG, kMask1);
-        } else if (isa == x64::avx2) {
-            auto& vGatherMask = vmmAuxContainer[kGatherMask.getIdx()];
-            vpand(vGatherMask, vGatherMask, vAux1);
-        }
-
-        uni_vmovups(vAux0, vmmZeros);
-        uniVpGatherDd(vAux0, ptr[regSrc + vSrcShift], kGatherMask);
-        if (jcp.dataTypeSize == 4) {
-            uni_vmovups_tail(ptr[regDst], kAuxMask1, vAux0);
-            sub(regWorkAmount, dataElPerVec);
-        } else {
-            storeVectorPart(regDst, regWorkAmount, vAux0, vAux1);
+            vSrcShift.release();
+            storeVectorPart(regDst, regWorkAmount, vmmSrc);
         }
     }
     L(lEnd);
 }
 
+template <x64::cpu_isa_t isa>
+poolVmm<isa> jitGatherKernelBase<isa>::shiftIdxAndGather(ShiftCalculator& shiftCalculator, bool shiftFirst) {
+    RegistersPool::Reg<Vmm> vmmCalculatedShifts;
+    RegistersPool::Reg<Vmask> kGatherMask;
+    std::tie(kGatherMask, vmmCalculatedShifts) = shiftCalculator.calcSrcShift(*this, shiftFirst);
+    RegistersPool::Reg<Vmm> vmmGatheredData {regPool};
+    uni_vmovups(vmmGatheredData, vmmZeros);
+    uniVpGatherDd(vmmGatheredData, ptr[regSrc + vmmCalculatedShifts], kGatherMask);
+    return vmmGatheredData;
+}
+
 template <>
-void jitUniGatherKernel<x64::avx512_core>::fillRestWorkMask(Vmask& kDstMask, Vmm& vmmAux, const Xbyak::Reg64& rWorkRest,
-        const Xbyak::Reg64& rAux0, const Xbyak::Reg64& rAux1) {
+void jitGatherKernelBase<x64::avx2>::uniVpGatherDd(Vmm& vDst, const Xbyak::Address& srcAddr, Vmask& kMask) {
+    vpgatherdd(vDst, srcAddr, kMask);
+}
+template <>
+void jitGatherKernelBase<x64::avx512_core>::uniVpGatherDd(Vmm& vDst, const Xbyak::Address& srcAddr, Vmask& kMask) {
+    vpgatherdd(vDst | kMask, srcAddr);
+}
+
+template <>
+poolVmask<x64::avx2> jitGatherKernelBase<x64::avx2>::normalizeIndexesAndCalcShifts(Vmm& vRawIndices, poolVmask<x64::avx2> kDstMask) {
+    // Compensate negative indices.
+    if (reverseIndexing) {
+        RegistersPool::Reg<Vmask> zerosOrAxisDimForNegativeIndexes {regPool};
+        vpcmpgtd(zerosOrAxisDimForNegativeIndexes, vmmZeros, vRawIndices);
+        vpand(zerosOrAxisDimForNegativeIndexes, zerosOrAxisDimForNegativeIndexes, vmmAxisDim);
+
+        uni_vpaddd(vRawIndices, vRawIndices, zerosOrAxisDimForNegativeIndexes);
+    }
+    // Check boundaries.
+    if (!kDstMask.isInitialized()) {
+        kDstMask = RegistersPool::Reg<Vmask>{regPool};
+    }
+    vpcmpgtd(kDstMask, vmmAxisDim, vRawIndices);
+    RegistersPool::Reg<Vmask> negativeIndexesMask {regPool};
+    vpcmpgtd(negativeIndexesMask, vmmZeros, vRawIndices);
+    vpandn(kDstMask, negativeIndexesMask, kDstMask);
+    // Multiply by type size.
+    if (getDataTypeSize() > 1)
+        uni_vpslld(vRawIndices, vRawIndices, getDataTypeShift());
+    return kDstMask;
+}
+
+template <>
+poolVmask<x64::avx512_core> jitGatherKernelBase<x64::avx512_core>::normalizeIndexesAndCalcShifts(
+        Vmm& vRawIndices, poolVmask<x64::avx512_core> kDstMask) {
+    RegistersPool::Reg<Vmask> kAuxMask {regPool};
+    // Compensate negative indices.
+    if (reverseIndexing) {
+        vpcmpgtd(kAuxMask, vmmZeros, vRawIndices);
+        uni_vpaddd(vRawIndices | kAuxMask, vRawIndices, vmmAxisDim);
+    }
+    // Check boundaries.
+    if (!kDstMask.isInitialized()) {
+        kDstMask = RegistersPool::Reg<Vmask>{regPool};
+    }
+    vpcmpgtd(kAuxMask, vmmAxisDim, vRawIndices);
+    vpcmpd(static_cast<Vmask&>(kDstMask) | kAuxMask, vmmZeros, vRawIndices, 2); // 2 - LE
+    // Multiply by type size.
+    if (getDataTypeSize() > 1) {
+        uni_vpslld(vRawIndices, vRawIndices, getDataTypeShift());
+    }
+    return kDstMask;
+}
+
+
+template <>
+void jitGatherKernelBase<x64::avx512_core>::fillRestWorkMask(Vmask& kDstMask, const Xbyak::Reg& rWorkRest) {
     Xbyak::Label lKmov;
-    Xbyak::Reg32 rOnes(rAux1.getIdx());
+    RegistersPool::Reg<Xbyak::Reg32> rOnes {regPool};
     mov(rOnes, 0x0000FFFF);
-    cmp(rWorkRest, idxElPerVec);
+    cmp(rWorkRest, getIdxElPerVec());
     jge(lKmov);
-        Xbyak::Reg8 rShift(Xbyak::Operand::CL);
-        mov(rShift, idxElPerVec);
-        sub(rShift, rWorkRest);
-        shr(rOnes, rShift);
+    Xbyak::Reg8 rShift(Xbyak::Operand::CL);
+    mov(rShift, getIdxElPerVec());
+    sub(rShift, rWorkRest);
+    shr(rOnes, rShift);
     L(lKmov);
     kmovw(kDstMask, rOnes);
 }
 
 template <>
-void jitUniGatherKernel<x64::avx2>::fillRestWorkMask(Vmask& kDstMask, Vmm& vAux, const Xbyak::Reg64& rWorkRest,
-        const Xbyak::Reg64& rAux0, const Xbyak::Reg64& rAux1) {
+void jitGatherKernelBase<x64::avx2>::fillRestWorkMask(Vmask& kDstMask, const Xbyak::Reg& rWorkRest) {
     Xbyak::Label lEnd;
+    RegistersPool::Reg<Xbyak::Reg64> rAux0 {regPool};
     mov(rAux0, rWorkRest);
-    Xbyak::Reg32 rOnes(rAux1.getIdx());
+    RegistersPool::Reg<Xbyak::Reg32> rOnes {regPool};
     mov(rOnes, 0xFFFFFFFF);
-    Xbyak::Xmm xmmAux(vAux.getIdx());
+    RegistersPool::Reg<Xbyak::Xmm> xmmAux{regPool};
     uni_vmovups(kDstMask, vmmZeros);
-    for (uint8_t i = 0; i < idxElPerVec; i++) {
+    for (uint8_t i = 0; i < getIdxElPerVec(); i++) {
         cmp(rAux0, 0);
         je(lEnd, T_NEAR);
 
         if (i % 4 == 0)
-            uni_vmovups(xmmAux, xmmZeros);
+            uni_vmovups(xmmAux, Xbyak::Xmm(vmmZeros.getIdx()));
 
         vpinsrd(xmmAux, xmmAux, rOnes, i % 4);
         vinserti128(kDstMask, kDstMask, xmmAux, i / 4);
@@ -984,10 +223,11 @@ void jitUniGatherKernel<x64::avx2>::fillRestWorkMask(Vmask& kDstMask, Vmm& vAux,
 }
 
 template <x64::cpu_isa_t isa>
-void jitUniGatherKernel<isa>::storeVectorPart(const Xbyak::Reg64& rDst, const Xbyak::Reg64& rToStoreCounter, Vmm& vmmSrc, Vmm& vAux) {
+void jitGatherKernelBase<isa>::storeVectorPart(const Xbyak::Reg& rDst, const Xbyak::Reg& rToStoreCounter, Vmm& vmmSrc) {
+    static const uint32_t vlenXmm = x64::cpu_isa_traits<x64::sse41>::vlen;
     Xbyak::Label lEnd;
-    Xbyak::Xmm xAux(vAux.getIdx());
-    for (int j = 0; j < vlen / vlenXmm; j++) {
+    RegistersPool::Reg<Xbyak::Xmm> xAux {regPool};
+    for (int j = 0; j < getVecLen() / vlenXmm; j++) {
         if (isa == x64::avx2)
             vextracti128(xAux, vmmSrc, j);
         else if (isa == x64::avx512_core)
@@ -997,49 +237,930 @@ void jitUniGatherKernel<isa>::storeVectorPart(const Xbyak::Reg64& rDst, const Xb
             cmp(rToStoreCounter, 0);
             jle(lEnd, T_NEAR);
 
-            if (jcp.dataTypeSize == 4)
+            if (getDataTypeSize() == 4)
                 uni_vpextrd(ptr[rDst], xAux, k);
-            else if (jcp.dataTypeSize == 2)
+            else if (getDataTypeSize() == 2)
                 uni_vpextrw(ptr[rDst], xAux, k * 2);
-            else if (jcp.dataTypeSize == 1)
+            else if (getDataTypeSize() == 1)
                 uni_vpextrb(ptr[rDst], xAux, k * 4);
 
-            add(rDst, jcp.dataTypeSize);
+            add(rDst, getDataTypeSize());
             sub(rToStoreCounter, 1);
         }
     }
     L(lEnd);
 }
 
+template<x64::cpu_isa_t isa>
+void jitGatherKernelForDataTypeSize<isa, DataType32bit>::processDataTypeSpecific(
+        typename jitGatherKernelBase<isa>::ShiftCalculator& shiftCalculator) {
+    Xbyak::Label lDstIdxLoop, lTail;
+
+    // First iteration
+    this->uni_vmovups(this->ptr[this->regDst], this->shiftIdxAndGather(shiftCalculator, false));
+
+    // Main loop
+    this->L(lDstIdxLoop);
+    {
+        this->add(this->regDst, this->getVecLen());
+        this->sub(this->regWorkAmount, this->getDataElPerVec());
+        this->cmp(this->regWorkAmount, this->getDataElPerVec());
+        this->jl(lTail, this->T_NEAR);
+
+        this->uni_vmovups(this->ptr[this->regDst], this->shiftIdxAndGather(shiftCalculator, true));
+
+        this->jmp(lDstIdxLoop, this->T_NEAR);
+    }
+
+    this->L(lTail);
+    this->tail(shiftCalculator, true);
+}
+
+
+template<x64::cpu_isa_t isa>
+void jitGatherKernelForDataTypeSize<isa, DataType16bit>::processDataTypeSpecific(
+        typename jitGatherKernelBase<isa>::ShiftCalculator& shiftCalculator) {
+    static const unsigned shufMask16bitUni[16] = {0x05040100, 0x0D0C0908, 0x80808080, 0x80808080, 0x05040100, 0x0D0C0908, 0x80808080, 0x80808080,
+                                                  0x05040100, 0x0D0C0908, 0x80808080, 0x80808080, 0x05040100, 0x0D0C0908, 0x80808080, 0x80808080};
+    static const unsigned permMask16bitA2[8]   = {0, 1, 4, 5, 2, 3, 6, 7};
+    static const unsigned permMask16bitA5[16]  = {0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15};
+
+    Xbyak::Label lDstIdxLoop1, lTail;
+    RegistersPool::Reg<Vmm> vPermMask {this->regPool};
+    RegistersPool::Reg<Vmm> vShufMask {this->regPool};
+    RegistersPool::Reg<Vmm> vBuff0 {this->regPool};
+
+    RegistersPool::Reg<Xbyak::Reg64> regAux1 {this->regPool};
+    this->mov(regAux1, reinterpret_cast<uintptr_t>(shufMask16bitUni));
+    this->uni_vmovups(vShufMask, this->ptr[regAux1]);
+    if (isa == x64::avx2) {
+        this->mov(regAux1, reinterpret_cast<uintptr_t>(permMask16bitA2));
+    } else if (isa == x64::avx512_core) {
+        this->mov(regAux1, reinterpret_cast<uintptr_t>(permMask16bitA5));
+    }
+    this->uni_vmovups(vPermMask, this->ptr[regAux1]);
+
+    // First iteration
+    this->vpshufb(vBuff0, this->shiftIdxAndGather(shiftCalculator, false), vShufMask);
+
+    RegistersPool::Reg<Vmm> vAux0 {this->regPool};
+    this->vpshufb(vAux0, this->shiftIdxAndGather(shiftCalculator, true), vShufMask);
+
+    this->vshufps(vAux0, vBuff0, vAux0, 0x44);
+    this->vpermd(vAux0, vPermMask, vAux0);
+
+    this->uni_vmovups(this->ptr[this->regDst], vAux0);
+
+    // Main loop.
+    this->L(lDstIdxLoop1);
+    {
+        this->add(this->regDst, this->getVecLen());
+        this->sub(this->regWorkAmount, this->getDataElPerVec());
+        this->cmp(this->regWorkAmount, this->getDataElPerVec());
+        this->jl(lTail, this->T_NEAR);
+
+        this->vpshufb(vBuff0, this->shiftIdxAndGather(shiftCalculator, true), vShufMask);
+
+        this->vpshufb(vAux0, this->shiftIdxAndGather(shiftCalculator, true), vShufMask);
+
+        this->vshufps(vAux0, vBuff0, vAux0, 0x44);
+        this->vpermd(vAux0, vPermMask, vAux0);
+
+        this->uni_vmovups(this->ptr[this->regDst], vAux0);
+
+        this->jmp(lDstIdxLoop1, this->T_NEAR);
+    }
+
+    this->L(lTail);
+    this->tail(shiftCalculator, true);
+}
+
+template<x64::cpu_isa_t isa>
+poolVmm<isa> jitGatherKernelForDataTypeSize<isa, DataType8bit>::calculateIdxShiftsForHalfIteration(
+        typename jitGatherKernelBase<isa>::ShiftCalculator& shiftCalculator, Vmm& vShufMask, bool shiftFirst, poolVmm<isa> halfPart) {
+    if (!halfPart.isInitialized()) {
+        halfPart = RegistersPool::Reg<Vmm>{this->regPool};
+    }
+    this->vpshufb(halfPart, this->shiftIdxAndGather(shiftCalculator, shiftFirst), vShufMask);
+    {
+        auto gatheredData = this->shiftIdxAndGather(shiftCalculator, true);
+        RegistersPool::Reg<Vmm> vAux0{this->regPool};
+        this->vpshufb(vAux0, gatheredData, vShufMask);
+        this->vshufps(halfPart, halfPart, vAux0, 0x0);
+    }
+    return halfPart;
+}
+
+template<x64::cpu_isa_t isa>
+void jitGatherKernelForDataTypeSize<isa, DataType8bit>::processDataTypeSpecific(
+        typename jitGatherKernelBase<isa>::ShiftCalculator& shiftCalculator) {
+    static const unsigned shufMask8bitUni[16]  = {0x0C080400, 0x80808080, 0x80808080, 0x80808080, 0x0C080400, 0x80808080, 0x80808080, 0x80808080,
+                                                  0x0C080400, 0x80808080, 0x80808080, 0x80808080, 0x0C080400, 0x80808080, 0x80808080, 0x80808080};
+    static const unsigned permMask8bitA2[8]    = {0, 4, 1, 5, 2, 6, 3, 7};
+    static const unsigned permMask8bitA5[16]   = {0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15};
+    Xbyak::Label lDstIdxLoop1, lTail;
+
+    {
+        RegistersPool::Reg<Vmm> vShufMask {this->regPool};
+
+        { // scope for regAux1
+            RegistersPool::Reg<Xbyak::Reg64> regAux1{this->regPool};
+            this->mov(regAux1, reinterpret_cast<uintptr_t>(shufMask8bitUni));
+            this->uni_vmovups(vShufMask, this->ptr[regAux1]);
+        }
+
+        // First iteration
+        RegistersPool::Reg<Vmm> vBuff0 = calculateIdxShiftsForHalfIteration(shiftCalculator, vShufMask, false);
+        RegistersPool::Reg<Vmm> vBuff1 = calculateIdxShiftsForHalfIteration(shiftCalculator, vShufMask, true);
+        RegistersPool::Reg<Vmm> vPermMask{this->regPool};
+        {
+            RegistersPool::Reg<Vmm> vAux0{this->regPool};
+            this->vshufps(vAux0, vBuff0, vBuff1, 0x88);
+
+            { // scope for regAux1
+                RegistersPool::Reg<Xbyak::Reg64> regAux1{this->regPool};
+                if (isa == x64::avx2) {
+                    this->mov(regAux1, reinterpret_cast<uintptr_t>(permMask8bitA2));
+                } else if (isa == x64::avx512_core) {
+                    this->mov(regAux1, reinterpret_cast<uintptr_t>(permMask8bitA5));
+                }
+                this->uni_vmovups(vPermMask, this->ptr[regAux1]);
+            }
+
+            this->vpermd(vAux0, vPermMask, vAux0);
+            if (isa == x64::avx2) {
+                vPermMask.release();
+            }
+
+            this->uni_vmovups(this->ptr[this->regDst], vAux0);
+        }
+
+        // Main loop.
+        this->L(lDstIdxLoop1);
+        {
+            this->add(this->regDst, this->getVecLen());
+            this->sub(this->regWorkAmount, this->getDataElPerVec());
+            this->cmp(this->regWorkAmount, this->getDataElPerVec());
+            this->jl(lTail, this->T_NEAR);
+
+            vBuff0 = calculateIdxShiftsForHalfIteration(shiftCalculator, vShufMask, true, std::move(vBuff0));
+            vBuff1 = calculateIdxShiftsForHalfIteration(shiftCalculator, vShufMask, true, std::move(vBuff1));
+            {
+                RegistersPool::Reg<Vmm> vAux0{this->regPool};
+                this->vshufps(vAux0, vBuff0, vBuff1, 0x88);
+
+                if (isa == x64::avx2) {
+                    vPermMask = RegistersPool::Reg<Vmm>{this->regPool};
+                    RegistersPool::Reg<Xbyak::Reg64> regAux1{this->regPool};
+                    this->mov(regAux1, reinterpret_cast<uintptr_t>(permMask8bitA2));
+                    this->uni_vmovups(vPermMask, this->ptr[regAux1]);
+                }
+                this->vpermd(vAux0, vPermMask, vAux0);
+
+                this->uni_vmovups(this->ptr[this->regDst], vAux0);
+            }
+
+            this->jmp(lDstIdxLoop1, this->T_NEAR);
+        }
+    }
+    this->L(lTail);
+    this->tail(shiftCalculator, true);
+}
+
+template<x64::cpu_isa_t isa, DataTypeSize S, AfterAxisCase C, Approach A>
+void jitGatherKernelForStaticShapes<isa, S, C, A>::generateDynamicitySpecific() {
+    this->uploadParamPtrWithVpbroadcastd(this->vmmSpecIdxSizeB, GET_OFF(specIndicesSize));
+    this->uni_vpslld(this->vmmSpecIdxSizeB, this->vmmSpecIdxSizeB, this->idxTypeShift); // multiply by indexes type size.
+
+    this->uploadParamPtrWithVmovups(this->vmmSpecIdxB, GET_OFF(specIdxB));
+
+    if (this->beforeAxisSize != 1lu) {
+        this->uploadParamPtrWithVmovups(this->vmmSrcBeforeAxisSumB, GET_OFF(dataBeforeAxisSumB));
+    }
+    shiftCalculator.allocateRegisters(*this);
+    shiftCalculator.uploadParamsForApproachSpecific(*this);
+    this->process(shiftCalculator);
+}
+
+template<x64::cpu_isa_t isa, DataTypeSize S>
+void jitGatherKernelForDynamicShapes<isa, S>::generateDynamicitySpecific() {
+    typename jitGatherKernelBase<isa>::template ShiftCalculatorImpl<ElementwiseCase, Long> elementwiseLong;
+    typename jitGatherKernelBase<isa>::template ShiftCalculatorImpl<ElementwiseCase, Short> elementwiseShort;
+    typename jitGatherKernelBase<isa>::template ShiftCalculatorImpl<BlockedCase, Short> blockedShort;
+    elementwiseLong.allocateRegisters(*this);
+
+    static const unsigned incVec[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    this->uploadParamPtrWithVpbroadcastd(this->vmmSpecIdxB, GET_OFF(start));
+    {
+        RegistersPool::Reg<Xbyak::Reg64> regAux1{this->regPool};
+        this->mov(regAux1, reinterpret_cast<uintptr_t>(incVec));
+        this->uni_vpaddd(this->vmmSpecIdxB, this->vmmSpecIdxB, this->ptr[regAux1]);
+    }
+    this->vcvtdq2ps(this->vmmSpecIdxB, this->vmmSpecIdxB);
+
+    // Formula: specIndices = (start % specIndicesSize) * idxTypeSize
+    this->uploadParamPtrWithVpbroadcastd(this->vmmSpecIdxSizeB, GET_OFF(specIndicesSize));
+    {
+        RegistersPool::Reg<Vmm> vAux1{this->regPool};
+        this->uni_vcvtdq2ps(vAux1, this->vmmSpecIdxSizeB);
+        this->uni_vdivps(this->vmmSrcBeforeAxisSumB, this->vmmSpecIdxB, vAux1);
+        this->uni_vroundps(this->vmmSrcBeforeAxisSumB, this->vmmSrcBeforeAxisSumB, 0x1);
+        this->uni_vfnmadd231ps(this->vmmSpecIdxB, this->vmmSrcBeforeAxisSumB, vAux1);
+    }
+    this->uni_vcvtps2dq(this->vmmSpecIdxB, this->vmmSpecIdxB);
+    this->uni_vpslld(this->vmmSpecIdxB, this->vmmSpecIdxB, this->idxTypeShift); // multiply by indices type size.
+    this->uni_vpslld(this->vmmSpecIdxSizeB, this->vmmSpecIdxSizeB, this->idxTypeShift); // multiply by indices type size.
+    RegistersPool::Reg<Xbyak::Reg64>& regSpecIdxSizeB = elementwiseLong.regSpecIdxSizeB;
+    this->uni_vmovd(Xbyak::Reg32(regSpecIdxSizeB.getIdx()), Xbyak::Xmm(this->vmmSpecIdxSizeB.getIdx()));
+
+    {
+        RegistersPool::Reg<Vmm> vAux1{this->regPool};
+        this->uploadParamPtrWithVpbroadcastd(vAux1, GET_OFF(betweenBatchAndAxisSize));
+        this->uni_vmovd(Xbyak::Reg32(elementwiseLong.regBetweenBatchAndAxisSize.getIdx()), Xbyak::Xmm(vAux1.getIdx()));
+        this->uni_vcvtdq2ps(vAux1, vAux1);
+        this->uni_vdivps(elementwiseLong.vmmIdxBatchSumB, this->vmmSrcBeforeAxisSumB, vAux1);
+        this->uni_vroundps(elementwiseLong.vmmIdxBatchSumB, elementwiseLong.vmmIdxBatchSumB, 0x1);
+        this->uni_vfnmadd231ps(this->vmmSrcBeforeAxisSumB, elementwiseLong.vmmIdxBatchSumB, vAux1);
+    }
+    this->uni_vcvtps2dq(this->vmmSrcBeforeAxisSumB, this->vmmSrcBeforeAxisSumB);
+    this->uni_vmovd(Xbyak::Reg32(elementwiseLong.regBetweenBatchAndAxisIter.getIdx()), Xbyak::Xmm(this->vmmSrcBeforeAxisSumB.getIdx()));
+    this->uni_vcvtps2dq(elementwiseLong.vmmIdxBatchSumB, elementwiseLong.vmmIdxBatchSumB);
+
+    this->uploadParamPtrWithVpbroadcastd(elementwiseLong.vmmAxisAndAfterAxisSizeB, GET_OFF(axisAndAfterAxisSizeB));
+    // Formula: srcBeforeAxisSum = ((start / specIndicesSize) % betweenBatchAndAxis) * axisAndAfterAxisSize + srcAfterBatchSize * idxBatchSum
+    if (this->beforeAxisSize != 1lu) {
+        RegistersPool::Reg<Vmm> vAux0{this->regPool};
+        this->uni_vpmulld(this->vmmSrcBeforeAxisSumB, this->vmmSrcBeforeAxisSumB, elementwiseLong.vmmAxisAndAfterAxisSizeB);
+        this->uploadParamPtrWithVpbroadcastd(vAux0, GET_OFF(srcAfterBatchSizeB));
+        this->uni_vpmulld(vAux0, vAux0, elementwiseLong.vmmIdxBatchSumB);
+        this->uni_vpaddd(this->vmmSrcBeforeAxisSumB, this->vmmSrcBeforeAxisSumB, vAux0);
+    }
+
+    // Formula: idxBatchSum = specIdxSize * (start / afterBatchSize)
+    this->uni_vpmulld(elementwiseLong.vmmIdxBatchSumB, elementwiseLong.vmmIdxBatchSumB, this->vmmSpecIdxSizeB);
+
+    Xbyak::Label lBlock, lEnd;
+    const Xbyak::Reg64& regAux2 = this->rsi;
+    this->mov(regAux2, this->ptr[this->regParams + GET_OFF(afterAxSize)]);
+    this->cmp(regAux2, 1);
+    this->jg(lBlock, this->T_NEAR);
+    {
+        Xbyak::Label lLessThanVector1, lTail1, lTail2, lE1;
+
+        this->cmp(regSpecIdxSizeB, this->getVecLen());
+        this->jl(lLessThanVector1, this->T_NEAR);
+        {
+            this->uni_vmovd(Xbyak::Reg32(elementwiseLong.regIdxIter.getIdx()), Xbyak::Xmm(this->vmmSpecIdxB.getIdx()));
+            this->fillVlenVector(elementwiseLong.vmmVecLenB);
+
+            this->process(elementwiseLong);
+            elementwiseLong.releaseRegisters();
+            this->jmp(lE1, this->T_NEAR);
+        }
+        this->L(lLessThanVector1);
+        {
+            elementwiseShort.allocateRegisters(*this);
+            this->uploadParamPtrWithVmovups(elementwiseShort.vmmPermIdxMask, GET_OFF(permIdxMask));
+            if (this->beforeAxisSize != 1lu) {
+                this->uploadParamPtrWithVmovups(elementwiseShort.vmmBeforeAxDiffB, GET_OFF(beforeAxisDiff));
+                if (this->getDataTypeSize() != 1)
+                    this->uni_vpslld(elementwiseShort.vmmBeforeAxDiffB, elementwiseShort.vmmBeforeAxDiffB,
+                                     this->getDataTypeShift()); // multiply by data type size
+            }
+            this->uploadParamPtrWithVpbroadcastd(elementwiseShort.vmmSrcAfterBatchSizeB, GET_OFF(srcAfterBatchSizeB));
+
+            this->process(elementwiseShort);
+            elementwiseShort.releaseRegisters();
+        }
+        this->L(lE1);
+        this->jmp(lEnd, this->T_NEAR);
+    }
+    this->L(lBlock); {
+        blockedShort.rSpecIdxAndAfterAxIterB = RegistersPool::Reg<Xbyak::Reg64>{this->regPool};
+        blockedShort.rSpecIdxAndAfterAxSizeB = RegistersPool::Reg<Xbyak::Reg64>{this->regPool};
+
+        blockedShort.vmmAxisAndAfterAxisSizeB = RegistersPool::Reg<Vmm>{this->regPool};
+        blockedShort.vmmSrcAfterBatchSizeB = RegistersPool::Reg<Vmm>{this->regPool};
+        blockedShort.vmmAfterAxisIdxB = RegistersPool::Reg<Vmm>{this->regPool};
+        blockedShort.vmmAfterAxisPermMask = RegistersPool::Reg<Vmm>{this->regPool};
+
+        Xbyak::Label lLessThanVector2, lTail3, lTail4, lE2;
+        {
+            RegistersPool::Reg<Vmm> vAux0{this->regPool};
+            this->uploadParamPtrWithVpbroadcastd(blockedShort.vmmAfterAxisIdxB, GET_OFF(start));
+            {
+                RegistersPool::Reg<Xbyak::Reg64> regAux1{this->regPool};
+                this->mov(regAux1, reinterpret_cast<uintptr_t>(incVec));
+                this->uni_vpaddd(blockedShort.vmmAfterAxisIdxB, blockedShort.vmmAfterAxisIdxB, this->ptr[regAux1]);
+                this->uni_vcvtdq2ps(blockedShort.vmmAfterAxisIdxB, blockedShort.vmmAfterAxisIdxB);
+
+                // afterAxIdxB = (start % afterAxSize) * idxTypeSize
+                this->movd(Xbyak::Xmm(vAux0.getIdx()), Xbyak::Reg32(regAux1.getIdx()));
+            }
+            RegistersPool::Reg<Vmm> vAux1{this->regPool};
+            this->uni_vpbroadcastd(vAux1, Xbyak::Xmm(vAux0.getIdx()));
+            this->uni_vcvtdq2ps(vAux1, vAux1);
+            this->uni_vdivps(this->vmmSrcBeforeAxisSumB, blockedShort.vmmAfterAxisIdxB, vAux1);
+            this->uni_vroundps(this->vmmSrcBeforeAxisSumB, this->vmmSrcBeforeAxisSumB, 0x1);
+            this->uni_vfnmadd231ps(blockedShort.vmmAfterAxisIdxB, this->vmmSrcBeforeAxisSumB, vAux1);
+            this->uni_vcvtps2dq(blockedShort.vmmAfterAxisIdxB, blockedShort.vmmAfterAxisIdxB);
+            this->uni_vpslld(blockedShort.vmmAfterAxisIdxB, blockedShort.vmmAfterAxisIdxB,
+                             this->idxTypeShift); // multiply by indices type size.
+
+            this->cmp(regAux2, this->getDataElPerVec());
+            this->jl(lLessThanVector2, this->T_NEAR);
+            this->uni_vmovd(Xbyak::Reg32(blockedShort.rSpecIdxAndAfterAxIterB.getIdx()), Xbyak::Xmm(this->vmmSpecIdxB.getIdx()));
+            //this->fillVlenVector(elementwiseLong.vmmVecLenB);
+
+            // process(blockedLong); // not implemented
+            this->jmp(lE2, this->T_NEAR);
+            this->L(lLessThanVector2);
+            RegistersPool::Reg<Vmm> vAux2{this->regPool};
+            // Calculate permute mask
+            this->uni_vmovd(Xbyak::Xmm(vAux0.getIdx()), Xbyak::Reg32(regAux2.getIdx()));
+            this->uni_vpbroadcastd(vAux1, Xbyak::Xmm(vAux0.getIdx()));
+            idxElPerVec = this->getIdxElPerVec();
+            {
+                RegistersPool::Reg<Xbyak::Reg64> regAux1{this->regPool};
+                this->mov(regAux1, reinterpret_cast<uintptr_t>(&idxElPerVec));
+                this->uni_vpbroadcastd(vAux0, this->ptr[regAux1]);
+                this->uni_vpsubd(blockedShort.vmmAfterAxisPermMask, vAux0, vAux1);
+                this->mov(regAux1, reinterpret_cast<uintptr_t>(incVec));
+                this->uni_vpaddd(blockedShort.vmmAfterAxisPermMask, blockedShort.vmmAfterAxisPermMask,
+                                 this->ptr[regAux1]);
+            }
+            for (int i = 0; i < 6; i++) {
+                if (isa == x64::avx512_core) {
+                    Xbyak::Opmask kMask2 = Xbyak::Opmask(vAux2.getIdx());
+                    this->vpcmpgtd(kMask2, vAux0, blockedShort.vmmAfterAxisPermMask);
+                    this->uni_vpsubd(static_cast<Vmm &>(blockedShort.vmmAfterAxisPermMask) | kMask2,
+                                     blockedShort.vmmAfterAxisPermMask, vAux1);
+                } else {
+                    this->vpcmpgtd(vAux2, vAux0, blockedShort.vmmAfterAxisPermMask);
+                    this->vpandn(vAux2, vAux2, vAux1);
+                    this->uni_vpsubd(blockedShort.vmmAfterAxisPermMask, blockedShort.vmmAfterAxisPermMask, vAux2);
+                }
+            }
+        }
+
+        this->process(blockedShort);
+        this->L(lE2);
+    }
+    this->L(lEnd);
+}
+
+template<x64::cpu_isa_t isa> template<typename unused>
+void jitGatherKernelBase<isa>::ShiftCalculatorImpl<ElementwiseCase, Short, unused>::allocateRegisters(jitGatherKernelBase& kernel) {
+    vmmBeforeAxDiffB = RegistersPool::Reg<Vmm>{kernel.regPool, 12};
+    vmmSrcAfterBatchSizeB = RegistersPool::Reg<Vmm>{kernel.regPool, 13};
+    vmmPermIdxMask = RegistersPool::Reg<Vmm>{kernel.regPool, 14};
+}
+
+template<x64::cpu_isa_t isa> template<typename unused>
+void jitGatherKernelBase<isa>::ShiftCalculatorImpl<ElementwiseCase, Short, unused>::releaseRegisters() {
+    vmmBeforeAxDiffB.release();
+    vmmSrcAfterBatchSizeB.release();
+    vmmPermIdxMask.release();
+}
+
+template<x64::cpu_isa_t isa> template<typename unused>
+void jitGatherKernelBase<isa>::ShiftCalculatorImpl<ElementwiseCase, Short, unused>::uploadParamsForApproachSpecific(
+        jitGatherKernelBase& kernel) {
+    if (kernel.specIdxSize != 1 && kernel.specIdxSize != 2 && kernel.specIdxSize != 4 && kernel.specIdxSize != 8 &&
+        kernel.specIdxSize != 16) {
+        kernel.uploadParamPtrWithVmovups(vmmPermIdxMask, GET_OFF(permIdxMask));
+    }
+    if (kernel.beforeAxisSize != 1lu) {
+        kernel.uploadParamPtrWithVmovups(vmmBeforeAxDiffB, GET_OFF(beforeAxisDiff));
+        if (kernel.getDataTypeSize() != 1)
+            kernel.uni_vpslld(vmmBeforeAxDiffB, vmmBeforeAxDiffB, kernel.getDataTypeShift()); // multiply by data type size
+    }
+    if (kernel.batchDims > 0lu) {
+        kernel.uploadParamPtrWithVpbroadcastd(vmmSrcAfterBatchSizeB, GET_OFF(srcAfterBatchSizeB));
+    }
+}
+
 template <>
-void jitUniGatherKernel<x64::avx512_core>::fillVlenVector() {
-    mov(reg32Aux1, vlen);
+void jitGatherKernelBase<x64::avx512_core>::fillVlenVector(RegistersPool::Reg<Vmm>& vmmVecLenB) {
+    RegistersPool::Reg<Xbyak::Reg32> reg32Aux1 {regPool};
+    mov(reg32Aux1, this->getVecLen());
     vpbroadcastd(vmmVecLenB, reg32Aux1);
 }
 template <>
-void jitUniGatherKernel<x64::avx2>::fillVlenVector() {
+void jitGatherKernelBase<x64::avx2>::fillVlenVector(RegistersPool::Reg<Vmm>& vmmVecLenB) {
     vpcmpeqd(vmmVecLenB, vmmVecLenB, vmmVecLenB);
     vpsrld(vmmVecLenB, vmmVecLenB, 31); // Right shift to 1.
     uni_vpslld(vmmVecLenB, vmmVecLenB, 5);  // Left shift to 32.
 }
 
-template <x64::cpu_isa_t isa>
-bool jitUniGatherKernel<isa>::isSupportedConfiguration(uint64_t afterAxisSize) {
-    if (!jcp.dynamicShapes && afterAxisSize <= idxElPerVec) {
-        if (afterAxisSize > 1 && isa == x64::avx2 && (jcp.dataTypeSize == 1 || jcp.dataTypeSize == 2))
-            // There are no enough registers for these cases.
-            return false;
+template<x64::cpu_isa_t isa> template<typename unused>
+void jitGatherKernelBase<isa>::ShiftCalculatorImpl<ElementwiseCase, Long, unused>::allocateRegisters(jitGatherKernelBase& kernel) {
+    regBetweenBatchAndAxisSize = Xbyak::Reg64(kernel.rbx.getIdx());
+    regSpecIdxSizeB = RegistersPool::Reg<Xbyak::Reg64>{kernel.regPool, 13};
+    regBetweenBatchAndAxisIter = RegistersPool::Reg<Xbyak::Reg64>{kernel.regPool, 15};
+    regIdxIter = RegistersPool::Reg<Xbyak::Reg64>{kernel.regPool, 11};
 
-        return true;
-    }
-    if (jcp.dynamicShapes && afterAxisSize == 1) {
-        return true;
-    }
-    return false;
+    vmmIdxBatchSumB = RegistersPool::Reg<Vmm>{kernel.regPool, 14};
+    vmmVecLenB = RegistersPool::Reg<Vmm>{kernel.regPool, 13};
+    vmmAxisAndAfterAxisSizeB = RegistersPool::Reg<Vmm>{kernel.regPool, 12};
 }
 
-template struct jitUniGatherKernel<x64::avx2>;
-template struct jitUniGatherKernel<x64::avx512_core>;
+template<x64::cpu_isa_t isa> template<typename unused>
+void jitGatherKernelBase<isa>::ShiftCalculatorImpl<ElementwiseCase, Long, unused>::releaseRegisters() {
+    regSpecIdxSizeB.release();
+    regBetweenBatchAndAxisIter.release();
+    regIdxIter.release();
+
+    vmmIdxBatchSumB.release();
+    vmmVecLenB.release();
+    vmmAxisAndAfterAxisSizeB.release();
+}
+
+template<x64::cpu_isa_t isa> template<typename unused>
+void jitGatherKernelBase<isa>::ShiftCalculatorImpl<ElementwiseCase, Long, unused>::uploadParamsForApproachSpecific(
+        jitGatherKernelBase& kernel) {
+    kernel.uni_vmovd(Xbyak::Reg32(regSpecIdxSizeB.getIdx()), Xbyak::Xmm(kernel.vmmSpecIdxSizeB.getIdx()));
+    if (kernel.beforeAxisSize != 1lu) {
+        kernel.uploadParamPtrWithVpbroadcastd(vmmAxisAndAfterAxisSizeB, GET_OFF(axisAndAfterAxisSizeB));
+    }
+    kernel.uploadParamPtrWithVmovups(vmmIdxBatchSumB, GET_OFF(idxBatchSumB));
+    RegistersPool::Reg<Xbyak::Reg64> regAux {kernel.regPool};
+    kernel.mov(regAux, kernel.ptr[kernel.regParams + GET_OFF(betweenBatchAndAxisSize)]);
+    kernel.mov(regBetweenBatchAndAxisSize, kernel.ptr[regAux]);
+    kernel.mov(regBetweenBatchAndAxisIter, kernel.ptr[kernel.regParams + GET_OFF(betweenBatchAndAxisIter)]);
+
+    kernel.uni_vmovd(Xbyak::Reg32(regIdxIter.getIdx()), Xbyak::Xmm(kernel.vmmSpecIdxB.getIdx()));
+    kernel.fillVlenVector(vmmVecLenB);
+}
+
+template<x64::cpu_isa_t isa> template<typename unused>
+void jitGatherKernelBase<isa>::ShiftCalculatorImpl<BlockedCase, Short, unused>::allocateRegisters(jitGatherKernelBase& kernel) {
+    rSpecIdxAndAfterAxIterB = RegistersPool::Reg<Xbyak::Reg64>{kernel.regPool, 11};
+    rSpecIdxAndAfterAxSizeB = RegistersPool::Reg<Xbyak::Reg64>{kernel.regPool, 13};
+
+    vmmAxisAndAfterAxisSizeB = RegistersPool::Reg<Vmm>{kernel.regPool, 12};
+    vmmSrcAfterBatchSizeB = RegistersPool::Reg<Vmm>{kernel.regPool, 13};
+    vmmAfterAxisIdxB = RegistersPool::Reg<Vmm>{kernel.regPool, 15};
+    vmmAfterAxisPermMask = RegistersPool::Reg<Vmm>{kernel.regPool, 14};
+    vmmSpecIdxDiff = RegistersPool::Reg<Vmm>{kernel.regPool, 4};
+    vmmAfterAxisSize = RegistersPool::Reg<Vmm>{kernel.regPool, 5};
+    vmmBeforeAxPermMask = RegistersPool::Reg<Vmm>{kernel.regPool, 6};
+}
+
+template<x64::cpu_isa_t isa> template<typename unused>
+void jitGatherKernelBase<isa>::ShiftCalculatorImpl<BlockedCase, Short, unused>::uploadParamsForApproachSpecific(
+        jitGatherKernelBase& kernel) {
+    kernel.uploadParamPtrWithVmovups(vmmAfterAxisIdxB, GET_OFF(afterAxIdxB));
+    kernel.uploadParamPtrWithVmovups(vmmAfterAxisPermMask, GET_OFF(afterAxisPermMask));
+    kernel.uploadParamPtrWithVmovups(vmmSpecIdxDiff, GET_OFF(specIdxDiff));
+    kernel.uploadParamPtrWithVpbroadcastd(vmmSrcAfterBatchSizeB, GET_OFF(srcAfterBatchSizeB));
+    kernel.uploadParamPtrWithVpbroadcastd(vmmAfterAxisSize, GET_OFF(afterAxisSize));
+
+    if (kernel.beforeAxisSize != 1lu) {
+        kernel.mov(rSpecIdxAndAfterAxIterB, kernel.ptr[kernel.regParams + GET_OFF(specIdxAndAfterAxIterB)]);
+        kernel.mov(rSpecIdxAndAfterAxSizeB, kernel.ptr[kernel.regParams + GET_OFF(specIdxAndAfterAxSizeB)]);
+        if (kernel.specIdxSize * kernel.afterAxisSize < kernel.getIdxElPerVec()) {
+            auto& vmmBeforeAxDiffB = vmmAxisAndAfterAxisSizeB;
+            kernel.uploadParamPtrWithVmovups(vmmBeforeAxDiffB, GET_OFF(beforeAxisDiff));
+        } else {
+            kernel.uploadParamPtrWithVpbroadcastd(vmmAxisAndAfterAxisSizeB, GET_OFF(axisAndAfterAxisSizeB));
+        }
+        const uint64_t specIdxAndAfterAxisSize = kernel.specIdxSize * kernel.afterAxisSize;
+        if (specIdxAndAfterAxisSize != 1 && specIdxAndAfterAxisSize != 2 && specIdxAndAfterAxisSize != 4 &&
+            specIdxAndAfterAxisSize != 8 && specIdxAndAfterAxisSize != 16) {
+            kernel.uploadParamPtrWithVmovups(vmmBeforeAxPermMask, GET_OFF(beforeAxisPermMask));
+        }
+    }
+}
+
+
+template<x64::cpu_isa_t isa>
+poolVmask<isa> jitGatherKernelBase<isa>::calcAllOnesMask(Vmm& vAux) {
+    RegistersPool::Reg<Vmask> onesMask {regPool};
+    vpcmpeqd(onesMask, vAux, vAux);
+    return onesMask;
+}
+
+template<x64::cpu_isa_t isa>
+std::tuple<poolVmask<isa> /*kDstMask*/, poolVmm<isa> /*vDstShifts*/>
+        jitGatherKernelBase<isa>::calculateIndexesForShortCase(Vmm& srcBeforeAxisSumB, Vmm& srcAfterBatchSizeB) {
+    RegistersPool::Reg<Vmm> vDstShifts;
+    if (batchDims > 0lu) {
+        // Calculate indices batch sum.
+        RegistersPool::Reg<Vmm> vAux0{regPool};
+        uni_vcvtdq2ps(vAux0, srcBeforeAxisSumB);
+        {
+            RegistersPool::Reg<Vmm> vmmSrcAfterBatchSizeBFloat{regPool};
+            uni_vcvtdq2ps(vmmSrcAfterBatchSizeBFloat, srcAfterBatchSizeB);
+            uni_vdivps(vAux0, vAux0, vmmSrcAfterBatchSizeBFloat);
+        }
+        uni_vroundps(vAux0, vAux0, 0x1);
+        uni_vcvtps2dq(vAux0, vAux0);
+
+        uni_vpmulld(vAux0, vAux0, vmmSpecIdxSizeB);
+        uni_vpaddd(vAux0, vAux0, vmmSpecIdxB);
+
+        vDstShifts = RegistersPool::Reg<Vmm> {regPool};
+        uniVpGatherDd(vDstShifts, ptr[regIndices + vAux0], calcAllOnesMask(vAux0));
+    } else {
+        vDstShifts = RegistersPool::Reg<Vmm> {regPool};
+        uniVpGatherDd(vDstShifts, ptr[regIndices + vmmSpecIdxB], calcAllOnesMask(vDstShifts));
+    }
+
+    RegistersPool::Reg<Vmask> kDstMask = normalizeIndexesAndCalcShifts(vDstShifts);
+    return {std::move(kDstMask), std::move(vDstShifts)};
+}
+
+template<x64::cpu_isa_t isa> template<typename unused>
+std::tuple<poolVmask<isa> /*kDstMask*/, poolVmm<isa> /*vDstShifts*/>
+jitGatherKernelBase<isa>::ShiftCalculatorImpl<ElementwiseCase, Short, unused>::calcSrcShift(
+        jitGatherKernelBase& kernel, bool shiftFirst) {
+    if (shiftFirst) {
+        if (kernel.beforeAxisSize != 1lu)
+            kernel.uni_vpaddd(kernel.vmmSrcBeforeAxisSumB, kernel.vmmSrcBeforeAxisSumB, vmmBeforeAxDiffB);
+        // No sense to permute if specIdxSize is one of {1, 2, 4, 8, 16}. 0 is reserved for dynamic case.
+        if (kernel.specIdxSize != 1 && kernel.specIdxSize != 2 && kernel.specIdxSize != 4 && kernel.specIdxSize != 8 &&
+            kernel.specIdxSize != 16) {
+            kernel.vpermd(kernel.vmmSpecIdxB, vmmPermIdxMask, kernel.vmmSpecIdxB);
+            if (kernel.beforeAxisSize != 1lu)
+                kernel.vpermd(vmmBeforeAxDiffB, vmmPermIdxMask, vmmBeforeAxDiffB);
+        }
+    }
+
+    RegistersPool::Reg<Vmm> vDstShifts;
+    RegistersPool::Reg<Vmask> kDstMask;
+    std::tie(kDstMask, vDstShifts) = kernel.calculateIndexesForShortCase(kernel.vmmSrcBeforeAxisSumB, vmmSrcAfterBatchSizeB);
+
+    if (kernel.beforeAxisSize != 1lu)
+        kernel.uni_vpaddd(vDstShifts, vDstShifts, kernel.vmmSrcBeforeAxisSumB);
+    return {std::move(kDstMask), std::move(vDstShifts)};
+}
+
+template <>
+void jitGatherKernelBase<x64::avx2>::normWithUpperBound(Vmm& vTarget, Vmm& vMax, Vmask& kAuxMask) {
+    vpcmpgtd(kAuxMask, vMax, vTarget);
+    vpandn(kAuxMask, kAuxMask, vMax);
+    uni_vpsubd(vTarget, vTarget, kAuxMask);
+}
+
+template <>
+void jitGatherKernelBase<x64::avx512_core>::normWithUpperBound(Vmm& vTarget, Vmm& vMax, Vmask& kAuxMask) {
+    vpcmpd(kAuxMask, vMax, vTarget, 2); // 2 -> LE
+    uni_vpsubd(vTarget | kAuxMask, vTarget, vMax);
+}
+
+template<x64::cpu_isa_t isa> template<typename unused>
+std::tuple<poolVmask<isa> /*kDstMask*/, poolVmm<isa> /*vDstShifts*/>
+jitGatherKernelBase<isa>::ShiftCalculatorImpl<BlockedCase, Short, unused>::calcSrcShift(
+        jitGatherKernelBase& kernel, bool shiftFirst) {
+    RegistersPool::Reg<Vmm> vAux1{kernel.regPool};
+    const uint64_t specIdxAndAfterAxisSize = kernel.specIdxSize * kernel.afterAxisSize;
+
+    if (shiftFirst) {
+        if (kernel.specIdxSize != 1 && vmmSpecIdxDiff.isInitialized()) {
+            kernel.uni_vpaddd(kernel.vmmSpecIdxB, kernel.vmmSpecIdxB, vmmSpecIdxDiff);
+            RegistersPool::Reg<Vmask> kAuxMask0 {kernel.regPool};
+            kernel.normWithUpperBound(kernel.vmmSpecIdxB, kernel.vmmSpecIdxSizeB, kAuxMask0);
+        }
+        // No sense to permute if afterAxisSize is one of {1, 2, 4, 8, 16}. 0 is reserved for dynamic case.
+        if (kernel.afterAxisSize != 1 && kernel.afterAxisSize != 2 && kernel.afterAxisSize != 4 &&
+            kernel.afterAxisSize != 8 && kernel.afterAxisSize != 16) {
+            kernel.vpermd(vmmAfterAxisIdxB, vmmAfterAxisPermMask, vmmAfterAxisIdxB);
+            if (kernel.specIdxSize != 1 && vmmSpecIdxDiff.isInitialized())
+                kernel.vpermd(vmmSpecIdxDiff, vmmAfterAxisPermMask, vmmSpecIdxDiff);
+        }
+
+        if (kernel.beforeAxisSize != 1lu) {
+            if (!kernel.dynamicShapes) {
+                if (specIdxAndAfterAxisSize > 0lu && specIdxAndAfterAxisSize <= kernel.getIdxElPerVec()) {
+                    auto& vmmBeforeAxDiffB = vmmAxisAndAfterAxisSizeB;
+                    kernel.uni_vpaddd(kernel.vmmSrcBeforeAxisSumB, kernel.vmmSrcBeforeAxisSumB, vmmBeforeAxDiffB);
+                    kernel.uni_vmovups(vAux1, kernel.vmmSrcBeforeAxisSumB);
+                    if (specIdxAndAfterAxisSize != 1 && specIdxAndAfterAxisSize != 2 &&
+                        specIdxAndAfterAxisSize != 4 &&
+                        specIdxAndAfterAxisSize != 8 && specIdxAndAfterAxisSize != 16 && vmmBeforeAxPermMask.isInitialized())
+                        kernel.vpermd(vmmBeforeAxDiffB, vmmBeforeAxPermMask, vmmBeforeAxDiffB);
+                } else {
+                    Xbyak::Label lBeforeAxStep, lBeforeAxStepEnd;
+                    kernel.add(rSpecIdxAndAfterAxIterB, kernel.getIdxElPerVec() * kernel.getDataTypeSize());
+                    kernel.cmp(rSpecIdxAndAfterAxIterB, rSpecIdxAndAfterAxSizeB);
+                    kernel.jl(lBeforeAxStep, kernel.T_NEAR);
+                    kernel.sub(rSpecIdxAndAfterAxIterB, rSpecIdxAndAfterAxSizeB);
+
+                    RegistersPool::Reg<Vmm> vAux0{kernel.regPool};
+                    if (vmmAfterAxisSize.isInitialized()) {
+                        kernel.vpmulld(vAux0, kernel.vmmSpecIdxB, vmmAfterAxisSize);
+                    }
+                    kernel.uni_vpaddd(vAux0, vAux0, vmmAfterAxisIdxB);
+                    kernel.uni_vpbroadcastd(vAux1, Xbyak::Xmm(vAux0.getIdx()));
+                    if (isa == x64::avx512_core) {
+                        RegistersPool::Reg<Xbyak::Opmask> kMask0 {kernel.regPool};
+                        kernel.vpcmpgtd(kMask0, vAux1, vAux0);
+                        kernel.uni_vmovups(vAux1, kernel.vmmSrcBeforeAxisSumB);
+                        kernel.uni_vpaddd(static_cast<Vmm&>(vAux1) | kMask0, kernel.vmmSrcBeforeAxisSumB,
+                                          vmmAxisAndAfterAxisSizeB);
+                    } else {
+                        kernel.vpcmpgtd(vAux1, vAux1, vAux0);
+                        kernel.vpand(vAux1, vAux1, vmmAxisAndAfterAxisSizeB);
+                        kernel.uni_vpaddd(vAux1, kernel.vmmSrcBeforeAxisSumB, vAux1);
+                    }
+                    kernel.uni_vpaddd(kernel.vmmSrcBeforeAxisSumB, kernel.vmmSrcBeforeAxisSumB,
+                                      vmmAxisAndAfterAxisSizeB);
+                    kernel.jmp(lBeforeAxStepEnd);
+                    kernel.L(lBeforeAxStep);
+                    kernel.uni_vmovups(vAux1, kernel.vmmSrcBeforeAxisSumB);
+                    kernel.L(lBeforeAxStepEnd);
+                }
+            } else {
+            }
+        }
+    } else {
+        if (kernel.beforeAxisSize != 1lu) {
+            kernel.uni_vmovups(vAux1, kernel.vmmSrcBeforeAxisSumB);
+            if (specIdxAndAfterAxisSize > kernel.getIdxElPerVec()) {
+                // Broadcast the last element.
+                if (isa == x64::avx512_core) {
+                    kernel.vshuff64x2(kernel.vmmSrcBeforeAxisSumB, kernel.vmmSrcBeforeAxisSumB,
+                                      kernel.vmmSrcBeforeAxisSumB, 0xFF);
+                } else {
+                    kernel.vpermq(kernel.vmmSrcBeforeAxisSumB, kernel.vmmSrcBeforeAxisSumB, 0xFF);
+                }
+                kernel.vpshufd(kernel.vmmSrcBeforeAxisSumB, kernel.vmmSrcBeforeAxisSumB, 0xFF);
+
+                Xbyak::Label lBeforeAxStepEnd1;
+                kernel.add(rSpecIdxAndAfterAxIterB, kernel.getIdxElPerVec() * kernel.getDataTypeSize());
+                kernel.cmp(rSpecIdxAndAfterAxIterB, rSpecIdxAndAfterAxSizeB);
+                kernel.jl(lBeforeAxStepEnd1, kernel.T_NEAR);
+                kernel.sub(rSpecIdxAndAfterAxIterB, rSpecIdxAndAfterAxSizeB);
+                kernel.cmp(rSpecIdxAndAfterAxIterB, 0);
+                kernel.jne(lBeforeAxStepEnd1, kernel.T_NEAR);
+                kernel.uni_vpaddd(kernel.vmmSrcBeforeAxisSumB, kernel.vmmSrcBeforeAxisSumB,
+                                  vmmAxisAndAfterAxisSizeB);
+                kernel.L(lBeforeAxStepEnd1);
+            }
+        }
+    }
+
+    RegistersPool::Reg<Vmm> vDstShifts;
+    RegistersPool::Reg<Vmask> kDstMask;
+    std::tie(kDstMask, vDstShifts) = kernel.calculateIndexesForShortCase(vAux1, vmmSrcAfterBatchSizeB);
+
+    if (kernel.afterAxisSize != 1lu) {
+        if (vmmAfterAxisSize.isInitialized()) {
+            kernel.vpmulld(vDstShifts, vDstShifts, vmmAfterAxisSize);
+        }
+        kernel.uni_vpaddd(vDstShifts, vDstShifts, vmmAfterAxisIdxB);
+    }
+    if (kernel.beforeAxisSize != 1lu)
+        kernel.uni_vpaddd(vDstShifts, vDstShifts, vAux1);
+    return {std::move(kDstMask), std::move(vDstShifts)};
+}
+
+template<x64::cpu_isa_t isa> template<typename unused>
+std::tuple<poolVmask<isa> /*kDstMask*/, poolVmm<isa> /*vDstShifts*/>
+jitGatherKernelBase<isa>::ShiftCalculatorImpl<ElementwiseCase, Long, unused>::calcSrcShift(
+        jitGatherKernelBase& kernel, bool shiftFirst) {
+    if (isa == x64::avx2) {
+        Xbyak::Label lIdxStride, lExit;
+        if (shiftFirst)
+            kernel.uni_vpaddd(kernel.vmmSpecIdxB, kernel.vmmSpecIdxB, vmmVecLenB);
+
+        kernel.add(regIdxIter, kernel.getVecLen());
+        kernel.cmp(regIdxIter, regSpecIdxSizeB);
+        kernel.jge(lIdxStride, kernel.T_NEAR);
+        RegistersPool::Reg<Vmask> kDstMask;
+        RegistersPool::Reg<Vmm> vDstShifts {kernel.regPool};
+        {
+            RegistersPool::Reg<Xbyak::Reg32> reg32Aux1{kernel.regPool};
+            if (kernel.batchDims > 0lu) {
+                kernel.uni_vpaddd(vDstShifts, vmmIdxBatchSumB, kernel.vmmSpecIdxB);
+                kernel.uni_vmovd(reg32Aux1, Xbyak::Xmm(vDstShifts.getIdx()));
+            } else {
+                kernel.uni_vmovd(reg32Aux1, Xbyak::Xmm(kernel.vmmSpecIdxB.getIdx()));
+            }
+            kernel.vmovdqu(vDstShifts, kernel.ptr[kernel.regIndices + Xbyak::Reg64(reg32Aux1.getIdx())]);
+            kDstMask = kernel.normalizeIndexesAndCalcShifts(vDstShifts);
+            if (kernel.beforeAxisSize != 1lu)
+                kernel.uni_vpaddd(vDstShifts, vDstShifts, kernel.vmmSrcBeforeAxisSumB);
+        }
+        kernel.jmp(lExit, kernel.T_NEAR);
+        kernel.L(lIdxStride);
+        {
+            kernel.sub(regIdxIter, regSpecIdxSizeB);
+            RegistersPool::Reg<Vmm> vAux0;
+            RegistersPool::Reg<Vmm> vAux1{kernel.regPool};
+            kernel.vpcmpeqd(kDstMask, vAux1, vAux1);
+            if (shiftFirst) {
+                vAux0 = RegistersPool::Reg<Vmm>{kernel.regPool};
+                kernel.vpcmpgtd(vAux0, kernel.vmmSpecIdxSizeB, kernel.vmmSpecIdxB);
+                kernel.vpandn(vAux1, vAux0, kernel.vmmSpecIdxSizeB);
+                kernel.uni_vpsubd(vAux1, kernel.vmmSpecIdxB, vAux1);
+                if (kernel.batchDims > 0lu)
+                    kernel.uni_vpaddd(vAux1, vmmIdxBatchSumB, vAux1);
+                kernel.uni_vpsubd(kernel.vmmSpecIdxB, kernel.vmmSpecIdxB, kernel.vmmSpecIdxSizeB);
+            } else {
+                if (kernel.batchDims > 0lu) {
+                    RegistersPool::Reg<Vmm> vAux{kernel.regPool};
+                    kernel.uni_vpaddd(vAux, vmmIdxBatchSumB, kernel.vmmSpecIdxB);
+                    kernel.uniVpGatherDd(vDstShifts, kernel.ptr[kernel.regIndices + vAux], kDstMask);
+                } else {
+                    kernel.uniVpGatherDd(vDstShifts, kernel.ptr[kernel.regIndices + kernel.vmmSpecIdxB], kDstMask);
+                }
+                kDstMask = kernel.normalizeIndexesAndCalcShifts(vDstShifts, std::move(kDstMask));
+
+                vAux0 = RegistersPool::Reg<Vmm>{kernel.regPool};
+                kernel.uni_vpbroadcastd(vAux0, Xbyak::Xmm(kernel.vmmSpecIdxB.getIdx()));
+                kernel.vpcmpgtd(vAux1, vAux0, kernel.vmmSpecIdxB);
+                kernel.vpandn(vAux0, vAux1, kernel.vmmSpecIdxSizeB);
+                kernel.uni_vpsubd(kernel.vmmSpecIdxB, kernel.vmmSpecIdxB, vAux0);
+
+                if (kernel.beforeAxisSize != 1lu) {
+                    kernel.uni_vpaddd(vDstShifts, vDstShifts, kernel.vmmSrcBeforeAxisSumB);
+                    kernel.vpandn(vAux0, vAux1, vmmAxisAndAfterAxisSizeB);
+                    kernel.uni_vpaddd(kernel.vmmSrcBeforeAxisSumB, kernel.vmmSrcBeforeAxisSumB, vAux0);
+                }
+            }
+
+            if (kernel.batchDims > 0lu) {
+                Xbyak::Label l1;
+                kernel.inc(regBetweenBatchAndAxisIter);
+                kernel.cmp(regBetweenBatchAndAxisIter, regBetweenBatchAndAxisSize);
+                kernel.jl(l1, kernel.T_NEAR);
+                kernel.mov(regBetweenBatchAndAxisIter, 0);
+                if (shiftFirst) {
+                    kernel.uni_vpaddd(vmmIdxBatchSumB, vmmIdxBatchSumB, kernel.vmmSpecIdxSizeB);
+                    kernel.vpandn(vDstShifts, vAux0, kernel.vmmSpecIdxSizeB);
+                    kernel.uni_vpaddd(vAux1, vAux1, vDstShifts);
+                } else {
+                    kernel.vpandn(vAux0, vAux1, kernel.vmmSpecIdxSizeB);
+                    kernel.uni_vpaddd(vmmIdxBatchSumB, vmmIdxBatchSumB, vAux0);
+                }
+                kernel.L(l1);
+            }
+
+            if (shiftFirst) {
+                kernel.uniVpGatherDd(vDstShifts, kernel.ptr[kernel.regIndices + vAux1], kDstMask);
+                vAux1.release();
+                kDstMask = kernel.normalizeIndexesAndCalcShifts(vDstShifts, std::move(kDstMask));
+
+                if (kernel.beforeAxisSize != 1lu) {
+                    kernel.vpandn(vAux0, vAux0, vmmAxisAndAfterAxisSizeB);
+                    kernel.uni_vpaddd(vAux0, vAux0, kernel.vmmSrcBeforeAxisSumB);
+                    kernel.uni_vpaddd(kernel.vmmSrcBeforeAxisSumB, kernel.vmmSrcBeforeAxisSumB,
+                                      vmmAxisAndAfterAxisSizeB);
+
+                    kernel.uni_vpaddd(vDstShifts, vDstShifts, vAux0);
+                }
+            }
+        }
+        kernel.L(lExit);
+        return {std::move(kDstMask), std::move(vDstShifts)};
+    } else if (isa == x64::avx512_core) {
+        RegistersPool::Reg<Xbyak::Zmm> vAux0{kernel.regPool};
+        RegistersPool::Reg<Xbyak::Zmm> vAux1{kernel.regPool};
+        RegistersPool::Reg<Xbyak::Opmask> kAuxMask1{kernel.regPool};
+
+        Xbyak::Label lIdxStride, lExit;
+        if (shiftFirst)
+            kernel.uni_vpaddd(kernel.vmmSpecIdxB, kernel.vmmSpecIdxB, vmmVecLenB);
+
+        kernel.add(regIdxIter, kernel.getVecLen());
+        kernel.cmp(regIdxIter, regSpecIdxSizeB);
+        kernel.jge(lIdxStride, kernel.T_NEAR);
+        RegistersPool::Reg<Xbyak::Reg32> reg32Aux1 {kernel.regPool};
+        RegistersPool::Reg<Vmm> vDstShifts {kernel.regPool};
+        RegistersPool::Reg<Vmask> kDstMask;
+        {
+            if (kernel.batchDims > 0lu) {
+                kernel.uni_vpaddd(vDstShifts, vmmIdxBatchSumB, kernel.vmmSpecIdxB);
+                kernel.uni_vmovd(reg32Aux1, Xbyak::Xmm(vDstShifts.getIdx()));
+            } else {
+                kernel.uni_vmovd(reg32Aux1, Xbyak::Xmm(kernel.vmmSpecIdxB.getIdx()));
+            }
+            kernel.vmovdqu64(vDstShifts, kernel.ptr[kernel.regIndices + Xbyak::Reg64(reg32Aux1.getIdx())]);
+            kDstMask = kernel.normalizeIndexesAndCalcShifts(vDstShifts);
+            if (kernel.beforeAxisSize != 1lu)
+                kernel.uni_vpaddd(vDstShifts, vDstShifts, kernel.vmmSrcBeforeAxisSumB);
+        }
+        kernel.jmp(lExit, kernel.T_NEAR);
+        kernel.L(lIdxStride);
+        {
+            kernel.sub(regIdxIter, regSpecIdxSizeB);
+            kernel.vpcmpeqd(kDstMask, vDstShifts, vDstShifts);
+            if (shiftFirst) {
+                kernel.vpcmpd(kAuxMask1, kernel.vmmSpecIdxSizeB, kernel.vmmSpecIdxB, 2); // 2 -> LE
+                if (kernel.batchDims > 0lu) {
+                    kernel.uni_vpaddd(vAux1, vmmIdxBatchSumB, kernel.vmmSpecIdxB);
+                    kernel.uni_vpsubd(static_cast<Xbyak::Zmm&>(vAux1) | kAuxMask1, vAux1, kernel.vmmSpecIdxSizeB);
+                } else {
+                    kernel.uni_vmovups(vAux1, kernel.vmmSpecIdxB);
+                    kernel.uni_vpsubd(static_cast<Xbyak::Zmm&>(vAux1) | kAuxMask1, kernel.vmmSpecIdxB,
+                                      kernel.vmmSpecIdxSizeB);
+                }
+                kernel.uni_vpsubd(kernel.vmmSpecIdxB, kernel.vmmSpecIdxB, kernel.vmmSpecIdxSizeB);
+            } else {
+                if (kernel.batchDims > 0lu) {
+                    kernel.uni_vpaddd(vAux0, vmmIdxBatchSumB, kernel.vmmSpecIdxB);
+                    kernel.uniVpGatherDd(vDstShifts, kernel.ptr[kernel.regIndices + vAux0], kDstMask);
+                } else {
+                    kernel.uniVpGatherDd(vDstShifts, kernel.ptr[kernel.regIndices + kernel.vmmSpecIdxB], kDstMask);
+                }
+                kDstMask = kernel.normalizeIndexesAndCalcShifts(vDstShifts, std::move(kDstMask));
+
+                kernel.uni_vpbroadcastd(vAux0, Xbyak::Xmm(kernel.vmmSpecIdxB.getIdx()));
+                kernel.vpcmpd(kAuxMask1, vAux0, kernel.vmmSpecIdxB, 2); // 2 -> LE
+                kernel.uni_vpsubd(Xbyak::Zmm(kernel.vmmSpecIdxB.getIdx()) | kAuxMask1, kernel.vmmSpecIdxB,
+                                  kernel.vmmSpecIdxSizeB);
+
+                if (kernel.beforeAxisSize != 1lu) {
+                    kernel.uni_vpaddd(vDstShifts, vDstShifts, kernel.vmmSrcBeforeAxisSumB);
+                    kernel.uni_vpaddd(Xbyak::Zmm(kernel.vmmSrcBeforeAxisSumB.getIdx()) | kAuxMask1,
+                                      kernel.vmmSrcBeforeAxisSumB, vmmAxisAndAfterAxisSizeB);
+                }
+            }
+
+            if (kernel.batchDims > 0lu) {
+                Xbyak::Label l1;
+                kernel.inc(regBetweenBatchAndAxisIter);
+                kernel.cmp(regBetweenBatchAndAxisIter, regBetweenBatchAndAxisSize);
+                kernel.jl(l1, kernel.T_NEAR);
+                kernel.mov(regBetweenBatchAndAxisIter, 0);
+                if (shiftFirst) {
+                    kernel.uni_vpaddd(vmmIdxBatchSumB, vmmIdxBatchSumB, kernel.vmmSpecIdxSizeB);
+                    kernel.uni_vpaddd(static_cast<Xbyak::Zmm&>(vAux1) | kAuxMask1, vAux1, kernel.vmmSpecIdxSizeB);
+                } else {
+                    kernel.uni_vpaddd(Xbyak::Zmm(vmmIdxBatchSumB.getIdx()) | kAuxMask1, vmmIdxBatchSumB,
+                                      kernel.vmmSpecIdxSizeB);
+                }
+                kernel.L(l1);
+            }
+
+            if (shiftFirst) {
+                kernel.uniVpGatherDd(vDstShifts, kernel.ptr[kernel.regIndices + vAux1], kDstMask);
+                kDstMask = kernel.normalizeIndexesAndCalcShifts(vDstShifts, std::move(kDstMask));
+
+                if (kernel.beforeAxisSize != 1lu) {
+                    kernel.uni_vpaddd(vDstShifts, vDstShifts, kernel.vmmSrcBeforeAxisSumB);
+                    kernel.uni_vpaddd(static_cast<Vmm>(vDstShifts) | kAuxMask1, vDstShifts, vmmAxisAndAfterAxisSizeB);
+                    kernel.uni_vpaddd(kernel.vmmSrcBeforeAxisSumB, kernel.vmmSrcBeforeAxisSumB,
+                                      vmmAxisAndAfterAxisSizeB);
+                }
+            }
+        }
+        kernel.L(lExit);
+        return {std::move(kDstMask), std::move(vDstShifts)};
+    }
+}
+
+
+template <x64::cpu_isa_t isa, DataTypeSize S, AfterAxisCase C>
+std::shared_ptr<jitGatherKernelInterface> createJitUniGatherKernel(bool isShortCase) {
+    if (isShortCase)
+        return std::make_shared<jitGatherKernelForStaticShapes<isa, S, C, Short>>();
+    if (C == ElementwiseCase)
+        return std::make_shared<jitGatherKernelForStaticShapes<isa, S, ElementwiseCase, Long>>();
+    return {}; // BlockedCase Long not implemented
+}
+
+template <x64::cpu_isa_t isa, DataTypeSize S>
+std::shared_ptr<jitGatherKernelInterface> createJitUniGatherKernel(uint64_t afterAxisSize, uint64_t specIdxSize, uint64_t idxElPerVec) {
+    if (afterAxisSize == 1lu)
+        return createJitUniGatherKernel<isa, S, ElementwiseCase>(specIdxSize < idxElPerVec);
+    return createJitUniGatherKernel<isa, S, BlockedCase>(afterAxisSize <= idxElPerVec);
+}
+
+template <x64::cpu_isa_t isa, DataTypeSize S>
+std::shared_ptr<jitGatherKernelInterface> createJitUniGatherKernel(
+        uint64_t afterAxisSize, uint64_t specIdxSize, uint64_t idxElPerVec, bool isDynamicNode) {
+    if (isDynamicNode) {
+        if (afterAxisSize != 1lu) {
+            return {}; // BlockedCase for dynamic shapes not implemented
+        }
+        return std::make_shared<jitGatherKernelForDynamicShapes<isa, S>>();
+    }
+    return createJitUniGatherKernel<isa, S>(afterAxisSize, specIdxSize, idxElPerVec);
+}
+
+template <x64::cpu_isa_t isa>
+std::shared_ptr<jitGatherKernelInterface> createJitUniGatherKernel(
+        uint64_t dataTypeSize, bool isDynamicNode, uint64_t afterAxisSize, uint64_t specIdxSize, uint64_t idxElPerVec) {
+    if (dataTypeSize == 4) {
+        return createJitUniGatherKernel<isa, DataType32bit>(afterAxisSize, specIdxSize, idxElPerVec, isDynamicNode);
+    } else if (isa == x64::avx512_core || afterAxisSize == 1) {
+        if (dataTypeSize == 2) {
+            return createJitUniGatherKernel<isa, DataType16bit>(afterAxisSize, specIdxSize, idxElPerVec, isDynamicNode);
+        }
+        return createJitUniGatherKernel<isa, DataType8bit>(afterAxisSize, specIdxSize, idxElPerVec, isDynamicNode);
+    }
+    return {}; // not implemented case
+}
+
+std::shared_ptr<jitGatherKernelInterface> jitGatherKernelInterface::createJitUniGatherKernel(x64::cpu_isa_t isa,
+        uint64_t dataTypeSize, bool isDynamicNode, uint64_t afterAxisSize, uint64_t specIdxSize, uint64_t idxElPerVec) {
+    if (isa == x64::avx512_core)
+        return intel_cpu::createJitUniGatherKernel<x64::avx512_core>(dataTypeSize, isDynamicNode, afterAxisSize, specIdxSize, idxElPerVec);
+    return intel_cpu::createJitUniGatherKernel<x64::avx2>(dataTypeSize, isDynamicNode, afterAxisSize, specIdxSize, idxElPerVec);
+}
 
 }   // namespace intel_cpu
 }   // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/kernels/gather_uni_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/gather_uni_kernel.hpp
@@ -24,6 +24,7 @@
 
 #include "cpu/x64/jit_generator.hpp"
 #include <dnnl_types.h>
+#include "registers_pool.hpp"
 
 namespace ov {
 namespace intel_cpu {
@@ -69,142 +70,233 @@ struct gatherJitExecArgs {
     uint64_t betweenBatchAndAxisIter;
 };
 
-struct jitGatherKernelBase {
-    void (*ker_)(const gatherJitExecArgs *);
-    void operator()(const gatherJitExecArgs *args) {
+struct jitGatherKernelInterface {
+    virtual ~jitGatherKernelInterface() = default;
+    virtual void initialize(const jGatherConfParams& jcp) = 0;
+    virtual bool isSameParams(const jGatherConfParams& jcp) = 0;
+    virtual void operator()(const gatherJitExecArgs *args) = 0;
+    virtual void create_ker() = 0;
+    virtual uint64_t getVecLen() const = 0;
+    virtual uint64_t getDataElPerVec() const = 0;
+    virtual uint64_t getIdxElPerVec() const = 0;
+    static std::shared_ptr<jitGatherKernelInterface> createJitUniGatherKernel(x64::cpu_isa_t isa,
+        uint64_t dataTypeSize, bool isDynamicNode, uint64_t afterAxisSize, uint64_t specIdxSize, uint64_t idxElPerVec);
+};
+
+using namespace dnnl::impl::cpu;
+
+enum DataTypeSize {
+    DataType32bit,
+    DataType16bit,
+    DataType8bit
+};
+
+enum Approach {
+    Long,
+    Short
+};
+
+enum AfterAxisCase {
+    ElementwiseCase,
+    BlockedCase
+};
+
+template <x64::cpu_isa_t isa>
+class jitGatherKernelBase;
+
+template<x64::cpu_isa_t isa>
+using poolVmask = RegistersPool::Reg<typename jitGatherKernelBase<isa>::Vmask>;
+
+template<x64::cpu_isa_t isa>
+using poolVmm = RegistersPool::Reg<typename jitGatherKernelBase<isa>::Vmm>;
+
+template <x64::cpu_isa_t isa>
+class jitGatherKernelBase : public jitGatherKernelInterface, public x64::jit_generator {
+public:
+    using Vmm = typename x64::cpu_isa_traits<isa>::Vmm;
+    using Vmask = typename dnnl::impl::utils::conditional<isa == x64::avx2, Xbyak::Ymm, Xbyak::Opmask>::type;
+    jitGatherKernelBase(const char *name) : x64::jit_generator(name) {}
+
+protected:
+    static const uint32_t indicesTypeSize = sizeof(uint32_t);
+    static const uint8_t idxTypeShift = 2;
+
+    struct ShiftCalculator {
+        virtual ~ShiftCalculator() = default;
+        virtual std::tuple<poolVmask<isa> /*kDstMask*/, poolVmm<isa> /*vDstShifts*/> calcSrcShift(jitGatherKernelBase& kernel, bool shiftFirst) = 0;
+    };
+
+    template<AfterAxisCase C, Approach A, typename unused = void>
+    struct ShiftCalculatorImpl : public ShiftCalculator {};
+
+    template<typename unused>
+    struct ShiftCalculatorImpl<ElementwiseCase, Short, unused> : public ShiftCalculator {
+        void allocateRegisters(jitGatherKernelBase& kernel);
+        void releaseRegisters();
+        void uploadParamsForApproachSpecific(jitGatherKernelBase& kernel);
+        std::tuple<poolVmask<isa> /*kDstMask*/, poolVmm<isa> /*vDstShifts*/> calcSrcShift(jitGatherKernelBase& kernel, bool shiftFirst) override;
+
+        RegistersPool::Reg<Vmm> vmmBeforeAxDiffB;
+        RegistersPool::Reg<Vmm> vmmSrcAfterBatchSizeB;
+        RegistersPool::Reg<Vmm>  vmmPermIdxMask;
+    };
+
+    template<typename unused>
+    struct ShiftCalculatorImpl<ElementwiseCase, Long, unused> : public ShiftCalculator {
+        void allocateRegisters(jitGatherKernelBase& kernel);
+        void releaseRegisters();
+        void uploadParamsForApproachSpecific(jitGatherKernelBase& kernel);
+        std::tuple<poolVmask<isa> /*kDstMask*/, poolVmm<isa> /*vDstShifts*/> calcSrcShift(jitGatherKernelBase& kernel, bool shiftFirst) override;
+
+        Xbyak::Reg64 regBetweenBatchAndAxisSize;
+        RegistersPool::Reg<Xbyak::Reg64> regSpecIdxSizeB;
+        RegistersPool::Reg<Xbyak::Reg64> regBetweenBatchAndAxisIter;
+        RegistersPool::Reg<Xbyak::Reg64> regIdxIter;
+
+        RegistersPool::Reg<Vmm> vmmIdxBatchSumB;
+        RegistersPool::Reg<Vmm> vmmVecLenB;
+        RegistersPool::Reg<Vmm> vmmAxisAndAfterAxisSizeB;
+    };
+
+    template<typename unused>
+    struct ShiftCalculatorImpl<BlockedCase, Short, unused> : public ShiftCalculator {
+        void allocateRegisters(jitGatherKernelBase& kernel);
+        void uploadParamsForApproachSpecific(jitGatherKernelBase& kernel);
+        std::tuple<poolVmask<isa> /*kDstMask*/, poolVmm<isa> /*vDstShifts*/> calcSrcShift(jitGatherKernelBase& kernel, bool shiftFirst) override;
+
+        RegistersPool::Reg<Xbyak::Reg64> rSpecIdxAndAfterAxIterB;
+        RegistersPool::Reg<Xbyak::Reg64> rSpecIdxAndAfterAxSizeB;
+
+        RegistersPool::Reg<Vmm> vmmAxisAndAfterAxisSizeB;
+        RegistersPool::Reg<Vmm> vmmSrcAfterBatchSizeB;
+        RegistersPool::Reg<Vmm> vmmAfterAxisIdxB;
+        RegistersPool::Reg<Vmm> vmmAfterAxisPermMask;
+        RegistersPool::Reg<Vmm> vmmSpecIdxDiff;
+        RegistersPool::Reg<Vmm> vmmAfterAxisSize;
+        RegistersPool::Reg<Vmm> vmmBeforeAxPermMask;
+    };
+
+
+public:
+    void initialize(const jGatherConfParams& jcp) override;
+    bool isSameParams(const jGatherConfParams& jcp) override;
+    void create_ker() override;
+    void generate() override;
+    void operator() (const gatherJitExecArgs *args) override {
         assert(ker_);
         ker_(args);
     }
-    explicit jitGatherKernelBase(const jGatherConfParams& jcp) : ker_(nullptr), jcp(jcp) {}
-    virtual ~jitGatherKernelBase() {}
-
-    virtual void create_ker() = 0;
-    uint64_t getVecLen() {
-        return vlen;
-    }
-    uint64_t getDataElPerVec() {
-        return dataElPerVec;
-    }
-    uint64_t getIdxElPerVec() {
-        return idxElPerVec;
-    }
-    virtual bool isSupportedConfiguration(uint64_t afterAxisSize) = 0;
+    uint64_t getVecLen() const override { return x64::cpu_isa_traits<isa>::vlen; }
+    uint64_t getDataElPerVec() const override { return getVecLen() / getDataTypeSize(); }
+    uint64_t getIdxElPerVec() const override { return getVecLen() / indicesTypeSize; }
+    virtual uint64_t getDataTypeSize() const = 0;
+    virtual uint8_t getDataTypeShift() const = 0;
 
 protected:
-    jGatherConfParams jcp;
-    uint64_t vlen = 0lu;
-    uint64_t dataElPerVec = 0lu;
-    uint64_t idxElPerVec = 0lu;
-    static const unsigned shufMask8bitUni[16];
-    static const unsigned permMask8bitA2[8];
-    static const unsigned permMask8bitA5[16];
-    static const unsigned shufMask16bitUni[16];
-    static const unsigned permMask16bitA2[8];
-    static const unsigned permMask16bitA5[16];
-    static const unsigned incVec[16];
-
-    int shortPermIdx[16];
-    int shortBeforeAxisDiff[16];
-};
-
-template <dnnl::impl::cpu::x64::cpu_isa_t isa>
-struct jitUniGatherKernel : public jitGatherKernelBase, public dnnl::impl::cpu::x64::jit_generator {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jitUniGatherKernel)
-
-    explicit jitUniGatherKernel(const jGatherConfParams& jcp);
-
-    void create_ker() override;
-    void generate() override;
-
-    bool isSupportedConfiguration(uint64_t afterAxisSize) override;
+    std::tuple<poolVmask<isa> /*kDstMask*/, poolVmm<isa> /*vDstShifts*/> calculateIndexesForShortCase(
+            Vmm& srcBeforeAxisSumB, Vmm& srcAfterBatchSizeB);
+    poolVmask<isa> calcAllOnesMask(Vmm& vAux);
+    void uploadParamPtrWithVpbroadcastd(const Vmm& vmmDest, size_t offset);
+    void uploadParamPtrWithVmovups(const Vmm& vmmDest, size_t offset);
+    virtual void generateDynamicitySpecific() = 0;
+    void process(ShiftCalculator& shiftCalculator);
+    virtual void processDataTypeSpecific(ShiftCalculator& shiftCalculator) = 0;
+    void tail(ShiftCalculator& shiftCalculator, bool shiftFirst);
+    poolVmm<isa> shiftIdxAndGather(ShiftCalculator& shiftCalculator, bool shiftFirst);
+    void uniVpGatherDd(Vmm& vDst, const Xbyak::Address& srcAddr, Vmask& vMask);
+    poolVmask<isa> normalizeIndexesAndCalcShifts(Vmm& rawIndices, poolVmask<isa> kDstMask = poolVmask<isa>());
+    void fillRestWorkMask(Vmask& kMask, const Xbyak::Reg& rWorkRest);
+    void combineMasks(Vmask& maskA, const Vmask& maskB);
+    void normWithUpperBound(Vmm& vTarget, Vmm& vMax, Vmask& kAuxMask);
+    void fillVlenVector(RegistersPool::Reg<Vmm>& vmmVecLenB);
+    void storeVectorPart(const Xbyak::Reg& rDst, const Xbyak::Reg& rToStoreCounter, Vmm& vmmSrc);
 
 protected:
-    using Vmm = typename dnnl::impl::utils::conditional<isa == dnnl::impl::cpu::x64::avx2, Xbyak::Ymm, Xbyak::Zmm>::type;
-    using Vmask = typename dnnl::impl::utils::conditional<isa == dnnl::impl::cpu::x64::avx2, Xbyak::Ymm, Xbyak::Opmask>::type;
-    static const uint32_t vlenXmm = dnnl::impl::cpu::x64::cpu_isa_traits<dnnl::impl::cpu::x64::sse41>::vlen;
-    static const uint32_t indicesTypeSize = sizeof(uint32_t);
-    static const uint8_t idxTypeShift = 2;
-    uint8_t dataTypeShift = 0;
-
-    // Suffix B means "In Bytes".
-    // 64b registers.
-    const Xbyak::Reg64& regSrc = r8;
-    const Xbyak::Reg64& regDst = r9;
-    const Xbyak::Reg64& regIndices = r10;
-    const Xbyak::Reg64& regIdxIter = r11;
-    const Xbyak::Reg64& regWorkAmount = r12;
-    const Xbyak::Reg64& regSpecIdxSizeB = r13;
-    const Xbyak::Reg64& regAux1 = r14;
-    const Xbyak::Reg64& regAux2 = rsi;
-    const Xbyak::Reg64& regBetweenBatchAndAxisIter = r15;
-    const Xbyak::Reg64& regBetweenBatchAndAxisSize = rbx;
-    const Xbyak::Reg64& rSpecIdxAndAfterAxIterB = regIdxIter;
-    const Xbyak::Reg64& rSpecIdxAndAfterAxSizeB = regSpecIdxSizeB;
+    void (*ker_)(const gatherJitExecArgs *);
+    using Reg64 = Xbyak::Reg64;
+    using Operand = Xbyak::Operand;
+    RegistersPool::Ptr regPool = RegistersPool::create<isa>({
+        // the list of the registers to be excluded from pool
+        Reg64(Operand::RAX), Reg64(Operand::RCX), Reg64(Operand::RDX), Reg64(Operand::RBX),
+        Reg64(Operand::RBP), Reg64(Operand::RDI),
+        Xbyak::Opmask(0), // Do not use k0 with gather instruction. The k0 has special meaning there.
+    });
+    uint64_t beforeAxisSize = 0lu;
+    uint64_t specIdxSize = 0lu;
+    uint64_t batchDims = 0lu;
+    uint64_t afterAxisSize = 0lu;
+    bool reverseIndexing = true;
+    bool dynamicShapes = false;
 
     const Xbyak::Reg64 regParams = Xbyak::Reg64(dnnl::impl::cpu::x64::abi_param_regs[0]);
+    const RegistersPool::Reg<Xbyak::Reg64> regDst {regPool, 9};
+    const RegistersPool::Reg<Xbyak::Reg64> regIndices {regPool, 10};
+    const RegistersPool::Reg<Xbyak::Reg64> regWorkAmount {regPool, 12};
+    RegistersPool::Reg<Vmm> vmmSpecIdxSizeB {this->regPool, 10};
+    RegistersPool::Reg<Vmm> vmmSpecIdxB {this->regPool, 9};
+    RegistersPool::Reg<Vmm> vmmSrcBeforeAxisSumB {this->regPool, 8};
 
-    // 32b registers.
-    Xbyak::Reg32 reg32IdxIter = Xbyak::Reg32(regIdxIter.getIdx());
-    Xbyak::Reg32 reg32SpecIdxSizeB = Xbyak::Reg32(regSpecIdxSizeB.getIdx());
-    Xbyak::Reg32 reg32BetweenBatchAndAxisSize = Xbyak::Reg32(regBetweenBatchAndAxisSize.getIdx());
-    Xbyak::Reg32 reg32BetweenBatchAndAxisIter = Xbyak::Reg32(regBetweenBatchAndAxisIter.getIdx());
-    Xbyak::Reg32 reg32Aux1 = Xbyak::Reg32(regAux1.getIdx());
-    Xbyak::Reg32 reg32Aux2 = Xbyak::Reg32(regAux2.getIdx());
+private:
+    const RegistersPool::Reg<Xbyak::Reg64> regSrc {regPool, 8};
+    RegistersPool::Reg<Vmm> vmmZeros {regPool, 7};
+    RegistersPool::Reg<Vmm> vmmAxisDim {regPool, 11};
+};
 
-    // Masks pool. Do not use k0 with gather instruction!
-    Vmask masksContainer[8] = {Vmask(0), Vmask(1), Vmask(2), Vmask(3), Vmask(4), Vmask(5), Vmask(6), Vmask(7)};
-    // Auxiliary pool.
-    Vmm vmmAuxContainer[12] = {Vmm(0), Vmm(1), Vmm(2), Vmm(3), Vmm(4), Vmm(5), Vmm(6), /*AVX5*/ Vmm(16), Vmm(17), Vmm(18), Vmm(19), Vmm(20)};
-    // Common.
-    Vmm vmmZeros = Vmm(7);
-    Vmm vmmSrcBeforeAxisSumB = Vmm(8);
-    Vmm vmmSpecIdxB = Vmm(9);
-    Vmm vmmSpecIdxSizeB = Vmm(10);
-    Vmm vmmAxisDim = Vmm(11);
-    Vmm vmmAxisAndAfterAxisSizeB = Vmm(12);
+template<x64::cpu_isa_t isa, DataTypeSize S>
+struct jitGatherKernelForDataTypeSize : public jitGatherKernelBase<isa> {};
 
-    // Only short.
-    Vmm  vmmSrcAfterBatchSizeB = Vmm(13);
-    Vmm  vmmPermIdxMask = Vmm(14);
-    Vmm& vmmBeforeAxDiffB = vmmAxisAndAfterAxisSizeB;
-    // Blocked short.
-    Vmm& vmmSpecIdxDiff = vmmAuxContainer[4];
-    Vmm& vmmAfterAxisSize = vmmAuxContainer[5];
-    Vmm  vmmAfterAxisIdxB = Vmm(15);
-    Vmm& vmmAfterAxisPermMask = vmmPermIdxMask;
-    Vmm& vmmBeforeAxPermMask = vmmAuxContainer[6];
-    // Only long.
-    Vmm vmmVecLenB = Vmm(13);
-    Vmm vmmIdxBatchSumB = Vmm(14);
+template<x64::cpu_isa_t isa>
+struct jitGatherKernelForDataTypeSize<isa, DataType32bit> : public jitGatherKernelBase<isa> {
+    using Vmm = typename jitGatherKernelBase<isa>::Vmm;
+    jitGatherKernelForDataTypeSize(const char *name) : jitGatherKernelBase<isa>(name) {}
+    uint64_t getDataTypeSize() const override { return 4lu; }
+    uint8_t getDataTypeShift() const override { return 2; }
+    void processDataTypeSpecific(typename jitGatherKernelBase<isa>::ShiftCalculator& shiftCalculator) override;
+};
 
-    // XMM
-    Xbyak::Xmm xmmAuxContainer[6] = {Xbyak::Xmm(0), Xbyak::Xmm(1), Xbyak::Xmm(2), Xbyak::Xmm(3), Xbyak::Xmm(4), Xbyak::Xmm(16)};
-    Xbyak::Xmm xmmZeros = Xbyak::Xmm(vmmZeros.getIdx());
-    Xbyak::Xmm xmmSrcBeforeAxisSum = Xbyak::Xmm(vmmSrcBeforeAxisSumB.getIdx());
-    Xbyak::Xmm xmmSpecIdxSizeB = Xbyak::Xmm(vmmSpecIdxSizeB.getIdx());
-    Xbyak::Xmm xmmSpecIdxB = Xbyak::Xmm(vmmSpecIdxB.getIdx());
+template<x64::cpu_isa_t isa>
+struct jitGatherKernelForDataTypeSize<isa, DataType16bit> : public jitGatherKernelBase<isa> {
+    using Vmm = typename jitGatherKernelBase<isa>::Vmm;
+    jitGatherKernelForDataTypeSize(const char *name) : jitGatherKernelBase<isa>(name) {}
+    uint64_t getDataTypeSize() const override { return 2lu; }
+    uint8_t getDataTypeShift() const override { return 1; }
+    void processDataTypeSpecific(typename jitGatherKernelBase<isa>::ShiftCalculator& shiftCalculator) override;
+};
 
 
-    void calcSrcShiftLong(Vmm* vAuxPool, bool shiftFirst = true);
-    void calcSrcShiftLongBlock(Vmm* vAuxPool, bool shiftFirst = true);
-    void calcSrcShiftShort(Vmm* vAuxPool, bool shiftFirst = true);
-    void calcSrcShiftShortBlock(Vmm* vAuxPool, bool shiftFirst);
-    void process(bool isShortIdx, bool blocked);
-    void process32b(bool isShortIdx, bool blocked);
-    void process16b(bool isShortIdx, bool blocked);
-    void process8b(bool isShortIdx, bool blocked);
-    void shiftIdxAndGather(Vmm* vAuxPool, bool isShortIdx, bool shiftFirst, bool blocked);
-    void tail(bool isShortIdx, bool shiftFirst = true, bool blocked = false);
-    // Aux functions.
-    void normalizeRawIndices(Vmm& rawIndices, Vmask& dstMask, Vmask& aux);
-    void normWithUpperBound(Vmm& vTarget, Vmm& vMax, Vmask& kAuxMask);
-    void fillRestWorkMask(Vmask& kMask, Vmm& vAux, const Xbyak::Reg64& rWorkRest, const Xbyak::Reg64& rAux0, const Xbyak::Reg64& rAux1);
-    void storeVectorPart(const Xbyak::Reg64& rDst, const Xbyak::Reg64& rToStoreCounter, Vmm& vmmSrc, Vmm& vAux);
-    void uniVpGatherDd(Vmm& vDst, const Xbyak::Address& srcAddr, Vmask& vMask);
-    void fillVlenVector();
+template<x64::cpu_isa_t isa>
+struct jitGatherKernelForDataTypeSize<isa, DataType8bit> : public jitGatherKernelBase<isa> {
+    using Vmm = typename jitGatherKernelBase<isa>::Vmm;
+    jitGatherKernelForDataTypeSize(const char *name) : jitGatherKernelBase<isa>(name) {}
+    uint64_t getDataTypeSize() const override { return 1lu; }
+    uint8_t getDataTypeShift() const override { return 0; }
+    void processDataTypeSpecific(typename jitGatherKernelBase<isa>::ShiftCalculator& shiftCalculator) override;
+    poolVmm<isa> calculateIdxShiftsForHalfIteration(typename jitGatherKernelBase<isa>::ShiftCalculator& shiftCalculator,
+                                                    Vmm& vShufMask, bool shiftFirst, poolVmm<isa> halfPart = poolVmm<isa>());
+};
 
-    const unsigned* permMask8bitUni;
-    const unsigned* permMask16bitUni;
+
+template<x64::cpu_isa_t isa, DataTypeSize S, AfterAxisCase C, Approach A>
+struct jitGatherKernelForStaticShapes : public jitGatherKernelForDataTypeSize<isa, S> {
+    using Vmm = typename jitGatherKernelBase<isa>::Vmm;
+    jitGatherKernelForStaticShapes() : jitGatherKernelForDataTypeSize<isa, S>(jit_name()) {}
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jitGatherKernelForDynamicity)
+protected:
+    void generateDynamicitySpecific() override;
+
+    typename jitGatherKernelBase<isa>::template ShiftCalculatorImpl<C, A> shiftCalculator;
+};
+
+
+template<x64::cpu_isa_t isa, DataTypeSize S>
+struct jitGatherKernelForDynamicShapes : public jitGatherKernelForDataTypeSize<isa, S> {
+    using Vmm = typename jitGatherKernelBase<isa>::Vmm;
+    jitGatherKernelForDynamicShapes() : jitGatherKernelForDataTypeSize<isa, S>(jit_name()) {}
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jitGatherKernelForDynamicShapes)
+protected:
+    void generateDynamicitySpecific() override;
+
+    uint64_t idxElPerVec = 0lu;
 };
 
 }   // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/kernels/stack_allocator.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/stack_allocator.hpp
@@ -1,0 +1,474 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <ie/ie_common.h>
+#include <cpu/x64/jit_generator.hpp>
+
+namespace ov {
+namespace intel_cpu {
+
+namespace x64 = dnnl::impl::cpu::x64;
+
+class StackAllocator final {
+public:
+    class Transaction;
+    class Address;
+    template<typename TReg>
+    class Reg;
+
+    StackAllocator(x64::jit_generator& code_gen)
+            : StackAllocator{code_gen, code_gen.rbp} {
+    }
+
+    StackAllocator(x64::jit_generator& code_gen, const Xbyak::Reg& bp)
+            : StackAllocator{code_gen, bp, 1} {
+    }
+
+    StackAllocator(x64::jit_generator& code_gen, const size_t alignment)
+            : StackAllocator{code_gen, code_gen.rbp, alignment} {
+    }
+
+    StackAllocator(x64::jit_generator& code_gen,
+                   const Xbyak::Reg& bp,
+                   const size_t alignment)
+            : code_generator{code_gen}
+            , base_pointer{Xbyak::Reg64{bp.getIdx()}}
+            , alignment{alignment} {
+        checkUnique(true);
+        alignStack(true);
+        code_generator.mov(base_pointer, code_generator.rsp);
+    }
+
+    ~StackAllocator() {
+        release();
+        alignStack(false);
+        checkUnique(false);
+    }
+
+    void release() {
+        current_offset = {};
+        commit();
+    }
+
+    friend void stack_mov(Address& addr, const Xbyak::Xmm& vmm);
+    friend void stack_mov(Address& addr, const Xbyak::Reg& reg);
+    friend void stack_mov(const Xbyak::Xmm& vmm, const Address& addr);
+    friend void stack_mov(const Xbyak::Reg& reg, const Address& addr);
+
+private:
+    struct Allocation {
+        using Ptr = std::shared_ptr<Allocation>;
+
+        Allocation(const Xbyak::Address& address,
+                   const size_t offset,
+                   const size_t size)
+                : address(address)
+                , offset(offset)
+                , size(size) {}
+
+        bool is_used = true;
+        bool is_transaction = false;
+        Xbyak::Address address;
+        size_t offset{};
+        size_t size{};
+    };
+
+    void alignStack(bool isCtor) {
+        if (1 != alignment) {
+            constexpr size_t kReg64Size = 0x08;
+            if (isCtor) {
+                Xbyak::Label l_stack_aligned;
+                const Xbyak::Reg64 reg_base_stack_offset{base_pointer.getIdx()};
+                code_generator.mov(reg_base_stack_offset, static_cast<uint64_t>(kReg64Size));
+
+                const Xbyak::Reg64 reg_base_addr{Xbyak::Operand::RAX};
+                const Xbyak::Reg64 reg_reminder{Xbyak::Operand::RDX};
+                const Xbyak::Reg64 reg_alignment{Xbyak::Operand::RCX};
+
+                code_generator.push(reg_base_addr);
+                code_generator.push(reg_reminder);
+                code_generator.push(reg_alignment);
+
+                code_generator.xor_(reg_reminder, reg_reminder);
+
+                code_generator.mov(reg_base_addr, code_generator.rsp);
+                code_generator.add(reg_base_addr, 3 * kReg64Size - kReg64Size);
+                code_generator.mov(reg_alignment, alignment);
+                code_generator.idiv(reg_alignment);
+                code_generator.cmp(reg_reminder, static_cast<uint64_t>(0x00));
+                code_generator.je(l_stack_aligned);
+                code_generator.add(reg_base_stack_offset, reg_reminder);
+                code_generator.L(l_stack_aligned);
+
+                code_generator.pop(reg_alignment);
+                code_generator.pop(reg_reminder);
+                code_generator.pop(reg_base_addr);
+
+                code_generator.sub(code_generator.rsp, reg_base_stack_offset);
+                code_generator.mov(code_generator.ptr[code_generator.rsp], reg_base_stack_offset);
+            } else {
+                code_generator.add(code_generator.rsp, code_generator.ptr[code_generator.rsp]);
+            }
+        }
+    }
+
+    Allocation::Ptr allocate(const size_t alloc_size,
+                             const size_t requested_alignment,
+                             const bool is_transaction = false) {
+        if (alignment % requested_alignment != 0) {
+            IE_THROW() << "Requested alignment should have 0 reminder of alignment % align !!";
+        }
+
+        std::vector<Allocation::Ptr> free_allocations{};
+        for (const auto& alloc : allocations) {
+            if (!alloc->is_used &&
+                alloc_size <= alloc->size &&
+                (alloc->offset % requested_alignment) == 0) {
+                free_allocations.push_back(alloc);
+            }
+        }
+        std::sort(free_allocations.begin(), free_allocations.end(),
+                  [](const Allocation::Ptr& alloc0, const Allocation::Ptr& alloc1) {
+                      return alloc0->size < alloc1->size;
+                  });
+        if (!free_allocations.empty()) {
+            const auto alloc = free_allocations.front();
+            alloc->is_used = true;
+            alloc->is_transaction = is_transaction;
+            return alloc;
+        } else {
+            size_t alloc_offset = 0;
+            if (requested_alignment > 1) {
+                alloc_offset = (requested_alignment - ((current_offset+alloc_size) % requested_alignment));
+            }
+
+            const size_t aligned_alloc_size = alloc_offset + alloc_size;
+            current_offset += aligned_alloc_size;
+            Xbyak::Address addr = code_generator.ptr[base_pointer - current_offset];
+            const auto alloc = std::make_shared<Allocation>(addr, current_offset, aligned_alloc_size);
+            alloc->is_transaction = is_transaction;
+            allocations.push_back(alloc);
+            return alloc;
+        }
+    }
+
+    void deallocate() {
+        while (!allocations.empty()) {
+            const auto& last = allocations.back();
+            if (last->is_used) {
+                break;
+            }
+            current_offset -= last->size;
+            allocations.pop_back();
+        }
+    }
+
+    void checkUnique(bool isCtor) {
+        static thread_local bool isCreated = false;
+        if (isCtor) {
+            if (isCreated) {
+                IE_THROW() << "There should be only one instance of StackAllocator per thread !!";
+            }
+            isCreated = true;
+        } else {
+            isCreated = false;
+        }
+    }
+
+    bool isTransaction() const {
+        return is_transaction_;
+    }
+
+    void begin() {
+        is_transaction_ = true;
+    }
+
+    void commit() {
+        if (current_offset > offset) {
+            code_generator.sub(code_generator.rsp, current_offset - offset);
+            offset = current_offset;
+        } else if (offset > current_offset) {
+            code_generator.add(code_generator.rsp, offset - current_offset);
+            offset = current_offset;
+        }
+        is_transaction_ = false;
+        for (auto& alloc : allocations) {
+            alloc->is_transaction = false;
+        }
+    }
+
+    x64::jit_generator& code_generator;
+    const Xbyak::Reg base_pointer;
+
+    bool is_transaction_{};
+    size_t offset{};
+    size_t current_offset{};
+    size_t alignment{};
+    std::vector<Allocation::Ptr> allocations{};
+};
+
+void stack_mov(StackAllocator::Address& addr, const Xbyak::Xmm& vmm);
+void stack_mov(StackAllocator::Address& addr, const Xbyak::Reg& reg);
+void stack_mov(const Xbyak::Xmm& vmm, const StackAllocator::Address& addr);
+void stack_mov(const Xbyak::Reg& reg, const StackAllocator::Address& addr);
+
+class StackAllocator::Transaction {
+public:
+    friend class StackAllocator::Address;
+
+    Transaction(StackAllocator& stack_allocator)
+            : stack_allocator_{stack_allocator} {
+        checkUnique(true);
+    }
+
+    ~Transaction() {
+        checkUnique(false);
+        commit();
+    }
+
+    void begin() {
+        stack_allocator_.begin();
+    }
+
+    void commit() {
+        stack_allocator_.commit();
+    }
+
+private:
+    void checkUnique(bool isCtor) {
+        static thread_local bool isCreated = false;
+        if (isCtor) {
+            if (isCreated) {
+                IE_THROW() << "There should be only one instance of Transaction per thread !!";
+            }
+            isCreated = true;
+        } else {
+            isCreated = false;
+        }
+    }
+
+    StackAllocator& stack_allocator_;
+};
+
+class StackAllocator::Address {
+public:
+    Address(Transaction& transaction,
+            const size_t alloc_size,
+            const size_t requested_alignment = 1)
+            : transaction_{&transaction}
+            , stack_allocator_{transaction.stack_allocator_}
+            , allocation_{stack_allocator_.allocate(alloc_size, requested_alignment, true)} {
+        transaction.begin();
+    }
+
+    Address(StackAllocator& stack_allocator,
+            const size_t alloc_size,
+            const size_t requested_alignment = 1)
+            : stack_allocator_{stack_allocator}
+            , allocation_{stack_allocator_.allocate(alloc_size, requested_alignment)} {
+        if (stack_allocator_.isTransaction()) {
+            IE_THROW() << "Cannot allocate Address out of transaction. Please, finish first transaction !!";
+        }
+        stack_allocator_.commit();
+    }
+
+    Address(const Address& addr) = delete;
+    Address& operator=(const Address& addr) = delete;
+    Address(Address&& addr) noexcept = delete;
+    Address& operator=(Address&& addr) noexcept = delete;
+
+    virtual ~Address() {
+        if (transaction_) {
+            release(*transaction_);
+        } else {
+            release();
+            stack_allocator_.commit();
+        }
+    }
+
+    void release(Transaction& transaction) {
+        if (allocation_) {
+            transaction.begin();
+            allocation_->is_used = false;
+            stack_allocator_.deallocate();
+        }
+        allocation_ = {};
+    }
+
+    void release() {
+        if (allocation_) {
+            if (stack_allocator_.isTransaction()) {
+                IE_THROW() << "Cannot release Address out of transaction. Please, finish first transaction !!";
+            }
+            allocation_->is_used = false;
+            stack_allocator_.deallocate();
+            stack_allocator_.commit();
+        }
+        allocation_ = {};
+    }
+
+    operator Xbyak::Address&() {
+        ensureValid();
+        return allocation_->address;
+    }
+
+    operator const Xbyak::Address&() const {
+        ensureValid();
+        return allocation_->address;
+    }
+
+    virtual Address& operator=(const Xbyak::Xmm& vmm) {
+        stack_mov(*this, vmm);
+        return *this;
+    }
+
+    virtual Address& operator=(const Xbyak::Reg& reg) {
+        stack_mov(*this, reg);
+        return *this;
+    }
+
+    explicit operator bool() const {
+        return isInitialized();
+    }
+
+    bool isInitialized() const {
+        return allocation_ && !allocation_->is_transaction;
+    }
+
+    friend void ::ov::intel_cpu::stack_mov(Address& addr, const Xbyak::Xmm& vmm);
+    friend void ::ov::intel_cpu::stack_mov(Address& addr, const Xbyak::Reg& reg);
+    friend void ::ov::intel_cpu::stack_mov(const Xbyak::Xmm& vmm, const Address& addr);
+    friend void ::ov::intel_cpu::stack_mov(const Xbyak::Reg& reg, const Address& addr);
+
+private:
+    void ensureSize(const Xbyak::Reg& reg) const {
+        ensureValid();
+        const size_t reg_size = reg.getBit() / 8;
+        if (reg_size > allocation_->size) {
+            IE_THROW() << "reg size is bigger than space allocated in StackAllocator !!";
+        }
+    }
+
+    void ensureValid() const {
+        if (!isInitialized()) {
+            IE_THROW() << "StackAllocator::Address is either not initialized or released !!";
+        }
+    }
+
+    x64::jit_generator& generator() const {
+        return stack_allocator_.code_generator;
+    }
+
+    Transaction* transaction_{};
+    StackAllocator& stack_allocator_;
+    Allocation::Ptr allocation_;
+};
+
+template<typename TReg>
+class StackAllocator::Reg : public StackAllocator::Address {
+public:
+    static_assert(std::is_base_of<Xbyak::Reg, TReg>::value, "TReg should be a Xbyak::Reg based !!");
+
+    Reg(StackAllocator::Transaction& transaction)
+            : Address{transaction, TReg{}.getBit() / 8, getAlignment()} {
+    }
+
+    Reg(StackAllocator& stack_allocator)
+            : Address{stack_allocator, TReg{}.getBit() / 8, getAlignment()} {
+    }
+
+    Reg& operator=(const Xbyak::Xmm& vmm) override {
+        Address::operator=(vmm);
+        return *this;
+    }
+
+    Reg& operator=(const Xbyak::Reg& reg) override {
+        Address::operator=(reg);
+        return *this;
+    }
+
+private:
+    static size_t getAlignment() {
+        if (std::is_same<TReg, Xbyak::Zmm>::value) {
+            return x64::cpu_isa_traits<x64::avx512_core>::vlen;
+        } else if (std::is_same<TReg, Xbyak::Ymm>::value) {
+            return x64::cpu_isa_traits<x64::avx2>::vlen;
+        } else if (std::is_same<TReg, Xbyak::Xmm>::value) {
+            return x64::cpu_isa_traits<x64::sse41>::vlen;
+        } else {
+            return 1;
+        }
+    }
+};
+
+inline
+void stack_mov(StackAllocator::Address& addr, const Xbyak::Xmm& vmm) {
+    addr.ensureSize(vmm);
+    x64::jit_generator& generator = addr.generator();
+    if (vmm.isXMM()) {
+        generator.uni_vmovdqu(addr.allocation_->address, Xbyak::Xmm{vmm.getIdx()});
+    } else if (vmm.isYMM()) {
+        generator.uni_vmovdqu(addr.allocation_->address, Xbyak::Ymm{vmm.getIdx()});
+    } else if (vmm.isZMM()) {
+        generator.uni_vmovdqu(addr.allocation_->address, Xbyak::Zmm{vmm.getIdx()});
+    } else {
+        IE_THROW() << "Unknown simd register !!";
+    }
+}
+
+inline
+void stack_mov(StackAllocator::Address& addr, const Xbyak::Reg& reg) {
+    addr.ensureSize(reg);
+    x64::jit_generator& generator = addr.generator();
+    if (reg.isREG(8)) {
+        generator.mov(addr.allocation_->address, Xbyak::Reg8{reg.getIdx()});
+    } else if (reg.isREG(16)) {
+        generator.mov(addr.allocation_->address, Xbyak::Reg16{reg.getIdx()});
+    } else if (reg.isREG(32)) {
+        generator.mov(addr.allocation_->address, Xbyak::Reg32{reg.getIdx()});
+    } else if (reg.isREG(64)) {
+        generator.mov(addr.allocation_->address, Xbyak::Reg64{reg.getIdx()});
+    } else {
+        IE_THROW() << "Unknown general purpose register !!";
+    }
+}
+
+inline
+void stack_mov(const Xbyak::Xmm& vmm, const StackAllocator::Address& addr) {
+    addr.ensureSize(vmm);
+    x64::jit_generator& generator = addr.generator();
+    if (vmm.isXMM()) {
+        generator.uni_vmovdqu(Xbyak::Xmm{vmm.getIdx()}, addr.allocation_->address);
+    } else if (vmm.isYMM()) {
+        generator.uni_vmovdqu(Xbyak::Ymm{vmm.getIdx()}, addr.allocation_->address);
+    } else if (vmm.isZMM()) {
+        generator.uni_vmovdqu(Xbyak::Zmm{vmm.getIdx()}, addr.allocation_->address);
+    } else {
+        IE_THROW() << "Unknown simd register !!";
+    }
+}
+
+inline
+void stack_mov(const Xbyak::Reg& reg, const StackAllocator::Address& addr) {
+    addr.ensureSize(reg);
+    x64::jit_generator& generator = addr.generator();
+    if (reg.isREG(8)) {
+        generator.mov(Xbyak::Reg8{reg.getIdx()}, addr.allocation_->address);
+    } else if (reg.isREG(16)) {
+        generator.mov(Xbyak::Reg16{reg.getIdx()}, addr.allocation_->address);
+    } else if (reg.isREG(32)) {
+        generator.mov(Xbyak::Reg32{reg.getIdx()}, addr.allocation_->address);
+    } else if (reg.isREG(64)) {
+        generator.mov(Xbyak::Reg64{reg.getIdx()}, addr.allocation_->address);
+    } else {
+        IE_THROW() << "Unknown general purpose register !!";
+    }
+}
+
+} // namespace intel_cpu
+} // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/gather.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/gather.cpp
@@ -282,4 +282,27 @@ const auto gatherParamsVec3 = testing::Combine(
 
 INSTANTIATE_TEST_CASE_P(smoke_Vec3, Gather8LayerTest, gatherParamsVec3, Gather8LayerTest::getTestCaseName);
 
+
+const std::vector<std::vector<size_t>> dataShapesBasic = {
+        {6}
+};
+const std::vector<std::vector<size_t>> idxShapesBasic = {
+        {3}
+};
+const std::vector<std::tuple<int, int>> axesBatchesBasic = {
+        {0, 0}
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_static_basic, Gather8LayerTest,
+                        testing::Combine(
+                                testing::ValuesIn(dataShapesBasic),
+                                testing::ValuesIn(idxShapesBasic),
+                                testing::ValuesIn(axesBatchesBasic),
+                                testing::ValuesIn(netPrecisions),
+                                testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                                testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                                testing::Values(InferenceEngine::Layout::ANY),
+                                testing::Values(InferenceEngine::Layout::ANY),
+                                testing::Values(CommonTestUtils::DEVICE_CPU)),
+                        Gather8LayerTest::getTestCaseName);
 }  // namespace

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/gather.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/gather.cpp
@@ -295,9 +295,9 @@ const std::vector<std::tuple<int, int>> axesBatchesBasic = {
 
 INSTANTIATE_TEST_CASE_P(smoke_static_basic, Gather8LayerTest,
                         testing::Combine(
-                                testing::ValuesIn(dataShapesBasic),
-                                testing::ValuesIn(idxShapesBasic),
-                                testing::ValuesIn(axesBatchesBasic),
+                                testing::Values(std::vector<size_t>{6}), // dataShapes
+                                testing::Values(std::vector<size_t>{3}), // idxShapes
+                                testing::Values(std::tuple<int, int>{0, 0}), // axesBatches
                                 testing::ValuesIn(netPrecisions),
                                 testing::Values(InferenceEngine::Precision::UNSPECIFIED),
                                 testing::Values(InferenceEngine::Precision::UNSPECIFIED),
@@ -305,4 +305,18 @@ INSTANTIATE_TEST_CASE_P(smoke_static_basic, Gather8LayerTest,
                                 testing::Values(InferenceEngine::Layout::ANY),
                                 testing::Values(CommonTestUtils::DEVICE_CPU)),
                         Gather8LayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(smoke_static_basic2, Gather8LayerTest,
+                        testing::Combine(
+                                testing::Values(std::vector<size_t>{6, 2}), // dataShapes
+                                testing::Values(std::vector<size_t>{3}), // idxShapes
+                                testing::Values(std::tuple<int, int>{0, 0}), // axesBatches
+                                testing::ValuesIn(netPrecisions),
+                                testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                                testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                                testing::Values(InferenceEngine::Layout::ANY),
+                                testing::Values(InferenceEngine::Layout::ANY),
+                                testing::Values(CommonTestUtils::DEVICE_CPU)),
+                        Gather8LayerTest::getTestCaseName);
+
 }  // namespace


### PR DESCRIPTION
The next cases were implemented for the JIT kernel of the Gather operator.
The Blocked/Short case for static shapes for avx2 for 8-bit and 16-bit data types was implemented.
The Blocked/Short case for dynamic shapes for avx2 and avx512 for 8-bit, 16-bit, and 32-bit data types.

The implementation map for the JIT kernel for the Gather operation.
- avx512
    - dynamic shapes
        - Elementwise case
            - Short subcase  Implemented
            - Long subcase   Implemented
        - Blocked case
            - Short subcase  Implemented in this PR
            - Long subcase   Not implemented
    - static shapes
        - Elementwise case
            - Short subcase  Implemented
            - Long subcase   Implemented
        - Blocked case
            - Short subcase  Implemented
            - Long subcase   Not implemented
- avx2
    - dynamic shapes
        - Elementwise case
            - Short subcase  Implemented
            - Long subcase   Implemented
        - Blocked case
            - Short subcase  Implemented in this PR
            - Long subcase   Not implemented
    - static shapes
        - Elementwise case
            - Short subcase  Implemented
            - Long subcase   Implemented
        - Blocked case
            - Short subcase  Implemented in this PR for 8 bit and 16 bit data types, for 32 bit was implemented earlier
            - Long subcase   Not implemented
- SSE4.1                     Not implemented

This PR uses and depends on the StackAllocator from PR #13790 
This PR is a continuation of PR #13070  and is based on it.
