### PR TITLE
Convert node single layer tests leverage common test utilities to generate inputs

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/conversion.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/conversion.cpp
@@ -86,18 +86,12 @@ protected:
 
         auto shape = targetInputStaticShapes.front();
         size_t size = shape_size(shape);
-        ov::Tensor tensor = ov::test::utils::create_and_fill_tensor(funcInputs[0].get_element_type(), shape, 2 * size);
-
-        if (inPrc == Precision::FP32) {
-            auto *rawBlobDataPtr = static_cast<float *>(tensor.data());
-            for (size_t i = 0; i < size; ++i) {
-                rawBlobDataPtr[i] = rawBlobDataPtr[i] / size - 1;
-            }
-        } else if (inPrc == Precision::BF16) {
-            auto *rawBlobDataPtr = static_cast<ngraph::bfloat16 *>(tensor.data());
-            for (size_t i = 0; i < size; ++i) {
-                rawBlobDataPtr[i] = rawBlobDataPtr[i] / size - 1;
-            }
+        auto element_type = funcInputs[0].get_element_type();
+        auto tensor = ov::Tensor{element_type, shape};
+        if (element_type == ElementType::f32) {
+            CommonTestUtils::fill_tensor_random_float<ElementType::f32>(tensor, 2, -1, size);
+        } else if (element_type == ElementType::bf16) {
+            CommonTestUtils::fill_tensor_random_float<ElementType::bf16>(tensor, 2, -1, size);
         } else {
             FAIL() << "Generating inputs with precision" << inPrc << " isn't supported, if output precision is boolean.";
         }

--- a/src/tests/ie_test_utils/common_test_utils/data_utils.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/data_utils.hpp
@@ -243,13 +243,7 @@ void inline fill_random_unique_sequence(T* rawBlobDataPtr,
     while (elems.size() != size) {
         auto value = static_cast<float>(dist(generator));
         value /= static_cast<float>(k);
-        if (std::is_same<ngraph::float16, T>::value) {
-            elems.insert(static_cast<T>(ngraph::float16(value).to_bits()));
-        } else if (std::is_same<ngraph::bfloat16, T>::value) {
-            elems.insert(static_cast<T>(ngraph::bfloat16(value).to_bits()));
-        } else {
-            elems.insert(static_cast<T>(value));
-        }
+        elems.insert(static_cast<T>(value));
     }
     std::copy(elems.begin(), elems.end(), rawBlobDataPtr);
 }
@@ -290,13 +284,7 @@ fill_tensor_random_float(ov::Tensor& tensor, const uint32_t range, int32_t start
     for (size_t i = 0; i < tensor.get_size(); i++) {
         auto value = static_cast<float>(distribution(random));
         value /= static_cast<float>(k);
-        if (DT == ov::element::Type_t::f16) {
-            rawBlobDataPtr[i] = static_cast<T>(ngraph::float16(value).to_bits());
-        } else if (DT == ov::element::Type_t::bf16) {
-            rawBlobDataPtr[i] = static_cast<T>(ngraph::bfloat16(value).to_bits());
-        } else {
-            rawBlobDataPtr[i] = static_cast<T>(value);
-        }
+        rawBlobDataPtr[i] = static_cast<T>(value);
     }
 }
 
@@ -407,13 +395,7 @@ fill_data_random_float(InferenceEngine::Blob::Ptr &blob, const uint32_t range, i
     for (size_t i = 0; i < blob->size(); i++) {
         auto value = static_cast<float>(distribution(random));
         value /= static_cast<float>(k);
-        if (PRC == InferenceEngine::Precision::FP16) {
-            rawBlobDataPtr[i] = static_cast<T>(ngraph::float16(value).to_bits());
-        } else if (PRC == InferenceEngine::Precision::BF16) {
-            rawBlobDataPtr[i] = static_cast<T>(ngraph::bfloat16(value).to_bits());
-        } else {
-            rawBlobDataPtr[i] = static_cast<T>(value);
-        }
+        rawBlobDataPtr[i] = static_cast<T>(value);
     }
 }
 


### PR DESCRIPTION
### Details:
 - *Supplementary PR of https://github.com/openvinotoolkit/openvino/pull/14174. Convert node single layer tests leverage common test utilities to generate inputs.*
 - *Fix bug about constructing ngraph::bfloat16 and ngraph::float16 in test utilities. Take bfloat16 as an example, fp32 can be used to construct bfloat16 directly. But if we use ngraph::bfloat16(fp32_value).to_bits(), which is an integer union of the original fp32, to construct bfloat16, the integer will be static casted to fp32, then construct bfloat16. It's not the original value any more.*

