### PR TITLE
[CPU] Fix ports configuration for bf16 RNN primitives

### DIFF
--- a/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.h
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.h
@@ -6,6 +6,7 @@
 
 #include <onednn/dnnl.h>
 #include "cpu_types.h"
+#include "cpu_shape.h"
 
 #include <ie_layouts.h>
 #include <ie_blob.h>

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -38,7 +38,7 @@ std::vector<std::string> disabledTestPatterns() {
         // TODO: Issue 43417 sporadic issue, looks like an issue in test, reproducible only on Windows platform
         R"(.*decomposition1_batch=5_hidden_size=10_input_size=30_.*tanh.relu.*_clip=0_linear_before_reset=1.*_targetDevice=CPU_.*)",
         // Skip platforms that do not support BF16 (i.e. sse, avx, avx2)
-        R"(.*(BF|bf)16.*(jit_avx(?!5)|jit_sse|ref).*)",
+        R"(.*(BF|bf)16.*(jit_avx(?!5)|jit_sse).*)",
         // TODO: Incorrect blob sizes for node BinaryConvolution_X
         R"(.*BinaryConvolutionLayerTest.*)",
         // TODO: 53618. BF16 gemm ncsp convolution crash
@@ -185,6 +185,10 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*GridSampleLayerTestCPU.*(BILINEAR|BICUBIC).*(i32|i8).*)",
         // 94989. BF16 Reference produces different results.
         R"(.*GridSampleLayerTestCPU.*(BILINEAR|BICUBIC).*gridPrc=bf16.*)",
+        // // Issue: 95915
+        R"(smoke_dynamic/AUGRUCellCPUTest.CompareWithRefs/IS=\(\[\?\.1\]_\[\?\.1\]_\[\?\.1\]_\)_TS=\{\(1\.1\)_\(1\.1\)_\(1\.1\)\}_\{\(3\.1\)_\(3\.1\)_\(3\.1\)\}_\{\(5\.1\)_\(5\.1\)_\(5\.1\)\}_decompose=0_activations=\(sigmoid\.tanh\)_clip=0_linear=0_netPrec=f32__inFmts=nc\.nc_outFmts=nc_primitive=ref_any_PluginConf_ENFORCE_BF16=YES)", // NOLINT
+        R"(smoke_dynamic/GRUCellCPUTest.CompareWithRefs/IS=\(\[\?.1\]_\[\?\.1\]_\)_TS=\{\(1\.1\)_\(1\.1\)\}_\{\(3\.1\)_\(3\.1\)\}_\{\(5\.1\)_\(5\.1\)\}_decompose=0_activations=\(sigmoid\.tanh\)_clip=0_linear=0_netPrec=f32__inFmts=nc\.nc_outFmts=nc_primitive=ref_any_PluginConf_ENFORCE_BF16=YES)", // NOLINT
+        R"(nightly_dynamic_bf16/RNNSequenceCPUTest.*activations=\(relu\).*)",
     };
 
 #define FIX_62820 0

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/augru_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/augru_sequence.cpp
@@ -92,13 +92,6 @@ protected:
         if (inputDynamicShapes.size() == 2 && inputDynamicShapes[0][0].is_dynamic() && inputDynamicShapes[1][0].is_dynamic())
             throw std::runtime_error("Invalid test case. If 3rd input is constant, batch dimension must be static.");
 
-        // Method MemoryDesc::isSame can't correct compute layout for tensor with strides = 1
-        // returned output format always tnc
-        if (inFmts.size() == 2 && (inputDynamicShapes[0][0].is_static() && inputDynamicShapes[0][0].get_length() == 1 ||
-                inputDynamicShapes[1].is_static() && ov::shape_size(inputDynamicShapes[1].to_shape()) == 1)) {
-            inFmts[1] = tnc;
-        }
-
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         const size_t hiddenSize = targetStaticShapes.front()[1][2];
@@ -144,15 +137,6 @@ protected:
                                                      direction,
                                                      seqMode);
 
