### PR TITLE
Add missing opset5 header for LSTMSequence in LPT

### DIFF
--- a/src/common/low_precision_transformations/src/markup_precisions.cpp
+++ b/src/common/low_precision_transformations/src/markup_precisions.cpp
@@ -11,6 +11,7 @@
 
 #include <ngraph/opsets/opset1.hpp>
 #include <ngraph/opsets/opset4.hpp>
+#include <ngraph/opsets/opset5.hpp>
 #include <ngraph/opsets/opset6.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/pattern/op/or.hpp>


### PR DESCRIPTION
### Details:
Fix building error due missing header `<ngraph/opsets/opset5.hpp>` introduced by following two PRs:
 - https://github.com/openvinotoolkit/openvino/pull/12981 added `opset5::LSTMSequence` as follow: https://github.com/openvinotoolkit/openvino/blob/71c23489c6265e1f678a4dbc0e194e4ffc82c990/src/common/low_precision_transformations/src/markup_precisions.cpp#L223
 - https://github.com/openvinotoolkit/openvino/pull/13469 removed `#include <ngraph/opsets/opset5.hpp>`
