### PR TITLE
reorder fix

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -339,9 +339,6 @@ void Reorder::execute(dnnl::stream strm) {
     } else if (canUseNcsp2Nspc) {
         optimizedNcsp2Nspc();
     } else {
-        src_blocked->setDataHandle(getParentEdgeAt(0)->getMemory().GetData());
-        dst_blocked->setDataHandle(getChildEdgeAt(0)->getMemory().GetData());
-
         if (prim) {
             prim.execute(strm, primArgs);
         } else {

--- a/src/plugins/intel_cpu/src/nodes/reorder.h
+++ b/src/plugins/intel_cpu/src/nodes/reorder.h
@@ -79,7 +79,7 @@ private:
 
     void optimizedNspc2Ncsp();
     void optimizedNcsp2Nspc();
-    void createReorderPrimitive(const dnnl::memory::desc &srcDesc, const dnnl::memory::desc &dstDesc);
+    void createReorderPrimitive(const DnnlMemoryDescPtr &srcDesc, const DnnlMemoryDescPtr &dstDesc);
 };
 
 }   // namespace node

--- a/src/plugins/intel_cpu/src/nodes/reorder.h
+++ b/src/plugins/intel_cpu/src/nodes/reorder.h
@@ -70,9 +70,6 @@ private:
 
     std::vector<int> src_permutation;
 
-    MemoryPtr dst_blocked;
-    MemoryPtr src_blocked;
-
     bool isOptimized = false;
 
     bool isNspc2NcspCase = false;
@@ -82,7 +79,7 @@ private:
 
     void optimizedNspc2Ncsp();
     void optimizedNcsp2Nspc();
-    void createReorderPrimitive(const dnnl::memory::desc &srcDesc, void* srcPtr, const dnnl::memory::desc &dstDesc, void* dstPtr);
+    void createReorderPrimitive(const dnnl::memory::desc &srcDesc, const dnnl::memory::desc &dstDesc);
 };
 
 }   // namespace node


### PR DESCRIPTION
### Details:
 - *There are legacy input and output memory object(src_blocked and dst_blocked class member), used for execute() as src and dst. At current the src and dst is set to primArgs = {{DNNL_ARG_SRC, src}, {DNNL_ARG_DST, dst}} in prepareParams(), and use this as runtime memory. The redundant memory object is removed*
 - *replace dnnl::memory::desc with lightweight DnnlMemoryDescPtr when possible*

### Tickets:
 -  97946
