### PR TITLE
[GPU] Fixed invalid offset for tensor with batch padding

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -578,8 +578,8 @@ JitDefinitions DataTensorJitConstant::GetDefinitions() const {
         } else {
             auto f_pad = toCodeString(_tensor.Feature().pad.before);
             auto f_size = toCodeString(_tensor.Feature().v);
-            definitions.push_back({ safe_index_func_name, "((" + f_pad + " + (f)) % " + f_size + ")" });
-            definitions.push_back({ index_func_name, "(" + toCodeString(_tensor.Feature().pad.before) + " + (f))" });
+            definitions.push_back({ safe_index_func_name, "((" + offset + " + (f)) % " + f_size + ")" });
+            definitions.push_back({ index_func_name, "(" + offset + " + (f))" });
         }
     } else {
         definitions.push_back({ safe_index_func_name, safe_index_func_val });


### PR DESCRIPTION
### Details:
 - Tensor offset generated for some crop cases didn't respect batch padding. This patch adds such checks. Related PR to 22.3 release branch: #14459 

### Tickets:
 - *95768*