### PR TITLE
[GNA] Add 1DConv validator for GNA 3.5

### DIFF
--- a/src/plugins/intel_gna/src/backend/gna_limitations.hpp
+++ b/src/plugins/intel_gna/src/backend/gna_limitations.hpp
@@ -142,6 +142,11 @@ public:
 
     virtual bool IsPaddingSupported() const = 0;
 
+    virtual bool ValidateCnn1D(const std::string& name, const uint32_t inHeight, const uint32_t inWidth,
+        const uint32_t inChannels, const uint32_t kH, const uint32_t kW, const uint32_t kN,
+        const uint32_t strideH, const uint32_t strideW, const uint32_t dilationH, const uint32_t dilationW,
+        OvGnaType inPrecision, bool exception = true) const = 0;
+
     static std::unique_ptr<AbstractValidator> Create(const std::string&);
 };
 
@@ -169,20 +174,51 @@ public:
         bool exception = true) const override;
 
     bool IsPaddingSupported() const override;
+
+    bool ValidateCnn1D(const std::string& name, const uint32_t inHeight, const uint32_t inWidth,
+    const uint32_t inChannels, const uint32_t kH, const uint32_t kW, const uint32_t kN,
+    const uint32_t strideH, const uint32_t strideW, const uint32_t dilationH, const uint32_t dilationW,
+    OvGnaType inPrecision, bool exception = true) const override;
 };
 
 class Validator_35 : public AbstractValidator {
-    static const RangeLimit2D kInputHWLimit;
-    static const RangeLimit kInputChannelsNumberLimit1B;
-    static const RangeLimit kInputChannelsNumberLimit2B;
+    struct CnnLimits {
+        const RangeLimit2D kInputHWLimit;
+        const RangeLimit kInputChannelsNumberLimit1B;
+        const RangeLimit kInputChannelsNumberLimit2B;
+        const RangeLimit kKernelNumberLimit;
+        const RangeLimit2D kKerneHWlLimit1B;
+        const RangeLimit2D kKerneHWlLimit2B;
+        const RangeLimit2D kStrideHWLimit1B;
+        const RangeLimit2D kStrideHWLimit2B;
+        const RangeLimit2D kDilationLimit;
+        const RangeLimit2D kPoolingWindowHWLimit;
+        const RangeLimit2D kPoolingStrideHWLimit;
+    };
 
-    static const RangeLimit kKernelNumberLimit;
-    static const RangeLimit2D kKerneHWlLimit;
-    static const RangeLimit2D kStrideHWLimit;
-    static const RangeLimit2D kDilationLimit;
+    static const CnnLimits kCnn2DLimits;
+    static const CnnLimits kCnn1DLimits;
 
-    static const RangeLimit2D kPoolingWindowHWLimit;
-    static const RangeLimit2D kPoolingStrideHWLimit;
+    std::string ValidateCnn(const CnnLimits& limits,
+                       const std::string& name,
+                       const uint32_t inHeight,
+                       const uint32_t inWidth,
+                       const uint32_t inChannels,
+                       const uint32_t kH,
+                       const uint32_t kW,
+                       const uint32_t kN,
+                       const uint32_t strideH,
+                       const uint32_t strideW,
+                       const uint32_t dilationH,
+                       const uint32_t dilationW,
+                       OvGnaType inPrecision) const;
+
+    std::string ValidatePooling(const CnnLimits& limits,
+                                const std::string& name,
+                           const uint32_t windowH,
+                           const uint32_t windowW,
+                           const uint32_t strideH,
+                           const uint32_t strideW) const;
 
 public:
     Validator_35() = default;
@@ -198,6 +234,11 @@ public:
         bool exception = true) const override;
 
     bool IsPaddingSupported() const override;
+
+    bool ValidateCnn1D(const std::string& name, const uint32_t inHeight, const uint32_t inWidth,
+        const uint32_t inChannels, const uint32_t kH, const uint32_t kW, const uint32_t kN,
+        const uint32_t strideH, const uint32_t strideW, const uint32_t dilationH, const uint32_t dilationW,
+        OvGnaType inPrecision, bool exception = true) const override;
 };
 } // namespace Cnn2D
 

