### PR TITLE
[MyriadX][CVS-89635] - ovtf data->_producerEdge != nullptr - fix

### DIFF
--- a/src/common/legacy/src/graph_transformer.cpp
+++ b/src/common/legacy/src/graph_transformer.cpp
@@ -475,17 +475,19 @@ void ConstTransformer::fullTrim() {
     auto sortedLayers = details::CNNSubnetSortTopologically({inputs, outputs});
     auto constMapLayers = getConstLayers(sortedLayers);
 
-    for (auto& layer : sortedLayers) {
-        if (layer->type == "Const") {
-            for (auto& out : outputs) {
-                for (auto& out_const : layer->outData) {
-                    if (out_const == out) {
-                        constMapLayers.erase(layer->name);
-                        break;
+    for (const auto& layer : sortedLayers) {
+        [&] {
+            if (layer->type == "Const") {
+                for (const auto& out : outputs) {
+                    for (const auto& out_const : layer->outData) {
+                        if (out_const == out) {
+                            constMapLayers.erase(layer->name);
+                            return;
+                        }
                     }
                 }
             }
-        }
+        }();
     }
 
     auto constData = getConstData(constMapLayers, sortedLayers);

--- a/src/common/legacy/src/graph_transformer.cpp
+++ b/src/common/legacy/src/graph_transformer.cpp
@@ -233,6 +233,9 @@ const std::map<std::string, bool> ConstTransformer::getConstLayers(const std::ve
     for (const auto& layer : sortedLayers) {
         // Layers with "Shape" and "Const" type are Const by definition
         if (layer->type == "Shape" || layer->type == "Const") {
+            if (layer->insData.size() == 0 && layer->type == "Const") {
+                continue;
+            }
             mapConstLayers[layer->name] = false;
         } else if (std::find(skipConstInfer.begin(), skipConstInfer.end(), layer->type) == skipConstInfer.end() &&
                    !isForLayers(*layer, {"FakeQuantize", "Quantize"})) {


### PR DESCRIPTION
### Ticket:
https://jira.devtools.intel.com/browse/CVS-89635

### Description:
OVTF faced issue with new clusters that work fine on CPU.
**Old cluster:**
![old_ovtf](https://user-images.githubusercontent.com/52502732/201533777-7e0f8fce-a869-4516-b1b7-be60f3fb7561.png)
**Recent clusters with issues:**
![new_ovtf](https://user-images.githubusercontent.com/52502732/201533797-a7cc4de2-1208-46be-9b5e-5d0f6d5d6b1d.png)

### Solution and findings:
`removeConstLayers` removes Const layers, including `StatefulPartitionedCall/StatefulPartitionedCall/bert_pack_inputs/PartitionedCall/RaggedConcat/RaggedFromTensor_1/RaggedFromUniformRowLength/RowPartitionFromUniformRowLength/range/delta` which is used later, so we need to keep it.

Fails here:
```
if (data->_usage == DataUsage::Output) {
   IE_ASSERT(data->_producerEdge != nullptr);
}
```

### Without fix:
<img width="365" alt="fail" src="https://user-images.githubusercontent.com/52502732/201535101-59659178-d1dd-4920-a93f-999f099395cf.png">

### With fix:
<img width="375" alt="ok_ovtf" src="https://user-images.githubusercontent.com/52502732/201535107-44686496-d5f6-4233-9ace-26668821a93b.png">
