### PR TITLE
[GPU] Fix dead lock from exceeded max size of host memory allocation.

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
@@ -194,14 +194,6 @@ protected:
 
     void regLockedBlob(void* handle, const RemoteBlobImpl* blob);
 
-    void acquire_lock() {
-        while (_lock.test_and_set(std::memory_order_acquire)) {}
-    }
-
-    void release_lock() {
-        _lock.clear(std::memory_order_release);
-    }
-
 public:
     using Ptr = std::shared_ptr<RemoteAllocator>;
 
@@ -228,6 +220,14 @@ public:
     * @return false if handle cannot be released, otherwise - true.
     */
     bool free(void* handle) noexcept override { return true; }
+
+    void lock() {
+        while (_lock.test_and_set(std::memory_order_acquire)) {}
+    }
+
+    void unlock() {
+        _lock.clear(std::memory_order_release);
+    }
 };
 
 class USMHostAllocator : public InferenceEngine::IAllocator {
@@ -316,12 +316,12 @@ public:
     InferenceEngine::gpu_handle_param GetExternalQueue() const { return m_external_queue; }
     const std::weak_ptr<InferenceEngine::IInferencePlugin> GetPlugin() const { return m_plugin; }
 
-    void acquire_lock() {
-        while (lock.test_and_set(std::memory_order_acquire)) {}
+    void lock() {
+        while (m_lock.test_and_set(std::memory_order_acquire)) {}
     }
 
-    void release_lock() {
-        lock.clear(std::memory_order_release);
+    void unlock() {
+        m_lock.clear(std::memory_order_release);
     }
 
 protected:
@@ -333,7 +333,7 @@ protected:
 
     ContextType m_type;
     std::weak_ptr<InferenceEngine::IInferencePlugin> m_plugin;
-    std::atomic_flag lock;
+    std::atomic_flag m_lock;
 };
 
 template<typename TpublicContextAPI>
@@ -371,7 +371,7 @@ class TypedExecutionContext : public TpublicContextAPI {
         cldnn::shared_surface surf = param_map_obj_getter::_ObjFromParamSimple<cldnn::shared_surface>(params, GPU_PARAM_KEY(DEV_OBJECT_HANDLE));
         surf_key skey(surf, plane);
 #endif
-        _impl.acquire_lock();
+        std::lock_guard<ExecutionContextImpl> locker(_impl);
 
         // try to locate previously shared surface
         auto itr = shared_surf_reg.find(skey);
@@ -396,7 +396,6 @@ class TypedExecutionContext : public TpublicContextAPI {
             shared_surf_reg[skey] = ret;
         }
 
-        _impl.release_lock();
         return ret;
     }
 
@@ -405,7 +404,7 @@ class TypedExecutionContext : public TpublicContextAPI {
                                                RemoteBlobImpl::BlobType blob_type) {
         InferenceEngine::RemoteBlob::Ptr ret = nullptr;
 
-        _impl.acquire_lock();
+        std::lock_guard<ExecutionContextImpl> locker(_impl);
         auto& stream = _impl.GetEngine()->get_program_stream();
 
         // try to locate previously shared object
@@ -442,7 +441,6 @@ class TypedExecutionContext : public TpublicContextAPI {
             shared_obj_reg[mem] = ret;
         }
 
-        _impl.release_lock();
         return ret;
     }
 

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -209,10 +209,9 @@ void Plugin::UpdateStatistics(const RemoteCLContext::Ptr& context) const {
 
         std::map<std::string, uint64_t> statistics;
         auto impl = getContextImpl(context);
-        impl->acquire_lock();
+        std::lock_guard<ExecutionContextImpl> locker(*impl);
         std::shared_ptr<cldnn::engine> eng = impl->GetEngine();
         statistics = eng->get_memory_statistics();
-        impl->release_lock();
 
         // if the same context exists, the statistics is replaced with the latest one
         // (currently, memory usage is accumulated for several networks in the same context)

--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -132,48 +132,54 @@ void RemoteBlobImpl::allocate() {
     auto _impl = getContextImpl(m_context.lock());
     _impl->acquire_lock();
 
-    switch (m_mem_type) {
-    case BlobType::BT_BUF_INTERNAL: {
-        m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::cl_mem);
-        break;
-    }
-    case BlobType::BT_USM_HOST_INTERNAL: {
-        m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::usm_host);
-        break;
-    }
-    case BlobType::BT_USM_DEVICE_INTERNAL: {
-        m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::usm_device);
-        break;
-    }
-    case BlobType::BT_BUF_SHARED: {
-        m_memObject = m_engine->share_buffer(m_layout, m_mem);
-        break;
-    }
-    case BlobType::BT_USM_SHARED: {
-        m_memObject = m_engine->share_usm(m_layout, m_mem);
-        break;
-    }
+    try {
+        switch (m_mem_type) {
+        case BlobType::BT_BUF_INTERNAL: {
+            m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::cl_mem);
+            break;
+        }
+        case BlobType::BT_USM_HOST_INTERNAL: {
+            m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::usm_host);
+            break;
+        }
+        case BlobType::BT_USM_DEVICE_INTERNAL: {
+            m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::usm_device);
+            break;
+        }
+        case BlobType::BT_BUF_SHARED: {
+            m_memObject = m_engine->share_buffer(m_layout, m_mem);
+            break;
+        }
+        case BlobType::BT_USM_SHARED: {
+            m_memObject = m_engine->share_usm(m_layout, m_mem);
+            break;
+        }
 #ifdef _WIN32
-    case BlobType::BT_SURF_SHARED: {
-        m_memObject = m_engine->share_surface(m_layout, m_mem, m_plane);
-        break;
-    }
-    case BlobType::BT_DX_BUF_SHARED: {
-        m_memObject = m_engine->share_dx_buffer(m_layout, m_mem);
-        break;
-    }
+        case BlobType::BT_SURF_SHARED: {
+            m_memObject = m_engine->share_surface(m_layout, m_mem, m_plane);
+            break;
+        }
+        case BlobType::BT_DX_BUF_SHARED: {
+            m_memObject = m_engine->share_dx_buffer(m_layout, m_mem);
+            break;
+        }
 #else
-    case BlobType::BT_SURF_SHARED: {
-        m_memObject = m_engine->share_surface(m_layout, m_surf, m_plane);
-        break;
-    }
+        case BlobType::BT_SURF_SHARED: {
+            m_memObject = m_engine->share_surface(m_layout, m_surf, m_plane);
+            break;
+        }
 #endif
-    case BlobType::BT_IMG_SHARED: {
-        m_memObject = m_engine->share_image(m_layout, m_mem);
-        break;
-    }
-    default:
-        m_memObject.reset();
+        case BlobType::BT_IMG_SHARED: {
+            m_memObject = m_engine->share_image(m_layout, m_mem);
+            break;
+        }
+        default:
+            m_memObject.reset();
+        }
+    } catch (const std::exception& e) {
+        _impl->release_lock();
+        std::cerr << e.what() << '\n';
+        throw e;
     }
     _impl->release_lock();
 }

