### PR TITLE
[GPU] add using output_partial_shape in calc_output_layout of reshape primitive

### DIFF
--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -22,6 +22,14 @@ layout reshape_inst::calc_output_layout(reshape_node const& node, kernel_impl_pa
            "Output data type forcing is not supported for reshape_node!");
     auto input_layout = impl_param.get_non_padded_input_layout();
     auto desc = impl_param.typed_desc<reshape>();
+    if (desc->output_shape.count() == 0) {
+        if (desc->output_partial_shape.size() != 0) {
+            return layout{desc->output_partial_shape, input_layout.data_type, input_layout.format};
+        } else {
+            OPENVINO_ASSERT("[GPU] Output shape is not provided");
+        }
+    }
+
     auto sizes = desc->output_shape.sizes();
     auto input_sizes = input_layout.get_tensor().sizes();
     size_t need_recalc = 0;

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/strided_slice.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/strided_slice.cpp
@@ -64,6 +64,8 @@ std::vector<StridedSliceSpecificParams> ss_only_test_cases_fp32 = {
                                 { 0, 1 }, { 0, 1 },  { 0, 0 },  { 0, 0 },  { 0, 0 } },
         StridedSliceSpecificParams{ { 5, 5, 5, 5 }, { -1, 0, -1, 0 }, { -50, 0, -60, 0 }, { -1, 1, -1, 1 },
                                 { 0, 0, 0, 0 }, { 0, 1, 0, 1 },  { 0, 0, 0, 0 },  { 0, 0, 0, 0 },  { 0, 0, 0, 0 } },
+        StridedSliceSpecificParams{ { 128, 1, 1024 }, { -1, 0, 0 }, { 0, 0, 0 }, { 1, 1, 1 },
+                            { 0, 1, 1 }, { 0, 1, 1 },  { 0, 0, 0 },  { 1, 0, 0 },  { 0, 0, 0 } },
 };
 
 std::vector<StridedSliceSpecificParams> ss_only_test_cases_i64 = {


### PR DESCRIPTION
### Details:
 - add using output_partial_shape in calc_output_layout of reshape primitive
 - add single layer test of strided_slice for the fix. input shape and op attributes from real model(XLNET_IMDB)

### Tickets:
 - 95822
