### PR TITLE
[CPU] Fix for the convolution node dummy shapes generation

### DIFF
--- a/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.cpp
@@ -157,5 +157,18 @@ Shape MemoryDescUtils::makeDummyShape(const Shape &shape, Dim dummyVal) {
     return Shape(dummyDims);
 }
 
+Shape MemoryDescUtils::makeDummyShape(const Shape &shape, const VectorDims& dummyVals) {
+    if (shape.getRank() != dummyVals.size()) {
+        IE_THROW() << "makeDummyShape(): dummyVals vector size and shape ranks mismatch";
+    }
+    const auto& minDims = shape.getMinDims();
+    const auto& maxDims = shape.getMaxDims();
+    const auto& dims = shape.getDims();
+    VectorDims dummyDims(dims.size());
+    for (size_t i = 0; i < dims.size(); ++i) {
+        dummyDims[i] = dims[i] == Shape::UNDEFINED_DIM ? std::min(maxDims[i], std::max(minDims[i], dummyVals[i])) : dims[i];
+    }
+    return Shape(dummyDims);
+}
 }   // namespace intel_cpu
 }   // namespace ov

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.h
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.h
@@ -93,7 +93,7 @@ public:
 
     /**
     * @brief Makes a static dummy shape where all undefined values are replaced with the smallest value between the parameter and the upper bound dim
-    * @param shape a shape from which the new static shape is generated
+    * @param shape a Shape object from which the new static shape is generated
     * @param dummyVal Dim value to replace undefined dimensions
     * @return a new Shape with dummy values instead of undefined dims
     */
