### PR TITLE
keep the whole ShapeOf subgraph in fp32

### DIFF
--- a/src/common/transformations/include/transformations/common_optimizations/mark_precision_sensitive_subgraphs.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/mark_precision_sensitive_subgraphs.hpp
@@ -24,5 +24,9 @@ class TRANSFORMATIONS_API MarkPrecisionSensitiveSubgraphs;
 class ov::pass::MarkPrecisionSensitiveSubgraphs : public ModelPass {
 public:
     OPENVINO_RTTI("MarkPrecisionSensitiveSubgraphs", "0");
+    explicit MarkPrecisionSensitiveSubgraphs(bool mark_only_consts=true): m_mark_only_consts(mark_only_consts) {}
     bool run_on_model(const std::shared_ptr<ov::Model>& f) override;
+
+private:
+    bool m_mark_only_consts=true;
 };

--- a/src/common/transformations/include/transformations/common_optimizations/mark_precision_sensitive_subgraphs.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/mark_precision_sensitive_subgraphs.hpp
@@ -17,16 +17,20 @@ class TRANSFORMATIONS_API MarkPrecisionSensitiveSubgraphs;
 
 /**
  * @ingroup ie_transformation_common_api
- * @brief MarkPrecisionSensitiveSubgraphs transformation marks the constants
+ * @brief MarkPrecisionSensitiveSubgraphs transformation goes up and marks nodes
  * inside the subgraph starting from precision-sensitive input and ending at
  * the ShapeOf node as disabled for FP16 compression.
+ *
+ * If mark_only_consts is true only Consts are marked. False value is used
+ * during offline_transformations. For the GPU plugin need to keep
+ * the whole shape subgraph in FP32, therefore mark_only_consts need to be set false for GPU.
  */
 class ov::pass::MarkPrecisionSensitiveSubgraphs : public ModelPass {
 public:
     OPENVINO_RTTI("MarkPrecisionSensitiveSubgraphs", "0");
-    explicit MarkPrecisionSensitiveSubgraphs(bool mark_only_consts=true): m_mark_only_consts(mark_only_consts) {}
+    explicit MarkPrecisionSensitiveSubgraphs(bool mark_only_consts = true) : m_mark_only_consts(mark_only_consts) {}
     bool run_on_model(const std::shared_ptr<ov::Model>& f) override;
 
 private:
-    bool m_mark_only_consts=true;
+    bool m_mark_only_consts = true;
 };

