### PR TITLE
DOCS: Edits to streamline Install OpenVINO Overview Page - port to 22.1

### DIFF
--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -24,7 +24,6 @@ If you are a C++ developer, you must first install OpenVINO Runtime separately t
 
 Once OpenVINO Runtime is installed, you may install OpenVINO Development Tools for access to tools like Model Optimizer, Model Downloader, Benchmark Tool, and other utilities that will help you optimize your model and develop your application. Follow the steps in the <a href="#install-dev-tools">Installing OpenVINO Development Tools</a> section on this page to install it. In Step 4, make sure that you follow the instructions in the "C++" tab.
 
-
 ## <a name="install-dev-tools"></a>Installing OpenVINO™ Development Tools
 Follow these step-by-step instructions to install OpenVINO Development Tools on your computer.
 

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -16,7 +16,6 @@ In both cases, Python 3.6 - 3.9 need be installed on your machine before startin
 
 ## <a name="python-developers"></a>For Python Developers
 
-
 If you are a Python developer, follow the steps in the <a href="#install-dev-tools">Installing OpenVINO Development Tools</a> section on this page to install it. Installing OpenVINO Development Tools will also install OpenVINO Runtime as a dependency, so you don’t need to install OpenVINO Runtime separately. This option is recommended for new users.
 
 ## <a name="cpp-developers"></a>For C++ Developers

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -99,7 +99,6 @@ mo -h
 You will see the help message for Model Optimizer if installation finished successfully.
 
 
-<a name="cpp-developers"></a>
 
 ## <a name="get-started"></a>What's Next?
 Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications! Learn more about how to integrate a model in OpenVINO applications by trying out the following tutorials.

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -10,7 +10,7 @@ If you want to download, convert, optimize and tune pre-trained deep learning mo
 
 The instructions on this page show how to install OpenVINO Development Tools. If you are a Python developer, it only takes a few simple steps to install the tools with PyPI. If you are developing in C++, OpenVINO Runtime must be installed separately before installing OpenVINO Development Tools.
 
-In both cases, Python 3.6 - 3.10 need be installed on your machine before starting.
+In both cases, Python 3.6 - 3.9 need be installed on your machine before starting.
 
 > **NOTE**: From the 2022.1 release, the OpenVINO™ Development Tools can only be installed via PyPI.
 
@@ -101,27 +101,36 @@ You will see the help message for Model Optimizer if installation finished succe
 
 <a name="cpp-developers"></a>
 
-## What's Next?
-Learn more about OpenVINO and use it in your own application by trying out some of these examples!
+## <a name="get-started"></a>What's Next?
+Now that you've installed OpenVINO Runtime, you're ready to run your own machine learning applications! Learn more about how to integrate a model in OpenVINO applications by trying out the following tutorials.
 
-### Get started with Python
-<img src="https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif" width=400>
+@sphinxdirective
+.. tab:: Get started with Python
 