@@ -101,7 +101,7 @@ public:
 
     /**
     * @brief Makes a static dummy shape where all undefined values are replaced with the smallest value between the parameter and the upper bound dim
-    * @param shape a shape from which the new static shape is generated
+    * @param shape a Shape object from which the new static shape is generated
     * @param dummyVals vector of values to replace undefined dimensions
     * @return a new Shape with dummy values instead of undefined dims
     */

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.h
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.h
@@ -100,6 +100,14 @@ public:
     static Shape makeDummyShape(const Shape& shape, Dim dummyVal = DEFAULT_DUMMY_VAL);
 
     /**
+    * @brief Makes a static dummy shape where all undefined values are replaced with the smallest value between the parameter and the upper bound dim
+    * @param shape a shape from which the new static shape is generated
+    * @param dummyVals vector of values to replace undefined dimensions
+    * @return a new Shape with dummy values instead of undefined dims
+    */
+    static Shape makeDummyShape(const Shape& shape, const VectorDims& dummyVals);
+
+    /**
      * @brief Converts dim to string, undefined dim represented as ?
      * @param dim Dim to be converted
      * @return dim as string

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -916,7 +916,8 @@ void Convolution::addLegacyZeroPoints(dnnl::primitive_attr& attr) {
 void Convolution::SetPostOpsAndZeroPoints(std::vector<dnnl::primitive_attr> &attrs) {
     // attr[0] - Legacy post ops + Legacy zero points.
     attrs.resize(1);
-    setPostOps(attrs[0], outputStaticShape(), true);
+    auto outputShape = outputStaticShape();
+    setPostOps(attrs[0], outputShape, true);
     addLegacyZeroPoints(attrs[0]);
     //dw-conv would be fused into conv only on AVX2 platform. no need attr[1]. Avoid extra useless attribute.
     if (attrs[0].get_post_ops().get()->find(dnnl::impl::primitive_kind::convolution) != -1) {
@@ -938,9 +939,9 @@ void Convolution::SetPostOpsAndZeroPoints(std::vector<dnnl::primitive_attr> &att
         //WR to ONEDNN limitation. attr[1] - legacy post ops + stock zero point.
         //@todo:Unify to use binary postops+stock zero point when limitation is fixed.
         //For now, have to adapt to JIT_AMX kernel for performance.
-        setPostOps(attrs[1], ouptuShape.getStaticDims(), true);
+        setPostOps(attrs[1], outputShape, true);
     else
-        setPostOps(attrs[1], ouptuShape.getStaticDims(), false);
+        setPostOps(attrs[1], outputShape, false);
     addZeroPoints(attrs[1]);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -826,8 +826,7 @@ void Convolution::createDescriptor(const std::vector<MemoryDescPtr>& inputDesc,
     if (inputDesc[0]->isDefined()) {
         inpDesc = inputDesc[0];
     } else {
-        auto dummyInDims = MemoryDescUtils::makeDummyShape(inputDesc[0]->getShape()).getStaticDims();
-        dummyInDims[1] = IC;
+        auto dummyInDims = makeInputDummyShape(inputDesc[0]->getShape());
         inpDesc = inputDesc[0]->cloneWithNewDims(dummyInDims);
     }
     DnnlMemoryDescPtr definedInpMemDesc = MemoryDescUtils::convertToDnnlMemoryDesc(inpDesc);
@@ -917,7 +916,14 @@ void Convolution::addLegacyZeroPoints(dnnl::primitive_attr& attr) {
 void Convolution::SetPostOpsAndZeroPoints(std::vector<dnnl::primitive_attr> &attrs) {
     // attr[0] - Legacy post ops + Legacy zero points.
     attrs.resize(1);
-    setPostOps(attrs[0], MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), true);
+    auto ouptuShape = getOutputShapeAtPort(0);
+    if (ouptuShape.isDynamic()) {
+        auto inpDummyShape = makeInputDummyShape(getInputShapeAtPort(0));
+        auto outputDims = shapeInferGeneric({ Shape(inpDummyShape), Shape(weightDims) });
+        ouptuShape = Shape(outputDims.front());
+    }
+
+    setPostOps(attrs[0], ouptuShape.getStaticDims(), true);
     addLegacyZeroPoints(attrs[0]);
     //dw-conv would be fused into conv only on AVX2 platform. no need attr[1]. Avoid extra useless attribute.
     if (attrs[0].get_post_ops().get()->find(dnnl::impl::primitive_kind::convolution) != -1) {
@@ -939,9 +945,9 @@ void Convolution::SetPostOpsAndZeroPoints(std::vector<dnnl::primitive_attr> &att
         //WR to ONEDNN limitation. attr[1] - legacy post ops + stock zero point.
         //@todo:Unify to use binary postops+stock zero point when limitation is fixed.
         //For now, have to adapt to JIT_AMX kernel for performance.
-        setPostOps(attrs[1], MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), true);
+        setPostOps(attrs[1], ouptuShape.getStaticDims(), true);
     else
-        setPostOps(attrs[1], MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), false);
+        setPostOps(attrs[1], ouptuShape.getStaticDims(), false);
     addZeroPoints(attrs[1]);
 }
 
@@ -1613,7 +1619,13 @@ void Convolution::initTryBrgconvFlag() {
             // should remove after binary postops performance issue resolved
             // heuristics: if it's  avx512 ISA model && it doesn't have binary post ops or per channel zero point.
             dnnl::primitive_attr attr;
-            setPostOps(attr, MemoryDescUtils::makeDummyShape(getOutputShapeAtPort(0)).getStaticDims(), false);
+            auto ouptuShape = getOutputShapeAtPort(0);
+            if (ouptuShape.isDynamic()) {
+                auto inpDummyShape = makeInputDummyShape(getInputShapeAtPort(0));
+                auto outputDims = shapeInferGeneric({ Shape(inpDummyShape), Shape(weightDims) });
+                ouptuShape = Shape(outputDims.front());
+            }
+            setPostOps(attr, ouptuShape.getStaticDims(), false);
             const auto& ops = attr.get_post_ops();
             if (ops.get()->find(dnnl::impl::primitive_kind::binary) != -1) {
                 shouldTryBrgconv = false;
@@ -1639,6 +1651,25 @@ void Convolution::initializeInputZeroPoints(const uint8_t* inputZpData, const si
     if (inputZeroPointType == zpType::PerTensor &&
         (impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core_amx) || impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core_vnni)))
         inputZeroPoints.push_back(static_cast<int32_t>(inputZpData[0]));
+}
+
+VectorDims Convolution::makeInputDummyShape(const Shape& inpShape) const {
+    constexpr Dim dummyOuputDim = 64;
+
+    const size_t spatialRank = stride.size();
+    const size_t filterStartIndx = weightDims.size() - spatialRank;
+
+    VectorDims dummyInputShapeVals(inpShape.getRank());
+    dummyInputShapeVals[0] = 1; //minibatch
+    dummyInputShapeVals[1] = IC; //channels
+
+    for (size_t i = 0; i < spatialRank; i++) {
+        dummyInputShapeVals[2 + i] = (dummyOuputDim - 1) * stride[i] -
+                                        (paddingL[i] + paddingR[i]) +
+                                        weightDims[filterStartIndx + i] +
+                                        (weightDims[filterStartIndx + i]- 1) * (dilation[i]);
+    }
+    return MemoryDescUtils::makeDummyShape(inpShape, dummyInputShapeVals).getStaticDims();
 }
 
 }   // namespace node

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -1660,7 +1660,7 @@ VectorDims Convolution::makeInputDummyShape(const Shape& inpShape) const {
     const size_t filterStartIndx = weightDims.size() - spatialRank;
 
     VectorDims dummyInputShapeVals(inpShape.getRank());
-    dummyInputShapeVals[0] = 1; //minibatch
+    dummyInputShapeVals[0] = isWino ? 64 : 1; //minibatch
     dummyInputShapeVals[1] = IC; //channels
 
     for (size_t i = 0; i < spatialRank; i++) {

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -113,7 +113,7 @@ private:
     MemoryDescPtr getSumMemDesc(dnnl::primitive_desc_iterator &primitive_desc_it);
     MemoryPtr getOutputMemory() const;
     VectorDims makeInputDummyShape(const Shape& inpShape) const;
-
+    VectorDims outputStaticShape() const;
     void appendLegacyZeroPointsArgs();
     void appendZeroPointsArgs();
     void initTryBrgconvFlag();

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -112,6 +112,7 @@ private:
     void updatePadding();
     MemoryDescPtr getSumMemDesc(dnnl::primitive_desc_iterator &primitive_desc_it);
     MemoryPtr getOutputMemory() const;
+    VectorDims makeInputDummyShape(const Shape& inpShape) const;
 
     void appendLegacyZeroPointsArgs();
     void appendZeroPointsArgs();

--- a/src/plugins/intel_cpu/tests/functional/test_utils/cpu_test_utils.cpp
+++ b/src/plugins/intel_cpu/tests/functional/test_utils/cpu_test_utils.cpp
@@ -222,7 +222,7 @@ void CPUTestsBase::CheckPluginRelatedResultsImpl(const std::shared_ptr<const ov:
 }
 
 bool CPUTestsBase::primTypeCheck(std::string primType) const {
-    return selectedType == CPUTestsBase::any_type || selectedType == primType;
+    return selectedType.find(CPUTestsBase::any_type) != std::string::npos || selectedType == primType;
 }
 
 std::string CPUTestsBase::getTestCaseName(CPUSpecificParams params) {


### PR DESCRIPTION
### Details:
Now dummy shape dimensions consider relations between the filter size, strides, dilations and padding.
PR to master: https://github.com/openvinotoolkit/openvino/pull/14520

### Tickets:
 - 95197
