### PR TITLE
[BENCHMARK_APP/C++] Prevent benchmark app inconsistent results from Windows priority behavior

### DIFF
--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -27,6 +27,10 @@
 #include "remote_tensors_filling.hpp"
 #include "statistics_report.hpp"
 #include "utils.hpp"
+
+#ifdef __WINDOWS__
+# include <windows.h>
+#endif
 // clang-format on
 
 bool parse_and_check_command_line(int argc, char* argv[]) {
@@ -186,6 +190,10 @@ void setDeviceProperty(ov::Core& core,
 int main(int argc, char* argv[]) {
     std::shared_ptr<StatisticsReport> statistics;
     try {
+        #ifdef __WINDOWS__
+        DisableMinimizeButton();
+        #endif
+
         ov::CompiledModel compiledModel;
 
         // ----------------- 1. Parsing and validating input arguments
@@ -1275,6 +1283,10 @@ int main(int argc, char* argv[]) {
         }
 
         slog::info << "Throughput:   " << double_to_string(fps) << " FPS" << slog::endl;
+
+        #ifdef __WINDOWS__
+        EnableMinimizeButton();
+        #endif
 
     } catch (const std::exception& ex) {
         slog::err << ex.what() << slog::endl;

--- a/samples/cpp/benchmark_app/utils.hpp
+++ b/samples/cpp/benchmark_app/utils.hpp
@@ -12,8 +12,24 @@
 #include <string>
 #include <vector>
 
+#ifdef __WINDOWS__
+#include <windows.h>
+inline void DisableMinimizeButton(){
+    HWND hwnd = GetForegroundWindow();
+    SetWindowLong(hwnd, GWL_STYLE,
+    GetWindowLong(hwnd, GWL_STYLE) & ~WS_MINIMIZEBOX);
+}
+inline void EnableMinimizeButton()
+{
+    HWND hwnd = GetForegroundWindow();
+    SetWindowLong(hwnd, GWL_STYLE,
+    GetWindowLong(hwnd, GWL_STYLE) | WS_MINIMIZEBOX);
+}
+#endif
+
 typedef std::chrono::high_resolution_clock Time;
 typedef std::chrono::nanoseconds ns;
+
 
 inline uint64_t get_duration_in_milliseconds(uint32_t duration) {
     return duration * 1000LL;


### PR DESCRIPTION
### Details:
 - Minimize button is now off when running the application to prevent background processing mode
 - Process priority is set to high to reduce background influence on performance speed

### Tickets:
 - 86971