--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -132,53 +132,48 @@ void RemoteBlobImpl::allocate() {
     auto _impl = getContextImpl(m_context.lock());
     std::lock_guard<ExecutionContextImpl> locker(*_impl);
 
-    try {
-        switch (m_mem_type) {
-        case BlobType::BT_BUF_INTERNAL: {
-            m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::cl_mem);
-            break;
-        }
-        case BlobType::BT_USM_HOST_INTERNAL: {
-            m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::usm_host);
-            break;
-        }
-        case BlobType::BT_USM_DEVICE_INTERNAL: {
-            m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::usm_device);
-            break;
-        }
-        case BlobType::BT_BUF_SHARED: {
-            m_memObject = m_engine->share_buffer(m_layout, m_mem);
-            break;
-        }
-        case BlobType::BT_USM_SHARED: {
-            m_memObject = m_engine->share_usm(m_layout, m_mem);
-            break;
-        }
+    switch (m_mem_type) {
+    case BlobType::BT_BUF_INTERNAL: {
+        m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::cl_mem);
+        break;
+    }
+    case BlobType::BT_USM_HOST_INTERNAL: {
+        m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::usm_host);
+        break;
+    }
+    case BlobType::BT_USM_DEVICE_INTERNAL: {
+        m_memObject = m_engine->allocate_memory(m_layout, cldnn::allocation_type::usm_device);
+        break;
+    }
+    case BlobType::BT_BUF_SHARED: {
+        m_memObject = m_engine->share_buffer(m_layout, m_mem);
+        break;
+    }
+    case BlobType::BT_USM_SHARED: {
+        m_memObject = m_engine->share_usm(m_layout, m_mem);
+        break;
+    }
 #ifdef _WIN32
-        case BlobType::BT_SURF_SHARED: {
-            m_memObject = m_engine->share_surface(m_layout, m_mem, m_plane);
-            break;
-        }
-        case BlobType::BT_DX_BUF_SHARED: {
-            m_memObject = m_engine->share_dx_buffer(m_layout, m_mem);
-            break;
-        }
+    case BlobType::BT_SURF_SHARED: {
+        m_memObject = m_engine->share_surface(m_layout, m_mem, m_plane);
+        break;
+    }
+    case BlobType::BT_DX_BUF_SHARED: {
+        m_memObject = m_engine->share_dx_buffer(m_layout, m_mem);
+        break;
+    }
 #else
-        case BlobType::BT_SURF_SHARED: {
-            m_memObject = m_engine->share_surface(m_layout, m_surf, m_plane);
-            break;
-        }
+    case BlobType::BT_SURF_SHARED: {
+        m_memObject = m_engine->share_surface(m_layout, m_surf, m_plane);
+        break;
+    }
 #endif
-        case BlobType::BT_IMG_SHARED: {
-            m_memObject = m_engine->share_image(m_layout, m_mem);
-            break;
-        }
-        default:
-            m_memObject.reset();
-        }
-    } catch(const std::exception& e) {
-        std::cerr << e.what() << '\n';
-        throw e;
+    case BlobType::BT_IMG_SHARED: {
+        m_memObject = m_engine->share_image(m_layout, m_mem);
+        break;
+    }
+    default:
+        m_memObject.reset();
     }
 }
 


### PR DESCRIPTION
Dead lock hang issue because remote_context ignore the exception and return null. Handling unlock through lock_guard.
target model: imagesr with not enough host memory machine (device <=15G, host M<=15G)

Signed-off-by: hyunback <hyunback.kim@intel.com>


### Tickets:
 - *98315*
