### PR TITLE
benchmark_app python: fix incorrect -i argument parsing for wavernn-rnn input names

### DIFF
--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -314,7 +314,7 @@ def parse_path(path, app_input_info):
     """
     input_names = list(info.name for info in app_input_info)
     input_node_names = list(info.node_name for info in app_input_info)
-    parsed_names = re.findall(r"([^,]\w+):", path)
+    parsed_names = re.findall(r"((?=[^,])[\w\.]+):", path)
     wrong_names = list(name for name in parsed_names if name not in input_names + input_node_names)
     if wrong_names:
         raise Exception(
@@ -323,7 +323,7 @@ def parse_path(path, app_input_info):
             "Please check `-i` input data"
         )
     tensor_names = [parsed_name if parsed_name in input_names else input_names[input_node_names.index(parsed_name)] for parsed_name in parsed_names]
-    input_pathes = [path for path in re.split(r"[^,]\w+:", path) if path]
+    input_pathes = [path for path in re.split(r"(?=[^,])[\w\.]+:", path) if path]
     input_path_mapping = defaultdict(list)
     # input mapping is used
     if tensor_names:

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -314,7 +314,7 @@ def parse_path(path, app_input_info):
     """
     input_names = list(info.name for info in app_input_info)
     input_node_names = list(info.node_name for info in app_input_info)
-    parsed_names = re.findall(r"((?=[^,])[\w\.]+):", path)
+    parsed_names = re.findall(r"((?=[^,])(?![a-zA-Z]:\\)[\w\.]+):", path)
     wrong_names = list(name for name in parsed_names if name not in input_names + input_node_names)
     if wrong_names:
         raise Exception(
@@ -323,7 +323,7 @@ def parse_path(path, app_input_info):
             "Please check `-i` input data"
         )
     tensor_names = [parsed_name if parsed_name in input_names else input_names[input_node_names.index(parsed_name)] for parsed_name in parsed_names]
-    input_pathes = [path for path in re.split(r"(?=[^,])[\w\.]+:", path) if path]
+    input_pathes = [path for path in re.split(r"(?=[^,])(?![a-zA-Z]:\\)[\w\.]+:", path) if path]
     input_path_mapping = defaultdict(list)
     # input mapping is used
     if tensor_names:


### PR DESCRIPTION
The Python benchmark_app incorrectly parses `-i` argument with files mapped to the network inputs in the following cases:
* Input name contains `.` character (`h1.1` input of [wavernn-rnn](https://github.com/openvinotoolkit/open_model_zoo/tree/master/models/public/wavernn#wavernn-rnn-model-specification))
* Input name has length 1 (`x` input)

The C++ version of the tool works fine with this inputs in command line.

### Details:
How to reproduce on wavernn-rnn model:
```
benchmark_app -m models/public/wavernn/wavernn-rnn/FP32/wavernn-rnn.xml -i x:data/wavernn-rnn/x

 [ ERROR ] Path 'x:data/wavernn-rnn/x' doesn't exist 
 x:data/wavernn-rnn/x
Traceback (most recent call last):
  File "/mnt/c/github/openvino/tools/benchmark_tool/openvino/tools/benchmark/main.py", line 467, in main
    data_queue = get_input_data(paths_to_input, app_inputs_info)
  File "/mnt/c/github/openvino/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py", line 82, in get_input_data
    image_mapping, binary_mapping = get_input_file_mappings(paths_to_input, app_input_info)
  File "/mnt/c/github/openvino/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py", line 294, in get_input_file_mappings
    image_dict, binary_dict = parse_path(path, app_input_info)
  File "/mnt/c/github/openvino/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py", line 342, in parse_path
    raise Exception(f"Path '{str(input_path)}' doesn't exist \n {str(input_path)}")
Exception: Path 'x:data/wavernn-rnn/x' doesn't exist 
 x:data/wavernn-rnn/x
 ```
  ```
benchmark_app -m models/public/wavernn/wavernn-rnn/FP32/wavernn-rnn.xml -i h1.1:data/wavernn-rnn/h1.1
 
[ ERROR ] Wrong input mapping! Cannot find inputs: ['.1']. Available inputs: ['m_t', 'a1_t', 'a2_t', 'a3_t', 'a4_t', 'h1.1', 'h2.1', 'x']. Please check `-i` input data
Traceback (most recent call last):
  File "/mnt/c/github/openvino/tools/benchmark_tool/openvino/tools/benchmark/main.py", line 467, in main
    data_queue = get_input_data(paths_to_input, app_inputs_info)
  File "/mnt/c/github/openvino/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py", line 82, in get_input_data
    image_mapping, binary_mapping = get_input_file_mappings(paths_to_input, app_input_info)
  File "/mnt/c/github/openvino/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py", line 294, in get_input_file_mappings
    image_dict, binary_dict = parse_path(path, app_input_info)
  File "/mnt/c/github/openvino/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py", line 320, in parse_path
    raise Exception(
Exception: Wrong input mapping! Cannot find inputs: ['.1']. Available inputs: ['m_t', 'a1_t', 'a2_t', 'a3_t', 'a4_t', 'h1.1', 'h2.1', 'x']. Please check `-i` input data
```
but `-i m_t:data/wavernn-rnn/m_t` works fine
