### PR TITLE
Avoid gold linker usage in case of cross-compilation

### DIFF
--- a/cmake/developer_package/compile_flags/os_flags.cmake
+++ b/cmake/developer_package/compile_flags/os_flags.cmake
@@ -383,3 +383,11 @@ function(link_system_libraries TARGET_NAME)
         endif()
     endforeach()
 endfunction()
+
+function(ov_try_use_gold_linker)
+    # gold linker on ubuntu20.04 may fail to link binaries build with sanitizer
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT ENABLE_SANITIZER AND NOT CMAKE_CROSSCOMPILING)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=gold" PARENT_SCOPE)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=gold" PARENT_SCOPE)
+    endif()
+endfunction()

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -5,11 +5,7 @@ set(TARGET_NAME ov_core_unit_tests)
 
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT ENABLE_SANITIZER)
-    # gold linker on ubuntu20.04 may fail to link binaries build with sanitizer
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=gold")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=gold")
-endif()
+ov_try_use_gold_linker()
 
 add_definitions(-DSERIALIZED_ZOO=\"${TEST_MODEL_ZOO}/core/models\")
 
@@ -50,7 +46,7 @@ endif()
 ov_add_test_target(
     NAME ${TARGET_NAME}
         ROOT ${CMAKE_CURRENT_SOURCE_DIR}
-        EXCLUDED_SOURCE_PATHS 
+        EXCLUDED_SOURCE_PATHS
             ${EXCLUDE_TESTS}
         DEPENDENCIES
             ${UNIT_TESTS_DEPENDENCIES}

--- a/src/frontends/onnx/tests/CMakeLists.txt
+++ b/src/frontends/onnx/tests/CMakeLists.txt
@@ -4,17 +4,12 @@
 
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT ENABLE_SANITIZER)
-    # gold linker on ubuntu20.04 may fail to link binaries build with sanitizer
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=gold")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=gold")
-endif()
+ov_try_use_gold_linker()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     ie_add_compiler_flags(/wd4244)
     ie_add_compiler_flags(/wd4267)
 endif()
-
 
 message(STATUS "ONNX frontend test enabled")
 

--- a/src/tests_deprecated/unit/CMakeLists.txt
+++ b/src/tests_deprecated/unit/CMakeLists.txt
@@ -124,11 +124,7 @@ target_link_libraries(${TARGET_NAME} PRIVATE
     inference_engine_lp_transformations
     )
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT ENABLE_SANITIZER)
-    # gold linker on ubuntu20.04 may fail to link binaries build with sanitizer
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=gold")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=gold")
-endif()
+ov_try_use_gold_linker()
 
 add_test(NAME ${TARGET_NAME} COMMAND ${TARGET_NAME})
 set_property(TEST ${TARGET_NAME} PROPERTY LABELS IE)


### PR DESCRIPTION
### Details:

It might not be available in some cross-toolchains.

Extract the code for switching to gold linker into separate CMake utility function to avoid duplication between multiple CMake scripts.
