### PR TITLE
Fix for MO IR reader loading old meta data.

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/ir_engine/ir_engine.py
+++ b/tools/mo/openvino/tools/mo/utils/ir_engine/ir_engine.py
@@ -28,6 +28,8 @@ ElementTree = defuse_stdlib()[ET].ElementTree
 
 def read_rt_info_attr(elem):
     if len(elem) == 0:
+        if not hasattr(elem.attrib, 'value'):
+            return None
         value = elem.attrib['value']
         return value
     val_dict = {}

--- a/tools/mo/openvino/tools/mo/utils/ir_engine/ir_engine.py
+++ b/tools/mo/openvino/tools/mo/utils/ir_engine/ir_engine.py
@@ -28,7 +28,7 @@ ElementTree = defuse_stdlib()[ET].ElementTree
 
 def read_rt_info_attr(elem):
     if len(elem) == 0:
-        if not hasattr(elem.attrib, 'value'):
+        if 'value' not in elem.attrib:
             return None
         value = elem.attrib['value']
         return value


### PR DESCRIPTION
Root cause analysis: 
Solution: 

Ticket: 97172


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update