### PR TITLE
[Core] Fix Pad shape inference for Edge and Reflect modes

### DIFF
--- a/src/core/shape_inference/include/pad_shape_inference.hpp
+++ b/src/core/shape_inference/include/pad_shape_inference.hpp
@@ -110,7 +110,7 @@ void shape_infer(const Pad* op,
                     const auto& dim = arg_shape[i].get_length();
                     output_shape[i] = static_cast<size_t>(begin + dim + end);
 
-                    if (i > 1) {
+                    if (begin > 0 || end > 0) {
                         NODE_VALIDATION_CHECK(op,
                                               pad_mode != op::PadMode::EDGE || arg_shape[i].get_length() >= 1,
                                               "EDGE padding mode requires an input of dimension of "

--- a/src/core/tests/type_prop/pad.cpp
+++ b/src/core/tests/type_prop/pad.cpp
@@ -213,3 +213,21 @@ TEST(type_prop, pad_v1_dynamic_output_with_static_rank) {
     auto pad = make_shared<op::v1::Pad>(arg, pads_begin, pads_end, arg_pad_value, op::PadMode::CONSTANT);
     ASSERT_EQ(pad->get_output_partial_shape(0), PartialShape::dynamic(3));
 }
+
+TEST(type_prop, pad_v1_any_dim_for_padding_reflect) {
+    auto arg = make_shared<op::Parameter>(element::f32, Shape{1, 48, 48, 1});
+    auto pads_begin = make_shared<op::Constant>(element::i64, Shape{4}, std::vector<int64_t>{0, 1, 1, 0});
+    auto pads_end = make_shared<op::Constant>(element::i64, Shape{4}, std::vector<int64_t>{0, 1, 1, 0});
+
+    auto pad = make_shared<op::v1::Pad>(arg, pads_begin, pads_end, op::PadMode::REFLECT);
+    ASSERT_TRUE(pad->get_output_partial_shape(0).same_scheme(PartialShape{1, 50, 50, 1}));
+}
+
+TEST(type_prop, pad_v1_any_dim_for_padding_edge) {
+    auto arg = make_shared<op::Parameter>(element::f32, PartialShape{1, 48, Dimension::dynamic(), 1});
+    auto pads_begin = make_shared<op::Constant>(element::i64, Shape{4}, std::vector<int64_t>{1, 2, 0, 0});
+    auto pads_end = make_shared<op::Constant>(element::i64, Shape{4}, std::vector<int64_t>{0, 3, 0, 0});
+
+    auto pad = make_shared<op::v1::Pad>(arg, pads_begin, pads_end, op::PadMode::EDGE);
+    ASSERT_TRUE(pad->get_output_partial_shape(0).same_scheme(PartialShape{2, 53, Dimension::dynamic(), 1}));
+}


### PR DESCRIPTION
**Details:** Pad shape infer logic is adapted to NCWH layout and it expects to pad only spatial dimensions based on its logic.

**Ticket:** 95067

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