-        // method MemoryDesc::isSame can't correct compute layout for tensor with strides = 1
-        // returned output format always tnc
-        if (augruSequenceOp->get_output_partial_shape(0).is_static() && ov::shape_size(augruSequenceOp->get_output_shape(0)) == 1) {
-            outFmts[0] = tnc;
-        } else if (augruSequenceOp->get_output_partial_shape(1).is_static() && ov::shape_size(augruSequenceOp->get_output_shape(1)) == 1 ||
-                augruSequenceOp->get_output_partial_shape(0)[0].is_static() && augruSequenceOp->get_output_partial_shape(0)[0].get_length() == 1) {
-            outFmts[1] = tnc;
-        }
-
         function = makeNgraphFunction(netPrecision, params, augruSequenceOp, "augruSequenceOp");
 
         if (seqMode != ngraph::helpers::SequenceTestsMode::PURE_SEQ) {
@@ -195,7 +179,7 @@ std::vector<std::map<std::string, std::string>> additionalConfig
        {{InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16, InferenceEngine::PluginConfigParams::YES}}};
 
 CPUSpecificParams cpuParams{{ntc, tnc}, {ntc, tnc}, {"ref_any"}, "ref_any"};
-CPUSpecificParams cpuParamsBatchSizeOne{{tnc, ntc}, {tnc, ntc}, {"ref_any"}, "ref_any"};;
+CPUSpecificParams cpuParamsBatchSizeOne{{tnc, tnc}, {tnc, tnc}, {"ref_any"}, "ref_any"};;
 
 std::vector<ngraph::helpers::SequenceTestsMode> mode{ngraph::helpers::SequenceTestsMode::PURE_SEQ};
 // output values increase rapidly without clip, so use only seq_lengths = 2
