### PR TITLE
Set out tensor shape in FakeQuantize evaluate

### DIFF
--- a/src/core/src/op/fake_quantize.cpp
+++ b/src/core/src/op/fake_quantize.cpp
@@ -88,6 +88,8 @@ bool evaluate(const HostTensorPtr& arg0,
               const ngraph::op::FakeQuantize* parent) {
     OV_OP_SCOPE(v0_FakeQuantize_evaluate);
     using T = typename element_type_traits<ET>::value_type;
+    out->set_shape(arg0->get_shape());
+    out->set_element_type(arg0->get_element_type());
     runtime::reference::fake_quantize<T>(arg0->get_data_ptr<const T>(),
                                          arg1->get_data_ptr<const T>(),
                                          arg2->get_data_ptr<const T>(),


### PR DESCRIPTION
### Details:
 - Set output tensor shape in FakeQuantize operator. It solve issue when output tensor has not set shape because of dynamic input when operator created. The output shape can be evaluated when do inference on input data which have got set shapes.

### Tickets:
 - 97870
