### PR TITLE
[GNA] Fix logger initialization order

### DIFF
--- a/src/plugins/intel_gna/src/gna_plugin.cpp
+++ b/src/plugins/intel_gna/src/gna_plugin.cpp
@@ -356,8 +356,8 @@ GNAPlugin::GNAPlugin(const std::map<std::string, std::string>& configMap) :
     graphCompiler(config) {
     Init();
     SetConfig(configMap);
+    log::set_log_level(gnaFlags->log_level);
     InitGNADevice();
-    GnaLog(gnaFlags->log_level);
 }
 
 void GNAPlugin::Init() {

--- a/src/plugins/intel_gna/src/log/log.hpp
+++ b/src/plugins/intel_gna/src/log/log.hpp
@@ -35,17 +35,17 @@ class GnaLog {
     /** Log level of particular log message */
     ov::log::Level message_level_ = ov::log::Level::NO;
 
+    static GnaLog& get_instance() {
+        static GnaLog log_obj;
+        return log_obj;
+    }
+
  public :
     GnaLog(const GnaLog&) = delete;
     void operator = (const GnaLog&) = delete;
 
-    GnaLog(ov::log::Level log_level) {
+    static void set_log_level(ov::log::Level log_level) {
         get_instance().log_level_ = log_level;
-    }
-
-    static GnaLog& get_instance() {
-        static GnaLog log_obj;
-        return log_obj;
     }
 
     static ov::log::Level get_log_level() {

--- a/src/plugins/intel_gna/tests/unit/log/logger.cpp
+++ b/src/plugins/intel_gna/tests/unit/log/logger.cpp
@@ -38,7 +38,8 @@ TEST_P(GnaLogTest, LogLevel) {
     ov::log::Level log_level, message_level;
     std::tie(log_level, message_level) = GetParam();
 
-    GnaLog log(log_level);
+    const auto prev_log_level = GnaLog::get_log_level();
+    GnaLog::set_log_level(log_level);
 
     switch (message_level) {
     case ov::log::Level::ERR :
@@ -74,6 +75,7 @@ TEST_P(GnaLogTest, LogLevel) {
 
     std::cout.rdbuf(sbuf);
     std::cerr.rdbuf(ebuf);
+    GnaLog::set_log_level(prev_log_level);
 }
 
 INSTANTIATE_TEST_SUITE_P(smoke_GnaLogTest,


### PR DESCRIPTION
### Details:
 - Fix GNA Plugin logger log level initialization order
 - Clean-up GnaLog class

### Tickets:
 - 97849