-Try the [Python Quick Start Example](https://docs.openvino.ai/2022.2/notebooks/201-vision-monodepth-with-output.html) to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+   Try the `Python Quick Start Example <https://docs.openvino.ai/2022.2/notebooks/201-vision-monodepth-with-output.html>`_ to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
+   
+   .. image:: https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif
+      :width: 400
 
-Visit the [Tutorials](../tutorials.md) page for more Jupyter Notebooks to get you started with OpenVINO, such as:
-* [OpenVINO Python API Tutorial](https://docs.openvino.ai/2022.2/notebooks/002-openvino-api-with-output.html)
-* [Basic image classification program with Hello Image Classification](https://docs.openvino.ai/2022.2/notebooks/001-hello-world-with-output.html)
-* [Convert a PyTorch model and use it for image background removal](https://docs.openvino.ai/2022.2/notebooks/205-vision-background-removal-with-output.html)
+   Visit the :ref:`Tutorials <notebook tutorials>` page for more Jupyter Notebooks to get you started with OpenVINO, such as:
+   
+   * `OpenVINO Python API Tutorial <https://docs.openvino.ai/2022.2/notebooks/002-openvino-api-with-output.html>`_
+   * `Basic image classification program with Hello Image Classification <https://docs.openvino.ai/2022.2/notebooks/001-hello-world-with-output.html>`_
+   * `Convert a PyTorch model and use it for image background removal <https://docs.openvino.ai/2022.2/notebooks/205-vision-background-removal-with-output.html>`_
 
-### Get started with C++
-<img src="https://user-images.githubusercontent.com/36741649/127170593-86976dc3-e5e4-40be-b0a6-206379cd7df5.jpg" width=400>
+.. tab:: Get started with C++
 
-Try the [C++ Quick Start Example](@ref openvino_docs_get_started_get_started_demos) for step-by-step instructions on building and running a basic image classification C++ application.
+   Try the `C++ Quick Start Example <openvino_docs_get_started_get_started_demos.html>`_ for step-by-step instructions on building and running a basic image classification C++ application.
+   
+   .. image:: https://user-images.githubusercontent.com/36741649/127170593-86976dc3-e5e4-40be-b0a6-206379cd7df5.jpg
+      :width: 400
 
-Visit the [Samples](../OV_Runtime_UG/Samples_Overview.md) page for other C++ example applications to get you started with OpenVINO, such as:
-* [Basic object detection with the Hello Reshape SSD C++ sample](@ref openvino_inference_engine_samples_hello_reshape_ssd_README)
-* [Automatic speech recognition C++ sample](@ref openvino_inference_engine_samples_speech_sample_README)
+   Visit the :ref:`Samples <code samples>` page for other C++ example applications to get you started with OpenVINO, such as:
+   
+   * `Basic object detection with the Hello Reshape SSD C++ sample <openvino_inference_engine_samples_hello_reshape_ssd_README.html>`_
+   * `Automatic speech recognition C++ sample <openvino_inference_engine_samples_speech_sample_README.html>`_
+
+@endsphinxdirective
 
 > **NOTE**: Model Optimizer support for TensorFlow 1.x environment has been deprecated. Use TensorFlow 2.x environment to convert both TensorFlow 1.x and 2.x models. The `tensorflow` value is provided only for compatibility reasons, use the `tensorflow2` value instead.
 

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -8,12 +8,15 @@ If you want to download, convert, optimize and tune pre-trained deep learning mo
 * Post-Training Optimization Tool
 * Model Downloader and other Open Model Zoo tools
 
+The instructions on this page show how to install OpenVINO Development Tools. If you are a Python developer, it only takes a few simple steps to install the tools with PyPI. If you are developing in C++, OpenVINO Runtime must be installed separately before installing OpenVINO Development Tools.
+
+In both cases, Python 3.6 - 3.10 need be installed on your machine before starting.
+
 > **NOTE**: From the 2022.1 release, the OpenVINO™ Development Tools can only be installed via PyPI.
 
-<a name="python-developers"></a>
+## <a name="python-developers"></a>For Python Developers
 
-## For Python Developers
-If you are a Python developer, you can find the main steps below to install OpenVINO Development Tools. For more details, see <https://pypi.org/project/openvino-dev>.
+If you are a Python developer, follow the steps in the <a href="#install-dev-tools">Installing OpenVINO Development Tools</a> section on this page to install it. Installing OpenVINO Development Tools will also install OpenVINO Runtime as a dependency, so you don’t need to install OpenVINO Runtime separately. This option is recommended for new users.
 
 ## <a name="cpp-developers"></a>For C++ Developers
 If you are a C++ developer, you must first install OpenVINO Runtime separately to set up the C++ libraries, sample code, and dependencies for building applications with OpenVINO. These files are not included with the PyPI distribution. See the [Install OpenVINO Runtime](./installing-openvino-runtime.md) page to install OpenVINO Runtime from an archive file for your operating system.
@@ -98,41 +101,27 @@ You will see the help message for Model Optimizer if installation finished succe
 
 <a name="cpp-developers"></a>
 
-## For C++ Developers
-Note the following things:
+## What's Next?
+Learn more about OpenVINO and use it in your own application by trying out some of these examples!
 
-* To install OpenVINO Development Tools, you must have OpenVINO Runtime installed first. You can install OpenVINO Runtime through the following ways:
-  * For OpenVINO 2022.1: [Install OpenVINO on Linux Using the Installer](installing-openvino-linux.md), [Install OpenVINO on Linux from APT](installing-openvino-apt.md), [Install OpenVINO on Linux from YUM](installing-openvino-yum.md), [Install OpenVINO on Windows Using the Installer](installing-openvino-windows.md), or [Install OpenVINO on macOS Using the Installer](installing-openvino-macos.md).
-  * For OpenVINO 2022.1.1: [Install OpenVINO on Linux from Archive](2022.1.1/installing-openvino-from-archive-linux.md), [Install OpenVINO on Windows from Archive](2022.1.1/installing-openvino-from-archive-windows.md), or [Install OpenVINO on macOS from Archive](2022.1.1/installing-openvino-from-archive-macos.md).
-* Ensure that the version of OpenVINO Development Tools you are installing matches that of OpenVINO Runtime.
+### Get started with Python
+<img src="https://user-images.githubusercontent.com/15709723/127752390-f6aa371f-31b5-4846-84b9-18dd4f662406.gif" width=400>
 
-Use either of the following ways to install OpenVINO Development Tools:
+Try the [Python Quick Start Example](https://docs.openvino.ai/2022.2/notebooks/201-vision-monodepth-with-output.html) to estimate depth in a scene using an OpenVINO monodepth model in a Jupyter Notebook inside your web browser.
 
-### Recommended: Install Using the Requirements Files
+Visit the [Tutorials](../tutorials.md) page for more Jupyter Notebooks to get you started with OpenVINO, such as:
+* [OpenVINO Python API Tutorial](https://docs.openvino.ai/2022.2/notebooks/002-openvino-api-with-output.html)
+* [Basic image classification program with Hello Image Classification](https://docs.openvino.ai/2022.2/notebooks/001-hello-world-with-output.html)
+* [Convert a PyTorch model and use it for image background removal](https://docs.openvino.ai/2022.2/notebooks/205-vision-background-removal-with-output.html)
 
-1. After you have installed OpenVINO Runtime from an installer, APT, YUM, or an archive file (2022.1.1 only), you can find a set of requirements files in the `<INSTALL_DIR>\tools\` directory. Select the most suitable ones to use.
-2. Install the same version of OpenVINO Development Tools by using the requirements files.
-   To install mandatory requirements only, use the following command:
-   ```
-   pip install -r <INSTALL_DIR>\tools\requirements.txt
-   ```
-3. Make sure that you also install your additional frameworks with the corresponding requirements files. For example, if you are using a TensorFlow model, use the following command to install requirements for TensorFlow:  
-```
-pip install -r <INSTALL_DIR>\tools\requirements_tensorflow2.txt
-```
+### Get started with C++
+<img src="https://user-images.githubusercontent.com/36741649/127170593-86976dc3-e5e4-40be-b0a6-206379cd7df5.jpg" width=400>
 
-### Alternative: Install from the openvino-dev Package
+Try the [C++ Quick Start Example](@ref openvino_docs_get_started_get_started_demos) for step-by-step instructions on building and running a basic image classification C++ application.
 
-You can also use the following command to install the latest package version available in the index:
-```
-pip install openvino-dev[EXTRAS]
-```
-where the EXTRAS parameter specifies one or more deep learning frameworks via these values: `caffe`, `kaldi`, `mxnet`, `onnx`, `pytorch`, `tensorflow`, `tensorflow2`. Make sure that you install the corresponding frameworks for your models.
-
-If you have installed OpenVINO Runtime via the installer, to avoid version conflicts, specify your version in the command. For example:
-```
-pip install openvino-dev[tensorflow2,onnx]==2022.1
-```
+Visit the [Samples](../OV_Runtime_UG/Samples_Overview.md) page for other C++ example applications to get you started with OpenVINO, such as:
+* [Basic object detection with the Hello Reshape SSD C++ sample](@ref openvino_inference_engine_samples_hello_reshape_ssd_README)
+* [Automatic speech recognition C++ sample](@ref openvino_inference_engine_samples_speech_sample_README)
 
 > **NOTE**: Model Optimizer support for TensorFlow 1.x environment has been deprecated. Use TensorFlow 2.x environment to convert both TensorFlow 1.x and 2.x models. The `tensorflow` value is provided only for compatibility reasons, use the `tensorflow2` value instead.
 

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -10,8 +10,9 @@ If you want to download, convert, optimize and tune pre-trained deep learning mo
 
 > **NOTE**: From the 2022.1 release, the OpenVINO™ Development Tools can only be installed via PyPI. 
 
-## For Python Developers
+<a name="python-developers"></a>
 
+## For Python Developers
 If you are a Python developer, you can find the main steps below to install OpenVINO Development Tools. For more details, see <https://pypi.org/project/openvino-dev>.
 
 While installing OpenVINO Development Tools, OpenVINO Runtime will also be installed as a dependency, so you don't need to install OpenVINO Runtime separately.
@@ -92,8 +93,9 @@ mo -h
 You will see the help message for Model Optimizer if installation finished successfully.
 
 
-## For C++ Developers
+<a name="cpp-developers"></a>
 
+## For C++ Developers
 Note the following things:
 
 * To install OpenVINO Development Tools, you must have OpenVINO Runtime installed first. You can install OpenVINO Runtime through the following ways:

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -14,7 +14,6 @@ In both cases, Python 3.6 - 3.9 need be installed on your machine before startin
 
 > **NOTE**: From the 2022.1 release, the OpenVINO™ Development Tools can only be installed via PyPI.
 
-## <a name="python-developers"></a>For Python Developers
 
 
 

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -12,7 +12,7 @@ If you want to download, convert, optimize and tune pre-trained deep learning mo
 
 In both cases, Python 3.6 - 3.9 need be installed on your machine before starting.
 
-> **NOTE**: From the 2022.1 release, the OpenVINO™ Development Tools can only be installed via PyPI.
+## For Python Developers
 If you are a Python developer, you can find the main steps below to install OpenVINO Development Tools. For more details, see <https://pypi.org/project/openvino-dev>.
 
 

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -8,7 +8,7 @@ If you want to download, convert, optimize and tune pre-trained deep learning mo
 * Post-Training Optimization Tool
 * Model Downloader and other Open Model Zoo tools
 
-The instructions on this page show how to install OpenVINO Development Tools. If you are a Python developer, it only takes a few simple steps to install the tools with PyPI. If you are developing in C++, OpenVINO Runtime must be installed separately before installing OpenVINO Development Tools.
+> **NOTE**: From the 2022.1 release, the OpenVINO™ Development Tools can only be installed via PyPI.
 
 In both cases, Python 3.6 - 3.9 need be installed on your machine before starting.
 

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -10,7 +10,7 @@ If you want to download, convert, optimize and tune pre-trained deep learning mo
 
 > **NOTE**: From the 2022.1 release, the OpenVINO™ Development Tools can only be installed via PyPI.
 
-In both cases, Python 3.6 - 3.9 need be installed on your machine before starting.
+<a name="python-developers"></a>
 
 ## For Python Developers
 If you are a Python developer, you can find the main steps below to install OpenVINO Development Tools. For more details, see <https://pypi.org/project/openvino-dev>.

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -16,7 +16,6 @@ In both cases, Python 3.6 - 3.9 need be installed on your machine before startin
 
 ## <a name="python-developers"></a>For Python Developers
 
-If you are a Python developer, follow the steps in the <a href="#install-dev-tools">Installing OpenVINO Development Tools</a> section on this page to install it. Installing OpenVINO Development Tools will also install OpenVINO Runtime as a dependency, so you don’t need to install OpenVINO Runtime separately. This option is recommended for new users.
 
 ## <a name="cpp-developers"></a>For C++ Developers
 If you are a C++ developer, you must first install OpenVINO Runtime separately to set up the C++ libraries, sample code, and dependencies for building applications with OpenVINO. These files are not included with the PyPI distribution. See the [Install OpenVINO Runtime](./installing-openvino-runtime.md) page to install OpenVINO Runtime from an archive file for your operating system.

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -18,7 +18,6 @@ In both cases, Python 3.6 - 3.9 need be installed on your machine before startin
 
 
 ## <a name="cpp-developers"></a>For C++ Developers
-If you are a C++ developer, you must first install OpenVINO Runtime separately to set up the C++ libraries, sample code, and dependencies for building applications with OpenVINO. These files are not included with the PyPI distribution. See the [Install OpenVINO Runtime](./installing-openvino-runtime.md) page to install OpenVINO Runtime from an archive file for your operating system.
 
 While installing OpenVINO Development Tools, OpenVINO Runtime will also be installed as a dependency, so you don't need to install OpenVINO Runtime separately.
 

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -8,18 +8,21 @@ If you want to download, convert, optimize and tune pre-trained deep learning mo
 * Post-Training Optimization Tool
 * Model Downloader and other Open Model Zoo tools
 
-> **NOTE**: From the 2022.1 release, the OpenVINO™ Development Tools can only be installed via PyPI. 
+> **NOTE**: From the 2022.1 release, the OpenVINO™ Development Tools can only be installed via PyPI.
 
 <a name="python-developers"></a>
 
 ## For Python Developers
 If you are a Python developer, you can find the main steps below to install OpenVINO Development Tools. For more details, see <https://pypi.org/project/openvino-dev>.
 
+## <a name="cpp-developers"></a>For C++ Developers
+If you are a C++ developer, you must first install OpenVINO Runtime separately to set up the C++ libraries, sample code, and dependencies for building applications with OpenVINO. These files are not included with the PyPI distribution. See the [Install OpenVINO Runtime](./installing-openvino-runtime.md) page to install OpenVINO Runtime from an archive file for your operating system.
+
 While installing OpenVINO Development Tools, OpenVINO Runtime will also be installed as a dependency, so you don't need to install OpenVINO Runtime separately.
 
 ### Step 1. Set Up Python Virtual Environment
 
-Use a virtual environment to avoid dependency conflicts. 
+Use a virtual environment to avoid dependency conflicts.
 
 To create a virtual environment, use the following command:
 
@@ -28,16 +31,16 @@ To create a virtual environment, use the following command:
 .. tab:: Linux and macOS
 
    .. code-block:: sh
-   
+
       python3 -m venv openvino_env
-   
+
 .. tab:: Windows
 
    .. code-block:: sh
-   
+
       python -m venv openvino_env
-     
-     
+
+
 @endsphinxdirective
 
 
@@ -48,16 +51,16 @@ To create a virtual environment, use the following command:
 .. tab:: Linux and macOS
 
    .. code-block:: sh
-   
+
       source openvino_env/bin/activate
-   
+
 .. tab:: Windows
 
    .. code-block:: sh
-   
+
       openvino_env\Scripts\activate
-     
-     
+
+
 @endsphinxdirective
 
 
@@ -99,16 +102,16 @@ You will see the help message for Model Optimizer if installation finished succe
 Note the following things:
 
 * To install OpenVINO Development Tools, you must have OpenVINO Runtime installed first. You can install OpenVINO Runtime through the following ways:
-  * For OpenVINO 2022.1: [Install OpenVINO on Linux Using the Installer](installing-openvino-linux.md), [Install OpenVINO on Linux from APT](installing-openvino-apt.md), [Install OpenVINO on Linux from YUM](installing-openvino-yum.md), [Install OpenVINO on Windows Using the Installer](installing-openvino-windows.md), or [Install OpenVINO on macOS Using the Installer](installing-openvino-macos.md). 
+  * For OpenVINO 2022.1: [Install OpenVINO on Linux Using the Installer](installing-openvino-linux.md), [Install OpenVINO on Linux from APT](installing-openvino-apt.md), [Install OpenVINO on Linux from YUM](installing-openvino-yum.md), [Install OpenVINO on Windows Using the Installer](installing-openvino-windows.md), or [Install OpenVINO on macOS Using the Installer](installing-openvino-macos.md).
   * For OpenVINO 2022.1.1: [Install OpenVINO on Linux from Archive](2022.1.1/installing-openvino-from-archive-linux.md), [Install OpenVINO on Windows from Archive](2022.1.1/installing-openvino-from-archive-windows.md), or [Install OpenVINO on macOS from Archive](2022.1.1/installing-openvino-from-archive-macos.md).
-* Ensure that the version of OpenVINO Development Tools you are installing matches that of OpenVINO Runtime. 
+* Ensure that the version of OpenVINO Development Tools you are installing matches that of OpenVINO Runtime.
 
 Use either of the following ways to install OpenVINO Development Tools:
 
 ### Recommended: Install Using the Requirements Files
 
 1. After you have installed OpenVINO Runtime from an installer, APT, YUM, or an archive file (2022.1.1 only), you can find a set of requirements files in the `<INSTALL_DIR>\tools\` directory. Select the most suitable ones to use.
-2. Install the same version of OpenVINO Development Tools by using the requirements files. 
+2. Install the same version of OpenVINO Development Tools by using the requirements files.
    To install mandatory requirements only, use the following command:
    ```
    pip install -r <INSTALL_DIR>\tools\requirements.txt
@@ -130,7 +133,7 @@ If you have installed OpenVINO Runtime via the installer, to avoid version confl
 ```
 pip install openvino-dev[tensorflow2,onnx]==2022.1
 ```
-    
+
 > **NOTE**: Model Optimizer support for TensorFlow 1.x environment has been deprecated. Use TensorFlow 2.x environment to convert both TensorFlow 1.x and 2.x models. The `tensorflow` value is provided only for compatibility reasons, use the `tensorflow2` value instead.
 
 For more details, see <https://pypi.org/project/openvino-dev/>.

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -13,7 +13,7 @@ If you want to download, convert, optimize and tune pre-trained deep learning mo
 In both cases, Python 3.6 - 3.9 need be installed on your machine before starting.
 
 > **NOTE**: From the 2022.1 release, the OpenVINO™ Development Tools can only be installed via PyPI.
-
+If you are a Python developer, you can find the main steps below to install OpenVINO Development Tools. For more details, see <https://pypi.org/project/openvino-dev>.
 
 
 

--- a/docs/install_guides/installing-model-dev-tools.md
+++ b/docs/install_guides/installing-model-dev-tools.md
@@ -17,7 +17,6 @@ In both cases, Python 3.6 - 3.9 need be installed on your machine before startin
 ## <a name="python-developers"></a>For Python Developers
 
 
-## <a name="cpp-developers"></a>For C++ Developers
 
 While installing OpenVINO Development Tools, OpenVINO Runtime will also be installed as a dependency, so you don't need to install OpenVINO Runtime separately.
 

--- a/docs/install_guides/installing-openvino-overview.md
+++ b/docs/install_guides/installing-openvino-overview.md
@@ -53,7 +53,7 @@ The following methods are available to install OpenVINO Runtime:
 
 * Linux: You can install OpenVINO Runtime using archive files or Docker. See [Install OpenVINO on Linux](installing-openvino-linux-header.md).
 * Windows: You can install OpenVINO Runtime using archive files or Docker. See [Install OpenVINO on Windows](installing-openvino-windows-header.md).
-* macOS: You can install OpenVINO Runtime using archive files or Docker. See [Install OpenVINO on macOS](installing-openvino-macos-header.md).
+* macOS: You can install OpenVINO Runtime using an [Installer](installing-openvino-macos.md) or [Anaconda Cloud](installing-openvino-conda.md).
 * [Raspbian OS](installing-openvino-raspbian.md)
 
 ### Option 3. Build OpenVINO from source

--- a/docs/install_guides/installing-openvino-overview.md
+++ b/docs/install_guides/installing-openvino-overview.md
@@ -70,3 +70,4 @@ Follow these links to install OpenVINO:
 - [Install OpenVINO Development Tools](installing-model-dev-tools.md)
 - [Install OpenVINO Runtime](installing-openvino-runtime.md)
 - [Build from Source](https://github.com/openvinotoolkit/openvino/wiki/BuildingCode)
+- [Create a Yocto Image](installing-openvino-yocto.md)

--- a/docs/install_guides/installing-openvino-overview.md
+++ b/docs/install_guides/installing-openvino-overview.md
@@ -52,7 +52,7 @@ OpenVINO Runtime may also be installed on its own without OpenVINO Development T
 The following methods are available to install OpenVINO Runtime:
 
 * Linux: You can install OpenVINO Runtime using archive files or Docker. See [Install OpenVINO on Linux](installing-openvino-linux-header.md).
-* Windows: You can install OpenVINO Runtime using archive files or Docker. See [Install OpenVINO on Windows](installing-openvino-windows-header.md).
+* Windows: You can install OpenVINO Runtime using an [Installer](installing-openvino-windows.md), [Anaconda Cloud](installing-openvino-conda.md), or [Docker](installing-openvino-docker-windows.md).
 * macOS: You can install OpenVINO Runtime using an [Installer](installing-openvino-macos.md) or [Anaconda Cloud](installing-openvino-conda.md).
 * [Raspbian OS](installing-openvino-raspbian.md)
 

--- a/docs/install_guides/installing-openvino-overview.md
+++ b/docs/install_guides/installing-openvino-overview.md
@@ -51,7 +51,7 @@ OpenVINO Runtime may also be installed on its own without OpenVINO Development T
 
 The following methods are available to install OpenVINO Runtime:
 
-* Linux: You can install OpenVINO Runtime using archive files or Docker. See [Install OpenVINO on Linux](installing-openvino-linux-header.md).
+* Linux: You can install OpenVINO Runtime using an [Installer](installing-openvino-linux.md), [APT](installing-openvino-apt.md), [YUM](installing-openvino-yum.md), [Anaconda Cloud](installing-openvino-conda.md), or [Docker](installing-openvino-docker-linux.md).
 * Windows: You can install OpenVINO Runtime using an [Installer](installing-openvino-windows.md), [Anaconda Cloud](installing-openvino-conda.md), or [Docker](installing-openvino-docker-windows.md).
 * macOS: You can install OpenVINO Runtime using an [Installer](installing-openvino-macos.md) or [Anaconda Cloud](installing-openvino-conda.md).
 * [Raspbian OS](installing-openvino-raspbian.md)

--- a/docs/install_guides/installing-openvino-overview.md
+++ b/docs/install_guides/installing-openvino-overview.md
@@ -5,7 +5,7 @@
 .. toctree::
    :maxdepth: 3
    :hidden:
-   
+
    OpenVINO Runtime 2022.1 <openvino_docs_install_guides_install_runtime>
    OpenVINO Runtime 2022.1.1 <openvino_docs_install_guides_install_runtime_2022_1_1>
    OpenVINO Development Tools <openvino_docs_install_guides_install_dev_tools>
@@ -14,46 +14,59 @@
 
 @endsphinxdirective
 
-Intel® Distribution of OpenVINO™ toolkit is a comprehensive toolkit for developing applications and solutions based on deep learning tasks, such as: emulation of human vision, automatic speech recognition, natural language processing, recommendation systems, etc. It provides high-performance and rich deployment options, from edge to cloud. Some of its advantages are:
+Intel® Distribution of OpenVINO™ toolkit is a comprehensive toolkit for developing applications and solutions based on deep learning tasks, such as computer vision, automatic speech recognition, natural language processing, recommendation systems, and more. It provides high-performance and rich deployment options, from edge to cloud. Some of its advantages are:
 
-* Enabling CNN-based deep learning inference on the edge.
-* Supporting various execution modes across Intel® technologies: Intel® CPU, Intel® Integrated Graphics, Intel® Neural Compute Stick 2, and Intel® Vision Accelerator Design with Intel® Movidius™ VPUs.
-* Speeding time-to-market via an easy-to-use library of computer vision functions and pre-optimized kernels.
+* Enables CNN-based and transformer-based deep learning inference on the edge or cloud.
+* Supports various execution modes across Intel® technologies: Intel® CPU, Intel® Integrated Graphics, Intel® Discrete Graphics, Intel® Neural Compute Stick 2, and Intel® Vision Accelerator Design with Intel® Movidius™ VPUs.
+* Speeds time-to-market via an easy-to-use library of computer vision functions and pre-optimized kernels.
+* Compatible with models from a wide variety of frameworks, including TensorFlow, PyTorch, PaddlePaddle, ONNX, and more.
 
-## Installation Options
+## Install OpenVINO
 
-Since the 2022.1 release, the OpenVINO installation package has been distributed in two parts: OpenVINO Runtime and OpenVINO Development Tools. See the following instructions to choose your installation process.
+Since the 2022.1 release, the OpenVINO installation package is distributed in two parts: OpenVINO Runtime and OpenVINO Development Tools.
 
-### Decide What to Install
+* **OpenVINO Runtime** contains the core set of libraries for running machine learning model inference on processor devices.
+* **OpenVINO Development Tools** is a set of utilities for working with OpenVINO and OpenVINO models. It includes the following tools:
+  - Model Optimizer
+  - Post-Training Optimization Tool
+  - Benchmark Tool
+  - Accuracy Checker and Annotation Converter
+  - Model Downloader and other Open Model Zoo tools
 
-**If you have already finished developing your models and converting them to the OpenVINO model format, you can [install OpenVINO Runtime](installing-openvino-runtime.md) to deploy your applications on various devices**. OpenVINO Runtime contains a set of libraries for easy inference integration with your products.
+### Option 1. Install OpenVINO Runtime and OpenVINO Development Tools (recommended)
 
-**If you want to download models from [Open Model Zoo](../model_zoo.md), [convert your own models to OpenVINO IR](../MO_DG/Deep_Learning_Model_Optimizer_DevGuide.md), or [optimize and tune pre-trained deep learning models](../optimization_guide/model_optimization_guide.md)**, [install OpenVINO Development Tools](installing-model-dev-tools.md), which provides the following tools:
+The best way to get started with OpenVINO is to install OpenVINO Development Tools, which will also install the OpenVINO Runtime Python package as a dependency. Follow the instructions on the [Install OpenVINO Development Tools](installing-model-dev-tools.md) page to install it.
 
-  * Model Optimizer
-  * Post-Training Optimization Tool
-  * Benchmark Tool
-  * Accuracy Checker and Annotation Converter
-  * Model Downloader and other Open Model Zoo tools
+**Python**
 
+For developers working in Python, OpenVINO Development Tools can easily be installed using PyPI. See the <a href="openvino_docs_install_guides_install_dev_tools.html#python-developers">For Python Developers</a> section of the Install OpenVINO Development Tools page for instructions.
 
-### Choose Your Installation Method
+**C++**
 
-For Python developers, the easiest way is to [install OpenVINO Development Tools](installing-model-dev-tools.md), which will install both OpenVINO Runtime and OpenVINO Development Tools with a few steps. If you want to install OpenVINO Runtime only, see [Install OpenVINO Runtime from PyPI](installing-openvino-pip.md).
+For developers working in C++, the core OpenVINO Runtime libraries must be installed separately. Then, OpenVINO Development Tools can be installed using requirements files or PyPI. See the <a href="openvino_docs_install_guides_install_dev_tools.html#cpp-developers">For C++ Developers</a> section of the Install OpenVINO Development Tools page for instructions.
 
-For C++ developers, you may choose one of the following installation options for OpenVINO Runtime on your specific operating system:
+### Option 2. Install OpenVINO Runtime only
 
-* Linux: You can install OpenVINO Runtime using an [Installer](installing-openvino-linux.md), [APT](installing-openvino-apt.md), [YUM](installing-openvino-yum.md), [Anaconda Cloud](installing-openvino-conda.md), or [Docker](installing-openvino-docker-linux.md).
-* Windows: You can install OpenVINO Runtime using an [Installer](installing-openvino-windows.md), [Anaconda Cloud](installing-openvino-conda.md), or [Docker](installing-openvino-docker-windows.md).
-* macOS: You can install OpenVINO Runtime using an [Installer](installing-openvino-macos.md) or [Anaconda Cloud](installing-openvino-conda.md).
-* [Raspbian OS](installing-openvino-raspbian.md).
+OpenVINO Runtime may also be installed on its own without OpenVINO Development Tools. This is recommended for users who already have an optimized model and want to deploy it in an application that uses OpenVINO for inference on their device. To install OpenVINO Runtime only, follow the instructions on the [Install OpenVINO Runtime](installing-openvino-runtime.md) page.
 
-> **NOTE**: With the introduction of the 2022.1 release, the OpenVINO Development Tools can be installed **only** via PyPI. See [Install OpenVINO Development Tools](installing-model-dev-tools.md) for detailed steps.
-Source files are also available in the [OpenVINO toolkit GitHub repository](https://github.com/openvinotoolkit/openvino/), so you can build your own package for the supported platforms, as described in [OpenVINO Build Instructions](https://github.com/openvinotoolkit/openvino/wiki/BuildingCode).
+The following methods are available to install OpenVINO Runtime:
+
+* Linux: You can install OpenVINO Runtime using archive files or Docker. See [Install OpenVINO on Linux](installing-openvino-linux-header.md).
+* Windows: You can install OpenVINO Runtime using archive files or Docker. See [Install OpenVINO on Windows](installing-openvino-windows-header.md).
+* macOS: You can install OpenVINO Runtime using archive files or Docker. See [Install OpenVINO on macOS](installing-openvino-macos-header.md).
+* [Raspbian OS](installing-openvino-raspbian.md)
+
+### Option 3. Build OpenVINO from source
+
+Source files are also available in the OpenVINO Toolkit GitHub repository. If you want to build OpenVINO from source for your platform, follow the [OpenVINO Build Instructions](https://github.com/openvinotoolkit/openvino/wiki/BuildingCode).
 
 ## Next Steps
+Still unsure if you want to install OpenVINO toolkit? Check out the [OpenVINO tutorials](../tutorials.md) to run example applications directly in your web browser without installing it locally. Here are some exciting demos you can explore:
+- [Monodepth Estimation with OpenVINO](https://docs.openvino.ai/latest/notebooks/201-vision-monodepth-with-output.html)
+- [Style Transfer on ONNX Models with OpenVINO](https://docs.openvino.ai/latest/notebooks/212-onnx-style-transfer-with-output.html)
+- [OpenVINO API Tutorial](https://docs.openvino.ai/latest/notebooks/002-openvino-api-with-output.html)
 
-- [Install OpenVINO Runtime](installing-openvino-runtime.md)
+Follow these links to install OpenVINO:
 - [Install OpenVINO Development Tools](installing-model-dev-tools.md)
+- [Install OpenVINO Runtime](installing-openvino-runtime.md)
 - [Build from Source](https://github.com/openvinotoolkit/openvino/wiki/BuildingCode)
-- [Create a Yocto Image](installing-openvino-yocto.md)


### PR DESCRIPTION
Porting:
https://github.com/openvinotoolkit/openvino/pull/13830/

Details:

Edit install-openvino-overview.md to list 3 options for installing OpenVINO, with Installing OpenVINO Development Tools being the recommended option for new users
