### PR TITLE
[GPU][DG2] Fix deconv unit tests

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -1185,7 +1185,7 @@ void program_node::init_onednn_primitive_attributes() {
 
                 // 4. clamp
                 {
-                    if (q_param->has_clamp) {
+                    if (q_param->has_clamp || idx < cldnn_post_ops.size() - 1) {
                         float out_lo = q_param->has_min_clamp ? q_param->out_lo : data_type_traits::min<float>(out_dt);
                         float out_hi = q_param->has_max_clamp ? q_param->out_hi : data_type_traits::max<float>(out_dt);
                         post_ops.append_eltwise(1.0f, dnnl::algorithm::eltwise_clip, out_lo, out_hi);

--- a/src/plugins/intel_gpu/tests/fusions/deconvolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/deconvolution_fusion_test.cpp
@@ -475,18 +475,6 @@ TEST_P(deconv_actv_eltw_actv, basic) {
         activation("act2", input_info("eltw"), activation_func::relu),
         reorder("out", input_info("act2"), p.default_format, data_types::f32)
     );
-
-    // Waiting MFDNN-8947
-    std::set<deconv_test_params> onednn_skip = {
-        deconv_test_params{CASE_DECONV_U8S8_6, 2, 5},
-        deconv_test_params{CASE_DECONV_U8S8_7, 2, 5},
-        deconv_test_params{CASE_DECONV_S8S8_6, 2, 5},
-        deconv_test_params{CASE_DECONV_S8S8_7, 2, 5},
-    };
-    if (engine.get_device_info().supports_immad && onednn_skip.count(p)) {
-        std::cout << "SKIP" << std::endl;
-        return;
-    }
     // Need much higher tolerance because of deconvolution -> convolution optimization
     tolerance = 1.f;
     execute(p);
@@ -702,20 +690,6 @@ TEST_P(deconv_scale_actv_quant_u8_eltw_scale_actv_quant_i8, basic) {
                  input_info("out2_lo"), input_info("out2_hi"), 255, data_types::i8),
         reorder("out", input_info("quant2"), p.default_format, data_types::f32)
     );
-
-    // Waiting MFDNN-8947
-    std::set<deconv_test_params> onednn_skip = {
-        deconv_test_params{CASE_DECONV_FP16_2, 2, 9},
-        deconv_test_params{CASE_DECONV_FP16_3, 2, 9},
-        deconv_test_params{CASE_DECONV_FP16_6, 2, 9},
-        deconv_test_params{CASE_DECONV_FP16_7, 2, 9},
-        deconv_test_params{CASE_DECONV_S8S8_6, 2, 9},
-        deconv_test_params{CASE_DECONV_S8S8_7, 2, 9},
-    };
-    if (engine.get_device_info().supports_immad && onednn_skip.count(p)) {
-        std::cout << "SKIP" << std::endl;
-        return;
-    }
     tolerance = 2.1f;
     execute(p);
 }


### PR DESCRIPTION
### Related Test Cases:
 - Accuracy Issue
   - fusings_gpu/deconv_scale_actv_quant_u8_eltw_scale_actv_quant_i8.basic/15
 - Remove WA
   - fusings_gpu/deconv_actv_eltw_actv.basic/20
   - fusings_gpu/deconv_scale_actv_quant_u8_eltw_scale_actv_quant_i8.basic/8

### Details:
 - fusings_gpu/deconv_scale_actv_quant_u8_eltw_scale_actv_quant_i8.basic/15
   - Quantize clamp optimization(prepare_quantization.cpp:227) for cldnn is not proper to onednn.
   - cast intermediate variable to output type after ~
     - cldnn:  every fused quantization.
     - onednn: all post-ops are processed.
   - A little perf regression expected in onednn because clamp is relatively heavier operation than type casting.
 - fusings_gpu/deconv_actv_eltw_actv.basic/20
   - 8947 fixed (#14139)
 - fusings_gpu/deconv_scale_actv_quant_u8_eltw_scale_actv_quant_i8.basic/8
   - 8947 fixed (#14139)

### Tickets:
 - 67491
