### PR TITLE
keep the behavior of setting batch config through auto/multi

### DIFF
--- a/src/plugins/auto/plugin.cpp
+++ b/src/plugins/auto/plugin.cpp
@@ -413,7 +413,7 @@ IExecutableNetworkInternal::Ptr MultiDeviceInferencePlugin::LoadNetworkImpl(cons
                              config.second.c_str());
             }
             // carry on batch configs only if user explicitly sets
-            if (config.find(CONFIG_KEY(ALLOW_AUTO_BATCHING)) != config.end())
+            if (config.find(CONFIG_KEY(ALLOW_AUTO_BATCHING)) != config.end() || loadConfig._isBatchConfigSet)
                 insertPropToConfig(CONFIG_KEY(ALLOW_AUTO_BATCHING), iter->deviceName, configs);
             if (config.find(CONFIG_KEY(AUTO_BATCH_TIMEOUT)) != config.end())
                 insertPropToConfig(CONFIG_KEY(AUTO_BATCH_TIMEOUT), iter->deviceName, configs);
@@ -466,7 +466,7 @@ IExecutableNetworkInternal::Ptr MultiDeviceInferencePlugin::LoadNetworkImpl(cons
                 LOG_INFO_TAG("set %s=%s", tmpiter->first.c_str(), tmpiter->second.c_str());
                 multiSContext->_batchingDisabled = true;
             }
-            if (config.find(CONFIG_KEY(ALLOW_AUTO_BATCHING)) != config.end())
+            if (config.find(CONFIG_KEY(ALLOW_AUTO_BATCHING)) != config.end() || loadConfig._isBatchConfigSet)
                 p.config.insert({tmpiter->first, tmpiter->second});
         }
         if (config.find(CONFIG_KEY(AUTO_BATCH_TIMEOUT)) != config.end())

--- a/src/plugins/auto/utils/config.hpp
+++ b/src/plugins/auto/utils/config.hpp
@@ -129,11 +129,17 @@ struct PluginConfig {
                         << " for key: " << kvp.first;
                 }
             } else if (kvp.first == ov::hint::allow_auto_batching) {
-                if (kvp.second == PluginConfigParams::NO) _disableAutoBatching = true;
-                else if (kvp.second == PluginConfigParams::YES) _disableAutoBatching = false;
-                else
+                if (kvp.second == PluginConfigParams::NO) {
+                    _disableAutoBatching = true;
+                    // temp flag, to be removed when unify this key to ie core
+                    _isBatchConfigSet = true;
+                } else if (kvp.second == PluginConfigParams::YES) {
+                    _disableAutoBatching = false;
+                    _isBatchConfigSet = true;
+                } else {
                     IE_THROW() << "Unsupported config value: " << kvp.second
                             << " for key: " << kvp.first;
+                }
             } else if (kvp.first == ov::auto_batch_timeout) {
                 try {
                     auto batchTimeout = std::stoi(kvp.second);
@@ -282,6 +288,7 @@ struct PluginConfig {
     // Add this flag to check if user app sets hint with none value that is equal to the default value of hint.
     bool _isSetPerHint = false;
     bool _isSetCacheDir = false;
+    bool _isBatchConfigSet = false;
     std::map<std::string, std::string> _passThroughConfig;
     std::map<std::string, std::string> _keyConfigMap;
     const std::set<std::string> _availableDevices = {"AUTO",


### PR DESCRIPTION
Signed-off-by: fishbell <bell.song@intel.com>

### Details:
 - currently , before the batch keys been unified to ie core, we have to continue support in multi/auto to allow user sets the batch keys.

### Tickets:
 - 