--- a/src/common/transformations/src/transformations/common_optimizations/convert_compression_only_to_legacy.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convert_compression_only_to_legacy.cpp
@@ -38,13 +38,11 @@ bool ov::pass::ConvertCompressedOnlyToLegacy::run_on_model(const std::shared_ptr
         // Skip precision sensitive nodes with marking and pass_callback:
         // callback skips (returns true) for nodes marked as precision sensitive/disabled_f16_compression.
         // Skipping was done by callback in order to impact behavior of ConvertPrecision as little as possible
-        manager.register_pass<ov::pass::MarkPrecisionSensitiveSubgraphs>();
+        // false is set to keep whole ShapeOf subgraph in FP32 not only Constants
+        manager.register_pass<ov::pass::MarkPrecisionSensitiveSubgraphs>(false);
         get_pass_config()->set_callback<ngraph::pass::ConvertPrecision>(
             [](const std::shared_ptr<const Node>& node) -> bool {
-                auto const const_node = std::dynamic_pointer_cast<const ov::opset8::Constant>(node);
-                if (!const_node)
-                    return false;
-                return ov::fp16_compression_is_disabled(node) && const_node->get_output_element_type(0) == element::f32;
+                return ov::fp16_compression_is_disabled(node);
             });
 
         const precisions_array convert_precision_list{{ov::element::f32, ov::element::f16}};

--- a/src/common/transformations/src/transformations/common_optimizations/mark_precision_sensitive_subgraphs.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/mark_precision_sensitive_subgraphs.cpp
@@ -34,7 +34,7 @@ bool ov::pass::MarkPrecisionSensitiveSubgraphs::run_on_model(const std::shared_p
 
     auto markup_func = [this](Node* node) {
         if (m_mark_only_consts && !ov::is_type<ov::opset8::Constant>(node))
-            return ;
+            return;
         ov::disable_fp16_compression(node->shared_from_this());
     };
 

--- a/src/common/transformations/src/transformations/common_optimizations/mark_precision_sensitive_subgraphs.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/mark_precision_sensitive_subgraphs.cpp
@@ -32,10 +32,10 @@ bool ov::pass::MarkPrecisionSensitiveSubgraphs::run_on_model(const std::shared_p
         visited.insert(r.get());
     }
 
-    auto markup_func = [](Node* node) {
-        if (ov::is_type<ov::opset8::Constant>(node)) {
-            ov::disable_fp16_compression(node->shared_from_this());
-        }
+    auto markup_func = [this](Node* node) {
+        if (m_mark_only_consts && !ov::is_type<ov::opset8::Constant>(node))
+            return ;
+        ov::disable_fp16_compression(node->shared_from_this());
     };
 
     while (!nodes.empty()) {

--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -133,20 +133,12 @@ bool convert_precision(ov::pass::PassBase& pass,
         bool res = false;
         // Handle case with Constants as they can have consumers from other nGraph Function object
         const auto constant = ov::as_type_ptr<opset10::Constant>(node);
-        // skip precision sensitive marked Constants in ShapeOf subgraphs and leave them in f32 precision
-        if (constant && pass.transformation_callback(constant) && constant->get_output_element_type(0) == element::f32)
-            return res;
-
         const auto it = const_to_internal_output.find(node.get());
         if (constant && constant->get_output_element_type(0) == from && it != const_to_internal_output.end()) {
             return fuse_type_to_constant(node, to, it->second);
         }
 
         for (const auto& output : node->outputs()) {
-            // skip precision sensitive marked nodes in ShapeOf subgraphs and leave them in f32 precision
-            if (pass.transformation_callback(node) && output.get_element_type() == element::f32)
-                continue;
-
             if (output.get_element_type() == from) {
                 // Check that node type exists in map and we can fuse type into node
                 const auto t2f_it = type_to_fuse.find(node->get_type_info());
@@ -204,6 +196,9 @@ bool convert_precision(ov::pass::PassBase& pass,
             bool is_output_precision_changed = false;
 
             for (auto& node : ops) {
+                // skip precision sensitive nodes
+                if (pass.transformation_callback(node))
+                    continue;
                 is_output_precision_changed |= convert_node_output_precision(node);
             }
 

--- a/src/common/transformations/tests/utils/convert_precision.cpp
+++ b/src/common/transformations/tests/utils/convert_precision.cpp
@@ -17,6 +17,8 @@
 #include <ngraph/opsets/opset8.hpp>
 #include <ngraph/opsets/opset10.hpp>
 #include <transformations/convert_precision.hpp>
+#include <ngraph/pass/visualize_tree.hpp>
+
 #include <transformations/utils/utils.hpp>
 #include <ngraph/pass/manager.hpp>
 #include <ov_ops/type_relaxed.hpp>
@@ -828,9 +830,8 @@ TEST(TransformationTests, ConvertPrecision_skip_precision_sensitive) {
         manager.register_pass<ov::pass::MarkPrecisionSensitiveSubgraphs>();
         manager.get_pass_config()->set_callback<ngraph::pass::ConvertPrecision>(
                 [](const std::shared_ptr<const Node>& node) -> bool {
-                    return ov::fp16_compression_is_disabled(node) && node->get_element_type() == element::f32;
+                    return ov::fp16_compression_is_disabled(node);
                 });
-
         manager.register_pass<pass::ConvertPrecision>(precisions_array {{ element::f32, element::f16 }});
         manager.run_passes(model);
     }
@@ -860,8 +861,8 @@ TEST(TransformationTests, ConvertPrecision_without_callback) {
 
         interpolate = std::make_shared<opset8::Interpolate>(input, sizes, scales, attrs);
         model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
-        pass::Manager manager;
 
+        pass::Manager manager;
         manager.register_pass<ov::pass::MarkPrecisionSensitiveSubgraphs>();
         manager.register_pass<pass::ConvertPrecision>(precisions_array {{ element::f32, element::f16 }});
         manager.run_passes(model);
@@ -869,6 +870,283 @@ TEST(TransformationTests, ConvertPrecision_without_callback) {
 
     ASSERT_FALSE(has_type<element::Type_t::f32>(model));
     ASSERT_TRUE(interpolate->input_value(2).get_element_type() == element::Type_t::f16);
+}
+
+TEST(TransformationTests, ConvertPrecision_check_marking_does_not_leak_in_trivial_case) {
+    std::shared_ptr<ov::Model> model(nullptr), model_ref(nullptr);
+    {
+        auto input_1 = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 3, 720, 1280});
+        auto input_2 = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 3, 720, 1280});
+        auto new_shape = std::make_shared<opset8::ShapeOf>(input_2);
+        auto reshape = std::make_shared<opset8::Reshape>(input_1, new_shape, false);
+        model = std::make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+
+        pass::Manager manager;
+        manager.register_pass<ov::pass::MarkPrecisionSensitiveSubgraphs>(false);
+        manager.get_pass_config()->set_callback<ngraph::pass::ConvertPrecision>(
+                [](const std::shared_ptr<const Node>& node) -> bool {
+                    return ov::fp16_compression_is_disabled(node);
+                });
+        manager.register_pass<pass::ConvertPrecision>(precisions_array {{ element::f32, element::f16 }});
+        manager.run_passes(model);
+    }
+    {
+        auto input_1 = std::make_shared<opset8::Parameter>(element::f16, Shape{1, 3, 720, 1280});
+        auto input_2 = std::make_shared<opset8::Parameter>(element::f16, Shape{1, 3, 720, 1280});
+        auto new_shape = std::make_shared<opset8::ShapeOf>(input_2);
+        auto reshape = std::make_shared<opset8::Reshape>(input_1, new_shape, false);
+
+        model_ref = std::make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+    }
+
+    const auto fc = FunctionsComparator::with_default()
+            .enable(FunctionsComparator::PRECISIONS)
+            .enable(FunctionsComparator::CONST_VALUES);
+    const auto res = fc.compare(model, model_ref);
+    ASSERT_TRUE(res.valid) << res.message;
+}
+
+TEST(TransformationTests, ConvertPrecision_whole_shape_subgraph_is_marked_1) {
+    std::shared_ptr<ov::Model> model(nullptr), model_ref(nullptr);
+    {
+        auto input_1 = std::make_shared<opset8::Parameter>(element::f32, Shape{360, 640});
+        auto input_2 = std::make_shared<opset8::Parameter>(element::f32, Shape{720, 1280});
+        auto shapeof = std::make_shared<opset8::ShapeOf>(input_2);
+
+        auto convert_to_float = std::make_shared<opset8::Convert>(shapeof, element::f32);
+        auto const_denominator = opset8::Constant::create(element::f32, Shape{}, {2.0f});
+        auto div = std::make_shared<opset8::Divide>(convert_to_float, const_denominator);
+        auto new_shape = std::make_shared<opset8::Convert>(div, element::i64);
+
+        auto reshape = std::make_shared<opset8::Reshape>(input_1, new_shape, false);
+        model = std::make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+
+        pass::Manager manager;
+        manager.register_pass<ov::pass::MarkPrecisionSensitiveSubgraphs>(false);
+        manager.get_pass_config()->set_callback<ngraph::pass::ConvertPrecision>(
+                [](const std::shared_ptr<const Node>& node) -> bool {
+                    return ov::fp16_compression_is_disabled(node);
+                });
+        manager.register_pass<pass::ConvertPrecision>(precisions_array {{ element::f32, element::f16 }});
+        manager.run_passes(model);
+    }
+    {
+        auto input_1 = std::make_shared<opset8::Parameter>(element::f16, Shape{360, 640});
+        auto input_2 = std::make_shared<opset8::Parameter>(element::f16, Shape{720, 1280});
+        auto shapeof_1 = std::make_shared<opset8::ShapeOf>(input_2);
+
+        auto convert_to_float = std::make_shared<opset8::Convert>(shapeof_1, element::f32);
+        auto const_denominator = opset8::Constant::create(element::f32, Shape{}, {2.0f});
+        auto div = std::make_shared<opset8::Divide>(convert_to_float, const_denominator);
+        auto new_shape = std::make_shared<opset8::Convert>(div, element::i64);
+
+        auto reshape = std::make_shared<opset8::Reshape>(input_1, new_shape, false);
+        model_ref = std::make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+    }
+
+    const auto fc = FunctionsComparator::with_default()
+            .enable(FunctionsComparator::PRECISIONS)
+            .enable(FunctionsComparator::CONST_VALUES);
+    const auto res = fc.compare(model, model_ref);
+    ASSERT_TRUE(res.valid) << res.message;
+}
+
+TEST(TransformationTests, ConvertPrecision_whole_shape_subgraph_is_marked_2) {
+    std::shared_ptr<ov::Model> model(nullptr), model_ref(nullptr);
+    {
+        auto input_1 = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 1, 720, 1280});
+        auto shapeof_1 = std::make_shared<opset8::ShapeOf>(input_1);
+        auto indices = opset8::Constant::create(element::i64, Shape{1}, {3});
+        auto gather_axis = opset8::Constant::create(element::i64, Shape{}, {0});
+        auto gather_1 = std::make_shared<opset8::Gather>(shapeof_1, indices, gather_axis);
+
+        auto convert_to_float = std::make_shared<opset8::Convert>(gather_1, element::f32);
+        auto const_denominator = opset8::Constant::create(element::f32, Shape{}, {2.0f});
+        auto div = std::make_shared<opset8::Divide>(convert_to_float, const_denominator);
+        auto new_dim_size = std::make_shared<opset8::Convert>(div, element::i64);
+
+        auto const_ends = opset8::Constant::create(element::i64, Shape{3}, {-1, -1, -1});
+        auto concat_with_ends = std::make_shared<opset8::Concat>(OutputVector{const_ends, new_dim_size}, 0);  // scales
+
+        auto begin = opset8::Constant::create(element::i64, Shape{4}, {0, 0, 0, 0});
+        std::vector<int64_t> begin_mask = {0, 0, 0, 0};
+        std::vector<int64_t> end_mask = {0, 0, 0, 0};
+        auto slice = std::make_shared<opset8::StridedSlice>(input_1, begin, concat_with_ends,
+                                                            begin_mask, end_mask);
+        auto result = std::make_shared<opset8::Result>(slice);
+        model = std::make_shared<ov::Model>(NodeVector{result}, ParameterVector{input_1});
+
+        pass::Manager manager;
+        manager.register_pass<ov::pass::MarkPrecisionSensitiveSubgraphs>(false);
+        manager.get_pass_config()->set_callback<ngraph::pass::ConvertPrecision>(
+                [](const std::shared_ptr<const Node>& node) -> bool {
+                    return ov::fp16_compression_is_disabled(node);
+                });
+        manager.register_pass<pass::ConvertPrecision>(precisions_array {{ element::f32, element::f16 }});
+        manager.register_pass<ov::pass::VisualizeTree>("after.svg");
+        manager.run_passes(model);
+    }
+    {
+        auto input_1 = std::make_shared<opset8::Parameter>(element::f16, Shape{1, 1, 720, 1280});
+        auto shapeof_1 = std::make_shared<opset8::ShapeOf>(input_1);
+        auto indices = opset8::Constant::create(element::i64, Shape{1}, {3});
+        auto gather_axis = opset8::Constant::create(element::i64, Shape{}, {0});
+        auto gather_1 = std::make_shared<opset8::Gather>(shapeof_1, indices, gather_axis);
+
+        auto convert_to_float = std::make_shared<opset8::Convert>(gather_1, element::f32);
+        auto const_denominator = opset8::Constant::create(element::f32, Shape{}, {2.0f});
+        auto div = std::make_shared<opset8::Divide>(convert_to_float, const_denominator);
+        auto new_dim_size = std::make_shared<opset8::Convert>(div, element::i64);
+
+        auto const_ends = opset8::Constant::create(element::i64, Shape{3}, {-1, -1, -1});
+        auto concat_with_ends = std::make_shared<opset8::Concat>(OutputVector{const_ends, new_dim_size}, 0);  // scales
+
+        auto begin = opset8::Constant::create(element::i64, Shape{4}, {0, 0, 0, 0});
+        std::vector<int64_t> begin_mask = {0, 0, 0, 0};
+        std::vector<int64_t> end_mask = {0, 0, 0, 0};
+        auto slice = std::make_shared<opset8::StridedSlice>(input_1, begin, concat_with_ends,
+                                                            begin_mask, end_mask);
+        auto result = std::make_shared<opset8::Result>(slice);
+        model_ref = std::make_shared<ov::Model>(NodeVector{result}, ParameterVector{input_1});
+
+        pass::Manager manager;
+        manager.register_pass<ov::pass::VisualizeTree>("model_ref.svg");
+        manager.run_passes(model_ref);
+    }
+
+    const auto fc = FunctionsComparator::with_default()
+            .enable(FunctionsComparator::PRECISIONS)
+            .enable(FunctionsComparator::CONST_VALUES);
+    const auto res = fc.compare(model, model_ref);
+    ASSERT_TRUE(res.valid) << res.message;
+}
+
+TEST(TransformationTests, ConvertPrecision_whole_shape_subgraph_is_marked_3) {
+    std::shared_ptr<ov::Model> model(nullptr);
+    std::shared_ptr<ov::Model> model_ref(nullptr);
+    {
+        auto input_1 = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 3, 720, 1280});
+        auto input_2 = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 3, 720, 1280});
+        auto shapeof_1 = std::make_shared<opset8::ShapeOf>(input_1);
+        auto shapeof_2 = std::make_shared<opset8::ShapeOf>(input_2);
+
+        auto const_1 = opset8::Constant::create(element::i64, Shape{2}, {2, 3});
+        auto axis_const = opset8::Constant::create(element::i64, Shape{}, {0});
+        auto gather_1 = std::make_shared<opset8::Gather>(shapeof_2, const_1, axis_const);
+        auto convert_1 = std::make_shared<opset8::Convert>(shapeof_1, element::f32);
+
+        auto convert_2 = std::make_shared<opset8::Convert>(gather_1, element::f32);
+        auto const_2 = opset8::Constant::create(element::f32, Shape{2}, {512, 512});
+        auto div_1 = std::make_shared<opset8::Divide>(const_2, convert_2);
+        auto const_3 = opset8::Constant::create(element::f32, Shape{2}, {1, 1});
+        auto concat = std::make_shared<opset8::Concat>(OutputVector{const_3, div_1}, 0);  // scales
+
+        auto mul_1 = std::make_shared<opset8::Multiply>(convert_1, concat);
+        auto convert_3 = std::make_shared<opset8::Convert>(mul_1, element::i64);  // sizes
+
+        opset8::Interpolate::InterpolateAttrs attrs;
+        attrs.mode = opset8::Interpolate::InterpolateMode::LINEAR_ONNX;
+        attrs.shape_calculation_mode = opset8::Interpolate::ShapeCalcMode::SIZES;
+        attrs.nearest_mode = opset8::Interpolate::NearestMode::FLOOR;
+        attrs.pads_begin = std::vector<size_t>{0};
+        attrs.pads_end = std::vector<size_t>{0};
+        attrs.antialias = false;
+        attrs.coordinate_transformation_mode = opset8::Interpolate::CoordinateTransformMode::PYTORCH_HALF_PIXEL;
+        attrs.cube_coeff = -0.75f;
+
+        auto interpolate = std::make_shared<opset8::Interpolate>(input_1, convert_3, concat, attrs);
+
+        auto const_4 = opset8::Constant::create(element::f32, Shape{}, {0.1f});
+        auto add_1 = std::make_shared<ngraph::opset5::Add>(input_1, const_4);
+        auto result_1 = std::make_shared<ngraph::opset5::Result>(add_1);
+        auto result_2 = std::make_shared<ngraph::opset5::Result>(interpolate);
+        model = std::make_shared<ov::Model>(NodeVector{result_1, result_2}, ParameterVector{input_1, input_2});
+        pass::Manager manager;
+
+        manager.register_pass<ov::pass::MarkPrecisionSensitiveSubgraphs>(false);
+        manager.get_pass_config()->set_callback<ngraph::pass::ConvertPrecision>(
+                [](const std::shared_ptr<const Node>& node) -> bool {
+                    return ov::fp16_compression_is_disabled(node);
+                });
+        manager.register_pass<pass::ConvertPrecision>(precisions_array {{ element::f32, element::f16 }});
+        manager.run_passes(model);
+    }
+
+    {
+        auto input_1 = std::make_shared<opset8::Parameter>(element::f16, Shape{1, 3, 720, 1280});
+        auto input_2 = std::make_shared<opset8::Parameter>(element::f16, Shape{1, 3, 720, 1280});
+        auto shapeof_1 = std::make_shared<opset8::ShapeOf>(input_1);
+        auto shapeof_2 = std::make_shared<opset8::ShapeOf>(input_2);
+
+        auto const_1 = opset8::Constant::create(element::i64, Shape{2}, {2, 3});
+        auto axis_const = opset8::Constant::create(element::i64, Shape{}, {0});
+        auto gather_1 = std::make_shared<opset8::Gather>(shapeof_2, const_1, axis_const);
+        auto convert_1 = std::make_shared<opset8::Convert>(shapeof_1, element::f32);
+
+        auto convert_2 = std::make_shared<opset8::Convert>(gather_1, element::f32);
+        auto const_2 = opset8::Constant::create(element::f32, Shape{2}, {512, 512});
+        auto div_1 = std::make_shared<opset8::Divide>(const_2, convert_2);
+        auto const_3 = opset8::Constant::create(element::f32, Shape{2}, {1, 1});
+        auto concat = std::make_shared<opset8::Concat>(OutputVector{const_3, div_1}, 0);  // scales
+
+        auto mul_1 = std::make_shared<opset8::Multiply>(convert_1, concat);
+        auto convert_3 = std::make_shared<opset8::Convert>(mul_1, element::i64);  // sizes
+
+        opset8::Interpolate::InterpolateAttrs attrs;
+        attrs.mode = opset8::Interpolate::InterpolateMode::LINEAR_ONNX;
+        attrs.shape_calculation_mode = opset8::Interpolate::ShapeCalcMode::SIZES;
+        attrs.nearest_mode = opset8::Interpolate::NearestMode::FLOOR;
+        attrs.pads_begin = std::vector<size_t>{0};
+        attrs.pads_end = std::vector<size_t>{0};
+        attrs.antialias = false;
+        attrs.coordinate_transformation_mode = opset8::Interpolate::CoordinateTransformMode::PYTORCH_HALF_PIXEL;
+        attrs.cube_coeff = -0.75f;
+
+        auto interpolate = std::make_shared<opset8::Interpolate>(input_1, convert_3, concat, attrs);
+
+        auto const_4 = opset8::Constant::create(element::f16, Shape{}, {0.1f});
+        auto add_1 = std::make_shared<ngraph::opset5::Add>(input_1, const_4);
+        auto result_1 = std::make_shared<ngraph::opset5::Result>(add_1);
+        auto result_2 = std::make_shared<ngraph::opset5::Result>(interpolate);
+        model_ref = std::make_shared<ov::Model>(NodeVector{result_1, result_2}, ParameterVector{input_1, input_2});
+    }
+
+    const auto fc = FunctionsComparator::with_default()
+            .enable(FunctionsComparator::PRECISIONS)
+            .enable(FunctionsComparator::CONST_VALUES);
+    const auto res = fc.compare(model, model_ref);
+    ASSERT_TRUE(res.valid) << res.message;
+}
+
+TEST(TransformationTests, ConvertPrecision_shape_subgraph_after_marking_deliberately_exception_is_thrown) {
+    std::shared_ptr<ov::Model> model(nullptr), model_ref(nullptr);
+    std::function<void(void)> build_model = [&]()
+    {
+        auto input_1 = std::make_shared<opset8::Parameter>(element::f32, Shape{360, 640});
+        auto input_2 = std::make_shared<opset8::Parameter>(element::f32, Shape{720, 1280});
+        auto shapeof_1 = std::make_shared<opset8::ShapeOf>(input_2);
+
+        auto convert_to_float = std::make_shared<opset8::Convert>(shapeof_1, element::f32);
+        auto const_denominator = opset8::Constant::create(element::f32, Shape{}, {2.0f});
+        auto div = std::make_shared<opset8::Divide>(convert_to_float, const_denominator);
+        auto new_shape = std::make_shared<opset8::Convert>(div, element::i64);
+
+        auto reshape = std::make_shared<opset8::Reshape>(input_1, new_shape, false);
+
+        model = std::make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+        pass::Manager manager;
+
+        // if mark_only_consts = true then element type inconsistency exception should be thrown
+        manager.register_pass<ov::pass::MarkPrecisionSensitiveSubgraphs>(true);
+        manager.get_pass_config()->set_callback<ngraph::pass::ConvertPrecision>(
+                [](const std::shared_ptr<const Node>& node) -> bool {
+                    return ov::fp16_compression_is_disabled(node);
+                });
+        manager.register_pass<pass::ConvertPrecision>(precisions_array {{ element::f32, element::f16 }});
+        manager.run_passes(model);
+    };
+
+    ASSERT_THROW(build_model(), NodeValidationFailure);
 }
 
 template <typename From, typename To>

