### PR TITLE
[GPU] Allow devices which don't support OOO queue

### DIFF
--- a/docs/snippets/gpu/context_sharing_va.cpp
+++ b/docs/snippets/gpu/context_sharing_va.cpp
@@ -1,5 +1,6 @@
 #ifdef ENABLE_LIBVA
 #include <openvino/runtime/core.hpp>
+#define OV_GPU_USE_OPENCL_HPP
 #include <openvino/runtime/intel_gpu/ocl/va.hpp>
 #include <openvino/runtime/intel_gpu/properties.hpp>
 #include <openvino/core/preprocess/pre_post_process.hpp>
@@ -37,11 +38,11 @@ int main() {
 
     auto input0 = model->get_parameters().at(0);
     auto input1 = model->get_parameters().at(1);
-    
+
     auto shape = input0->get_shape();
     auto width = shape[1];
     auto height = shape[2];
-    
+
     // execute decoding and obtain decoded surface handle
     VASurfaceID va_surface = decode_va_surface();
     //     ...

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.cpp
@@ -36,7 +36,7 @@ std::vector<std::string> split(const std::string& s, char delim) {
     return result;
 }
 
-bool does_device_match_config(bool out_of_order, const cl::Device& device) {
+bool does_device_match_config(const cl::Device& device) {
     if (device.getInfo<CL_DEVICE_TYPE>() != CL_DEVICE_TYPE_GPU) {
         return false;
     }
@@ -44,16 +44,6 @@ bool does_device_match_config(bool out_of_order, const cl::Device& device) {
     // TODO: Remove the check below once kernels are fixed
     if (device.getInfo<CL_DEVICE_VENDOR_ID>() != cldnn::INTEL_VENDOR_ID)
         return false;
-
-    // Does device support OOOQ?
-    if (out_of_order) {
-        auto queue_properties = device.getInfo<CL_DEVICE_QUEUE_PROPERTIES>();
-        using cmp_t = std::common_type<decltype(queue_properties),
-            typename std::underlying_type<cl::QueueProperties>::type>::type;
-        if (!(static_cast<cmp_t>(queue_properties) & static_cast<cmp_t>(cl::QueueProperties::OutOfOrder))) {
-            return false;
-        }
-    }
 
     int32_t ocl_major = -1;
     int32_t ocl_minor = -1;
@@ -161,14 +151,13 @@ std::map<std::string, device::ptr> ocl_device_detector::get_available_devices(vo
                                                                               void* user_device,
                                                                               int ctx_device_id,
                                                                               int target_tile_id) const {
-    bool host_out_of_order = true;  // Change to false, if debug requires in-order queue.
     std::vector<device::ptr> devices_list;
     if (user_context != nullptr) {
-        devices_list = create_device_list_from_user_context(host_out_of_order, user_context, ctx_device_id);
+        devices_list = create_device_list_from_user_context(user_context, ctx_device_id);
     } else if (user_device != nullptr) {
-        devices_list = create_device_list_from_user_device(host_out_of_order, user_device);
+        devices_list = create_device_list_from_user_device(user_device);
     } else {
-        devices_list = create_device_list(host_out_of_order);
+        devices_list = create_device_list();
     }
 
     devices_list = sort_devices(devices_list);
@@ -198,7 +187,7 @@ std::map<std::string, device::ptr> ocl_device_detector::get_available_devices(vo
     return ret;
 }
 
-std::vector<device::ptr> ocl_device_detector::create_device_list(bool out_out_order) const {
+std::vector<device::ptr> ocl_device_detector::create_device_list() const {
     cl_uint num_platforms = 0;
     // Get number of platforms availible
     cl_int error_code = clGetPlatformIDs(0, NULL, &num_platforms);
@@ -215,7 +204,7 @@ std::vector<device::ptr> ocl_device_detector::create_device_list(bool out_out_or
         std::vector<cl::Device> devices;
         platform.getDevices(CL_DEVICE_TYPE_ALL, &devices);
         for (auto& device : devices) {
-            if (!does_device_match_config(out_out_order, device))
+            if (!does_device_match_config(device))
                 continue;
             supported_devices.emplace_back(std::make_shared<ocl_device>(device, cl::Context(device), id));
         }
@@ -224,14 +213,14 @@ std::vector<device::ptr> ocl_device_detector::create_device_list(bool out_out_or
     return supported_devices;
 }
 
-std::vector<device::ptr>  ocl_device_detector::create_device_list_from_user_context(bool out_out_order, void* user_context, int ctx_device_id) const {
+std::vector<device::ptr> ocl_device_detector::create_device_list_from_user_context(void* user_context, int ctx_device_id) const {
     cl::Context ctx = cl::Context(static_cast<cl_context>(user_context), true);
     auto all_devices = ctx.getInfo<CL_CONTEXT_DEVICES>();
 
     std::vector<device::ptr> supported_devices;
     for (size_t i = 0; i < all_devices.size(); i++) {
         auto& device = all_devices[i];
-        if (!does_device_match_config(out_out_order, device) || static_cast<int>(i) != ctx_device_id)
+        if (!does_device_match_config(device) || static_cast<int>(i) != ctx_device_id)
             continue;
         supported_devices.emplace_back(std::make_shared<ocl_device>(device, ctx, device.getInfo<CL_DEVICE_PLATFORM>()));
     }
@@ -240,7 +229,7 @@ std::vector<device::ptr>  ocl_device_detector::create_device_list_from_user_cont
     return supported_devices;
 }
 
-std::vector<device::ptr> ocl_device_detector::create_device_list_from_user_device(bool out_out_order, void* user_device) const {
+std::vector<device::ptr> ocl_device_detector::create_device_list_from_user_device(void* user_device) const {
     cl_uint num_platforms = 0;
     // Get number of platforms availible
     cl_int error_code = clGetPlatformIDs(0, NULL, &num_platforms);
@@ -283,7 +272,7 @@ std::vector<device::ptr> ocl_device_detector::create_device_list_from_user_devic
             &devices);
 
         for (auto& device : devices) {
-            if (!does_device_match_config(out_out_order, device))
+            if (!does_device_match_config(device))
                 continue;
 
             cl_context_properties props[] = {

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.hpp
@@ -24,9 +24,9 @@ public:
     static std::vector<device::ptr> sort_devices(const std::vector<device::ptr>& devices_list);
 
 private:
-    std::vector<device::ptr> create_device_list(bool out_out_order) const;
-    std::vector<device::ptr> create_device_list_from_user_context(bool out_out_order, void* user_context, int ctx_device_id = 0) const;
-    std::vector<device::ptr> create_device_list_from_user_device(bool out_out_order, void* user_device) const;
+    std::vector<device::ptr> create_device_list() const;
+    std::vector<device::ptr> create_device_list_from_user_context(void* user_context, int ctx_device_id = 0) const;
+    std::vector<device::ptr> create_device_list_from_user_device(void* user_device) const;
 };
 
 }  // namespace ocl


### PR DESCRIPTION
### Details:
 - Currently all devices w/o OOO queue support are rejected. This patch changes this policy and just use in-order queue in such cases