### PR TITLE
[GPU] fix handling shrink_axis_mask in StridedSlice

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/ops/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/strided_slice.cpp
@@ -227,14 +227,14 @@ static void CreateStridedSliceOp(Program& p, const std::shared_ptr<ngraph::op::v
 
         // Reshape in case of deleting of axis
         if (!shrink_axis_mask.empty()) {
-            std::vector<int64_t> output_pattern(output_shape.size());
+            std::vector<size_t> output_pattern(output_shape.size());
             auto out_p = output_pattern.begin();
             for (auto s = output_shape.begin(); s != output_shape.end() && out_p != output_pattern.end(); s++, out_p++) {
                 *out_p = *s;
             }
 
-            auto reshapeOutName = op->get_friendly_name() + "/Crop";
-            auto reshapePrim = cldnn::reshape(reshapeOutName, layerName, false, output_pattern, output_pshape);
+            auto reshapeOutName = op->get_friendly_name() + "/Reshape";
+            auto reshapePrim = cldnn::reshape(reshapeOutName, layerName, tensor_from_dims(output_pattern));
             p.add_primitive(*op, reshapePrim);
             last_layer_primitive = reshapeOutName;
         }

--- a/src/tests/functional/plugin/gpu/subgraph_tests/strided_slice_matmul.cpp
+++ b/src/tests/functional/plugin/gpu/subgraph_tests/strided_slice_matmul.cpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include <openvino/opsets/opset10.hpp>
+
+namespace {
+
+using namespace ov;
+
+class StridedSliceMatMul : virtual public test::SubgraphBaseTest {
+protected:
+    void SetUp() override {
+        targetDevice = CommonTestUtils::DEVICE_GPU;
+        auto type = element::f32;
+        Shape input_shape{1, 128, 768};
+        auto input = std::make_shared<opset10::Parameter>(type, input_shape);
+        auto begin = opset10::Constant::create(element::i32, Shape{3}, {0, 0, 0});
+        auto end = opset10::Constant::create(element::i32, Shape{3}, {0, 1, 0});
+        auto stride = opset10::Constant::create(element::i32, Shape{3}, {1, 1, 1});
+        std::vector<int64_t> begin_mask{1, 0, 1};
+        std::vector<int64_t> end_mask{1, 0, 1};
+        std::vector<int64_t> new_axis_mask{0, 0, 0};
+        std::vector<int64_t> shrink_axis_mask{0, 1, 0};
+        auto strided_slice = std::make_shared<opset10::StridedSlice>(input, begin, end, stride, begin_mask, end_mask, new_axis_mask, shrink_axis_mask);
+        Shape weights_shape{768, 768};
+        auto weights = opset10::Constant::create(type, weights_shape, {1});
+        auto matmul = std::make_shared<opset10::MatMul>(strided_slice, weights);
+        function = std::make_shared<Model>(matmul, ParameterVector{input});
+
+        targetStaticShapes.push_back({input_shape});
+    }
+};
+
+TEST_F(StridedSliceMatMul, smoke_StridedSliceMatMul) {
+    run();
+}
+
+}  // namespace


### PR DESCRIPTION
Use tensor_from_dims function to create a valid
output pattern for reshape to squeeze the dimensions specified by shrink_axis_mask.

Tickets: 97009 and 97010