### PR TITLE
[TF FE] Break the cycle in the different way

### DIFF
--- a/src/frontends/tensorflow/tests/convert_model.cpp
+++ b/src/frontends/tensorflow/tests/convert_model.cpp
@@ -13,6 +13,8 @@ using TFConvertModelTest = FrontEndConvertModelTest;
 
 static const std::vector<std::string> models{
     std::string("2in_2out/2in_2out.pb"),
+    std::string("forward_edge_model/forward_edge_model.pb"),
+    std::string("forward_edge_model2/forward_edge_model2.pb"),
 };
 
 INSTANTIATE_TEST_SUITE_P(TFConvertModelTest,

--- a/src/frontends/tensorflow/tests/test_models/models_pbtxt/forward_edge_model.pbtxt
+++ b/src/frontends/tensorflow/tests/test_models/models_pbtxt/forward_edge_model.pbtxt
@@ -1,0 +1,79 @@
+node {
+  name: "Const"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 2.0
+      }
+    }
+  }
+}
+node {
+  name: "x"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 2
+        }
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "Relu"
+  op: "Relu"
+  input: "x"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "add"
+  op: "AddV2"
+  input: "Relu"
+  input: "Const"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "Mul"
+  op: "Mul"
+  input: "add"
+  input: "Relu"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}

--- a/src/frontends/tensorflow/tests/test_models/models_pbtxt/forward_edge_model.py
+++ b/src/frontends/tensorflow/tests/test_models/models_pbtxt/forward_edge_model.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+
+import tensorflow.compat.v1 as tf
+
+tf.reset_default_graph()
+
+with tf.Session() as sess:
+    const2 = tf.constant(2.0, dtype=tf.float32)
+    x = tf.placeholder(dtype=tf.float32, shape=[2, 3], name='x')
+    relu = tf.nn.relu(x)    
+    add = tf.add(relu, const2, name="add")
+    # it has forward-edge from relu to multiply
+    # i.e. edge skipping direct child
+    tf.multiply(add, relu)
+
+    tf.global_variables_initializer()
+    tf.io.write_graph(sess.graph, '.', 'forward_edge_model.pb', as_text=False)

--- a/src/frontends/tensorflow/tests/test_models/models_pbtxt/forward_edge_model2.pbtxt
+++ b/src/frontends/tensorflow/tests/test_models/models_pbtxt/forward_edge_model2.pbtxt
@@ -1,0 +1,79 @@
+node {
+  name: "Const"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 2.0
+      }
+    }
+  }
+}
+node {
+  name: "x"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 2
+        }
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "Relu"
+  op: "Relu"
+  input: "x"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "mul"
+  op: "Mul"
+  input: "Relu"
+  input: "Const"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "Add"
+  op: "AddV2"
+  input: "Relu"
+  input: "mul"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}

--- a/src/frontends/tensorflow/tests/test_models/models_pbtxt/forward_edge_model2.py
+++ b/src/frontends/tensorflow/tests/test_models/models_pbtxt/forward_edge_model2.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+
+import tensorflow.compat.v1 as tf
+
+tf.reset_default_graph()
+
+with tf.Session() as sess:
+    const2 = tf.constant(2.0, dtype=tf.float32)
+    x = tf.placeholder(dtype=tf.float32, shape=[2, 3], name='x')
+    relu = tf.nn.relu(x)    
+    mul = tf.multiply(relu, const2, name="mul")
+    # it has forward-edge from relu to multiply
+    # i.e. edge skipping direct child
+    tf.add(relu, mul)
+
+    tf.global_variables_initializer()
+    tf.io.write_graph(sess.graph, '.', 'forward_edge_model2.pb', as_text=False)


### PR DESCRIPTION
**Details:** Earlier solution was incorrect due to inproper handling of forward edges cases (edges going from parent to grand-child) for which topological sorting of nodes can be interrupted.

**Ticket:** 98057

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