@@ -283,53 +267,57 @@ const std::vector<std::vector<InputShape>> dynamicShapes = {
       { {-1, 1, 10},                                // Dynamic shape 1
         { {10, 1, 10}, {3, 1, 10}, {5, 1, 10} } },  // Target shapes
       { {{0, 11}, -1, 1},                           // Dynamic shape 3
-        { {10, 2, 1}, {3, 4, 1}, {5, 5, 1} } },   // Target shapes
+        { {10, 2, 1}, {3, 4, 1}, {5, 5, 1} } },     // Target shapes
       { {-1},                                       // Dynamic shape 2
-        { {10}, {3}, {5} } } },                       // Target shapes
+        { {10}, {3}, {5} } } },                     // Target shapes
     { { {{0, 11}, -1, {7, 11}},                     // #2. Dynamic shape 0
         { {10, 2, 10}, {3, 4, 10}, {5, 5, 10} } },  // Target shapes
       { {-1, 1, {8, 12}},                           // Dynamic shape 1
         { {10, 1, 10}, {3, 1, 10}, {5, 1, 10} } },  // Target shapes
       { {{0, 11}, -1, 1},                           // Dynamic shape 3
-        { {10, 2, 1}, {3, 4, 1}, {5, 5, 1} } } ,   // Target shapes
+        { {10, 2, 1}, {3, 4, 1}, {5, 5, 1} } } ,    // Target shapes
       { {-1},                                       // Dynamic shape 2
-        { {10}, {3}, {5} } } },                       // Target shapes
+        { {10}, {3}, {5} } } },                     // Target shapes
     { { {-1, {0, 7}, 10},                           // #3. Dynamic shape 0
         { {1, 2, 10}, {1, 3, 10}, {1, 6, 10} } },   // Target shapes
       { {-1, 1, 1},                                 // Dynamic shape 1
         { {1, 1, 1}, {1, 1, 1}, {1, 1, 1} } },      // Target shapes
       { {-1, {0, 7}, 1},                            // Dynamic shape 3
-        { {1, 2, 1}, {1, 3, 1}, {1, 6, 1} } },    // Target shapes
+        { {1, 2, 1}, {1, 3, 1}, {1, 6, 1} } },      // Target shapes
       { {-1},                                       // Dynamic shape 2
-        { {1}, {1}, {1} } } },                       // Target shapes
+        { {1}, {1}, {1} } } },                      // Target shapes
     { { {1, -1, 10},                                // #4. Dynamic shape 0
         { {1, 2, 10}, {1, 4, 10}, {1, 8, 10} } },   // Target shapes
       { {1, 1, 10},                                 // Dynamic shape 1
         { {1, 1, 10}, {1, 1, 10}, {1, 1, 10} } },   // Target shapes
       { {1, -1, 1},                                 // Dynamic shape 0
-        { {1, 2, 1}, {1, 4, 1}, {1, 8, 1} } },    // Target shapes
+        { {1, 2, 1}, {1, 4, 1}, {1, 8, 1} } },      // Target shapes
       { {-1},                                       // Dynamic shape 2
-        { {1}, {1}, {1} } } },                        // Target shapes
+        { {1}, {1}, {1} } } },                      // Target shapes
     { { {-1, -1, -1},                               // #5. Dynamic shape 0
         { {1, 2, 10}, {1, 4, 10}, {1, 8, 10} } },   // Target shapes
       { {-1, -1, -1},                               // Dynamic shape 1
         { {1, 1, 10}, {1, 1, 10}, {1, 1, 10} } },   // Target shapes
       { {-1, -1, -1},                               // Dynamic shape 0
-        { {1, 2, 1}, {1, 4, 1}, {1, 8, 1} } },    // Target shapes
+        { {1, 2, 1}, {1, 4, 1}, {1, 8, 1} } },      // Target shapes
       { {-1},                                       // Dynamic shape 2
-        { {1}, {1}, {1} } } },                        // Target shapes
+        { {1}, {1}, {1} } } },                      // Target shapes
     { { {2, {1, 5}, 10},                            // #6. Dynamic shape 0
         { {2, 2, 10}, {2, 3, 10}, {2, 4, 10} } },   // Target shapes
       { {2, 1, 1},                                  // Dynamic shape 1
         { {2, 1, 1}, {2, 1, 1}, {2, 1, 1} } },      // Target shapes
       { {2, {1, 5}, 1},                             // Dynamic shape 2
-        { {2, 2, 1}, {2, 3, 1}, {2, 4, 1} } } },    // Target shapes
+        { {2, 2, 1}, {2, 3, 1}, {2, 4, 1} } },      // Target shapes
+      { {-1},                                       // Dynamic shape 2
+        { {2}, {2}, {2} } } },                      // Target shapes
     { { {5, -1, 10},                                // #7. Dynamic shape 0
         { {5, 2, 10}, {5, 4, 10}, {5, 5, 10} } },   // Target shapes
       { {5, 1, 10},                                 // Dynamic shape 1
         { {5, 1, 10}, {5, 1, 10}, {5, 1, 10} } },   // Target shapes
       { {5, -1, 1},                                 // Dynamic shape 0
-        { {5, 2, 1}, {5, 4, 1}, {5, 5, 1} } } },    // Target shapes
+        { {5, 2, 1}, {5, 4, 1}, {5, 5, 1} } },      // Target shapes
+      { {-1},                                       // Dynamic shape 2
+        { {5}, {5}, {5} } } },                      // Target shapes
     { { {{0, 11}, -1, {7, 11}},                     // #8. Dynamic shape 0
         { {10, 2, 10}, {3, 4, 10}, {5, 5, 10}, {10, 2, 10}, {5, 5, 10} } },  // Target shapes
       { {-1, 1, {8, 12}},                           // Dynamic shape 1

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/gru_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/gru_sequence.cpp
@@ -92,13 +92,6 @@ protected:
         if (inputDynamicShapes.size() == 2 && inputDynamicShapes[0][0].is_dynamic() && inputDynamicShapes[1][0].is_dynamic())
             throw std::runtime_error("Invalid test case. If 3rd input is constant, batch dimension must be static.");
 
-        // Method MemoryDesc::isSame can't correct compute layout for tensor with strides = 1
-        // returned output format always tnc
-        if (inFmts.size() == 2 && (inputDynamicShapes[0][0].is_static() && inputDynamicShapes[0][0].get_length() == 1 ||
-                inputDynamicShapes[1].is_static() && ov::shape_size(inputDynamicShapes[1].to_shape()) == 1)) {
-            inFmts[1] = tnc;
-        }
-
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         const size_t hiddenSize = targetStaticShapes.front()[1][2];
@@ -139,15 +132,6 @@ protected:
                                                      true,
                                                      direction,
                                                      seqMode);
-
-        // method MemoryDesc::isSame can't correct compute layout for tensor with strides = 1
-        // returned output format always tnc
-        if (gruSequenceOp->get_output_partial_shape(0).is_static() && ov::shape_size(gruSequenceOp->get_output_shape(0)) == 1) {
-            outFmts[0] = tnc;
-        } else if (gruSequenceOp->get_output_partial_shape(1).is_static() && ov::shape_size(gruSequenceOp->get_output_shape(1)) == 1 ||
-                gruSequenceOp->get_output_partial_shape(0)[0].is_static() && gruSequenceOp->get_output_partial_shape(0)[0].get_length() == 1) {
-            outFmts[1] = tnc;
-        }
 
         function = makeNgraphFunction(netPrecision, params, gruSequenceOp, "gruSequenceOp");
 
@@ -196,7 +180,7 @@ std::vector<std::map<std::string, std::string>> additionalConfig
        {{InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16, InferenceEngine::PluginConfigParams::YES}}};
 
 CPUSpecificParams cpuParams{{ntc, tnc}, {ntc, tnc}, {"ref_any"}, "ref_any"};
