### PR TITLE
copy() and deepcopy() tests for PartialShape.

### DIFF
--- a/src/bindings/python/tests/test_graph/test_core.py
+++ b/src/bindings/python/tests/test_graph/test_core.py
@@ -221,27 +221,27 @@ def test_partial_shape():
 
     shape = PartialShape("[?, 3, ..224, 28..224, 25..]")
     copied_shape = copy.copy(shape)
-    assert shape == copied_shape, 'Copied shape {} is not equal to original shape {}.'.format(copied_shape, shape)
+    assert shape == copied_shape, "Copied shape {0} is not equal to original shape {1}.".format(copied_shape, shape)
 
     shape = PartialShape("[...]")
     copied_shape = copy.copy(shape)
-    assert shape == copied_shape, 'Copied shape {} is not equal to original shape {}.'.format(copied_shape, shape)
+    assert shape == copied_shape, "Copied shape {0} is not equal to original shape {1}.".format(copied_shape, shape)
 
-    shape = PartialShape([Dimension(-1,100), 25, -1])
+    shape = PartialShape([Dimension(-1, 100), 25, -1])
     copied_shape = copy.copy(shape)
-    assert shape == copied_shape, 'Copied shape {} is not equal to original shape {}.'.format(copied_shape, shape)
+    assert shape == copied_shape, "Copied shape {0} is not equal to original shape {1}.".format(copied_shape, shape)
 
     shape = PartialShape("[?, 3, ..224, 28..224, 25..]")
     copied_shape = copy.deepcopy(shape)
-    assert shape == copied_shape, 'Copied shape {} is not equal to original shape {}.'.format(copied_shape, shape)
+    assert shape == copied_shape, "Copied shape {0} is not equal to original shape {1}.".format(copied_shape, shape)
 
     shape = PartialShape("[...]")
     copied_shape = copy.deepcopy(shape)
-    assert shape == copied_shape, 'Copied shape {} is not equal to original shape {}.'.format(copied_shape, shape)
+    assert shape == copied_shape, "Copied shape {0} is not equal to original shape {1}.".format(copied_shape, shape)
 
     shape = PartialShape([Dimension(-1, 100), 25, -1])
     copied_shape = copy.deepcopy(shape)
-    assert shape == copied_shape, 'Copied shape {} is not equal to original shape {}.'.format(copied_shape, shape)
+    assert shape == copied_shape, "Copied shape {0} is not equal to original shape {1}.".format(copied_shape, shape)
 
 
 def test_partial_shape_compatible():

--- a/src/bindings/python/tests/test_graph/test_core.py
+++ b/src/bindings/python/tests/test_graph/test_core.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2018-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
+
 import numpy as np
 import pytest
 
@@ -216,6 +218,30 @@ def test_partial_shape():
 
     shape = Shape()
     assert len(shape) == 0
+
+    shape = PartialShape("[?, 3, ..224, 28..224, 25..]")
+    copied_shape = copy.copy(shape)
+    assert shape == copied_shape, 'Copied shape {} is not equal to original shape {}.'.format(copied_shape, shape)
+
+    shape = PartialShape("[...]")
+    copied_shape = copy.copy(shape)
+    assert shape == copied_shape, 'Copied shape {} is not equal to original shape {}.'.format(copied_shape, shape)
+
+    shape = PartialShape([Dimension(-1,100), 25, -1])
+    copied_shape = copy.copy(shape)
+    assert shape == copied_shape, 'Copied shape {} is not equal to original shape {}.'.format(copied_shape, shape)
+
+    shape = PartialShape("[?, 3, ..224, 28..224, 25..]")
+    copied_shape = copy.deepcopy(shape)
+    assert shape == copied_shape, 'Copied shape {} is not equal to original shape {}.'.format(copied_shape, shape)
+
+    shape = PartialShape("[...]")
+    copied_shape = copy.deepcopy(shape)
+    assert shape == copied_shape, 'Copied shape {} is not equal to original shape {}.'.format(copied_shape, shape)
+
+    shape = PartialShape([Dimension(-1, 100), 25, -1])
+    copied_shape = copy.deepcopy(shape)
+    assert shape == copied_shape, 'Copied shape {} is not equal to original shape {}.'.format(copied_shape, shape)
 
 
 def test_partial_shape_compatible():


### PR DESCRIPTION
Description: 
Added copy() and deepcopy() tests for PartialShape.
Leftover after PR: https://github.com/openvinotoolkit/openvino/pull/14136

Ticket: 96984

Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update
