### PR TITLE
[GPU] updated memory accessor

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -980,7 +980,7 @@ void primitive_inst::save(cldnn::BinaryOutputBuffer& ob) const {
             ob << cldnn::make_data(_outputs[0]->buffer_ptr(), data_size);
         } else {
             mem_lock<char, mem_lock_type::read> lock{_outputs[0], get_node().get_program().get_stream()};
-            ob << cldnn::make_data(lock.begin(), data_size);
+            ob << cldnn::make_data(lock.data(), data_size);
         }
     } else {
         object_type _object_type = object_type::EXECUTABLE_INST;


### PR DESCRIPTION
### Details:
 - Checked iterators are enabled in Windows Debug builds, and cannot be converted to 'void *'.
 - This patch changes the memory accessor from `begin()` to `data()`.

### Tickets:
 - 96522
