### PR TITLE
DOCS: Rewrite "Install OpenVINO Development Tools" page - port to 22.1

### DIFF
--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -16,7 +16,7 @@ In both cases, Python 3.6 - 3.9 need be installed on your machine before startin
 
 ## <a name="python-developers"></a>For Python Developers
 
-If you are a Python developer, follow the steps in the <a href="openvino_docs_install_guides_install_dev_tools.html#install-dev-tools">Installing OpenVINO Development Tools</a> section on this page to install it. Installing OpenVINO Development Tools will also install OpenVINO Runtime as a dependency, so you don’t need to install OpenVINO Runtime separately. This option is recommended for new users.
+If you are a Python developer, follow the steps in the <a href="#install-dev-tools">Installing OpenVINO Development Tools</a> section on this page to install it. Installing OpenVINO Development Tools will also install OpenVINO Runtime as a dependency, so you don’t need to install OpenVINO Runtime separately. This option is recommended for new users.
 
 ## <a name="cpp-developers"></a>For C++ Developers
 If you are a C++ developer, you must first install OpenVINO Runtime separately to set up the C++ libraries, sample code, and dependencies for building applications with OpenVINO. These files are not included with the PyPI distribution. See the [Install OpenVINO Runtime](./installing-openvino-runtime.md) page to install OpenVINO Runtime from an archive file for your operating system.


### PR DESCRIPTION
Porting:
https://github.com/openvinotoolkit/openvino/pull/13820/

Details:

Rewrote the introductory section to give more explanation of what OpenVINO Dev Tools is
Added "For Python Developers" and "For C++ Developers" sections in the introduction to explain the difference in the install process
Changed the existing "For Python Developers" section to "Installing OpenVINO Development Tools"
In Step 4, added a Sphinx tab to provide different instructions for Python and C++ users. Python users install using pip install openvino-dev, while C++ install using requirements.txt files. (C++ can alternatively install using pip install openvino-dev, but must be careful to use the right version.)
In Step 5, added a sentence to tell users to visit the Troubleshooting page if they encountered errors
Removed the old "For C++ Developers" section
Changed the "What's Next?" section to add more enticing links, similar to https://github.com/openvinotoolkit/openvino/pull/13219
