### PR TITLE
[GNA] Fix scale factor calculation for int8 convolution weights

### DIFF
--- a/src/plugins/intel_gna/src/frontend/layer_quantizer.hpp
+++ b/src/plugins/intel_gna/src/frontend/layer_quantizer.hpp
@@ -25,11 +25,34 @@ InferenceEngine::Precision GetInputPrecision();
  * @brief Returns layer's target weights precision
  * @param layer_info Layer's information
  * @param quant_layer_params Layer's quantization parameters
+ * @param gna_config GNA Plugin configuration
  * @return layer's target weights precision
  */
 InferenceEngine::Precision GetWeightsPrecision(const LayerInfo& layer_info,
                                                const QuantizedLayerParams& quant_layer_params,
                                                const Config& gna_config);
+
+/**
+ * @brief Returns layer's target biases precision
+ * @param layer_info Layer's information
+ * @param quant_layer_params Layer's quantization parameters
+ * @param gna_config GNA Plugin configuration
+ * @return layer's target biases precision
+ */
+InferenceEngine::Precision GetBiasesPrecision(const LayerInfo& layer_info,
+                                              const QuantizedLayerParams& quant_layer_params,
+                                              const Config& gna_config);
+
+/**
+ * @brief Checks whether layer's target biases are compound
+ * @param layer_info Layer's information
+ * @param quant_layer_params Layer's quantization parameters
+ * @param gna_config GNA Plugin configuration
+ * @return true if layer's target biases are compound
+ */
+bool IsBiasCompound(const LayerInfo& layer_info,
+                    const QuantizedLayerParams& quant_layer_params,
+                    const Config& gna_config);
 
 class LayerQuantizer {
     const Config& gna_config;
@@ -65,10 +88,7 @@ class LayerQuantizer {
     inline bool ShouldAlwaysAllocate();
 
     size_t GetBiasSizeForLayer(InferenceEngine::WeightableLayer& wl);
-    bool IsBiasCompound(const LayerInfo& layer_info, const QuantizedLayerParams* quant_layer_params);
     InferenceEngine::Precision GetOutputPrecision();
-    InferenceEngine::Precision GetBiasesPrecision(const LayerInfo& layer_info,
-                                                  const QuantizedLayerParams& quant_layer_params);
 
 public:
     LayerQuantizer(const Config& gna_config);

--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/single_layer_tests/conv_low_precision.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/single_layer_tests/conv_low_precision.cpp
@@ -66,10 +66,8 @@ public:
     }
 
     InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo& info) const override {
-        return FuncTestUtils::createAndFillBlob(info.getTensorDesc(),
-                                                -0.05f,
-                                                0.05f,
-                                                1 / inputDataResolution);
+        return FuncTestUtils::createAndFillBlobFloatNormalDistribution(
+            info.getTensorDesc(), 0.0f, 0.2f, 7235346);
     }
 
     ParameterVector createInputVector(const Type& type, const vector<std::size_t>& shapes) {
@@ -113,7 +111,7 @@ protected:
         // Create network
         auto inputVector = createInputVector(ngPrc, {inputShape});
         auto inputFQ = createFQNode(ngPrc, inputVector[0], fqMin, fqMax, levels);
-        auto kernelWeights = makeConstant<float>(ngPrc, {8, 8, kernelHeight, 2}, {0.1f});
+        auto kernelWeights = makeConstant<float>(ngPrc, {8, 8, kernelHeight, 2}, {}, true, 1.0f, -1.0f, 7235346);
         auto weightsFQ = createFQNode(ngPrc, kernelWeights, fqMin, fqMax, levels);
         auto convolution = make_shared<Convolution>(inputFQ,
                                                     weightsFQ,
@@ -171,7 +169,7 @@ const vector<Shape> inputShapes = {
 };
 
 const vector<pair<float, float>> fqMinMax = {
-    {-8, 8}
+    {-1.0f, 1.0f}
 };
 
 const vector<std::size_t> levels = {


### PR DESCRIPTION
### Details:
 - Fix scale factor calculation for convolution layers with int8 weights
 - Fix tests for the above layer type.

### Tickets:
 - 97011