--- a/src/common/transformations/tests/utils/convert_precision.cpp
+++ b/src/common/transformations/tests/utils/convert_precision.cpp
@@ -17,7 +17,6 @@
 #include <ngraph/opsets/opset8.hpp>
 #include <ngraph/opsets/opset10.hpp>
 #include <transformations/convert_precision.hpp>
-#include <ngraph/pass/visualize_tree.hpp>
 
 #include <transformations/utils/utils.hpp>
 #include <ngraph/pass/manager.hpp>
@@ -983,7 +982,6 @@ TEST(TransformationTests, ConvertPrecision_whole_shape_subgraph_is_marked_2) {
                     return ov::fp16_compression_is_disabled(node);
                 });
         manager.register_pass<pass::ConvertPrecision>(precisions_array {{ element::f32, element::f16 }});
-        manager.register_pass<ov::pass::VisualizeTree>("after.svg");
         manager.run_passes(model);
     }
     {
@@ -1010,7 +1008,6 @@ TEST(TransformationTests, ConvertPrecision_whole_shape_subgraph_is_marked_2) {
         model_ref = std::make_shared<ov::Model>(NodeVector{result}, ParameterVector{input_1});
 
         pass::Manager manager;
-        manager.register_pass<ov::pass::VisualizeTree>("model_ref.svg");
         manager.run_passes(model_ref);
     }
 

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -236,15 +236,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
         auto pass_config = manager.get_pass_config();
         pass_config->disable<ov::pass::EyeDecomposition>();
-        // Skip precision sensitive nodes with marking and pass_callback:
-        // callback skips (returns true) for nodes marked as precision sensitive/disabled_f16_compression.
-        // Skipping was done by callback in order to impact behavior of ConvertPrecision as little as possible
-        // false is set to keep the whole ShapeOf subgraph in FP32 not only Constants
-        manager.register_pass<ov::pass::MarkPrecisionSensitiveSubgraphs>(false);
-        pass_config->set_callback<ngraph::pass::ConvertPrecision>(
-                [](const std::shared_ptr<const Node>& node) -> bool {
-                    return ov::fp16_compression_is_disabled(node);
-                });
+
         // in order to keep ShapeOf precision sensitive subgraphs in FP32
         pass_config->enable<ov::pass::MarkPrecisionSensitiveSubgraphs>();
         pass_config->enable<ov::pass::ConvertCompressedOnlyToLegacy>();


### PR DESCRIPTION
### Details:
 - Continuation of https://github.com/openvinotoolkit/openvino/pull/14204 
 - Last fix causes type mismatch errors when ShapeOf subgraph is not constant folded therefore need to mark the whole subgraph to cover cases when for some reason Shape subgraph survived `ConstantFolding` and came to `ConvertPrecission` unfolded. Also when in future dynamism on GPU will be enabled shape subgraphs will have to be always kept unfolded.
 - [ ] validation: run, some errors were caught, fixed them, need to run one more validation
- [x] unit-tests: done

#### Update1:
- `ConvertPrecission` can be triggered either directly either indirectly by calling `ConvertCompressedOnlyToLegacy`. Some plugins call `ConvertCompressedOnlyToLegacy` and to make such call safer behavior of `ConvertCompressedOnlyToLegacy` must be kept conservative as much as possible. Keeping the ShapeOf subgraph in fp32 must be activated only explicitly by plugins which can handle simultaneously f32 and f16 values (e.g. GPU). Added changes for that: on GPU `transformations_pipeline.cpp` explicitly activates `MarkPrecisionSensitiveSubgraphs` (by default for all other plugins this is deactivated). Covered such cases with unit-tests.

### Tickets:
 - xxx-98224, xxx-91832
