### PR TITLE
reduce_reshape_transformation_fix

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/reduce_reshape_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/reduce_reshape_fusion.cpp
@@ -17,10 +17,14 @@
 ov::pass::ReduceReshapeFusion::ReduceReshapeFusion() {
     MATCHER_SCOPE(ReduceReshapeFusion);
 
+    const auto reduce_predicate = [](const Output<Node>& output) -> bool {
+        return pattern::has_static_shape()(output) && pattern::consumers_count(1)(output);
+    };
+
     const auto reduce_axes = pattern::wrap_type<opset9::Constant>();
     const auto reduce = pattern::wrap_type<op::util::ArithmeticReductionKeepDims, op::util::LogicalReductionKeepDims>(
         {pattern::any_input(), reduce_axes},
-        pattern::has_static_shape());
+        reduce_predicate);
     const auto reshape =
         pattern::wrap_type<opset9::Reshape>({reduce, pattern::any_input()}, pattern::has_static_shape());
 


### PR DESCRIPTION
### Details:
 - *this transformation only applicable when reduce have one consumer(reshape). have possible incompatible shape for other branch*

```
before transformation:
        reduce(keep_dim is false, output shape is [5])
                    /                      \
                   /                        \
      reshape(1,1,1,5)            output(layout is C, only 1 dims tensor is acceptable)

after transformation:
        reduce(keep_dim is true, output shape is [1,1,1,5])
                    /                         \
                   /                           \
     reshape(skipped)              output(layout should be C, incompatible with 4 dims tensor) 
```


### Tickets:
 - *97191*
