### PR TITLE
[TF FE] Use output_shapes attribute for Placeholder

### DIFF
--- a/src/frontends/tensorflow/src/decoder_proto.cpp
+++ b/src/frontends/tensorflow/src/decoder_proto.cpp
@@ -108,9 +108,10 @@ ov::Any DecoderProto::get_attribute(const std::string& name) const {
         if (tf_shape.unknown_rank()) {
             return ov::PartialShape::dynamic();
         }
-        std::vector<ov::Dimension> dims(tf_shape.dim_size());
-        for (int i = 0; i < tf_shape.dim_size(); ++i) {
-            dims[i] = tf_shape.dim(i).size();
+        size_t shape_rank = static_cast<size_t>(tf_shape.dim_size());
+        std::vector<ov::Dimension> dims(shape_rank);
+        for (size_t i = 0; i < shape_rank; ++i) {
+            dims[i] = static_cast<ov::Dimension>(tf_shape.dim(i).size());
         }
         return ov::PartialShape(dims);
     }
@@ -139,14 +140,22 @@ ov::Any DecoderProto::get_attribute(const std::string& name) const {
             return std::vector<bool>(list.b().begin(), list.b().end());
 
         if (list.shape_size()) {
-            std::vector<ov::PartialShape> res;
-            for (const auto& it : list.shape()) {
-                std::vector<ov::Dimension> dims;
-                for (int i = 0; i < it.dim_size(); i++) {
-                    dims.emplace_back(it.dim(i).size());
+            size_t shapes_size = static_cast<size_t>(list.shape_size());
+            std::vector<ov::PartialShape> res(shapes_size);
+            for (size_t shape_ind = 0; shape_ind < shapes_size; ++shape_ind) {
+                auto shape = list.shape(shape_ind);
+                if (shape.unknown_rank()) {
+                    res[shape_ind] = ov::PartialShape::dynamic();
+                } else {
+                    size_t shape_rank = static_cast<size_t>(shape.dim_size());
+                    std::vector<ov::Dimension> dims(shape_rank);
+                    for (size_t dim_ind = 0; dim_ind < shape_rank; ++dim_ind) {
+                        dims[dim_ind] = static_cast<ov::Dimension>(shape.dim(dim_ind).size());
+                    }
+                    res[shape_ind] = dims;
                 }
-                res.emplace_back(dims);
             }
+            return res;
         }
 
         if (list.type_size()) {

--- a/src/frontends/tensorflow/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow/tests/convert_tricky_models.cpp
@@ -13,27 +13,59 @@ using namespace std;
 using namespace ov;
 using namespace ov::frontend;
 
-TEST(FrontEndConvertModelTest, test_undefined_input_shape) {
+namespace {
+shared_ptr<Model> convert_model(const string& model_path) {
     FrontEndManager fem;
-    FrontEnd::Ptr frontEnd;
-    InputModel::Ptr inputModel;
-    ASSERT_NO_THROW(frontEnd = fem.load_by_framework(TF_FE));
-    ASSERT_NE(frontEnd, nullptr);
-    auto model_filename = FrontEndTestUtils::make_model_path(string(TEST_TENSORFLOW_MODELS_DIRNAME) +
-                                                             string("undefined_input_shape/undefined_input_shape.pb"));
-    ASSERT_NO_THROW(inputModel = frontEnd->load(model_filename));
-    ASSERT_NE(inputModel, nullptr);
+    auto front_end = fem.load_by_framework(TF_FE);
+    if (!front_end) {
+        throw "TensorFlow Frontend is not initialized";
+    }
+    auto model_filename = FrontEndTestUtils::make_model_path(string(TEST_TENSORFLOW_MODELS_DIRNAME) + model_path);
+    auto input_model = front_end->load(model_filename);
+    if (!input_model) {
+        throw "Input model is not read";
+    }
+    auto model = front_end->convert(input_model);
+    if (!model) {
+        throw "Model is not converted";
+    }
+
+    return model;
+}
+}  // namespace
+
+TEST(FrontEndConvertTrickyModels, undefined_input_shape) {
     shared_ptr<Model> model;
-    ASSERT_NO_THROW(model = frontEnd->convert(inputModel));
-    ASSERT_NE(model, nullptr);
+    try {
+        model = convert_model("undefined_input_shape/undefined_input_shape.pb");
+    } catch (std::exception& ex) {
+        ASSERT_TRUE(false) << ex.what();
+    }
 
     for (auto& node : model->get_ordered_ops()) {
         if (node->get_friendly_name() == "x") {
-            ASSERT_TRUE(node->get_output_partial_shape(0).same_scheme(PartialShape::dynamic()));
+            ASSERT_TRUE(node->get_output_partial_shape(0).same_scheme(ov::PartialShape::dynamic()));
         } else if (node->get_friendly_name() == "y") {
-            ASSERT_TRUE(node->get_output_partial_shape(0).same_scheme(PartialShape{2, 3}));
+            ASSERT_TRUE(node->get_output_partial_shape(0).same_scheme(ov::PartialShape{2, 3}));
         } else if (node->get_friendly_name() == "z") {
-            ASSERT_TRUE(node->get_output_partial_shape(0).same_scheme(PartialShape::dynamic()));
+            ASSERT_TRUE(node->get_output_partial_shape(0).same_scheme(ov::PartialShape::dynamic()));
+        }
+    }
+}
+
+TEST(FrontEndConvertTrickyModels, model_with_output_shapes) {
+    shared_ptr<Model> model;
+    try {
+        model = convert_model("model_with_output_shapes_attr/model_with_output_shapes_attr.pb");
+    } catch (std::exception& ex) {
+        ASSERT_TRUE(false) << ex.what();
+    }
+
+    for (auto& node : model->get_ordered_ops()) {
+        if (node->get_friendly_name() == "x") {
+            ASSERT_TRUE(node->get_output_partial_shape(0).same_scheme(ov::PartialShape{2, 3}));
+        } else if (node->get_friendly_name() == "relu") {
+            ASSERT_TRUE(node->get_output_partial_shape(0).same_scheme(ov::PartialShape{2, 3}));
         }
     }
 }


### PR DESCRIPTION
**Details:** In case of scalar `shape` attribute, we should use `_output_shapes` attributes to set a shape of Placeholder based on specifics of some models. `_output_shapes` attribute defines the right shape in this case.

**Ticket:** 95066

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
