### PR TITLE
[CPU] Support brgconv->concat in place

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -316,7 +316,8 @@ void Concat::selectOptimalPrimitiveDescriptor() {
 
     // we only add brg nhwc support, not change the main nhwc assumption.
     auto tryBrgNHWCInplace = [&](int spdIdx) {
-        if (canBeInPlace && convertTo == LayoutType::nspc) {
+        // disable bf16 and int8 due to regressions.
+        if (canBeInPlace && convertTo == LayoutType::nspc && inputPrecision == Precision::FP32) {
             bool allBrg = true;
             for (size_t i = 0; i < getParentEdges().size(); i++) {
                 auto parentEdge = getParentEdgeAt(i);

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -326,8 +326,8 @@ void Concat::selectOptimalPrimitiveDescriptor() {
                 if (parent_pdesc == nullptr)
                     continue;
 
-                const auto& parent_config = parent_pdesc->getConfig();
-                if ((parent_pdesc->getImplementationType() & brgconv_avx512) != brgconv_avx512) {
+                if ((parent_pdesc->getImplementationType() & brgconv_avx512) != brgconv_avx512 &&
+                    parent->getType() != Type::Concatenation) {
                     allBrg = false;
                     break;
                 }

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -328,7 +328,6 @@ void Snippet::define_schedule() {
         auto& shapes = std::get<0>(shapes_infos);
         if (std::get<2>(infos) && shapes.size() > 1) {
             auto& strides = std::get<1>(infos);
-            // ignore batch dimension because blocked layout already takes into account
             auto elements = std::accumulate(shapes.begin() + 1, shapes.end(), size_t{1}, std::multiplies<size_t>());
             input_has_strides.push_back(elements != strides[0]);
             input_strides.push_back(std::move(strides));

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_brgconv_inplace.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_brgconv_inplace.cpp
@@ -275,7 +275,7 @@ TEST_P(ConcatBrgConvInPlaceTest1, CompareWithRefs) {
 }
 
 INSTANTIATE_TEST_SUITE_P(smoke_ConcatBrgConvInPlaceTest1_CPU, ConcatBrgConvInPlaceTest1,
-    testing::Values(Precision::FP32, Precision::BF16),
+    testing::Values(Precision::FP32), // disable bf16 due to regressions.
     ConcatBrgConvInPlaceTest1::getTestCaseName);
 
 TEST_P(ConcatBrgConvInPlaceTest2, CompareWithRefs) {
@@ -299,7 +299,7 @@ TEST_P(ConcatBrgConvInPlaceTest2, CompareWithRefs) {
 
 INSTANTIATE_TEST_SUITE_P(smoke_ConcatBrgConvInPlaceTest2_CPU,
                          ConcatBrgConvInPlaceTest2,
-                         testing::Values(Precision::FP32, Precision::BF16),
+                         testing::Values(Precision::FP32), // disable bf16 due to regressions.
                          ConcatBrgConvInPlaceTest2::getTestCaseName);
 
 TEST_P(ConcatBrgConvInPlaceTest3, CompareWithRefs) {
@@ -323,9 +323,10 @@ TEST_P(ConcatBrgConvInPlaceTest3, CompareWithRefs) {
     CheckPluginRelatedResults(executableNetwork, "Concatenation");
 }
 
-INSTANTIATE_TEST_SUITE_P(smoke_ConcatBrgConvInPlaceTest3_CPU,
-                         ConcatBrgConvInPlaceTest3,
-                         testing::Values(Precision::FP32),
-                         ConcatBrgConvInPlaceTest3::getTestCaseName);
+// disable int8 due to regressions.
+// INSTANTIATE_TEST_SUITE_P(smoke_ConcatBrgConvInPlaceTest3_CPU,
+//                          ConcatBrgConvInPlaceTest3,
+//                          testing::Values(Precision::FP32),
+//                          ConcatBrgConvInPlaceTest3::getTestCaseName);
 }// namespace
 } // namespace SubgraphTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_brgconv_inplace.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_brgconv_inplace.cpp
@@ -13,13 +13,13 @@ using namespace InferenceEngine;
 namespace SubgraphTestsDefinitions {
 // Subgraph:
 /*
- *           paramter
+ *            param
  *              |
- *            reLu
+ *            relu
  *              |
  *              /\
  *             /  \
- *           conv conv
+ *           conv1 conv2
  *             |   |
  *              \ /
  *            concat(inplace)
@@ -31,6 +31,11 @@ namespace SubgraphTestsDefinitions {
  *             concat(inplace)
  *               |
  *             result
+ * cover: FP32+BF16
+ *        conv1: 1x1
+ *        conv2: normal
+ *        subgraph: in/out stride
+ *        concat inplace: brg->concat, concat->concat
  */
 
 class ConcatBrgConvInPlaceTest1 : public testing::WithParamInterface<InferenceEngine::Precision>, public CPUTestsBase,
@@ -43,7 +48,7 @@ public:
     }
 
     void SetUp() override {
-        const std::vector<size_t> inputShape = {1, 64, 120, 120};
+        const std::vector<size_t> inputShape = {1, 64, 120, 12};
         const InferenceEngine::SizeVector kernel1 = {1, 1};
         const InferenceEngine::SizeVector kernel2 = {3, 3};
         const InferenceEngine::SizeVector stride = {1, 1};
@@ -52,12 +57,12 @@ public:
         const std::vector<ptrdiff_t> padEnd1 = {0, 0};
         const std::vector<ptrdiff_t> padBegin2 = {1, 1};
         const std::vector<ptrdiff_t> padEnd2 = {1, 1};
-        const size_t convOutChannels = 64;
+        const size_t convOutChannels = 80;
         const auto targetFormat = nhwc;
         inPrc = outPrc = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
 
-        auto inputParams = ngraph::builder::makeParams(ngPrc, {inputShape, inputShape});
+        auto inputParams = ngraph::builder::makeParams(ngPrc, {inputShape});
 
         auto relu = std::make_shared<ngraph::opset3::Relu>(inputParams[0]);
         relu->get_rt_info() = CPUTestsBase::makeCPUInfo({targetFormat}, {targetFormat}, {});
@@ -79,35 +84,41 @@ public:
 
 // Subgraph:
 /*
- *           paramter
- *              |
- *            reLu
- *              |
- *              /\
- *             /  \
- *           conv conv
- *             |   |
- *              \ /
- *            concat(inplace)
- *               \  conv
- *                \  /
- *                 \/
- *                concat(inplace)
- *                  |
- *                result
+ *          param1       param2
+ *            |            |
+ *           relu1       relu2
+ *           /    \        |
+ *         conv1  conv2  conv3
+ *           |      |      |
+ *           |      |    relu3
+ *            \     |     /
+ *             concat(inplace)
+ *               |
+ *             result
+ * cover: FP32
+ *        conv1: 1x1
+ *        conv2: exec_vpad
+ *        conv3: exec_base
+ *        relu3: perform_outwork
+ *        BF16
+ *        conv1: 1x1
+ *        conv2: exec_trans
+ *        conv3: exec_trans
+ *        relu3: perform_outwork
  */
 
-class ConcatBrgConvInPlaceTest : public testing::WithParamInterface<InferenceEngine::Precision>, public CPUTestsBase,
+class ConcatBrgConvInPlaceTest2 : public testing::WithParamInterface<InferenceEngine::Precision>, public CPUTestsBase,
     virtual public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<InferenceEngine::Precision> obj) {
         std::ostringstream result;
-        result << "ConcatBrgConvInPlaceTest" << obj.param.name();
+        result << "ConcatBrgConvInPlaceTest2" << obj.param.name();
         return result.str();
     }
 
     void SetUp() override {
-        const std::vector<size_t> inputShape = {1, 64, 120, 120};
+        const std::vector<size_t> inputShape1 = {1, 64, 120, 12};
+        const std::vector<size_t> inputShape2 = {1, 64, 119, 11};
         const InferenceEngine::SizeVector kernel1 = {1, 1};
         const InferenceEngine::SizeVector kernel2 = {3, 3};
         const InferenceEngine::SizeVector stride = {1, 1};
@@ -116,54 +127,135 @@ public:
         const std::vector<ptrdiff_t> padEnd1 = {0, 0};
         const std::vector<ptrdiff_t> padBegin2 = {1, 1};
         const std::vector<ptrdiff_t> padEnd2 = {1, 1};
-        const size_t convOutChannels = 64;
+        const std::vector<ptrdiff_t> padBegin3 = {3, 3};
+        const std::vector<ptrdiff_t> padEnd3 = {0, 0};
+        const size_t convOutChannels = 80;
         const auto targetFormat = nhwc;
         inPrc = outPrc = this->GetParam();
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
 
-        auto inputParams = ngraph::builder::makeParams(ngPrc, {inputShape, inputShape});
+        auto inputParams = ngraph::builder::makeParams(ngPrc, {inputShape1, inputShape2});
 
-        auto relu = std::make_shared<ngraph::opset3::Relu>(inputParams[0]);
-        relu->get_rt_info() = CPUTestsBase::makeCPUInfo({targetFormat}, {targetFormat}, {});
-        auto conv1 = ngraph::builder::makeConvolution(relu, ngPrc, kernel1, stride, padBegin1,
+        auto relu1 = std::make_shared<ngraph::opset3::Relu>(inputParams[0]);
+        relu1->get_rt_info() = CPUTestsBase::makeCPUInfo({targetFormat}, {targetFormat}, {});
+        auto relu2 = std::make_shared<ngraph::opset3::Relu>(inputParams[1]);
+        relu2->get_rt_info() = CPUTestsBase::makeCPUInfo({targetFormat}, {targetFormat}, {});
+        auto conv1 = ngraph::builder::makeConvolution(relu1, ngPrc, kernel1, stride, padBegin1,
                                                      padEnd1, dilation, ngraph::op::PadType::AUTO, convOutChannels);
-        auto conv2 = ngraph::builder::makeConvolution(relu, ngPrc, kernel2, stride, padBegin2,
+        auto conv2 = ngraph::builder::makeConvolution(relu1, ngPrc, kernel1, stride, padBegin2,
                                                      padEnd2, dilation, ngraph::op::PadType::AUTO, convOutChannels);
+        auto conv3 = ngraph::builder::makeConvolution(relu2, ngPrc, kernel2, stride, padBegin3,
+                                                     padEnd3, dilation, ngraph::op::PadType::EXPLICIT, convOutChannels);
 
-        auto concat1 = ngraph::builder::makeConcat(ngraph::OutputVector{conv1, conv2}, 1);
-        auto conv3 = ngraph::builder::makeConvolution(relu, ngPrc, kernel1, stride, padBegin1,
-                                                     padEnd1, dilation, ngraph::op::PadType::AUTO, convOutChannels);
-        auto concat2 = ngraph::builder::makeConcat(ngraph::OutputVector{concat1, conv3}, 1);
+        auto fusedRelu = std::make_shared<ngraph::opset3::Relu>(conv3);
+        auto concat = ngraph::builder::makeConcat(ngraph::OutputVector{conv1, conv2, fusedRelu}, 1);
 
-        ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(concat2)};
+        ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(concat)};
+        function = std::make_shared<ngraph::Function>(results, inputParams, "ConcatBrgconvInPlace");
+        targetDevice = CommonTestUtils::DEVICE_CPU;
+    }
+};
+
+// Subgraph:
+/*
+ *           param1       param2
+ *              |           |
+ *            relu1       relu2
+ *              |           |
+ *              /\          |
+ *             /  \         |
+ *            fq1 fq2      fq3
+ *             |   |        |
+ *           conv1 conv2  conv3
+ *             |   |        |
+ *             |   |      relu3
+ *             \   |       /
+ *             concat(inplace)
+ *                    |
+ *                  result
+ * cover: VNNI I8
+ *        conv1: 1x1(use_buffer branch)
+ *        conv2: exec_vpad(use_buffer branch)
+ *        conv3: exec_base(use_buffer branch)
+ *        relu3: perform_outwork(use_buffer branch)
+ *        AMX I8
+ *        conv1: 1x1
+ *        conv2: exec_trans
+ *        conv3: exec_trans
+ *        relu3: perform_outwork
+ */
+
+class ConcatBrgConvInPlaceTest3 : public testing::WithParamInterface<InferenceEngine::Precision>, public CPUTestsBase,
+    virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<InferenceEngine::Precision> obj) {
+        std::ostringstream result;
+        result << "ConcatBrgConvInPlaceTest3" << obj.param.name();
+        return result.str();
+    }
+
+    void SetUp() override {
+        // amx_int8 seems it does not work when input channel > 20480
+        const auto extraInChannel = InferenceEngine::with_cpu_x86_avx512_core_amx_int8() ? 0ul : 16ul;
+        const std::vector<size_t> inputShape1 = {1ul, 20480ul + extraInChannel, 5ul, 5ul};
+        const std::vector<size_t> inputShape2 = {1ul, 20480ul + extraInChannel, 4ul, 4ul};
+        const InferenceEngine::SizeVector kernel1 = {1, 1};
+        const InferenceEngine::SizeVector kernel2 = {3, 3};
+        const InferenceEngine::SizeVector strides = {1, 1};
+        const InferenceEngine::SizeVector dilations = {1, 1};
+        const std::vector<ptrdiff_t> padsBegin1 = {0, 0};
+        const std::vector<ptrdiff_t> padsEnd1 = {0, 0};
+        const std::vector<ptrdiff_t> padsBegin2 = {1, 1};
+        const std::vector<ptrdiff_t> padsEnd2 = {1, 1};
+        const std::vector<ptrdiff_t> padsBegin3 = {3, 3};
+        const std::vector<ptrdiff_t> padsEnd3 = {0, 0};
+        const size_t convOutChannels = 80;
+        const auto targetFormat = nhwc;
+        inPrc = outPrc = this->GetParam();
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+
+        auto inputParams = ngraph::builder::makeParams(ngPrc, {inputShape1, inputShape2});
+
+        auto relu1 = std::make_shared<ngraph::opset3::Relu>(inputParams[0]);
+        relu1->get_rt_info() = CPUTestsBase::makeCPUInfo({targetFormat}, {targetFormat}, {});
+        auto relu2 = std::make_shared<ngraph::opset3::Relu>(inputParams[1]);
+        relu2->get_rt_info() = CPUTestsBase::makeCPUInfo({targetFormat}, {targetFormat}, {});
+
+        auto data_fake1 = ngraph::builder::makeFakeQuantize(relu1, ngPrc, 255, {1ull}, {-10.f}, {10.f}, {-10.f}, {10.f});
+        auto data_fake2 = ngraph::builder::makeFakeQuantize(relu1, ngPrc, 255, {1ull}, {-10.f}, {10.f}, {-10.f}, {10.f});
+        auto data_fake3 = ngraph::builder::makeFakeQuantize(relu2, ngPrc, 255, {1ull}, {-10.f}, {10.f}, {-10.f}, {10.f});
+        const auto weights1 = ngraph::builder::makeConstant(
+            ngraph::element::f32,
+            ngraph::Shape{ convOutChannels, inputShape1[1], kernel1[0], kernel1[1] },
+            std::vector<float>{}, true);
+        const auto weights2 = ngraph::builder::makeConstant(
+            ngraph::element::f32,
+            ngraph::Shape{ convOutChannels, inputShape1[1], kernel2[0], kernel2[1] },
+            std::vector<float>{}, true);
+        const auto weights3 = ngraph::builder::makeConstant(
+            ngraph::element::f32,
+            ngraph::Shape{ convOutChannels, inputShape1[1], kernel2[0], kernel2[1] },
+            std::vector<float>{}, true);
+        auto weight_fake1 = ngraph::builder::makeFakeQuantize(weights1, ngPrc, 255, {1ull}, {-10.f}, {10.f}, {-10.f}, {10.f});
+        auto weight_fake2 = ngraph::builder::makeFakeQuantize(weights2, ngPrc, 255, {1ull}, {-10.f}, {10.f}, {-10.f}, {10.f});
+        auto weight_fake3 = ngraph::builder::makeFakeQuantize(weights3, ngPrc, 255, {1ull}, {-10.f}, {10.f}, {-10.f}, {10.f});
+        auto conv1 = std::make_shared<ngraph::opset1::Convolution>(
+            data_fake1, weight_fake1, strides, padsBegin1, padsEnd1, dilations);
+        auto conv2 = std::make_shared<ngraph::opset1::Convolution>(
+            data_fake2, weight_fake2, strides, padsBegin2, padsEnd2, dilations);
+        auto conv3 = std::make_shared<ngraph::opset1::Convolution>(
+            data_fake3, weight_fake3, strides, padsBegin3, padsEnd3, dilations);
+        auto fusedRelu = std::make_shared<ngraph::opset3::Relu>(conv3);
+
+        auto concat = ngraph::builder::makeConcat(ngraph::OutputVector{conv1, conv2, fusedRelu}, 1);
+
+        ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(concat)};
         function = std::make_shared<ngraph::Function>(results, inputParams, "ConcatBrgconvInPlace");
         targetDevice = CommonTestUtils::DEVICE_CPU;
     }
 };
 
 namespace {
-TEST_P(ConcatBrgConvInPlaceTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-    if (!InferenceEngine::with_cpu_x86_avx512_core())
-        GTEST_SKIP();
-    if (this->GetParam() == Precision::BF16 && !InferenceEngine::with_cpu_x86_bfloat16())
-        GTEST_SKIP();
-
-    Run();
-
-    if (this->GetParam() == Precision::BF16) {
-        selectedType = "unknown_BF16";
-    } else {
-        selectedType = "unknown_FP32";
-    }
-    CheckNumberOfNodesWithType(executableNetwork, "Reorder", 5);
-    CheckPluginRelatedResults(executableNetwork, "Concatenation");
-}
-
-INSTANTIATE_TEST_SUITE_P(smoke_ConcatBrgConvInPlaceTest_CPU, ConcatBrgConvInPlaceTest,
-    testing::Values(Precision::FP32, Precision::BF16),
-    ConcatBrgConvInPlaceTest::getTestCaseName);
-
 TEST_P(ConcatBrgConvInPlaceTest1, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
     if (!InferenceEngine::with_cpu_x86_avx512_core())
@@ -184,7 +276,56 @@ TEST_P(ConcatBrgConvInPlaceTest1, CompareWithRefs) {
 
 INSTANTIATE_TEST_SUITE_P(smoke_ConcatBrgConvInPlaceTest1_CPU, ConcatBrgConvInPlaceTest1,
     testing::Values(Precision::FP32, Precision::BF16),
-    ConcatBrgConvInPlaceTest::getTestCaseName);
+    ConcatBrgConvInPlaceTest1::getTestCaseName);
 
+TEST_P(ConcatBrgConvInPlaceTest2, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    if (!InferenceEngine::with_cpu_x86_avx512_core_vnni())
+        GTEST_SKIP();
+    if (this->GetParam() == Precision::BF16 && !InferenceEngine::with_cpu_x86_bfloat16())
+        GTEST_SKIP();
+
+    Run();
+
+    if (this->GetParam() == Precision::BF16) {
+        selectedType = "unknown_BF16";
+    } else {
+        selectedType = "unknown_FP32";
+    }
+
+    CheckNumberOfNodesWithType(executableNetwork, "Reorder", 6);
+    CheckPluginRelatedResults(executableNetwork, "Concatenation");
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_ConcatBrgConvInPlaceTest2_CPU,
+                         ConcatBrgConvInPlaceTest2,
+                         testing::Values(Precision::FP32, Precision::BF16),
+                         ConcatBrgConvInPlaceTest2::getTestCaseName);
+
+TEST_P(ConcatBrgConvInPlaceTest3, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    if (!InferenceEngine::with_cpu_x86_avx512_core_vnni())
+        GTEST_SKIP();
+    if (this->GetParam() == Precision::BF16 && !InferenceEngine::with_cpu_x86_bfloat16())
+        GTEST_SKIP();
+
+    Run();
+
+    if (this->GetParam() == Precision::BF16) {
+        selectedType = "unknown_BF16";
+    } else if (this->GetParam() == Precision::FP32) {
+        selectedType = "unknown_FP32";
+    } else {
+        selectedType = "unknown_I8";
+    }
+
+    CheckNumberOfNodesWithType(executableNetwork, "Reorder", 6);
+    CheckPluginRelatedResults(executableNetwork, "Concatenation");
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_ConcatBrgConvInPlaceTest3_CPU,
+                         ConcatBrgConvInPlaceTest3,
+                         testing::Values(Precision::FP32),
+                         ConcatBrgConvInPlaceTest3::getTestCaseName);
 }// namespace
 } // namespace SubgraphTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_brgconv_inplace.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_brgconv_inplace.cpp
@@ -1,0 +1,157 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils/cpu_test_utils.hpp"
+#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "ngraph_functions/builders.hpp"
+
+using namespace CPUTestUtils;
+using namespace InferenceEngine;
+
+namespace SubgraphTestsDefinitions {
+// Subgraph:
+/*
+ *           paramter
+ *              |
+ *            reLu
+ *              |
+ *              /\
+ *             /  \
+ *           conv conv
+ *             |   |
+ *              \ /
+ *            concat(inplace)
+ *               |
+ *             result
+ */
+
+class ConcatBrgConvInPlaceTest : public testing::WithParamInterface<InferenceEngine::Precision>, public CPUTestsBase,
+    virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<InferenceEngine::Precision> obj) {
+        std::ostringstream result;
+        result << "ConcatBrgConvInPlaceTest" << obj.param.name();
+        return result.str();
+    }
+
+    void SetUp() override {
+        const std::vector<size_t> inputShape = {1, 64, 120, 120};
+        const InferenceEngine::SizeVector kernel1 = {1, 1};
+        const InferenceEngine::SizeVector kernel2 = {3, 3};
+        const InferenceEngine::SizeVector stride = {1, 1};
+        const InferenceEngine::SizeVector dilation = {1, 1};
+        const std::vector<ptrdiff_t> padBegin1 = {0, 0};
+        const std::vector<ptrdiff_t> padEnd1 = {0, 0};
+        const std::vector<ptrdiff_t> padBegin2 = {1, 1};
+        const std::vector<ptrdiff_t> padEnd2 = {1, 1};
+        const size_t convOutChannels = 64;
+        const auto targetFormat = nhwc;
+        inPrc = outPrc = this->GetParam();
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+
+        auto inputParams = ngraph::builder::makeParams(ngPrc, {inputShape, inputShape});
+
+        auto relu = std::make_shared<ngraph::opset3::Relu>(inputParams[0]);
+        relu->get_rt_info() = CPUTestsBase::makeCPUInfo({targetFormat}, {targetFormat}, {});
+        auto conv1 = ngraph::builder::makeConvolution(relu, ngPrc, kernel1, stride, padBegin1,
+                                                     padEnd1, dilation, ngraph::op::PadType::AUTO, convOutChannels);
+        auto conv2 = ngraph::builder::makeConvolution(relu, ngPrc, kernel2, stride, padBegin2,
+                                                     padEnd2, dilation, ngraph::op::PadType::AUTO, convOutChannels);
+
+        auto concat = ngraph::builder::makeConcat(ngraph::OutputVector{conv1, conv2}, 1);
+
+        ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(concat)};
+        function = std::make_shared<ngraph::Function>(results, inputParams, "ConcatBrgconvInPlace");
+        targetDevice = CommonTestUtils::DEVICE_CPU;
+    }
+};
+
+// Subgraph:
+/*
+ *           paramter
+ *              |
+ *            reLu
+ *              |
+ *              /\
+ *             /  \
+ *           conv conv
+ *             |   |
+ *              \ /
+ *            concat(inplace)
+ *               \  conv
+ *                \  /
+ *                 \/
+ *                concat(inplace)
+ *                  |
+ *                result
+ */
+
+class ConcatBrgConvInPlaceTest1 : public testing::WithParamInterface<InferenceEngine::Precision>, public CPUTestsBase,
+    virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<InferenceEngine::Precision> obj) {
+        std::ostringstream result;
+        result << "ConcatBrgConvInPlaceTest1" << obj.param.name();
+        return result.str();
+    }
+
+    void SetUp() override {
+        const std::vector<size_t> inputShape = {1, 64, 120, 120};
+        const InferenceEngine::SizeVector kernel1 = {1, 1};
+        const InferenceEngine::SizeVector kernel2 = {3, 3};
+        const InferenceEngine::SizeVector stride = {1, 1};
+        const InferenceEngine::SizeVector dilation = {1, 1};
+        const std::vector<ptrdiff_t> padBegin1 = {0, 0};
+        const std::vector<ptrdiff_t> padEnd1 = {0, 0};
+        const std::vector<ptrdiff_t> padBegin2 = {1, 1};
+        const std::vector<ptrdiff_t> padEnd2 = {1, 1};
+        const size_t convOutChannels = 64;
+        const auto targetFormat = nhwc;
+        inPrc = outPrc = this->GetParam();
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+
+        auto inputParams = ngraph::builder::makeParams(ngPrc, {inputShape, inputShape});
+
+        auto relu = std::make_shared<ngraph::opset3::Relu>(inputParams[0]);
+        relu->get_rt_info() = CPUTestsBase::makeCPUInfo({targetFormat}, {targetFormat}, {});
+        auto conv1 = ngraph::builder::makeConvolution(relu, ngPrc, kernel1, stride, padBegin1,
+                                                     padEnd1, dilation, ngraph::op::PadType::AUTO, convOutChannels);
+        auto conv2 = ngraph::builder::makeConvolution(relu, ngPrc, kernel2, stride, padBegin2,
+                                                     padEnd2, dilation, ngraph::op::PadType::AUTO, convOutChannels);
+
+        auto concat1 = ngraph::builder::makeConcat(ngraph::OutputVector{conv1, conv2}, 1);
+        auto conv3 = ngraph::builder::makeConvolution(relu, ngPrc, kernel1, stride, padBegin1,
+                                                     padEnd1, dilation, ngraph::op::PadType::AUTO, convOutChannels);
+        auto concat2 = ngraph::builder::makeConcat(ngraph::OutputVector{concat1, conv3}, 1);
+
+        ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(concat2)};
+        function = std::make_shared<ngraph::Function>(results, inputParams, "ConcatBrgconvInPlace");
+        targetDevice = CommonTestUtils::DEVICE_CPU;
+    }
+};
+
+namespace {
+TEST_P(ConcatBrgConvInPlaceTest, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    if (!InferenceEngine::with_cpu_x86_avx512_core())
+        GTEST_SKIP();
+
+    Run();
+    if (this->GetParam() == Precision::BF16) {
+        CheckNumberOfNodesWithType(executableNetwork, "Reorder", 4);
+        selectedType = "unknown_BF16";
+        CheckPluginRelatedResults(executableNetwork, "Concat");
+    } else {
+        CheckNumberOfNodesWithType(executableNetwork, "Reorder", 4);
+        selectedType = "unknown_FP32";
+        CheckPluginRelatedResults(executableNetwork, "Concat");
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_ConcatBrgConvInPlaceTest_CPU, ConcatBrgConvInPlaceTest,
+    testing::Values(Precision::FP32, Precision::BF16),
+    ConcatBrgConvInPlaceTest::getTestCaseName);
+} // namespace
+} // namespace SubgraphTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/conv_concat.cpp
@@ -148,7 +148,8 @@ namespace Kernel_1x1 {
 const std::vector<CPUSpecificParams> CPUParams2DConv = {
     conv_sse42_2D_1x1,
     conv_avx2_2D_1x1,
-    conv_avx512_2D_1x1
+    conv_avx512_2D_1x1,
+    conv_avx512_2D_1x1_nspc_brgconv
 };
 
 commonConvParams convParams2D1x1 = commonConvParams{{1, 1}, {1, 1}, {0, 0}, {0, 0}, dilation2D, numOutChannels, paddingType, 1};
@@ -291,7 +292,8 @@ const std::vector<CPUSpecificParams> CPUParams2D = {
     conv_gemm_2D,
     conv_sse42_2D,
     conv_avx2_2D,
-    conv_avx512_2D
+    conv_avx512_2D,
+    conv_avx512_2D_nspc_brgconv
 };
 
 const auto params2D = ::testing::Combine(


### PR DESCRIPTION
### Details:
 - *support concat in place when the pattern is the following:*
```    
brgconv  -->concat(in channel axis)
brgconv ___|

or

 brgconv    ...
       |    /
concat(inplace)
       |   \
   subgraph \
       \     /
         \  /
     concat(inplace)
```

 - *subgraph supports in/out stride, brgconv supports out stride*
### Tickets:
 - *96585*