--- a/src/plugins/intel_gna/src/gna_graph_compiler.hpp
+++ b/src/plugins/intel_gna/src/gna_graph_compiler.hpp
@@ -32,14 +32,14 @@ class GNAGraphCompiler {
 private:
     std::shared_ptr<GNAPluginNS::backend::AMIntelDNN> dnn;
     std::shared_ptr<GNAPluginNS::gna_memory_type> gnamem;
-    std::shared_ptr<GNAPluginNS::GNAFlags> gnaFlags;
     std::shared_ptr<GNAPluginNS::GnaInputs> inputs_ptr_;
 
     // layers with extra storage for connections and additional
     // non trivial processing
 
-    SplitConnection  split_connection;
-    CropConnection   crop_connection;
+    SplitConnection split_connection;
+    CropConnection crop_connection;
+    const Config& gna_config;
 
     intel_dnn_component_t * find_first_unused_input(InferenceEngine::CNNLayerPtr current);
 
@@ -51,15 +51,17 @@ private:
 
     std::unique_ptr<const GNALimitations::Cnn2D::AbstractValidator> cnn2dValidator;
 
+    bool ShouldUseOnlyConv2DGnaIface() const;
+
 public:
     GNAPluginNS::backend::DnnComponents dnnComponents;
     MemoryConnection memory_connection;
     ConcatConnection concat_connection;
     ConstConnections const_connections;
 
+    GNAGraphCompiler(const Config& gna_config);
     void setGNAMemoryPtr(std::shared_ptr<GNAPluginNS::gna_memory_type> gnaMemPtr);
     void setDNNPtr(std::shared_ptr<GNAPluginNS::backend::AMIntelDNN> dnnPtr);
-    void setGNAFlagsPtr(std::shared_ptr<GNAPluginNS::GNAFlags> gnaFlagsPtr);
     void setInputsPtr(std::shared_ptr<GNAPluginNS::GnaInputs> inputsPtr);
 
     void fillMemoryConnections(std::unordered_map<std::string,

--- a/src/plugins/intel_gna/src/gna_plugin.cpp
+++ b/src/plugins/intel_gna/src/gna_plugin.cpp
@@ -335,7 +335,8 @@ void GNAPlugin::ImportFrames(void *ptr_dst,
     }
 }
 
-GNAPlugin::GNAPlugin() {
+GNAPlugin::GNAPlugin() :
+    graphCompiler(config) {
     Init();
     UpdateFieldsFromConfig();
     InitGNADevice();
@@ -350,7 +351,8 @@ std::string GNAPluginNS::GNAPlugin::GetCompileTarget() const {
     return common::kGnaTarget3_0;
 }
 
-GNAPlugin::GNAPlugin(const std::map<std::string, std::string>& configMap) {
+GNAPlugin::GNAPlugin(const std::map<std::string, std::string>& configMap) :
+    graphCompiler(config) {
     Init();
     SetConfig(configMap);
     InitGNADevice();
@@ -365,7 +367,6 @@ void GNAPlugin::Init() {
     outputs_ = GNAPluginNS::GnaOutputs();
 
     graphCompiler.setDNNPtr(dnn);
-    graphCompiler.setGNAFlagsPtr(gnaFlags);
     graphCompiler.setInputsPtr(inputs_ptr_);
 
     requestWorkerPool_ = std::make_shared<request::WorkerPoolImpl>();

--- a/src/plugins/intel_gna/src/layers/gna_convolution_layer.cpp
+++ b/src/plugins/intel_gna/src/layers/gna_convolution_layer.cpp
@@ -25,9 +25,8 @@ bool isMappableFrom2DTo1D(const uint32_t inHeight, const uint32_t inWidth, const
              (inHeight == kernelHeight && strideHeight == 1 && in_channels == 1)));
 }
 
-// 3D input or 2D kernel
-bool isConv2D(const uint32_t inHeight, const uint32_t inWidth, const uint32_t inDepth,
-                 const uint32_t kernelHeight, const uint32_t kernelWidth) {
+bool is3DInputOr2DKernel(const uint32_t inHeight, const uint32_t inWidth, const uint32_t inDepth,
+                         const uint32_t kernelHeight, const uint32_t kernelWidth) {
     return (kernelHeight > 1 && kernelWidth > 1) || (inHeight > 1 && inWidth > 1 && inDepth > 1);
 }
 
@@ -45,7 +44,7 @@ double getWeightsReducer(InferenceEngine::ConvolutionLayer& conv) {
         InferenceEngine::GetDataDimByName(conv.insData.front().lock(), InferenceEngine::DataDimName::H);
     const auto inWidth =
         InferenceEngine::GetDataDimByName(conv.insData.front().lock(), InferenceEngine::DataDimName::W);
-    if (isConv2D(inHeight, inWidth, inDepth, conv._kernel_y, conv._kernel_x) &&
+    if (is3DInputOr2DKernel(inHeight, inWidth, inDepth, conv._kernel_y, conv._kernel_x) &&
          !isMappableFrom2DTo1D(inHeight, inWidth, inDepth, conv._kernel_y, conv._kernel_x, conv._stride_y, conv._stride_x)) {
         const auto kernelSize = conv._kernel_x * conv._kernel_y;
         auto r = std::lower_bound(reducers.begin(), reducers.end(), kernelSize,

--- a/src/plugins/intel_gna/src/layers/gna_convolution_layer.hpp
+++ b/src/plugins/intel_gna/src/layers/gna_convolution_layer.hpp
@@ -14,9 +14,8 @@ bool isMappableFrom2DTo1D(const uint32_t inHeight, const uint32_t inWidth, const
                           const uint32_t kernelHeight, const uint32_t kernelWidth,
                           const uint32_t strideHeight, const uint32_t strideWidth);
 
-// 3D input or 2D kernel
-bool isConv2D(const uint32_t inHeight, const uint32_t inWidth, const uint32_t inDepth,
-    const uint32_t kernelHeight, const uint32_t kernelWidth);
+bool is3DInputOr2DKernel(const uint32_t inHeight, const uint32_t inWidth, const uint32_t inDepth,
+                         const uint32_t kernelHeight, const uint32_t kernelWidth);
 
 double getWeightsReducer(InferenceEngine::ConvolutionLayer& conv);
 

--- a/src/plugins/intel_gna/src/transformations/split_convolution_with_large_buffer_size.cpp
+++ b/src/plugins/intel_gna/src/transformations/split_convolution_with_large_buffer_size.cpp
@@ -31,7 +31,7 @@ static bool shouldSplitCnn(const ngraph::Output<ngraph::Node>& node) {
         auto kW = filters.at(3);
         auto sH = convolution->get_strides().at(0);
         auto sW = convolution->get_strides().at(1);
-        if (GNAPluginNS::GNAConvolutionLayer::isConv2D(height, width, in_channels, kH, kW) &&
+        if (GNAPluginNS::GNAConvolutionLayer::is3DInputOr2DKernel(height, width, in_channels, kH, kW) &&
             !GNAPluginNS::GNAConvolutionLayer::isMappableFrom2DTo1D(height, width, in_channels, kH, kW, sH, sW)) {
             return false;
         }

--- a/src/plugins/intel_gna/tests/functional/pass_tests/conv_with_padding.cpp
+++ b/src/plugins/intel_gna/tests/functional/pass_tests/conv_with_padding.cpp
@@ -68,7 +68,7 @@ protected:
         std::tie(precision, targetDevice, configuration, input_shape, filter_shape, padding_size) = this->GetParam();
 
         GnaLayerTestCheck::SetUp(targetDevice);
-        if (GnaLayerTestCheck::gnaLibVersionLessThan(3.5f)) {
+        if (GnaLayerTestCheck::gnaLibVersionLessThan("3.5")) {
             GTEST_SKIP() << GnaLayerTestCheck::getLastCmpResultMsg() << std::endl;
         }
 

--- a/src/plugins/intel_gna/tests/functional/pass_tests/conv_with_padding.cpp
+++ b/src/plugins/intel_gna/tests/functional/pass_tests/conv_with_padding.cpp
@@ -120,29 +120,64 @@ const std::vector<std::map<std::string, std::string>> configs_gna_3_0 = {
 const std::vector<std::map<std::string, std::string>> configs_gna_3_5 = {
     {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}}};
 
-const std::vector<size_t> input = {1, 8, 16, 16};
-const std::vector<size_t> filter = {8, 8, 2, 2};
-const std::vector<std::ptrdiff_t> no_padding{};
-const std::vector<std::ptrdiff_t> padding{1, 1};
+const std::vector<size_t> input2D = {1, 8, 16, 16};
+const std::vector<size_t> filter2D = {8, 8, 2, 2};
+const std::vector<std::vector<size_t>> inputs2D_gna_3_5 = {{1, 1, 4, 16}, {1, 1, 16, 16}};
+const std::vector<std::vector<size_t>> inputs1D_gna_3_5 = {{1, 1, 1, 16}};
+const std::vector<std::vector<size_t>> filters1D_gna_3_5 = {{1, 1, 1, 2}, {1, 1, 1, 16}};
+const std::vector<std::vector<size_t>> filters2D_mappable_to_1D_gna_3_5 = {{1, 1, 2, 16}};
+const std::vector<std::ptrdiff_t> no_padding ={0, 0};
+const std::vector<std::ptrdiff_t> padding1D = {0, 1};
+const std::vector<std::ptrdiff_t> padding2D = {1, 1};
 
 INSTANTIATE_TEST_SUITE_P(smoke_conv_without_padding,
                          ConvWithPaddingTestPos,
                          ::testing::Combine(::testing::Values(net_precisions),
                                             ::testing::Values(CommonTestUtils::DEVICE_GNA),
                                             ::testing::ValuesIn(configs_gna_3_0_to_3_5),
-                                            ::testing::Values(input),
-                                            ::testing::Values(filter),
+                                            ::testing::Values(input2D),
+                                            ::testing::Values(filter2D),
                                             ::testing::Values(no_padding)),
                          ConvWithPaddingTestPos::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_conv_with_padding_gna_3_5,
+INSTANTIATE_TEST_SUITE_P(smoke_conv_with_padding_input1D_filter1D_gna_3_5,
                          ConvWithPaddingTestPos,
                          ::testing::Combine(::testing::Values(net_precisions),
                                             ::testing::Values(CommonTestUtils::DEVICE_GNA),
                                             ::testing::ValuesIn(configs_gna_3_5),
-                                            ::testing::Values(input),
-                                            ::testing::Values(filter),
-                                            ::testing::Values(padding)),
+                                            ::testing::ValuesIn(inputs1D_gna_3_5),
+                                            ::testing::ValuesIn(filters1D_gna_3_5),
+                                            ::testing::Values(padding1D)),
+                         ConvWithPaddingTestPos::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_conv_with_padding_input2D_filter1D_gna_3_5,
+                         ConvWithPaddingTestPos,
+                         ::testing::Combine(::testing::Values(net_precisions),
+                                            ::testing::Values(CommonTestUtils::DEVICE_GNA),
+                                            ::testing::ValuesIn(configs_gna_3_5),
+                                            ::testing::ValuesIn(inputs2D_gna_3_5),
+                                            ::testing::ValuesIn(filters1D_gna_3_5),
+                                            ::testing::Values(padding1D)),
+                         ConvWithPaddingTestPos::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_conv_with_padding_2D_mappable_to_1D_gna_3_5,
+                         ConvWithPaddingTestPos,
+                         ::testing::Combine(::testing::Values(net_precisions),
+                                            ::testing::Values(CommonTestUtils::DEVICE_GNA),
+                                            ::testing::ValuesIn(configs_gna_3_5),
+                                            ::testing::ValuesIn(inputs2D_gna_3_5),
+                                            ::testing::ValuesIn(filters2D_mappable_to_1D_gna_3_5),
+                                            ::testing::Values(padding1D)),
+                         ConvWithPaddingTestPos::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_conv_with_padding_2D_gna_3_5,
+                         ConvWithPaddingTestPos,
+                         ::testing::Combine(::testing::Values(net_precisions),
+                                            ::testing::Values(CommonTestUtils::DEVICE_GNA),
+                                            ::testing::ValuesIn(configs_gna_3_5),
+                                            ::testing::Values(input2D),
+                                            ::testing::Values(filter2D),
+                                            ::testing::Values(padding2D)),
                          ConvWithPaddingTestPos::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_expect_exception_for_conv_with_padding_when_gna_3_0,
@@ -150,8 +185,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_expect_exception_for_conv_with_padding_when_gna_3
                          ::testing::Combine(::testing::Values(net_precisions),
                                             ::testing::Values(CommonTestUtils::DEVICE_GNA),
                                             ::testing::ValuesIn(configs_gna_3_0),
-                                            ::testing::Values(input),
-                                            ::testing::Values(filter),
-                                            ::testing::Values(padding)),
+                                            ::testing::Values(input2D),
+                                            ::testing::Values(filter2D),
+                                            ::testing::Values(padding2D)),
                          ConvWithPaddingTestNeg::getTestCaseName);
 }  // namespace LayerTestsDefinitions

--- a/src/plugins/intel_gna/tests/functional/pass_tests/convert_padded_to_valid_conv.cpp
+++ b/src/plugins/intel_gna/tests/functional/pass_tests/convert_padded_to_valid_conv.cpp
@@ -102,6 +102,8 @@ public:
     }
 
 protected:
+    GnaLayerTestCheck gnaVersionCheck;
+
     void SetUp() override {
         threshold = 0.015f;
         convSpecificParams convParams;
@@ -200,25 +202,21 @@ protected:
 
         auto result = std::make_shared<Result>(lastOp);
         function = std::make_shared<Function>(ResultVector{result}, ParameterVector{input});
+        gnaVersionCheck.SetUp(targetDevice);
     }
 };
 
-class Gna30PaddedToValidConvTest : public PaddedToValidConvTest {
-protected:
-    void Run() override {
-        PaddedToValidConvTest::Run();
-    }
-
-    void SetUp() override {
-        PaddedToValidConvTest::SetUp();
-    }
-};
+using Gna35PaddedToValidConvTest = PaddedToValidConvTest;
 
 TEST_P(PaddedToValidConvTest, CompareWithRefs) {
     Run();
 }
 
-TEST_P(Gna30PaddedToValidConvTest, CompareWithRefs) {
+TEST_P(Gna35PaddedToValidConvTest, CompareWithRefs) {
+    if (gnaVersionCheck.gnaLibVersionLessThan("3.5")) {
+        GTEST_SKIP() << gnaVersionCheck.getLastCmpResultMsg() << std::endl;
+        return;
+    }
     Run();
 }
 
@@ -232,14 +230,19 @@ const std::vector<std::map<std::string, std::string>> configs1D = {
         {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
         {"GNA_SCALE_FACTOR_0", "1"},
         {"GNA_EXEC_TARGET", "GNA_TARGET_2_0"}
-    }
-};
-
-const std::vector<std::map<std::string, std::string>> configs1D_Gna30 = {
+    },
     {
         {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
         {"GNA_SCALE_FACTOR_0", "1"},
         {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}
+    }
+};
+
+const std::vector<std::map<std::string, std::string>> configs1D_Gna35 = {
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+        {"GNA_SCALE_FACTOR_0", "1"},
+        {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}
     }
 };
 
@@ -248,6 +251,14 @@ const std::vector<std::map<std::string, std::string>> configs2D = {
         {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
         {"GNA_SCALE_FACTOR_0", "1"},
         {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}
+    }
+};
+
+const std::vector<std::map<std::string, std::string>> configs2D_Gna35 = {
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+        {"GNA_SCALE_FACTOR_0", "1"},
+        {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}
     }
 };
 
@@ -338,26 +349,37 @@ INSTANTIATE_TEST_SUITE_P(smoke_1DPaddedToValid, PaddedToValidConvTest,
         ::testing::ValuesIn(models)),
     PaddedToValidConvTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_1DPaddedToValid, Gna30PaddedToValidConvTest,
+INSTANTIATE_TEST_SUITE_P(smoke_1DPaddedToValid, Gna35PaddedToValidConvTest,
     ::testing::Combine(
         conv1DParams,
         misc1DParams,
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(CommonTestUtils::DEVICE_GNA),
-        ::testing::ValuesIn(configs1D_Gna30),
+        ::testing::ValuesIn(configs1D_Gna35),
         ::testing::ValuesIn(input1DNHWC),
         ::testing::ValuesIn(models)),
-    Gna30PaddedToValidConvTest::getTestCaseName);
+    Gna35PaddedToValidConvTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_2DPaddedToValid, Gna30PaddedToValidConvTest,
+INSTANTIATE_TEST_SUITE_P(smoke_2DPaddedToValid, PaddedToValidConvTest,
     ::testing::Combine(
         conv2DParams,
         misc2DParams,
         ::testing::ValuesIn(netPrecisions),
         ::testing::Values(CommonTestUtils::DEVICE_GNA),
-        ::testing::ValuesIn(configs2D),
+        ::testing::ValuesIn(configs2D_Gna35),
         ::testing::ValuesIn(input2DNHWC),
         ::testing::ValuesIn(models)),
-    Gna30PaddedToValidConvTest::getTestCaseName);
+    PaddedToValidConvTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_2DPaddedToValid, Gna35PaddedToValidConvTest,
+    ::testing::Combine(
+        conv2DParams,
+        misc2DParams,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configs2D_Gna35),
+        ::testing::ValuesIn(input2DNHWC),
+        ::testing::ValuesIn(models)),
+    Gna35PaddedToValidConvTest::getTestCaseName);
 
 } // namespace LayerTestsDefinitions

--- a/src/plugins/intel_gna/tests/functional/pass_tests/decompose_2d_conv.cpp
+++ b/src/plugins/intel_gna/tests/functional/pass_tests/decompose_2d_conv.cpp
@@ -15,6 +15,7 @@
 #include "transformations/init_node_info.hpp"
 #include "ngraph_functions/builders.hpp"
 #include "shared_test_classes/base/layer_test_utils.hpp"
+#include "../shared_tests_instances/skip_tests_check.hpp"
 
 using namespace ngraph;
 using namespace opset1;
@@ -101,6 +102,8 @@ public:
     }
 
 protected:
+    GnaLayerTestCheck gnaVersionCheck;
+
     void SetUp() override {
         threshold = 0.015f;
         convSpecificParams convParams;
@@ -199,10 +202,21 @@ protected:
 
         auto result = std::make_shared<Result>(lastOp);
         function = std::make_shared<Function>(ResultVector{result}, ParameterVector{input});
+        gnaVersionCheck.SetUp(targetDevice);
     }
 };
 
+using Gna35Decompose2DConvTest = Decompose2DConvTest;
+
 TEST_P(Decompose2DConvTest, CompareWithRefs) {
+    Run();
+}
+
+TEST_P(Gna35Decompose2DConvTest, CompareWithRefs) {
+    if (gnaVersionCheck.gnaLibVersionLessThan("3.5")) {
+        GTEST_SKIP() << gnaVersionCheck.getLastCmpResultMsg() << std::endl;
+        return;
+    }
     Run();
 }
 
@@ -365,6 +379,14 @@ const std::vector<std::map<std::string, std::string>> configsGNA30 = {
     }
 };
 
+const std::vector<std::map<std::string, std::string>> configsGNA35 = {
+    {
+        {"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+        {"GNA_SCALE_FACTOR_0", "1"},
+        {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}
+    }
+};
+
 const std::vector<op::PadType> padTypesGNA30 = {
     op::PadType::VALID,
 };
@@ -410,5 +432,16 @@ INSTANTIATE_TEST_SUITE_P(smoke_Decompose2DConvGNA30, Decompose2DConvTest,
         ::testing::ValuesIn(input2DNHWCGNA30),
         ::testing::ValuesIn(modelsGNA30)),
     Decompose2DConvTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Decompose2DConvGNA35, Gna35Decompose2DConvTest,
+    ::testing::Combine(
+        conv2DParamsGNA30,
+        miscParamsGNA30,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA),
+        ::testing::ValuesIn(configsGNA35),
+        ::testing::ValuesIn(input2DNHWCGNA30),
+        ::testing::ValuesIn(modelsGNA30)),
+    Gna35Decompose2DConvTest::getTestCaseName);
 
 } // namespace LayerTestsDefinitions

