### PR TITLE
[CPU] Avoid extra copying of Loop/TI bodies

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/generic.cpp
+++ b/src/plugins/intel_cpu/src/nodes/generic.cpp
@@ -17,8 +17,34 @@ namespace ov {
 namespace intel_cpu {
 namespace node {
 
+namespace {
+/**
+ * Dummy Shape Inference while Generic op doesn't support Dynamism
+ *
+ */
+class GenericShapeInfer : public ShapeInferEmptyPads {
+public:
+    GenericShapeInfer() = default;
+    std::vector<VectorDims> infer(
+        const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
+        const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
+        IE_THROW(Unexpected) << "Generic operations doesn't support shape inference.";
+        return {};
+    }
+
+    port_mask_t get_port_mask() const override { return EMPTY_PORT_MASK; }
+};
+
+class GenericShapeInferFactory : public ShapeInferFactory {
+public:
+    ShapeInferPtr makeShapeInfer() const override {
+        return std::make_shared<GenericShapeInfer>();
+    }
+};
+} // namespace
+
 Generic::Generic(const std::shared_ptr<ngraph::Node>& op, const dnnl::engine& eng, WeightsSharing::Ptr &cache)
-    : Node(op, eng, cache, NgraphShapeInferFactory(op, EMPTY_PORT_MASK)), ngraphOp(op) {
+    : Node(op, eng, cache, GenericShapeInferFactory()), ngraphOp(op) {
 }
 
 void Generic::getSupportedDescriptors() {


### PR DESCRIPTION
### Details:
 - *At the moment Generic op doesn't support dynamism so PR adds dummy `infer()` that throws exception instead of ngraph way with extra copying of ngraph op*

### Tickets:
 - *96878*
