### PR TITLE
[GNA] Fix log level settings to control exporting of diagnostic info

### DIFF
--- a/src/plugins/intel_gna/src/gna_device.cpp
+++ b/src/plugins/intel_gna/src/gna_device.cpp
@@ -45,6 +45,8 @@ GNADeviceHelper::GNADeviceHelper(std::string executionTargetIn,
       isPerformanceMeasuring(isPerformanceMeasuring),
       nGnaDeviceIndex{selectGnaDevice()},
       useDeviceEmbeddedExport(deviceEmbedded) {
+    per_request_diagnostics = log::get_log_level() >= ov::log::Level::TRACE;
+    per_model_diagnostics = log::get_log_level() >= ov::log::Level::DEBUG;
     open();
     initGnaPerfCounters();
 
@@ -134,10 +136,6 @@ std::string GNADeviceHelper::GetGnaLibraryVersion() {
     return gnaLibraryVersion;
 }
 
-void GNADeviceHelper::enableDiagnostics() {
-    debugLogEnabled = true;
-}
-
 void GNADeviceHelper::dumpAllAllocations(const uint64_t idx, const std::string& infix) const {
     for (auto&& a : allAllocations.GetAllocationsInExportOrder()) {
         const auto& name = a.GetTagName();
@@ -163,7 +161,7 @@ uint32_t GNADeviceHelper::enqueueRequest(const uint32_t requestConfigID, Gna2Acc
     const auto status1 = Gna2RequestConfigSetAccelerationMode(requestConfigID, gna2AccelerationMode);
     checkGna2Status(status1, "Gna2RequestConfigSetAccelerationMode");
 
-    if (debugLogEnabled) {
+    if (per_request_diagnostics) {
         dumpAllAllocations(debugLogIndexRequestEnqueue, "BeforeGna2RequestEnqueue");
         debugLogIndexRequestEnqueue++;
     }
@@ -211,7 +209,7 @@ uint32_t GNADeviceHelper::createModel(Gna2Model& gnaModel) const {
 
     GNAPluginNS::backend::AMIntelDNN::updateNumberOfOutputsIfPoolingEnabled(gnaModel, legacyExecTarget);
 
-    if (debugLogEnabled) {
+    if (per_model_diagnostics) {
         std::string path =
 #ifdef _WIN32
             ".\\";
@@ -479,7 +477,7 @@ GNAPluginNS::RequestStatus GNADeviceHelper::waitForRequest(uint32_t requestID, i
     }
     checkGna2Status(status, "Gna2RequestWait");
 
-    if (debugLogEnabled) {
+    if (per_request_diagnostics) {
         dumpAllAllocations(debugLogIndexRequestWait, "AfterGna2RequestWait");
         debugLogIndexRequestWait++;
     }

--- a/src/plugins/intel_gna/src/gna_device.hpp
+++ b/src/plugins/intel_gna/src/gna_device.hpp
@@ -64,7 +64,8 @@ class GNADeviceHelper : public GNAPluginNS::GNADevice {
     bool isPerformanceMeasuring = false;
     bool deviceOpened = false;
 
-    bool debugLogEnabled = false;
+    bool per_request_diagnostics = false;
+    bool per_model_diagnostics = false;
     uint64_t debugLogIndexRequestEnqueue = 0;
     uint64_t debugLogIndexRequestWait = 0;
     static constexpr const char* kDumpExt = ".bin";
@@ -82,8 +83,6 @@ public:
     GNADeviceHelper(GNADeviceHelper&&) = delete;
     GNADeviceHelper& operator=(GNADeviceHelper&&) = delete;
     ~GNADeviceHelper() override;
-
-    void enableDiagnostics();
 
     /**
      * @brief Dump raw memory of each GNA allocation to files

--- a/src/plugins/intel_gna/src/gna_plugin.cpp
+++ b/src/plugins/intel_gna/src/gna_plugin.cpp
@@ -384,9 +384,6 @@ void GNAPlugin::InitGNADevice() {
                     !config.dumpXNNPath.empty());
         size_t page_size_bytes = 4096;
         gnamem = std::make_shared<gna_memory_device>(memory::GNAAllocator(gnadevice), page_size_bytes);
-        if (gnaFlags->log_level == ov::log::Level::DEBUG) {
-            gnadevice->enableDiagnostics();
-        }
     }
     graphCompiler.setGNAMemoryPtr(gnamem);
 }

--- a/src/plugins/intel_gna/src/log/log.hpp
+++ b/src/plugins/intel_gna/src/log/log.hpp
@@ -48,6 +48,10 @@ class GnaLog {
         return log_obj;
     }
 
+    static ov::log::Level get_log_level() {
+        return get_instance().log_level_;
+    }
+
     /**
      * @brief Set ERROR log level
      * @return GnaLog object


### PR DESCRIPTION
### Details:
 - GNA text model description will be exported for log levels >= DEBUG (not only for DEBUG level)
 - GNA allocations will be exported for log level >=TRACE (not only for DEBUG level)

### Tickets:
 - 97849
