### PR TITLE
[TF FE] Support dynamic shape Placeholder freezing and PlaceholderWithDefault

### DIFF
--- a/src/frontends/tensorflow/src/input_model.cpp
+++ b/src/frontends/tensorflow/src/input_model.cpp
@@ -116,15 +116,18 @@ void InputModel::InputModelTFImpl::loadPlaces() {
         all_op_names.insert(op_name);
         m_op_places.push_back(op_place);
         m_op_places_map[op_name] = op_place;
-        if (op_type == "Placeholder") {
+        if (op_type == "Placeholder" || op_type == "PlaceholderWithDefault") {
+            // in case Placeholder we put created TensorPlace to both m_tensor_places container and m_inputs
+            // since they can be used if user does not override them
+            // in case PlaceholderWithDefault we put created TensorPlace only to m_tensor_places container
+            // so that we know its shape and type for a case of custom input
+            // by default, PlaceholderWithDefault is replaced by Constant with the default value
             auto pshape = ov::PartialShape::dynamic();
             auto shape_any = node_decoder->get_attribute("shape");
             if (shape_any.is<ov::PartialShape>()) {
                 // sometimes shape attribute can be absent in the graph
                 // so we need to check if Any object is initialized first
                 pshape = shape_any.as<ov::PartialShape>();
-            } else {
-                OPENVINO_DEBUG << "TensorFlow Frontend: Placeholder " << op_name << " does not have 'shape' attribute";
             }
             auto output_shapes_any = node_decoder->get_attribute("_output_shapes");
             if (pshape.rank().is_static() && pshape.rank().get_length() == 0 &&
@@ -148,7 +151,10 @@ void InputModel::InputModelTFImpl::loadPlaces() {
             std::vector<std::string> names = {op_name};
             auto tensor_place = std::make_shared<TensorPlace>(m_input_model, pshape, type, names);
             m_tensor_places[op_name] = tensor_place;
-            m_inputs.push_back(tensor_place);
+            if (op_type == "Placeholder") {
+                // by default, PlaceholderWithDefault is NOT used as input
+                m_inputs.push_back(tensor_place);
+            }
         }
         for (size_t input_port_idx = 0; input_port_idx < node_decoder->get_input_size(); ++input_port_idx) {
             std::string producer_op_name;
@@ -331,9 +337,10 @@ ov::frontend::Place::Ptr InputModel::InputModelTFImpl::getPlaceByTensorName(cons
     std::string port_type;
     tensorflow::extract_operation_name_and_port(tensorName, operation_name, port_idx, port_type);
     if (m_op_places_map.find(operation_name) != m_op_places_map.end()) {
+        // new Tensor places must be constructed of dynamic rank and type
         std::vector<std::string> names = {tensorName};
         auto m_var_place =
-            std::make_shared<TensorPlace>(m_input_model, ov::PartialShape(), ov::element::undefined, names);
+            std::make_shared<TensorPlace>(m_input_model, ov::PartialShape::dynamic(), ov::element::undefined, names);
         m_tensor_places[tensorName] = m_var_place;
         return m_var_place;
     }
@@ -396,8 +403,14 @@ void InputModel::InputModelTFImpl::setTensorValue(ov::frontend::Place::Ptr place
     auto tensor_place = castToTensorPlace(place);
     auto p_shape = tensor_place->get_partial_shape();
     auto type = tensor_place->get_element_type();
-    auto constant = opset7::Constant::create(type, p_shape.to_shape(), value);
+    FRONT_END_GENERAL_CHECK(tensor_place->get_names().size() > 0,
+                            "TensorFlow Frontend: place to be frozen must have the name.");
     auto name = tensor_place->get_names()[0];
+    FRONT_END_GENERAL_CHECK(p_shape.is_static(),
+                            "TensorFlow Frontend: specify static shape for " + name + " to be frozen.");
+    FRONT_END_GENERAL_CHECK(type.is_static(),
+                            "TensorFlow Frontend: define static size type for " + name + " to be frozen.");
+    auto constant = opset7::Constant::create(type, p_shape.to_shape(), value);
     constant->set_friendly_name(name);
     m_tensor_values[name] = constant;
 }

--- a/src/frontends/tensorflow/src/input_model.cpp
+++ b/src/frontends/tensorflow/src/input_model.cpp
@@ -128,6 +128,8 @@ void InputModel::InputModelTFImpl::loadPlaces() {
                 // sometimes shape attribute can be absent in the graph
                 // so we need to check if Any object is initialized first
                 pshape = shape_any.as<ov::PartialShape>();
+            } else {
+                OPENVINO_DEBUG << "TensorFlow Frontend: Placeholder " << op_name << " does not have 'shape' attribute";
             }
             auto output_shapes_any = node_decoder->get_attribute("_output_shapes");
             if (pshape.rank().is_static() && pshape.rank().get_length() == 0 &&

--- a/tools/mo/unit_tests/moc_tf_fe/test_models/model_bool.pbtxt
+++ b/tools/mo/unit_tests/moc_tf_fe/test_models/model_bool.pbtxt
@@ -1,0 +1,52 @@
+node {
+  name: "in1"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_BOOL
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 2
+        }
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "in2"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_BOOL
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 2
+        }
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "LogicalAnd"
+  op: "LogicalAnd"
+  input: "in1"
+  input: "in2"
+}

--- a/tools/mo/unit_tests/moc_tf_fe/test_models/model_bool.py
+++ b/tools/mo/unit_tests/moc_tf_fe/test_models/model_bool.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import tensorflow.compat.v1 as tf
+
+tf.reset_default_graph()
+with tf.Session() as sess:
+    x = tf.placeholder(tf.bool, [2, 3], 'in1')
+    y = tf.placeholder(tf.bool, [2, 3], 'in2')
+    tf.math.logical_and(x, y)
+
+    tf.global_variables_initializer()
+    tf_net = sess.graph_def
+
+tf.io.write_graph(tf_net, './', 'model_bool.pbtxt', True)

--- a/tools/mo/unit_tests/moc_tf_fe/test_models/model_bool2.pbtxt
+++ b/tools/mo/unit_tests/moc_tf_fe/test_models/model_bool2.pbtxt
@@ -1,0 +1,70 @@
+node {
+  name: "in1"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "in2"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "cond"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_BOOL
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+      }
+    }
+  }
+}
+node {
+  name: "Select"
+  op: "Select"
+  input: "cond"
+  input: "in1"
+  input: "in2"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}

--- a/tools/mo/unit_tests/moc_tf_fe/test_models/model_bool2.py
+++ b/tools/mo/unit_tests/moc_tf_fe/test_models/model_bool2.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import tensorflow.compat.v1 as tf
+
+tf.reset_default_graph()
+with tf.Session() as sess:
+    x = tf.placeholder(tf.float32, [3], 'in1')
+    y = tf.placeholder(tf.float32, [3], 'in2')
+    cond = tf.placeholder(tf.bool, [], 'cond')
+    tf.where(cond, x, y)
+
+    tf.global_variables_initializer()
+    tf_net = sess.graph_def
+
+tf.io.write_graph(tf_net, './', 'model_bool2.pbtxt', True)

--- a/tools/mo/unit_tests/moc_tf_fe/test_models/model_fp32.pbtxt
+++ b/tools/mo/unit_tests/moc_tf_fe/test_models/model_fp32.pbtxt
@@ -1,0 +1,58 @@
+node {
+  name: "in1"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 2
+        }
+        dim {
+          size: 2
+        }
+      }
+    }
+  }
+}
+node {
+  name: "in2"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 2
+        }
+        dim {
+          size: 2
+        }
+      }
+    }
+  }
+}
+node {
+  name: "add"
+  op: "AddV2"
+  input: "in1"
+  input: "in2"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}

