### PR TITLE
[GPU] Fixed device name in query network result

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -436,7 +436,7 @@ QueryNetworkResult Plugin::QueryNetwork(const CNNNetwork& network,
     });
 
     for (auto&& layerName : supported) {
-        res.supportedLayersMap.emplace(layerName, GetName());
+        res.supportedLayersMap.emplace(layerName, GetName() + "." + conf.device_id);
     }
 
     return res;

--- a/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/layer_test_utils.cpp
@@ -115,6 +115,15 @@ void LayerTestsCommon::QueryNetwork() {
 
     std::set<std::string> actual;
     for (auto&& res : queryNetworkResult.supportedLayersMap) {
+        std::shared_ptr<InferenceEngine::RemoteContext> ctx = nullptr;
+        try {
+            // Try to take fully specified name from the context to match it with query network result for devices that support remote contexts
+            ctx = core->GetDefaultContext(targetDevice);
+            ASSERT_EQ(res.second, ctx->getDeviceName());
+        } catch (...) {
+            // otherwise, compare with originally used device name
+            ASSERT_EQ(res.second, targetDevice);
+        }
         actual.insert(res.first);
     }
     ASSERT_EQ(expected, actual);


### PR DESCRIPTION
### Details:
 - Return fully specified name from QueryNetwork to ensure device ID is not lost in hetero scenario
 - 
### Tickets:
 - 96122