-CPUSpecificParams cpuParamsBatchSizeOne{{tnc, ntc}, {tnc, ntc}, {"ref_any"}, "ref_any"};;
+CPUSpecificParams cpuParamsBatchSizeOne{{tnc, tnc}, {tnc, tnc}, {"ref_any"}, "ref_any"};;
 
 std::vector<ngraph::helpers::SequenceTestsMode> mode{ngraph::helpers::SequenceTestsMode::PURE_SEQ};
 // output values increase rapidly without clip, so use only seq_lengths = 2
@@ -302,17 +286,21 @@ const std::vector<std::vector<InputShape>> dynamicShapes = {
     { { {2, {1, 5}, 10},                            // #6. Dynamic shape 0
         { {2, 2, 10}, {2, 3, 10}, {2, 4, 10} } },   // Target shapes
       { {2, 1, 1},                                  // Dynamic shape 1
-        { {2, 1, 1}, {2, 1, 1}, {2, 1, 1} } } },    // Target shapes
+        { {2, 1, 1}, {2, 1, 1}, {2, 1, 1} } },      // Target shapes
+      { {-1},                                       // Dynamic shape 2
+        { {2}, {2}, {2} } }},                       // Target shapes
     { { {5, -1, 10},                                // #7. Dynamic shape 0
         { {5, 2, 10}, {5, 4, 10}, {5, 5, 10} } },   // Target shapes
       { {5, 1, 10},                                 // Dynamic shape 1
-        { {5, 1, 10}, {5, 1, 10}, {5, 1, 10} } } }, // Target shapes
+        { {5, 1, 10}, {5, 1, 10}, {5, 1, 10} } },   // Target shapes
+      { {-1},                                       // Dynamic shape 2
+        { {5}, {5}, {5} } }},                       // Target shapes
     { { {{0, 11}, -1, {7, 11}},                     // #8. Dynamic shape 0
         { {10, 2, 10}, {3, 4, 10}, {5, 5, 10}, {10, 2, 10}, {5, 5, 10} } },  // Target shapes
       { {-1, 1, {8, 12}},                           // Dynamic shape 1
         { {10, 1, 10}, {3, 1, 10}, {5, 1, 10}, {10, 1, 10}, {5, 1, 10} } },  // Target shapes
       { {-1},                                       // Dynamic shape 2
-        { {10}, {3}, {5}, {10}, {5} } } }                                    // Target shapes
+        { {10}, {3}, {5}, {10}, {5} } } }           // Target shapes
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_dynamic, GRUSequenceCPUTest,

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/lstm_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/lstm_sequence.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <cstdlib>
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "ngraph_functions/builders.hpp"
 #include "test_utils/cpu_test_utils.hpp"
