### PR TITLE
[MO] Fix FusedBatchNormV3 in training format

### DIFF
--- a/tools/mo/openvino/tools/mo/middle/FusedBatchNormTraining.py
+++ b/tools/mo/openvino/tools/mo/middle/FusedBatchNormTraining.py
@@ -27,7 +27,8 @@ class FusedBatchNormTraining(MiddleReplacementPattern):
     force_shape_inference = True
     force_clean_up = True
     # transformation works for the NHWC layout because transformation inserts Reshape to fuse N and H dimensions
-    graph_condition = [lambda graph: graph.graph['layout'] == 'NHWC']
+    graph_condition = [lambda graph: graph.graph['layout'] == 'NHWC' or
+                                     getattr(graph.graph['cmd_params'], 'auto_disable_nhwc_to_nchw', False)]
 
     def pattern(self):
         return dict(


### PR DESCRIPTION
### Details:
 - *In case model doesn't have convolutions internal MO layout will be set as `NCHW` to disable layout permutations inside MO, but actual layout is still `NHWC` so transformation for replacing `FusedBatchNormV3` should still be triggered.*

### Tickets:
 - *96012*
