### PR TITLE
Fix of double printing of errors in MO

### DIFF
--- a/tools/mo/openvino/tools/mo/main.py
+++ b/tools/mo/openvino/tools/mo/main.py
@@ -27,13 +27,17 @@ from openvino.runtime import serialize
 
 
 def main(cli_parser: argparse.ArgumentParser, framework=None):
-    argv = cli_parser.parse_args()
-    argv.model_name = get_model_name_from_args(argv)
-    argv = vars(argv)
-
     # Initialize logger with 'ERROR' as default level to be able to form nice messages
     # before arg parser deliver log_level requested by user
     init_logger('ERROR', False)
+    logger = log.getLogger()
+    # Disable logging for parse_args() as inner convert runs parse_args() second time
+    # which result in duplicating of warnings
+    logger.disabled = True
+    argv = cli_parser.parse_args()
+    logger.disabled = False
+    argv.model_name = get_model_name_from_args(argv)
+    argv = vars(argv)
 
     if framework is not None:
         argv['framework'] = framework

--- a/tools/mo/unit_tests/mo/frontend_ngraph_test.py
+++ b/tools/mo/unit_tests/mo/frontend_ngraph_test.py
@@ -67,10 +67,13 @@ def test_main_error_log():
             os.path.join(os.path.dirname(__file__), 'main_test_error_log.py')]
 
     status = subprocess.run(args, env=os.environ, capture_output=True)
+    test_log = status.stderr.decode("utf-8").replace("\r\n", "\n")
 
     # Check that log has exactly one warning from parse_args and
     # exactly one error message "FW ERROR"
-    assert status.stderr == b'[ WARNING ]  warning\r\n[ FRAMEWORK ERROR ]  FW ERROR MESSAGE\r\n'
+    ref_log = "[ WARNING ]  warning\n[ FRAMEWORK ERROR ]  FW ERROR MESSAGE\n"
+
+    assert test_log == ref_log
 
 
 def test_mo_extensions_test():

--- a/tools/mo/unit_tests/mo/frontend_ngraph_test.py
+++ b/tools/mo/unit_tests/mo/frontend_ngraph_test.py
@@ -73,7 +73,6 @@ def test_main_error_log():
     assert status.stderr == b'[ WARNING ]  warning\r\n[ FRAMEWORK ERROR ]  FW ERROR MESSAGE\r\n'
 
 
-
 def test_mo_extensions_test():
     setup_env()
     args = [sys.executable, '-m', 'pytest',

--- a/tools/mo/unit_tests/mo/frontend_ngraph_test.py
+++ b/tools/mo/unit_tests/mo/frontend_ngraph_test.py
@@ -61,6 +61,19 @@ def test_main_test():
     assert not status.returncode
 
 
+def test_main_error_log():
+    setup_env()
+    args = [sys.executable,
+            os.path.join(os.path.dirname(__file__), 'main_test_error_log.py')]
+
+    status = subprocess.run(args, env=os.environ, capture_output=True)
+
+    # Check that log has exactly one warning from parse_args and
+    # exactly one error message "FW ERROR"
+    assert status.stderr == b'[ WARNING ]  warning\r\n[ FRAMEWORK ERROR ]  FW ERROR MESSAGE\r\n'
+
+
+
 def test_mo_extensions_test():
     setup_env()
     args = [sys.executable, '-m', 'pytest',

--- a/tools/mo/unit_tests/mo/main_test_error_log.py
+++ b/tools/mo/unit_tests/mo/main_test_error_log.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+from unittest.mock import patch
+
+from openvino.tools.mo.utils.error import FrameworkError
+
+
+def mocked_parse_args(*argv):
+    # Mock parse_args method which generates warning
+    import logging as log
+    log.error("warning", extra={'is_warning': True})
+    argv = argparse.Namespace()
+    return argv
+
+
+@patch('argparse.ArgumentParser.parse_args', mocked_parse_args)
+@patch('openvino.tools.mo.convert_impl.driver', side_effect=FrameworkError('FW ERROR MESSAGE'))
+def run_main(mock_driver):
+    from openvino.tools.mo.main import main
+    # runs main() method where driver() raises FrameworkError
+    main(argparse.ArgumentParser())
+
+
+if __name__ == "__main__":
+    run_main()


### PR DESCRIPTION
Root cause analysis: 
parse_agrs() in main() stands before initialization of logger. If parse_args() prints anything to logger, like deprecated parameter warning, it leads to breaking of logger and printing of all messages two times.
Also parse_agrs() is used two times in main() and in inner convert() method. Which leads to printing of messages from parse_args() two times.

Solution: 
1. Initialize logger before parse_agrs() in main()
2. Mute logger for parse_agrs() in main() to have messages only from inner parse_agrs().

Ticket: 


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update