@@ -93,16 +94,6 @@ protected:
         const size_t hiddenSize = targetStaticShapes.front()[1][2];
         const size_t numDirections = direction == ov::op::RecurrentSequenceDirection::BIDIRECTIONAL ? 2 : 1;
 
-        // method MemoryDesc::isSame can't correct compute layout for tensor with strides = 1
-        // returned output format always tnc
-        if (inFmts.size() >= 3) {
-            for (size_t i = 1; i < 3; i++) {
-                if (inputDynamicShapes[i].is_static() && ov::shape_size(inputDynamicShapes[i].to_shape()) == 1) {
-                    inFmts[i] = tnc;
-                }
-            }
-        }
-
         float WRB_range = 0;
         auto it_dynamic_batch = additionalConfig.find("_dynamic_batch_test");
         if (it_dynamic_batch != additionalConfig.end() && it_dynamic_batch->second == "yes") {
@@ -139,27 +130,16 @@ protected:
         std::vector<ov::Shape> WRB = {{numDirections, 4 * hiddenSize, inputSize}, {numDirections, 4 * hiddenSize, hiddenSize},
                 {numDirections, 4 * hiddenSize}, {batchSize}};
         auto lstmSequenceOp = ngraph::builder::makeLSTM(ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes(params)),
-                                                       WRB,
-                                                       hiddenSize,
-                                                       activations,
-                                                       {},
-                                                       {},
-                                                       clip,
-                                                       true,
-                                                       direction,
-                                                       seqMode,
-                                                       WRB_range);
-
-        // method MemoryDesc::isSame can't correct compute layout for tensor with strides = 1
-        // returned output format always tnc
-        if (outFmts.size() >= 3) {
-            for (size_t i = 1; i < 3; i++) {
-                if (lstmSequenceOp->get_output_partial_shape(i).is_static() && ov::shape_size(lstmSequenceOp->get_output_shape(i)) == 1 ||
-                        lstmSequenceOp->get_output_partial_shape(0).is_static() && lstmSequenceOp->get_output_shape(0) == ov::Shape{1, 1, 2, 10}) {
-                    outFmts[i] = tnc;
-                }
-            }
-        }
+                                                        WRB,
+                                                        hiddenSize,
+                                                        activations,
+                                                        {},
+                                                        {},
+                                                        clip,
+                                                        true,
+                                                        direction,
+                                                        seqMode,
+                                                        WRB_range);
 
         function = makeNgraphFunction(netPrecision, params, lstmSequenceOp, "lstmSequenceOp");
 
@@ -208,7 +188,8 @@ std::vector<std::map<std::string, std::string>> additionalConfig
        {{InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16, InferenceEngine::PluginConfigParams::YES}}};
 
 CPUSpecificParams cpuParams{{ntc, tnc, tnc}, {ntc, tnc, tnc}, {"ref_any"}, "ref_any"};
-CPUSpecificParams cpuParamsBatchSizeOne{{tnc, ntc, ntc}, {tnc, ntc, ntc}, {"ref_any"}, "ref_any"};
+// CPUSpecificParams cpuParamsBatchSizeOne{{tnc, ntc, ntc}, {tnc, ntc, ntc}, {"ref_any"}, "ref_any"};
+CPUSpecificParams cpuParamsBatchSizeOne{{tnc, tnc, tnc}, {tnc, tnc, tnc}, {"ref_any"}, "ref_any"};
 
 std::vector<ngraph::helpers::SequenceTestsMode> mode{ngraph::helpers::SequenceTestsMode::PURE_SEQ};
 // oneDNN supports only sigmoid-tanh-tanh
