### PR TITLE
[GPU] Replace cl2.hpp with opencl.hpp in cmake search for docs and BA

### DIFF
--- a/docs/snippets/CMakeLists.txt
+++ b/docs/snippets/CMakeLists.txt
@@ -24,7 +24,7 @@ file(GLOB SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
 find_package(OpenCL)
 find_path(OpenCL_HPP_INCLUDE_DIR
     NAMES
-      CL/cl2.hpp OpenCL/cl2.hpp
+      CL/opencl.hpp OpenCL/opencl.hpp
     HINTS
       ${opencl_root_hints}
       ENV "PROGRAMFILES(X86)"

--- a/samples/cpp/benchmark_app/CMakeLists.txt
+++ b/samples/cpp/benchmark_app/CMakeLists.txt
@@ -58,6 +58,23 @@ if(SAMPLES_ENABLE_OPENCL)
 
     find_path(OpenCL_HPP_INCLUDE_DIR
         NAMES
+        CL/opencl.hpp OpenCL/opencl.hpp
+        HINTS
+        ${opencl_root_hints}
+        ENV "PROGRAMFILES(X86)"
+        ENV AMDAPPSDKROOT
+        ENV INTELOCLSDKROOT
+        ENV NVSDKCOMPUTE_ROOT
+        ENV CUDA_PATH
+        ENV ATISTREAMSDKROOT
+        ENV OCL_ROOT
+        PATH_SUFFIXES
+        include
+        OpenCL/common/inc
+        "AMD APP/include")
+
+    find_path(CL2_HPP_INCLUDE_DIR
+        NAMES
         CL/cl2.hpp OpenCL/cl2.hpp
         HINTS
         ${opencl_root_hints}
@@ -77,9 +94,15 @@ if(SAMPLES_ENABLE_OPENCL)
         # Use OpenCL CPP headers from sources if present
         set(OpenCL_HEADERS ${OPENCL_HEADERS_DIR})
         set(OpenCL_LIB "OpenCL")
-    elseif(OpenCL_HPP_INCLUDE_DIR)
+    elseif(OpenCL_HPP_INCLUDE_DIR OR CL2_HPP_INCLUDE_DIR)
         # Append OpenCL CPP headers to C headers and use both
-        set(OpenCL_HEADERS ${OpenCL_INCLUDE_DIR} ${OpenCL_HPP_INCLUDE_DIR})
+        set(OpenCL_HEADERS ${OpenCL_INCLUDE_DIR})
+        if (OpenCL_HPP_INCLUDE_DIR)
+            list(APPEND ${OpenCL_HEADERS} ${OpenCL_HPP_INCLUDE_DIR})
+        endif()
+        if (CL2_HPP_INCLUDE_DIR)
+            list(APPEND ${OpenCL_HEADERS} ${CL2_HPP_INCLUDE_DIR})
+        endif()
         set(OpenCL_LIB "OpenCL::OpenCL")
     else()
         MESSAGE(WARNING "OpenCL CPP header is not found, ${TARGET_NAME} will be built without OpenCL support. Download it from: https://github.com/KhronosGroup/OpenCL-CLHPP and set -Dopencl_root_hints=[PATH]/OpenCL-CLHPP/include to cmake.")
@@ -89,6 +112,10 @@ if(SAMPLES_ENABLE_OPENCL)
         target_link_libraries(${TARGET_NAME} PRIVATE ${OpenCL_LIB})
         target_include_directories(${TARGET_NAME} PRIVATE ${OpenCL_HEADERS})
         target_compile_definitions(${TARGET_NAME} PRIVATE HAVE_GPU_DEVICE_MEM_SUPPORT)
+        if (OpenCL_HPP_INCLUDE_DIR OR OPENCL_HEADERS_DIR)
+            # the macro below is defined when opencl.hpp is found to suppress deprecation message from cl2.hpp
+            target_compile_definitions(${TARGET_NAME} PRIVATE OV_GPU_USE_OPENCL_HPP)
+        endif()
     endif()
 endif()
 

--- a/samples/cpp/benchmark_app/remote_tensors_filling.cpp
+++ b/samples/cpp/benchmark_app/remote_tensors_filling.cpp
@@ -12,7 +12,6 @@
 #include <vector>
 
 #ifdef HAVE_DEVICE_MEM_SUPPORT
-#    define OV_GPU_USE_OPENCL_HPP
 #    include <openvino/runtime/intel_gpu/ocl/ocl.hpp>
 #    include <openvino/runtime/intel_gpu/ocl/ocl_wrapper.hpp>
 #endif

--- a/samples/cpp/benchmark_app/remote_tensors_filling.hpp
+++ b/samples/cpp/benchmark_app/remote_tensors_filling.hpp
@@ -5,9 +5,6 @@
 #pragma once
 
 #if defined(HAVE_GPU_DEVICE_MEM_SUPPORT)
-#    ifndef OV_GPU_USE_OPENCL_HPP
-#        define OV_GPU_USE_OPENCL_HPP
-#    endif
 #    define HAVE_DEVICE_MEM_SUPPORT
 #    include <gpu/gpu_context_api_ocl.hpp>
 #endif


### PR DESCRIPTION
### Details:
 - In case if  GPU plugin build is disabled, OCL is installed and found, but opencl.hpp is not present snippets and benchmark_app could cause build errors due to attempt to include "opencl.hpp". This patch changes corresponding cmake files to look for opencl.hpp instead of cl2.hpp as code contains `#define OV_GPU_USE_OPENCL_HPP` before ocl wrapper include.

### Tickets:
 - *96814*
