### PR TITLE
[GPU] Async static kernels compile for dynamic flow

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -24,15 +24,6 @@
 
 namespace cldnn {
 
-using CompilationTask = std::function<void(kernels_cache&)>;
-template<typename TaskType>
-class CompilationContext {
-public:
-    virtual void push_task(TaskType&& task) = 0;
-    virtual void cancel() noexcept = 0;
-    virtual ~CompilationContext() = default;
-};
-
 /// @brief Represents network output returned by @ref network::get_output().
 struct network_output {
     /// @brief Returns @ref event associated with the output.
@@ -59,6 +50,7 @@ private:
 };
 
 class primitive_inst;
+class ICompilationContext;
 
 struct network {
 public:
@@ -242,8 +234,8 @@ public:
     /// Return in_mem_kernels_cache
     KernelsCache& get_in_mem_kernels_cache() const { return *_in_mem_kernels_cache; }
 
-    CompilationContext<CompilationTask>& get_compilation_context() const { return *_compilation_context; }
-    std::mutex& get_in_mem_cache_mutex() const { return _in_mem_cache_mutex; }
+    ICompilationContext& get_compilation_context() const { return *_compilation_context; }
+    std::mutex& get_impl_cache_mutex() const { return _in_mem_cache_mutex; }
 
 private:
     using output_chains_map = std::map<primitive_id, std::vector<std::shared_ptr<primitive_inst>>>;
@@ -270,7 +262,7 @@ private:
     output_chains_map _output_chains;
 
     mutable std::mutex _in_mem_cache_mutex;
-    std::unique_ptr<CompilationContext<CompilationTask>> _compilation_context;
+    std::unique_ptr<ICompilationContext> _compilation_context;
 
     void build_exec_order();
     void allocate_primitive_instance(program_node const& node);

--- a/src/plugins/intel_gpu/src/graph/compilation_context.cpp
+++ b/src/plugins/intel_gpu/src/graph/compilation_context.cpp
@@ -1,0 +1,54 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "compilation_context.hpp"
+#include "threading/ie_thread_safe_containers.hpp"
+#include "kernel_selector/kernel_base.h"
+
+namespace cldnn {
+
+class CompilationContext : public ICompilationContext {
+public:
+    using compilation_queue_t = InferenceEngine::ThreadSafeQueue<ICompilationContext::Task>;
+
+    CompilationContext(cldnn::engine& engine, size_t program_id) {
+        _kernels_cache = cldnn::make_unique<kernels_cache>(engine, program_id, kernel_selector::KernelBase::get_db().get_batch_header_str());
+        _worker = std::thread([this](){
+            while (!_stop_compilation) {
+                CompilationContext::Task task;
+                bool success = _queue.try_pop(task);
+                if (success) {
+                    task(*_kernels_cache);
+                } else {
+                    std::chrono::milliseconds ms{1};
+                    std::this_thread::sleep_for(ms);
+                }
+            }
+        });
+    }
+
+    void push_task(ICompilationContext::Task&& task) override {
+        _queue.push(task);
+    }
+
+    void cancel() noexcept override {
+        _stop_compilation = true;
+        if (_worker.joinable())
+            _worker.join();
+    }
+
+    ~CompilationContext() noexcept { cancel(); }
+
+private:
+    std::unique_ptr<kernels_cache> _kernels_cache;
+    compilation_queue_t _queue;
+    std::thread _worker;
+    std::atomic_bool _stop_compilation{false};
+};
+
+std::unique_ptr<ICompilationContext> ICompilationContext::create(cldnn::engine& engine, size_t program_id) {
+    return cldnn::make_unique<CompilationContext>(engine, program_id);
+}
+
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/include/compilation_context.hpp
+++ b/src/plugins/intel_gpu/src/graph/include/compilation_context.hpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "kernels_cache.hpp"
+#include <functional>
+#include <memory>
+
+namespace cldnn {
+
+class ICompilationContext {
+public:
+    using Task = std::function<void(kernels_cache&)>;
+    virtual void push_task(Task&& task) = 0;
+    virtual void cancel() noexcept = 0;
+    virtual ~ICompilationContext() = default;
+
+    static std::unique_ptr<ICompilationContext> create(cldnn::engine& engine, size_t program_id);
+};
+
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -45,6 +45,8 @@
 #include <functional>
 #include <fstream>
 
+#include "threading/ie_thread_safe_containers.hpp"
+
 #ifdef GPU_DEBUG_CONFIG
 #include <iomanip>
 #include <fstream>
@@ -54,6 +56,46 @@
 #endif
 
 namespace cldnn {
+
+template<typename TaskType>
+class CompilationContextImplT : public CompilationContext<TaskType> {
+public:
+    using compilation_queue_t = InferenceEngine::ThreadSafeQueue<CompilationTask>;
+
+    CompilationContextImplT(cldnn::engine& engine, size_t program_id) {
+        _kernels_cache = cldnn::make_unique<kernels_cache>(engine, program_id, kernel_selector::KernelBase::get_db().get_batch_header_str());
+        _worker = std::thread([this](){
+            while (!_stop_compilation) {
+                CompilationTask task;
+                bool success = _queue.try_pop(task);
+                if (success) {
+                    task(*_kernels_cache);
+                } else {
+                    std::chrono::milliseconds ms{1};
+                    std::this_thread::sleep_for(ms);
+                }
+            }
+        });
+    }
+    void push_task(TaskType&& task) override {
+        _queue.push(task);
+    }
+
+    void cancel() noexcept override {
+        _stop_compilation = true;
+        if (_worker.joinable())
+            _worker.join();
+    }
+
+    ~CompilationContextImplT() noexcept { cancel(); }
+private:
+    std::unique_ptr<kernels_cache> _kernels_cache;
+    compilation_queue_t _queue;
+    std::thread _worker;
+    std::atomic_bool _stop_compilation{false};
+};
+
+using CompilationContextImpl = CompilationContextImplT<CompilationTask>;
 
 namespace {
 
@@ -308,22 +350,7 @@ network::network(program::ptr program, stream::ptr stream, bool is_internal, boo
                                                                         kernel_selector::KernelBase::get_db().get_batch_header_str()));
         _impls_cache = std::unique_ptr<ImplementationsCache>(new ImplementationsCache(_impls_cache_capacity));
         _in_mem_kernels_cache = std::unique_ptr<KernelsCache>(new KernelsCache(_in_mem_kernels_cache_capacity));
-        _compilation_queue = std::unique_ptr<compilation_queue_t>(new compilation_queue_t());
-        _compilation_executor = std::thread([this](){
-            auto& tasks = _compilation_queue;
-            auto kc = std::unique_ptr<kernels_cache>(new kernels_cache(_program->get_engine(), _program->get_id(),
-                                                         kernel_selector::KernelBase::get_db().get_batch_header_str()));
-            while (!_stop_compilation) {
-                compilation_task_t task;
-                bool success = tasks->try_pop(task);
-                if (success) {
-                    task(*kc);
-                } else {
-                    std::chrono::milliseconds ms{1};
-                    std::this_thread::sleep_for(ms);
-                }
-            }
-        });
+        _compilation_context = cldnn::make_unique<CompilationContextImpl>(program->get_engine(), program->get_id());
     }
 }
 
@@ -441,9 +468,8 @@ network::network(cldnn::BinaryInputBuffer& ib, stream::ptr stream, engine& engin
 }
 
 network::~network() {
-    _stop_compilation = true;
-    if (_compilation_executor.joinable())
-        _compilation_executor.join();
+    if (_compilation_context)
+        _compilation_context->cancel();
     _memory_pool->clear_pool_for_network(net_id);
     GPU_DEBUG_GET_INSTANCE(debug_config);
     GPU_DEBUG_IF(!debug_config->dump_profiling_data.empty()) {

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -362,8 +362,8 @@ void primitive_inst::update_impl() {
         }
         if (!has_cached_impl) {
             if (_dynamic_impl) {
-                auto& compilation_queue = get_network().get_compilation_queue();
-                compilation_queue.push([this, updated_params, layout_key](kernels_cache& kc) {
+                auto& compilation_context = get_network().get_compilation_context();
+                compilation_context.push_task([this, updated_params, layout_key](kernels_cache& kc) {
                     auto& cache = get_network().get_implementations_cache();
                     {
                         std::lock_guard<std::mutex> lock(get_network().get_in_mem_cache_mutex());


### PR DESCRIPTION
### Details:
 - each network now has compilation queue and thread worker for processing of that queue. 
 - When we have impl cache miss in dynamic flow, and shape agnostic impl is used, we put static version of that kernel into compilation queue to accelerate next iterations with the same shape.
