### PR TITLE
Remove braces around scalar initializer - android-arm64 post-commit check

### DIFF
--- a/src/core/tests/type_prop/unique.cpp
+++ b/src/core/tests/type_prop/unique.cpp
@@ -202,5 +202,5 @@ TEST(type_prop, unique_with_constant_input_no_axis) {
     const auto data = opset10::Constant::create(element::i32, Shape{5}, {5, 1, 4, 2, 5});
     const auto unique = make_shared<opset10::Unique>(data);
 
-    CHECK_OUTPUT_SHAPES(unique, {{Shape{{4}}, Shape{{4}}, Shape{{5}}, Shape{{4}}}});
+    CHECK_OUTPUT_SHAPES(unique, {{Shape{4}, Shape{4}, Shape{5}, Shape{4}}});
 }


### PR DESCRIPTION
### Details:
 - Remove braces around scalar initializer to fix android-arm64 postcommit check
 https://dev.azure.com/openvinoci/dldt/_build/results?buildId=434314&view=logs&j=92ba3447-fcaa-530d-6438-b829fe1e7d1d&t=b0a91e75-8666-5718-e63e-df215ecb48f9&l=2845

### Tickets:
 - N/A
