### PR TITLE
[CC] Upgrade oneDNN to fix CC inference test_model_fp32.xml crash issue.

### DIFF
--- a/.ci/azure/linux_conditional_compilation.yml
+++ b/.ci/azure/linux_conditional_compilation.yml
@@ -150,7 +150,7 @@ jobs:
   - script: ls -alR $(REPO_DIR)/bin/
     displayName: 'List bin files ON'
   # TODO: ebable after the fix on CPU side
-  # - script: |
-  #     $(REPO_DIR)/bin/intel64/Release/benchmark_app -niter 1 -nireq 1 -m $(MODELS_PATH)/models/test_model/test_model_fp32.xml -d CPU
-  #   workingDirectory: $(REPO_DIR)
-  #   displayName: 'Use OpenVINO after CC'
+  - script: |
+      $(REPO_DIR)/bin/intel64/Release/benchmark_app -niter 1 -nireq 1 -m $(MODELS_PATH)/models/test_model/test_model_fp32.xml -d CPU
+    workingDirectory: $(REPO_DIR)
+    displayName: 'Use OpenVINO after CC'


### PR DESCRIPTION
### Details:
 - *Porting https://github.com/openvinotoolkit/openvino/pull/14367 to releases/2022/3*

### Tickets:
 - *96476*