--- a/tools/mo/unit_tests/moc_tf_fe/test_models/model_fp32.py
+++ b/tools/mo/unit_tests/moc_tf_fe/test_models/model_fp32.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import tensorflow.compat.v1 as tf
+
+tf.reset_default_graph()
+with tf.Session() as sess:
+    x = tf.placeholder(tf.float32, [2, 2], 'in1')
+    y = tf.placeholder(tf.float32, [2, 2], 'in2')
+    tf.add(x, y, name="add")
+
+    tf.global_variables_initializer()
+    tf_net = sess.graph_def
+
+tf.io.write_graph(tf_net, './', 'model_fp32.pbtxt', True)

--- a/tools/mo/unit_tests/moc_tf_fe/test_models/model_int32.pbtxt
+++ b/tools/mo/unit_tests/moc_tf_fe/test_models/model_int32.pbtxt
@@ -1,0 +1,58 @@
+node {
+  name: "in1"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 2
+        }
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "in2"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 2
+        }
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "add"
+  op: "Mul"
+  input: "in1"
+  input: "in2"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}

--- a/tools/mo/unit_tests/moc_tf_fe/test_models/model_int32.py
+++ b/tools/mo/unit_tests/moc_tf_fe/test_models/model_int32.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import tensorflow.compat.v1 as tf
+
+tf.reset_default_graph()
+with tf.Session() as sess:
+    x = tf.placeholder(tf.int32, [2, 3], 'in1')
+    y = tf.placeholder(tf.int32, [2, 3], 'in2')
+    tf.multiply(x, y, name="add")
+
+    tf.global_variables_initializer()
+    tf_net = sess.graph_def
+
+tf.io.write_graph(tf_net, './', 'model_int32.pbtxt', True)

