### PR TITLE
[GPU] Move impl_cache to program.cpp to use single impl cache

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -226,12 +226,6 @@ public:
     /// Return kernels_cache
     kernels_cache& get_kernels_cache() const { return *_kernels_cache; }
 
-    /// Return implentations_cache
-    ImplementationsCache& get_implementations_cache() const { return *_impls_cache; }
-
-    /// Return in_mem_kernels_cache
-    KernelsCache& get_in_mem_kernels_cache() const { return *_in_mem_kernels_cache; }
-
 private:
     using output_chains_map = std::map<primitive_id, std::vector<std::shared_ptr<primitive_inst>>>;
     uint32_t net_id = 0;
@@ -267,11 +261,5 @@ private:
     output_chains_map::iterator add_output_chain(std::shared_ptr<primitive_inst>& p_inst);
 
     std::unique_ptr<kernels_cache> _kernels_cache;
-    // Move from cldnn::program to cldnn::network for multi-threads issue.
-    std::unique_ptr<ImplementationsCache> _impls_cache;
-    std::unique_ptr<KernelsCache> _in_mem_kernels_cache;
-    // TODO: initial version use unlimited caches. Need to adjust it once dynamic flow works on wide set of models.
-    const size_t _impls_cache_capacity = 0;
-    const size_t _in_mem_kernels_cache_capacity = 0;
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
@@ -255,7 +255,19 @@ public:
     bool is_local_block_io_supported() const;
     void query_local_block_io_supported();
 
+    /// Return implentations_cache
+    ImplementationsCache& get_implementations_cache() const { return *_impls_cache; }
+
+    /// Return in_mem_kernels_cache
+    KernelsCache& get_in_mem_kernels_cache() const { return *_in_mem_kernels_cache; }
+
 private:
+    std::unique_ptr<ImplementationsCache> _impls_cache;
+    std::unique_ptr<KernelsCache> _in_mem_kernels_cache;
+    // TODO: initial version use unlimited caches. Need to adjust it once dynamic flow works on wide set of models.
+    const size_t _impls_cache_capacity = 0;
+    const size_t _in_mem_kernels_cache_capacity = 0;
+
     uint32_t prog_id = 0;
     engine& _engine;
     stream::ptr _stream;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/lru_cache.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/lru_cache.hpp
@@ -50,6 +50,7 @@ public:
      * @return false Otherwise
      */
     bool add(const Key& key, const Value& value) {
+        std::lock_guard<std::mutex> guard(_mutex);
         auto map_iter = _key_map.find(key);
         if (map_iter != _key_map.end()) {
             touch_data(map_iter->second);
@@ -75,6 +76,7 @@ public:
      * @return false otherwise
      */
     bool has(const Key& key) const {
+        std::lock_guard<std::mutex> guard(_mutex);
         return (_key_map.find(key) != _key_map.end());
     }
 
@@ -85,6 +87,7 @@ public:
      * @return Value a value associated with input key. if the key is not existed in the cache, return nullptr
      */
     Value get(const Key& key) {
+        std::lock_guard<std::mutex> guard(_mutex);
         auto iter = _key_map.find(key);
         if (iter == _key_map.end()) {
             return Value();
@@ -161,6 +164,7 @@ private:
             _lru_data_list.pop_back();
         }
     }
+    mutable std::mutex _mutex;
 };
 
 using ImplementationsCache = cldnn::LruCache<size_t, std::shared_ptr<primitive_impl>>;

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -306,8 +306,6 @@ network::network(program::ptr program, stream::ptr stream, bool is_internal, boo
     if (is_dynamic()) {
         _kernels_cache = std::unique_ptr<kernels_cache>(new kernels_cache(program->get_engine(), program->get_id(),
                                                                         kernel_selector::KernelBase::get_db().get_batch_header_str()));
-        _impls_cache = std::unique_ptr<ImplementationsCache>(new ImplementationsCache(_impls_cache_capacity));
-        _in_mem_kernels_cache = std::unique_ptr<KernelsCache>(new KernelsCache(_in_mem_kernels_cache_capacity));
     }
 }
 

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -344,7 +344,8 @@ void primitive_inst::update_impl() {
         // Update param if fake_alignment is available
         auto updated_params = _node->type()->get_fake_aligned_params(*_impl_params);
         auto layout_key = get_layout_key(updated_params);
-        auto& cache = get_network().get_implementations_cache();
+        auto& cache = get_node().get_program().get_implementations_cache();
+
         if (cache.has(layout_key)) {
             _impl = cache.get(layout_key)->clone();
             GPU_DEBUG_PROFILED_STAGE_CACHE_HIT(true);
@@ -704,7 +705,7 @@ event::ptr primitive_inst::update_weights() {
         cldnn::kernel::ptr kernel = nullptr;
         auto layout_key = get_layout_key();
         if (layout_key != "") {
-            auto& cache = get_network().get_in_mem_kernels_cache();
+            auto& cache = get_node().get_program().get_in_mem_kernels_cache();
             if (cache.has(layout_key)) {
                 GPU_DEBUG_IF(debug_config->verbose >= 4) {
                     GPU_DEBUG_COUT << id() << ": reorder weights (cached) from " << original_layout << "\nto " << expected_layout << std::endl;

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -126,6 +126,9 @@ program::program(engine& engine_ref,
     } else {
         build_program(is_internal);
     }
+
+    _impls_cache = std::unique_ptr<ImplementationsCache>(new ImplementationsCache(_impls_cache_capacity));
+    _in_mem_kernels_cache = std::unique_ptr<KernelsCache>(new KernelsCache(_in_mem_kernels_cache_capacity));
 }
 
 program::program(engine& engine_ref,
@@ -147,6 +150,9 @@ program::program(engine& engine_ref,
     pm = std::unique_ptr<pass_manager>(new pass_manager(*this));
     prepare_nodes(nodes);
     build_program(is_internal);
+
+    _impls_cache = std::unique_ptr<ImplementationsCache>(new ImplementationsCache(_impls_cache_capacity));
+    _in_mem_kernels_cache = std::unique_ptr<KernelsCache>(new KernelsCache(_in_mem_kernels_cache_capacity));
 }
 
 program::program(engine& engine)


### PR DESCRIPTION
### Details:
 - *Current impl_cache only stores primitive_impl which is created on the own network and the each created primitive_impl is not shared with the other network.*
 - *To improve reusibilty of primitive_impl between each network, use single imple_cache which has mutex in load / store methods.*

### Tickets:
 - *95115*
