### PR TITLE
[Unique-10] Restore and align tests for Unique PythonAPI

### DIFF
--- a/src/bindings/python/tests/test_graph/test_create_op.py
+++ b/src/bindings/python/tests/test_graph/test_create_op.py
@@ -2270,3 +2270,59 @@ def test_is_nan_opset10():
     assert node.get_output_size() == 1
     assert list(node.get_output_shape(0)) == input_shape
     assert node.get_output_element_type(0) == Type.boolean
+
+
+def test_unique_opset10():
+    input_shape = [1, 2, 3, 4]
+    input_node = ov.parameter(input_shape, np.float, name="input_data")
+    axis = ov.constant([1], np.int32, [1])
+
+    node = ov_opset10.unique(input_node, axis, False, "i32")
+
+    assert node.get_type_name() == "Unique"
+    assert node.get_sorted() is False
+    assert node.get_output_size() == 4
+
+    assert node.get_output_partial_shape(0) == PartialShape([1, (1, 2), 3, 4])
+    assert node.get_output_partial_shape(1) == PartialShape([(1, 24)])
+    assert node.get_output_partial_shape(2) == PartialShape([2])
+    assert node.get_output_partial_shape(3) == PartialShape([(1, 24)])
+
+    assert node.get_output_element_type(0) == Type.f32
+    assert node.get_output_element_type(1) == Type.i32
+    assert node.get_output_element_type(2) == Type.i32
+    assert node.get_output_element_type(3) == Type.i64
+
+    # Axis default, means flattened result
+    node = ov_opset10.unique(input_node, None, False, "i32")
+
+    assert node.get_type_name() == "Unique"
+    assert node.get_sorted() is False
+    assert node.get_output_size() == 4
+
+    assert node.get_output_partial_shape(0) == PartialShape([(1, 24)])
+    assert node.get_output_partial_shape(1) == PartialShape([(1, 24)])
+    assert node.get_output_partial_shape(2) == PartialShape([24])
+    assert node.get_output_partial_shape(3) == PartialShape([(1, 24)])
+
+    assert node.get_output_element_type(0) == Type.f32
+    assert node.get_output_element_type(1) == Type.i32
+    assert node.get_output_element_type(2) == Type.i32
+    assert node.get_output_element_type(3) == Type.i64
+
+    # All arguments default
+    node = ov_opset10.unique(input_node)
+
+    assert node.get_type_name() == "Unique"
+    assert node.get_output_size() == 4
+    assert node.get_sorted() is True
+
+    assert node.get_output_partial_shape(0) == PartialShape([(1, 24)])
+    assert node.get_output_partial_shape(1) == PartialShape([(1, 24)])
+    assert node.get_output_partial_shape(2) == PartialShape([24])
+    assert node.get_output_partial_shape(3) == PartialShape([(1, 24)])
+
+    assert node.get_output_element_type(0) == Type.f32
+    assert node.get_output_element_type(1) == Type.i64
+    assert node.get_output_element_type(2) == Type.i64
+    assert node.get_output_element_type(3) == Type.i64

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_create_op.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_create_op.py
@@ -2334,3 +2334,60 @@ def test_is_nan_opset10():
     assert node.get_output_size() == 1
     assert list(node.get_output_shape(0)) == input_shape
     assert node.get_output_element_type(0) == Type.boolean
+
+
+def test_unique_opset10():
+    input_shape = [1, 2, 3, 4]
+    input_node = ng.parameter(input_shape, np.float, name="input_data")
+    axis = ng.constant([1], np.int32, [1])
+
+    node = ng_opset10.unique(input_node, axis, False, "i32")
+
+    assert node.get_type_name() == "Unique"
+    assert node.get_sorted() is False
+    assert node.get_output_size() == 4
+
+    assert node.get_output_partial_shape(0) == PartialShape([Dimension(1), Dimension(1, 2),
+                                                             Dimension(3), Dimension(4)])
+    assert node.get_output_partial_shape(1) == PartialShape([Dimension(1, 24)])
+    assert node.get_output_partial_shape(2) == PartialShape([2])
+    assert node.get_output_partial_shape(3) == PartialShape([Dimension(1, 24)])
+
+    assert node.get_output_element_type(0) == Type.f32
+    assert node.get_output_element_type(1) == Type.i32
+    assert node.get_output_element_type(2) == Type.i32
+    assert node.get_output_element_type(3) == Type.i64
+
+    # Axis default, means flattened result
+    node = ng_opset10.unique(input_node, None, False, "i32")
+
+    assert node.get_type_name() == "Unique"
+    assert node.get_sorted() is False
+    assert node.get_output_size() == 4
+
+    assert node.get_output_partial_shape(0) == PartialShape([Dimension(1, 24)])
+    assert node.get_output_partial_shape(1) == PartialShape([Dimension(1, 24)])
+    assert node.get_output_partial_shape(2) == PartialShape([24])
+    assert node.get_output_partial_shape(3) == PartialShape([Dimension(1, 24)])
+
+    assert node.get_output_element_type(0) == Type.f32
+    assert node.get_output_element_type(1) == Type.i32
+    assert node.get_output_element_type(2) == Type.i32
+    assert node.get_output_element_type(3) == Type.i64
+
+    # All arguments default
+    node = ng_opset10.unique(input_node)
+
+    assert node.get_type_name() == "Unique"
+    assert node.get_output_size() == 4
+    assert node.get_sorted() is True
+
+    assert node.get_output_partial_shape(0) == PartialShape([Dimension(1, 24)])
+    assert node.get_output_partial_shape(1) == PartialShape([Dimension(1, 24)])
+    assert node.get_output_partial_shape(2) == PartialShape([24])
+    assert node.get_output_partial_shape(3) == PartialShape([Dimension(1, 24)])
+
+    assert node.get_output_element_type(0) == Type.f32
+    assert node.get_output_element_type(1) == Type.i64
+    assert node.get_output_element_type(2) == Type.i64
+    assert node.get_output_element_type(3) == Type.i64


### PR DESCRIPTION
### Details:
 -  Restore and align tests for Unique PythonAPI
 
With the Unique-10 reference implementation PR, shape inference for the third output was improved, 
so the tests need alignment.
The tests were previously removed to unblock CI: https://github.com/openvinotoolkit/openvino/pull/14102
### Tickets:
 - N/A
