### PR TITLE
[GNA] Remove internal overload correction algorithm

### DIFF
--- a/src/plugins/intel_gna/tests/functional/pass_tests/fq_fusion_with_multiple_weights.cpp
+++ b/src/plugins/intel_gna/tests/functional/pass_tests/fq_fusion_with_multiple_weights.cpp
@@ -72,8 +72,8 @@ protected:
         auto weights = ngraph::builder::makeConstant<float>(ngPrc, {outChannels, inputShape[1], 1, kernelSize},
             CommonTestUtils::generate_float_numbers(outChannels * inputShape[1] * kernelSize,
                                                     weightsMinMax.first, weightsMinMax.second));
-        auto weightsLowNode = ngraph::builder::makeConstant<float>(ngPrc, {1}, { weightsMinMax.first });
-        auto weightsHighNode = ngraph::builder::makeConstant<float>(ngPrc, {1}, { weightsMinMax.second });
+        auto weightsLowNode = ngraph::builder::makeConstant<float>(ngPrc, {1}, { weightsMinMax.first * 2 });
+        auto weightsHighNode = ngraph::builder::makeConstant<float>(ngPrc, {1}, { weightsMinMax.second * 2 });
         auto weightsFQ = std::make_shared<ngraph::opset7::FakeQuantize>(weights,
             weightsLowNode, weightsHighNode, weightsLowNode, weightsHighNode, levels);
 

--- a/src/plugins/intel_gna/tests/functional/pass_tests/fq_maxpool_reordering.cpp
+++ b/src/plugins/intel_gna/tests/functional/pass_tests/fq_maxpool_reordering.cpp
@@ -96,8 +96,8 @@ protected:
             inputLowNode1, inputHighNode1, inputLowNode1, inputHighNode1, levels);
 
         auto filterWeightsNode = ngraph::builder::makeConstant<float>(ngPrc, {8, inputShape[1], 1, 8}, { 1.0f });
-        auto convLowNode = ngraph::builder::makeConstant(ngraph::element::f32, std::vector<size_t>{ 1 }, std::vector<float>{inputDataMin1});
-        auto convHighNode = ngraph::builder::makeConstant(ngraph::element::f32, std::vector<size_t>{ 1 }, std::vector<float>{inputDataMax1});
+        auto convLowNode = ngraph::builder::makeConstant(ngraph::element::f32, std::vector<size_t>{ 1 }, std::vector<float>{inputDataMin1 * 35});
+        auto convHighNode = ngraph::builder::makeConstant(ngraph::element::f32, std::vector<size_t>{ 1 }, std::vector<float>{inputDataMax1 * 35});
         auto convWeightsFQNode = std::make_shared<ngraph::opset1::FakeQuantize>(filterWeightsNode,
             convLowNode, convHighNode, convLowNode, convHighNode, levels);
         auto convWeightsFQ = std::dynamic_pointer_cast<ngraph::opset1::FakeQuantize>(convWeightsFQNode);
