### PR TITLE
[MO][POC] TensorBoard for ov::Model - Alternative to Netron

### DIFF
--- a/tools/mo/automation/package_BOM.txt
+++ b/tools/mo/automation/package_BOM.txt
@@ -1092,6 +1092,7 @@ openvino/tools/mo/utils/telemetry_params.py
 openvino/tools/mo/utils/telemetry_stub.py
 openvino/tools/mo/utils/telemetry_utils.py
 openvino/tools/mo/utils/tensorboard_util.py
+openvino/tools/mo/utils/tensorboard/writer.py
 openvino/tools/mo/utils/type_utils.py
 openvino/tools/mo/utils/unsupported_ops.py
 openvino/tools/mo/utils/utils.py

--- a/tools/mo/automation/package_BOM.txt
+++ b/tools/mo/automation/package_BOM.txt
@@ -1091,8 +1091,8 @@ openvino/tools/mo/utils/summarize_graph.py
 openvino/tools/mo/utils/telemetry_params.py
 openvino/tools/mo/utils/telemetry_stub.py
 openvino/tools/mo/utils/telemetry_utils.py
-openvino/tools/mo/utils/tensorboard_util.py
 openvino/tools/mo/utils/tensorboard/writer.py
+openvino/tools/mo/utils/tensorboard_util.py
 openvino/tools/mo/utils/type_utils.py
 openvino/tools/mo/utils/unsupported_ops.py
 openvino/tools/mo/utils/utils.py

--- a/tools/mo/openvino/tools/mo/convert_impl.py
+++ b/tools/mo/openvino/tools/mo/convert_impl.py
@@ -732,6 +732,12 @@ def driver(argv: argparse.Namespace, non_default_params: dict):
     if res_ngraph_function is None:
         return res_ngraph_function
 
+    if argv.tensorboard_ir_logdir:
+        from openvino.tools.mo.utils.tensorboard.writer import SummaryWriter
+        writer = SummaryWriter(argv.tensorboard_ir_logdir)
+        writer.add_graph(res_ngraph_function)
+        writer.close()
+
     if not argv.silent:
         elapsed_time = datetime.datetime.now() - start_time
         print('[ SUCCESS ] Total execution time: {:.2f} seconds. '.format(elapsed_time.total_seconds()))

--- a/tools/mo/openvino/tools/mo/utils/cli_parser.py
+++ b/tools/mo/openvino/tools/mo/utils/cli_parser.py
@@ -586,6 +586,9 @@ mo_convert_params = {
         extensions_to_str_or_extensions_class),
     'batch': ParamDescription(
         'Input batch size', '', '', batch_to_int),
+    'tensorboard_ir_logdir': ParamDescription(
+        'Dump the generated OpenVINO model to a given directory to be opened by TensorBoard.', '', '',
+        path_to_str),
     'silent': ParamDescription(
         'Prevent any output messages except those that correspond to log level equals '
         'ERROR, that can be set with the following option: --log_level. '
@@ -1027,6 +1030,10 @@ def get_common_cli_parser(parser: argparse.ArgumentParser = None):
                               help=mo_convert_params_common['transform'].description.format(
                                   mo_convert_params_common['transform'].possible_types_command_line),
                               default="")
+    common_group.add_argument('--tensorboard_ir_logdir',
+                              help=mo_convert_params['tensorboard_ir_logdir'].description,
+                              action=CanonicalizePathCheckExistenceAction,
+                              type=readable_file_or_dir)
     common_group.add_argument('--disable_fusing',
                               help='[DEPRECATED] Turn off fusing of linear operations to Convolution.',
                               action=DeprecatedStoreTrue)
@@ -1113,6 +1120,7 @@ def get_common_cli_options(model_name):
     d['reverse_input_channels'] = '- Reverse input channels'
     d['static_shape'] = '- Enable IR generation for fixed input shape'
     d['transformations_config'] = '- Use the transformations config file'
+    d['tensorboard_ir_logdir'] = ['- The directory with TensorBoard logs for IR', lambda x: x if x else 'Not specified']
     return d
 
 

--- a/tools/mo/openvino/tools/mo/utils/cli_parser.py
+++ b/tools/mo/openvino/tools/mo/utils/cli_parser.py
@@ -1031,7 +1031,7 @@ def get_common_cli_parser(parser: argparse.ArgumentParser = None):
                                   mo_convert_params_common['transform'].possible_types_command_line),
                               default="")
     common_group.add_argument('--tensorboard_ir_logdir',
-                              help=mo_convert_params['tensorboard_ir_logdir'].description,
+                              help=mo_convert_params_common['tensorboard_ir_logdir'].description,
                               action=CanonicalizePathCheckExistenceAction,
                               type=readable_file_or_dir)
     common_group.add_argument('--disable_fusing',

--- a/tools/mo/openvino/tools/mo/utils/tensorboard/writer.py
+++ b/tools/mo/openvino/tools/mo/utils/tensorboard/writer.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     raise Error(
         'For generation of TensorBoard logs for OpenVINO Model,'
-        'nstall required dependencies: pip install tensorflow protobuf tensorboard')
+        'Install required dependencies: pip install tensorflow protobuf tensorboard')
 
 from openvino.runtime import Model  # pylint: disable=no-name-in-module,import-error
 

--- a/tools/mo/openvino/tools/mo/utils/tensorboard/writer.py
+++ b/tools/mo/openvino/tools/mo/utils/tensorboard/writer.py
@@ -88,9 +88,8 @@ class SummaryWriter(object):
             graph_def_str += node_def_str
         graph_def = tf.GraphDef()
         text_format.Merge(graph_def_str, graph_def)
