### PR TITLE
[GNA] Fix 2D->1D mapping of Convolutions

### DIFF
--- a/src/plugins/intel_gna/src/gna_graph_compiler.cpp
+++ b/src/plugins/intel_gna/src/gna_graph_compiler.cpp
@@ -347,7 +347,10 @@ void GNAGraphCompiler::ConvolutionPrimitive(InferenceEngine::CNNLayerPtr layer) 
         GNAConvolutionLayer::isMappableFrom2DTo1D(in_height, in_width, in_channels,
                                                   convolution._kernel_y, convolution._kernel_x,
                                                   convolution._stride_y, convolution._stride_x)) {
-        transpose_h_w = (in_height == convolution._kernel_y);
+        transpose_h_w = GNAConvolutionLayer::should_transpose_h_w(in_height,
+                                                                  convolution._kernel_y,
+                                                                  in_channels,
+                                                                  convolution._stride_y);
         in_width *= in_height;
         in_height = 1;
         out_width *= out_height;

--- a/src/plugins/intel_gna/src/layers/gna_convolution_layer.cpp
+++ b/src/plugins/intel_gna/src/layers/gna_convolution_layer.cpp
@@ -16,7 +16,6 @@
 
 namespace GNAPluginNS {
 namespace GNAConvolutionLayer {
-
 bool should_transpose_h_w(const uint32_t in_height,
                           const uint32_t kernel_height,
                           const uint32_t in_channels,
@@ -28,7 +27,7 @@ bool isMappableFrom2DTo1D(const uint32_t inHeight, const uint32_t inWidth, const
                           const uint32_t kernelHeight, const uint32_t kernelWidth,
                           const uint32_t strideHeight, const uint32_t strideWidth) {
     if (inHeight <= 1 || inWidth <= 1) {
-        // Mapping from 2D-> 1D is only needed if the input is non-trivial 2D
+        // Mapping not needed since input is already 1D
         return false;
     }
     return (inWidth == kernelWidth && strideWidth == 1) ||

--- a/src/plugins/intel_gna/src/layers/gna_convolution_layer.cpp
+++ b/src/plugins/intel_gna/src/layers/gna_convolution_layer.cpp
@@ -17,12 +17,22 @@
 namespace GNAPluginNS {
 namespace GNAConvolutionLayer {
 
+bool should_transpose_h_w(const uint32_t in_height,
+                          const uint32_t kernel_height,
+                          const uint32_t in_channels,
+                          const uint32_t stride_height) {
+    return in_height == kernel_height && in_channels == 1 && stride_height == 1;
+}
+
 bool isMappableFrom2DTo1D(const uint32_t inHeight, const uint32_t inWidth, const uint32_t in_channels,
                           const uint32_t kernelHeight, const uint32_t kernelWidth,
                           const uint32_t strideHeight, const uint32_t strideWidth) {
-    return ((inHeight > 1 && inWidth > 1) &&
-            ((inWidth == kernelWidth && strideWidth == 1) ||
-             (inHeight == kernelHeight && strideHeight == 1 && in_channels == 1)));
+    if (inHeight <= 1 || inWidth <= 1) {
+        // Mapping from 2D-> 1D is only needed if the input is non-trivial 2D
+        return false;
+    }
+    return (inWidth == kernelWidth && strideWidth == 1) ||
+           should_transpose_h_w(inHeight, kernelHeight, in_channels, strideHeight);
 }
 
 bool is3DInputOr2DKernel(const uint32_t inHeight, const uint32_t inWidth, const uint32_t inDepth,

--- a/src/plugins/intel_gna/src/layers/gna_convolution_layer.hpp
+++ b/src/plugins/intel_gna/src/layers/gna_convolution_layer.hpp
@@ -10,6 +10,12 @@
 
 namespace GNAPluginNS {
 namespace GNAConvolutionLayer {
+
+bool should_transpose_h_w(const uint32_t in_height,
+                          const uint32_t kernel_height,
+                          const uint32_t in_channels,
+                          const uint32_t stride_height);
+
 bool isMappableFrom2DTo1D(const uint32_t inHeight, const uint32_t inWidth, const uint32_t inChannels,
                           const uint32_t kernelHeight, const uint32_t kernelWidth,
                           const uint32_t strideHeight, const uint32_t strideWidth);

--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/single_layer_tests/convolution.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/single_layer_tests/convolution.cpp
@@ -99,7 +99,7 @@ const std::vector<std::vector<size_t >> dilations2D = { {1, 1},
 };
 const std::vector<size_t> numOutCannels2D = { 8, 16, 32};
 
-const std::vector<size_t> numOutCannels2D_to_map = {4, 8, 12};
+const std::vector<size_t> num_out_channels_for_mapped_2d = {4, 8, 12};
 
 const std::vector<size_t> input2DNCHW = { 1, 8, 20, 16 };
 
@@ -135,7 +135,7 @@ const auto conv2DParams_Kernels2D_3x3 = ::testing::Combine(
     ::testing::ValuesIn(padBegins2D),
     ::testing::ValuesIn(padEnds2D),
     ::testing::ValuesIn(dilations2D),
-    ::testing::ValuesIn(numOutCannels2D_to_map),
+    ::testing::ValuesIn(num_out_channels_for_mapped_2d),
     ::testing::Values(ngraph::op::PadType::EXPLICIT)
 );
 
@@ -145,7 +145,7 @@ const auto conv2DParams_Kernels2D_5x6 = ::testing::Combine(
     ::testing::ValuesIn(padBegins2D),
     ::testing::ValuesIn(padEnds2D),
     ::testing::ValuesIn(dilations2D),
-    ::testing::ValuesIn(numOutCannels2D_to_map),
+    ::testing::ValuesIn(num_out_channels_for_mapped_2d),
     ::testing::Values(ngraph::op::PadType::EXPLICIT)
 );
 

--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/single_layer_tests/convolution.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/single_layer_tests/convolution.cpp
@@ -81,6 +81,13 @@ const std::vector<std::vector<size_t >> kernels2D_big = {
         {7, 7},
 };
 
+const std::vector<std::vector<size_t>> kernels2D_3x3 = {
+    {3, 3},
+};
+const std::vector<std::vector<size_t>> kernels2D_5x6 = {
+    {5, 6},
+};
+
 const std::vector<std::vector<size_t >> strides2D = {
         {1, 1},
 };
@@ -92,7 +99,12 @@ const std::vector<std::vector<size_t >> dilations2D = { {1, 1},
 };
 const std::vector<size_t> numOutCannels2D = { 8, 16, 32};
 
+const std::vector<size_t> numOutCannels2D_to_map = {4, 8, 12};
+
 const std::vector<size_t> input2DNCHW = { 1, 8, 20, 16 };
+
+const std::vector<size_t> input2DNCHW_3x3 = {1, 16, 3, 3};
+const std::vector<size_t> input2DNCHW_5x6 = {1, 16, 5, 6};
 
 const std::vector<std::vector<size_t>> inputShapesMapTo1d = {{1, 1, 56, 5},
                                                              {1, 32, 56, 5},
@@ -114,6 +126,26 @@ const auto conv2DParams_Kernels2D_big = ::testing::Combine(
     ::testing::ValuesIn(padEnds2D),
     ::testing::ValuesIn(dilations2D),
     ::testing::ValuesIn(numOutCannels2D),
+    ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+const auto conv2DParams_Kernels2D_3x3 = ::testing::Combine(
+    ::testing::ValuesIn(kernels2D_3x3),
+    ::testing::ValuesIn(strides2D),
+    ::testing::ValuesIn(padBegins2D),
+    ::testing::ValuesIn(padEnds2D),
+    ::testing::ValuesIn(dilations2D),
+    ::testing::ValuesIn(numOutCannels2D_to_map),
+    ::testing::Values(ngraph::op::PadType::EXPLICIT)
+);
+
+const auto conv2DParams_Kernels2D_5x6 = ::testing::Combine(
+    ::testing::ValuesIn(kernels2D_5x6),
+    ::testing::ValuesIn(strides2D),
+    ::testing::ValuesIn(padBegins2D),
+    ::testing::ValuesIn(padEnds2D),
+    ::testing::ValuesIn(dilations2D),
+    ::testing::ValuesIn(numOutCannels2D_to_map),
     ::testing::Values(ngraph::op::PadType::EXPLICIT)
 );
 
@@ -267,4 +299,28 @@ INSTANTIATE_TEST_SUITE_P(smoke_Convolution2D_Kernels2D_big, GnaConvolutionLayerT
         ::testing::Values(input2DNCHW),
         ::testing::Values(CommonTestUtils::DEVICE_GNA)),
     GnaConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Convolution2D_Map2D_Not_Transpose_h_w_3_3, ConvolutionLayerTest,
+    ::testing::Combine(
+        conv2DParams_Kernels2D_3x3,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(input2DNCHW_3x3),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA)),
+    ConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Convolution2D_Map2D_Not_Transpose_h_w_5_6, ConvolutionLayerTest,
+    ::testing::Combine(
+        conv2DParams_Kernels2D_5x6,
+        ::testing::ValuesIn(netPrecisions),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(InferenceEngine::Layout::ANY),
+        ::testing::Values(input2DNCHW_5x6),
+        ::testing::Values(CommonTestUtils::DEVICE_GNA)),
+    ConvolutionLayerTest::getTestCaseName);
 }  // namespace


### PR DESCRIPTION
[GNA] Fix 2D->1D mapping of Convolutions where transpose BTW H and W is not applicable

### Details:
 - Only convolution with a single channel may be subject to filters transposition BTW H and W (see https://github.com/openvinotoolkit/openvino/pull/9474)
 - New tests added to verify 78578 (kernel size equal to input size with multiple input/filter channels)

### Tickets:
 - 78578
