### PR TITLE
cmake: removed global definitions for plugins

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -195,24 +195,8 @@ if (ENABLE_PROFILING_RAW)
     add_definitions(-DENABLE_PROFILING_RAW=1)
 endif()
 
-if (ENABLE_INTEL_MYRIAD)
-    add_definitions(-DENABLE_INTEL_MYRIAD=1)
-endif()
-
-if (ENABLE_MYRIAD_NO_BOOT AND ENABLE_INTEL_MYRIAD)
-    add_definitions(-DENABLE_MYRIAD_NO_BOOT=1)
-endif()
-
-if (ENABLE_INTEL_GPU)
-    add_definitions(-DENABLE_INTEL_GPU=1)
-endif()
-
 if (ENABLE_INTEL_CPU)
     add_definitions(-DENABLE_INTEL_CPU=1)
-endif()
-
-if (ENABLE_INTEL_GNA)
-    add_definitions(-DENABLE_INTEL_GNA)
 endif()
 
 print_enabled_features()

--- a/src/tests_deprecated/behavior/CMakeLists.txt
+++ b/src/tests_deprecated/behavior/CMakeLists.txt
@@ -4,6 +4,6 @@
 
 add_subdirectory(shared_tests)
 
-if (ENABLE_HDDL OR ENABLE_INTEL_MYRIAD)
+if (ENABLE_INTEL_MYRIAD)
     add_subdirectory(vpu)
 endif()

--- a/src/tests_deprecated/behavior/vpu/CMakeLists.txt
+++ b/src/tests_deprecated/behavior/vpu/CMakeLists.txt
@@ -23,12 +23,6 @@ function(enable_vpu TARGET_NAME FLAG_NAME PLUGIN_NAME)
         list(APPEND TEST_SRC ${VPU_TESTS})
     endif()
 
-    # Tests for HDDL plugin
-    if (ENABLE_HDDL)
-        file(GLOB HDDL_TESTS hddl_tests/*.cpp)
-        list(APPEND TEST_SRC ${HDDL_TESTS})
-    endif()
-
     list(APPEND DEPENDENCIES
             ${PLUGIN_NAME}
             vpu_copy_firmware)

--- a/src/tests_deprecated/behavior/vpu/myriad_tests/aot_behavior_tests.cpp
+++ b/src/tests_deprecated/behavior/vpu/myriad_tests/aot_behavior_tests.cpp
@@ -4,8 +4,6 @@
 
 ///  @rationale aot tests aim to test network export/import  functionality
 
-#if defined(ENABLE_INTEL_MYRIAD)
-
 #include <behavior_test_plugin.h>
 #include <mvnc.h>
 #include <vpu/backend/blob_format.hpp>
@@ -202,5 +200,3 @@ const BehTestParams vpuValues[] = {
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest, AOTBehaviorTests, ValuesIn(vpuValues), getTestCaseName);
-
-#endif


### PR DESCRIPTION
### Details:
 - They are not used now