-        event_writer = EventFileWriter(".", 10, 120, "")
         event = event_pb2.Event(graph_def=graph_def.SerializeToString())
-        event_writer.add_event(event)
+        self.event_writer.add_event(event)
 
     def flush(self):
         """

--- a/tools/mo/openvino/tools/mo/utils/tensorboard/writer.py
+++ b/tools/mo/openvino/tools/mo/utils/tensorboard/writer.py
@@ -1,0 +1,109 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from openvino.tools.mo.utils.error import Error
+
+try:
+    import tensorflow.compat.v1 as tf
+    from google.protobuf import text_format
+    from tensorboard.compat.proto import event_pb2
+    from tensorboard.summary.writer.event_file_writer import EventFileWriter
+except ImportError:
+    raise Error(
+        'For generation of TensorBoard logs for OpenVINO Model,'
+        'nstall required dependencies: pip install tensorflow protobuf tensorboard')
+
+from openvino.runtime import Model  # pylint: disable=no-name-in-module,import-error
+
+
+class SummaryWriter(object):
+    """
+    Writes TensorBoard logs for OpenVINO model object
+    """
+
+    def __init__(
+            self,
+            log_dir=None,
+            max_queue=10,
+            flush_secs=120,
+            filename_suffix="",
+    ):
+        if not log_dir:
+            import socket
+            from datetime import datetime
+            current_time = datetime.now().strftime("%b%d_%H-%M-%S")
+            log_dir = os.path.join(
+                "runs", current_time + "_" + socket.gethostname()
+            )
+        # initialize the event writer for OpenVINO Model
+        self.event_writer = EventFileWriter(log_dir, max_queue, flush_secs, filename_suffix)
+
+    def add_graph(
+            self, ov_model: Model
+    ):
+        """
+        Add OpenVINO model data to summary.
+        """
+        # write ov::Model in protobuf format
+        graph_def_str = ""
+        for op_node in ov_model.get_ordered_ops():
+            op_type = op_node.get_type_name()
+            node_name = op_node.get_friendly_name()
+            node_def_str = "  name: \"{}\"\n".format(node_name)
+            node_def_str += "  op: \"{}\"\n".format(op_type)
+            for ind, input_value in enumerate(op_node.input_values()):
+                if op_node.get_input_size() == 1:
+                    node_def_str += "  input: \"{}\"\n".format(input_value.get_node().get_friendly_name())
+                else:
+                    node_def_str += "  input: \"{}:{}\"\n".format(input_value.get_node().get_friendly_name(), ind)
+            # TODO: add other attributes, not only _output_shapes
+            # generate a list of output shapes
+            attr_def_str = "  attr {\n"
+            attr_def_str += "    key: \"_output_shapes\"\n"
+            attr_def_str += "    value {\n"
+            attr_def_str += "      list {\n"
+            for ind in range(0, op_node.get_output_size()):
+                partial_shape = op_node.get_output_partial_shape(ind)
+                if partial_shape.rank.is_static:
+                    attr_def_str += "        shape {\n"
+                    for dim in partial_shape:
+                        dim_value = -1
+                        if dim.is_static:
+                            dim_value = dim.get_length()
+                        attr_def_str += "          dim {\n"
+                        attr_def_str += "            size: {}\n".format(dim_value)
+                        attr_def_str += "          }\n"
+                    attr_def_str += "        }\n"
+                else:
+                    attr_def_str += "        shape {\n"
+                    attr_def_str += "        }\n"
+
+            attr_def_str += "      }\n"
+            attr_def_str += "    }\n"
+            attr_def_str += "  }\n"
+            node_def_str = "node {\n" + node_def_str + attr_def_str
+            node_def_str += "}\n"
+            graph_def_str += node_def_str
+        graph_def = tf.GraphDef()
+        text_format.Merge(graph_def_str, graph_def)
+        event_writer = EventFileWriter(".", 10, 120, "")
+        event = event_pb2.Event(graph_def=graph_def.SerializeToString())
+        event_writer.add_event(event)
+
+    def flush(self):
+        """
+        Flushes the event file to disk.
+        """
+        self.event_writer.flush()
+
+    def close(self):
+        self.event_writer.flush()
+        self.event_writer.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()


### PR DESCRIPTION
**Details:** Implemented alternative way to visualize IR, ov::Model via TensorBoard tool.
Implemented functionality generates TensorBoard logs for IR and ov::Model

Currently the frameworks (PyTorch, Paddle, not only TensorFlow) use TensorBoard to visualize their models. The idea is to generate TensorBoard logs for the input model and open it up via TensorBoard tool.
Here is an example for PyTorch by this [link](https://pytorch.org/tutorials/intermediate/tensorboard_tutorial.html).

There is a similar way to visualize Pytorch model in TensorBoard like as follows:

```
from torch.utils.tensorboard import SummaryWriter
writer = SummaryWriter('logs_dir')
writer.add_graph(net, images)
writer.close()
```

In OpenVINO we have two ways to generate TB logs. The first one is using OpenVino Tools API:

```
from openvino.tools.mo.utils.tensorboard.writer import SummaryWriter
writer = SummaryWriter('logs_dir')
writer.add_graph(ov_model)
writer.close()
```

The second way is using new MO option `--tensorboard_ir_logdir`.

Example of how IR for FaceNet is displayed in TensorBoard:
![image](https://user-images.githubusercontent.com/35459624/202916144-ac92c2ce-d277-426f-b0f3-9e958aa05048.png)

TODO:

* [ ] Support Loop, If
* [ ] Support attributes
* [ ] Constant values
* [ ] Fill GitHub issue in TB repo: complain on bugs in the visualization


**Ticket:** TBD

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
