### PR TITLE
copy() and deepcopy() methods for PartialShape.

### DIFF
--- a/src/bindings/python/src/pyopenvino/graph/partial_shape.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/partial_shape.cpp
@@ -190,5 +190,13 @@ void regclass_graph_PartialShape(py::module m) {
         return "<PartialShape: " + py::cast(self).attr("__str__")().cast<std::string>() + ">";
     });
 
+    shape.def("__copy__", [](const ov::PartialShape& self) -> ov::PartialShape {
+        return ov::PartialShape(self);
+    });
+
+    shape.def("__deepcopy__", [](const ov::PartialShape &self, py::dict) -> ov::PartialShape {
+            return ov::PartialShape(self);
+    }, "memo");
+
     shape.def("to_string", &ov::PartialShape::to_string);
 }

--- a/src/bindings/python/src/pyopenvino/graph/partial_shape.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/partial_shape.cpp
@@ -194,9 +194,12 @@ void regclass_graph_PartialShape(py::module m) {
         return ov::PartialShape(self);
     });
 
-    shape.def("__deepcopy__", [](const ov::PartialShape &self, py::dict) -> ov::PartialShape {
+    shape.def(
+        "__deepcopy__",
+        [](const ov::PartialShape& self, py::dict) -> ov::PartialShape {
             return ov::PartialShape(self);
-    }, "memo");
+        },
+        "memo");
 
     shape.def("to_string", &ov::PartialShape::to_string);
 }


### PR DESCRIPTION
Root cause analysis: 
During converting models with while loops subgraphs are copied using deepcopy() method.
Such subgraphs have attributes with PartialShape type which fail on deepcopy, because PartialShape does not have __deepcopy__() method. 

Solution: define __copy__() and __deepcopy__() methods for PartialShape.

Ticket: 96984

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update
