### PR TITLE
[GPU] Reusing "is_subgroup_local_block_io_supported"

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
@@ -268,7 +268,6 @@ private:
     std::unique_ptr<pass_manager> pm;
     std::shared_ptr<kernel_selector::TuningCache> tuning_cache;
     bool is_body_program;
-    int8_t is_subgroup_local_block_io_supported;
 
     std::map<primitive_id, std::shared_ptr<program_node>> nodes_map;
     std::list<primitive_id> optimized_out;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/device.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/device.hpp
@@ -19,7 +19,7 @@ struct device {
 public:
     using ptr = std::shared_ptr<device>;
     virtual device_info get_info() const = 0;
-    virtual void set_info(device_info info) {}
+    virtual void set_info(const device_info& info) = 0;
     virtual memory_capabilities get_mem_caps() const = 0;
 
     virtual bool is_same(const device::ptr other) = 0;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/device.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/device.hpp
@@ -19,6 +19,7 @@ struct device {
 public:
     using ptr = std::shared_ptr<device>;
     virtual device_info get_info() const = 0;
+    virtual void set_info(device_info info) {}
     virtual memory_capabilities get_mem_caps() const = 0;
 
     virtual bool is_same(const device::ptr other) = 0;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
@@ -59,6 +59,7 @@ struct device_info {
     bool supports_subgroups_short;              ///< Does engine support cl_intel_subgroups_short extension.
     bool supports_subgroups_char;               ///< Does engine support cl_intel_subgroups_char extension.
     bool supports_local_block_io;               ///< Does engine support cl_intel_subgroup_local_block_io extension. Check program build with this option.
+    int8_t supports_subgroup_local_block_io;    ///< Does engine support subgroup_local_block_io. Will be checked by program build.
     bool supports_queue_families;               ///< Does engine support cl_intel_command_queue_families extension.
     bool supports_image;                        ///< Does engine support images (CL_DEVICE_IMAGE_SUPPORT cap).
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
@@ -187,6 +187,7 @@ device_info init_device_info(const cl::Device& device) {
     info.supports_usm = extensions.find("cl_intel_unified_shared_memory") != std::string::npos;
 
     info.supports_local_block_io = extensions.find("cl_intel_subgroup_local_block_io") != std::string::npos;
+    info.supports_subgroup_local_block_io = -1;
 
     info.supports_queue_families = extensions.find("cl_intel_command_queue_families") != std::string::npos;
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.hpp
@@ -21,6 +21,7 @@ public:
     ocl_device(const cl::Device dev, const cl::Context& ctx, const cl_platform_id platform);
 
     device_info get_info() const override { return _info; }
+    void set_info(device_info info) override { _info = info; }
     memory_capabilities get_mem_caps() const override { return _mem_caps; }
 
     const cl::Device& get_device() const { return _device; }

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.hpp
@@ -21,7 +21,7 @@ public:
     ocl_device(const cl::Device dev, const cl::Context& ctx, const cl_platform_id platform);
 
     device_info get_info() const override { return _info; }
-    void set_info(device_info info) override { _info = info; }
+    void set_info(const device_info& info) override { _info = info; }
     memory_capabilities get_mem_caps() const override { return _mem_caps; }
 
     const cl::Device& get_device() const { return _device; }

--- a/src/plugins/intel_gpu/tests/module_tests/device_test.cpp
+++ b/src/plugins/intel_gpu/tests/module_tests/device_test.cpp
@@ -22,6 +22,7 @@ public:
     }
 
     device_info get_info() const override { return _info; }
+    void set_info(const device_info& info) override { _info = info; }
     memory_capabilities get_mem_caps() const override { return _mem_caps; }
     bool is_same(const device::ptr other) override {
         return this == other.get();


### PR DESCRIPTION
### Details:
 - If kernel caching is not enabled, `program::query_local_block_io_supported()` is executed twice.
   - As a result, in the case of model caching, the overhead of creating a cache increases.
 - This PR prevents this situation by saving the results of `program::query_local_block_io_supported()` in `device_info`.

### Tickets:
 - 93862
