### PR TITLE
fix out of bound indices of Gather reference

### DIFF
--- a/src/core/reference/include/ngraph/runtime/reference/gather.hpp
+++ b/src/core/reference/include/ngraph/runtime/reference/gather.hpp
@@ -44,7 +44,7 @@ void gather(const T* const data,
                 idx = indices[i + batch_indices_mul * batch];
                 if (idx < 0)
                     idx += axis_size;
-                // for out of bound values have to be left with zeros
+                // for out of bound values have to be filled with zeros
                 if (idx >= axis_size || idx < 0)
                     continue;
 

--- a/src/core/reference/include/ngraph/runtime/reference/gather.hpp
+++ b/src/core/reference/include/ngraph/runtime/reference/gather.hpp
@@ -33,6 +33,8 @@ void gather(const T* const data,
 
     int64_t axis_size = data_shape[axis];
     int64_t data_offset, out_offset, idx;
+    // for out of bound indices is filled with zeros
+    std::fill(out, out + shape_size(out_shape), 0);
 
     for (int64_t batch = 0; batch < batch_size; batch++)
         for (int64_t outer_idx = 0; outer_idx < outer_size; outer_idx++) {
@@ -40,13 +42,11 @@ void gather(const T* const data,
             out_offset = batch_out_mul * batch + indices_size * inner_size * outer_idx;
             for (int64_t i = 0; i < indices_size; i++) {
                 idx = indices[i + batch_indices_mul * batch];
-                // clang-format off
-                            // todo: check if bound check is needed
-                            // if (idx >= axis_size || (idx < 0 && -idx >= axis_size))
-                            //    throw std::domain_error{"indices values of Gather exceed size along axis"};
-                // clang-format on
                 if (idx < 0)
                     idx += axis_size;
+                // for out of bound values have to be left with zeros
+                if (idx >= axis_size || idx < 0)
+                    continue;
 
                 const auto src_begin = std::next(data, data_offset + inner_size * idx);
                 const auto src_end = std::next(src_begin, inner_size);

--- a/src/plugins/template/tests/functional/op_reference/gather.cpp
+++ b/src/plugins/template/tests/functional/op_reference/gather.cpp
@@ -912,6 +912,54 @@ std::vector<GatherParamsV7> generateParamsV8() {
             reference_tests::Tensor(ET, {3}, std::vector<T>{
                 1, 4, 5}),
             "gather_v8_1d_negative_indices"),
+        // zeros are not present in the original data but appear because of the out of bound values
+        GatherParamsV7(
+                reference_tests::Tensor(ET, {5}, std::vector<T>{
+                        1, 2, 3, 4, 5}),
+                reference_tests::Tensor(ET_I, {3}, std::vector<T_I>{
+                        0, 20, 4}),
+                reference_tests::Tensor(ET_A, {}, std::vector<T_A>{0}),
+                0,
+                reference_tests::Tensor(ET, {3}, std::vector<T>{
+                        1, 0, 5}),
+                "gather_v8_out_of_bound_indices_1"),
+        GatherParamsV7(
+                reference_tests::Tensor(ET, {2, 1, 5, 4}, std::vector<T>{
+                        1,  2,  3,  4,
+                        5,  6,  7,  8,
+                        9,  10, 11, 12,
+                        13, 14, 15, 16,
+                        17, 18, 19, 20,
+
+                        21, 22, 23, 24,
+                        25, 26, 27, 28,
+                        29, 30, 31, 32,
+                        33, 34, 35, 36,
+                        37, 38, 39, 40}),
+                reference_tests::Tensor(ET_I, {2, 3}, std::vector<T_I>{
+                        1, 2, 200,
+                        4, 200, 2}),
+                reference_tests::Tensor(ET_A, {}, std::vector<T_A>{2}),
+                1,
+                reference_tests::Tensor(ET, {2, 1, 3, 4}, std::vector<T>{
+                        5,  6,  7,  8,
+                        9,  10, 11, 12,
+                        0, 0, 0, 0,
+
+                        37, 38, 39, 40,
+                        0, 0, 0, 0,
+                        29, 30, 31, 32}),
+                "gather_v8_4d_data_axis_2_batch_dims_1_out_of_bound_indices_2"),
+        GatherParamsV7(
+                reference_tests::Tensor(ET, {5}, std::vector<T>{
+                        1, 2, 3, 4, 5}),
+                reference_tests::Tensor(ET_I, {3}, std::vector<T_I>{
+                        0, -200, 4}),
+                reference_tests::Tensor(ET_A, {}, std::vector<T_A>{0}),
+                0,
+                reference_tests::Tensor(ET, {3}, std::vector<T>{
+                        1, 0, 5}),
+                "gather_v8_out_of_bound_negative_index"),
     };
     return params;
 }


### PR DESCRIPTION
### Details:
Gather-8 conformance tests crash on the line https://github.com/openvinotoolkit/openvino/blob/master/src/core/reference/include/ngraph/runtime/reference/gather.hpp#L54

because of the out of bound index values.

But according to specification Gather-8 for out of bound indices should fill with zeros  https://github.com/openvinotoolkit/openvino/blob/master/docs/ops/movement/Gather_8.md?plain=1#L148-L156

Added check for out of bound, added filling with zeros and added unit-test for that case

### Tickets:
 - xxx-96723