--- a/tools/mo/unit_tests/moc_tf_fe/test_models/model_three_inputs.pbtxt
+++ b/tools/mo/unit_tests/moc_tf_fe/test_models/model_three_inputs.pbtxt
@@ -1,0 +1,84 @@
+node {
+  name: "x"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "y"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "z"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "add"
+  op: "AddV2"
+  input: "x"
+  input: "y"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "multiply"
+  op: "Mul"
+  input: "add"
+  input: "z"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}

--- a/tools/mo/unit_tests/moc_tf_fe/test_models/model_three_inputs.py
+++ b/tools/mo/unit_tests/moc_tf_fe/test_models/model_three_inputs.py
@@ -1,0 +1,17 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import tensorflow.compat.v1 as tf
+
+tf.reset_default_graph()
+with tf.Session() as sess:
+    x = tf.placeholder(tf.float32, [3], 'x')
+    y = tf.placeholder(tf.float32, [3], 'y')
+    z = tf.placeholder(tf.float32, [3], 'z')
+    add = tf.add(x, y, name="add")
+    tf.multiply(add, z, name="multiply")
+
+    tf.global_variables_initializer()
+    tf_net = sess.graph_def
+
+tf.io.write_graph(tf_net, './', 'model_three_inputs.pbtxt', True)

--- a/tools/mo/unit_tests/moc_tf_fe/test_models/mul_with_unknown_rank_y.pbtxt
+++ b/tools/mo/unit_tests/moc_tf_fe/test_models/mul_with_unknown_rank_y.pbtxt
@@ -1,0 +1,50 @@
+node {
+  name: "x"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "y"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        unknown_rank: true
+      }
+    }
+  }
+}
+node {
+  name: "Mul"
+  op: "Mul"
+  input: "x"
+  input: "y"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}

--- a/tools/mo/unit_tests/moc_tf_fe/test_models/mul_with_unknown_rank_y.py
+++ b/tools/mo/unit_tests/moc_tf_fe/test_models/mul_with_unknown_rank_y.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import tensorflow.compat.v1 as tf
+
+tf.reset_default_graph()
+with tf.Session() as sess:
+    x = tf.placeholder(tf.float32, [3], 'x')
+    keep_prob = tf.placeholder(tf.float32, None, 'y')
+    tf.multiply(x, keep_prob)
+
+    tf.global_variables_initializer()
+    tf_net = sess.graph_def
+
+tf.io.write_graph(tf_net, './', 'mul_with_unknown_rank_y.pbtxt', True)

--- a/tools/mo/unit_tests/moc_tf_fe/test_models/placeholder_with_default.pbtxt
+++ b/tools/mo/unit_tests/moc_tf_fe/test_models/placeholder_with_default.pbtxt
@@ -1,0 +1,86 @@
+node {
+  name: "x"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: -1
+        }
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "Const"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+          dim {
+            size: 3
+          }
+        }
+        tensor_content: "\001\000\000\000\002\000\000\000\003\000\000\000\004\000\000\000\005\000\000\000\006\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "y"
+  op: "PlaceholderWithDefault"
+  input: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: -1
+        }
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "Add"
+  op: "AddV2"
+  input: "x"
+  input: "y"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}

--- a/tools/mo/unit_tests/moc_tf_fe/test_models/placeholder_with_default.py
+++ b/tools/mo/unit_tests/moc_tf_fe/test_models/placeholder_with_default.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import tensorflow.compat.v1 as tf
+
+tf.reset_default_graph()
+with tf.Session() as sess:
+    x = tf.placeholder(tf.int32, [None, 3], 'x')
+    y = tf.placeholder_with_default(tf.constant([[1, 2, 3], [4, 5, 6]], dtype=tf.int32),
+                                    [None, 3], 'y')
+    tf.add(x, y)
+
+    tf.global_variables_initializer()
+    tf_net = sess.graph_def
+
+tf.io.write_graph(tf_net, './', 'placeholder_with_default.pbtxt', True)


### PR DESCRIPTION
**Details:** It supports of extraction of the original shape and type for PlaceholderWithDefault nodes and freezing Placeholders of dynamic shape for which cases shape of created Constant will be deduces on the value shape.
Also, this PR contains reorganization of python unit tests for TF FE that covers conversion and inference of different models in pbtxt. This mini-infrastructure will be used in the future for TF FE support.

**Tickets:** 98459, 98458

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
