### PR TITLE
Filter out samples tests on GNA for Debian

### DIFF
--- a/.ci/azure/linux_debian.yml
+++ b/.ci/azure/linux_debian.yml
@@ -424,7 +424,8 @@ jobs:
       export IE_APP_PYTHON_PATH=$(PYTHON_SAMPLES_INSTALL_DIR)/
       export SHARE=$(INSTALL_TEST_DIR)/smoke_tests/samples_smoke_tests_data/
       export WORKSPACE=$(INSTALL_DIR)
-      python3 -m pytest $(INSTALL_TEST_DIR)/smoke_tests/  --env_conf $(INSTALL_TEST_DIR)/smoke_tests/env_config.yml -s --junitxml=$(INSTALL_TEST_DIR)/TEST-SamplesSmokeTests.xml
+      # GNA isn't a part of Debian package, so filter out that tests
+      python3 -m pytest $(INSTALL_TEST_DIR)/smoke_tests/ -k "not GNA" --env_conf $(INSTALL_TEST_DIR)/smoke_tests/env_config.yml -s --junitxml=$(INSTALL_TEST_DIR)/TEST-SamplesSmokeTests.xml
     displayName: 'Samples Smoke Tests'
     continueOnError: false
 


### PR DESCRIPTION
Since GNA isn't a part of Debian package, no need to run tests on it

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
