### PR TITLE
Added telemetry initialization before running main subprocess.

### DIFF
--- a/tools/mo/openvino/tools/mo/__main__.py
+++ b/tools/mo/openvino/tools/mo/__main__.py
@@ -2,4 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openvino.tools.mo.subprocess_main import subprocess_main
+from openvino.tools.mo.utils.telemetry_utils import init_mo_telemetry
+init_mo_telemetry()
 subprocess_main(framework=None)

--- a/tools/mo/openvino/tools/mo/mo.py
+++ b/tools/mo/openvino/tools/mo/mo.py
@@ -5,5 +5,7 @@
 
 
 if __name__ == "__main__":
+    from openvino.tools.mo.utils.telemetry_utils import init_mo_telemetry
+    init_mo_telemetry()
     from subprocess_main import subprocess_main  # nosec; pylint: disable=no-name-in-module
     subprocess_main(framework=None)

--- a/tools/mo/openvino/tools/mo/mo_caffe.py
+++ b/tools/mo/openvino/tools/mo/mo_caffe.py
@@ -6,4 +6,6 @@
 
 if __name__ == "__main__":
     from openvino.tools.mo.subprocess_main import subprocess_main
+    from openvino.tools.mo.utils.telemetry_utils import init_mo_telemetry
+    init_mo_telemetry()
     subprocess_main(framework='caffe')

--- a/tools/mo/openvino/tools/mo/mo_kaldi.py
+++ b/tools/mo/openvino/tools/mo/mo_kaldi.py
@@ -6,4 +6,6 @@
 
 if __name__ == "__main__":
     from openvino.tools.mo.subprocess_main import subprocess_main
+    from openvino.tools.mo.utils.telemetry_utils import init_mo_telemetry
+    init_mo_telemetry()
     subprocess_main(framework='kaldi')

--- a/tools/mo/openvino/tools/mo/mo_mxnet.py
+++ b/tools/mo/openvino/tools/mo/mo_mxnet.py
@@ -6,4 +6,6 @@
 
 if __name__ == "__main__":
     from openvino.tools.mo.subprocess_main import subprocess_main
+    from openvino.tools.mo.utils.telemetry_utils import init_mo_telemetry
+    init_mo_telemetry()
     subprocess_main(framework='mxnet')

--- a/tools/mo/openvino/tools/mo/mo_onnx.py
+++ b/tools/mo/openvino/tools/mo/mo_onnx.py
@@ -6,4 +6,6 @@
 
 if __name__ == "__main__":
     from openvino.tools.mo.subprocess_main import subprocess_main
+    from openvino.tools.mo.utils.telemetry_utils import init_mo_telemetry
+    init_mo_telemetry()
     subprocess_main(framework='onnx')

--- a/tools/mo/openvino/tools/mo/mo_paddle.py
+++ b/tools/mo/openvino/tools/mo/mo_paddle.py
@@ -5,4 +5,6 @@
 
 if __name__ == "__main__":
     from openvino.tools.mo.subprocess_main import subprocess_main
+    from openvino.tools.mo.utils.telemetry_utils import init_mo_telemetry
+    init_mo_telemetry()
     subprocess_main(framework='paddle')

--- a/tools/mo/openvino/tools/mo/mo_tf.py
+++ b/tools/mo/openvino/tools/mo/mo_tf.py
@@ -6,4 +6,6 @@
 
 if __name__ == "__main__":
     from openvino.tools.mo.subprocess_main import subprocess_main
+    from openvino.tools.mo.utils.telemetry_utils import init_mo_telemetry
+    init_mo_telemetry()
     subprocess_main(framework='tf')

--- a/tools/mo/openvino/tools/mo/utils/telemetry_utils.py
+++ b/tools/mo/openvino/tools/mo/utils/telemetry_utils.py
@@ -10,11 +10,16 @@ from openvino.tools.mo.graph.graph import Graph
 from openvino.tools.mo.middle.pattern_match import for_graph_and_each_sub_graph_recursively
 from openvino.tools.mo.utils.cli_parser import get_params_with_paths_list
 from openvino.tools.mo.utils.telemetry_params import telemetry_params
+from openvino.tools.mo.utils.version import get_simplified_mo_version
 
 try:
     import openvino_telemetry as tm
 except ImportError:
     import openvino.tools.mo.utils.telemetry_stub as tm
+
+
+def init_mo_telemetry():
+    _ = tm.Telemetry(tid=get_tid(), app_name='Model Optimizer', app_version=get_simplified_mo_version())
 
 
 def send_op_names_info(framework: str, graph: Graph):


### PR DESCRIPTION
Root cause analysis: 
Telemetry library checks if it is in main process or not. If the process is not main, it does not show dialog. Which caused dialog stop to show in MO, which runs conversion in subprocess.

Solution: Initialize telemetry library before running subprocess with conversion.

Ticket: 97035


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update