### PR TITLE
Fix XML vulnerabilities found by bandit

### DIFF
--- a/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/merge_xmls.py
+++ b/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/merge_xmls.py
@@ -6,6 +6,7 @@ import os
 import glob
 
 import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as dET
 
 from utils import utils
 
@@ -49,8 +50,8 @@ def aggregate_test_results(aggregated_results: ET.SubElement, xml_reports: list,
     for xml in xml_reports:
         logger.info(f" Processing: {xml}")
         try:
-            xml_root = ET.parse(xml).getroot()
-        except ET.ParseError:
+            xml_root = dET.parse(xml).getroot()
+        except dET.ParseError:
             logger.error(f' {xml} is corrupted and skipped')
             continue
         xml_results = xml_root.find("results")
@@ -113,9 +114,9 @@ def merge_xml(input_folder_paths: list, output_folder_paths: str, output_filenam
         xml_root = None
         for xml_report in xml_reports:
             try:
-                xml_root = ET.parse(xml_report).getroot()
+                xml_root = dET.parse(xml_report).getroot()
                 break
-            except ET.ParseError:
+            except dET.ParseError:
                 logger.error(f'{xml_report} is incorrect! Error to get a xml root')
         if xml_root is None:
             logger.error(f'{folder_path} does not contain the correct xml files')
@@ -135,7 +136,7 @@ def merge_xml(input_folder_paths: list, output_folder_paths: str, output_filenam
             os.mkdir(output_folder_paths)
         out_file_path = os.path.join(output_folder_paths, f'{output_filename}.xml')
         with open(out_file_path, "w") as xml_file:
-            xml_file.write(ET.tostring(summary).decode('utf8'))
+            xml_file.write(dET.tostring(summary).decode('utf8'))
             logger.info(f" Final report is saved to file: '{out_file_path}'")
     if xml_root is None:
         raise Exception("Error to make a XML root. Exit the app")

--- a/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/rename_conformance_ir.py
+++ b/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/rename_conformance_ir.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 from argparse import ArgumentParser
 from pathlib import Path

--- a/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/requirements.txt
+++ b/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/requirements.txt
@@ -1,2 +1,3 @@
 jinja2==3.1.2
 gitpython
+defusedxml>=0.7.1

--- a/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/run_conformance.py
+++ b/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/run_conformance.py
@@ -12,7 +12,7 @@ from merge_xmls import merge_xml
 from pathlib import Path, PurePath
 from sys import version, platform
 
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 import os
 

--- a/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/summarize.py
+++ b/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/summarize.py
@@ -4,12 +4,18 @@
 import argparse
 import os
 import csv
-import xml.etree.ElementTree as ET
-import defusedxml.ElementTree as dET
+import defusedxml.ElementTree as ET
+from defusedxml import defuse_stdlib
 
 from jinja2 import Environment, FileSystemLoader
 
 from utils import utils
+
+# defuse_stdlib provide patched version of xml.etree.ElementTree which allows to use objects from xml.etree.ElementTree
+# in a safe manner without including unsafe xml.etree.ElementTree
+ET_defused = defuse_stdlib()[ET]
+Element = ET_defused.Element
+SubElement = ET_defused.SubElement
 
 NOT_RUN = "NOT RUN"
 NA = "N/A"
@@ -51,15 +57,15 @@ def parse_arguments():
 def merge_xmls(xml_paths: list):
     logger.info("Merging XML files is started")
 
-    summary = ET.Element("report")
+    summary = Element("report")
     timestamp = None
-    summary_results = ET.SubElement(summary, "results")
-    ops_list = ET.SubElement(summary, "ops_list")
+    summary_results = SubElement(summary, "results")
+    ops_list = SubElement(summary, "ops_list")
     for xml_path in xml_paths:
         try:
-            xml_root = dET.parse(xml_path).getroot()
+            xml_root = ET.parse(xml_path).getroot()
             logger.info(f'Info from {xml_path} is adding to the final summary')
-        except dET.ParseError:
+        except ET.ParseError:
             logger.error(f'Error parsing {xml_path}')
 
         if timestamp is None or timestamp < xml_root.attrib["timestamp"]:
@@ -68,7 +74,7 @@ def merge_xmls(xml_paths: list):
 
         for op in xml_root.find("ops_list"):
             if ops_list.find(op.tag) is None:
-                ET.SubElement(ops_list, op.tag)
+                SubElement(ops_list, op.tag)
 
         for device in xml_root.find("results"):
             device_results = summary_results.find(device.tag)
@@ -104,7 +110,7 @@ def merge_xmls(xml_paths: list):
     return summary
 
 
-def collect_statistic(root: ET.Element, is_conformance_mode: bool):
+def collect_statistic(root: Element, is_conformance_mode: bool):
     logger.info("Statistic collecting is started")
     trusted_ops = dict()
     pass_rate_avg = dict()
@@ -219,7 +225,7 @@ def serialize_to_csv(report_filename: str, output_dir: os.path, op_list: list, d
     logger.info(f'Final CSV report is saved to {csv_filename}')
 
 
-def create_summary(summary_root: ET.Element, output_folder: os.path, expected_devices:list, report_tag: str, report_version: str,
+def create_summary(summary_root: Element, output_folder: os.path, expected_devices:list, report_tag: str, report_version: str,
                    is_conformance_mode: bool,  is_serialize_to_csv: bool, output_filename='report'):
     if is_conformance_mode:
         utils.update_conformance_test_counters(summary_root, logger)

--- a/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/summarize.py
+++ b/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/summarize.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import csv
 import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as dET
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -56,9 +57,9 @@ def merge_xmls(xml_paths: list):
     ops_list = ET.SubElement(summary, "ops_list")
     for xml_path in xml_paths:
         try:
-            xml_root = ET.parse(xml_path).getroot()
+            xml_root = dET.parse(xml_path).getroot()
             logger.info(f'Info from {xml_path} is adding to the final summary')
-        except ET.ParseError:
+        except dET.ParseError:
             logger.error(f'Error parsing {xml_path}')
 
         if timestamp is None or timestamp < xml_root.attrib["timestamp"]:

--- a/src/tests_deprecated/functional/vpu/tester.py
+++ b/src/tests_deprecated/functional/vpu/tester.py
@@ -11,6 +11,8 @@ from typing import Union
 
 import xml.etree.cElementTree as et
 import xml.dom.minidom as dom
+import defusedxml.ElementTree as dET
+import defusedxml.minidom as ddom
 
 
 def get_path(entry: Union[str, Path], is_directory=False, check_exists=True, file_or_directory=False):
@@ -75,7 +77,7 @@ def build_argument_parser():
 
 
 def tostring(layer, num_tabs=0):
-    return '\t' * num_tabs + str(et.tostring(layer, encoding='utf-8').decode())
+    return '\t' * num_tabs + str(dET.tostring(layer, encoding='utf-8').decode())
 
 
 def tags(node):
@@ -159,12 +161,12 @@ def extract_weights(source, layers, destination):
 
 def prettify(element, indent=0):
     header = dom.Document().toxml()
-    string = dom.parseString(tostring(element)).toprettyxml()[len(header) + 1:]
+    string = ddom.parseString(tostring(element)).toprettyxml()[len(header) + 1:]
     return '\n'.join(['\t' * indent + line for line in string.split('\n') if line.strip()])
 
 
 def dump(input_model, elements, output_model):
-    root = et.parse(str(input_model)).getroot()
+    root = dET.parse(str(input_model)).getroot()
     net = et.Element('net', attrib={'name': root.attrib['name'], 'version': root.attrib['version']})
 
     layers = et.Element('layers')
@@ -185,12 +187,12 @@ def dump(input_model, elements, output_model):
 
 def main():
     arguments = build_argument_parser().parse_args()
-    model = dom.parse(str(input_model))
+    model = ddom.parse(str(input_model))
     if int(model.version) < 10:
         print('Error: only IR version 10 or newer is supported, IRv{} has been given'.format(model.version))
         sys.exit(-1)
 
-    layers, edges, _ = et.parse(str(arguments.model)).getroot()
+    layers, edges, _ = dET.parse(str(arguments.model)).getroot()
     layers_identifiers = {}
     for layer in layers:
         layers_identifiers[int(layer.attrib['id'])] = layer

--- a/src/tests_deprecated/functional/vpu/tester.py
+++ b/src/tests_deprecated/functional/vpu/tester.py
@@ -9,11 +9,16 @@ from argparse import ArgumentParser
 
 from typing import Union
 
-import xml.etree.cElementTree as et
-import xml.dom.minidom as dom
-import defusedxml.ElementTree as dET
-import defusedxml.minidom as ddom
+import defusedxml.ElementTree as ET
+import defusedxml.minidom as dom
+from defusedxml import defuse_stdlib
 
+# defuse_stdlib provide patched version of xml.etree.ElementTree which allows to use objects from xml.etree.ElementTree
+# in a safe manner without including unsafe xml.etree.ElementTree
+ET_defused = defuse_stdlib()[ET]
+Element = ET_defused.Element
+dom_defused = defuse_stdlib()[dom]
+Document = dom_defused.Document
 
 def get_path(entry: Union[str, Path], is_directory=False, check_exists=True, file_or_directory=False):
     try:
@@ -77,7 +82,7 @@ def build_argument_parser():
 
 
 def tostring(layer, num_tabs=0):
-    return '\t' * num_tabs + str(dET.tostring(layer, encoding='utf-8').decode())
+    return '\t' * num_tabs + str(ET.tostring(layer, encoding='utf-8').decode())
 
 
 def tags(node):
@@ -88,17 +93,17 @@ def tags(node):
 
 
 def make_input(layer, port_id):
-    output = et.Element('output')
+    output = Element('output')
     output_port = next(port for port in tags(layer)['output'] if int(port.attrib['id']) == int(port_id))
     output.append(output_port)
 
     precision_to_element_type = {'FP16': 'f16', 'I32': 'i32', 'FP32': 'f32'}
-    data = et.Element('data', attrib={
+    data = Element('data', attrib={
         'element_type': precision_to_element_type[output_port.attrib['precision']],
         'shape': ','.join([dim.text for dim in output_port])}
     )
 
-    input_layer = et.Element('layer', attrib={
+    input_layer = Element('layer', attrib={
         'id': layer.attrib['id'],
         'name': layer.attrib['name'],
         'type': 'Parameter',
@@ -111,11 +116,11 @@ def make_input(layer, port_id):
 
 
 def make_output(layer, port_id):
-    input_section = et.Element('input')
+    input_section = Element('input')
     input_port = next(port for port in tags(layer)['input'] if int(port.attrib['id']) == int(port_id))
     input_section.append(input_port)
 
-    output_layer = et.Element('layer', attrib={
+    output_layer = Element('layer', attrib={
         'id': layer.attrib['id'],
         'name': layer.attrib['name'],
         'type': 'Result',
@@ -160,20 +165,20 @@ def extract_weights(source, layers, destination):
 
 
 def prettify(element, indent=0):
-    header = dom.Document().toxml()
-    string = ddom.parseString(tostring(element)).toprettyxml()[len(header) + 1:]
+    header = Document().toxml()
+    string = dom.parseString(tostring(element)).toprettyxml()[len(header) + 1:]
     return '\n'.join(['\t' * indent + line for line in string.split('\n') if line.strip()])
 
 
 def dump(input_model, elements, output_model):
-    root = dET.parse(str(input_model)).getroot()
-    net = et.Element('net', attrib={'name': root.attrib['name'], 'version': root.attrib['version']})
+    root = ET.parse(str(input_model)).getroot()
+    net = Element('net', attrib={'name': root.attrib['name'], 'version': root.attrib['version']})
 
-    layers = et.Element('layers')
+    layers = Element('layers')
     for layer in elements['layers']:
         layers.append(layer)
 
-    edges = et.Element('edges')
+    edges = Element('edges')
     for edge in elements['edges']:
         edges.append(edge)
 
@@ -187,12 +192,12 @@ def dump(input_model, elements, output_model):
 
 def main():
     arguments = build_argument_parser().parse_args()
-    model = ddom.parse(str(input_model))
+    model = dom.parse(str(input_model))
     if int(model.version) < 10:
         print('Error: only IR version 10 or newer is supported, IRv{} has been given'.format(model.version))
         sys.exit(-1)
 
-    layers, edges, _ = dET.parse(str(arguments.model)).getroot()
+    layers, edges, _ = ET.parse(str(arguments.model)).getroot()
     layers_identifiers = {}
     for layer in layers:
         layers_identifiers[int(layer.attrib['id'])] = layer

--- a/tests/layer_tests/common/layer_test_class.py
+++ b/tests/layer_tests/common/layer_test_class.py
@@ -5,7 +5,7 @@ import itertools
 import os
 import re
 import warnings
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from pathlib import Path
 
 import numpy as np

--- a/tests/layer_tests/common/utils/parsers.py
+++ b/tests/layer_tests/common/utils/parsers.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import xml.etree.ElementTree
+import defusedxml.ElementTree as ET
 
 
 def mapping_parser(file):
@@ -13,7 +13,7 @@ def mapping_parser(file):
     """
     mapping_dict = {}
     if os.path.splitext(file)[1] == '.mapping' and os.path.isfile(file):
-        xml_tree = xml.etree.ElementTree.parse(file)
+        xml_tree = ET.parse(file)
         xml_root = xml_tree.getroot()
         for child in xml_root:
             framework_info = child.find('.//framework')

--- a/tests/stress_tests/scripts/get_testdata.py
+++ b/tests/stress_tests/scripts/get_testdata.py
@@ -18,7 +18,7 @@ import sys
 from distutils.dir_util import copy_tree
 from inspect import getsourcefile
 from pathlib import Path
-from xml.etree import ElementTree as ET
+import defusedxml.ElementTree as ET
 
 log.basicConfig(format="{file}: [ %(levelname)s ] %(message)s".format(file=os.path.basename(__file__)),
                 level=log.INFO, stream=sys.stdout)

--- a/tests/stress_tests/scripts/memcheck_upload.py
+++ b/tests/stress_tests/scripts/memcheck_upload.py
@@ -17,7 +17,7 @@ import logging
 import os
 import re
 import sys
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from glob import glob
 from inspect import getsourcefile
 from types import SimpleNamespace

--- a/tests/stress_tests/scripts/requirements.txt
+++ b/tests/stress_tests/scripts/requirements.txt
@@ -6,3 +6,4 @@ pandas>=1.3.5
 h5py>=3.1.0
 scipy~=1.7; python_version == '3.7'
 scipy>=1.8; python_version >= '3.8'
+defusedxml>=0.7.1

--- a/tools/mo/unit_tests/mo/back/ie_ir_ver_2/emitter_test.py
+++ b/tools/mo/unit_tests/mo/back/ie_ir_ver_2/emitter_test.py
@@ -3,7 +3,8 @@
 
 import unittest
 from unittest.mock import MagicMock
-from xml.etree.ElementTree import Element, tostring
+import defusedxml.ElementTree as ET
+from defusedxml import defuse_stdlib
 
 import numpy as np
 
@@ -12,6 +13,12 @@ from openvino.tools.mo.graph.graph import Node
 from openvino.tools.mo.utils.error import Error
 from openvino.tools.mo.utils.runtime_info import RTInfo, OldAPIMapOrder, OldAPIMapElementType
 from unit_tests.utils.graph import build_graph, result, regular_op
+
+# defuse_stdlib provide patched version of xml.etree.ElementTree which allows to use objects from xml.etree.ElementTree
+# in a safe manner without including unsafe xml.etree.ElementTree
+ET_defused = defuse_stdlib()[ET]
+Element = ET_defused.Element
+tostring = ET_defused.tostring
 
 expected_result = b'<net><dim>2</dim><dim>10</dim><dim>50</dim><dim>50</dim></net>'
 


### PR DESCRIPTION
### Details:
 - According to bandit scan `xml.ElementTree`, `xml.dom.minidom`  [are vulnerable and better to use](https://pypi.org/project/defusedxml/#toc-entry-10) `defusedxml`.

### Tickets:
 - 93400
