### PR TITLE
[GPU] Fix exception for dyn reshape followed by static node

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -789,6 +789,12 @@ event::ptr primitive_inst::update_weights() {
         }
 
         return ev;
+    } else {
+        // If kernel doesn't says that it doesn't require weights reorder, but weights were reordered previously, then
+        // incorrect memory buffer may be assigned, so reset cached weights for such case
+        if (weights_params.engine == kernel_selector::GenericKernelParams::Engine::NONE) {
+            _impl_params->reordered_weights.reset();
+        }
     }
     GPU_DEBUG_PROFILED_STAGE_CACHE_HIT(true);
 

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -113,7 +113,7 @@ std::unique_ptr<json_composite> program_node::desc_to_json() const {
     s << get_preferred_impl_type();
     node_info->add("preferred impl", s.str());
 
-    node_info->add("output layout", output_layouts[0].to_string());
+    node_info->add("output layout", output_layouts[0].to_short_string());
 
     node_info->add("constant", bool_to_str(constant));
     node_info->add("in data flow", bool_to_str(data_flow));

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -143,6 +143,7 @@ std::string reshape_inst::to_string(reshape_node const& node) {
     json_composite reshape_info;
     reshape_info.add("input id", input.id());
     reshape_info.add("output shape", desc->output_shape);
+    reshape_info.add("output pshape", desc->output_partial_shape);
 
     node_info->add("reshape info", reshape_info);
     node_info->dump(primitive_description);

--- a/src/plugins/intel_gpu/tests/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/passes/prepare_buffer_fusing_test.cpp
@@ -9,6 +9,7 @@
 #include "intel_gpu/graph/program.hpp"
 #include "data_inst.h"
 #include "reshape_inst.h"
+#include "fully_connected_inst.h"
 #include "permute_inst.h"
 #include "intel_gpu/graph/network.hpp"
 #include "pass_manager.h"
@@ -58,4 +59,51 @@ TEST(prepare_buffer_fusing, optimize_reshape) {
 
     ASSERT_NE(out_mem, nullptr);
     ASSERT_EQ(out_mem->count(), 16);
+}
+
+TEST(prepare_buffer_fusing, static_node_after_optimized_out_dyn_reshape) {
+    auto& engine = get_test_engine();
+    auto in_layout = layout{ ov::PartialShape{1, 2, -1}, data_types::f32, format::bfyx };
+    auto weights_layout = layout{ov::PartialShape{2, 4}, data_types::f32, format::bfyx};
+    auto weights_memory = engine.allocate_memory(weights_layout);
+    set_values<float>(weights_memory, {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
+
+    topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(data("weights", weights_memory));
+    topology.add(permute("permute1", "input", {0, 2, 1}));
+    topology.add(reshape("reshape", "permute1", false, {2, 4}, ov::PartialShape{2, 4}));
+    topology.add(fully_connected("fc", "reshape", "weights", "", {}, 2));
+    topology.add(reorder("reorder", "fc", format::bfyx, data_types::f32));
+
+    build_options build_opts;
+    build_opts.set_option(build_option::allow_new_shape_infer(true));
+    auto prog = program::build_program(engine, topology, build_opts, false, true);
+    ASSERT_NE(prog, nullptr);
+
+    prog->get_node("reorder").get_output_layout(true);
+    program_wrapper::apply_opt_pass<prepare_buffer_fusing>(*prog);
+    program_wrapper::apply_opt_pass<compile_graph>(*prog);
+    ASSERT_NO_THROW(prog->get_node("reshape"));
+    ASSERT_FALSE(prog->get_node("reshape").can_be_optimized());
+    prog->compile();
+    prog->init_kernels();
+
+    ASSERT_TRUE(has_node_with_type<reshape>(*prog));
+
+    cldnn::network net(prog, 0);
+
+    auto input_memory = engine.allocate_memory(layout{ ov::PartialShape{1, 2, 4}, data_types::f32, format::bfyx });
+    set_values<float>(input_memory, {0.1, 1.1, 2.2, 3.0, 4.0, -5.0, 0.1, 0.7});
+
+    net.set_input_data("input", input_memory);
+    std::map<cldnn::primitive_id, cldnn::network_output> output;
+    ASSERT_NO_THROW(output = net.execute());
+    auto out_l = net.get_output_layout("reorder");
+    auto out_mem = output.at("reorder").get_memory();
+
+    ASSERT_NE(out_mem, nullptr);
+    ov::PartialShape expected_shape = {2, 2};
+    ASSERT_EQ(out_mem->count(), 4);
+    ASSERT_EQ(out_mem->get_layout().get_partial_shape(), expected_shape);
 }


### PR DESCRIPTION
### Details:
 - Fixed one bert version which had an exception due to attempt to set not allocated input buffer in static FC due to optimized out dynamic reshape
