### PR TITLE
[PyOV] Fix typo in filename generator

### DIFF
--- a/src/bindings/python/tests/test_utils/test_utils.py
+++ b/src/bindings/python/tests/test_utils/test_utils.py
@@ -83,6 +83,6 @@ def test_deprecation_decorator():
 
 
 def create_filename_for_test(test_name):
-    python_version = str(sys.version_info.major) + "." + str(sys.version_info.minor)
+    python_version = str(sys.version_info.major) + "_" + str(sys.version_info.minor)
     filename = "./" + test_name.replace("test_", "") + "_" + python_version
     return (filename + ".xml", filename + ".bin")


### PR DESCRIPTION
### Details:
 - Replace `.` with `_` so file extension won't be misread.

### Tickets:
 - *N/A*
