### PR TITLE
[PyOV] Fix compatibility if-ops test

### DIFF
--- a/src/bindings/python/tests/test_runtime/test_compiled_model.py
+++ b/src/bindings/python/tests/test_runtime/test_compiled_model.py
@@ -6,9 +6,8 @@ import os
 import pytest
 import numpy as np
 
-# TODO: refactor into absolute paths
-from ..conftest import model_path
-from ..test_utils.test_utils import generate_image
+from tests.conftest import model_path
+from tests.test_utils.test_utils import generate_image
 from openvino.runtime import Model, ConstOutput, Shape
 
 from openvino.runtime import Core, Tensor

--- a/src/bindings/python/tests/test_runtime/test_core.py
+++ b/src/bindings/python/tests/test_runtime/test_core.py
@@ -20,14 +20,14 @@ from openvino.runtime import (
     compile_model,
 )
 
-from ..conftest import (
+from tests.conftest import (
     model_path,
     model_onnx_path,
     plugins_path,
     get_model_with_template_extension,
 )
 
-from ..test_utils.test_utils import (
+from tests.test_utils.test_utils import (
     generate_image,
     generate_relu_model,
 )

--- a/src/bindings/python/tests/test_runtime/test_function.py
+++ b/src/bindings/python/tests/test_runtime/test_function.py
@@ -22,7 +22,7 @@ from openvino.runtime import (
     serialize,
 )
 
-from ..test_utils.test_utils import generate_add_model  # TODO: reformat into an absolute path
+from tests.test_utils.test_utils import generate_add_model, create_filename_for_test
 
 
 def test_test_descriptor_tensor():
@@ -452,7 +452,8 @@ def test_reshape_with_python_types(device):
     )
 
 
-def test_serialize_rt_info():
+# request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
+def test_serialize_rt_info(request):
     version = "TestVersion"
     config = "TestConfig"
     framework_batch = "1"
@@ -473,8 +474,7 @@ def test_serialize_rt_info():
             assert model.get_rt_info(["optimization", "test"])
 
     core = Core()
-    xml_path = "./serialized_model.xml"
-    bin_path = "./serialized_model.bin"
+    xml_path, bin_path = create_filename_for_test(request.node.name)
     input_shape = PartialShape([1])
     param = ops.parameter(input_shape, dtype=np.float32, name="data")
     relu1 = ops.relu(param, name="relu1")

--- a/src/bindings/python/tests/test_runtime/test_infer_request.py
+++ b/src/bindings/python/tests/test_runtime/test_infer_request.py
@@ -15,9 +15,8 @@ from openvino.runtime import Core, AsyncInferQueue, Tensor, ProfilingInfo, Model
 from openvino.runtime import Type, PartialShape, Shape, Layout
 from openvino.preprocess import PrePostProcessor
 
-# TODO: reformat into absolute paths
-from ..conftest import model_path
-from ..test_utils.test_utils import generate_image
+from tests.conftest import model_path
+from tests.test_utils.test_utils import generate_image
 
 is_myriad = os.environ.get("TEST_DEVICE") == "MYRIAD"
 test_net_xml, test_net_bin = model_path(is_myriad)

--- a/src/bindings/python/tests/test_runtime/test_tensor.py
+++ b/src/bindings/python/tests/test_runtime/test_tensor.py
@@ -14,7 +14,7 @@ from openvino.helpers import pack_data, unpack_data
 
 import pytest
 
-from ..test_utils.test_utils import generate_image  # TODO: reformat into an absolute path
+from tests.test_utils.test_utils import generate_image
 
 
 @pytest.mark.parametrize(("ov_type", "numpy_dtype"), [

--- a/src/bindings/python/tests_compatibility/__init__.py
+++ b/src/bindings/python/tests_compatibility/__init__.py
@@ -141,7 +141,6 @@ xfail_issue_81976 = xfail_test(reason="RuntimeError: z node not found in graph c
 xfail_issue_82038 = xfail_test(reason="ScatterElements, ScatterND, AssertionError: Result mismatch")
 xfail_issue_82039 = xfail_test(reason="Unsupported data type Optional, RuntimeError: [ NOT_IMPLEMENTED ] "
                                       "CPU plugin: Input image format UNSPECIFIED is not supported yet...")
-skip_issue_86384 = pytest.mark.skip(reason="If op compatibility tests failing only when triggering whole test suite")
 xfail_issue_90649 = xfail_test(reason="RuntimeError: OV does not support the following ONNX operations:"
                                       "BlackmanWindow, DFT, HammingWindow, HannWindow, LayerNormalization, "
                                       "MelWeightMatrix, SequenceMap, STFT")

--- a/src/bindings/python/tests_compatibility/test_inference_engine/test_Blob.py
+++ b/src/bindings/python/tests_compatibility/test_inference_engine/test_Blob.py
@@ -8,7 +8,7 @@ import os
 
 from openvino.inference_engine import TensorDesc, Blob, IECore
 from tests_compatibility.conftest import model_path
-from ..test_utils.test_utils import generate_image  # TODO: reformat into an absolute path
+from tests_compatibility.test_utils.test_utils import generate_image
 
 
 def test_init_with_tensor_desc():

--- a/src/bindings/python/tests_compatibility/test_inference_engine/test_ExecutableNetwork.py
+++ b/src/bindings/python/tests_compatibility/test_inference_engine/test_ExecutableNetwork.py
@@ -8,7 +8,7 @@ import time
 
 from openvino.inference_engine import ie_api as ie
 from tests_compatibility.conftest import model_path
-from ..test_utils.test_utils import generate_image  # TODO: reformat into an absolute path
+from tests_compatibility.test_utils.test_utils import generate_image
 
 
 is_myriad = os.environ.get("TEST_DEVICE") == "MYRIAD"

--- a/src/bindings/python/tests_compatibility/test_inference_engine/test_InferRequest.py
+++ b/src/bindings/python/tests_compatibility/test_inference_engine/test_InferRequest.py
@@ -10,7 +10,7 @@ import time
 
 from openvino.inference_engine import ie_api as ie
 from tests_compatibility.conftest import model_path, create_encoder
-from ..test_utils.test_utils import generate_image  # TODO: reformat into an absolute path
+from tests_compatibility.test_utils.test_utils import generate_image
 import ngraph as ng
 from ngraph.impl import Function, Type
 

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_convolution.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_convolution.py
@@ -173,7 +173,6 @@ def test_convolution_backprop_data():
     filter_data = np.array([[1.0, 0.0, -1.0], [2.0, 0.0, -2.0], [1.0, 0.0, -1.0]], dtype=np.float32).reshape(
         1, 1, 3, 3
     )
-
     model = runtime.computation(deconvolution, data_node, filter_node)
     result = model(input_data, filter_data)
     assert np.allclose(

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_convolution.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_convolution.py
@@ -173,6 +173,7 @@ def test_convolution_backprop_data():
     filter_data = np.array([[1.0, 0.0, -1.0], [2.0, 0.0, -2.0], [1.0, 0.0, -1.0]], dtype=np.float32).reshape(
         1, 1, 3, 3
     )
+
     model = runtime.computation(deconvolution, data_node, filter_node)
     result = model(input_data, filter_data)
     assert np.allclose(

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_if.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_if.py
@@ -11,6 +11,7 @@ from ngraph.utils.tensor_iterator_types import (
 )
 from tests_compatibility.runtime import get_runtime
 
+
 def create_simple_if_with_two_outputs(condition_val):
     condition = ng.constant(condition_val, dtype=np.bool)
 

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_if.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_if.py
@@ -9,9 +9,7 @@ from ngraph.utils.tensor_iterator_types import (
     TensorIteratorInvariantInputDesc,
     TensorIteratorBodyOutputDesc,
 )
-from tests_compatibility import skip_issue_86384
 from tests_compatibility.runtime import get_runtime
-
 
 def create_simple_if_with_two_outputs(condition_val):
     condition = ng.constant(condition_val, dtype=np.bool)
@@ -151,7 +149,6 @@ def check_if(if_model, cond_val, exp_results):
     check_results(results, exp_results)
 
 
-@skip_issue_86384
 def test_if_with_two_outputs():
     check_if(create_simple_if_with_two_outputs, True,
              [np.array([10], dtype=np.float32), np.array([-20], dtype=np.float32)])
@@ -159,7 +156,6 @@ def test_if_with_two_outputs():
              [np.array([17], dtype=np.float32), np.array([16], dtype=np.float32)])
 
 
-@skip_issue_86384
 def test_diff_if_with_two_outputs():
     check_if(create_diff_if_with_two_outputs, True,
              [np.array([10], dtype=np.float32), np.array([6, 4], dtype=np.float32)])
@@ -167,13 +163,11 @@ def test_diff_if_with_two_outputs():
              [np.array([4], dtype=np.float32), np.array([12, 16], dtype=np.float32)])
 
 
-@skip_issue_86384
 def test_simple_if():
     check_if(simple_if, True, [np.array([6, 4], dtype=np.float32)])
     check_if(simple_if, False, [np.array([5, 5], dtype=np.float32)])
 
 
-@skip_issue_86384
 def test_simple_if_without_body_parameters():
     check_if(simple_if_without_parameters, True, [np.array([0.7], dtype=np.float32)])
     check_if(simple_if_without_parameters, False, [np.array([9.0], dtype=np.float32)])

--- a/src/bindings/python/tests_compatibility/test_utils/test_utils.py
+++ b/src/bindings/python/tests_compatibility/test_utils/test_utils.py
@@ -2,30 +2,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import openvino
-from openvino.runtime import Model, Core, Shape, Type
-from openvino.runtime.op import Parameter
+import ngraph as ng
+from openvino.inference_engine import IECore, IENetwork
+from ngraph.impl import Function, Shape, Type
+from ngraph.impl.op import Parameter
+
 from typing import Tuple, Union, List
-import openvino.runtime.opset8 as ops
 import numpy as np
 
 
 def get_test_function():
     element_type = Type.f32
     param = Parameter(element_type, Shape([1, 3, 22, 22]))
-    relu = ops.relu(param)
-    func = Model([relu], [param], "test")
+    relu = ng.relu(param)
+    func = Function([relu], [param], "test")
     assert func is not None
     return func
-
-
-def test_compare_functions():
-    try:
-        from openvino.test_utils import compare_functions
-        func = get_test_function()
-        status, _ = compare_functions(func, func)
-        assert status
-    except ModuleNotFoundError:
-        print("openvino.test_utils.compare_functions is not available")
 
 
 def generate_image(shape: Tuple = (1, 3, 32, 32), dtype: Union[str, np.dtype] = "float32") -> np.array:
@@ -33,11 +25,13 @@ def generate_image(shape: Tuple = (1, 3, 32, 32), dtype: Union[str, np.dtype] = 
     return np.random.rand(*shape).astype(dtype)
 
 
-def generate_model(input_shape: List[int]) -> openvino.runtime.ie_api.CompiledModel:
-    param = ops.parameter(input_shape, np.float32, name="parameter")
-    relu = ops.relu(param, name="relu")
-    func = Model([relu], [param], "test")
+def generate_model(input_shape: List[int]) -> openvino.inference_engine.ExecutableNetwork:
+    param = ng.parameter(input_shape, np.float32, name="parameter")
+    relu = ng.relu(param, name="relu")
+    func = Function([relu], [param], "test")
     func.get_ordered_ops()[2].friendly_name = "friendly"
 
-    core = Core()
-    return core.compile_model(func, "CPU", {})
+    core = IECore()
+    caps = Function.to_capsule(func)
+    cnnNetwork = IENetwork(caps)
+    return core.load_network(cnnNetwork, "CPU", {})


### PR DESCRIPTION
### Details:
 - `test_utils.py` file in the `tests_compatibility` folder used the new API instead of old one that caused this issue.
 - add absolute import instead of relative one.

### Tickets:
 - 86384
