### PR TITLE
[ONNX] ConstantOfShape with empty tensor input

### DIFF
--- a/src/frontends/onnx/frontend/src/op/constant_of_shape.cpp
+++ b/src/frontends/onnx/frontend/src/op/constant_of_shape.cpp
@@ -7,7 +7,9 @@
 #include "core/tensor.hpp"
 #include "default_opset.hpp"
 #include "ngraph/op/constant.hpp"
+#include "onnx_import/core/null_node.hpp"
 #include "op/constant.hpp"
+#include "utils/common.hpp"
 #include "utils/reshape.hpp"
 
 namespace ngraph {
@@ -23,7 +25,12 @@ OutputVector constant_of_shape(const onnx_import::Node& node) {
     } else {
         constant_value = default_opset::Constant::create(element::f32, {}, {0});
     }
-    return {std::make_shared<default_opset::Broadcast>(constant_value, node.get_ng_inputs().at(0))};
+    const auto& inputs = node.get_ng_inputs();
+    if (inputs.size() == 0 || common::is_failsafe_node(inputs[0].get_node_shared_ptr()) ||
+        ngraph::op::is_null(inputs[0])) {
+        return {constant_value};
+    }
+    return {std::make_shared<default_opset::Broadcast>(constant_value, inputs[0])};
 }
 
 }  // namespace set_1

--- a/src/frontends/onnx/tests/models/constant_of_shape_empty_init.prototxt
+++ b/src/frontends/onnx/tests/models/constant_of_shape_empty_init.prototxt
@@ -1,0 +1,52 @@
+ir_version: 4
+producer_name: "onnx_frontend_test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "ConstantOfShape"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 6
+        int32_data: 1
+        name: "value"
+      }
+      type: TENSOR
+    }
+  }
+  name: "shape_of_test"
+  initializer {
+    dims: 0
+    data_type: 7
+    name: "x"
+    raw_data: ""
+  }
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim {
+            dim_value: 0
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 13
+}

--- a/src/frontends/onnx/tests/models/constant_of_shape_null_node.prototxt
+++ b/src/frontends/onnx/tests/models/constant_of_shape_null_node.prototxt
@@ -1,0 +1,33 @@
+ir_version: 4
+producer_name: "onnx_frontend_test"
+graph {
+  node {
+    input: ""
+    output: "y"
+    op_type: "ConstantOfShape"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 6
+        int32_data: 1
+        name: "value"
+      }
+      type: TENSOR
+    }
+  }
+  name: "shape_of_test"
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 13
+}

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -6096,7 +6096,7 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_is_nan) {
     auto test_case = test::TestCase(function, s_device);
 
     // clang-format off
-    
+
     test_case.add_input<float>(Shape{1, 2, 3}, {std::nanf(""), std::nanf(""), -0.6000f, -1.0000f, std::nanf(""), -1.0000f});
 
     test_case.add_expected_output<bool>(
@@ -6121,5 +6121,23 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_model_squeeze_default_domain_opset13) {
     auto test_case = test::TestCase(function, s_device);
     test_case.add_input(input);
     test_case.add_expected_output(expected_output);
+    test_case.run();
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_of_shape_empty_init) {
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_of_shape_empty_init.onnx"));
+    auto test_case = test::TestCase(function, s_device);
+    test_case.add_expected_output<int32_t>(Shape{}, {1});
+    test_case.run();
+}
+
+NGRAPH_TEST(${BACKEND_NAME}, onnx_constant_of_shape_null_node) {
+    auto function = onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                                        SERIALIZED_ZOO,
+                                                                        "onnx/constant_of_shape_null_node.onnx"));
+    auto test_case = test::TestCase(function, s_device);
+    test_case.add_expected_output<int32_t>(Shape{}, {1});
     test_case.run();
 }


### PR DESCRIPTION
### Details:
 - According to the ONNX standard ConstantOfShape with empty tensor input should lead to the scalar output shape.


### Tickets:
- https://github.com/openvinotoolkit/openvino/issues/13970
