### PR TITLE
Remove the pdb config to let each project use own vxx.pdb file.

### DIFF
--- a/cmake/developer_package/IEDevScriptsConfig.cmake
+++ b/cmake/developer_package/IEDevScriptsConfig.cmake
@@ -171,8 +171,6 @@ else()
     ov_set_if_not_defined(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_ROOT}/${BIN_FOLDER}/lib)
     ov_set_if_not_defined(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${OUTPUT_ROOT}/${BIN_FOLDER}/lib)
 endif()
-ov_set_if_not_defined(CMAKE_COMPILE_PDB_OUTPUT_DIRECTORY ${OUTPUT_ROOT}/${BIN_FOLDER})
-ov_set_if_not_defined(CMAKE_PDB_OUTPUT_DIRECTORY ${OUTPUT_ROOT}/${BIN_FOLDER})
 ov_set_if_not_defined(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_ROOT}/${BIN_FOLDER})
 
 if(APPLE)


### PR DESCRIPTION
### Details:
 - Remove the config for pdb directory to let each project use own vxxx.pdb file.
 
On Windows, the current config makes all cmake projects use bin/intel64/Release directory as intermediate directory for pdb files. Multiple cl.exe and linker.exe randomly access the pdb file at same time and crash for this. Close the config can solve random error:

fatal error C1041: cannot open program database 'xxx\openvino\bin\intel64\Release\vc140.pdb'; if multiple CL.EXE write to the same .PDB file, please use /FS
