### PR TITLE
[CC] Upgrade oneDNN to fix CC inference test_model_fp32.xml crash issue.

### DIFF
--- a/.ci/azure/linux_conditional_compilation.yml
+++ b/.ci/azure/linux_conditional_compilation.yml
@@ -185,8 +185,8 @@ jobs:
 
   - script: ls -alR $(REPO_DIR)/bin/
     displayName: 'List bin files ON'
-  # TODO: ebable after the fix on CPU side
-  # - script: |
-  #     $(REPO_DIR)/bin/intel64/Release/benchmark_app -niter 1 -nireq 1 -m $(MODELS_PATH)/models/test_model/test_model_fp32.xml -d CPU
-  #   workingDirectory: $(REPO_DIR)
-  #   displayName: 'Use OpenVINO after CC'
+
+  - script: |
+      $(REPO_DIR)/bin/intel64/Release/benchmark_app -niter 1 -nireq 1 -m $(MODELS_PATH)/models/test_model/test_model_fp32.xml -d CPU
+    workingDirectory: $(REPO_DIR)
+    displayName: 'Use OpenVINO after CC'

--- a/.ci/azure/windows_conditional_compilation.yml
+++ b/.ci/azure/windows_conditional_compilation.yml
@@ -131,15 +131,13 @@ jobs:
     displayName: 'List bin files'
 
   - script: |
+      set path=%path%;$(REPO_DIR)\temp\tbb\bin
       call "$(MSVS_VARS_PATH)" && python thirdparty\itt_collector\runtool\sea_runtool.py --bindir $(REPO_DIR)\bin\intel64\$(BUILD_TYPE) -o $(BUILD_DIR)\itt_stat ! $(REPO_DIR)\bin\intel64\$(BUILD_TYPE)\benchmark_app.exe -niter 1 -nireq 1 -m $(MODELS_PATH)\models\test_model\test_model_fp32.xml -d CPU
     workingDirectory: $(REPO_DIR)
     displayName: 'Code usage analysis'
 
-  - script: dir $(BUILD_DIR)\ /s /p
+  - script: dir $(BUILD_DIR)\*.csv /s /p
     displayName: 'List csv files'
-
-  - script: type $(BUILD_DIR)\itt_stat\*.log
-    displayName: 'Cat csv log files'
 
   - script: |
       call "$(MSVS_VARS_PATH)" && cmake -G"Visual Studio 16 2019" ^
@@ -174,9 +172,6 @@ jobs:
 
   - script: dir $(REPO_DIR)\bin\ /s
     displayName: 'List bin files ON'
-
-  - script: dir $(BUILD_DIR_2)\ /s /p
-    displayName: 'List BUILD_DIR_2 files ON'
 
   - script: type $(BUILD_DIR_2)\src\common\conditional_compilation\conditional_compilation_gen.h
     displayName: 'Display cc header'

--- a/.ci/azure/windows_conditional_compilation.yml
+++ b/.ci/azure/windows_conditional_compilation.yml
@@ -169,8 +169,7 @@ jobs:
   - script: dir $(REPO_DIR)\bin\ /s
     displayName: 'List bin files ON'
 
-  # TODO: Enable after the fix on CPU side
-  # - script: |
-  #     $(REPO_DIR)\bin\intel64\$(BUILD_TYPE)\benchmark_app.exe -niter 1 -nireq 1 -m $(MODELS_PATH)\models\test_model\test_model_fp32.xml -d CPU
-  #   workingDirectory: $(REPO_DIR)
-  #   displayName: 'Use OpenVINO after CC'
+  - script: |
+      $(REPO_DIR)\bin\intel64\$(BUILD_TYPE)\benchmark_app.exe -niter 1 -nireq 1 -m $(MODELS_PATH)\models\test_model\test_model_fp32.xml -d CPU
+    workingDirectory: $(REPO_DIR)
+    displayName: 'Use OpenVINO after CC'

--- a/.ci/azure/windows_conditional_compilation.yml
+++ b/.ci/azure/windows_conditional_compilation.yml
@@ -138,6 +138,9 @@ jobs:
   - script: dir $(BUILD_DIR)\ /s
     displayName: 'List csv files'
 
+  - script: cat $(BUILD_DIR)\itt_stat\*.log /s
+    displayName: 'Cat csv log files'
+
   - script: |
       call "$(MSVS_VARS_PATH)" && cmake -G"Visual Studio 16 2019" ^
         -DVERBOSE_BUILD=ON ^

--- a/.ci/azure/windows_conditional_compilation.yml
+++ b/.ci/azure/windows_conditional_compilation.yml
@@ -135,10 +135,10 @@ jobs:
     workingDirectory: $(REPO_DIR)
     displayName: 'Code usage analysis'
 
-  - script: dir $(BUILD_DIR)\ /s
+  - script: dir $(BUILD_DIR)\ /s /p
     displayName: 'List csv files'
 
-  - script: cat $(BUILD_DIR)\itt_stat\*.log /s
+  - script: type $(BUILD_DIR)\itt_stat\*.log
     displayName: 'Cat csv log files'
 
   - script: |
@@ -175,7 +175,10 @@ jobs:
   - script: dir $(REPO_DIR)\bin\ /s
     displayName: 'List bin files ON'
 
