### PR TITLE
[GPU] Retain engine ptr in RemoteBlob impl

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
@@ -82,6 +82,8 @@ public:
 protected:
     static RemoteAllocator m_allocator;
     std::weak_ptr<InferenceEngine::gpu::ClContext> m_context;
+    // retain engine ptr to ensure that memory object can be released properly in cases when RemoteContext if deleted before RemoteTensor
+    std::shared_ptr<cldnn::engine> m_engine;
     cldnn::stream& m_stream;
 
     // constructor stuff

--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -36,16 +36,16 @@ RemoteBlobImpl::RemoteBlobImpl(ClContext::Ptr context,
     , _handle(nullptr)
     , _allocator(nullptr) {
     auto _impl = getContextImpl(m_context.lock());
-    auto eng = _impl->GetEngine();
+    m_engine = _impl->GetEngine();
 
     // Verify shared buffer/usm memory and ensure that requested byte size is not greater than allocated one
     switch (m_mem_type) {
     case BlobType::BT_BUF_SHARED: {
-        eng->share_buffer(m_layout, m_mem);
+        m_engine->share_buffer(m_layout, m_mem);
         break;
     }
     case BlobType::BT_USM_SHARED: {
-        eng->share_usm(m_layout, m_mem);
+        m_engine->share_usm(m_layout, m_mem);
         break;
     }
     default: break;
@@ -131,46 +131,45 @@ void RemoteBlobImpl::allocate() {
 
     auto _impl = getContextImpl(m_context.lock());
     _impl->acquire_lock();
-    std::shared_ptr<cldnn::engine> eng = _impl->GetEngine();
 
     switch (m_mem_type) {
     case BlobType::BT_BUF_INTERNAL: {
-        m_memObject = eng->allocate_memory(m_layout, cldnn::allocation_type::cl_mem);
+        m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::cl_mem);
         break;
     }
     case BlobType::BT_USM_HOST_INTERNAL: {
-        m_memObject = eng->allocate_memory(m_layout, cldnn::allocation_type::usm_host);
+        m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::usm_host);
         break;
     }
     case BlobType::BT_USM_DEVICE_INTERNAL: {
-        m_memObject = eng->allocate_memory(m_layout, cldnn::allocation_type::usm_device);
+        m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::usm_device);
         break;
     }
     case BlobType::BT_BUF_SHARED: {
-        m_memObject = eng->share_buffer(m_layout, m_mem);
+        m_memObject = m_engine->share_buffer(m_layout, m_mem);
         break;
     }
     case BlobType::BT_USM_SHARED: {
-        m_memObject = eng->share_usm(m_layout, m_mem);
+        m_memObject = m_engine->share_usm(m_layout, m_mem);
         break;
     }
 #ifdef _WIN32
     case BlobType::BT_SURF_SHARED: {
-        m_memObject = eng->share_surface(m_layout, m_mem, m_plane);
+        m_memObject = m_engine->share_surface(m_layout, m_mem, m_plane);
         break;
     }
     case BlobType::BT_DX_BUF_SHARED: {
-        m_memObject = eng->share_dx_buffer(m_layout, m_mem);
+        m_memObject = m_engine->share_dx_buffer(m_layout, m_mem);
         break;
     }
 #else
     case BlobType::BT_SURF_SHARED: {
-        m_memObject = eng->share_surface(m_layout, m_surf, m_plane);
+        m_memObject = m_engine->share_surface(m_layout, m_surf, m_plane);
         break;
     }
 #endif
     case BlobType::BT_IMG_SHARED: {
-        m_memObject = eng->share_image(m_layout, m_mem);
+        m_memObject = m_engine->share_image(m_layout, m_mem);
         break;
     }
     default:


### PR DESCRIPTION
### Details:
 - When RemoteContext was removed earlier than RemoteTensors, we had invalid memory access in some cases on attempt to free device memory. This patch add engine shared ptr to RemoteBlobImpl to guarantee that it's not freed.
