### PR TITLE
Export `inference_engine_snippets` to `core` component

### DIFF
--- a/src/common/snippets/CMakeLists.txt
+++ b/src/common/snippets/CMakeLists.txt
@@ -17,7 +17,7 @@ source_group("include" FILES ${PUBLIC_HEADERS})
 
 # Create static library
 
-add_library(${TARGET_NAME} STATIC EXCLUDE_FROM_ALL
+add_library(${TARGET_NAME} STATIC
             ${LIBRARY_SRC}
             ${PUBLIC_HEADERS})
 
@@ -45,3 +45,5 @@ set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_REL
 # install
 
 ov_install_static_lib(${TARGET_NAME} ${OV_CPACK_COMP_CORE})
+
+openvino_developer_export_targets(COMPONENT ${OV_CPACK_COMP_CORE} TARGETS ${TARGET_NAME})

--- a/src/tests/ngraph_helpers/snippets_ngraph_functions/CMakeLists.txt
+++ b/src/tests/ngraph_helpers/snippets_ngraph_functions/CMakeLists.txt
@@ -34,4 +34,3 @@ ie_faster_build(${TARGET_NAME}
     UNITY
     PCH PRIVATE "src/precomp.hpp"
 )
-openvino_developer_export_targets(COMPONENT tests TARGETS inference_engine_snippets)


### PR DESCRIPTION
Details:
- `inference_engine_snippets` is not exported when building OpenVINO with `-D BUILD_SHARED_LIBS=ON -D BUILD_TESTS=OFF` CMake options
- this PR exports the library to allow its use in projects that use OpenVINO as a thirdparty component