@@ -148,7 +148,7 @@ const std::vector<std::map<std::string, std::string>> configs = {
 
 const std::vector<std::vector<size_t>> inputShape = {
     {1, 1, 1, 1024},
-    {1, 8, 1, 168},
+    {1, 8, 1, 168}
 };
 
 const std::vector<std::pair<float, float>> inputMinMax = {
@@ -156,11 +156,11 @@ const std::vector<std::pair<float, float>> inputMinMax = {
     {-2, 2},
     {-8, 8},
     {-5, 5},
-    {-17.5, 17.5},
+    {-17.5, 17.5}
 };
 
 const std::vector<size_t> levels = {
-    65535,
+    65535
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_fq_maxpool_reordering, FQMaxpoolReordering,

--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/subgraph_tests/conv_fq_eltwise.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/subgraph_tests/conv_fq_eltwise.cpp
@@ -13,7 +13,8 @@ using namespace SubgraphTestsDefinitions;
 namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
-        InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16,
+        InferenceEngine::Precision::FP32,
+        InferenceEngine::Precision::FP16
 };
 
 const std::vector<std::map<std::string, std::string>> configs = {
@@ -29,9 +30,12 @@ const size_t levels = 65535;
 
 const std::vector<std::vector<float>> inputParams = {{-10, 10, 1}};
 
+const float convFQValue = 2.0f;
+
 const auto fqParams = ::testing::Combine(
         ::testing::Values(levels),
-        ::testing::ValuesIn(inputParams)
+        ::testing::ValuesIn(inputParams),
+        ::testing::Values(convFQValue)
 );
 
 const std::vector<std::vector<size_t>> kernels = {{1, 3}};

--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/subgraph_tests/conv_fq_relu.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/subgraph_tests/conv_fq_relu.cpp
@@ -13,7 +13,8 @@ using namespace SubgraphTestsDefinitions;
 namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
-        InferenceEngine::Precision::FP32, InferenceEngine::Precision::FP16,
+        InferenceEngine::Precision::FP32,
+        InferenceEngine::Precision::FP16,
 };
 
 const std::vector<std::map<std::string, std::string>> configs = {
@@ -29,9 +30,12 @@ const size_t levels = 65535;
 
 const std::vector<std::vector<float>> inputParams = {{-100, 100, 1}};
 
+const float convFQValue = 2.0f;
+
 const auto fqParams = ::testing::Combine(
         ::testing::Values(levels),
-        ::testing::ValuesIn(inputParams)
+        ::testing::ValuesIn(inputParams),
+        ::testing::Values(convFQValue)
 );
 
 const std::vector<std::vector<size_t>> kernels = {{1, 3}};

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/conv_fq_eltwise.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/conv_fq_eltwise.hpp
@@ -17,7 +17,8 @@ namespace SubgraphTestsDefinitions {
 
 typedef std::tuple<
         size_t,                           // levels
-        std::vector<float>                // input generator data: low, high, resolution
+        std::vector<float>,               // input generator data: low, high, resolution
+        float                             // convolution weights' FQ min and max value
 > FqSpecificParams;
 
 typedef std::tuple<

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/conv_fq_relu.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/conv_fq_relu.hpp
@@ -17,7 +17,8 @@ namespace SubgraphTestsDefinitions {
 
 typedef std::tuple<
         size_t,                           // levels
-        std::vector<float>                // input generator data: low, high, resolution
+        std::vector<float>,               // input generator data: low, high, resolution
+        float                             // convolution weights' FQ min and max value
 > FqSpecificParams;
 
 typedef std::tuple<

--- a/src/tests/functional/shared_test_classes/src/subgraph/conv_fq_relu.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/conv_fq_relu.cpp
@@ -17,7 +17,8 @@ std::string ConvFqReluTest::getTestCaseName(const testing::TestParamInfo<ConvFqR
 
     size_t levels;
     std::vector<float> inputArg;
-    std::tie(levels, inputArg) = fqParams;
+    float convFQValue;
+    std::tie(levels, inputArg, convFQValue) = fqParams;
 
     std::vector<size_t> kernelShape;
     std::vector<size_t> strides;
@@ -36,6 +37,7 @@ std::string ConvFqReluTest::getTestCaseName(const testing::TestParamInfo<ConvFqR
      if (inputArg.size() == 3) {
         result << "_inputArg=" << inputArg[0] << "_" << inputArg[1] << "_" << inputArg[2];
     }
+    result << "_convFQ=" << convFQValue;
     result << "_KERNEL=" << CommonTestUtils::vec2str(kernelShape) << "_";
     result << "STRIDES=" << CommonTestUtils::vec2str(strides) << "_";
     result << "IC=" << inputChannels << "_";
@@ -54,7 +56,8 @@ void ConvFqReluTest::SetUp() {
 
     size_t levels;
     std::vector<float> inputArg;
-    std::tie(levels, inputArg) = fqParams;
+    float convFQValue;
+    std::tie(levels, inputArg, convFQValue) = fqParams;
     if (inputArg.size() == 3) {
         inputDataMin = inputArg[0];
         inputDataMax = inputArg[1];
@@ -80,8 +83,10 @@ void ConvFqReluTest::SetUp() {
     float weightVal = 0.2;
     auto filterWeightsNode = ngraph::builder::makeConstant<float>(ngPrc, {outputChannels, inputChannels, kernelShape[0], kernelShape[1]},
                                                                   { weightVal });
-    auto convLowNode = ngraph::builder::makeConstant(ngraph::element::f32, std::vector<size_t>{ 1 }, std::vector<float>{-weightVal});
-    auto convHighNode = ngraph::builder::makeConstant(ngraph::element::f32, std::vector<size_t>{ 1 }, std::vector<float>{weightVal});
+    auto convLowNode =
+        ngraph::builder::makeConstant(ngraph::element::f32, std::vector<size_t>{1}, std::vector<float>{-convFQValue});
+    auto convHighNode =
+        ngraph::builder::makeConstant(ngraph::element::f32, std::vector<size_t>{1}, std::vector<float>{convFQValue});
     auto convWeightsFQNode = std::make_shared<ngraph::opset1::FakeQuantize>(filterWeightsNode,
         convLowNode, convHighNode, convLowNode, convHighNode, levels);
     auto convWeightsFQ = std::dynamic_pointer_cast<ngraph::opset1::FakeQuantize>(convWeightsFQNode);


### PR DESCRIPTION
### Details:
 - remove plugin's internal overload correction algorithm for affine layers, which is now included in POT.

### Tickets:
 - 78001.