--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/single_layer_tests/conv_low_precision.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/single_layer_tests/conv_low_precision.cpp
@@ -135,8 +135,8 @@ TEST_P(ConvLowPrecisionTest, CompareWithRefs) {
 };
 
 TEST_P(ConvLowPrecisionTestLib35, CompareWithRefs) {
-    if (gnaVersionCheck.gnaLibVersionLessThan(3.5)) {
-        GTEST_SKIP() << "Disabled test due to GNA library version is less than " << 3.5 << std::endl;
+    if (gnaVersionCheck.gnaLibVersionLessThan("3.5")) {
+        GTEST_SKIP() << gnaVersionCheck.getLastCmpResultMsg() << std::endl;
         return;
     }
     Run();

--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/skip_tests_check.hpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/skip_tests_check.hpp
@@ -4,8 +4,11 @@
 
 #include <gna/gna_config.hpp>
 
+
 class GnaLayerTestCheck {
-    float gnaLibVer = 0.0f;
+    bool verRead = false;
+    int verMajor;
+    int verMinor;
     std::string lastMsg;
 
 public:
@@ -17,7 +20,7 @@ public:
             if (std::find(metrics.begin(), metrics.end(), METRIC_KEY(GNA_LIBRARY_FULL_VERSION)) != metrics.end()) {
                 auto gnaLibVerStr =
                     ieCore.GetMetric(deviceName, METRIC_KEY(GNA_LIBRARY_FULL_VERSION)).as<std::string>();
-                gnaLibVer = std::stof(gnaLibVerStr);
+                verRead = sscanf(gnaLibVerStr.c_str(), "%d.%d", &verMajor, &verMinor) == 2;
             }
         }
     }
@@ -26,9 +29,20 @@ public:
         return lastMsg;
     }
 
-    bool gnaLibVersionLessThan(float verToCmp) {
-        if (gnaLibVer && gnaLibVer < verToCmp) {
-            lastMsg = "GNA library version is less than " + std::to_string(verToCmp);
+    bool gnaLibVersionLessThan(std::string verToCmp) {
+        int verToCmpMajor;
+        int verToCmpMinor;
+
+        if (!verRead) {
+            IE_THROW() << "GnaLayerTestCheck requires initialization with SetUp()";
+        }
+
+        if (sscanf(verToCmp.c_str(), "%d.%d", &verToCmpMajor, &verToCmpMinor) != 2) {
+            return false;
+        }
+
+        if (verMajor < verToCmpMajor || (verMajor == verToCmpMajor && verMinor < verToCmpMinor)) {
+            lastMsg = "GNA library version is less than " + verToCmp;
             return true;
         }
         return false;


### PR DESCRIPTION
### Details:
 - Provide support for 1DConvolution with padding on GNA 3.5
 - Starting from GNA 3.5, GNA Library supports all convolutions (1D & 2D) using CNN 2D GNA model API (NHWC tensors having H==1).
 - Simple mapping from CNN 2D to 1D is not needed as 2D CNN are supported natively in GNA 3.5.

### Tickets:
 - 93535
