### PR TITLE
Fix value infer for ScatterUpdate in case of dynamic value in updates

### DIFF
--- a/tools/mo/openvino/tools/mo/ops/scatter.py
+++ b/tools/mo/openvino/tools/mo/ops/scatter.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 
-from openvino.tools.mo.front.common.partial_infer.utils import compatible_shapes, reverse_bypass_infer
+from openvino.tools.mo.front.common.partial_infer.utils import compatible_shapes, reverse_bypass_infer, shape_array
 from openvino.tools.mo.graph.graph import Node, Graph
 from openvino.tools.mo.ops.op import Op
 
@@ -186,4 +186,7 @@ class ScatterUpdate(Scatter):
             out_value = input_value.copy()
             for idx in np.ndindex(*input_shape[:axis]):
                 out_value[idx][indices_value] = updates_value[idx]
+            # update value can be dynamic, we need to create masked array in that case
+            if isinstance(updates_value, np.ma.masked_array):
+                out_value = shape_array(out_value, dtype=out_value.dtype)
             node.out_port(0).data.set_value(out_value)

--- a/tools/mo/unit_tests/mo/ops/scatter_test.py
+++ b/tools/mo/unit_tests/mo/ops/scatter_test.py
@@ -7,7 +7,7 @@ import numpy as np
 from generator import generator, generate
 
 from openvino.tools.mo.ops.scatter import ScatterElementsUpdate, ScatterUpdate
-from openvino.tools.mo.front.common.partial_infer.utils import int64_array
+from openvino.tools.mo.front.common.partial_infer.utils import int64_array, shape_array, dynamic_dimension_value
 from openvino.tools.mo.graph.graph import Node
 from unit_tests.utils.graph import build_graph, regular_op_with_empty_data, result, connect, valued_const_with_data
 
@@ -157,6 +157,13 @@ class ScatterUpdateInferTest(unittest.TestCase):
          # ref
          [[[7., 8., 9.], [6., 5., 4.], [3., 2., 1.]],
           [[7., 8., 9.], [6., 5., 4.], [3., 2., 1.]]]),
+
+        # dynamic updates
+        ([0, 0, 0],
+         [2],
+         shape_array([dynamic_dimension_value]),
+         0,
+         shape_array([0, 0, dynamic_dimension_value])),
     ])
     def test_scatter_update_value_infer(self, data, indices, updates, axis, ref_res):
         nodes = {


### PR DESCRIPTION
Root cause analysis: In case of dynamic value in `updates` of `ScatterUpdate` the value infer was incorrect, it was producing value `-1000000007` instead of dynamic value.

Solution: In case of masked array as `updates` produce masked array as value in value infer.

Ticket: 96978


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update