### PR TITLE
DOCS: Fixing version selector dropdown - porting #13187 to 22.1

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -9,6 +9,20 @@ main img {
 .doxyrest-title-code-block {
     margin-bottom: 0;
 }
+/* doc version dropdown formatting override*/
+
+[aria-labelledby="version-selector"]  {
+    min-width: 125px!important;
+    overflow-x: hidden!important;
+}
+
+.sst-dropdown #version-selector {
+    min-width: 125px!important;
+}
+
+[aria-labelledby="version-selector"]  .dropdown-item {
+    padding: 0.25rem 0.5rem!important;
+}
 
 /* code reference text formatting override */
 code {


### PR DESCRIPTION
Porting:
https://github.com/openvinotoolkit/openvino/pull/13187

Fixing the version selector dropdown, to avoid horizontal scrollbar and trimming text.

