### PR TITLE
Leftovers: safer get_output_types ConvertCompressedOnlyToLegacy, more readable Interval unit-tests

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/convert_compression_only_to_legacy.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convert_compression_only_to_legacy.cpp
@@ -40,7 +40,10 @@ bool ov::pass::ConvertCompressedOnlyToLegacy::run_on_model(const std::shared_ptr
         manager.register_pass<ov::pass::MarkPrecisionSensitiveSubgraphs>();
         get_pass_config()->set_callback<ngraph::pass::ConvertPrecision>(
             [](const std::shared_ptr<const Node>& node) -> bool {
-                return ov::fp16_compression_is_disabled(node) && node->get_element_type() == element::f32;
+                auto const const_node = std::dynamic_pointer_cast<const ov::opset8::Constant>(node);
+                if (!const_node)
+                    return false;
+                return ov::fp16_compression_is_disabled(node) && const_node->get_output_element_type(0) == element::f32;
             });
 
         const precisions_array convert_precision_list{{ov::element::f32, ov::element::f16}};

--- a/src/core/tests/dimension.cpp
+++ b/src/core/tests/dimension.cpp
@@ -69,37 +69,41 @@ TEST(dimension, dimension_mul_operator_1) {
 }
 
 TEST(dimension, dimension_mul_operator_2) {
-    Dimension large_interval(2, 9223372036854775806);
+    // overflow happens and clip_times keeps result within in64 limits
+    // (Interval::s_max - 1) * 2 = 9223372036854775806 * 2 = 18446744073709551612
+    // arithmetical result does not fit into int64, is clipped into int64_max
+    Dimension large_interval(2, Interval::s_max - 1);
     Dimension two(2);
-    Dimension ref_value(4, 9223372036854775807);
+    Dimension ref_value(4, Interval::s_max);
     EXPECT_EQ(ref_value, large_interval * two);
 }
 
 TEST(dimension, dimension_mul_operator_3) {
     // no overflow
-    Dimension large_interval(2, 4611686018427387903);
+    // (int64_max / 2) * 2= 4611686018427387903 * 2 = 9223372036854775806 = int64_max - 1
+    Dimension large_interval(2, ov::Interval::s_max / 2);
     Dimension two(2);
-    Dimension ref_value(4, 9223372036854775806);
+    Dimension ref_value(4, ov::Interval::s_max - 1);
     EXPECT_EQ(ref_value, large_interval * two);
 }
 
 TEST(dimension, dimension_mul_operator_4) {
     // overflow happens and clip_times keeps result within in64 limits
-    // 4611686018427387904 * 2 = 9223372036854775808 = int64_max - 1
-    // 9223372036854775808 does not fin into int64, is clipped into int64_max
-    Dimension large_interval(2, 4611686018427387904);
+    // (int64_max / 2 + 1) * 2 = 4611686018427387904 * 2 = 9223372036854775808 = int64_max + 1
+    // 9223372036854775808 does not fit into int64, is clipped into int64_max
+    Dimension large_interval(2, ov::Interval::s_max / 2 + 1);
     Dimension two(2);
-    Dimension ref_value(4, 9223372036854775807);
+    Dimension ref_value(4, ov::Interval::s_max);
     EXPECT_EQ(ref_value, large_interval * two);
 }
 
 TEST(dimension, dimension_mul_operator_5) {
+    // (int64_max / 3 + 2) = 3074457345618258604 * 3 = 9223372036854775812 = int64_max + 5
     // overflow happens and clip_times keeps result within in64 limits
-    // 3074457345618258604 * 3 = 9223372036854775812
     // 9223372036854775812 does not fit into int64, is clipped into int64_max
-    Dimension large_interval(2, 3074457345618258604);
+    Dimension large_interval(2, ov::Interval::s_max / 3 + 2);
     Dimension three(3);
-    Dimension ref_value(6, 9223372036854775807);
+    Dimension ref_value(6, ov::Interval::s_max);
     EXPECT_EQ(ref_value, large_interval * three);
 }
 


### PR DESCRIPTION
Details:
 - replaced `get_element_type` with `get_output_element_type` with explicit out port 0 and check if it's Const
 - more readable unit-test for out of bound Interval multiplication: instead of `9223372036854775806`, `4611686018427387903`, ... used  `ov::Interval::s_max - 1` , `ov::Interval::s_max / 2` and so on

### Tickets:
 - xxx-91832, xxx-93369