-  - script: cat $(BUILD_DIR)\src\common\conditional_compilation\conditional_compilation_gen.h /s
+  - script: dir $(BUILD_DIR)\ /s /p
+    displayName: 'List BUILD_DIR files ON'
+
+  - script: type $(BUILD_DIR)\src\common\conditional_compilation\conditional_compilation_gen.h
     displayName: 'Display cc header'
 
   - script: |

--- a/.ci/azure/windows_conditional_compilation.yml
+++ b/.ci/azure/windows_conditional_compilation.yml
@@ -135,6 +135,9 @@ jobs:
     workingDirectory: $(REPO_DIR)
     displayName: 'Code usage analysis'
 
+  - script: dir $(BUILD_DIR)\ /s
+    displayName: 'List csv files'
+
   - script: |
       call "$(MSVS_VARS_PATH)" && cmake -G"Visual Studio 16 2019" ^
         -DVERBOSE_BUILD=ON ^
@@ -168,6 +171,9 @@ jobs:
 
   - script: dir $(REPO_DIR)\bin\ /s
     displayName: 'List bin files ON'
+
+  - script: cat $(BUILD_DIR)\src\common\conditional_compilation\conditional_compilation_gen.h /s
+    displayName: 'Display cc header'
 
   - script: |
       set path=%path%;$(REPO_DIR)\bin\intel64\$(BUILD_TYPE);$(REPO_DIR)\temp\tbb\bin

--- a/.ci/azure/windows_conditional_compilation.yml
+++ b/.ci/azure/windows_conditional_compilation.yml
@@ -170,11 +170,11 @@ jobs:
     displayName: 'List bin files ON'
 
   - script: |
-      set path=%path%;$(REPO_DIR)\bin\intel64\$(BUILD_TYPE)
+      set path=%path%;$(REPO_DIR)\bin\intel64\$(BUILD_TYPE);$(REPO_DIR)\temp\tbb\bin
       set bin_path=$(REPO_DIR)\bin\intel64\$(BUILD_TYPE)
       set new_bin_path=%bin_path%\nbin_path
       mkdir %new_bin_path%
       cp %bin_path%\benchmark_app.exe %new_bin_path%
-      $(new_bin_path)\benchmark_app.exe -niter 1 -nireq 1 -m $(MODELS_PATH)\models\test_model\test_model_fp32.xml -d CPU
+      %new_bin_path%\benchmark_app.exe -niter 1 -nireq 1 -m $(MODELS_PATH)\models\test_model\test_model_fp32.xml -d CPU
     workingDirectory: $(REPO_DIR)
     displayName: 'Use OpenVINO after CC'

--- a/.ci/azure/windows_conditional_compilation.yml
+++ b/.ci/azure/windows_conditional_compilation.yml
@@ -175,10 +175,10 @@ jobs:
   - script: dir $(REPO_DIR)\bin\ /s
     displayName: 'List bin files ON'
 
-  - script: dir $(BUILD_DIR)\ /s /p
-    displayName: 'List BUILD_DIR files ON'
+  - script: dir $(BUILD_DIR_2)\ /s /p
+    displayName: 'List BUILD_DIR_2 files ON'
 
-  - script: type $(BUILD_DIR)\src\common\conditional_compilation\conditional_compilation_gen.h
+  - script: type $(BUILD_DIR_2)\src\common\conditional_compilation\conditional_compilation_gen.h
     displayName: 'Display cc header'
 
   - script: |

--- a/.ci/azure/windows_conditional_compilation.yml
+++ b/.ci/azure/windows_conditional_compilation.yml
@@ -171,6 +171,10 @@ jobs:
 
   - script: |
       set path=%path%;$(REPO_DIR)\bin\intel64\$(BUILD_TYPE)
-      $(REPO_DIR)\bin\intel64\$(BUILD_TYPE)\benchmark_app.exe -niter 1 -nireq 1 -m $(MODELS_PATH)\models\test_model\test_model_fp32.xml -d CPU
+      set bin_path=$(REPO_DIR)\bin\intel64\$(BUILD_TYPE)
+      set new_bin_path=%bin_path%\nbin_path
+      mkdir %new_bin_path%
+      cp %bin_path%\benchmark_app.exe %new_bin_path%
+      $(new_bin_path)\benchmark_app.exe -niter 1 -nireq 1 -m $(MODELS_PATH)\models\test_model\test_model_fp32.xml -d CPU
     workingDirectory: $(REPO_DIR)
     displayName: 'Use OpenVINO after CC'

--- a/.ci/azure/windows_conditional_compilation.yml
+++ b/.ci/azure/windows_conditional_compilation.yml
@@ -170,6 +170,7 @@ jobs:
     displayName: 'List bin files ON'
 
   - script: |
+      set path=%path%;$(REPO_DIR)\bin\intel64\$(BUILD_TYPE)
       $(REPO_DIR)\bin\intel64\$(BUILD_TYPE)\benchmark_app.exe -niter 1 -nireq 1 -m $(MODELS_PATH)\models\test_model\test_model_fp32.xml -d CPU
     workingDirectory: $(REPO_DIR)
     displayName: 'Use OpenVINO after CC'


### PR DESCRIPTION
### Details:
 - *Adding MACRO DECLARE_COMMON_PD_T for brgemm_conv in order to fix CC inference test_model_fp32 crash issue.*

### oneDNN fork PR

 - https://github.com/openvinotoolkit/oneDNN/pull/165

### Tickets:
 - *96476*
