### PR TITLE
[MO TESTS] PReLU tests fix

### DIFF
--- a/tests/layer_tests/onnx_tests/test_prelu.py
+++ b/tests/layer_tests/onnx_tests/test_prelu.py
@@ -94,9 +94,9 @@ class TestPRelu(OnnxRuntimeLayerTest):
     # Note: IE only support slopes of one element or of size equal to number of channels.
     test_data_shared_channels = [
         dict(shape=[10, 12], slope_shape=[12]),
-        dict(shape=[8, 10, 12], slope_shape=[10]),
-        dict(shape=[6, 8, 10, 12], slope_shape=[8]),
-        dict(shape=[4, 6, 8, 10, 12], slope_shape=[6])]
+        dict(shape=[8, 10, 12], slope_shape=[10, 1]),
+        dict(shape=[6, 8, 10, 12], slope_shape=[8, 1, 1]),
+        dict(shape=[4, 6, 8, 10, 12], slope_shape=[6, 1, 1, 1])]
 
     test_data_scalar_precommit = [
         dict(shape=[2, 4, 6, 8], slope_shape=[1]),
@@ -110,19 +110,6 @@ class TestPRelu(OnnxRuntimeLayerTest):
         dict(shape=[4, 6, 8, 10, 12], slope_shape=[1])]
 
     test_data_precommit = [dict(shape=[8, 10, 12], slope_shape=[12])]
-
-    @pytest.mark.parametrize("params", test_data_scalar)
-    @pytest.mark.nightly
-    def test_prelu_opset6_scalar(self, params, ie_device, precision, ir_version, temp_dir, use_old_api):
-        self._test(*self.create_net(**params, precision=precision, opset=6, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
-
-    @pytest.mark.parametrize("params", test_data_shared_channels)
-    @pytest.mark.nightly
-    def test_prelu_opset6_shared_channels(self, params, ie_device, precision, ir_version, temp_dir,
-                                          use_old_api):
-        self._test(*self.create_net(**params, precision=precision, opset=6, ir_version=ir_version),
-                   ie_device, precision, ir_version, temp_dir=temp_dir, use_old_api=use_old_api)
 
     @pytest.mark.parametrize("params", test_data_scalar)
     @pytest.mark.nightly


### PR DESCRIPTION
### Details:
- *After changing Caffe2 to ONNX RT https://github.com/openvinotoolkit/openvino/pull/13759 per channel broadcast stopped working for slope inputs. This PR modify slope inputs according to numpy broadcast.*
- *Removed opset6 tests as it is not supported by the ONNX RT*