@@ -238,7 +219,8 @@ const std::vector<std::vector<InputShape>> staticShapes = {
       { {}, { {1} } } },
     { { {}, { {1, 2, 10} } },  // Static shapes
       { {}, { {1, 1, 10} } },
-      { {}, { {1, 1, 10} } } }
+      { {}, { {1, 1, 10} } },
+      { {}, { {1} } } },
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_static, LSTMSequenceCPUTest,
@@ -264,14 +246,25 @@ INSTANTIATE_TEST_SUITE_P(smoke_static_BatchSizeOne, LSTMSequenceCPUTest,
                 LSTMSequenceCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(nightly_static_bf16, LSTMSequenceCPUTest,
-                ::testing::Combine(::testing::ValuesIn(std::vector<std::vector<InputShape>>{staticShapes[4]}),
+                ::testing::Combine(::testing::ValuesIn(std::vector<std::vector<InputShape>>{staticShapes[0]}),
                                    ::testing::ValuesIn(mode),
                                    ::testing::ValuesIn(activations),
                                    ::testing::ValuesIn(clip),
                                    ::testing::ValuesIn(direction),
                                    ::testing::ValuesIn(netPrecisions),
                                    ::testing::Values(cpuParams),
-                                   ::testing::Values(additionalConfig[1])),
+                                   ::testing::ValuesIn(additionalConfig)),
+                LSTMSequenceCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(nightly_static_bf16_BatchSizeOne, LSTMSequenceCPUTest,
+                ::testing::Combine(::testing::ValuesIn(std::vector<std::vector<InputShape>>{staticShapes[4]}),
+                                   ::testing::ValuesIn(mode),
+                                   ::testing::ValuesIn(activations),
+                                   ::testing::ValuesIn(clip),
+                                   ::testing::ValuesIn(direction),
+                                   ::testing::ValuesIn(netPrecisions),
+                                   ::testing::Values(cpuParamsBatchSizeOne),
+                                   ::testing::ValuesIn(additionalConfig)),
                 LSTMSequenceCPUTest::getTestCaseName);
 
 const std::vector<std::vector<InputShape>> dynamicShapes = {
@@ -328,7 +321,9 @@ const std::vector<std::vector<InputShape>> dynamicShapes = {
       { {3, -1, {0, 12}},                           // Dynamic shape 1
         { {3, 1, 10}, {3, 1, 10}, {3, 1, 10} } },   // Target shapes
       { {3, -1, {0, 12}},                           // Dynamic shape 2
-        { {3, 1, 10}, {3, 1, 10}, {3, 1, 10} } } }, // Target shapes
+        { {3, 1, 10}, {3, 1, 10}, {3, 1, 10} } },   // Target shapes
+      { {-1},                                       // Dynamic shape 3
+        { {3}, {3}, {3} } }},                       // Target shapes
     { { {{0, 11}, -1, {5, 15}},                     // #7. Dynamic shape 0
         { {10, 2, 10}, {3, 4, 10}, {5, 5, 10}, {10, 2, 10}, {5, 5, 10} } },  // Target shapes
       { {-1, 1, -1},                                // Dynamic shape 1
@@ -336,7 +331,7 @@ const std::vector<std::vector<InputShape>> dynamicShapes = {
       { {-1, 1, -1},                                // Dynamic shape 2
         { {10, 1, 10}, {3, 1, 10}, {5, 1, 10}, {10, 1, 10}, {5, 1, 10} } },  // Target shapes
       { {-1},                                       // Dynamic shape 3
-        { {10}, {3}, {5}, {10}, {5} } } }           // Target shapes
+        { {10}, {3}, {5}, {10}, {5} } } },          // Target shapes
 };
 
 
@@ -417,7 +412,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_dynamic_BatchSizeOne, LSTMSequenceCPUTest,
                                ::testing::ValuesIn(clip),
                                ::testing::ValuesIn(direction),
                                ::testing::ValuesIn(netPrecisions),
-                               ::testing::Values(CPUSpecificParams{{tnc}, {tnc}, {"ref_any"}, "ref_any"}),
+                               ::testing::Values(cpuParamsBatchSizeOne),
                                ::testing::Values(std::map<std::string, std::string>{})),
             LSTMSequenceCPUTest::getTestCaseName);
 
