### PR TITLE
[MO] remove '_tmp' files when layout is specified incorrectly

### DIFF
--- a/tools/mo/openvino/tools/mo/convert_impl.py
+++ b/tools/mo/openvino/tools/mo/convert_impl.py
@@ -472,14 +472,15 @@ def emit_ir(graph: Graph, argv: argparse.Namespace, non_default_params: dict):
         t = tm.Telemetry()
         t.send_event('mo', 'offline_transformations_status', message)
 
-        if return_code != 0:
-            raise Error("offline transformations step has failed.")
-
         for suf in [".xml", ".bin", ".mapping"]:
             # remove existing files
             path_to_file = orig_model_name + "_tmp" + suf
             if os.path.exists(path_to_file):
                 os.remove(path_to_file)
+
+        if return_code != 0:
+            raise Error("offline transformations step has failed.")
+
     return func
 
 


### PR DESCRIPTION
### Details:
 - Always remove `_tmp.xml`, `_tmp.bin`, `_tmp.mapping` files even if model fails because these files are confusing. 
 - Accuracy validation interprets as if there is any file (even `_tmp` then conversion was successful). Therefore not to confuse ourselves need always to cleanup these files not only after successful conversion.
 
### Tickets:
 - xxx-98168