@@ -440,6 +435,17 @@ INSTANTIATE_TEST_SUITE_P(nightly_dynamic_bf16, LSTMSequenceCPUTest,
                                ::testing::ValuesIn(direction),
                                ::testing::ValuesIn(netPrecisions),
                                ::testing::Values(cpuParams),
+                               ::testing::Values(additionalConfig[1])),
+            LSTMSequenceCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(nightly_dynamic_bf16_BatchSizeOne, LSTMSequenceCPUTest,
+            ::testing::Combine(::testing::ValuesIn({dynamicShapes[4]}),
+                               ::testing::ValuesIn(mode),
+                               ::testing::ValuesIn(activations),
+                               ::testing::ValuesIn(clip),
+                               ::testing::ValuesIn(direction),
+                               ::testing::ValuesIn(netPrecisions),
+                               ::testing::Values(cpuParamsBatchSizeOne),
                                ::testing::Values(additionalConfig[1])),
             LSTMSequenceCPUTest::getTestCaseName);
 } // namespace

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/rnn_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/rnn_sequence.cpp
@@ -253,7 +253,7 @@ const std::vector<std::vector<InputShape>> dynamicShapes = {
         { {1, 2, 10}, {1, 4, 10}, {1, 8, 10} } },        // Target shapes
       { {1, 1, 10},                                      // Dynamic shape 1
         { {1, 1, 10}, {1, 1, 10}, {1, 1, 10} } },        // Target shapes
-      { {-1},                                             // Dynamic shape 2
+      { {-1},                                            // Dynamic shape 2
         { {1}, {1}, {1} } } },                           // Target shapes
     { { {-1, -1, -1},                                    // #5. Dynamic shape 0
         { {1, 2, 10}, {1, 4, 10}, {1, 8, 10} } },        // Target shapes
@@ -262,13 +262,17 @@ const std::vector<std::vector<InputShape>> dynamicShapes = {
       { {-1},                                            // Dynamic shape 2
         { {1}, {1}, {1} } } },                           // Target shapes
     { { {7, {1, 5}, 10},                                 // #6. Dynamic shape 0
-        { {7, 2, 10}, {7, 3, 10}, {7, 4, 10} } },        // Target shapes
+        { {7, 2, 10}, {7, 3, 10}, {7, 5, 10}} },         // Target shapes
       { {7, 1, 1},                                       // Dynamic shape 1
-        { {7, 1, 1}, {7, 1, 1}, {7, 1, 1} } } },         // Target shapes
+        { {7, 1, 1}, {7, 1, 1}, {7, 1, 1} } },           // Target shapes
+      { {-1},                                            // Dynamic shape 2
+        { {7}, {7}, {7}} }},                             // Target shapes
     { { {5, -1, 10},                                     // #7. Dynamic shape 0
         { {5, 2, 10}, {5, 4, 10}, {5, 5, 10} } },        // Target shapes
       { {5, 1, 10},                                      // Dynamic shape 1
-        { {5, 1, 10}, {5, 1, 10}, {5, 1, 10} } } },      // Target shapes
+        { {5, 1, 10}, {5, 1, 10}, {5, 1, 10} } },        // Target shapes
+      { {-1},                                            // Dynamic shape 2
+        { {5}, {5}, {5} } }},                            // Target shapes
     { { {{0, 11}, -1, 10},                               // #8. Dynamic shape 0
         { {10, 2, 10}, {3, 4, 10}, {5, 5, 10}, {10, 2, 10}, {5, 5, 10} } },   // Target shapes
       { {-1, 1, 10},                                     // Dynamic shape 1

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/softmax.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/softmax.cpp
@@ -64,7 +64,7 @@ protected:
         }
 
         if (inType == ElementType::bf16) {
-            rel_threshold = 1e-2f;
+            rel_threshold = 2e-2f;
         }
         selectedType = makeSelectedTypeStr(selectedType, inType);
         init_input_shapes({config.inputShape});


### PR DESCRIPTION
### Details:
 - oneDNN requires particular input / output ports to have bf16 precision
 for bf16 primitive

### Tickets:
 - 96975
 - 97265
 - 97068