### PR TITLE
[GPU] Use ASSERT_* instead of EXPECT_* in most of the cases

### DIFF
--- a/src/plugins/intel_gpu/tests/module_tests/graph_manipulation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/module_tests/graph_manipulation_gpu_test.cpp
@@ -59,7 +59,7 @@ TEST(basic, test1) {
     for (auto& it : outputs)
     {
         cldnn::mem_lock<float> output(it.second.get_memory(), get_test_stream());
-        EXPECT_NEAR(7.8f, output[0], epsilon);
+        ASSERT_NEAR(7.8f, output[0], epsilon);
     }
 }
 
@@ -114,7 +114,7 @@ TEST(add_intermediate_gpu, test1)
         cldnn::mem_lock<float> output(it.second.get_memory(), get_test_stream());
         for (uint32_t x = 0; x < output_size; x++)
         {
-            EXPECT_FLOAT_EQ(expected_output_vec[x+output_size*output_index], output[x]);
+            ASSERT_FLOAT_EQ(expected_output_vec[x+output_size*output_index], output[x]);
         }
         output_index++;
     }
@@ -175,7 +175,7 @@ TEST(add_intermediate_gpu, test2)
         cldnn::mem_lock<float> output(it.second.get_memory(), get_test_stream());
         for (uint32_t x = 0; x < output_size; x++)
         {
-            EXPECT_FLOAT_EQ(expected_output_vec[x], output[x]);
+            ASSERT_FLOAT_EQ(expected_output_vec[x], output[x]);
         }
     }
 }

--- a/src/plugins/intel_gpu/tests/module_tests/test_uqr_distribution.cpp
+++ b/src/plugins/intel_gpu/tests/module_tests/test_uqr_distribution.cpp
@@ -49,10 +49,10 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_default)
     uqr_dist_param dist_param_instance1;
     using actual_uqr_dist_rt = typename decltype(dist_param_instance1)::distribution_type::result_type;
 
-    EXPECT_TRUE((std::is_same<actual_uqr_dist_rt, expected_uqr_dist_rt>::value));
-    EXPECT_EQ(dist_param_instance1.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance1.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance1.significand_rand_bits(), expected_srb);
+    ASSERT_TRUE((std::is_same<actual_uqr_dist_rt, expected_uqr_dist_rt>::value));
+    ASSERT_EQ(dist_param_instance1.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance1.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance1.significand_rand_bits(), expected_srb);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_a_b_srb)
@@ -67,9 +67,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_a_b_srb)
 
     uqr_dist_param dist_param_instance1(expected_a, expected_b, expected_srb);
 
-    EXPECT_EQ(dist_param_instance1.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance1.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance1.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance1.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance1.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance1.significand_rand_bits(), expected_srb);
 
     // Zero
     expected_a   = static_cast<expected_uqr_dist_rt>(57);
@@ -78,9 +78,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_a_b_srb)
 
     uqr_dist_param dist_param_instance2(expected_a, expected_b, expected_srb);
 
-    EXPECT_EQ(dist_param_instance2.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance2.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance2.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance2.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance2.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance2.significand_rand_bits(), expected_srb);
 
     // Almost Maximum
     expected_a   = static_cast<expected_uqr_dist_rt>(-65);
@@ -89,9 +89,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_a_b_srb)
 
     uqr_dist_param dist_param_instance3(expected_a, expected_b, expected_srb);
 
-    EXPECT_EQ(dist_param_instance3.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance3.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance3.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance3.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance3.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance3.significand_rand_bits(), expected_srb);
 
     // Maximum
     expected_a   = static_cast<expected_uqr_dist_rt>(0);
@@ -100,9 +100,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_a_b_srb)
 
     uqr_dist_param dist_param_instance4(expected_a, expected_b, expected_srb);
 
-    EXPECT_EQ(dist_param_instance4.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance4.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance4.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance4.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance4.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance4.significand_rand_bits(), expected_srb);
 
     // Over Maximum
     expected_a   = static_cast<expected_uqr_dist_rt>(-4);
@@ -113,16 +113,16 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_a_b_srb)
 
     uqr_dist_param dist_param_instance5(expected_a, expected_b, test_srb);
 
-    EXPECT_EQ(dist_param_instance5.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance5.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance5.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance5.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance5.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance5.significand_rand_bits(), expected_srb);
 
     // Throw std::invalid_argument (a > b)
     expected_a   = static_cast<expected_uqr_dist_rt>(40);
     expected_b   = static_cast<expected_uqr_dist_rt>(39);
     expected_srb = 1U;
 
-    EXPECT_THROW({
+    ASSERT_THROW({
         uqr_dist_param dist_param_instance6(expected_a, expected_b, test_srb);
     }, std::invalid_argument);
 
@@ -131,7 +131,7 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_a_b_srb)
     expected_b   = static_cast<expected_uqr_dist_rt>(39);
     expected_srb = 1U;
 
-    EXPECT_THROW({
+    ASSERT_THROW({
         uqr_dist_param dist_param_instance7(expected_a, expected_b, test_srb);
     }, std::invalid_argument);
 
@@ -140,7 +140,7 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_a_b_srb)
     expected_b   = std::numeric_limits<expected_uqr_dist_rt>::infinity();
     expected_srb = 1U;
 
-    EXPECT_THROW({
+    ASSERT_THROW({
         uqr_dist_param dist_param_instance8(expected_a, expected_b, test_srb);
     }, std::invalid_argument);
 }
@@ -158,36 +158,36 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_srb)
 
     uqr_dist_param dist_param_instance1(expected_srb);
 
-    EXPECT_EQ(dist_param_instance1.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance1.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance1.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance1.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance1.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance1.significand_rand_bits(), expected_srb);
 
     // Zero
     expected_srb = 0U;
 
     uqr_dist_param dist_param_instance2(expected_srb);
 
-    EXPECT_EQ(dist_param_instance2.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance2.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance2.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance2.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance2.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance2.significand_rand_bits(), expected_srb);
 
     // Almost Maximum
     expected_srb = std::numeric_limits<expected_uqr_dist_rt>::digits - 4U;
 
     uqr_dist_param dist_param_instance3(expected_srb);
 
-    EXPECT_EQ(dist_param_instance3.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance3.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance3.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance3.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance3.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance3.significand_rand_bits(), expected_srb);
 
     // Maximum
     expected_srb = std::numeric_limits<expected_uqr_dist_rt>::digits - 1U;
 
     uqr_dist_param dist_param_instance4(expected_srb);
 
-    EXPECT_EQ(dist_param_instance4.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance4.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance4.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance4.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance4.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance4.significand_rand_bits(), expected_srb);
 
     // Over Maximum
     expected_srb = std::numeric_limits<expected_uqr_dist_rt>::digits - 1U;
@@ -196,9 +196,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_srb)
 
     uqr_dist_param dist_param_instance5(test_srb);
 
-    EXPECT_EQ(dist_param_instance5.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance5.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance5.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance5.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance5.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance5.significand_rand_bits(), expected_srb);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_copy)
@@ -213,9 +213,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_copy)
     uqr_dist_param dist_param_instance1(expected_a, expected_b, expected_srb);
     uqr_dist_param dist_param_instance2(dist_param_instance1);
 
-    EXPECT_EQ(dist_param_instance2.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance2.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance2.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance2.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance2.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance2.significand_rand_bits(), expected_srb);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_move)
@@ -230,9 +230,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_construct_move)
     uqr_dist_param dist_param_instance1(expected_a, expected_b, expected_srb);
     uqr_dist_param dist_param_instance2(std::move(dist_param_instance1));
 
-    EXPECT_EQ(dist_param_instance2.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance2.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance2.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance2.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance2.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance2.significand_rand_bits(), expected_srb);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, param_assign_copy)
@@ -248,9 +248,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_assign_copy)
     uqr_dist_param dist_param_instance2(2U);
     dist_param_instance2 = dist_param_instance1;
 
-    EXPECT_EQ(dist_param_instance2.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance2.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance2.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance2.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance2.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance2.significand_rand_bits(), expected_srb);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, param_assign_move)
@@ -266,9 +266,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_assign_move)
     uqr_dist_param dist_param_instance2(2U);
     dist_param_instance2 = std::move(dist_param_instance1);
 
-    EXPECT_EQ(dist_param_instance2.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance2.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance2.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance2.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance2.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance2.significand_rand_bits(), expected_srb);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, param_equality_compare)
@@ -284,25 +284,25 @@ TYPED_TEST(uniform_quantized_real_distribution_test, param_equality_compare)
     uqr_dist_param dist_param_instance2(2U);
     uqr_dist_param dist_param_instance3 = dist_param_instance1;
 
-    EXPECT_TRUE (dist_param_instance1 == dist_param_instance1);
-    EXPECT_FALSE(dist_param_instance1 == dist_param_instance2);
-    EXPECT_TRUE (dist_param_instance1 == dist_param_instance3);
-    EXPECT_FALSE(dist_param_instance2 == dist_param_instance1);
-    EXPECT_TRUE (dist_param_instance2 == dist_param_instance2);
-    EXPECT_FALSE(dist_param_instance2 == dist_param_instance3);
-    EXPECT_TRUE (dist_param_instance3 == dist_param_instance1);
-    EXPECT_FALSE(dist_param_instance3 == dist_param_instance2);
-    EXPECT_TRUE (dist_param_instance3 == dist_param_instance3);
+    ASSERT_TRUE (dist_param_instance1 == dist_param_instance1);
+    ASSERT_FALSE(dist_param_instance1 == dist_param_instance2);
+    ASSERT_TRUE (dist_param_instance1 == dist_param_instance3);
+    ASSERT_FALSE(dist_param_instance2 == dist_param_instance1);
+    ASSERT_TRUE (dist_param_instance2 == dist_param_instance2);
+    ASSERT_FALSE(dist_param_instance2 == dist_param_instance3);
+    ASSERT_TRUE (dist_param_instance3 == dist_param_instance1);
+    ASSERT_FALSE(dist_param_instance3 == dist_param_instance2);
+    ASSERT_TRUE (dist_param_instance3 == dist_param_instance3);
 
-    EXPECT_FALSE(dist_param_instance1 != dist_param_instance1);
-    EXPECT_TRUE (dist_param_instance1 != dist_param_instance2);
-    EXPECT_FALSE(dist_param_instance1 != dist_param_instance3);
-    EXPECT_TRUE (dist_param_instance2 != dist_param_instance1);
-    EXPECT_FALSE(dist_param_instance2 != dist_param_instance2);
-    EXPECT_TRUE (dist_param_instance2 != dist_param_instance3);
-    EXPECT_FALSE(dist_param_instance3 != dist_param_instance1);
-    EXPECT_TRUE (dist_param_instance3 != dist_param_instance2);
-    EXPECT_FALSE(dist_param_instance3 != dist_param_instance3);
+    ASSERT_FALSE(dist_param_instance1 != dist_param_instance1);
+    ASSERT_TRUE (dist_param_instance1 != dist_param_instance2);
+    ASSERT_FALSE(dist_param_instance1 != dist_param_instance3);
+    ASSERT_TRUE (dist_param_instance2 != dist_param_instance1);
+    ASSERT_FALSE(dist_param_instance2 != dist_param_instance2);
+    ASSERT_TRUE (dist_param_instance2 != dist_param_instance3);
+    ASSERT_FALSE(dist_param_instance3 != dist_param_instance1);
+    ASSERT_TRUE (dist_param_instance3 != dist_param_instance2);
+    ASSERT_FALSE(dist_param_instance3 != dist_param_instance3);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, construct_default)
@@ -317,10 +317,10 @@ TYPED_TEST(uniform_quantized_real_distribution_test, construct_default)
     uqr_dist dist_instance1;
     using actual_uqr_dist_rt = typename decltype(dist_instance1)::result_type;
 
-    EXPECT_TRUE((std::is_same<actual_uqr_dist_rt, expected_uqr_dist_rt>::value));
-    EXPECT_EQ(dist_instance1.a(),                     expected_a);
-    EXPECT_EQ(dist_instance1.b(),                     expected_b);
-    EXPECT_EQ(dist_instance1.significand_rand_bits(), expected_srb);
+    ASSERT_TRUE((std::is_same<actual_uqr_dist_rt, expected_uqr_dist_rt>::value));
+    ASSERT_EQ(dist_instance1.a(),                     expected_a);
+    ASSERT_EQ(dist_instance1.b(),                     expected_b);
+    ASSERT_EQ(dist_instance1.significand_rand_bits(), expected_srb);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, construct_a_b_srb)
@@ -335,9 +335,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, construct_a_b_srb)
 
     uqr_dist dist_instance1(expected_a, expected_b, expected_srb);
 
-    EXPECT_EQ(dist_instance1.a(),                     expected_a);
-    EXPECT_EQ(dist_instance1.b(),                     expected_b);
-    EXPECT_EQ(dist_instance1.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance1.a(),                     expected_a);
+    ASSERT_EQ(dist_instance1.b(),                     expected_b);
+    ASSERT_EQ(dist_instance1.significand_rand_bits(), expected_srb);
 
     // Zero
     expected_a   = static_cast<expected_uqr_dist_rt>(47);
@@ -346,9 +346,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, construct_a_b_srb)
 
     uqr_dist dist_instance2(expected_a, expected_b, expected_srb);
 
-    EXPECT_EQ(dist_instance2.a(),                     expected_a);
-    EXPECT_EQ(dist_instance2.b(),                     expected_b);
-    EXPECT_EQ(dist_instance2.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance2.a(),                     expected_a);
+    ASSERT_EQ(dist_instance2.b(),                     expected_b);
+    ASSERT_EQ(dist_instance2.significand_rand_bits(), expected_srb);
 
     // Almost Maximum
     expected_a   = static_cast<expected_uqr_dist_rt>(-55);
@@ -357,9 +357,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, construct_a_b_srb)
 
     uqr_dist dist_instance3(expected_a, expected_b, expected_srb);
 
-    EXPECT_EQ(dist_instance3.a(),                     expected_a);
-    EXPECT_EQ(dist_instance3.b(),                     expected_b);
-    EXPECT_EQ(dist_instance3.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance3.a(),                     expected_a);
+    ASSERT_EQ(dist_instance3.b(),                     expected_b);
+    ASSERT_EQ(dist_instance3.significand_rand_bits(), expected_srb);
 
     // Maximum
     expected_a   = static_cast<expected_uqr_dist_rt>(2);
@@ -368,9 +368,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, construct_a_b_srb)
 
     uqr_dist dist_instance4(expected_a, expected_b, expected_srb);
 
-    EXPECT_EQ(dist_instance4.a(),                     expected_a);
-    EXPECT_EQ(dist_instance4.b(),                     expected_b);
-    EXPECT_EQ(dist_instance4.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance4.a(),                     expected_a);
+    ASSERT_EQ(dist_instance4.b(),                     expected_b);
+    ASSERT_EQ(dist_instance4.significand_rand_bits(), expected_srb);
 
     // Over Maximum
     expected_a   = static_cast<expected_uqr_dist_rt>(-3);
@@ -381,16 +381,16 @@ TYPED_TEST(uniform_quantized_real_distribution_test, construct_a_b_srb)
 
     uqr_dist dist_instance5(expected_a, expected_b, test_srb);
 
-    EXPECT_EQ(dist_instance5.a(),                     expected_a);
-    EXPECT_EQ(dist_instance5.b(),                     expected_b);
-    EXPECT_EQ(dist_instance5.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance5.a(),                     expected_a);
+    ASSERT_EQ(dist_instance5.b(),                     expected_b);
+    ASSERT_EQ(dist_instance5.significand_rand_bits(), expected_srb);
 
     // Throw std::invalid_argument (a > b)
     expected_a   = static_cast<expected_uqr_dist_rt>(-40);
     expected_b   = static_cast<expected_uqr_dist_rt>(-80);
     expected_srb = 1U;
 
-    EXPECT_THROW({
+    ASSERT_THROW({
         uqr_dist dist_instance6(expected_a, expected_b, test_srb);
     }, std::invalid_argument);
 
@@ -399,7 +399,7 @@ TYPED_TEST(uniform_quantized_real_distribution_test, construct_a_b_srb)
     expected_b   = static_cast<expected_uqr_dist_rt>(-80);
     expected_srb = 1U;
 
-    EXPECT_THROW({
+    ASSERT_THROW({
         uqr_dist dist_instance7(expected_a, expected_b, test_srb);
     }, std::invalid_argument);
 
@@ -408,7 +408,7 @@ TYPED_TEST(uniform_quantized_real_distribution_test, construct_a_b_srb)
     expected_b   = std::numeric_limits<expected_uqr_dist_rt>::infinity();
     expected_srb = 1U;
 
-    EXPECT_THROW({
+    ASSERT_THROW({
         uqr_dist dist_instance8(expected_a, expected_b, test_srb);
     }, std::invalid_argument);
 }
@@ -426,13 +426,13 @@ TYPED_TEST(uniform_quantized_real_distribution_test, construct_param)
     uqr_dist_param dist_param_instance1(expected_a, expected_b, expected_srb);
     uqr_dist dist_instance1(dist_param_instance1);
 
-    EXPECT_EQ(dist_param_instance1.a(),                     expected_a);
-    EXPECT_EQ(dist_param_instance1.b(),                     expected_b);
-    EXPECT_EQ(dist_param_instance1.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_param_instance1.a(),                     expected_a);
+    ASSERT_EQ(dist_param_instance1.b(),                     expected_b);
+    ASSERT_EQ(dist_param_instance1.significand_rand_bits(), expected_srb);
 
-    EXPECT_EQ(dist_instance1.a(),                     expected_a);
-    EXPECT_EQ(dist_instance1.b(),                     expected_b);
-    EXPECT_EQ(dist_instance1.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance1.a(),                     expected_a);
+    ASSERT_EQ(dist_instance1.b(),                     expected_b);
+    ASSERT_EQ(dist_instance1.significand_rand_bits(), expected_srb);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, construct_srb)
@@ -448,36 +448,36 @@ TYPED_TEST(uniform_quantized_real_distribution_test, construct_srb)
 
     uqr_dist dist_instance1(expected_srb);
 
-    EXPECT_EQ(dist_instance1.a(),                     expected_a);
-    EXPECT_EQ(dist_instance1.b(),                     expected_b);
-    EXPECT_EQ(dist_instance1.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance1.a(),                     expected_a);
+    ASSERT_EQ(dist_instance1.b(),                     expected_b);
+    ASSERT_EQ(dist_instance1.significand_rand_bits(), expected_srb);
 
     // Zero
     expected_srb = 0U;
 
     uqr_dist dist_instance2(expected_srb);
 
-    EXPECT_EQ(dist_instance2.a(),                     expected_a);
-    EXPECT_EQ(dist_instance2.b(),                     expected_b);
-    EXPECT_EQ(dist_instance2.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance2.a(),                     expected_a);
+    ASSERT_EQ(dist_instance2.b(),                     expected_b);
+    ASSERT_EQ(dist_instance2.significand_rand_bits(), expected_srb);
 
     // Almost Maximum
     expected_srb = std::numeric_limits<expected_uqr_dist_rt>::digits - 2U;
 
     uqr_dist dist_instance3(expected_srb);
 
-    EXPECT_EQ(dist_instance3.a(),                     expected_a);
-    EXPECT_EQ(dist_instance3.b(),                     expected_b);
-    EXPECT_EQ(dist_instance3.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance3.a(),                     expected_a);
+    ASSERT_EQ(dist_instance3.b(),                     expected_b);
+    ASSERT_EQ(dist_instance3.significand_rand_bits(), expected_srb);
 
     // Maximum
     expected_srb = std::numeric_limits<expected_uqr_dist_rt>::digits - 1U;
 
     uqr_dist dist_instance4(expected_srb);
 
-    EXPECT_EQ(dist_instance4.a(),                     expected_a);
-    EXPECT_EQ(dist_instance4.b(),                     expected_b);
-    EXPECT_EQ(dist_instance4.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance4.a(),                     expected_a);
+    ASSERT_EQ(dist_instance4.b(),                     expected_b);
+    ASSERT_EQ(dist_instance4.significand_rand_bits(), expected_srb);
 
     // Over Maximum
     expected_srb = std::numeric_limits<expected_uqr_dist_rt>::digits - 1U;
@@ -486,9 +486,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, construct_srb)
 
     uqr_dist dist_instance5(test_srb);
 
-    EXPECT_EQ(dist_instance5.a(),                     expected_a);
-    EXPECT_EQ(dist_instance5.b(),                     expected_b);
-    EXPECT_EQ(dist_instance5.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance5.a(),                     expected_a);
+    ASSERT_EQ(dist_instance5.b(),                     expected_b);
+    ASSERT_EQ(dist_instance5.significand_rand_bits(), expected_srb);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, construct_copy)
@@ -503,9 +503,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, construct_copy)
     uqr_dist dist_instance1(expected_a, expected_b, expected_srb);
     uqr_dist dist_instance2(dist_instance1);
 
-    EXPECT_EQ(dist_instance2.a(),                     expected_a);
-    EXPECT_EQ(dist_instance2.b(),                     expected_b);
-    EXPECT_EQ(dist_instance2.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance2.a(),                     expected_a);
+    ASSERT_EQ(dist_instance2.b(),                     expected_b);
+    ASSERT_EQ(dist_instance2.significand_rand_bits(), expected_srb);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, construct_move)
@@ -520,9 +520,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, construct_move)
     uqr_dist dist_instance1(expected_a, expected_b, expected_srb);
     uqr_dist dist_instance2(std::move(dist_instance1));
 
-    EXPECT_EQ(dist_instance2.a(),                     expected_a);
-    EXPECT_EQ(dist_instance2.b(),                     expected_b);
-    EXPECT_EQ(dist_instance2.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance2.a(),                     expected_a);
+    ASSERT_EQ(dist_instance2.b(),                     expected_b);
+    ASSERT_EQ(dist_instance2.significand_rand_bits(), expected_srb);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, assign_copy)
@@ -538,9 +538,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, assign_copy)
     uqr_dist dist_instance2(2U);
     dist_instance2 = dist_instance1;
 
-    EXPECT_EQ(dist_instance2.a(),                     expected_a);
-    EXPECT_EQ(dist_instance2.b(),                     expected_b);
-    EXPECT_EQ(dist_instance2.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance2.a(),                     expected_a);
+    ASSERT_EQ(dist_instance2.b(),                     expected_b);
+    ASSERT_EQ(dist_instance2.significand_rand_bits(), expected_srb);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, assign_move)
@@ -556,9 +556,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, assign_move)
     uqr_dist dist_instance2(3U);
     dist_instance2 = std::move(dist_instance1);
 
-    EXPECT_EQ(dist_instance2.a(),                     expected_a);
-    EXPECT_EQ(dist_instance2.b(),                     expected_b);
-    EXPECT_EQ(dist_instance2.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance2.a(),                     expected_a);
+    ASSERT_EQ(dist_instance2.b(),                     expected_b);
+    ASSERT_EQ(dist_instance2.significand_rand_bits(), expected_srb);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, get_param)
@@ -572,9 +572,9 @@ TYPED_TEST(uniform_quantized_real_distribution_test, get_param)
 
     uqr_dist dist_instance1(expected_a, expected_b, expected_srb);
 
-    EXPECT_EQ(dist_instance1.param().a(),                     expected_a);
-    EXPECT_EQ(dist_instance1.param().b(),                     expected_b);
-    EXPECT_EQ(dist_instance1.param().significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance1.param().a(),                     expected_a);
+    ASSERT_EQ(dist_instance1.param().b(),                     expected_b);
+    ASSERT_EQ(dist_instance1.param().significand_rand_bits(), expected_srb);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, set_param)
@@ -593,21 +593,21 @@ TYPED_TEST(uniform_quantized_real_distribution_test, set_param)
     uqr_dist dist_instance1(1U);
     dist_instance1.param(uqr_dist_param(expected_a, expected_b, expected_srb));
 
-    EXPECT_EQ(dist_instance1.param().a(),                     expected_a);
-    EXPECT_EQ(dist_instance1.param().b(),                     expected_b);
-    EXPECT_EQ(dist_instance1.param().significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance1.param().a(),                     expected_a);
+    ASSERT_EQ(dist_instance1.param().b(),                     expected_b);
+    ASSERT_EQ(dist_instance1.param().significand_rand_bits(), expected_srb);
 
-    EXPECT_TRUE(dist_instance1 == dist_instance_ref);
+    ASSERT_TRUE(dist_instance1 == dist_instance_ref);
 
     // From Other Distribution
     uqr_dist dist_instance2(2U);
     dist_instance2.param(dist_instance1.param());
 
-    EXPECT_EQ(dist_instance1.param().a(),                     expected_a);
-    EXPECT_EQ(dist_instance1.param().b(),                     expected_b);
-    EXPECT_EQ(dist_instance1.param().significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist_instance1.param().a(),                     expected_a);
+    ASSERT_EQ(dist_instance1.param().b(),                     expected_b);
+    ASSERT_EQ(dist_instance1.param().significand_rand_bits(), expected_srb);
 
-    EXPECT_TRUE(dist_instance2 == dist_instance_ref);
+    ASSERT_TRUE(dist_instance2 == dist_instance_ref);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, get_member_param_equivalence)
@@ -624,37 +624,37 @@ TYPED_TEST(uniform_quantized_real_distribution_test, get_member_param_equivalenc
     uqr_dist_param dist_param_instance1;
     uqr_dist dist_instance1;
 
-    EXPECT_EQ(dist_instance1.a(),                     dist_instance1.param().a());
-    EXPECT_EQ(dist_instance1.b(),                     dist_instance1.param().b());
-    EXPECT_EQ(dist_instance1.significand_rand_bits(), dist_instance1.param().significand_rand_bits());
+    ASSERT_EQ(dist_instance1.a(),                     dist_instance1.param().a());
+    ASSERT_EQ(dist_instance1.b(),                     dist_instance1.param().b());
+    ASSERT_EQ(dist_instance1.significand_rand_bits(), dist_instance1.param().significand_rand_bits());
 
-    EXPECT_EQ(dist_instance1.a(),                     dist_param_instance1.a());
-    EXPECT_EQ(dist_instance1.b(),                     dist_param_instance1.b());
-    EXPECT_EQ(dist_instance1.significand_rand_bits(), dist_param_instance1.significand_rand_bits());
+    ASSERT_EQ(dist_instance1.a(),                     dist_param_instance1.a());
+    ASSERT_EQ(dist_instance1.b(),                     dist_param_instance1.b());
+    ASSERT_EQ(dist_instance1.significand_rand_bits(), dist_param_instance1.significand_rand_bits());
 
     // Constructor (a, b, srb)
     uqr_dist_param dist_param_instance2(expected_a, expected_b, expected_srb);
     uqr_dist dist_instance2(expected_a, expected_b, expected_srb);
 
-    EXPECT_EQ(dist_instance2.a(),                     dist_instance2.param().a());
-    EXPECT_EQ(dist_instance2.b(),                     dist_instance2.param().b());
-    EXPECT_EQ(dist_instance2.significand_rand_bits(), dist_instance2.param().significand_rand_bits());
+    ASSERT_EQ(dist_instance2.a(),                     dist_instance2.param().a());
+    ASSERT_EQ(dist_instance2.b(),                     dist_instance2.param().b());
+    ASSERT_EQ(dist_instance2.significand_rand_bits(), dist_instance2.param().significand_rand_bits());
 
-    EXPECT_EQ(dist_instance2.a(),                     dist_param_instance2.a());
-    EXPECT_EQ(dist_instance2.b(),                     dist_param_instance2.b());
-    EXPECT_EQ(dist_instance2.significand_rand_bits(), dist_param_instance2.significand_rand_bits());
+    ASSERT_EQ(dist_instance2.a(),                     dist_param_instance2.a());
+    ASSERT_EQ(dist_instance2.b(),                     dist_param_instance2.b());
+    ASSERT_EQ(dist_instance2.significand_rand_bits(), dist_param_instance2.significand_rand_bits());
 
     // Constructor (srb)
     uqr_dist_param dist_param_instance3(expected_srb);
     uqr_dist dist_instance3(expected_srb);
 
-    EXPECT_EQ(dist_instance3.a(),                     dist_instance3.param().a());
-    EXPECT_EQ(dist_instance3.b(),                     dist_instance3.param().b());
-    EXPECT_EQ(dist_instance3.significand_rand_bits(), dist_instance3.param().significand_rand_bits());
+    ASSERT_EQ(dist_instance3.a(),                     dist_instance3.param().a());
+    ASSERT_EQ(dist_instance3.b(),                     dist_instance3.param().b());
+    ASSERT_EQ(dist_instance3.significand_rand_bits(), dist_instance3.param().significand_rand_bits());
 
-    EXPECT_EQ(dist_instance3.a(),                     dist_param_instance3.a());
-    EXPECT_EQ(dist_instance3.b(),                     dist_param_instance3.b());
-    EXPECT_EQ(dist_instance3.significand_rand_bits(), dist_param_instance3.significand_rand_bits());
+    ASSERT_EQ(dist_instance3.a(),                     dist_param_instance3.a());
+    ASSERT_EQ(dist_instance3.b(),                     dist_param_instance3.b());
+    ASSERT_EQ(dist_instance3.significand_rand_bits(), dist_param_instance3.significand_rand_bits());
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, get_min)
@@ -668,7 +668,7 @@ TYPED_TEST(uniform_quantized_real_distribution_test, get_min)
 
     uqr_dist dist_instance1(expected_a, expected_b, expected_srb);
 
-    EXPECT_EQ(dist_instance1.min(), expected_a);
+    ASSERT_EQ(dist_instance1.min(), expected_a);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, get_max)
@@ -682,7 +682,7 @@ TYPED_TEST(uniform_quantized_real_distribution_test, get_max)
 
     uqr_dist dist_instance1(expected_a, expected_b, expected_srb);
 
-    EXPECT_EQ(dist_instance1.max(), expected_b);
+    ASSERT_EQ(dist_instance1.max(), expected_b);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, equality_compare)
@@ -698,25 +698,25 @@ TYPED_TEST(uniform_quantized_real_distribution_test, equality_compare)
     uqr_dist dist_instance2(2U);
     uqr_dist dist_instance3(dist_instance1);
 
-    EXPECT_TRUE (dist_instance1 == dist_instance1);
-    EXPECT_FALSE(dist_instance1 == dist_instance2);
-    EXPECT_TRUE (dist_instance1 == dist_instance3);
-    EXPECT_FALSE(dist_instance2 == dist_instance1);
-    EXPECT_TRUE (dist_instance2 == dist_instance2);
-    EXPECT_FALSE(dist_instance2 == dist_instance3);
-    EXPECT_TRUE (dist_instance3 == dist_instance1);
-    EXPECT_FALSE(dist_instance3 == dist_instance2);
-    EXPECT_TRUE (dist_instance3 == dist_instance3);
+    ASSERT_TRUE (dist_instance1 == dist_instance1);
+    ASSERT_FALSE(dist_instance1 == dist_instance2);
+    ASSERT_TRUE (dist_instance1 == dist_instance3);
+    ASSERT_FALSE(dist_instance2 == dist_instance1);
+    ASSERT_TRUE (dist_instance2 == dist_instance2);
+    ASSERT_FALSE(dist_instance2 == dist_instance3);
+    ASSERT_TRUE (dist_instance3 == dist_instance1);
+    ASSERT_FALSE(dist_instance3 == dist_instance2);
+    ASSERT_TRUE (dist_instance3 == dist_instance3);
 
-    EXPECT_FALSE(dist_instance1 != dist_instance1);
-    EXPECT_TRUE (dist_instance1 != dist_instance2);
-    EXPECT_FALSE(dist_instance1 != dist_instance3);
-    EXPECT_TRUE (dist_instance2 != dist_instance1);
-    EXPECT_FALSE(dist_instance2 != dist_instance2);
-    EXPECT_TRUE (dist_instance2 != dist_instance3);
-    EXPECT_FALSE(dist_instance3 != dist_instance1);
-    EXPECT_TRUE (dist_instance3 != dist_instance2);
-    EXPECT_FALSE(dist_instance3 != dist_instance3);
+    ASSERT_FALSE(dist_instance1 != dist_instance1);
+    ASSERT_TRUE (dist_instance1 != dist_instance2);
+    ASSERT_FALSE(dist_instance1 != dist_instance3);
+    ASSERT_TRUE (dist_instance2 != dist_instance1);
+    ASSERT_FALSE(dist_instance2 != dist_instance2);
+    ASSERT_TRUE (dist_instance2 != dist_instance3);
+    ASSERT_FALSE(dist_instance3 != dist_instance1);
+    ASSERT_TRUE (dist_instance3 != dist_instance2);
+    ASSERT_FALSE(dist_instance3 != dist_instance3);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, serialize)
@@ -739,10 +739,10 @@ TYPED_TEST(uniform_quantized_real_distribution_test, serialize)
     const auto after_fill1  = std::cout.fill();
     const auto after_prec1  = std::cout.precision();
 
-    EXPECT_FALSE(!std::cout);
-    EXPECT_EQ(before_flags1, after_flags1);
-    EXPECT_EQ(before_fill1,  after_fill1);
-    EXPECT_EQ(before_prec1,  after_prec1);
+    ASSERT_FALSE(!std::cout);
+    ASSERT_EQ(before_flags1, after_flags1);
+    ASSERT_EQ(before_fill1,  after_fill1);
+    ASSERT_EQ(before_prec1,  after_prec1);
 
     // Preserve Stream Formatting #2
     std::wstringstream ss2;
@@ -756,10 +756,10 @@ TYPED_TEST(uniform_quantized_real_distribution_test, serialize)
     const auto after_fill2  = ss2.fill();
     const auto after_prec2  = ss2.precision();
 
-    EXPECT_FALSE(!ss2);
-    EXPECT_EQ(before_flags2, after_flags2);
-    EXPECT_EQ(before_fill2,  after_fill2);
-    EXPECT_EQ(before_prec2,  after_prec2);
+    ASSERT_FALSE(!ss2);
+    ASSERT_EQ(before_flags2, after_flags2);
+    ASSERT_EQ(before_fill2,  after_fill2);
+    ASSERT_EQ(before_prec2,  after_prec2);
 
     // Preserve Stream Formatting #3
     std::wstringstream ss3;
@@ -774,10 +774,10 @@ TYPED_TEST(uniform_quantized_real_distribution_test, serialize)
     const auto after_fill3  = ss3.fill();
     const auto after_prec3  = ss3.precision();
 
-    EXPECT_FALSE(!ss3);
-    EXPECT_EQ(before_flags3, after_flags3);
-    EXPECT_EQ(before_fill3,  after_fill3);
-    EXPECT_EQ(before_prec3,  after_prec3);
+    ASSERT_FALSE(!ss3);
+    ASSERT_EQ(before_flags3, after_flags3);
+    ASSERT_EQ(before_fill3,  after_fill3);
+    ASSERT_EQ(before_prec3,  after_prec3);
 
     // Serialize Do Not Change Internal State.
     std::wstringstream ss4;
@@ -785,8 +785,8 @@ TYPED_TEST(uniform_quantized_real_distribution_test, serialize)
 
     ss4 << dist_instance1;
 
-    EXPECT_FALSE(!ss4);
-    EXPECT_EQ(ss2.str(), ss4.str());
+    ASSERT_FALSE(!ss4);
+    ASSERT_EQ(ss2.str(), ss4.str());
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, deserialize)
@@ -812,19 +812,19 @@ TYPED_TEST(uniform_quantized_real_distribution_test, deserialize)
     ss1 >> dist_instance1 >> dist_instance2;
     const auto after_flags1  = ss1.flags();
 
-    EXPECT_FALSE(!ss1);
-    EXPECT_EQ(before_flags1, after_flags1);
+    ASSERT_FALSE(!ss1);
+    ASSERT_EQ(before_flags1, after_flags1);
 
-    EXPECT_TRUE(dist_instance1 == dist_instance_ref);
-    EXPECT_TRUE(dist_instance2 == dist_instance_ref);
+    ASSERT_TRUE(dist_instance1 == dist_instance_ref);
+    ASSERT_TRUE(dist_instance2 == dist_instance_ref);
 
     ss1_1 << dist_instance1;
     ss1_2 << dist_instance2;
 
-    EXPECT_TRUE(dist_instance1 == dist_instance_ref);
-    EXPECT_TRUE(dist_instance2 == dist_instance_ref);
+    ASSERT_TRUE(dist_instance1 == dist_instance_ref);
+    ASSERT_TRUE(dist_instance2 == dist_instance_ref);
 
-    EXPECT_EQ(ss1_1.str(), ss1_2.str());
+    ASSERT_EQ(ss1_1.str(), ss1_2.str());
 
     // Valid Deserialization (Wide String)
     std::wstringstream ss2, ss2_1, ss2_2;
@@ -836,19 +836,19 @@ TYPED_TEST(uniform_quantized_real_distribution_test, deserialize)
     ss2 >> dist_instance3 >> dist_instance4;
     const auto after_flags2  = ss2.flags();
 
-    EXPECT_FALSE(!ss2);
-    EXPECT_EQ(before_flags2, after_flags2);
+    ASSERT_FALSE(!ss2);
+    ASSERT_EQ(before_flags2, after_flags2);
 
-    EXPECT_TRUE(dist_instance3 == dist_instance_ref);
-    EXPECT_TRUE(dist_instance4 == dist_instance_ref);
+    ASSERT_TRUE(dist_instance3 == dist_instance_ref);
+    ASSERT_TRUE(dist_instance4 == dist_instance_ref);
 
     ss2_1 << dist_instance3;
     ss2_2 << dist_instance4;
 
-    EXPECT_TRUE(dist_instance1 == dist_instance_ref);
-    EXPECT_TRUE(dist_instance2 == dist_instance_ref);
+    ASSERT_TRUE(dist_instance1 == dist_instance_ref);
+    ASSERT_TRUE(dist_instance2 == dist_instance_ref);
 
-    EXPECT_EQ(ss2_1.str(), ss2_2.str());
+    ASSERT_EQ(ss2_1.str(), ss2_2.str());
 
     // Invalid Deserialization
     std::wstringstream ss3;
@@ -860,11 +860,11 @@ TYPED_TEST(uniform_quantized_real_distribution_test, deserialize)
     ss3 >> dist_instance5;
     const auto after_flags3  = ss3.flags();
 
-    EXPECT_TRUE(ss3.fail());
-    EXPECT_FALSE(ss3.bad());
-    EXPECT_EQ(before_flags3, after_flags3);
+    ASSERT_TRUE(ss3.fail());
+    ASSERT_FALSE(ss3.bad());
+    ASSERT_EQ(before_flags3, after_flags3);
 
-    EXPECT_TRUE(dist_instance5 == dist_instance_ref);
+    ASSERT_TRUE(dist_instance5 == dist_instance_ref);
 }
 
 TYPED_TEST(uniform_quantized_real_distribution_test, DISABLED_generate_random)
@@ -886,11 +886,11 @@ TYPED_TEST(uniform_quantized_real_distribution_test, DISABLED_generate_random)
     {
         expected_uqr_dist_rt rnd_val = dist1(g1);
 
-        EXPECT_GE(rnd_val, expected_a);
-        EXPECT_LE(rnd_val, expected_b);
+        ASSERT_GE(rnd_val, expected_a);
+        ASSERT_LE(rnd_val, expected_b);
 
         expected_uqr_dist_rt actual_ipart;
-        EXPECT_EQ(std::modf(rnd_val / expected_fract, &actual_ipart), val_zero);
+        ASSERT_EQ(std::modf(rnd_val / expected_fract, &actual_ipart), val_zero);
     }
 }
 
@@ -910,7 +910,7 @@ TYPED_TEST(uniform_quantized_real_distribution_test, generate_random_degen_a_b)
     {
         expected_uqr_dist_rt rnd_val = dist1(g1);
 
-        EXPECT_EQ(rnd_val, expected_a);
+        ASSERT_EQ(rnd_val, expected_a);
     }
 }
 
@@ -934,7 +934,7 @@ TYPED_TEST(uniform_quantized_real_distribution_test, DISABLED_generate_random_de
         if (rnd_val == expected_a) { ++count_a; }
         if (rnd_val == expected_b) { ++count_b; }
 
-        EXPECT_TRUE((rnd_val == expected_a) || (rnd_val == expected_b));
+        ASSERT_TRUE((rnd_val == expected_a) || (rnd_val == expected_b));
     }
     std::cout << "a: " << count_a << ", b: " << count_b << std::endl;
 }
@@ -959,10 +959,10 @@ TYPED_TEST(uniform_quantized_real_distribution_test, DISABLED_generate_random_c9
 
         ++counts[rnd_val];
 
-        EXPECT_GE(rnd_val, expected_a);
-        EXPECT_LE(rnd_val, expected_b);
+        ASSERT_GE(rnd_val, expected_a);
+        ASSERT_LE(rnd_val, expected_b);
     }
-    EXPECT_LE(counts.size(), 9U); // 2 ^ expected_srb + 1
+    ASSERT_LE(counts.size(), 9U); // 2 ^ expected_srb + 1
 
     std::cout << "elems: " << counts.size();
     for (const auto& count : counts)
@@ -992,10 +992,10 @@ TYPED_TEST(uniform_quantized_real_distribution_test, DISABLED_generate_random_c1
 
         ++counts[rnd_val];
 
-        EXPECT_GE(rnd_val, expected_a);
-        EXPECT_LE(rnd_val, expected_b);
+        ASSERT_GE(rnd_val, expected_a);
+        ASSERT_LE(rnd_val, expected_b);
     }
-    EXPECT_LE(counts.size(), 17U); // 2 ^ expected_srb + 1
+    ASSERT_LE(counts.size(), 17U); // 2 ^ expected_srb + 1
 
     std::cout << "elems: " << counts.size();
     for (const auto& count : counts)
@@ -1032,11 +1032,11 @@ TYPED_TEST(uniform_quantized_real_distribution_test, DISABLED_generate_random_pa
     {
         expected_uqr_dist_rt rnd_val = dist1(g1, dist_param1);
 
-        EXPECT_GE(rnd_val, expected_a);
-        EXPECT_LE(rnd_val, expected_b);
+        ASSERT_GE(rnd_val, expected_a);
+        ASSERT_LE(rnd_val, expected_b);
 
         expected_uqr_dist_rt actual_ipart;
-        EXPECT_EQ(std::modf(rnd_val / expected_fract, &actual_ipart), val_zero);
+        ASSERT_EQ(std::modf(rnd_val / expected_fract, &actual_ipart), val_zero);
     }
 
     // Original Param
@@ -1045,19 +1045,19 @@ TYPED_TEST(uniform_quantized_real_distribution_test, DISABLED_generate_random_pa
     expected_b     = test_b;
     expected_srb   = test_srb;
 
-    EXPECT_EQ(dist1.a(),                     expected_a);
-    EXPECT_EQ(dist1.b(),                     expected_b);
-    EXPECT_EQ(dist1.significand_rand_bits(), expected_srb);
+    ASSERT_EQ(dist1.a(),                     expected_a);
+    ASSERT_EQ(dist1.b(),                     expected_b);
+    ASSERT_EQ(dist1.significand_rand_bits(), expected_srb);
 
     for (std::size_t ii = 0; ii < TestFixture::rnd_iter_num; ++ii)
     {
         expected_uqr_dist_rt rnd_val = dist1(g1);
 
-        EXPECT_GE(rnd_val, expected_a);
-        EXPECT_LE(rnd_val, expected_b);
+        ASSERT_GE(rnd_val, expected_a);
+        ASSERT_LE(rnd_val, expected_b);
 
         expected_uqr_dist_rt actual_ipart;
-        EXPECT_EQ(std::modf(rnd_val / expected_fract, &actual_ipart), val_zero);
+        ASSERT_EQ(std::modf(rnd_val / expected_fract, &actual_ipart), val_zero);
     }
 }
 
@@ -1094,10 +1094,10 @@ TYPED_TEST(uniform_quantized_real_distribution_test, DISABLED_generate_random_eq
         dist8(g8);
         dist9(g9);
 
-        EXPECT_EQ(rnd_val1, rnd_val2);
-        EXPECT_EQ(rnd_val1, rnd_val3);
-        EXPECT_EQ(rnd_val1, rnd_val4);
-        EXPECT_EQ(rnd_val1, rnd_val5);
+        ASSERT_EQ(rnd_val1, rnd_val2);
+        ASSERT_EQ(rnd_val1, rnd_val3);
+        ASSERT_EQ(rnd_val1, rnd_val4);
+        ASSERT_EQ(rnd_val1, rnd_val5);
     }
 
     // Equivalent Assignment And Serialization.
@@ -1124,10 +1124,10 @@ TYPED_TEST(uniform_quantized_real_distribution_test, DISABLED_generate_random_eq
         expected_uqr_dist_rt rnd_val8 = dist8(g8);
         expected_uqr_dist_rt rnd_val9 = dist9(g9);
 
-        EXPECT_EQ(rnd_val1, rnd_val6);
-        EXPECT_EQ(rnd_val1, rnd_val7);
-        EXPECT_EQ(rnd_val1, rnd_val8);
-        EXPECT_EQ(rnd_val1, rnd_val9);
+        ASSERT_EQ(rnd_val1, rnd_val6);
+        ASSERT_EQ(rnd_val1, rnd_val7);
+        ASSERT_EQ(rnd_val1, rnd_val8);
+        ASSERT_EQ(rnd_val1, rnd_val9);
     }
 }
 

--- a/src/plugins/intel_gpu/tests/passes/reorder_inputs_test.cpp
+++ b/src/plugins/intel_gpu/tests/passes/reorder_inputs_test.cpp
@@ -53,7 +53,7 @@ TEST(reorder_inputs, propagation) {
         if (node->is_type<reorder>())
             reorder_cnt += 1;
     }
-    EXPECT_LE(reorder_cnt, 1u);
+    ASSERT_LE(reorder_cnt, 1u);
 
     auto& conv1_node = prog_impl->get_node("conv1");
     auto& conv2_node = prog_impl->get_node("conv2");
@@ -66,7 +66,7 @@ TEST(reorder_inputs, propagation) {
 
     auto& pool_node = prog_impl->get_node("pool");
 
-    EXPECT_EQ(pool_node.get_output_layout().format.value, conv_pref);
+    ASSERT_EQ(pool_node.get_output_layout().format.value, conv_pref);
 }
 
 TEST(reorder_inputs, impl_forcing_basic_format) {
@@ -94,17 +94,17 @@ TEST(reorder_inputs, impl_forcing_basic_format) {
     auto& pool_node = prog->get_node("pool");
     auto pool_layout = pool_node.get_output_layout();
 
-    EXPECT_EQ(pool_layout.format.value, format::yxfb);
+    ASSERT_EQ(pool_layout.format.value, format::yxfb);
 
     auto out_mem = network.get_output("pool").get_memory();
     cldnn::mem_lock<float> out_mem_ptr(out_mem, get_test_stream());
 
     ASSERT_EQ(out_mem_ptr.size(), 4u);
 
-    EXPECT_EQ(out_mem_ptr[0], 2.f);
-    EXPECT_EQ(out_mem_ptr[1], 7.f);
-    EXPECT_EQ(out_mem_ptr[2], 3.f);
-    EXPECT_EQ(out_mem_ptr[3], -1.f);
+    ASSERT_EQ(out_mem_ptr[0], 2.f);
+    ASSERT_EQ(out_mem_ptr[1], 7.f);
+    ASSERT_EQ(out_mem_ptr[2], 3.f);
+    ASSERT_EQ(out_mem_ptr[3], -1.f);
 }
 
 TEST(reorder_inputs, impl_forcing_not_existing) {
@@ -150,22 +150,22 @@ TEST(reorder_inputs, impl_forcing_basic_format_kernel) {
     ASSERT_NE(node.get_selected_impl(), nullptr);
     auto kernel_name = node.get_selected_impl()->get_kernel_name();
 
-    EXPECT_EQ(actv_layout.format.value, format::yxfb);
-    EXPECT_EQ(kernel_name, actv_impl.kernel_name);
+    ASSERT_EQ(actv_layout.format.value, format::yxfb);
+    ASSERT_EQ(kernel_name, actv_impl.kernel_name);
 
     auto out_mem = network.get_output("actv").get_memory();
     cldnn::mem_lock<float> out_mem_ptr(out_mem, get_test_stream());
 
     ASSERT_EQ(out_mem_ptr.size(), 8u);
 
-    EXPECT_EQ(out_mem_ptr[0], 0.f);
-    EXPECT_EQ(out_mem_ptr[1], 7.f);
-    EXPECT_EQ(out_mem_ptr[2], 2.f);
-    EXPECT_EQ(out_mem_ptr[3], 3.f);
-    EXPECT_EQ(out_mem_ptr[4], 0.f);
-    EXPECT_EQ(out_mem_ptr[5], 0.f);
-    EXPECT_EQ(out_mem_ptr[6], 0.5f);
-    EXPECT_EQ(out_mem_ptr[7], 0.f);
+    ASSERT_EQ(out_mem_ptr[0], 0.f);
+    ASSERT_EQ(out_mem_ptr[1], 7.f);
+    ASSERT_EQ(out_mem_ptr[2], 2.f);
+    ASSERT_EQ(out_mem_ptr[3], 3.f);
+    ASSERT_EQ(out_mem_ptr[4], 0.f);
+    ASSERT_EQ(out_mem_ptr[5], 0.f);
+    ASSERT_EQ(out_mem_ptr[6], 0.5f);
+    ASSERT_EQ(out_mem_ptr[7], 0.f);
 }
 
 // TODO Not yet implemented
@@ -204,22 +204,22 @@ TEST(reorder_inputs, impl_forcing_basic_format_kernel) {
 //        auto conv_sel_impl = conv_node.get_selected_impl();
 //        auto conv_layout = conv_node.get_output_layout();
 //
-//        EXPECT_EQ(conv_layout.format.value, impl.format);
-//        EXPECT_EQ(conv_sel_impl->get_kernel_name(), impl.kernel);
+//        ASSERT_EQ(conv_layout.format.value, impl.format);
+//        ASSERT_EQ(conv_sel_impl->get_kernel_name(), impl.kernel);
 //
 //        auto out_mem = network.get_output("output").get_memory();
 //        cldnn::mem_lock<float> out_mem_ptr(out_mem, get_test_stream());
 //
-//        EXPECT_EQ(out_mem_ptr.size(), 8);
+//        ASSERT_EQ(out_mem_ptr.size(), 8);
 //
-//        EXPECT_EQ(out_mem_ptr[0], 11.f);
-//        EXPECT_EQ(out_mem_ptr[1], 14.f);
-//        EXPECT_EQ(out_mem_ptr[2], 17.f);
-//        EXPECT_EQ(out_mem_ptr[3], 20.f);
+//        ASSERT_EQ(out_mem_ptr[0], 11.f);
+//        ASSERT_EQ(out_mem_ptr[1], 14.f);
+//        ASSERT_EQ(out_mem_ptr[2], 17.f);
+//        ASSERT_EQ(out_mem_ptr[3], 20.f);
 //
-//        EXPECT_EQ(out_mem_ptr[4], 23.f);
-//        EXPECT_EQ(out_mem_ptr[5], 30.f);
-//        EXPECT_EQ(out_mem_ptr[6], 37.f);
-//        EXPECT_EQ(out_mem_ptr[7], 44.f);
+//        ASSERT_EQ(out_mem_ptr[4], 23.f);
+//        ASSERT_EQ(out_mem_ptr[5], 30.f);
+//        ASSERT_EQ(out_mem_ptr[6], 37.f);
+//        ASSERT_EQ(out_mem_ptr[7], 44.f);
 //    }
 //}

--- a/src/plugins/intel_gpu/tests/passes/test_module_fusing_reorder.cpp
+++ b/src/plugins/intel_gpu/tests/passes/test_module_fusing_reorder.cpp
@@ -83,7 +83,7 @@ TEST(test_can_fuse_reorder, reorder_for_mixed_type_convolution_fsv32_onednn)
         auto& node = node_ptr->as<reorder>();
         auto& input = node.input();
         for (auto usr : node_ptr->get_users()) {
-            EXPECT_EQ(false, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
+            ASSERT_EQ(false, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
         }
     }
 }
@@ -124,7 +124,7 @@ TEST(test_can_fuse_reorder, reorder_for_mixed_type_convolution_fsv32_cldnn)
         auto& node = node_ptr->as<reorder>();
         auto& input = node.input();
         for (auto usr : node_ptr->get_users()) {
-            EXPECT_EQ(true, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
+            ASSERT_EQ(true, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
         }
     }
 }
@@ -201,7 +201,7 @@ TEST_P(test_fused_reorder_deep_depth, no_removal_for_deep_depth_conv)
         auto& node = node_ptr->as<reorder>();
         auto& input = node.input();
         for (auto usr : node_ptr->get_users()) {
-            EXPECT_EQ(p.expected_result, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
+            ASSERT_EQ(p.expected_result, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
         }
     }
 }
@@ -251,7 +251,7 @@ TEST_P(test_can_fuse_reorder_cldnn, reorder_for_firstconv_cldnn)
         auto& node = node_ptr->as<reorder>();
         auto& input = node.input();
         for (auto usr : node_ptr->get_users()) {
-            EXPECT_EQ(p.expected_result, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
+            ASSERT_EQ(p.expected_result, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
         }
     }
 }
@@ -298,7 +298,7 @@ TEST_P(test_can_fuse_reorder_onednn, reorder_for_firstconv_onednn)
         auto& node = node_ptr->as<reorder>();
         auto& input = node.input();
         for (auto usr : node_ptr->get_users()) {
-            EXPECT_EQ(p.expected_result, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
+            ASSERT_EQ(p.expected_result, lo.can_fuse_reorder(input, *usr, node.input().get_output_layout().format, usr->get_output_layout().format));
         }
     }
 }
@@ -467,7 +467,7 @@ TEST_P(test_can_fuse_reorder_onednn_errata, errata_case_for_conv)
         auto& node = node_ptr->as<reorder>();
         auto& prev = node.input();
         for (auto next : node_ptr->get_users()) {
-            EXPECT_EQ(p.expected_result, lo.can_fuse_reorder(prev, *next, prev.get_output_layout().format, next->get_output_layout().format));
+            ASSERT_EQ(p.expected_result, lo.can_fuse_reorder(prev, *next, prev.get_output_layout().format, next->get_output_layout().format));
         }
     }
 }
@@ -488,4 +488,3 @@ INSTANTIATE_TEST_SUITE_P(testing_can_fuse_reorder_errata_case_for_conv, test_can
                                                 true },
                                             }));
 #endif
-

--- a/src/plugins/intel_gpu/tests/test_cases/activation_simple_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/activation_simple_gpu_test.cpp
@@ -48,8 +48,8 @@ TEST(activation_f32_fw_gpu, not_basic_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "not");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "not");
 
     auto output_memory = outputs.at("not").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -59,11 +59,11 @@ TEST(activation_f32_fw_gpu, not_basic_yxfb) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
         EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
@@ -92,8 +92,8 @@ TEST(activation_f32_fw_gpu, erf_basic_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "not");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "not");
 
     auto output_memory = outputs.at("not").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -104,11 +104,11 @@ TEST(activation_f32_fw_gpu, erf_basic_yxfb) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
         EXPECT_FLOAT_EQ(std::erf(input_ptr[i]), output_ptr[i]);
@@ -138,8 +138,8 @@ TEST(activation_f32_fw_gpu, hard_sigmoid_basic_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "not");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "not");
 
     auto output_memory = outputs.at("not").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -150,11 +150,11 @@ TEST(activation_f32_fw_gpu, hard_sigmoid_basic_yxfb) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
         float res = std::fmax(0.0f, std::fmin(1.0f, params.a * input_ptr[i] + params.b));
@@ -184,8 +184,8 @@ TEST(activation_f32_fw_gpu, reciprocal_basic_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "not");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "not");
 
     auto output_memory = outputs.at("not").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -196,11 +196,11 @@ TEST(activation_f32_fw_gpu, reciprocal_basic_yxfb) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
         float res = 1 / input_ptr[i];
@@ -231,8 +231,8 @@ TEST(activation_f32_fw_gpu, selu_basic_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "not");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "not");
 
     auto output_memory = outputs.at("not").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -243,11 +243,11 @@ TEST(activation_f32_fw_gpu, selu_basic_yxfb) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
         float res = input_ptr[i] <= 0 ? params.b * (params.a * std::exp(input_ptr[i]) - params.a) :
@@ -278,8 +278,8 @@ TEST(activation_f32_fw_gpu, softplus_basic_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "not");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "not");
 
     auto output_memory = outputs.at("not").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -290,11 +290,11 @@ TEST(activation_f32_fw_gpu, softplus_basic_yxfb) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
         float res = std::log(std::exp(input_ptr[i]) + 1);
@@ -324,8 +324,8 @@ TEST(activation_f32_fw_gpu, softsign_basic_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "not");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "not");
 
     auto output_memory = outputs.at("not").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -336,11 +336,11 @@ TEST(activation_f32_fw_gpu, softsign_basic_yxfb) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
         float res = input_ptr[i] / (1 + std::abs(input_ptr[i]));
@@ -360,8 +360,8 @@ TEST(activation_f16_fw_gpu, softsign_basic_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "not");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "not");
 
     auto output_memory = outputs.at("not").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -372,11 +372,11 @@ TEST(activation_f16_fw_gpu, softsign_basic_yxfb) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 2);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 2);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
         EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
@@ -405,8 +405,8 @@ TEST(activation_f32_fw_gpu, sign_basic_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "not");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "not");
 
     auto output_memory = outputs.at("not").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -417,11 +417,11 @@ TEST(activation_f32_fw_gpu, sign_basic_yxfb) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
         float res = input_ptr[i] > 0 ? 1.0f : input_ptr[i] < 0 ? -1.0f : 0.0f;
@@ -443,8 +443,8 @@ TEST(activation_f32_fw_gpu, pow_basic_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "pow");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "pow");
 
     auto output_memory = outputs.at("pow").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -454,11 +454,11 @@ TEST(activation_f32_fw_gpu, pow_basic_yxfb) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 2);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 2);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
         EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
@@ -479,8 +479,8 @@ TEST(activation_f16_fw_gpu, pow_basic_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "pow");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "pow");
 
     auto output_memory = outputs.at("pow").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -490,11 +490,11 @@ TEST(activation_f16_fw_gpu, pow_basic_yxfb) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 2);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 2);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
         EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
@@ -536,8 +536,8 @@ TEST(activation_f32_fw_gpu, relu_basic_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "relu");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "relu");
 
     auto output_memory = outputs.at("relu").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -547,11 +547,11 @@ TEST(activation_f32_fw_gpu, relu_basic_yxfb) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
         EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
@@ -612,8 +612,8 @@ TEST(activation_f32_fw_gpu, relu_basic_bfzyx) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "relu");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "relu");
 
     auto output_memory = outputs.at("relu").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -624,12 +624,12 @@ TEST(activation_f32_fw_gpu, relu_basic_bfzyx) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfzyx);
-    EXPECT_EQ(z_size, 2);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfzyx);
+    ASSERT_EQ(z_size, 2);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
         EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
@@ -709,8 +709,8 @@ TEST(activation_f32_fw_gpu, basic_yxfb_all_functions)
             network network(engine, topology);
             network.set_input_data("input", input);
             auto outputs = network.execute();
-            EXPECT_EQ(outputs.size(), size_t(1));
-            EXPECT_EQ(outputs.begin()->first, "activation");
+            ASSERT_EQ(outputs.size(), size_t(1));
+            ASSERT_EQ(outputs.begin()->first, "activation");
 
             auto output_memory = outputs.at("activation").get_memory();
             auto output_layout = output_memory->get_layout();
@@ -721,11 +721,11 @@ TEST(activation_f32_fw_gpu, basic_yxfb_all_functions)
             int x_size = output_layout.spatial(0);
             int f_size = output_layout.feature();
             int b_size = output_layout.batch();
-            EXPECT_EQ(output_layout.format, format::yxfb);
-            EXPECT_EQ(y_size, 4);
-            EXPECT_EQ(x_size, 5);
-            EXPECT_EQ(f_size, 1);
-            EXPECT_EQ(b_size, 1);
+            ASSERT_EQ(output_layout.format, format::yxfb);
+            ASSERT_EQ(y_size, 4);
+            ASSERT_EQ(x_size, 5);
+            ASSERT_EQ(f_size, 1);
+            ASSERT_EQ(b_size, 1);
 
             for (size_t i = 0; i < output_layout.get_linear_size(); ++i)
             {
@@ -859,8 +859,8 @@ TEST(activation_f16_fw_gpu, basic_bfyx_all_functions)
             network network(engine, topology);
             network.set_input_data("input", input);
             auto outputs = network.execute();
-            EXPECT_EQ(outputs.size(), size_t(1));
-            EXPECT_EQ(outputs.begin()->first, "activation");
+            ASSERT_EQ(outputs.size(), size_t(1));
+            ASSERT_EQ(outputs.begin()->first, "activation");
 
             auto output_memory = outputs.at("activation").get_memory();
             auto output_layout = output_memory->get_layout();
@@ -871,11 +871,11 @@ TEST(activation_f16_fw_gpu, basic_bfyx_all_functions)
             int x_size = output_layout.spatial(0);
             int f_size = output_layout.feature();
             int b_size = output_layout.batch();
-            EXPECT_EQ(output_layout.format, format::bfyx);
-            EXPECT_EQ(y_size, 4);
-            EXPECT_EQ(x_size, 2);
-            EXPECT_EQ(f_size, 1);
-            EXPECT_EQ(b_size, 1);
+            ASSERT_EQ(output_layout.format, format::bfyx);
+            ASSERT_EQ(y_size, 4);
+            ASSERT_EQ(x_size, 2);
+            ASSERT_EQ(f_size, 1);
+            ASSERT_EQ(b_size, 1);
 
             for (size_t i = 0; i < output_layout.get_linear_size(); ++i) {
                 switch (func) {
@@ -937,8 +937,8 @@ TEST(activation_f32_fw_gpu, basic_yxfb_asin_acos_log_atan)
         network network(engine, topology);
         network.set_input_data("input", input);
         auto outputs = network.execute();
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "activation");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "activation");
 
         auto output_memory = outputs.at("activation").get_memory();
         auto output_layout = output_memory->get_layout();
@@ -949,11 +949,11 @@ TEST(activation_f32_fw_gpu, basic_yxfb_asin_acos_log_atan)
         int x_size = output_layout.spatial(0);
         int f_size = output_layout.feature();
         int b_size = output_layout.batch();
-        EXPECT_EQ(output_layout.format, format::yxfb);
-        EXPECT_EQ(y_size, 4);
-        EXPECT_EQ(x_size, 2);
-        EXPECT_EQ(f_size, 1);
-        EXPECT_EQ(b_size, 1);
+        ASSERT_EQ(output_layout.format, format::yxfb);
+        ASSERT_EQ(y_size, 4);
+        ASSERT_EQ(x_size, 2);
+        ASSERT_EQ(f_size, 1);
+        ASSERT_EQ(b_size, 1);
 
         for (size_t i = 0; i < output_layout.get_linear_size(); ++i)
         {
@@ -1023,7 +1023,7 @@ TEST(activation_f32_fw_gpu, relu_basic_acosh_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.begin()->first, "relu");
+    ASSERT_EQ(outputs.begin()->first, "relu");
 
     auto output_memory = outputs.at("relu").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -1034,11 +1034,11 @@ TEST(activation_f32_fw_gpu, relu_basic_acosh_yxfb) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (int i = 0; i < x_size * y_size * f_size * b_size; ++i) {
         EXPECT_FLOAT_EQ(std::acosh(input_ptr[i]), output_ptr[i]);
@@ -1089,7 +1089,7 @@ TEST(activation_f32_fw_gpu, relu_basic_input_padding_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.begin()->first, "relu");
+    ASSERT_EQ(outputs.begin()->first, "relu");
 
     auto output_memory = outputs.at("relu").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -1099,11 +1099,11 @@ TEST(activation_f32_fw_gpu, relu_basic_input_padding_yxfb) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
         EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
@@ -1176,7 +1176,7 @@ TEST(activation_f32_fw_gpu, relu_basic_input_padding_bfzyx) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.begin()->first, "relu");
+    ASSERT_EQ(outputs.begin()->first, "relu");
 
     auto output_memory = outputs.at("relu").get_memory();
 
@@ -1188,12 +1188,12 @@ TEST(activation_f32_fw_gpu, relu_basic_input_padding_bfzyx) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfzyx);
-    EXPECT_EQ(z_size, 2);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfzyx);
+    ASSERT_EQ(z_size, 2);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
         EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
@@ -1249,8 +1249,8 @@ TEST(activation_f32_fw_gpu, relu_basic_output_padding_yxfb) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "relu");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "relu");
 
     auto output_memory = outputs.at("relu").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -1261,11 +1261,11 @@ TEST(activation_f32_fw_gpu, relu_basic_output_padding_yxfb) {
     int x_size = output_size.spatial[0];
     int f_size = output_size.feature[0];
     int b_size = output_size.batch[0];
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 10);
-    EXPECT_EQ(x_size, 11);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 10);
+    ASSERT_EQ(x_size, 11);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
         EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
@@ -1292,8 +1292,8 @@ TEST(activation_f32_fw_gpu, basic_yxfb_floor_ceil)
         network network(engine, topology);
         network.set_input_data("input", input);
         auto outputs = network.execute();
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "activation");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "activation");
 
         auto output_memory = outputs.at("activation").get_memory();
         auto output_layout = output_memory->get_layout();
@@ -1304,11 +1304,11 @@ TEST(activation_f32_fw_gpu, basic_yxfb_floor_ceil)
         int x_size = output_layout.spatial(0);
         int f_size = output_layout.feature();
         int b_size = output_layout.batch();
-        EXPECT_EQ(output_layout.format, format::yxfb);
-        EXPECT_EQ(y_size, 4);
-        EXPECT_EQ(x_size, 2);
-        EXPECT_EQ(f_size, 1);
-        EXPECT_EQ(b_size, 1);
+        ASSERT_EQ(output_layout.format, format::yxfb);
+        ASSERT_EQ(y_size, 4);
+        ASSERT_EQ(x_size, 2);
+        ASSERT_EQ(f_size, 1);
+        ASSERT_EQ(b_size, 1);
 
         for (size_t i = 0; i < output_layout.get_linear_size(); ++i)
         {
@@ -1358,7 +1358,7 @@ TEST(activation_i8_fw_gpu, basic_yxfb_all_funcs)
         auto outputs = network.execute();
 
         ASSERT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "activation");
+        ASSERT_EQ(outputs.begin()->first, "activation");
 
         auto output_memory = outputs.at("activation").get_memory();
         auto output_layout = output_memory->get_layout();
@@ -1368,13 +1368,13 @@ TEST(activation_i8_fw_gpu, basic_yxfb_all_funcs)
         for (size_t i = 0; i < output_layout.get_linear_size(); ++i) {
             switch (func) {
             case activation_func::none:
-                EXPECT_EQ((int8_t)input_ptr[i], output_ptr[i]);
+                ASSERT_EQ((int8_t)input_ptr[i], output_ptr[i]);
                 break;
             case activation_func::negative:
-                EXPECT_EQ(-((int8_t)input_ptr[i]), output_ptr[i]);
+                ASSERT_EQ(-((int8_t)input_ptr[i]), output_ptr[i]);
                 break;
             case activation_func::negation:
-                EXPECT_EQ(!((int8_t)input_ptr[i]), output_ptr[i]);
+                ASSERT_EQ(!((int8_t)input_ptr[i]), output_ptr[i]);
                 break;
             default:
                 break;
@@ -1416,7 +1416,7 @@ TEST(activation_i32_fw_gpu, basic_yxfb_i32_funcs) {
         auto outputs = network.execute();
 
         ASSERT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "activation");
+        ASSERT_EQ(outputs.begin()->first, "activation");
 
         auto output_memory = outputs.at("activation").get_memory();
         auto output_layout = output_memory->get_layout();
@@ -1426,22 +1426,22 @@ TEST(activation_i32_fw_gpu, basic_yxfb_i32_funcs) {
         for (size_t i = 0; i < output_layout.get_linear_size(); ++i) {
             switch (func) {
             case activation_func::none:
-                EXPECT_EQ((int32_t)input_ptr[i], output_ptr[i]);
+                ASSERT_EQ((int32_t)input_ptr[i], output_ptr[i]);
                 break;
             case activation_func::negative:
-                EXPECT_EQ(-((int32_t)input_ptr[i]), output_ptr[i]);
+                ASSERT_EQ(-((int32_t)input_ptr[i]), output_ptr[i]);
                 break;
             case activation_func::negation:
-                EXPECT_EQ(!((int32_t)input_ptr[i]), output_ptr[i]);
+                ASSERT_EQ(!((int32_t)input_ptr[i]), output_ptr[i]);
                 break;
             case activation_func::relu:
-                EXPECT_EQ(std::max(static_cast<int32_t>(input_ptr[i]), 0), output_ptr[i]);
+                ASSERT_EQ(std::max(static_cast<int32_t>(input_ptr[i]), 0), output_ptr[i]);
                 break;
             case activation_func::clamp:
-                EXPECT_EQ(std::min(std::max(input_ptr[i], static_cast<int32_t>(params.a)), static_cast<int32_t>(params.b)), output_ptr[i]);
+                ASSERT_EQ(std::min(std::max(input_ptr[i], static_cast<int32_t>(params.a)), static_cast<int32_t>(params.b)), output_ptr[i]);
                 break;
             case activation_func::floor:
-                EXPECT_EQ((int32_t)std::floor(input_ptr[i]), output_ptr[i]);
+                ASSERT_EQ((int32_t)std::floor(input_ptr[i]), output_ptr[i]);
                 break;
             default:
                 break;
@@ -1495,7 +1495,7 @@ TEST(activation_f32_fw_gpu, b_fs_yx_fsv16_prelu) {
     ASSERT_EQ(expected.size(), out_ptr.size());
 
     for (size_t i = 0; i < expected.size(); ++i) {
-        EXPECT_EQ(expected[i], out_ptr[i]) << "at i=" << i;
+        ASSERT_EQ(expected[i], out_ptr[i]) << "at i=" << i;
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/activation_simple_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/activation_simple_gpu_test.cpp
@@ -66,7 +66,7 @@ TEST(activation_f32_fw_gpu, not_basic_yxfb) {
     ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
-        EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(output_vec[i], output_ptr[i]);
     }
 }
 
@@ -111,7 +111,7 @@ TEST(activation_f32_fw_gpu, erf_basic_yxfb) {
     ASSERT_EQ(b_size, 1);
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
-        EXPECT_FLOAT_EQ(std::erf(input_ptr[i]), output_ptr[i]);
+        ASSERT_FLOAT_EQ(std::erf(input_ptr[i]), output_ptr[i]);
     }
 }
 
@@ -158,7 +158,7 @@ TEST(activation_f32_fw_gpu, hard_sigmoid_basic_yxfb) {
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
         float res = std::fmax(0.0f, std::fmin(1.0f, params.a * input_ptr[i] + params.b));
-        EXPECT_FLOAT_EQ(res, output_ptr[i]);
+        ASSERT_FLOAT_EQ(res, output_ptr[i]);
     }
 }
 
@@ -204,7 +204,7 @@ TEST(activation_f32_fw_gpu, reciprocal_basic_yxfb) {
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
         float res = 1 / input_ptr[i];
-        EXPECT_FLOAT_EQ(res, output_ptr[i]);
+        ASSERT_FLOAT_EQ(res, output_ptr[i]);
     }
 }
 
@@ -252,7 +252,7 @@ TEST(activation_f32_fw_gpu, selu_basic_yxfb) {
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
         float res = input_ptr[i] <= 0 ? params.b * (params.a * std::exp(input_ptr[i]) - params.a) :
                                         params.b * input_ptr[i];
-        EXPECT_FLOAT_EQ(res, output_ptr[i]);
+        ASSERT_FLOAT_EQ(res, output_ptr[i]);
     }
 }
 
@@ -298,7 +298,7 @@ TEST(activation_f32_fw_gpu, softplus_basic_yxfb) {
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
         float res = std::log(std::exp(input_ptr[i]) + 1);
-        EXPECT_FLOAT_EQ(res, output_ptr[i]);
+        ASSERT_FLOAT_EQ(res, output_ptr[i]);
     }
 }
 
@@ -344,7 +344,7 @@ TEST(activation_f32_fw_gpu, softsign_basic_yxfb) {
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
         float res = input_ptr[i] / (1 + std::abs(input_ptr[i]));
-        EXPECT_FLOAT_EQ(res, output_ptr[i]);
+        ASSERT_FLOAT_EQ(res, output_ptr[i]);
     }
 }
 
@@ -379,7 +379,7 @@ TEST(activation_f16_fw_gpu, softsign_basic_yxfb) {
     ASSERT_EQ(b_size, 1);
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
-        EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(output_vec[i], output_ptr[i]);
     }
 }
 
@@ -425,7 +425,7 @@ TEST(activation_f32_fw_gpu, sign_basic_yxfb) {
 
     for (int i = 0; i < b_size * f_size * y_size * x_size; ++i) {
         float res = input_ptr[i] > 0 ? 1.0f : input_ptr[i] < 0 ? -1.0f : 0.0f;
-        EXPECT_FLOAT_EQ(res, output_ptr[i]);
+        ASSERT_FLOAT_EQ(res, output_ptr[i]);
     }
 }
 
@@ -461,7 +461,7 @@ TEST(activation_f32_fw_gpu, pow_basic_yxfb) {
     ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
-        EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(output_vec[i], output_ptr[i]);
     }
 }
 
@@ -497,7 +497,7 @@ TEST(activation_f16_fw_gpu, pow_basic_yxfb) {
     ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
-        EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(output_vec[i], output_ptr[i]);
     }
 }
 
@@ -554,7 +554,7 @@ TEST(activation_f32_fw_gpu, relu_basic_yxfb) {
     ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
-        EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(output_vec[i], output_ptr[i]);
     }
 }
 
@@ -632,7 +632,7 @@ TEST(activation_f32_fw_gpu, relu_basic_bfzyx) {
     ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
-        EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(output_vec[i], output_ptr[i]);
     }
 }
 
@@ -732,88 +732,88 @@ TEST(activation_f32_fw_gpu, basic_yxfb_all_functions)
                 switch (func)
                 {
                 case activation_func::none:
-                    EXPECT_FLOAT_EQ(input_ptr[i], output_ptr[i]);
+                    ASSERT_FLOAT_EQ(input_ptr[i], output_ptr[i]);
                     break;
                 case activation_func::logistic:
-                    EXPECT_FLOAT_EQ(1.f / (1.f + std::exp((float)-input_ptr[i])), output_ptr[i]);
+                    ASSERT_FLOAT_EQ(1.f / (1.f + std::exp((float)-input_ptr[i])), output_ptr[i]);
                     break;
                 case activation_func::hyperbolic_tan:
-                    EXPECT_FLOAT_EQ(std::tanh((float)input_ptr[i]), output_ptr[i]);
+                    ASSERT_FLOAT_EQ(std::tanh((float)input_ptr[i]), output_ptr[i]);
                     break;
                 case activation_func::relu:
-                    EXPECT_FLOAT_EQ(std::fmax((float)input_ptr[i], 0.f), output_ptr[i]);
+                    ASSERT_FLOAT_EQ(std::fmax((float)input_ptr[i], 0.f), output_ptr[i]);
                     break;
                 case activation_func::clamp:
-                    EXPECT_FLOAT_EQ(std::fmin((float)std::fmax((float)input_ptr[i], params.a), params.b), output_ptr[i]);
+                    ASSERT_FLOAT_EQ(std::fmin((float)std::fmax((float)input_ptr[i], params.a), params.b), output_ptr[i]);
                     break;
                 case activation_func::softrelu:
-                    EXPECT_FLOAT_EQ(std::log(1.f + std::exp((float)input_ptr[i])), output_ptr[i]);
+                    ASSERT_FLOAT_EQ(std::log(1.f + std::exp((float)input_ptr[i])), output_ptr[i]);
                     break;
                 case activation_func::abs:
-                    EXPECT_FLOAT_EQ(std::fabs(input_ptr[i]), output_ptr[i]);
+                    ASSERT_FLOAT_EQ(std::fabs(input_ptr[i]), output_ptr[i]);
                     break;
                 case activation_func::linear:
-                    EXPECT_FLOAT_EQ((params.a*input_ptr[i] + params.b), output_ptr[i]);
+                    ASSERT_FLOAT_EQ((params.a*input_ptr[i] + params.b), output_ptr[i]);
                     break;
                 case activation_func::square:
-                    EXPECT_FLOAT_EQ((input_ptr[i] * input_ptr[i]), output_ptr[i]);
+                    ASSERT_FLOAT_EQ((input_ptr[i] * input_ptr[i]), output_ptr[i]);
                     break;
                 case activation_func::sqrt:
                     if (input_ptr[i] >= 0)
                     {
-                        EXPECT_FLOAT_EQ(std::sqrt((float)input_ptr[i]), output_ptr[i]);
+                        ASSERT_FLOAT_EQ(std::sqrt((float)input_ptr[i]), output_ptr[i]);
                     }
                     break;
                 case activation_func::elu:
-                    EXPECT_FLOAT_EQ(std::fmax((float)input_ptr[i], 0.0f) +
+                    ASSERT_FLOAT_EQ(std::fmax((float)input_ptr[i], 0.0f) +
                                     params.a*(std::exp(std::fmin((float)input_ptr[i], 0.0f)) - 1), output_ptr[i]);
                     break;
                 case activation_func::sin:
-                    EXPECT_FLOAT_EQ(std::sin((float)input_ptr[i]), output_ptr[i]);
+                    ASSERT_FLOAT_EQ(std::sin((float)input_ptr[i]), output_ptr[i]);
                     break;
                 case activation_func::sinh:
-                    EXPECT_FLOAT_EQ(std::sinh((float)input_ptr[i]), output_ptr[i]);
+                    ASSERT_FLOAT_EQ(std::sinh((float)input_ptr[i]), output_ptr[i]);
                     break;
                 case activation_func::cos:
-                    EXPECT_FLOAT_EQ(std::cos((float)input_ptr[i]), output_ptr[i]);
+                    ASSERT_FLOAT_EQ(std::cos((float)input_ptr[i]), output_ptr[i]);
                     break;
                 case activation_func::cosh:
-                    EXPECT_FLOAT_EQ(std::cosh((float)input_ptr[i]), output_ptr[i]);
+                    ASSERT_FLOAT_EQ(std::cosh((float)input_ptr[i]), output_ptr[i]);
                     break;
                 case activation_func::exp:
-                    EXPECT_FLOAT_EQ(std::exp((float)input_ptr[i]), output_ptr[i]);
+                    ASSERT_FLOAT_EQ(std::exp((float)input_ptr[i]), output_ptr[i]);
                     break;
                 case activation_func::negation:
-                    EXPECT_FLOAT_EQ((float)(!input_ptr[i]), output_ptr[i]);
+                    ASSERT_FLOAT_EQ((float)(!input_ptr[i]), output_ptr[i]);
                     break;
                 case activation_func::log2:
                     if (input_ptr[i] > 0) //logarithm exist only for positive real values
                     {
-                        EXPECT_FLOAT_EQ(std::log2((float)input_ptr[i]), output_ptr[i]);
+                        ASSERT_FLOAT_EQ(std::log2((float)input_ptr[i]), output_ptr[i]);
                     }
                     break;
                 case activation_func::tan:
-                    EXPECT_FLOAT_EQ(std::tan((float)input_ptr[i]), output_ptr[i]);
+                    ASSERT_FLOAT_EQ(std::tan((float)input_ptr[i]), output_ptr[i]);
                     break;
                 case activation_func::negative:
-                    EXPECT_FLOAT_EQ(-((float)input_ptr[i]), output_ptr[i]);
+                    ASSERT_FLOAT_EQ(-((float)input_ptr[i]), output_ptr[i]);
                     break;
                 case activation_func::swish:
-                    EXPECT_FLOAT_EQ((float)input_ptr[i] / (1.f + std::exp((float)(-params.a * input_ptr[i]))), output_ptr[i]);
+                    ASSERT_FLOAT_EQ((float)input_ptr[i] / (1.f + std::exp((float)(-params.a * input_ptr[i]))), output_ptr[i]);
                     break;
                 case activation_func::hswish:
-                    EXPECT_FLOAT_EQ((float)input_ptr[i] * std::fmin(std::fmax(0.f, (float)input_ptr[i] + 3.f), 6.f) / 6.f, output_ptr[i]);
+                    ASSERT_FLOAT_EQ((float)input_ptr[i] * std::fmin(std::fmax(0.f, (float)input_ptr[i] + 3.f), 6.f) / 6.f, output_ptr[i]);
                     break;
                 case activation_func::mish:
-                    EXPECT_NEAR((float)input_ptr[i] * std::tanh(std::log(1.f + std::exp((float)input_ptr[i]))),
+                    ASSERT_NEAR((float)input_ptr[i] * std::tanh(std::log(1.f + std::exp((float)input_ptr[i]))),
                                 output_ptr[i], 1e-5f);
                     break;
                 case activation_func::gelu:
-                    EXPECT_NEAR(0.5f * (float)input_ptr[i] * (1.f + std::erf((float)(input_ptr[i]) / std::sqrt(2.0f))),
+                    ASSERT_NEAR(0.5f * (float)input_ptr[i] * (1.f + std::erf((float)(input_ptr[i]) / std::sqrt(2.0f))),
                                 output_ptr[i], 1e-5f);
                     break;
                 case activation_func::hsigmoid:
-                    EXPECT_FLOAT_EQ(std::fmin(std::fmax(0.f, (float)input_ptr[i] + 3.f), 6.f) / 6.f, output_ptr[i]);
+                    ASSERT_FLOAT_EQ(std::fmin(std::fmax(0.f, (float)input_ptr[i] + 3.f), 6.f) / 6.f, output_ptr[i]);
                     break;
                 default:
                     break;
@@ -882,26 +882,26 @@ TEST(activation_f16_fw_gpu, basic_bfyx_all_functions)
                 case activation_func::linear: {
                     VF<FLOAT16> output_vec = {FLOAT16(-11.5f), FLOAT16(-5.5f), FLOAT16(-2.5f), FLOAT16(3.5f),
                                               FLOAT16(4.7f), FLOAT16(6.5f), FLOAT16(8.0f), FLOAT16(9.5f)};
-                    EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
+                    ASSERT_FLOAT_EQ(output_vec[i], output_ptr[i]);
                     break;
                 }
                 case activation_func::mish:
-                    EXPECT_NEAR((FLOAT16)((float)input_ptr[i] * std::tanh(std::log(1.f + std::exp((float)input_ptr[i])))),
+                    ASSERT_NEAR((FLOAT16)((float)input_ptr[i] * std::tanh(std::log(1.f + std::exp((float)input_ptr[i])))),
                         output_ptr[i], 1e-2f);
                     break;
                 case activation_func::hswish:
-                    EXPECT_NEAR((FLOAT16)((float)input_ptr[i] * std::fmin(std::fmax(0.f, (float)input_ptr[i] + 3.f), 6.f) / 6.f),
+                    ASSERT_NEAR((FLOAT16)((float)input_ptr[i] * std::fmin(std::fmax(0.f, (float)input_ptr[i] + 3.f), 6.f) / 6.f),
                         output_ptr[i], 1e-3f);
                     break;
                 case activation_func::hard_sigmoid:
-                    EXPECT_NEAR((FLOAT16)(std::fmin(std::fmax(0.f, (float)input_ptr[i] + 3.f), 6.f) / 6.f),
+                    ASSERT_NEAR((FLOAT16)(std::fmin(std::fmax(0.f, (float)input_ptr[i] + 3.f), 6.f) / 6.f),
                         output_ptr[i], 1e-3f);
                     break;
                 case activation_func::round_half_to_even:
-                    EXPECT_FLOAT_EQ((FLOAT16)std::rint((float)input_ptr[i]), output_ptr[i]);
+                    ASSERT_FLOAT_EQ((FLOAT16)std::rint((float)input_ptr[i]), output_ptr[i]);
                     break;
                 case activation_func::round_half_away_from_zero:
-                    EXPECT_FLOAT_EQ((FLOAT16)std::round((float)input_ptr[i]), output_ptr[i]);
+                    ASSERT_FLOAT_EQ((FLOAT16)std::round((float)input_ptr[i]), output_ptr[i]);
                     break;
                 default:
                     break;
@@ -960,28 +960,28 @@ TEST(activation_f32_fw_gpu, basic_yxfb_asin_acos_log_atan)
             switch (func)
             {
             case activation_func::asin:
-                EXPECT_FLOAT_EQ(std::asin((float)input_ptr[i]), output_ptr[i]);
+                ASSERT_FLOAT_EQ(std::asin((float)input_ptr[i]), output_ptr[i]);
                 break;
             case activation_func::acos:
-                EXPECT_FLOAT_EQ(std::acos((float)input_ptr[i]), output_ptr[i]);
+                ASSERT_FLOAT_EQ(std::acos((float)input_ptr[i]), output_ptr[i]);
                 break;
             case activation_func::log:
-                EXPECT_FLOAT_EQ(std::log((float)input_ptr[i]), output_ptr[i]);
+                ASSERT_FLOAT_EQ(std::log((float)input_ptr[i]), output_ptr[i]);
                 break;
             case activation_func::log2:
-                EXPECT_FLOAT_EQ(std::log2((float)input_ptr[i]), output_ptr[i]);
+                ASSERT_FLOAT_EQ(std::log2((float)input_ptr[i]), output_ptr[i]);
                 break;
             case activation_func::atan:
-                EXPECT_FLOAT_EQ(std::atan((float)input_ptr[i]), output_ptr[i]);
+                ASSERT_FLOAT_EQ(std::atan((float)input_ptr[i]), output_ptr[i]);
                 break;
             case activation_func::asinh:
-                EXPECT_FLOAT_EQ(std::asinh((float)input_ptr[i]), output_ptr[i]);
+                ASSERT_FLOAT_EQ(std::asinh((float)input_ptr[i]), output_ptr[i]);
                 break;
             case activation_func::acosh:
-                EXPECT_FLOAT_EQ(std::acosh((float)input_ptr[i]), output_ptr[i]);
+                ASSERT_FLOAT_EQ(std::acosh((float)input_ptr[i]), output_ptr[i]);
                 break;
             case activation_func::atanh:
-                EXPECT_FLOAT_EQ(std::atanh((float)input_ptr[i]), output_ptr[i]);
+                ASSERT_FLOAT_EQ(std::atanh((float)input_ptr[i]), output_ptr[i]);
                 break;
             default:
                 break;
@@ -1041,7 +1041,7 @@ TEST(activation_f32_fw_gpu, relu_basic_acosh_yxfb) {
     ASSERT_EQ(b_size, 1);
 
     for (int i = 0; i < x_size * y_size * f_size * b_size; ++i) {
-        EXPECT_FLOAT_EQ(std::acosh(input_ptr[i]), output_ptr[i]);
+        ASSERT_FLOAT_EQ(std::acosh(input_ptr[i]), output_ptr[i]);
     }
 }
 
@@ -1106,7 +1106,7 @@ TEST(activation_f32_fw_gpu, relu_basic_input_padding_yxfb) {
     ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
-        EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(output_vec[i], output_ptr[i]);
     }
 }
 
@@ -1196,7 +1196,7 @@ TEST(activation_f32_fw_gpu, relu_basic_input_padding_bfzyx) {
     ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
-        EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(output_vec[i], output_ptr[i]);
     }
 }
 
@@ -1268,7 +1268,7 @@ TEST(activation_f32_fw_gpu, relu_basic_output_padding_yxfb) {
     ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
-        EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(output_vec[i], output_ptr[i]);
     }
 }
 
@@ -1315,10 +1315,10 @@ TEST(activation_f32_fw_gpu, basic_yxfb_floor_ceil)
             switch (func)
             {
             case activation_func::floor:
-                EXPECT_FLOAT_EQ(std::floor((float)input_ptr[i]), output_ptr[i]);
+                ASSERT_FLOAT_EQ(std::floor((float)input_ptr[i]), output_ptr[i]);
                 break;
             case activation_func::ceil:
-                EXPECT_FLOAT_EQ(std::ceil((float)input_ptr[i]), output_ptr[i]);
+                ASSERT_FLOAT_EQ(std::ceil((float)input_ptr[i]), output_ptr[i]);
                 break;
             default:
                 break;
@@ -1563,7 +1563,7 @@ struct activation_random_test : testing::TestWithParam<activation_random_test_pa
     }
 
     template <typename T>
-    bool compare_outputs(const memory::ptr out_ref, const memory::ptr out_opt) {
+    void compare_outputs(const memory::ptr out_ref, const memory::ptr out_opt) {
         auto output_lay = out_ref->get_layout();
         auto opt_output_lay = out_opt->get_layout();
         size_t b = output_lay.batch();
@@ -1586,14 +1586,12 @@ struct activation_random_test : testing::TestWithParam<activation_random_test_pa
                         auto ref_out_val = ref_ptr[ref_out_offset + xi * ref_x_pitch];
                         auto opt_out_val = opt_ptr[opt_out_offset + xi * opt_x_pitch];
                         if (ref_out_val != opt_out_val) {
-                            EXPECT_NEAR(ref_out_val, opt_out_val, 1e-4);
+                            ASSERT_NEAR(ref_out_val, opt_out_val, 1e-4);
                         }
                     }
                 }
             }
         }
-
-        return true;
     }
 
     void execute_compare(const activation_random_test_params& params, bool check_result) {

--- a/src/plugins/intel_gpu/tests/test_cases/adaptive_avg_pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/adaptive_avg_pooling_gpu_test.cpp
@@ -164,7 +164,7 @@ public:
         ASSERT_EQ(params.outputTensor.count(), out_ptr.size());
         ASSERT_EQ(params.outputTensor.count(), expected.size());
         for (size_t i = 0; i < expected.size(); ++i) {
-            EXPECT_NEAR(expected[i], out_ptr[i], getError<T>())
+            ASSERT_NEAR(expected[i], out_ptr[i], getError<T>())
                 << "i = " << i << ", format=" << fmt_to_str(target_layout);
         }
     }

--- a/src/plugins/intel_gpu/tests/test_cases/adaptive_max_pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/adaptive_max_pooling_gpu_test.cpp
@@ -192,7 +192,7 @@ public:
         ASSERT_EQ(params.outputTensor.count(), out_ptr.size());
         ASSERT_EQ(params.outputTensor.count(), expected.size());
         for (size_t i = 0; i < expected.size(); ++i) {
-            EXPECT_NEAR(expected[i], out_ptr[i], getError<T>())
+            ASSERT_NEAR(expected[i], out_ptr[i], getError<T>())
                 << "i = " << i << ", format=" << fmt_to_str(target_layout);
         }
 

--- a/src/plugins/intel_gpu/tests/test_cases/adaptive_max_pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/adaptive_max_pooling_gpu_test.cpp
@@ -168,7 +168,7 @@ public:
             membuf mem_buf;
             {
                 cldnn::network _network(engine, topology);
-                
+
                 std::ostream out_mem(&mem_buf);
                 BinaryOutputBuffer ob = BinaryOutputBuffer(out_mem);
                 _network.save(ob);
@@ -221,7 +221,7 @@ public:
         ASSERT_EQ(params.outputTensor.count(), indices_ptr.size());
         ASSERT_EQ(params.outputTensor.count(), expected_indices.size());
         for (size_t i = 0; i < expected_indices.size(); ++i) {
-            EXPECT_EQ(index_offset * expected_indices[i], indices_ptr[i]) 
+            ASSERT_EQ(index_offset * expected_indices[i], indices_ptr[i])
                 << "i = " << i << ", format=" << fmt_to_str(target_layout);
         }
     }

--- a/src/plugins/intel_gpu/tests/test_cases/add_reorders_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/add_reorders_gpu_test.cpp
@@ -59,7 +59,7 @@ TEST(add_reorders_gpu, two_convolutions_and_concatenation) {
     for (auto& it : outputs) {
         cldnn::mem_lock<float> output(it.second.get_memory(), get_test_stream());
         for (size_t cntr = 0; cntr < 2 * 2; cntr++) {
-            EXPECT_NEAR(expected_out[cntr], output[cntr], epsilon);
+            ASSERT_NEAR(expected_out[cntr], output[cntr], epsilon);
         }
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/add_reorders_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/add_reorders_gpu_test.cpp
@@ -50,7 +50,7 @@ TEST(add_reorders_gpu, two_convolutions_and_concatenation) {
     network.set_input_data("input", input);
 
     //concatenation accepts inputs in different formats, so no reorders should be added here
-    EXPECT_EQ(network.get_all_primitive_org_ids().size(), size_t(7));
+    ASSERT_EQ(network.get_all_primitive_org_ids().size(), size_t(7));
     auto outputs = network.execute();
 
     float expected_out[] = { 6.34f, 1.34f, 6.86f, 1.46f };
@@ -145,7 +145,7 @@ void test_add_reorders_gpu_basic_reshape_and_tile(bool is_caching_test) {
     network->set_input_data("input", input);
 
     //reorder is required as tile accepts only bfyx format
-    EXPECT_EQ(network->get_all_primitive_org_ids().size(), size_t(4));
+    ASSERT_EQ(network->get_all_primitive_org_ids().size(), size_t(4));
     auto outputs = network->execute();
 
     auto output = outputs.at("tile").get_memory();
@@ -153,7 +153,7 @@ void test_add_reorders_gpu_basic_reshape_and_tile(bool is_caching_test) {
     cldnn::mem_lock<T> output_ref_ptr(output_ref, get_test_stream());
 
     for (unsigned int i = 0; i < output_ref->count(); ++i) {
-        EXPECT_EQ(output_ptr[i], output_ref_ptr[i]);
+        ASSERT_EQ(output_ptr[i], output_ref_ptr[i]);
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/arg_max_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/arg_max_gpu_test.cpp
@@ -35,7 +35,7 @@ struct argmax_gpu_test : public testing::Test {
         cldnn::mem_lock<input_type> out_ptr(mem, get_test_stream());
         for (uint32_t i = 0; i < out_size; i++) {
             float out_value = get_value<input_type>(out_ptr.data(), i);
-            EXPECT_EQ(out_value, i < (out_size / 2) ? 0 : 1);
+            ASSERT_EQ(out_value, i < (out_size / 2) ? 0 : 1);
         }
     }
 };
@@ -132,8 +132,8 @@ TEST(arg_max_gpu_min_axis_batch_bfzyx, i32) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "arg_max");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "arg_max");
     const int out_size = y_size * feature_num * x_size * top_k;
     auto output = outputs.at("arg_max").get_memory();
     cldnn::mem_lock<int32_t> output_ptr(output, get_test_stream());
@@ -142,7 +142,7 @@ TEST(arg_max_gpu_min_axis_batch_bfzyx, i32) {
         out_buffer[i] = get_value<int32_t>(output_ptr.data(), i);
     }
     for (int i = 0; i < out_size; i++) {
-        EXPECT_EQ(out_buffer[i], i < (out_size / 2) ? 0 : 1);
+        ASSERT_EQ(out_buffer[i], i < (out_size / 2) ? 0 : 1);
     }
 }
 
@@ -199,8 +199,8 @@ TEST(arg_max_gpu_min_axis_y_yxfb, f32) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "arg_max");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "arg_max");
     const int out_size = y_size * feature_num * x_size * top_k;
     auto output = outputs.at("arg_max").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -209,7 +209,7 @@ TEST(arg_max_gpu_min_axis_y_yxfb, f32) {
         out_buffer[i] = get_value<float>(output_ptr.data(), i);
     }
     for (int i = 0; i < out_size; i++) {
-        EXPECT_EQ(out_buffer[i], ref_vec[i]);
+        ASSERT_EQ(out_buffer[i], ref_vec[i]);
     }
 }
 
@@ -264,8 +264,8 @@ TEST(arg_max_gpu_min_axis_batch_yxfb, f32) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "arg_max");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "arg_max");
     const int out_size = y_size * feature_num * x_size * top_k;
     auto output = outputs.at("arg_max").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -274,7 +274,7 @@ TEST(arg_max_gpu_min_axis_batch_yxfb, f32) {
         out_buffer[i] = get_value<float>(output_ptr.data(), i);
     }
     for (int i = 0; i < out_size; i++) {
-        EXPECT_EQ(out_buffer[i], ref_vec[i]);
+        ASSERT_EQ(out_buffer[i], ref_vec[i]);
     }
 }
 
@@ -321,8 +321,8 @@ TEST(arg_max_gpu_min_axis_y_yxfb_topk_2, f32) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "arg_max");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "arg_max");
     const int out_size = y_size * feature_num * x_size * top_k;
     auto output = outputs.at("arg_max").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -331,7 +331,7 @@ TEST(arg_max_gpu_min_axis_y_yxfb_topk_2, f32) {
         out_buffer[i] = get_value<float>(output_ptr.data(), i);
     }
     for (int i = 0; i < out_size; i++) {
-        EXPECT_EQ(out_buffer[i], ref_vec[i]);
+        ASSERT_EQ(out_buffer[i], ref_vec[i]);
     }
 }
 
@@ -365,8 +365,8 @@ TEST(top_k_layer_tests, second_output) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "arg_max");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "arg_max");
     const int out_size = y_size * feature_num * x_size * top_k;
     auto output = outputs.at("arg_max").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -379,8 +379,8 @@ TEST(top_k_layer_tests, second_output) {
         second_out_buffer[i] = get_value<float>(second_output_ptr.data(), i);
     }
     for (int i = 0; i < out_size; i++) {
-        EXPECT_EQ(out_buffer[i], i < (out_size / 2) ? 0 : 1);
-        EXPECT_EQ(second_out_buffer[i], input_vec[i]);
+        ASSERT_EQ(out_buffer[i], i < (out_size / 2) ? 0 : 1);
+        ASSERT_EQ(second_out_buffer[i], input_vec[i]);
     }
 }
 
@@ -459,8 +459,8 @@ TEST(top_k_layer_tests, second_output2) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "arg_max");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "arg_max");
     const int out_size = y_size * feature_num * x_size * top_k;
     auto output = outputs.at("arg_max").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -472,8 +472,8 @@ TEST(top_k_layer_tests, second_output2) {
         second_out_buffer[i] = get_value<float>(second_output_ptr.data(), i);
     }
     for (int i = 0; i < out_size; i++) {
-        EXPECT_EQ(out_buffer[i], ref_vec[i]);
-        EXPECT_EQ(second_out_buffer[i], second_ref_vec[i]);
+        ASSERT_EQ(out_buffer[i], ref_vec[i]);
+        ASSERT_EQ(second_out_buffer[i], second_ref_vec[i]);
     }
 }
 
@@ -548,8 +548,8 @@ TEST(top_k_layer_tests, multiple_outputs) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "concat");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "concat");
     const int out_size = y_size * feature_num * x_size * top_k * 2;
     auto output = outputs.at("concat").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -559,7 +559,7 @@ TEST(top_k_layer_tests, multiple_outputs) {
         out_buffer[i] = get_value<float>(output_ptr.data(), i);
     }
     for (int i = 0; i < out_size; i++) {
-        EXPECT_EQ(out_buffer[i], ref_result[i]);
+        ASSERT_EQ(out_buffer[i], ref_result[i]);
     }
 }
 
@@ -606,8 +606,8 @@ TEST(arg_max_gpu_min_axis_y_yxfb_topk_2, sort_by_values) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "arg_max");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "arg_max");
     const int out_size = y_size * feature_num * x_size * top_k;
     auto output = outputs.at("arg_max").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -616,7 +616,7 @@ TEST(arg_max_gpu_min_axis_y_yxfb_topk_2, sort_by_values) {
         out_buffer[i] = get_value<float>(output_ptr.data(), i);
     }
     for (int i = 0; i < out_size; i++) {
-        EXPECT_EQ(out_buffer[i], ref_vec[i]);
+        ASSERT_EQ(out_buffer[i], ref_vec[i]);
     }
 }
 
@@ -663,8 +663,8 @@ TEST(arg_max_gpu_min_axis_y_yxfb_topk_2, sort_by_indices) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "arg_max");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "arg_max");
     const int out_size = y_size * feature_num * x_size * top_k;
     auto output = outputs.at("arg_max").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -673,7 +673,7 @@ TEST(arg_max_gpu_min_axis_y_yxfb_topk_2, sort_by_indices) {
         out_buffer[i] = get_value<float>(output_ptr.data(), i);
     }
     for (int i = 0; i < out_size; i++) {
-        EXPECT_EQ(out_buffer[i], ref_vec[i]);
+        ASSERT_EQ(out_buffer[i], ref_vec[i]);
     }
 }
 
@@ -723,8 +723,8 @@ void test_top_k_layer_tests_sort_probabilities_by_indices(bool is_caching_test) 
     network->set_input_data("input", input);
     auto outputs = network->execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "arg_max");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "arg_max");
     const int out_size = top_k;
     auto output = outputs.at("arg_max").get_memory();
     cldnn::mem_lock<int> output_ptr(output, get_test_stream());
@@ -733,7 +733,7 @@ void test_top_k_layer_tests_sort_probabilities_by_indices(bool is_caching_test) 
         out_buffer[i] = get_value<int>(output_ptr.data(), i);
     }
     for (int i = 0; i < out_size; i++) {
-        EXPECT_EQ(out_buffer[i], ref_vec[i]);
+        ASSERT_EQ(out_buffer[i], ref_vec[i]);
     }
 }
 
@@ -890,11 +890,11 @@ void test_top_k_layer_md_sync(bool is_caching_test) {
     network->set_input_data("input1", input1);
     auto outputs = network->execute();
 
-    EXPECT_EQ(outputs.size(), size_t(2));
+    ASSERT_EQ(outputs.size(), size_t(2));
     auto output = outputs.at("arg_max.1").get_memory();
     mem_lock<T> output_ptr(output, get_test_stream());
 
-    EXPECT_EQ(output_ptr[0], output_ref);
+    ASSERT_EQ(output_ptr[0], output_ref);
 }
 
 TEST(top_k_layer_tests, md_sync) {

--- a/src/plugins/intel_gpu/tests/test_cases/average_unpooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/average_unpooling_gpu_test.cpp
@@ -59,11 +59,11 @@ TEST(average_unpooling_gpu, basic_in2x2x2x1) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     auto output_layout = output->get_layout();
 
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(output_layout.spatial(1), 2);
-    EXPECT_EQ(output_layout.spatial(0), 3);
-    EXPECT_EQ(output_layout.feature(), 2);
-    EXPECT_EQ(output_layout.batch(), 2);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(output_layout.spatial(1), 2);
+    ASSERT_EQ(output_layout.spatial(0), 3);
+    ASSERT_EQ(output_layout.feature(), 2);
+    ASSERT_EQ(output_layout.batch(), 2);
 
     std::vector<float> expected_output_vec = {
         0.625f, -0.5f, -1.125,
@@ -77,7 +77,7 @@ TEST(average_unpooling_gpu, basic_in2x2x2x1) {
     };
 
     for (size_t i = 0; i < expected_output_vec.size(); ++i) {
-        EXPECT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -131,11 +131,11 @@ TEST(average_unpooling_gpu, basic_in2x2x3x2_with_average_pooling_unpooling) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     auto output_layout = output->get_layout();
 
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(output_layout.spatial(1), 2);
-    EXPECT_EQ(output_layout.spatial(0), 3);
-    EXPECT_EQ(output_layout.feature(), 2);
-    EXPECT_EQ(output_layout.batch(), 2);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(output_layout.spatial(1), 2);
+    ASSERT_EQ(output_layout.spatial(0), 3);
+    ASSERT_EQ(output_layout.feature(), 2);
+    ASSERT_EQ(output_layout.batch(), 2);
 
     std::vector<float> expected_output_vec = {
         0.625f, 0.625f, -6,
@@ -149,7 +149,7 @@ TEST(average_unpooling_gpu, basic_in2x2x3x2_with_average_pooling_unpooling) {
     };
 
     for (size_t i = 0; i < expected_output_vec.size(); ++i) {
-        EXPECT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -198,11 +198,11 @@ TEST(average_unpooling_gpu, basic_in2x2x2x1_output_padding) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     auto output_layout = output->get_layout();
 
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(output_layout.spatial(1), 2);
-    EXPECT_EQ(output_layout.spatial(0), 3);
-    EXPECT_EQ(output_layout.feature(), 2);
-    EXPECT_EQ(output_layout.batch(), 2);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(output_layout.spatial(1), 2);
+    ASSERT_EQ(output_layout.spatial(0), 3);
+    ASSERT_EQ(output_layout.feature(), 2);
+    ASSERT_EQ(output_layout.batch(), 2);
 
     std::vector<float> expected_output_vec = {
         0.f, 0.f, 0.f, 0.f, 0.f,
@@ -228,7 +228,7 @@ TEST(average_unpooling_gpu, basic_in2x2x2x1_output_padding) {
     std::vector<float> out;
     for (size_t i = 0; i < expected_output_vec.size(); ++i) {
         out.push_back(output_ptr[i]);
-        EXPECT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -297,11 +297,11 @@ void test_average_unpooling_gpu_basic_in2x2x2x1_fp16(bool is_caching_test) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
     auto output_layout = output->get_layout();
 
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(output_layout.spatial(1), 2);
-    EXPECT_EQ(output_layout.spatial(0), 3);
-    EXPECT_EQ(output_layout.feature(), 2);
-    EXPECT_EQ(output_layout.batch(), 2);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(output_layout.spatial(1), 2);
+    ASSERT_EQ(output_layout.spatial(0), 3);
+    ASSERT_EQ(output_layout.feature(), 2);
+    ASSERT_EQ(output_layout.batch(), 2);
 
     std::vector<T> expected_output_vec = {
         0.625f, -0.5f, -1.125,
@@ -314,7 +314,7 @@ void test_average_unpooling_gpu_basic_in2x2x2x1_fp16(bool is_caching_test) {
         1.75f, 2.9375f, 1.1875f
     };
     for (size_t i = 0; i < expected_output_vec.size(); ++i) {
-        EXPECT_EQ(expected_output_vec[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_output_vec[i], half_to_float(output_ptr[i]));
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/barriers_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/barriers_test.cpp
@@ -49,8 +49,8 @@ TEST(DISABLED_oooq_test, simple)
     net.set_input_data("in", input_mem);
     auto output = net.execute().at("c9").get_memory();
 
-    EXPECT_TRUE(output->get_layout().spatial(0) == 2);
-    EXPECT_TRUE(output->get_layout().spatial(1) == 2);
-    EXPECT_TRUE(output->get_layout().feature() == 1);
-    EXPECT_TRUE(output->get_layout().batch() == 1);
+    ASSERT_TRUE(output->get_layout().spatial(0) == 2);
+    ASSERT_TRUE(output->get_layout().spatial(1) == 2);
+    ASSERT_TRUE(output->get_layout().feature() == 1);
+    ASSERT_TRUE(output->get_layout().batch() == 1);
 }

--- a/src/plugins/intel_gpu/tests/test_cases/batch_to_space_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/batch_to_space_gpu_test.cpp
@@ -54,7 +54,7 @@ TEST(batch_to_space_fp16_gpu, i8111_bs1222_cb0000_ce0000) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -104,7 +104,7 @@ TEST(batch_to_space_fp16_gpu, i4321_bs1212_cb0000_ce0000) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -151,7 +151,7 @@ TEST(batch_to_space_fp16_gpu, i4321_bs1212_cb0010_ce0101) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -198,7 +198,7 @@ TEST(batch_to_space_fp16_gpu, i62121_bs12311_cb02000_ce00110) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -249,7 +249,7 @@ TEST(batch_to_space_fp16_gpu, i1212112_bs112321_cb02000_ce00110) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -300,7 +300,7 @@ TEST(batch_to_space_fp16_gpu, i21611_bs1112_cb0000_ce0000_b_fs_yx_fsv16) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -350,7 +350,7 @@ TEST(batch_to_space_fp16_gpu, i2812_bs1112_cb0000_ce0000_b_fs_yx_fsv16) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -393,7 +393,7 @@ TEST(batch_to_space_fp32_gpu, i8111_bs1222_cb0000_ce0000) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -443,7 +443,7 @@ TEST(batch_to_space_fp32_gpu, i4321_bs1212_cb0000_ce0000) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -490,7 +490,7 @@ TEST(batch_to_space_fp32_gpu, i4321_bs1212_cb0010_ce0101) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -537,7 +537,7 @@ TEST(batch_to_space_fp32_gpu, i62121_bs12311_cb02000_ce00110) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -588,7 +588,7 @@ TEST(batch_to_space_fp32_gpu, i1212112_bs112321_cb02000_ce00110) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -640,7 +640,7 @@ TEST(batch_to_space_fp32_gpu, i21621_bs1112_cb0201_ce0810_b_fs_yx_fsv16) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -713,7 +713,7 @@ void test_batch_to_space_fp32_gpu_i41021_bs1221_cb0201_ce0810_b_fs_yx_fsv16(bool
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/binary_convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/binary_convolution_gpu_test.cpp
@@ -398,23 +398,23 @@ TEST(binary_convolution, basic_convolution_1x1_single_packed_channel) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "binary_conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "binary_conv");
 
     auto output_memory = outputs.at("binary_conv").get_memory();
     auto output_layout = output_memory->get_layout();
     cldnn::mem_lock<float> output_ptr(output_memory, get_test_stream());
 
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(output_layout.data_type, data_types::f32);
-    EXPECT_EQ(output_layout.batch(), 1);
-    EXPECT_EQ(output_layout.feature(), 4);
-    EXPECT_EQ(output_layout.spatial(1), 2);
-    EXPECT_EQ(output_layout.spatial(0), 2);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(output_layout.data_type, data_types::f32);
+    ASSERT_EQ(output_layout.batch(), 1);
+    ASSERT_EQ(output_layout.feature(), 4);
+    ASSERT_EQ(output_layout.spatial(1), 2);
+    ASSERT_EQ(output_layout.spatial(0), 2);
 
     for (size_t i = 0; i < output_layout.count(); i++)
     {
-        EXPECT_EQ(output_ptr[i], output_vec[i]) << "index="<< i;
+        ASSERT_EQ(output_ptr[i], output_vec[i]) << "index="<< i;
     }
 }
 
@@ -481,21 +481,21 @@ TEST(binary_convolution, basic_convolution_1x1_single_packed_channel_fp16) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "binary_conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "binary_conv");
 
     auto output_memory = outputs.at("binary_conv").get_memory();
     auto output_layout = output_memory->get_layout();
     cldnn::mem_lock<uint16_t> output_ptr(output_memory, get_test_stream());
 
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(output_layout.data_type, data_types::f16);
-    EXPECT_EQ(output_layout.batch(), 1);
-    EXPECT_EQ(output_layout.feature(), 4);
-    EXPECT_EQ(output_layout.spatial(1), 2);
-    EXPECT_EQ(output_layout.spatial(0), 2);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(output_layout.data_type, data_types::f16);
+    ASSERT_EQ(output_layout.batch(), 1);
+    ASSERT_EQ(output_layout.feature(), 4);
+    ASSERT_EQ(output_layout.spatial(1), 2);
+    ASSERT_EQ(output_layout.spatial(0), 2);
 
     for (size_t i = 0; i < output_layout.count(); i++) {
-        EXPECT_EQ(half_to_float(output_ptr[i]), output_vec[i]) << "index="<< i;
+        ASSERT_EQ(half_to_float(output_ptr[i]), output_vec[i]) << "index="<< i;
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/border_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/border_gpu_test.cpp
@@ -122,7 +122,7 @@ public:
         auto base_output = base_network.execute().at("border").get_memory();
         cldnn::mem_lock<T> base_output_ptr(base_output, get_test_stream());
 
-        EXPECT_TRUE(!memcmp(target_output_ptr.data(), base_output_ptr.data(), sizeof(T) * mult(sh_out)));
+        ASSERT_TRUE(!memcmp(target_output_ptr.data(), base_output_ptr.data(), sizeof(T) * mult(sh_out)));
     }
 };
 using border_test_i8 = border_test<char, data_types::i8>;
@@ -273,7 +273,7 @@ TEST(border_gpu, bsv16fsv16_without_reorder) {
                     b16f16_to_bfyx[index_bfyx(sh_out, b, f, y, x)] =
                         target_output_ptr.data()[index_bsv16fsv16(sh_out, b, f, y, x)];
 
-    EXPECT_TRUE(!memcmp(b16f16_to_bfyx.data(), base_output_ptr.data(), sizeof(T) * mult(sh_out)));
+    ASSERT_TRUE(!memcmp(b16f16_to_bfyx.data(), base_output_ptr.data(), sizeof(T) * mult(sh_out)));
 }
 
 TEST(border_gpu, zyx_bsv16fsv16) {
@@ -320,7 +320,7 @@ TEST(border_gpu, zyx_bsv16fsv16) {
     auto base_output = base_network.execute().at("border").get_memory();
     cldnn::mem_lock<T> base_output_ptr(base_output, get_test_stream());
 
-    EXPECT_TRUE(!memcmp(target_output_ptr.data(), base_output_ptr.data(), sizeof(T) * mult(sh_out)));
+    ASSERT_TRUE(!memcmp(target_output_ptr.data(), base_output_ptr.data(), sizeof(T) * mult(sh_out)));
 }
 
 TEST(border_gpu, basic_yxfb_0x0x1x2_0x0x3x4_border_constant) {
@@ -390,7 +390,7 @@ TEST(border_gpu, basic_yxfb_0x0x1x2_0x0x3x4_border_constant) {
                 for (auto x = 0; x < out_size_x; ++x) { // X
                     auto output_off = ((y * out_size_x + x) * out_size_f + f) * out_size_b + b; // YXFB
 
-                    EXPECT_EQ(output_ptr[output_off], out_data[output_off]);
+                    ASSERT_EQ(output_ptr[output_off], out_data[output_off]);
                 }
             }
         }
@@ -466,7 +466,7 @@ TEST(border_gpu, basic_fsv16_0x0x1x2_0x0x3x4_border_constant) {
                 for (auto x = 0; x < out_size_x; ++x) { // X
                     auto output_off = ((y * out_size_x + x) * out_size_f + f) * out_size_b + b; // YXFB
 
-                    EXPECT_EQ(output_ptr[output_off], out_data[output_off]);
+                    ASSERT_EQ(output_ptr[output_off], out_data[output_off]);
                 }
             }
         }
@@ -567,7 +567,7 @@ TEST(border_gpu, basic_bfzyx_0x0x1x01_0x0x0x0x3_border_constant) {
             for (auto z = 0; z < out_size_z; ++z) {     // z
                 for (auto y = 0; y < out_size_y; ++y) {     // Y
                     for (auto x = 0; x < out_size_x; ++x) { // X
-                        EXPECT_EQ(output_ptr[idx], out_data[idx]);
+                        ASSERT_EQ(output_ptr[idx], out_data[idx]);
                         idx++;
                     }
                 }
@@ -674,7 +674,7 @@ TEST(border_gpu, basic_bfwzyx_0x0x0x1x0x1_0x0x0x1x0x1_border_constant) {
                 for (auto z = 0; z < out_size_z; ++z) {     // z
                     for (auto y = 0; y < out_size_y; ++y) {     // Y
                         for (auto x = 0; x < out_size_x; ++x) { // X
-                            EXPECT_EQ(output_ptr[idx], out_data[idx]);
+                            ASSERT_EQ(output_ptr[idx], out_data[idx]);
                             idx++;
                         }
                     }
@@ -751,7 +751,7 @@ TEST(border_gpu, basic_yxfb_0x0x1x2_0x0x3x4_border_constant_non_constant) {
                 for (auto x = 0; x < out_size_x; ++x) { // X
                     auto output_off = ((y * out_size_x + x) * out_size_f + f) * out_size_b + b; // YXFB
 
-                    EXPECT_EQ(output_ptr[output_off], out_data[output_off]);
+                    ASSERT_EQ(output_ptr[output_off], out_data[output_off]);
                 }
             }
         }
@@ -824,7 +824,7 @@ TEST(border_gpu, basic_yxfb_0x0x1x2_0x0x3x4_border_mirror) {
                 for (auto x = 0; x < out_size_x; ++x) { // X
                     auto output_off = ((y * out_size_x + x) * out_size_f + f) * out_size_b + b; // YXFB
 
-                    EXPECT_EQ(output_ptr[output_off], out_data[output_off]);
+                    ASSERT_EQ(output_ptr[output_off], out_data[output_off]);
                 }
             }
         }
@@ -896,7 +896,7 @@ TEST(border_gpu, basic_bfzyx_0x0x0x0x1_0x0x0x0x1_border_mirror) {
 
                         auto input_off = (((in_b * in_size_f + in_f) * in_size_z + in_z) * in_size_y + in_y) * in_size_x + in_x; // BFZYX
 
-                        EXPECT_EQ(output_ptr[output_off], input_data[input_off]);
+                        ASSERT_EQ(output_ptr[output_off], input_data[input_off]);
                     }
                 }
             }
@@ -976,7 +976,7 @@ TEST(border_gpu, basic_bfzyxw_0x0x0x0x1_0x0x0x0x1_border_mirror) {
 
                             auto input_off = ((((in_b * in_size_f + in_f) * in_size_w + in_w)* in_size_z + in_z) * in_size_y + in_y) * in_size_x + in_x; // BFZYX
 
-                            EXPECT_EQ(output_ptr[output_off], input_data[input_off]);
+                            ASSERT_EQ(output_ptr[output_off], input_data[input_off]);
                         }
                     }
                 }
@@ -1053,7 +1053,7 @@ TEST(border_gpu, basic_yxfb_0x0x1x2_0x0x3x4_border_mirror_101) {
                 for (auto x = 0; x < out_size_x; ++x) { // X
                     auto output_off = ((y * out_size_x + x) * out_size_f + f) * out_size_b + b; // YXFB
 
-                    EXPECT_EQ(output_ptr[output_off], out_data[output_off]);
+                    ASSERT_EQ(output_ptr[output_off], out_data[output_off]);
                 }
             }
         }
@@ -1130,7 +1130,7 @@ TEST(border_gpu, basic_bfzyx_0x0x0x0x1_0x0x0x0x1_border_mirror_101) {
             for (auto z = 0; z < out_size_z; ++z) {         // Z
                 for (auto y = 0; y < out_size_y; ++y) {     // Y
                     for (auto x = 0; x < out_size_x; ++x) { // X
-                        EXPECT_EQ(output_ptr[idx], out_data[idx]);
+                        ASSERT_EQ(output_ptr[idx], out_data[idx]);
                         idx++;
                     }
                 }
@@ -1224,7 +1224,7 @@ TEST(border_gpu, basic_bfwzyx_0x0x0x0x1x1_0x0x0x0x1x1_border_mirror_101) {
                 for (auto z = 0; z < out_size_z; ++z) {         // Z
                     for (auto y = 0; y < out_size_y; ++y) {     // Y
                         for (auto x = 0; x < out_size_x; ++x) { // X
-                            EXPECT_EQ(output_ptr[idx], out_data[idx]);
+                            ASSERT_EQ(output_ptr[idx], out_data[idx]);
                             idx++;
                         }
                     }
@@ -1302,7 +1302,7 @@ TEST(border_gpu, basic_yxfb_0x0x1x2_0x0x3x4_border_edge) {
                 for (auto x = 0; x < out_size_x; ++x) { // X
                     auto output_off = ((y * out_size_x + x) * out_size_f + f) * out_size_b + b; // YXFB
 
-                    EXPECT_EQ(output_ptr[output_off], out_data[output_off]);
+                    ASSERT_EQ(output_ptr[output_off], out_data[output_off]);
                 }
             }
         }
@@ -1365,12 +1365,12 @@ TEST(border_gpu, basic_bfyx_2x1x2x3_1x2x3x4_border_constant) {
                         y < blt_size_y || y >= out_size_y - brb_size_y ||
                         x < blt_size_x || x >= out_size_x - brb_size_x)
                     {
-                        EXPECT_EQ(output_ptr[output_off], 0.0f);
+                        ASSERT_EQ(output_ptr[output_off], 0.0f);
                     }
                     else
                     {
                         auto input_off  = (((b - blt_size_b) * in_size_f + f - blt_size_f) * in_size_y + y - blt_size_y) * in_size_x + x - blt_size_x; // BFYX
-                        EXPECT_EQ(output_ptr[output_off], input_data[input_off]);
+                        ASSERT_EQ(output_ptr[output_off], input_data[input_off]);
                     }
                 }
             }
@@ -1435,7 +1435,7 @@ TEST(border_gpu, basic_bfyx_2x1x2x3_1x2x3x4_border_mirror) {
 
                     auto input_off  = ((in_b * in_size_f + in_f) * in_size_y + in_y) * in_size_x + in_x; // BFYX
 
-                    EXPECT_EQ(output_ptr[output_off], input_data[input_off]);
+                    ASSERT_EQ(output_ptr[output_off], input_data[input_off]);
                 }
             }
         }
@@ -1498,7 +1498,7 @@ TEST(border_gpu, basic_bfyx_2x1x2x3_1x2x3x4_border_mirror_101) {
 
                     auto input_off  = ((in_b * in_size_f + in_f) * in_size_y + in_y) * in_size_x + in_x; // BFYX
 
-                    EXPECT_EQ(output_ptr[output_off], input_data[input_off]);
+                    ASSERT_EQ(output_ptr[output_off], input_data[input_off]);
                 }
             }
         }
@@ -1561,7 +1561,7 @@ TEST(border_gpu, basic_bfyx_2x1x2x3_1x2x3x4_border_edge) {
 
                     auto input_off  = ((in_b * in_size_f + in_f) * in_size_y + in_y) * in_size_x + in_x; // BFYX
 
-                    EXPECT_EQ(output_ptr[output_off], input_data[input_off]);
+                    ASSERT_EQ(output_ptr[output_off], input_data[input_off]);
                 }
             }
         }

--- a/src/plugins/intel_gpu/tests/test_cases/broadcast_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/broadcast_gpu_test.cpp
@@ -20,14 +20,14 @@ template<typename T>
 void start_broadcast_test(format cldnn_format, data_types cldnn_data_type, std::vector<size_t> output_shape,
                           std::vector<size_t> input_shape, std::vector<size_t> broadcast_axes) {
     size_t input_data_size = accumulate(input_shape.rbegin(), input_shape.rend(), (size_t)1, std::multiplies<size_t>());
-    EXPECT_GE(input_data_size, (size_t)1);
+    ASSERT_GE(input_data_size, (size_t)1);
     std::vector<T> input_data = {};
     for (size_t i = 1; i <= input_data_size; ++i) {
         input_data.push_back((T)i);
     }
 
     size_t output_data_size = accumulate(output_shape.rbegin(), output_shape.rend(), (size_t)1, std::multiplies<size_t>());
-    EXPECT_GE(output_data_size, (size_t)1);
+    ASSERT_GE(output_data_size, (size_t)1);
     std::vector<T> output_data(output_data_size);
     ngraph::runtime::reference::broadcast(reinterpret_cast<const char*>(input_data.data()), reinterpret_cast<char*>(output_data.data()),
                                           ov::Shape(input_shape.begin(), input_shape.end()), ov::Shape(output_shape.begin(), output_shape.end()),
@@ -90,14 +90,14 @@ void start_broadcast_test_dynamic(format input_format,
                                   ov::AxisSet broadcast_axes,
                                   bool is_output_static = false) {
     size_t input_data_size = accumulate(input_data_shape.rbegin(), input_data_shape.rend(), (size_t)1, std::multiplies<size_t>());
-    EXPECT_GE(input_data_size, (size_t)1);
+    ASSERT_GE(input_data_size, (size_t)1);
     std::vector<T> input_data = {};
     for (size_t i = 1; i <= input_data_size; ++i) {
         input_data.push_back((T)i);
     }
 
     size_t output_data_size = accumulate(output_shape.rbegin(), output_shape.rend(), (size_t)1, std::multiplies<size_t>());
-    EXPECT_GE(output_data_size, (size_t)1);
+    ASSERT_GE(output_data_size, (size_t)1);
     std::vector<T> output_data(output_data_size);
     ngraph::runtime::reference::broadcast(reinterpret_cast<const char*>(input_data.data()), reinterpret_cast<char*>(output_data.data()),
                                           ov::Shape(input_data_shape.begin(), input_data_shape.end()), ov::Shape(output_shape.begin(), output_shape.end()),
@@ -168,14 +168,14 @@ void start_broadcast_test_5d(format cldnn_format, data_types cldnn_data_type, st
                              std::vector<size_t> input_shape, std::vector<size_t> broadcast_axes, bool is_caching_test=false)
 {
     size_t input_data_size = accumulate(input_shape.rbegin(), input_shape.rend(), (size_t)1, std::multiplies<size_t>());
-    EXPECT_GE(input_data_size, (size_t)1);
+    ASSERT_GE(input_data_size, (size_t)1);
     std::vector<T> input_data = {};
     for (size_t i = 1; i <= input_data_size; ++i) {
         input_data.push_back((T)i);
     }
 
     size_t output_data_size = accumulate(output_shape.rbegin(), output_shape.rend(), (size_t)1, std::multiplies<size_t>());
-    EXPECT_GE(output_data_size, (size_t)1);
+    ASSERT_GE(output_data_size, (size_t)1);
     std::vector<T> output_data(output_data_size);
     ngraph::runtime::reference::broadcast(reinterpret_cast<const char*>(input_data.data()), reinterpret_cast<char*>(output_data.data()),
                                           ov::Shape(input_shape.begin(), input_shape.end()), ov::Shape(output_shape.begin(), output_shape.end()),

--- a/src/plugins/intel_gpu/tests/test_cases/broadcast_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/broadcast_gpu_test.cpp
@@ -33,7 +33,7 @@ void start_broadcast_test(format cldnn_format, data_types cldnn_data_type, std::
                                           ov::Shape(input_shape.begin(), input_shape.end()), ov::Shape(output_shape.begin(), output_shape.end()),
                                           ov::AxisSet(broadcast_axes), sizeof(T));
 
-    EXPECT_EQ(output_data.size(), accumulate(output_shape.rbegin(), output_shape.rend(), (size_t)1, std::multiplies<size_t>()));
+    ASSERT_EQ(output_data.size(), accumulate(output_shape.rbegin(), output_shape.rend(), (size_t)1, std::multiplies<size_t>()));
 
     std::vector<tensor::value_type> output_4d(4, 1);
     for (size_t i = 0; i < output_shape.size(); ++i) {
@@ -76,7 +76,7 @@ void start_broadcast_test(format cldnn_format, data_types cldnn_data_type, std::
             for (tensor::value_type y = 0; y < output_4d.at(2); ++y) {
                 for (tensor::value_type x = 0; x < output_4d.at(3); ++x) {
                     auto output_off = ((b * output_4d.at(1) + f) * output_4d.at(2) + y) * output_4d.at(3) + x;
-                    EXPECT_EQ(output_ptr[output_off], output_data[output_off]);
+                    ASSERT_EQ(output_ptr[output_off], output_data[output_off]);
                 }
             }
         }
@@ -103,7 +103,7 @@ void start_broadcast_test_dynamic(format input_format,
                                           ov::Shape(input_data_shape.begin(), input_data_shape.end()), ov::Shape(output_shape.begin(), output_shape.end()),
                                           ov::AxisSet(broadcast_axes), sizeof(T));
 
-    EXPECT_EQ(output_data.size(), accumulate(output_shape.rbegin(), output_shape.rend(), (size_t)1, std::multiplies<size_t>()));
+    ASSERT_EQ(output_data.size(), accumulate(output_shape.rbegin(), output_shape.rend(), (size_t)1, std::multiplies<size_t>()));
 
     int64_t input_rank = input_data_shape.size();
     ASSERT_EQ(input_rank, broadcast_axes.size());
@@ -111,7 +111,7 @@ void start_broadcast_test_dynamic(format input_format,
 
     auto& engine = get_test_engine();
     auto input = engine.allocate_memory({ov::PartialShape(input_data_shape), input_data_type, fmt});
- 
+
     topology topology;
     memory::ptr target_shape_mem = nullptr;
     if (is_output_static) {
@@ -159,7 +159,7 @@ void start_broadcast_test_dynamic(format input_format,
     cldnn::mem_lock<T> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < output_data_size; ++i) {
-        EXPECT_EQ(output_ptr[i], output_data[i]);
+        ASSERT_EQ(output_ptr[i], output_data[i]);
     }
 }
 
@@ -181,7 +181,7 @@ void start_broadcast_test_5d(format cldnn_format, data_types cldnn_data_type, st
                                           ov::Shape(input_shape.begin(), input_shape.end()), ov::Shape(output_shape.begin(), output_shape.end()),
                                           ov::AxisSet(broadcast_axes), sizeof(T));
 
-    EXPECT_EQ(output_data.size(), accumulate(output_shape.rbegin(), output_shape.rend(), (size_t)1, std::multiplies<size_t>()));
+    ASSERT_EQ(output_data.size(), accumulate(output_shape.rbegin(), output_shape.rend(), (size_t)1, std::multiplies<size_t>()));
 
     std::vector<tensor::value_type> output_5d(5, 1);
     for (size_t i = 0; i < output_shape.size(); ++i) {
@@ -243,7 +243,7 @@ void start_broadcast_test_5d(format cldnn_format, data_types cldnn_data_type, st
                 for (tensor::value_type y = 0; y < output_5d.at(3); ++y) {
                     for (tensor::value_type x = 0; x < output_5d.at(4); ++x) {
                         auto output_off = (((b * output_5d.at(1) + f) * output_5d.at(2) + z) * output_5d.at(3) + y) * output_5d.at(4) + x;
-                        EXPECT_EQ(output_ptr[output_off], output_data[output_off]);
+                        ASSERT_EQ(output_ptr[output_off], output_data[output_off]);
                     }
                 }
             }

--- a/src/plugins/intel_gpu/tests/test_cases/bucketize_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/bucketize_gpu_test.cpp
@@ -87,7 +87,7 @@ struct bucketize_test : testing::TestWithParam<bucketize_test_params<I, B, O>> {
             cldnn::mem_lock<O> output_ptr(output, get_test_stream());
             ASSERT_EQ(output_ptr.size(), p.output_values_right_bound.size());
             for (size_t i = 0; i < output_ptr.size(); ++i) {
-                EXPECT_EQ(p.output_values_right_bound[i], output_ptr[i]);
+                ASSERT_EQ(p.output_values_right_bound[i], output_ptr[i]);
             }
         }
 
@@ -96,7 +96,7 @@ struct bucketize_test : testing::TestWithParam<bucketize_test_params<I, B, O>> {
             cldnn::mem_lock<O> output_ptr(output, get_test_stream());
             ASSERT_EQ(output_ptr.size(), p.output_values_left_bound.size());
             for (size_t i = 0; i < output_ptr.size(); ++i) {
-                EXPECT_EQ(p.output_values_left_bound[i], output_ptr[i]);
+                ASSERT_EQ(p.output_values_left_bound[i], output_ptr[i]);
             }
         }
     }

--- a/src/plugins/intel_gpu/tests/test_cases/cache_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/cache_test.cpp
@@ -230,7 +230,7 @@ public:
             if (compare_implementation.not_equal) {
                 EXPECT_NE(exec_impl, compare_implementation.value);
             } else {
-                EXPECT_EQ(exec_impl, compare_implementation.value);
+                ASSERT_EQ(exec_impl, compare_implementation.value);
             }
         }
 
@@ -240,7 +240,7 @@ public:
             auto eus = _engine.get_device_info().execution_units_count;
             replace(expected_cache, eus_marker, eus);
 
-            EXPECT_EQ(cache, expected_cache);
+            ASSERT_EQ(cache, expected_cache);
         }
     }
 

--- a/src/plugins/intel_gpu/tests/test_cases/cl_mem_input_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/cl_mem_input_test.cpp
@@ -153,7 +153,7 @@ void start_cl_mem_check_2_inputs(bool is_caching_test) {
     cldnn::mem_lock<T> output_ptr(output_prim, get_test_stream());
     int size = width * height * 3;
     for (auto i = 0; i < size; i++) {
-        EXPECT_NEAR(reference_results[i], output_ptr[i], 1.001f);
+        ASSERT_NEAR(reference_results[i], output_ptr[i], 1.001f);
     }
     checkStatus(clReleaseMemObject(nv12_image_plane_uv), "clReleaseMemObject");
     checkStatus(clReleaseMemObject(nv12_image_plane_y), "clReleaseMemObject");
@@ -270,7 +270,7 @@ TEST(cl_mem_check, check_input) {
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
     int size = width * height * 3;
     for (auto i = 0; i < size; i++) {
-        EXPECT_NEAR(reference_results[i], output_ptr[i], 1.001f);
+        ASSERT_NEAR(reference_results[i], output_ptr[i], 1.001f);
     }
     checkStatus(clReleaseMemObject(img), "clReleaseMemObject");
 }

--- a/src/plugins/intel_gpu/tests/test_cases/command_queue_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/command_queue_test.cpp
@@ -60,8 +60,8 @@ void exexute_network(cldnn::engine& engine, bool is_caching_test=false) {
     network->set_input_data("input", input);
     auto outputs = network->execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "arg_max");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "arg_max");
     const int out_size = y_size * feature_num * x_size * top_k;
     auto output = outputs.at("arg_max").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -70,7 +70,7 @@ void exexute_network(cldnn::engine& engine, bool is_caching_test=false) {
         out_buffer[i] = get_value<float>(output_ptr.data(), i);
     }
     for (int i = 0; i < out_size; i++) {
-        EXPECT_EQ(out_buffer[i], i < (out_size / 2) ? 0 : 1);
+        ASSERT_EQ(out_buffer[i], i < (out_size / 2) ? 0 : 1);
     }
 }
 }  // namespace

--- a/src/plugins/intel_gpu/tests/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/concatenation_gpu_test.cpp
@@ -69,8 +69,8 @@ TEST(concat_gpu, mixed_input_types) {
     network.set_input_data("input4", input4);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "concat");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "concat");
 
     auto output_memory = outputs.at("concat").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -80,14 +80,14 @@ TEST(concat_gpu, mixed_input_types) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 3);
-    EXPECT_EQ(x_size, 4);
-    EXPECT_EQ(f_size, 5);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 3);
+    ASSERT_EQ(x_size, 4);
+    ASSERT_EQ(f_size, 5);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t x = 0; x < output_layout.count(); ++x) {
-        EXPECT_EQ(output_vec[x], output_ptr[x]);
+        ASSERT_EQ(output_vec[x], output_ptr[x]);
     }
 }
 
@@ -141,8 +141,8 @@ TEST(concat_gpu, mixed_input_types_5d) {
     network.set_input_data("input3", input3);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "concat");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "concat");
 
     auto output_memory = outputs.at("concat").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -153,15 +153,15 @@ TEST(concat_gpu, mixed_input_types_5d) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfzyx);
-    EXPECT_EQ(z_size, 3);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 1);
-    EXPECT_EQ(f_size, 4);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfzyx);
+    ASSERT_EQ(z_size, 3);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 1);
+    ASSERT_EQ(f_size, 4);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t x = 0; x < output_layout.count(); ++x) {
-        EXPECT_EQ(output_vec[x], output_ptr[x]);
+        ASSERT_EQ(output_vec[x], output_ptr[x]);
     }
 }
 
@@ -214,8 +214,8 @@ TEST(concat_gpu, i8_optimization_with_pool) {
     network.set_input_data("input1", input1);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output_memory = outputs.at("reorder").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -225,14 +225,14 @@ TEST(concat_gpu, i8_optimization_with_pool) {
     int x_size = output_layout.spatial(1);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 7);
-    EXPECT_EQ(x_size, 2);
-    EXPECT_EQ(f_size, 2);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 7);
+    ASSERT_EQ(x_size, 2);
+    ASSERT_EQ(f_size, 2);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t x = 0; x < output_layout.count(); ++x) {
-        EXPECT_EQ(output_vec[x], output_ptr[x]);
+        ASSERT_EQ(output_vec[x], output_ptr[x]);
     }
 }
 
@@ -317,8 +317,8 @@ TEST(concat_gpu, i8_optimization_with_conv) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -328,14 +328,14 @@ TEST(concat_gpu, i8_optimization_with_conv) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t x = 0; x < output_layout.count(); ++x) {
-        EXPECT_EQ(output_vec[x], output_ptr[x]);
+        ASSERT_EQ(output_vec[x], output_ptr[x]);
     }
 }
 
@@ -417,8 +417,8 @@ TEST(concat_gpu, i8_optimization_with_pool_conv) {
     network.set_input_data("input1", input1);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -428,14 +428,14 @@ TEST(concat_gpu, i8_optimization_with_pool_conv) {
     int x_size = output_layout.spatial(1);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 3);
-    EXPECT_EQ(x_size, 1);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 3);
+    ASSERT_EQ(x_size, 1);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t x = 0; x < output_layout.count(); ++x) {
-        EXPECT_EQ(output_vec[x], output_ptr[x]);
+        ASSERT_EQ(output_vec[x], output_ptr[x]);
     }
 }
 
@@ -611,7 +611,7 @@ public:
 
                             auto ref_val = in_data[in_i][bi][fi][yi][xi];
                             auto actual_val = out_ptr[output_offset];
-                            EXPECT_EQ(ref_val, actual_val)
+                            ASSERT_EQ(ref_val, actual_val)
                                 << " b=" << bi << ", f=" << f_sum + fi << "(input " << in_i << "), y=" << yi << ", x=" << xi;
                         }
                     }
@@ -701,7 +701,7 @@ public:
 
                             auto ref_val = in_data[in_i][bi][fi][yi][xi];
                             auto actual_val = out_ptr[output_offset];
-                            EXPECT_EQ(ref_val, actual_val)
+                            ASSERT_EQ(ref_val, actual_val)
                                 << " b=" << bi << ", f=" << fi << ", y=" << yi << ", x=" << x_sum + xi << "(input " << in_i << ")";
                         }
                         x_sum += input_x[in_i];
@@ -1009,7 +1009,7 @@ public:
 
         bool concat_opt_enabled = options.get<build_option_type::optimize_data>()->enabled();
         bool concat_opt_result = std::static_pointer_cast<concatenation_inst>(concat_network->get_primitive("concat"))->can_be_optimized();
-        EXPECT_TRUE(concat_opt_enabled==concat_opt_result);
+        EXPECT_EQ(concat_opt_enabled, concat_opt_result);
 
         return concat_network->get_output("reorder").get_memory();
     }
@@ -1042,12 +1042,12 @@ public:
         auto out_mem2 = run_concat_network(input, fmt, options2);
         cldnn::mem_lock<Type> out_ptr2(out_mem2, get_test_stream());
 
-        EXPECT_EQ(out_ptr1.size(), out_ptr2.size());
+        ASSERT_EQ(out_ptr1.size(), out_ptr2.size());
         size_t diff_count = 0;
         for (size_t i = 0; i < out_ptr1.size(); ++i) {
             if (out_ptr1[i] != out_ptr2[i]) diff_count++;
         }
-        EXPECT_EQ(diff_count, 0);
+        ASSERT_EQ(diff_count, 0);
     }
 };
 
@@ -1129,8 +1129,8 @@ TEST(concat_gpu_onednn, basic_input_types) {
     network.set_input_data("input4", input4);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "concat");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "concat");
 
     auto output_memory = outputs.at("concat").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -1140,14 +1140,14 @@ TEST(concat_gpu_onednn, basic_input_types) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 3);
-    EXPECT_EQ(x_size, 4);
-    EXPECT_EQ(f_size, 5);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 3);
+    ASSERT_EQ(x_size, 4);
+    ASSERT_EQ(f_size, 5);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t x = 0; x < output_layout.count(); ++x) {
-        EXPECT_EQ(output_vec[x], output_ptr[x]);
+        ASSERT_EQ(output_vec[x], output_ptr[x]);
     }
 }
 
@@ -1229,7 +1229,7 @@ public:
 
         bool concat_opt_enabled = options.get<build_option_type::optimize_data>()->enabled();
         bool concat_opt_result = std::static_pointer_cast<concatenation_inst>(concat_network.get_primitive("concat"))->node->can_be_optimized();
-        EXPECT_TRUE(concat_opt_enabled==concat_opt_result);
+        EXPECT_EQ(concat_opt_enabled, concat_opt_result);
 
         return concat_network.get_output("reorder").get_memory();
     }
@@ -1269,12 +1269,12 @@ public:
         auto out_mem2 = run_concat_network(input, fmt, options2);
         cldnn::mem_lock<Type> out_ptr2(out_mem2, get_test_stream());
 
-        EXPECT_EQ(out_ptr1.size(), out_ptr2.size());
+        ASSERT_EQ(out_ptr1.size(), out_ptr2.size());
         size_t diff_count = 0;
         for (size_t i = 0; i < out_ptr1.size(); ++i) {
             if (out_ptr1[i] != out_ptr2[i]) diff_count++;
         }
-        EXPECT_EQ(diff_count, 0);
+        ASSERT_EQ(diff_count, 0);
     }
 };
 

--- a/src/plugins/intel_gpu/tests/test_cases/condition_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/condition_gpu_test.cpp
@@ -127,14 +127,14 @@ TEST(DISABLED_condition_gpu, basic_equal_comp) {
     net.set_input_data("compare", compare);
     out = net.execute();
     auto out_data_true = out.at("output").get_memory();
-    EXPECT_TRUE(is_output_equal(out_data_true, {20.0f, 40.0f}));
+    ASSERT_TRUE(is_output_equal(out_data_true, {20.0f, 40.0f}));
 
     //WHEN FALSE
     set_values(compare, { 4.0f });
     net.set_input_data("compare", compare);
     out = net.execute();
     auto out_data_false = out.at("output").get_memory();
-    EXPECT_TRUE(is_output_equal(out_data_false, { 15.0f, 35.0f }));
+    ASSERT_TRUE(is_output_equal(out_data_false, { 15.0f, 35.0f }));
 
 }
 
@@ -200,7 +200,7 @@ TEST(DISABLED_condition_gpu, basic_range_equal_comp) {
     outputs = net.execute();
 
     auto out_data_true = outputs.at("condi").get_memory();
-    EXPECT_TRUE(is_output_equal(out_data_true, pooling_when_true_data));
+    ASSERT_TRUE(is_output_equal(out_data_true, pooling_when_true_data));
 
     //CHECK FALSE
     set_values(compare, compare_data_false);
@@ -208,7 +208,7 @@ TEST(DISABLED_condition_gpu, basic_range_equal_comp) {
     outputs = net.execute();
 
     auto out_data_false = outputs.at("condi").get_memory();
-    EXPECT_TRUE(is_output_equal(out_data_false, pooling_when_false_data));
+    ASSERT_TRUE(is_output_equal(out_data_false, pooling_when_false_data));
 }
 
 TEST(DISABLED_condition_gpu, generic_test_true_false) {
@@ -294,7 +294,7 @@ TEST(DISABLED_condition_gpu, generic_test_true_false) {
                 outputs = net.execute();
 
                 auto out_data_true = outputs.at("condi").get_memory();
-                EXPECT_TRUE(is_output_equal(out_data_true, pooling_when_true_data));
+                ASSERT_TRUE(is_output_equal(out_data_true, pooling_when_true_data));
 
                 //CHECK FALSE
                 set_values(compare, comp_values_false);
@@ -302,7 +302,7 @@ TEST(DISABLED_condition_gpu, generic_test_true_false) {
                 outputs = net.execute();
 
                 auto out_data_false = outputs.at("condi").get_memory();
-                EXPECT_TRUE(is_output_equal(out_data_false, pooling_when_false_data));
+                ASSERT_TRUE(is_output_equal(out_data_false, pooling_when_false_data));
 
             }
         }
@@ -376,7 +376,7 @@ TEST(DISABLED_condition_gpu, basic_stacked_ifs) {
     auto outputs = net.execute();
 
     auto out_data = outputs.at("condi2").get_memory();
-    EXPECT_TRUE(is_output_equal(out_data, {1.0f, 2.0f}));
+    ASSERT_TRUE(is_output_equal(out_data, {1.0f, 2.0f}));
 }
 
 TEST(DISABLED_condition_gpu, basic_nested_ifs) {
@@ -469,7 +469,7 @@ TEST(DISABLED_condition_gpu, basic_nested_ifs) {
     auto outputs = net.execute();
 
     auto out_data = outputs.at("condi").get_memory();
-    EXPECT_TRUE(is_output_equal(out_data, { 10.0f, 20.0f }));
+    ASSERT_TRUE(is_output_equal(out_data, { 10.0f, 20.0f }));
 }
 
 TEST(DISABLED_condition_gpu, negative_compare_wrong_layout) {

--- a/src/plugins/intel_gpu/tests/test_cases/convert_color_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/convert_color_gpu_test.cpp
@@ -94,7 +94,7 @@ TEST(convert_color, nv12_to_rgb_two_planes_buffer_fp32) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_res.size(); ++i) {
-        EXPECT_NEAR(ref_res[i], output_ptr[i], 1.001f);
+        ASSERT_NEAR(ref_res[i], output_ptr[i], 1.001f);
     }
 }
 
@@ -134,7 +134,7 @@ TEST(convert_color, nv12_to_bgr_two_planes_buffer_fp32) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_res.size(); ++i) {
-        EXPECT_NEAR(ref_res[i], output_ptr[i], 1.001f);
+        ASSERT_NEAR(ref_res[i], output_ptr[i], 1.001f);
     }
 }
 
@@ -174,7 +174,7 @@ TEST(convert_color, nv12_to_rgb_two_planes_buffer_u8) {
     cldnn::mem_lock<uint8_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_res.size(); ++i) {
-        EXPECT_NEAR(ref_res[i], static_cast<float>(output_ptr[i]), 1.001f);
+        ASSERT_NEAR(ref_res[i], static_cast<float>(output_ptr[i]), 1.001f);
     }
 }
 
@@ -214,7 +214,7 @@ TEST(convert_color, nv12_to_rgb_two_planes_buffer_fp16) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
      for (size_t i = 0; i < ref_res.size(); ++i) {
-        EXPECT_NEAR(ref_res[i], half_to_float(output_ptr[i]), 1.001f);
+        ASSERT_NEAR(ref_res[i], half_to_float(output_ptr[i]), 1.001f);
     }
 }
 
@@ -250,7 +250,7 @@ TEST(convert_color, nv12_to_rgb_single_plane_buffer_fp32) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_res.size(); ++i) {
-        EXPECT_NEAR(ref_res[i], output_ptr[i], 1.001f);
+        ASSERT_NEAR(ref_res[i], output_ptr[i], 1.001f);
     }
 }
 
@@ -286,7 +286,7 @@ TEST(convert_color, nv12_to_rgb_single_plane_buffer_u8) {
     cldnn::mem_lock<uint8_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_res.size(); ++i) {
-        EXPECT_NEAR(ref_res[i], static_cast<float>(output_ptr[i]), 1.001f);
+        ASSERT_NEAR(ref_res[i], static_cast<float>(output_ptr[i]), 1.001f);
     }
 }
 
@@ -363,7 +363,7 @@ TEST(convert_color, nv12_to_rgb_two_planes_surface_u8) {
     auto output_prim = outputs.begin()->second.get_memory();
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
     for (size_t i = 0; i < reference_results.size(); i++) {
-        EXPECT_NEAR(reference_results[i], output_ptr[i], 1.001f);
+        ASSERT_NEAR(reference_results[i], output_ptr[i], 1.001f);
     }
     checkStatus(clReleaseMemObject(nv12_image_plane_uv), "clReleaseMemObject");
     checkStatus(clReleaseMemObject(nv12_image_plane_y), "clReleaseMemObject");
@@ -426,7 +426,7 @@ TEST(convert_color, nv12_to_rgb_single_plane_surface_u8) {
     auto output_prim = outputs.begin()->second.get_memory();
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
     for (size_t i = 0; i < reference_results.size(); i++) {
-        EXPECT_NEAR(reference_results[i], output_ptr[i], 1.001f);
+        ASSERT_NEAR(reference_results[i], output_ptr[i], 1.001f);
     }
     checkStatus(clReleaseMemObject(nv12_image), "clReleaseMemObject");
 }
@@ -521,7 +521,7 @@ TEST(convert_color, i420_to_rgb_three_planes_buffer_fp32) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_res.size(); ++i) {
-        EXPECT_NEAR(ref_res[i], output_ptr[i], 1.001f);
+        ASSERT_NEAR(ref_res[i], output_ptr[i], 1.001f);
     }
 }
 
@@ -625,7 +625,7 @@ void test_convert_color_i420_to_rgb_three_planes_surface_u8(bool is_caching_test
     auto output_prim = outputs.begin()->second.get_memory();
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
     for (size_t i = 0; i < reference_results.size(); i++) {
-        EXPECT_NEAR(reference_results[i], output_ptr[i], 1.001f);
+        ASSERT_NEAR(reference_results[i], output_ptr[i], 1.001f);
     }
     checkStatus(clReleaseMemObject(i420_image_plane_y), "clReleaseMemObject");
     checkStatus(clReleaseMemObject(i420_image_plane_u), "clReleaseMemObject");

--- a/src/plugins/intel_gpu/tests/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/convolution_gpu_test.cpp
@@ -363,7 +363,7 @@ TEST(deformable_convolution_f32_fw_gpu, basic_deformable_convolution_def_group1_
     ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
-        EXPECT_NEAR(output_vec[i], output_ptr[i], 0.1);
+        ASSERT_NEAR(output_vec[i], output_ptr[i], 0.1);
     }
 }
 
@@ -494,7 +494,7 @@ TEST(deformable_convolution_f32_fw_gpu, basic_deformable_convolution_def_group1)
     ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
-        EXPECT_NEAR(output_vec[i], output_ptr[i], 0.1);
+        ASSERT_NEAR(output_vec[i], output_ptr[i], 0.1);
     }
 }
 
@@ -657,7 +657,7 @@ TEST(deformable_convolution_f32_fw_gpu, basic_deformable_convolution) {
     ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
-        EXPECT_NEAR(output_vec[i], output_ptr[i], 0.1);
+        ASSERT_NEAR(output_vec[i], output_ptr[i], 0.1);
     }
 }
 
@@ -1206,7 +1206,7 @@ TEST(convolution_f32_fw_gpu, three_convolutions_same_weights) {
 
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
-            EXPECT_FLOAT_EQ(8.0f, output_ptr[y * x_size + x]);
+            ASSERT_FLOAT_EQ(8.0f, output_ptr[y * x_size + x]);
         }
     }
 }
@@ -2091,7 +2091,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x1x1_nopad_random) {
 
     for (size_t i = 0; i < output_rnd.size(); ++i) {
         float x = float_round(output_rnd_vec[i]), y = float_round(output_ptr[i]);
-        EXPECT_FLOAT_EQ(x, y) << "random seed = " << random_seed << std::endl;
+        ASSERT_FLOAT_EQ(x, y) << "random seed = " << random_seed << std::endl;
     }
 }
 
@@ -2161,7 +2161,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in2x2x1x2_nopad_random) {
 
     for (size_t i = 0; i < output_rnd.size(); ++i) {
         float x = float_round(output_rnd_vec[i]), y = float_round(output_ptr[i]);
-        EXPECT_FLOAT_EQ(x, y) << "random seed = " << random_seed << std::endl;
+        ASSERT_FLOAT_EQ(x, y) << "random seed = " << random_seed << std::endl;
     }
 }
 
@@ -2217,10 +2217,10 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x1x1_nopad) {
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(8.0f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(0.5f, output_ptr[1]);
-    EXPECT_FLOAT_EQ(6.0f, output_ptr[2]);
-    EXPECT_FLOAT_EQ(9.0f, output_ptr[3]);
+    ASSERT_FLOAT_EQ(8.0f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(0.5f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(6.0f, output_ptr[2]);
+    ASSERT_FLOAT_EQ(9.0f, output_ptr[3]);
 }
 
 TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in2x2x1x2_nopad) {
@@ -2271,8 +2271,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in2x2x1x2_nopad) {
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(3.65f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(3.65f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[1]);
 }
 
 TEST(convolution_f32_fw_gpu, basic_ofm_wsiz2x1x2x1_in1x2x1_nopad) {
@@ -2323,8 +2323,8 @@ TEST(convolution_f32_fw_gpu, basic_ofm_wsiz2x1x2x1_in1x2x1_nopad) {
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(5.1f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(-5.2f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(5.1f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(-5.2f, output_ptr[1]);
 }
 
 TEST(convolution_f32_fw_gpu, basic_ofm_wsiz3x2x2x1_in2x2x1_nopad) {
@@ -2382,9 +2382,9 @@ TEST(convolution_f32_fw_gpu, basic_ofm_wsiz3x2x2x1_in2x2x1_nopad) {
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(25.0f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(64.0f, output_ptr[1]);
-    EXPECT_FLOAT_EQ(103.0f, output_ptr[2]);
+    ASSERT_FLOAT_EQ(25.0f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(64.0f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(103.0f, output_ptr[2]);
 }
 
 TEST(convolution_f32_fw_gpu, basic_wsiz2x2x1x3_wstr2x2_in2x2x1x1_nopad) {
@@ -2494,7 +2494,7 @@ TEST(convolution_f32_fw_gpu, wsiz3x3_wstr2x2_in2x2x1x1_zeropad) {
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(12.25f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(12.25f, output_ptr[0]);
 }
 
 TEST(convolution_f32_fw_gpu, offsets_wsiz3x3_wstr2x2_in2x2x1x1_zeropad) {
@@ -2559,7 +2559,7 @@ TEST(convolution_f32_fw_gpu, offsets_wsiz3x3_wstr2x2_in2x2x1x1_zeropad) {
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(-7.25f, output_ptr[4]);
+    ASSERT_FLOAT_EQ(-7.25f, output_ptr[4]);
 }
 
 TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x1_nopad_split2) {
@@ -2639,14 +2639,14 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x1_nopad_split2) {
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(8.0f,   output_ptr[0]);
-    EXPECT_FLOAT_EQ(3.65f,  output_ptr[1]);
-    EXPECT_FLOAT_EQ(0.5f,   output_ptr[2]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[3]);
-    EXPECT_FLOAT_EQ(6.0f,   output_ptr[4]);
-    EXPECT_FLOAT_EQ(3.65f,  output_ptr[5]);
-    EXPECT_FLOAT_EQ(9.0f,   output_ptr[6]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[7]);
+    ASSERT_FLOAT_EQ(8.0f,   output_ptr[0]);
+    ASSERT_FLOAT_EQ(3.65f,  output_ptr[1]);
+    ASSERT_FLOAT_EQ(0.5f,   output_ptr[2]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[3]);
+    ASSERT_FLOAT_EQ(6.0f,   output_ptr[4]);
+    ASSERT_FLOAT_EQ(3.65f,  output_ptr[5]);
+    ASSERT_FLOAT_EQ(9.0f,   output_ptr[6]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[7]);
 }
 
 TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_split2) {
@@ -2737,22 +2737,22 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_split2) {
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(8.0f,   output_ptr[0]);
-    EXPECT_FLOAT_EQ(8.0f,   output_ptr[1]);
-    EXPECT_FLOAT_EQ(3.65f,  output_ptr[2]);
-    EXPECT_FLOAT_EQ(3.65f,  output_ptr[3]);
-    EXPECT_FLOAT_EQ(0.5f,   output_ptr[4]);
-    EXPECT_FLOAT_EQ(0.5f,   output_ptr[5]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[6]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[7]);
-    EXPECT_FLOAT_EQ(6.0f,   output_ptr[8]);
-    EXPECT_FLOAT_EQ(6.0f,   output_ptr[9]);
-    EXPECT_FLOAT_EQ(3.65f,  output_ptr[10]);
-    EXPECT_FLOAT_EQ(3.65f,  output_ptr[11]);
-    EXPECT_FLOAT_EQ(9.0f,   output_ptr[12]);
-    EXPECT_FLOAT_EQ(9.0f,   output_ptr[13]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[14]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[15]);
+    ASSERT_FLOAT_EQ(8.0f,   output_ptr[0]);
+    ASSERT_FLOAT_EQ(8.0f,   output_ptr[1]);
+    ASSERT_FLOAT_EQ(3.65f,  output_ptr[2]);
+    ASSERT_FLOAT_EQ(3.65f,  output_ptr[3]);
+    ASSERT_FLOAT_EQ(0.5f,   output_ptr[4]);
+    ASSERT_FLOAT_EQ(0.5f,   output_ptr[5]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[6]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[7]);
+    ASSERT_FLOAT_EQ(6.0f,   output_ptr[8]);
+    ASSERT_FLOAT_EQ(6.0f,   output_ptr[9]);
+    ASSERT_FLOAT_EQ(3.65f,  output_ptr[10]);
+    ASSERT_FLOAT_EQ(3.65f,  output_ptr[11]);
+    ASSERT_FLOAT_EQ(9.0f,   output_ptr[12]);
+    ASSERT_FLOAT_EQ(9.0f,   output_ptr[13]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[14]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[15]);
 }
 
 TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x1_nopad_group2) {
@@ -2801,14 +2801,14 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x1_nopad_group2) {
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(8.0f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(3.65f, output_ptr[1]);
-    EXPECT_FLOAT_EQ(0.5f, output_ptr[2]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[3]);
-    EXPECT_FLOAT_EQ(6.0f, output_ptr[4]);
-    EXPECT_FLOAT_EQ(3.65f, output_ptr[5]);
-    EXPECT_FLOAT_EQ(9.0f, output_ptr[6]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[7]);
+    ASSERT_FLOAT_EQ(8.0f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(3.65f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(0.5f, output_ptr[2]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[3]);
+    ASSERT_FLOAT_EQ(6.0f, output_ptr[4]);
+    ASSERT_FLOAT_EQ(3.65f, output_ptr[5]);
+    ASSERT_FLOAT_EQ(9.0f, output_ptr[6]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[7]);
 }
 
 TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x1_nopad_group2_bfyx) {
@@ -2859,14 +2859,14 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x1_nopad_group2_bfyx) 
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(8.0f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(0.5f, output_ptr[1]);
-    EXPECT_FLOAT_EQ(6.0f, output_ptr[2]);
-    EXPECT_FLOAT_EQ(9.0f, output_ptr[3]);
-    EXPECT_FLOAT_EQ(3.65f, output_ptr[4]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[5]);
-    EXPECT_FLOAT_EQ(3.65f, output_ptr[6]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[7]);
+    ASSERT_FLOAT_EQ(8.0f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(0.5f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(6.0f, output_ptr[2]);
+    ASSERT_FLOAT_EQ(9.0f, output_ptr[3]);
+    ASSERT_FLOAT_EQ(3.65f, output_ptr[4]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[5]);
+    ASSERT_FLOAT_EQ(3.65f, output_ptr[6]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[7]);
 }
 
 TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_group2) {
@@ -2916,22 +2916,22 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_group2) {
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(8.0f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(8.0f, output_ptr[1]);
-    EXPECT_FLOAT_EQ(3.65f, output_ptr[2]);
-    EXPECT_FLOAT_EQ(3.65f, output_ptr[3]);
-    EXPECT_FLOAT_EQ(0.5f, output_ptr[4]);
-    EXPECT_FLOAT_EQ(0.5f, output_ptr[5]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[6]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[7]);
-    EXPECT_FLOAT_EQ(6.0f, output_ptr[8]);
-    EXPECT_FLOAT_EQ(6.0f, output_ptr[9]);
-    EXPECT_FLOAT_EQ(3.65f, output_ptr[10]);
-    EXPECT_FLOAT_EQ(3.65f, output_ptr[11]);
-    EXPECT_FLOAT_EQ(9.0f, output_ptr[12]);
-    EXPECT_FLOAT_EQ(9.0f, output_ptr[13]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[14]);
-    EXPECT_FLOAT_EQ(-5.36f, output_ptr[15]);
+    ASSERT_FLOAT_EQ(8.0f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(8.0f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(3.65f, output_ptr[2]);
+    ASSERT_FLOAT_EQ(3.65f, output_ptr[3]);
+    ASSERT_FLOAT_EQ(0.5f, output_ptr[4]);
+    ASSERT_FLOAT_EQ(0.5f, output_ptr[5]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[6]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[7]);
+    ASSERT_FLOAT_EQ(6.0f, output_ptr[8]);
+    ASSERT_FLOAT_EQ(6.0f, output_ptr[9]);
+    ASSERT_FLOAT_EQ(3.65f, output_ptr[10]);
+    ASSERT_FLOAT_EQ(3.65f, output_ptr[11]);
+    ASSERT_FLOAT_EQ(9.0f, output_ptr[12]);
+    ASSERT_FLOAT_EQ(9.0f, output_ptr[13]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[14]);
+    ASSERT_FLOAT_EQ(-5.36f, output_ptr[15]);
 }
 
 TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_split2_depthwise_sep_opt) {
@@ -3020,7 +3020,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_split2_depthw
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -3113,7 +3113,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_split2_depthw
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -3208,7 +3208,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_group16) {
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -3307,7 +3307,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_group16_bfyx)
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -3389,10 +3389,10 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_group16_bfyx)
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(-2.25f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(7.5f, output_ptr[1]);
-    EXPECT_FLOAT_EQ(-1.75f, output_ptr[2]);
-    EXPECT_FLOAT_EQ(2.25f, output_ptr[3]);
+    ASSERT_FLOAT_EQ(-2.25f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(7.5f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(-1.75f, output_ptr[2]);
+    ASSERT_FLOAT_EQ(2.25f, output_ptr[3]);
 }
 
 TEST(convolution_f32_fw_gpu, basic_wsiz1x1_wstr2x2_in1x1x2x1_nopad_split2) {
@@ -3470,10 +3470,10 @@ TEST(convolution_f32_fw_gpu, basic_wsiz1x1_wstr2x2_in1x1x2x1_nopad_split2) {
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(-2.0f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(6.5f, output_ptr[1]);
-    EXPECT_FLOAT_EQ(1.0f, output_ptr[2]);
-    EXPECT_FLOAT_EQ(3.5f, output_ptr[3]);
+    ASSERT_FLOAT_EQ(-2.0f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(6.5f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(1.0f, output_ptr[2]);
+    ASSERT_FLOAT_EQ(3.5f, output_ptr[3]);
 }
 
 TEST(convolution_f32_fw_gpu, basic_wsiz1x1_wstr2x2_in1x1x4x1_filter_1x3x2x1x1_nopad_split2) {
@@ -3557,12 +3557,12 @@ TEST(convolution_f32_fw_gpu, basic_wsiz1x1_wstr2x2_in1x1x4x1_filter_1x3x2x1x1_no
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(-1.5f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(8.0f, output_ptr[1]);
-    EXPECT_FLOAT_EQ(7.75f, output_ptr[2]);
-    EXPECT_FLOAT_EQ(11.0f, output_ptr[3]);
-    EXPECT_FLOAT_EQ(6.0f, output_ptr[4]);
-    EXPECT_FLOAT_EQ(-2.0f, output_ptr[5]);
+    ASSERT_FLOAT_EQ(-1.5f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(8.0f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(7.75f, output_ptr[2]);
+    ASSERT_FLOAT_EQ(11.0f, output_ptr[3]);
+    ASSERT_FLOAT_EQ(6.0f, output_ptr[4]);
+    ASSERT_FLOAT_EQ(-2.0f, output_ptr[5]);
 
 }*/
 
@@ -3636,10 +3636,10 @@ TEST(convolution_gpu, trivial_convolution_relu) {
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(4.0f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(0.0f, output_ptr[1]);
-    EXPECT_FLOAT_EQ(2.0f, output_ptr[2]);
-    EXPECT_FLOAT_EQ(5.0f, output_ptr[3]);
+    ASSERT_FLOAT_EQ(4.0f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(0.0f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(2.0f, output_ptr[2]);
+    ASSERT_FLOAT_EQ(5.0f, output_ptr[3]);
 }
 
 TEST(convolution_gpu, relu_with_negative_slope) {
@@ -3714,10 +3714,10 @@ TEST(convolution_gpu, relu_with_negative_slope) {
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(4.0f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(-0.35f, output_ptr[1]);
-    EXPECT_FLOAT_EQ(2.0f, output_ptr[2]);
-    EXPECT_FLOAT_EQ(5.0f, output_ptr[3]);
+    ASSERT_FLOAT_EQ(4.0f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(-0.35f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(2.0f, output_ptr[2]);
+    ASSERT_FLOAT_EQ(5.0f, output_ptr[3]);
 }
 
 TEST(convolution_gpu, DISABLED_two_1x1_kernels_after_each_other) {
@@ -4039,7 +4039,7 @@ TEST(convolution_f32_fw_gpu, byte_activation) {
     for (int f = 0; f < f_size; f++)
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
-                EXPECT_NEAR(output_vec[f][y][x], ((float)output_ptr[f * y_size * x_size + y * x_size + x]), 3.0f);
+                ASSERT_NEAR(output_vec[f][y][x], ((float)output_ptr[f * y_size * x_size + y * x_size + x]), 3.0f);
             }
         }
 }
@@ -4105,7 +4105,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_symmetric) {
     for (int f = 0; f < f_size; f++)
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
-                EXPECT_NEAR(output_vec[f][y][x], ((float)output_ptr[f * y_size * x_size + y * x_size + x]), 1e-5f) <<
+                ASSERT_NEAR(output_vec[f][y][x], ((float)output_ptr[f * y_size * x_size + y * x_size + x]), 1e-5f) <<
                 " x="<<x << " y=" << y << " f=" << f;
             }
         }
@@ -4179,7 +4179,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_weight_an
     for (int f = 0; f < f_size; f++)
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
-                EXPECT_NEAR(output_vec[f][y][x], ((float)output_ptr[f * y_size * x_size + y * x_size + x]), 1e-5f) <<
+                ASSERT_NEAR(output_vec[f][y][x], ((float)output_ptr[f * y_size * x_size + y * x_size + x]), 1e-5f) <<
                 " x="<< x << " y=" << y << " f=" << f;
             }
         }
@@ -4250,7 +4250,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
     for (int f = 0; f < f_size; f++)
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
-                EXPECT_NEAR(output_vec[f][y][x], ((float)output_ptr[f * y_size * x_size + y * x_size + x]), 1e-5f) <<
+                ASSERT_NEAR(output_vec[f][y][x], ((float)output_ptr[f * y_size * x_size + y * x_size + x]), 1e-5f) <<
                 " x="<< x << " y=" << y << " f=" << f;
             }
         }
@@ -4335,7 +4335,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
     for (int f = 0; f < f_size; f++)
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
-                EXPECT_NEAR(output_vec[f][y][x], ((float)output_ptr[f * y_size * x_size + y * x_size + x]), 1e-5f) <<
+                ASSERT_NEAR(output_vec[f][y][x], ((float)output_ptr[f * y_size * x_size + y * x_size + x]), 1e-5f) <<
                 " x="<< x << " y=" << y << " f=" << f;
             }
         }
@@ -4436,7 +4436,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
     for (int f = 0; f < f_size; f++)
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
-                EXPECT_NEAR(output_vec[f][y][x], ((float)output_ptr[f * y_size * x_size + y * x_size + x]), 1e-5f) <<
+                ASSERT_NEAR(output_vec[f][y][x], ((float)output_ptr[f * y_size * x_size + y * x_size + x]), 1e-5f) <<
                 " x="<< x << " y=" << y << " f=" << f;
             }
         }
@@ -4507,7 +4507,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_weights_p
     for (int f = 0; f < f_size; f++)
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
-                EXPECT_NEAR(output_vec[f][y][x], ((float)output_ptr[f * y_size * x_size + y * x_size + x]), 1e-5f) <<
+                ASSERT_NEAR(output_vec[f][y][x], ((float)output_ptr[f * y_size * x_size + y * x_size + x]), 1e-5f) <<
                 " x="<< x << " y=" << y << " f=" << f;
             }
         }

--- a/src/plugins/intel_gpu/tests/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/convolution_gpu_test.cpp
@@ -345,8 +345,8 @@ TEST(deformable_convolution_f32_fw_gpu, basic_deformable_convolution_def_group1_
     network.set_input_data("trans", trans);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -356,11 +356,11 @@ TEST(deformable_convolution_f32_fw_gpu, basic_deformable_convolution_def_group1_
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 4);
-    EXPECT_EQ(f_size, 4);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 4);
+    ASSERT_EQ(f_size, 4);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
         EXPECT_NEAR(output_vec[i], output_ptr[i], 0.1);
@@ -476,8 +476,8 @@ TEST(deformable_convolution_f32_fw_gpu, basic_deformable_convolution_def_group1)
     network.set_input_data("trans", trans);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -487,11 +487,11 @@ TEST(deformable_convolution_f32_fw_gpu, basic_deformable_convolution_def_group1)
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 4);
-    EXPECT_EQ(f_size, 4);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 4);
+    ASSERT_EQ(f_size, 4);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
         EXPECT_NEAR(output_vec[i], output_ptr[i], 0.1);
@@ -639,8 +639,8 @@ TEST(deformable_convolution_f32_fw_gpu, basic_deformable_convolution) {
     network.set_input_data("trans", trans);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -650,11 +650,11 @@ TEST(deformable_convolution_f32_fw_gpu, basic_deformable_convolution) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 4);
-    EXPECT_EQ(f_size, 4);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 4);
+    ASSERT_EQ(f_size, 4);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
         EXPECT_NEAR(output_vec[i], output_ptr[i], 0.1);
@@ -701,8 +701,8 @@ TEST(convolution_f32_fw_gpu, basic_convolution_no_bias) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -712,14 +712,14 @@ TEST(convolution_f32_fw_gpu, basic_convolution_no_bias) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
-            EXPECT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
         }
     }
 
@@ -778,8 +778,8 @@ TEST(convolution_f32_fw_gpu, basic_convolution_int8_no_bias) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -789,14 +789,14 @@ TEST(convolution_f32_fw_gpu, basic_convolution_int8_no_bias) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
-            EXPECT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
         }
     }
 }
@@ -830,8 +830,8 @@ TEST(convolution_f32_fw_gpu, basic_convolution3D_no_bias) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -842,15 +842,15 @@ TEST(convolution_f32_fw_gpu, basic_convolution3D_no_bias) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(z_size, 1);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(z_size, 1);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
-            EXPECT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
         }
     }
 }
@@ -966,8 +966,8 @@ TEST(convolution_f32_fw_gpu, basic_convolution3D) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -978,17 +978,17 @@ TEST(convolution_f32_fw_gpu, basic_convolution3D) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfzyx);
-    EXPECT_EQ(z_size, 3);
-    EXPECT_EQ(y_size, 3);
-    EXPECT_EQ(x_size, 3);
+    ASSERT_EQ(output_layout.format, format::bfzyx);
+    ASSERT_EQ(z_size, 3);
+    ASSERT_EQ(y_size, 3);
+    ASSERT_EQ(x_size, 3);
 
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
     for (int z = 0; z < z_size; ++z) {
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
-                EXPECT_EQ(output_vec[z][y][x], output_ptr[z * y_size * x_size + y * x_size + x]);
+                ASSERT_EQ(output_vec[z][y][x], output_ptr[z * y_size * x_size + y * x_size + x]);
             }
         }
     }
@@ -1096,8 +1096,8 @@ TEST(convolution_f32_fw_gpu, basic_convolution3D_group2) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -1108,17 +1108,17 @@ TEST(convolution_f32_fw_gpu, basic_convolution3D_group2) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfzyx);
-    EXPECT_EQ(b_size, 1);
-    EXPECT_EQ(f_size, 2);
-    EXPECT_EQ(z_size, 3);
-    EXPECT_EQ(y_size, 3);
-    EXPECT_EQ(x_size, 3);
+    ASSERT_EQ(output_layout.format, format::bfzyx);
+    ASSERT_EQ(b_size, 1);
+    ASSERT_EQ(f_size, 2);
+    ASSERT_EQ(z_size, 3);
+    ASSERT_EQ(y_size, 3);
+    ASSERT_EQ(x_size, 3);
     for (int f = 0; f < f_size; ++f) {
         for (int z = 0; z < z_size; ++z) {
             for (int y = 0; y < y_size; ++y) {
                 for (int x = 0; x < x_size; ++x) {
-                    EXPECT_EQ(output_vec[f][z][y][x],
+                    ASSERT_EQ(output_vec[f][z][y][x],
                         output_ptr[f * z_size * y_size * x_size + z * y_size * x_size + y * x_size + x]);
                 }
             }
@@ -1145,9 +1145,9 @@ TEST(convolution_f32_fw_gpu, with_output_size_same_input) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(2));
-    EXPECT_EQ(outputs.begin()->first, "conv1");
-    EXPECT_EQ(outputs.rbegin()->first, "conv2");
+    ASSERT_EQ(outputs.size(), size_t(2));
+    ASSERT_EQ(outputs.begin()->first, "conv1");
+    ASSERT_EQ(outputs.rbegin()->first, "conv2");
 }
 
 TEST(convolution_f32_fw_gpu, three_convolutions_same_weights) {
@@ -1198,11 +1198,11 @@ TEST(convolution_f32_fw_gpu, three_convolutions_same_weights) {
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
 
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 2);
-    EXPECT_EQ(f_size, 2);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 2);
+    ASSERT_EQ(f_size, 2);
+    ASSERT_EQ(b_size, 1);
 
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
@@ -1257,8 +1257,8 @@ TEST(convolution_f32_fw_gpu, basic_convolution) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -1268,14 +1268,14 @@ TEST(convolution_f32_fw_gpu, basic_convolution) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
-            EXPECT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
         }
     }
 }
@@ -1318,8 +1318,8 @@ TEST(convolution_f32_fw_gpu, basic_convolution_bfyx_weights_as_input_layout) {
     network.set_input_data("weights", weights);
     network.set_input_data("biases", biases);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -1329,14 +1329,14 @@ TEST(convolution_f32_fw_gpu, basic_convolution_bfyx_weights_as_input_layout) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
-            EXPECT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
         }
     }
 }
@@ -1378,8 +1378,8 @@ TEST(convolution_f32_fw_gpu, basic_convolution_bfyx_weights_as_input_layout_non_
     network.set_input_data("input", input);
     network.set_input_data("weights", weights);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -1389,14 +1389,14 @@ TEST(convolution_f32_fw_gpu, basic_convolution_bfyx_weights_as_input_layout_non_
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
-            EXPECT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
         }
     }
 }
@@ -1469,8 +1469,8 @@ TEST(convolution_f32_fw_gpu, basic_convolution_input_padding) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -1480,15 +1480,15 @@ TEST(convolution_f32_fw_gpu, basic_convolution_input_padding) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 6);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 6);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
-            EXPECT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
         }
     }
 
@@ -1571,8 +1571,8 @@ TEST(convolution_f32_fw_gpu, basic_convolution_sym_input_padding) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -1582,15 +1582,15 @@ TEST(convolution_f32_fw_gpu, basic_convolution_sym_input_padding) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 6);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 6);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
-            EXPECT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
         }
     }
 }
@@ -1667,8 +1667,8 @@ TEST(convolution_f32_fw_gpu, basic_convolution_asym_input_padding) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -1678,15 +1678,15 @@ TEST(convolution_f32_fw_gpu, basic_convolution_asym_input_padding) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 7);
-    EXPECT_EQ(x_size, 6);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 7);
+    ASSERT_EQ(x_size, 6);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
-            EXPECT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
         }
     }
 }
@@ -1774,8 +1774,8 @@ TEST(convolution_f32_fw_gpu, basic_convolution_sym_input_padding_with_pad) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -1785,15 +1785,15 @@ TEST(convolution_f32_fw_gpu, basic_convolution_sym_input_padding_with_pad) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 10);
-    EXPECT_EQ(x_size, 7);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 10);
+    ASSERT_EQ(x_size, 7);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
-            EXPECT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
         }
     }
 }
@@ -1883,8 +1883,8 @@ TEST(convolution_f32_fw_gpu, basic_convolution_asym_input_padding_with_pad) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -1894,11 +1894,11 @@ TEST(convolution_f32_fw_gpu, basic_convolution_asym_input_padding_with_pad) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 11);
-    EXPECT_EQ(x_size, 8);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 11);
+    ASSERT_EQ(x_size, 8);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
@@ -1981,8 +1981,8 @@ TEST(convolution_f32_fw_gpu, basic_convolution_input_and_output_padding) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_memory = outputs.at("conv").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -1994,22 +1994,22 @@ TEST(convolution_f32_fw_gpu, basic_convolution_input_and_output_padding) {
     int f_size = padded_dims[1];
     int y_size = padded_dims[2];
     int x_size = padded_dims[3];
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 8);
-    EXPECT_EQ(x_size, 9);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 8);
+    ASSERT_EQ(x_size, 9);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
-    EXPECT_EQ(non_padded_dims[0], 1);
-    EXPECT_EQ(non_padded_dims[1], 1);
-    EXPECT_EQ(non_padded_dims[2], 6);
-    EXPECT_EQ(non_padded_dims[3], 5);
+    ASSERT_EQ(non_padded_dims[0], 1);
+    ASSERT_EQ(non_padded_dims[1], 1);
+    ASSERT_EQ(non_padded_dims[2], 6);
+    ASSERT_EQ(non_padded_dims[3], 5);
 
     for (int y = y_pad; y < y_size - y_pad; ++y)
     {
         for (int x = x_pad; x < x_size - x_pad; ++x)
         {
-            EXPECT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
         }
     }
 
@@ -2082,8 +2082,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x1x1_nopad_random) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2152,8 +2152,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in2x2x1x2_nopad_random) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2210,8 +2210,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x1x1_nopad) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2264,8 +2264,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in2x2x1x2_nopad) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2316,8 +2316,8 @@ TEST(convolution_f32_fw_gpu, basic_ofm_wsiz2x1x2x1_in1x2x1_nopad) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2375,8 +2375,8 @@ TEST(convolution_f32_fw_gpu, basic_ofm_wsiz3x2x2x1_in2x2x1_nopad) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2431,16 +2431,16 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2x1x3_wstr2x2_in2x2x1x1_nopad) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_TRUE(are_equal(3.08f, output_ptr[0]));
-    EXPECT_TRUE(are_equal(2.12f, output_ptr[1]));
-    EXPECT_TRUE(are_equal(0.7f,  output_ptr[2]));
+    ASSERT_TRUE(are_equal(3.08f, output_ptr[0]));
+    ASSERT_TRUE(are_equal(2.12f, output_ptr[1]));
+    ASSERT_TRUE(are_equal(0.7f,  output_ptr[2]));
 }
 
 TEST(convolution_f32_fw_gpu, wsiz3x3_wstr2x2_in2x2x1x1_zeropad) {
@@ -2487,8 +2487,8 @@ TEST(convolution_f32_fw_gpu, wsiz3x3_wstr2x2_in2x2x1x1_zeropad) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2552,8 +2552,8 @@ TEST(convolution_f32_fw_gpu, offsets_wsiz3x3_wstr2x2_in2x2x1x1_zeropad) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2632,8 +2632,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x1_nopad_split2) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2730,8 +2730,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_split2) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2794,8 +2794,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x1_nopad_group2) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2852,8 +2852,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x1_nopad_group2_bfyx) 
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2909,8 +2909,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_group2) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -3004,8 +3004,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_split2_depthw
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -3093,8 +3093,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_split2_depthw
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -3192,8 +3192,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_group16) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -3287,8 +3287,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_group16_bfyx)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -3382,8 +3382,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_group16_bfyx)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -3463,8 +3463,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz1x1_wstr2x2_in1x1x2x1_nopad_split2) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -3550,8 +3550,8 @@ TEST(convolution_f32_fw_gpu, basic_wsiz1x1_wstr2x2_in1x1x4x1_filter_1x3x2x1x1_no
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "conv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "conv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -3629,8 +3629,8 @@ TEST(convolution_gpu, trivial_convolution_relu) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -3707,8 +3707,8 @@ TEST(convolution_gpu, relu_with_negative_slope) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -3758,7 +3758,7 @@ TEST(convolution_gpu, DISABLED_two_1x1_kernels_after_each_other) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.size(), size_t(1));
 
     auto output_prim = outputs.at("conv_2").get_memory();
 
@@ -3776,7 +3776,7 @@ TEST(convolution_gpu, DISABLED_two_1x1_kernels_after_each_other) {
             for (int y = 0; y < y_size; ++y) {
                 for (int x = 0; x < x_size; ++x) {
                     int idx = b * b_offset + f * f_offset + y * x_size + x;
-                    EXPECT_TRUE(are_equal(conv_1x1_output[idx], output_ptr[idx]));
+                    ASSERT_TRUE(are_equal(conv_1x1_output[idx], output_ptr[idx]));
                 }
             }
         }
@@ -3935,8 +3935,8 @@ TEST(convolution_gpu, basic_yxfb_4_4_yxfb_2_2_b16_if2_of16_st2_2_p0_sp1_fp32)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -3951,7 +3951,7 @@ TEST(convolution_gpu, basic_yxfb_4_4_yxfb_2_2_b16_if2_of16_st2_2_p0_sp1_fp32)
             for (uint32_t bi = 0; bi < batch_size; ++bi, ++i)
             {
                 auto equal = are_equal(output_vals[i], output_ptr[i]);
-                EXPECT_TRUE(equal);
+                ASSERT_TRUE(equal);
                 if (!equal)
                 {
                     std::cout << "Failed at position (" << yxi << ", output feature = " << ofi << ", batch = " << bi << "): "
@@ -4021,7 +4021,7 @@ TEST(convolution_f32_fw_gpu, byte_activation) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_memory = outputs.at("out").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -4031,11 +4031,11 @@ TEST(convolution_f32_fw_gpu, byte_activation) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 2);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 2);
+    ASSERT_EQ(b_size, 1);
     for (int f = 0; f < f_size; f++)
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
@@ -4087,7 +4087,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_symmetric) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_memory = outputs.at("out").get_memory();
     cldnn::mem_lock<float> output_ptr(output_memory, get_test_stream());
@@ -4097,11 +4097,11 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_symmetric) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 2);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 2);
+    ASSERT_EQ(b_size, 1);
     for (int f = 0; f < f_size; f++)
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
@@ -4161,7 +4161,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_weight_an
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_memory = outputs.at("out").get_memory();
     cldnn::mem_lock<float> output_ptr(output_memory, get_test_stream());
@@ -4171,11 +4171,11 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_weight_an
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 2);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 2);
+    ASSERT_EQ(b_size, 1);
     for (int f = 0; f < f_size; f++)
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
@@ -4232,7 +4232,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_memory = outputs.at("out").get_memory();
     cldnn::mem_lock<float> output_ptr(output_memory, get_test_stream());
@@ -4242,11 +4242,11 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 2);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 2);
+    ASSERT_EQ(b_size, 1);
     for (int f = 0; f < f_size; f++)
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
@@ -4317,7 +4317,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_memory = outputs.at("out").get_memory();
     cldnn::mem_lock<float> output_ptr(output_memory, get_test_stream());
@@ -4327,11 +4327,11 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 2);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 2);
+    ASSERT_EQ(b_size, 1);
     for (int f = 0; f < f_size; f++)
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
@@ -4418,7 +4418,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_memory = outputs.at("out").get_memory();
     cldnn::mem_lock<float> output_ptr(output_memory, get_test_stream());
@@ -4428,11 +4428,11 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 2);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 2);
+    ASSERT_EQ(b_size, 1);
     for (int f = 0; f < f_size; f++)
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
@@ -4489,7 +4489,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_weights_p
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_memory = outputs.at("out").get_memory();
     cldnn::mem_lock<float> output_ptr(output_memory, get_test_stream());
@@ -4499,11 +4499,11 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_weights_p
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 2);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 2);
+    ASSERT_EQ(b_size, 1);
     for (int f = 0; f < f_size; f++)
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
@@ -4521,7 +4521,7 @@ TEST(convolution_gpu, basic_yxfb_4_4_yxfb_2_2_b16_if2_of16_st2_2_p0_sp1_fp16)
 
     if (!engine.get_device_info().supports_fp16) {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -4685,8 +4685,8 @@ TEST(convolution_gpu, basic_yxfb_4_4_yxfb_2_2_b16_if2_of16_st2_2_p0_sp1_fp16)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -4701,7 +4701,7 @@ TEST(convolution_gpu, basic_yxfb_4_4_yxfb_2_2_b16_if2_of16_st2_2_p0_sp1_fp16)
             for (uint32_t bi = 0; bi < batch_size; ++bi, ++i)
             {
                 auto equal = are_equal(output_vals[i] /*get_value(expected_ptr, i)*/, output_ptr[i], 0.002f);
-                EXPECT_TRUE(equal);
+                ASSERT_TRUE(equal);
                 if (!equal)
                 {
                     std::cout << "Failed at position (" << yxi << ", output feature = " << ofi << ", batch = " << bi << "): "
@@ -4940,7 +4940,7 @@ TEST_P(convolution_gpu_fs_byx_fsv32, fs_byx_fsv32)
 
     if (!engine.get_device_info().supports_fp16) {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -5061,7 +5061,7 @@ TEST_P(convolution_gpu_fs_byx_fsv32, fs_byx_fsv32)
                                         xi * 32 +
                                         fi % 32];
                     auto equal = are_equal(val_ref, val, 1e-2f);
-                    EXPECT_TRUE(equal);
+                    ASSERT_TRUE(equal);
                     if (!equal)
                     {
                         std::cout << "At b = " << bi << ", fi = " << fi << ", xi = " << xi << ", yi = " << yi << std::endl;
@@ -5074,7 +5074,7 @@ TEST(convolution_f16_fsv_gpu, convolution_f16_fsv_gpu_padding) {
 
     if (!engine.get_device_info().supports_fp16) {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -5162,7 +5162,7 @@ TEST(convolution_f16_fsv_gpu, convolution_f16_fsv_gpu_padding) {
                         xi * 32 +
                         fi % 32];
                     auto equal = are_equal(val_ref, val, 1e-2f);
-                    EXPECT_TRUE(equal);
+                    ASSERT_TRUE(equal);
                     if (!equal)
                     {
                         std::cout << "At b = " << bi << ", fi = " << fi << ", xi = " << xi << ", yi = " << yi << std::endl;
@@ -5205,7 +5205,7 @@ TEST_P(convolution_gpu_fs_byx_fsv32_crop, fs_byx_fsv32_crop)
 
     if (!engine.get_device_info().supports_fp16) {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -5368,7 +5368,7 @@ TEST_P(convolution_gpu_fs_byx_fsv32_crop, fs_byx_fsv32_crop)
                         yi * output_xy +
                         xi];
                     auto equal = are_equal(val_ref, val, 1e-2f);
-                    EXPECT_TRUE(equal);
+                    ASSERT_TRUE(equal);
                     if (!equal)
                     {
                         std::cout << "At b = " << bi << ", fi = " << fi << ", xi = " << xi << ", yi = " << yi << std::endl;
@@ -5422,8 +5422,8 @@ TEST(convolution_f32_fw_gpu, convolution_int8_b_fs_yx_fsv4_to_bfyx) {
     network_ref.set_input_data("input", input);
 
     auto outputs = network_ref.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -5446,8 +5446,8 @@ TEST(convolution_f32_fw_gpu, convolution_int8_b_fs_yx_fsv4_to_bfyx) {
     network_act.set_input_data("input", input);
 
     auto outputs_act = network_act.execute();
-    EXPECT_EQ(outputs_act.size(), size_t(1));
-    EXPECT_EQ(outputs_act.begin()->first, "output");
+    ASSERT_EQ(outputs_act.size(), size_t(1));
+    ASSERT_EQ(outputs_act.begin()->first, "output");
 
     auto output_memory_act = outputs_act.at("output").get_memory();
     cldnn::mem_lock<float> output_act_ptr(output_memory_act, get_test_stream());
@@ -5456,15 +5456,15 @@ TEST(convolution_f32_fw_gpu, convolution_int8_b_fs_yx_fsv4_to_bfyx) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 720);
-    EXPECT_EQ(x_size, 1280);
-    EXPECT_EQ(f_size, output_f);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 720);
+    ASSERT_EQ(x_size, 1280);
+    ASSERT_EQ(f_size, output_f);
+    ASSERT_EQ(b_size, 1);
     for (int o = 0; o < f_size; ++o) {
         for (int y = 0; y < y_size; ++y) {
             for (int x = 0; x < x_size; ++x) {
-                EXPECT_EQ(output_act_ptr[o * x_size * y_size + y * x_size + x], output_ptr[o * x_size * y_size + y * x_size + x]);
+                ASSERT_EQ(output_act_ptr[o * x_size * y_size + y * x_size + x], output_ptr[o * x_size * y_size + y * x_size + x]);
             }
         }
     }
@@ -5477,7 +5477,7 @@ TEST(convolution_gpu, bfyx_iyxo_5x5_fp16)
 
     if (!engine.get_device_info().supports_fp16) {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -5601,7 +5601,7 @@ TEST(convolution_gpu, bfyx_iyxo_5x5_fp16)
                                         yi * output_x +
                                         xi];
                     auto equal = are_equal(val_ref, val, 1e-2f);
-                    EXPECT_TRUE(equal);
+                    ASSERT_TRUE(equal);
                     if (!equal)
                     {
                         std::cout << "At b = " << bi << ", fi = " << fi << ", xi = " << xi << ", yi = " << yi << std::endl;
@@ -5637,7 +5637,7 @@ void blockedFormatZeroCheck(cldnn::memory::ptr out_mem) {
         size_t f_tmp = f_mod;
         while (f_tmp % 16 != 0) {
             auto equal = are_equal(out_ptr[zero_ind], 0, 1e-2f);
-            EXPECT_TRUE(equal);
+            ASSERT_TRUE(equal);
             if (!equal) {
                 std::cout << "Should be zero idx: " << zero_ind << std::endl;
                 return;
@@ -5828,7 +5828,7 @@ TEST_P(convolution_gpu_block_layout3D, bfzyx_bsv16_fsv16_fp32)
 
     for (size_t i = 0; i < out_ptr_bfyx.size(); i++) {
         auto equal = are_equal(flatten_ref[i], out_ptr_bfyx[i], 1e-2f);
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal)
         {
             std::cout << "Difference at idx = " << i << std::endl;
@@ -5844,7 +5844,7 @@ TEST_P(convolution_gpu_block_layout3D, bfzyx_bsv16_fsv16_fp16)
 
     if (!engine.get_device_info().supports_fp16) {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -5965,7 +5965,7 @@ TEST_P(convolution_gpu_block_layout3D, bfzyx_bsv16_fsv16_fp16)
 
     for (size_t i = 0; i < out_ptr_bfyx.size(); i++) {
         auto equal = are_equal(flatten_ref[i], out_ptr_bfyx[i], 1);
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal)
         {
             std::cout << "Difference at idx = " << i << std::endl;
@@ -6101,7 +6101,7 @@ TEST_P(convolution_gpu_block_layout3D, bfzyx_bsv16_fsv16_fp32_fused_ops)
 
     for (size_t i = 0; i < out_ptr_bfyx.size(); i++) {
         auto equal = are_equal(flatten_ref[i] * scalar, out_ptr_bfyx[i], 1e-2f);
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal)
         {
             std::cout << "Difference at idx = " << i << std::endl;
@@ -6155,7 +6155,7 @@ TEST_P(convolution_gpu_block_layout, bfyx_bsv16_fsv16_fp32)
     if (batch_num <= 16)
     {
         std::cout << "[ SKIPPED ] The test is skipped (for bs_fs_yx_bsv16_fsv16 batch should be greater than 16)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -6262,7 +6262,7 @@ TEST_P(convolution_gpu_block_layout, bfyx_bsv16_fsv16_fp32)
 
     for (size_t i = 0; i < out_ptr_bfyx.size(); i++) {
         auto equal = are_equal(flatten_ref[i], out_ptr_bfyx[i], 1e-2f);
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal)
         {
             std::cout << "Difference at idx = " << i << std::endl;
@@ -6277,7 +6277,7 @@ TEST_P(convolution_gpu_block_layout, bfyx_bsv16_fsv16_fp16)
 
     if (!engine.get_device_info().supports_fp16) {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -6294,7 +6294,7 @@ TEST_P(convolution_gpu_block_layout, bfyx_bsv16_fsv16_fp16)
     if (batch_num % 32 != 0)
     {
         std::cout << "[ SKIPPED ] The test is skipped (for fp16 batch should be multiple of 32)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -6402,7 +6402,7 @@ TEST_P(convolution_gpu_block_layout, bfyx_bsv16_fsv16_fp16)
 
     for (size_t i = 0; i < out_ptr_bfyx.size(); i++) {
         auto equal = are_equal(flatten_ref[i], out_ptr_bfyx[i], 1);
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal) {
             std::cout << "Difference at idx = " << i << std::endl;
             return;
@@ -6416,7 +6416,7 @@ TEST_P(convolution_gpu_block_layout, bfyx_bsv16_fsv16_fp32_fused_ops)
 
     if (!engine.get_device_info().supports_fp16) {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -6540,7 +6540,7 @@ TEST_P(convolution_gpu_block_layout, bfyx_bsv16_fsv16_fp32_fused_ops)
 
     for (size_t i = 0; i < out_ptr_bfyx.size(); i++) {
         auto equal = are_equal(flatten_ref[i] * scalar, out_ptr_bfyx[i], 1e-2f);
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal) {
             std::cout << "Difference at idx = " << i << std::endl;
             return;
@@ -6590,7 +6590,7 @@ TEST_P(convolution_depthwise_gpu, depthwise_conv_fs_b_yx_fsv32)
 
     if (!engine.get_device_info().supports_fp16) {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -6682,7 +6682,7 @@ TEST_P(convolution_depthwise_gpu, depthwise_conv_fs_b_yx_fsv32)
                                        xi * 32 +
                                        fi % 32];
                     auto equal = are_equal(val_ref, val, 1e-2f);
-                    EXPECT_TRUE(equal);
+                    ASSERT_TRUE(equal);
                     if (!equal)
                     {
                         std::cout << "At b = " << bi << ", fi = " << fi << ", yi = " << yi << ", xi = " << xi << std::endl;
@@ -6732,7 +6732,7 @@ TEST_P(convolution_depthwise_gpu_fsv16, depthwise_conv_b_fs_yx_fsv16)
 
     if (!engine.get_device_info().supports_fp16) {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -6826,7 +6826,7 @@ TEST_P(convolution_depthwise_gpu_fsv16, depthwise_conv_b_fs_yx_fsv16)
                         xi * f_group_size +
                         fi % f_group_size];
                     auto equal = are_equal(val_ref, val, 1e-2f);
-                    EXPECT_TRUE(equal);
+                    ASSERT_TRUE(equal);
                     if (!equal)
                     {
                         std::cout << "At b = " << bi << ", fi = " << fi << ", yi = " << yi << ", xi = " << xi << std::endl;
@@ -6862,7 +6862,7 @@ TEST_P(convolution_depthwise_gpu_fsv16_xy, depthwise_conv_b_fs_yx_fsv16)
 
     if (!engine.get_device_info().supports_fp16) {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -6957,7 +6957,7 @@ TEST_P(convolution_depthwise_gpu_fsv16_xy, depthwise_conv_b_fs_yx_fsv16)
                         xi * f_group_size +
                         fi % f_group_size];
                     auto equal = are_equal(val_ref, val, 1e-2f);
-                    EXPECT_TRUE(equal);
+                    ASSERT_TRUE(equal);
                 }
 }
 
@@ -7028,8 +7028,8 @@ TEST(convolution_depthwise_gpu_fsv16, depthwise_conv_b_fs_yx_fsv16_in_feature_pa
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_memory = outputs.at("out").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -7040,18 +7040,18 @@ TEST(convolution_depthwise_gpu_fsv16, depthwise_conv_b_fs_yx_fsv16_in_feature_pa
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
 
-    EXPECT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(output_layout.format, format::bfyx);
 
-    EXPECT_EQ(y_size, output_size.spatial[1]);
-    EXPECT_EQ(x_size, output_size.spatial[0]);
-    EXPECT_EQ(f_size, output_size.feature[0]);
-    EXPECT_EQ(b_size, output_size.batch[0]);
+    ASSERT_EQ(y_size, output_size.spatial[1]);
+    ASSERT_EQ(x_size, output_size.spatial[0]);
+    ASSERT_EQ(f_size, output_size.feature[0]);
+    ASSERT_EQ(b_size, output_size.batch[0]);
 
     for (int b = 0; b < b_size; ++b) {
         for (int f = 0; f < f_size; ++f) {
             for (int y = 0; y < y_size; ++y) {
                 for (int x = 0; x < x_size; ++x) {
-                    EXPECT_EQ(
+                    ASSERT_EQ(
                         output_vec[b * f_size * y_size * x_size + f * y_size * x_size + y * x_size + x],
                         output_ptr[b * f_size * y_size * x_size + f * y_size * x_size + y * x_size + x]
                     );
@@ -7069,7 +7069,7 @@ TEST_P(convolution_depthwise_gpu_bfyx, depthwise_conv_bfyx)
 
     if (!engine.get_device_info().supports_fp16) {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -7488,7 +7488,7 @@ TEST_P(convolution_grouped_gpu, base) {
                             std::cout << "Value at batch: " << bi << ", output_f: " << ofi << ", z: " << zi << ", y: " << yi << ", x: " << xi << " = " << val << std::endl;
                             std::cout << "Reference value at batch: " << bi << ", output_f: " << ofi << ", z: " << zi << ", y: " << yi << ", x: " << xi << " = " << val_ref << std::endl;
                         }
-                        EXPECT_TRUE(equal);
+                        ASSERT_TRUE(equal);
                     }
 }
 
@@ -7518,7 +7518,7 @@ TEST_P(convolution_general_gpu, conv_fp16_cases) {
 
     if (!engine.get_device_info().supports_fp16) {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -7648,7 +7648,7 @@ TEST_P(convolution_general_gpu, conv_fp16_cases) {
                         std::cout << "Reference value at batch: " << bi << ", output_f: " << ofi << ", y: " << yi
                                   << ", x: " << xi << " = " << static_cast<float>(val_ref) << std::endl;
                     }
-                    EXPECT_TRUE(equal);
+                    ASSERT_TRUE(equal);
                 }
 }
 
@@ -7674,7 +7674,7 @@ TEST_P(convolution_gpu_fsv16_to_bfyx, conv_b_fs_yx_fsv16_to_bfyx_padding)
     if (!engine.get_device_info().supports_fp16)
     {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -7753,7 +7753,7 @@ TEST_P(convolution_gpu_fsv16_to_bfyx, conv_b_fs_yx_fsv16_to_bfyx_padding)
         auto diff = std::fabs(ref_val - target_val);
         auto equal = (diff > 1e-5f) ? false : true;
 
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal)
         {
             std::cout << "i:" << i \
@@ -7773,7 +7773,7 @@ TEST_P(convolution_gpu_fsv16_to_bfyx, conv_b_fs_yx_fsv16_to_bfyx_different_type)
     if (!engine.get_device_info().supports_fp16)
     {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -7849,7 +7849,7 @@ TEST_P(convolution_gpu_fsv16_to_bfyx, conv_b_fs_yx_fsv16_to_bfyx_different_type)
         auto diff = std::abs(ref_val - target_val);
         auto equal = (diff > 1e-5f) ? false : true;
 
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal)
         {
             std::cout << "i:" << i \
@@ -8977,7 +8977,7 @@ TEST_P(convolution_gpu_onednn, conv_onednn_cases) {
     if (!engine.get_device_info().supports_fp16)
     {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -9108,7 +9108,7 @@ TEST_P(convolution_gpu_onednn, conv_onednn_cases) {
                         std::cout << "Reference value at batch: " << bi << ", output_f: " << ofi << ", y: " << yi
                                   << ", x: " << xi << " = " << static_cast<float>(val_ref) << std::endl;
                     }
-                    EXPECT_TRUE(equal);
+                    ASSERT_TRUE(equal);
                 }
 }
 
@@ -9163,10 +9163,10 @@ TEST(convolution_gpu_onednn, padding_for_cldnn_kernel_after_onednn) {
     auto outputs_test = network_test.execute();
     auto outputs_ref = network_ref.execute();
 
-    EXPECT_EQ(outputs_test.size(), size_t(1));
-    EXPECT_EQ(outputs_test.begin()->first, "reorder");
-    EXPECT_EQ(outputs_ref.size(), size_t(1));
-    EXPECT_EQ(outputs_ref.begin()->first, "reorder");
+    ASSERT_EQ(outputs_test.size(), size_t(1));
+    ASSERT_EQ(outputs_test.begin()->first, "reorder");
+    ASSERT_EQ(outputs_ref.size(), size_t(1));
+    ASSERT_EQ(outputs_ref.begin()->first, "reorder");
 
     auto output_memory_test = outputs_test.at("reorder").get_memory();
     auto output_layout_test = output_memory_test->get_layout();
@@ -9176,15 +9176,15 @@ TEST(convolution_gpu_onednn, padding_for_cldnn_kernel_after_onednn) {
     auto output_layout_ref = output_memory_ref->get_layout();
     cldnn::mem_lock<float> output_ptr_ref(output_memory_ref, get_test_stream());
 
-    EXPECT_EQ(output_layout_test.spatial(0), output_x);
-    EXPECT_EQ(output_layout_test.spatial(1), output_y);
-    EXPECT_EQ(output_layout_test.feature(), output_f);
-    EXPECT_EQ(output_layout_test.batch(), output_b);
+    ASSERT_EQ(output_layout_test.spatial(0), output_x);
+    ASSERT_EQ(output_layout_test.spatial(1), output_y);
+    ASSERT_EQ(output_layout_test.feature(), output_f);
+    ASSERT_EQ(output_layout_test.batch(), output_b);
 
-    EXPECT_EQ(output_layout_ref.spatial(0), output_x);
-    EXPECT_EQ(output_layout_ref.spatial(1), output_y);
-    EXPECT_EQ(output_layout_ref.feature(), output_f);
-    EXPECT_EQ(output_layout_ref.batch(), output_b);
+    ASSERT_EQ(output_layout_ref.spatial(0), output_x);
+    ASSERT_EQ(output_layout_ref.spatial(1), output_y);
+    ASSERT_EQ(output_layout_ref.feature(), output_f);
+    ASSERT_EQ(output_layout_ref.batch(), output_b);
 
     for (size_t i = 0; i < output_memory_ref->count(); i++) {
         ASSERT_EQ(output_ptr_ref.data()[i], output_ptr_test.data()[i]);
@@ -9304,7 +9304,7 @@ void test_convolution_f32_gpu_convolution_gpu_bfyx_f16_depthwise_x_bloxk_size_1(
                         xi * f_group_size +
                         fi % f_group_size];
                     auto equal = are_equal(val_ref, val, 1e-2f);
-                    EXPECT_TRUE(equal);
+                    ASSERT_TRUE(equal);
                     if (!equal)
                     {
                         std::cout << "At b = " << bi << ", fi = " << fi << ", yi = " << yi << ", xi = " << xi << std::endl;

--- a/src/plugins/intel_gpu/tests/test_cases/crop_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/crop_gpu_test.cpp
@@ -72,7 +72,7 @@ TEST(crop_gpu, basic_in2x3x2x2_crop_all) {
                 for (int x = 0; x < crop_x_size; ++x) { //X
                     int linear_id = b + batch_num * (f + feature_num * (x + x_size * y));
                     int output_linear_id = b + crop_batch_num * (f + crop_feature_num * (x + crop_x_size * y));
-                    EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                    ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                 }
             }
         }
@@ -119,7 +119,7 @@ TEST(crop_gpu, basic_in2x2x2x3_crop_all) {
                 for (int x = 0; x < crop_x_size; ++x) { //X
                     int linear_id = b + batch_num * (f + feature_num * (x + x_size * y));
                     int output_linear_id = b + crop_batch_num * (f + crop_feature_num * (x + crop_x_size * y));
-                    EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                    ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                 }
             }
         }
@@ -167,7 +167,7 @@ TEST(crop_gpu, basic_i32_in2x3x2x2_crop_all) {
                 for (int x = 0; x < crop_x_size; ++x) { //X
                     int linear_id = b + batch_num * (f + feature_num * (x + x_size * y));
                     int output_linear_id = b + crop_batch_num * (f + crop_feature_num * (x + crop_x_size * y));
-                    EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                    ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                 }
             }
         }
@@ -215,7 +215,7 @@ TEST(crop_gpu, basic_i64_in2x3x2x2_crop_all) {
                 for (int x = 0; x < crop_x_size; ++x) { //X
                     int linear_id = b + batch_num * (f + feature_num * (x + x_size * y));
                     int output_linear_id = b + crop_batch_num * (f + crop_feature_num * (x + crop_x_size * y));
-                    EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                    ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                 }
             }
         }
@@ -264,7 +264,7 @@ TEST(crop_gpu, basic_in2x3x2x2_crop_all_bfyx) {
                     int linear_id = x + x_size * (y + y_size * (f + feature_num * b));
                     int output_linear_id = x + crop_x_size * (y + crop_y_size * (f + crop_feature_num * b));
                     a.push_back(output_ptr[output_linear_id]);
-                    EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                    ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                 }
             }
         }
@@ -313,7 +313,7 @@ TEST(crop_gpu, basic_i32_in2x3x2x2_crop_all_bfyx) {
                     int linear_id = x + x_size * (y + y_size * (f + feature_num * b));
                     int output_linear_id = x + crop_x_size * (y + crop_y_size * (f + crop_feature_num * b));
                     a.push_back(output_ptr[output_linear_id]);
-                    EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                    ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                 }
             }
         }
@@ -362,7 +362,7 @@ TEST(crop_gpu, basic_i64_in2x3x2x2_crop_all_bfyx) {
                     int linear_id = x + x_size * (y + y_size * (f + feature_num * b));
                     int output_linear_id = x + crop_x_size * (y + crop_y_size * (f + crop_feature_num * b));
                     a.push_back(output_ptr[output_linear_id]);
-                    EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                    ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                 }
             }
         }
@@ -409,7 +409,7 @@ TEST(crop_gpu, basic_in2x3x2x2_crop_all_fyxb) {
                 for (int x = 0; x < crop_x_size; ++x) { //X
                     int linear_id = b + batch_num * (x + x_size * (y + y_size * f));
                     int output_linear_id = b + crop_batch_num * (x + crop_x_size * (y + crop_y_size * f));
-                    EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                    ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                 }
             }
         }
@@ -456,7 +456,7 @@ TEST(crop_gpu, basic_i32_in2x3x2x2_crop_all_fyxb) {
                 for (int x = 0; x < crop_x_size; ++x) { //X
                     int linear_id = b + batch_num * (x + x_size * (y + y_size * f));
                     int output_linear_id = b + crop_batch_num * (x + crop_x_size * (y + crop_y_size * f));
-                    EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                    ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                 }
             }
         }
@@ -503,7 +503,7 @@ TEST(crop_gpu, basic_i64_in2x3x2x2_crop_all_fyxb) {
                 for (int x = 0; x < crop_x_size; ++x) { //X
                     int linear_id = b + batch_num * (x + x_size * (y + y_size * f));
                     int output_linear_id = b + crop_batch_num * (x + crop_x_size * (y + crop_y_size * f));
-                    EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                    ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                 }
             }
         }
@@ -568,7 +568,7 @@ TEST(crop_gpu, basic_in2x3x2x2_crop_offsets) {
                 for (int x = 0; x < crop_x_size; ++x) { //X
                     int linear_id = (b + batch_offset) + batch_num * ((f + feature_offset) + feature_num * ((x + x_offset) + x_size * (y + y_offset)));
                     int output_linear_id = b + crop_batch_num * (f + crop_feature_num * (x + crop_x_size * y));
-                    EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                    ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                 }
             }
         }
@@ -633,7 +633,7 @@ TEST(crop_gpu, basic_i32_in2x3x2x2_crop_offsets) {
                 for (int x = 0; x < crop_x_size; ++x) { //X
                     int linear_id = (b + batch_offset) + batch_num * ((f + feature_offset) + feature_num * ((x + x_offset) + x_size * (y + y_offset)));
                     int output_linear_id = b + crop_batch_num * (f + crop_feature_num * (x + crop_x_size * y));
-                    EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                    ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                 }
             }
         }
@@ -698,7 +698,7 @@ TEST(crop_gpu, basic_i64_in2x3x2x2_crop_offsets) {
                 for (int x = 0; x < crop_x_size; ++x) { //X
                     int linear_id = (b + batch_offset) + batch_num * ((f + feature_offset) + feature_num * ((x + x_offset) + x_size * (y + y_offset)));
                     int output_linear_id = b + crop_batch_num * (f + crop_feature_num * (x + crop_x_size * y));
-                    EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                    ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                 }
             }
         }
@@ -771,14 +771,14 @@ TEST(crop_gpu, basic_in1x4x1x1_split) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < out1.size();i++)
-        EXPECT_EQ(output_ptr[i], out1[i]);
+        ASSERT_EQ(output_ptr[i], out1[i]);
 
     std::cout << std::endl;
     auto output_2 = outputs.at("crop2").get_memory();
     cldnn::mem_lock<float> output_ptr_2(output_2, get_test_stream());
 
     for (size_t i = 0; i < out2.size();i++)
-        EXPECT_EQ(output_ptr_2[i], out2[i]);
+        ASSERT_EQ(output_ptr_2[i], out2[i]);
 }
 
 TEST(crop_gpu, basic_in1x4x1x1_crop_pad) {
@@ -818,7 +818,7 @@ TEST(crop_gpu, basic_in1x4x1x1_crop_pad) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < out1.size();i++)
-        EXPECT_EQ(output_ptr[i], out1[i]);
+        ASSERT_EQ(output_ptr[i], out1[i]);
 }
 
 TEST(crop_gpu, basic_i32_in1x4x1x1_split) {
@@ -887,13 +887,13 @@ TEST(crop_gpu, basic_i32_in1x4x1x1_split) {
     cldnn::mem_lock<int32_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < out1.size(); i++)
-        EXPECT_EQ(output_ptr[i], out1[i]);
+        ASSERT_EQ(output_ptr[i], out1[i]);
 
     auto output_2 = outputs.at("crop2").get_memory();
     cldnn::mem_lock<int32_t> output_ptr_2(output_2, get_test_stream());
 
     for (size_t i = 0; i < out2.size(); i++)
-        EXPECT_EQ(output_ptr_2[i], out2[i]);
+        ASSERT_EQ(output_ptr_2[i], out2[i]);
 }
 
 TEST(crop_gpu, basic_i64_in1x4x1x1_split) {
@@ -962,13 +962,13 @@ TEST(crop_gpu, basic_i64_in1x4x1x1_split) {
     cldnn::mem_lock<int64_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < out1.size(); i++)
-        EXPECT_EQ(output_ptr[i], out1[i]);
+        ASSERT_EQ(output_ptr[i], out1[i]);
 
     auto output_2 = outputs.at("crop2").get_memory();
     cldnn::mem_lock<int64_t> output_ptr_2(output_2, get_test_stream());
 
     for (size_t i = 0; i < out2.size(); i++)
-        EXPECT_EQ(output_ptr_2[i], out2[i]);
+        ASSERT_EQ(output_ptr_2[i], out2[i]);
 }
 
 TEST(crop_gpu, basic_in1x4x1x1_split_w_relu) {
@@ -1041,16 +1041,16 @@ TEST(crop_gpu, basic_in1x4x1x1_split_w_relu) {
 
     // check if crop has been executed in place
     auto in_place = engine->is_the_same_buffer(*outputs.at("crop1").get_memory(), *outputs.at("relu").get_memory());
-    EXPECT_TRUE(in_place);
+    ASSERT_TRUE(in_place);
 
     for (size_t i = 0; i < out1.size();i++)
-        EXPECT_EQ(output_ptr[i], out1[i]);
+        ASSERT_EQ(output_ptr[i], out1[i]);
 
     auto output_2 = outputs.at("relu2").get_memory();
     cldnn::mem_lock<float> output_ptr_2(output_2, get_test_stream());
 
     for (size_t i = 0; i < out2.size();i++)
-        EXPECT_EQ(output_ptr_2[i], out2[i]);
+        ASSERT_EQ(output_ptr_2[i], out2[i]);
 }
 
 TEST(crop_gpu, basic_in3x1x2x2x1_crop_all_bfzyx) {
@@ -1096,7 +1096,7 @@ TEST(crop_gpu, basic_in3x1x2x2x1_crop_all_bfzyx) {
                     for (int x = 0; x < crop_x_size; ++x) { //X
                         int linear_id = x + x_size * (y + y_size * (z + z_size * (f + feature_num * b)));
                         int output_linear_id = x + crop_x_size * (y + crop_y_size * (z + crop_z_size * (f + crop_feature_num * b)));
-                        EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                        ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                     }
                 }
             }
@@ -1153,7 +1153,7 @@ TEST(crop_gpu, basic_in3x1x3x2x2x1_crop_all_bfwzyx) {
                         for (int x = 0; x < crop_x_size; ++x) { //X
                             int linear_id = x + x_size * (y + y_size * (z + z_size * (w + w_size * (f + feature_num * b))));
                             int output_linear_id = x + crop_x_size * (y + crop_y_size * (z + crop_z_size * (w + crop_w_size * (f + crop_feature_num * b))));
-                            EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                            ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                         }
                     }
                 }
@@ -1241,7 +1241,7 @@ TEST_P(crop_gpu, pad_test) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < res.size(); i++)
-        EXPECT_EQ(output_ptr[i], res[i]);
+        ASSERT_EQ(output_ptr[i], res[i]);
 }
 
 static std::vector<std::pair<cldnn::format,cldnn::format>> formats = {
@@ -1323,7 +1323,7 @@ TEST(crop_gpu, dynamic_i32_in2x3x2x2_crop_offsets) {
                 for (int x = 0; x < crop_x_size; ++x) { //X
                     int linear_id = (b + batch_offset) * (feature_num * y_size * x_size) + (f + feature_offset) * (y_size * x_size) + (y + y_offset) * x_size + (x + x_offset);
                     int output_linear_id = b * (crop_feature_num * crop_y_size * crop_x_size) + f * (crop_y_size * crop_x_size) + y * crop_x_size + x;
-                    EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                    ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                 }
             }
         }
@@ -1378,13 +1378,13 @@ TEST(crop_gpu, dynamic_in1x4x1x1_split) {
     cldnn::mem_lock<int32_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < out1.size(); i++)
-        EXPECT_EQ(output_ptr[i], out1[i]);
+        ASSERT_EQ(output_ptr[i], out1[i]);
 
     auto output_2 = outputs.at("crop2").get_memory();
     cldnn::mem_lock<int32_t> output_ptr_2(output_2, get_test_stream());
 
     for (size_t i = 0; i < out2.size(); i++)
-        EXPECT_EQ(output_ptr_2[i], out2[i]);
+        ASSERT_EQ(output_ptr_2[i], out2[i]);
 }
 
 TEST(crop_gpu, dynamic_in1x4x1x1_varaidic_split) {
@@ -1440,13 +1440,13 @@ TEST(crop_gpu, dynamic_in1x4x1x1_varaidic_split) {
     cldnn::mem_lock<int32_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < out1.size(); i++)
-        EXPECT_EQ(output_ptr[i], out1[i]);
+        ASSERT_EQ(output_ptr[i], out1[i]);
 
     auto output_2 = outputs.at("crop2").get_memory();
     cldnn::mem_lock<int32_t> output_ptr_2(output_2, get_test_stream());
 
     for (size_t i = 0; i < out2.size(); i++)
-        EXPECT_EQ(output_ptr_2[i], out2[i]);
+        ASSERT_EQ(output_ptr_2[i], out2[i]);
 }
 
 TEST(crop_gpu, static_split_batch) {

--- a/src/plugins/intel_gpu/tests/test_cases/crop_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/crop_gpu_test.cpp
@@ -1485,17 +1485,17 @@ TEST(crop_gpu, static_split_batch) {
     cldnn::mem_lock<int32_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < out1.size(); i++)
-        EXPECT_EQ(output_ptr[i], out1[i]);
+        ASSERT_EQ(output_ptr[i], out1[i]);
 
     auto output_2 = outputs.at("crop2").get_memory();
     cldnn::mem_lock<int32_t> output_ptr_2(output_2, get_test_stream());
 
     for (size_t i = 0; i < out2.size(); i++)
-        EXPECT_EQ(output_ptr_2[i], out2[i]);
+        ASSERT_EQ(output_ptr_2[i], out2[i]);
 
     auto output_3 = outputs.at("crop3").get_memory();
     cldnn::mem_lock<int32_t> output_ptr_3(output_3, get_test_stream());
 
     for (size_t i = 0; i < out3.size(); i++)
-        EXPECT_EQ(output_ptr_3[i], out3[i]);
+        ASSERT_EQ(output_ptr_3[i], out3[i]);
 }

--- a/src/plugins/intel_gpu/tests/test_cases/ctc_loss_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/ctc_loss_gpu_test.cpp
@@ -128,8 +128,8 @@ public:
         }
         const auto outputs = network->execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "reordered_ctc_loss");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "reordered_ctc_loss");
 
         auto output = outputs.at("reordered_ctc_loss").get_memory();
         cldnn::mem_lock<TF> output_ptr(output, get_test_stream());

--- a/src/plugins/intel_gpu/tests/test_cases/ctc_loss_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/ctc_loss_gpu_test.cpp
@@ -136,7 +136,7 @@ public:
 
         ASSERT_EQ(output_ptr.size(), p.expected_values.size());
         for (size_t i = 0; i < output_ptr.size(); ++i) {
-            EXPECT_NEAR(p.expected_values[i], output_ptr[i], 0.1);
+            ASSERT_NEAR(p.expected_values[i], output_ptr[i], 0.1);
         }
     }
 

--- a/src/plugins/intel_gpu/tests/test_cases/cum_sum_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/cum_sum_gpu_test.cpp
@@ -210,8 +210,8 @@ public:
 
         auto outputs = network->execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "cum_sum");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "cum_sum");
 
         auto output = outputs.at("cum_sum").get_memory();
         cldnn::mem_lock<output_type> output_ptr(output, get_test_stream());
@@ -219,7 +219,7 @@ public:
         auto answers = cumsum<output_type>(inputVals, in_out_format, { b, f, w, z, y, x }, axis, exclusive, reverse);
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i) {
-            EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+            ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
         }
     }
 };
@@ -307,8 +307,8 @@ TEST(cum_sum_gpu_f16, DISABLED_basic_1d) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "cum_sum");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "cum_sum");
 
     auto output = outputs.at("cum_sum").get_memory();
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
@@ -317,7 +317,7 @@ TEST(cum_sum_gpu_f16, DISABLED_basic_1d) {
 
     ASSERT_EQ(output->count(), answers.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], half_to_float(output_ptr[i]))) << i;
+        ASSERT_TRUE(are_equal(answers[i], half_to_float(output_ptr[i]))) << i;
     }
 }
 
@@ -348,8 +348,8 @@ TEST(cum_sum_gpu_fp32, dynamic) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "cum_sum");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "cum_sum");
 
     auto output = outputs.at("cum_sum").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -358,6 +358,6 @@ TEST(cum_sum_gpu_fp32, dynamic) {
 
     ASSERT_EQ(output->count(), answers.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/custom_gpu_primitive_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/custom_gpu_primitive_test.cpp
@@ -88,8 +88,8 @@ TEST(custom_gpu_primitive_f32, add_basic_in2x2x2x2) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "user_kernel");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "user_kernel");
 
     auto output = outputs.at("user_kernel").get_memory();
 
@@ -101,7 +101,7 @@ TEST(custom_gpu_primitive_f32, add_basic_in2x2x2x2) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (int i = 0; i < 16; i++) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -195,7 +195,7 @@ void add_basic_in2x2x2x2_with_reorder()
     auto outputs = network.execute();
 
     ASSERT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "to_float");
+    ASSERT_EQ(outputs.begin()->first, "to_float");
 
     auto output = outputs.at("to_float").get_memory();
 
@@ -208,7 +208,7 @@ void add_basic_in2x2x2x2_with_reorder()
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -294,8 +294,8 @@ TEST(custom_gpu_primitive_f32, eltwise_add_basic_in2x2x2x2) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "user_kernel");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "user_kernel");
 
     auto output = outputs.at("user_kernel").get_memory();
 
@@ -309,7 +309,7 @@ TEST(custom_gpu_primitive_f32, eltwise_add_basic_in2x2x2x2) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -387,8 +387,8 @@ TEST(custom_gpu_primitive_f32, add_eltwise_basic_in2x2x2x2) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -402,7 +402,7 @@ TEST(custom_gpu_primitive_f32, add_eltwise_basic_in2x2x2x2) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -488,8 +488,8 @@ TEST(custom_gpu_primitive_f32, two_kernels_with_same_entry_point_basic_in2x2x2x2
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "user_kernel2");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "user_kernel2");
 
     auto output = outputs.at("user_kernel2").get_memory();
 
@@ -497,7 +497,7 @@ TEST(custom_gpu_primitive_f32, two_kernels_with_same_entry_point_basic_in2x2x2x2
     cldnn::mem_lock<float> input_ptr(input, get_test_stream());
 
     for (int i = 0; i < 16; i++) {
-        EXPECT_TRUE(are_equal(input_ptr[i] + 7, output_ptr[i]));
+        ASSERT_TRUE(are_equal(input_ptr[i] + 7, output_ptr[i]));
     }
 }
 
@@ -570,8 +570,8 @@ void test_custom_gpu_primitive_u8_add_basic_in2x2x2x2(bool is_caching_test) {
     network->set_input_data("input2", input2);
     auto outputs = network->execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "user_kernel");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "user_kernel");
 
     auto output = outputs.at("user_kernel").get_memory();
 
@@ -585,7 +585,7 @@ void test_custom_gpu_primitive_u8_add_basic_in2x2x2x2(bool is_caching_test) {
     cldnn::mem_lock<T> output_ptr(output, get_test_stream());
 
     for (int i = 0; i < 16; i++) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/deconvolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/deconvolution_gpu_test.cpp
@@ -181,8 +181,8 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x1_nopad) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "plane_output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "plane_output");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -241,8 +241,8 @@ TYPED_TEST(deconvolution_basic, no_bias_basic_wsiz2x2_in2x2x1x1_nopad) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "plane_output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "plane_output");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -303,8 +303,8 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x1_nopad_bfyx) {    //  Fil
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "plane_output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "plane_output");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -732,8 +732,8 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x2_bfyx_stride2_pad1_input_p
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "deconv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "deconv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -801,8 +801,8 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2x2_in2x2x1x1_stride2_pad1_input_padd
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "deconv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "deconv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -1747,8 +1747,8 @@ TYPED_TEST(deconvolution_basic, basic_f16_k9x9_s2x2_pad4x4) {
     network_act.set_input_data("input_act", input);
 
     auto outputs_act = network_act.execute();
-    EXPECT_EQ(outputs_act.size(), size_t(1));
-    EXPECT_EQ(outputs_act.begin()->first, "out");
+    ASSERT_EQ(outputs_act.size(), size_t(1));
+    ASSERT_EQ(outputs_act.begin()->first, "out");
     auto output_act_prim = outputs_act.begin()->second.get_memory();
     cldnn::mem_lock<FLOAT16> output_act_ptr(output_act_prim, get_test_stream());
 
@@ -1808,8 +1808,8 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x2_b_fs_yx_fsv16_stride2_pad
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -1879,8 +1879,8 @@ TEST(deconvolution_f16_fw_gpu, basic_wsiz2x2_in2x2x1x2_b_fs_yx_fsv16_stride2_pad
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -1928,8 +1928,8 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in1x2x2x2_b_fs_yx_fsv16_stride2_pad
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -1976,8 +1976,8 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in1x2x2x2_b_fs_yx_fsv16_stride2_pad
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2022,8 +2022,8 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_nopad_b_fs_yx_fsv16_dw) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2076,8 +2076,8 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_pad1_b_fs_yx_fsv16_dw) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2118,8 +2118,8 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_stride2_nopad_b_fs_yx_fsv
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2174,8 +2174,8 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_stride4_pad2_b_fs_yx_fsv1
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2230,8 +2230,8 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_stride4_pad2_b_fs_yx_fsv1
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2315,8 +2315,8 @@ TEST(deconvolution_f32_fw_gpu, bs_fs_zyx_bsv16_fsv16_wsiz2x2x2_in1x1x2x2x2_strid
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
@@ -2384,8 +2384,8 @@ void test_deconvolution_f16_fw_gpu_basic_wsiz2x2_in1x2x2x2_fs_b_yx_fsv32_stride1
     network->set_input_data("input", input);
 
     auto outputs = network->execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -2996,8 +2996,8 @@ TEST(deconvolution_f32_fw_gpu_onednn, basic_wsiz2x2_in2x2x1x1_stride2_nopad) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "deconv");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "deconv");
 
     auto output_prim = outputs.begin()->second.get_memory();
 

--- a/src/plugins/intel_gpu/tests/test_cases/deconvolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/deconvolution_gpu_test.cpp
@@ -196,7 +196,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x1_nopad) {
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -256,7 +256,7 @@ TYPED_TEST(deconvolution_basic, no_bias_basic_wsiz2x2_in2x2x1x1_nopad) {
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -318,7 +318,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x1_nopad_bfyx) {    //  Fil
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -370,7 +370,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x1_pad1) {
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(0.75f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(0.75f, output_ptr[0]);
 }
 
 TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x1_stride2_nopad) {
@@ -430,7 +430,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x1_stride2_nopad) {
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -494,7 +494,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x1_stride4_pad2) {
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -555,7 +555,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x2_stride2_pad1) {
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -622,7 +622,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2x2_in2x2x1x1_stride2_pad1) {
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -683,7 +683,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x2_bfyx_stride2_pad1) {
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -746,7 +746,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x2_bfyx_stride2_pad1_input_p
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -815,7 +815,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2x2_in2x2x1x1_stride2_pad1_input_padd
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -877,7 +877,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x2_bfyx_yxfb_stride2_pad1) 
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -946,7 +946,7 @@ TYPED_TEST(deconvolution_basic, basic_f16_wsiz2x2_in2x2x1x2_bfyx_yxfb_stride2_pa
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], half_to_float(output_ptr[i]));
+        ASSERT_FLOAT_EQ(expected_output_vec[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1014,7 +1014,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in1x2x2x2_bfyx_stride2_pad1_split2
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -1059,7 +1059,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in1x2x2x2_bfyx_stride2_pad1_group2
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -1142,7 +1142,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in1x2x2x2_bfyx_stride2_pad1_group1
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -1232,7 +1232,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in1x2x2x2_bfyx_stride2_pad1_group1
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -1280,7 +1280,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in1x6x1x1_bfyx_stride2_pad1_group2
     };
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -1357,7 +1357,7 @@ TYPED_TEST(deconvolution_basic_3d, basic3D_wsiz2x2x1_in1x1x2x2x1_nopad) {
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -1546,7 +1546,7 @@ TYPED_TEST(deconvolution_basic_3d, basic3D_wsiz3x3x3_in1x1x4x4x4_nopad) {
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -1614,7 +1614,7 @@ TYPED_TEST(deconvolution_basic_3d, basic3D_wsiz2x2x2_in1x1x2x2x2_stride2_nopad) 
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -1673,7 +1673,7 @@ TYPED_TEST(deconvolution_basic_3d, basic3D_wsiz2x2x2_in1x1x2x2x2_stride2_pad1) {
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 
 }
@@ -1755,7 +1755,7 @@ TYPED_TEST(deconvolution_basic, basic_f16_k9x9_s2x2_pad4x4) {
     std::vector<float> output_vec;
     for (unsigned int i = 0; i < output_act_prim->get_layout().count(); i++) {
         float x = float_round(output_act_ptr[i]), y = float_round(output_vec_ref[i]);
-        EXPECT_NEAR(x, y, 1e-0f);
+        ASSERT_NEAR(x, y, 1e-0f);
     }
 }
 
@@ -1821,7 +1821,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x2_b_fs_yx_fsv16_stride2_pad
     };
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++) {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -1892,7 +1892,7 @@ TEST(deconvolution_f16_fw_gpu, basic_wsiz2x2_in2x2x1x2_b_fs_yx_fsv16_stride2_pad
     };
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++) {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], half_to_float(output_ptr[i]));
+        ASSERT_FLOAT_EQ(expected_output_vec[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1941,7 +1941,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in1x2x2x2_b_fs_yx_fsv16_stride2_pad
     };
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++) {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -1989,7 +1989,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in1x2x2x2_b_fs_yx_fsv16_stride2_pad
     };
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++) {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -2041,7 +2041,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_nopad_b_fs_yx_fsv16_dw) {
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -2083,8 +2083,8 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_pad1_b_fs_yx_fsv16_dw) {
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_FLOAT_EQ(0.75f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(0.75f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(0.75f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(0.75f, output_ptr[1]);
 }
 
 
@@ -2140,7 +2140,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_stride2_nopad_b_fs_yx_fsv
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -2193,7 +2193,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_stride4_pad2_b_fs_yx_fsv1
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -2259,7 +2259,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_stride4_pad2_b_fs_yx_fsv1
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 
@@ -2400,7 +2400,7 @@ void test_deconvolution_f16_fw_gpu_basic_wsiz2x2_in1x2x2x2_fs_b_yx_fsv32_stride1
     ASSERT_EQ(expected_output_vec.size(), output_prim->count());
 
     for (size_t i = 0; i < expected_output_vec.size(); i++) {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]) << " index=" << i;
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]) << " index=" << i;
     }
 }
 
@@ -3012,7 +3012,7 @@ TEST(deconvolution_f32_fw_gpu_onednn, basic_wsiz2x2_in2x2x1x1_stride2_nopad) {
 
     for (unsigned int i = 0; i < expected_output_vec.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_output_vec[i], output_ptr[i]);
     }
 }
 #endif

--- a/src/plugins/intel_gpu/tests/test_cases/depth_concatenate_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/depth_concatenate_gpu_test.cpp
@@ -79,16 +79,16 @@ TEST(depth_concatenate_f32_gpu, test01) {
     auto output = outputs.at("depth1").get_memory();
 
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
-    EXPECT_FLOAT_EQ(0.5f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(0.7f, output_ptr[1]);
-    EXPECT_FLOAT_EQ(0.2f, output_ptr[2]);
-    EXPECT_FLOAT_EQ(0.4f, output_ptr[3]);
-    EXPECT_FLOAT_EQ(1.0f, output_ptr[4]);
-    EXPECT_FLOAT_EQ(0.1f, output_ptr[5]);
-    EXPECT_FLOAT_EQ(0.3f, output_ptr[6]);
-    EXPECT_FLOAT_EQ(-0.5f, output_ptr[7]);
-    EXPECT_FLOAT_EQ(0.0f, output_ptr[8]);
-    EXPECT_FLOAT_EQ(-0.2f, output_ptr[9]);
+    ASSERT_FLOAT_EQ(0.5f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(0.7f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(0.2f, output_ptr[2]);
+    ASSERT_FLOAT_EQ(0.4f, output_ptr[3]);
+    ASSERT_FLOAT_EQ(1.0f, output_ptr[4]);
+    ASSERT_FLOAT_EQ(0.1f, output_ptr[5]);
+    ASSERT_FLOAT_EQ(0.3f, output_ptr[6]);
+    ASSERT_FLOAT_EQ(-0.5f, output_ptr[7]);
+    ASSERT_FLOAT_EQ(0.0f, output_ptr[8]);
+    ASSERT_FLOAT_EQ(-0.2f, output_ptr[9]);
 }
 
 template <data_types DType>
@@ -143,7 +143,7 @@ void concat_basic_with_reorder() {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     int ptr_cntr = 0;
     for (const auto& ref : outs) {
-        EXPECT_FLOAT_EQ(ref, output_ptr[ptr_cntr++]);
+        ASSERT_FLOAT_EQ(ref, output_ptr[ptr_cntr++]);
     }
 }
 
@@ -218,22 +218,22 @@ TEST(depth_concatenate_f32_gpu, test02) {
     auto output = outputs.at("depth1").get_memory();
 
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
-    EXPECT_FLOAT_EQ(0.5f, output_ptr[0]);
-    EXPECT_FLOAT_EQ(0.7f, output_ptr[1]);
-    EXPECT_FLOAT_EQ(0.2f, output_ptr[2]);
-    EXPECT_FLOAT_EQ(0.4f, output_ptr[3]);
-    EXPECT_FLOAT_EQ(1.0f, output_ptr[4]);
-    EXPECT_FLOAT_EQ(0.1f, output_ptr[5]);
-    EXPECT_FLOAT_EQ(0.3f, output_ptr[6]);
-    EXPECT_FLOAT_EQ(-0.5f, output_ptr[7]);
-    EXPECT_FLOAT_EQ(0.0f, output_ptr[8]);
-    EXPECT_FLOAT_EQ(-0.2f, output_ptr[9]);
-    EXPECT_FLOAT_EQ(1.0f, output_ptr[10]);
-    EXPECT_FLOAT_EQ(0.1f, output_ptr[11]);
-    EXPECT_FLOAT_EQ(0.3f, output_ptr[12]);
-    EXPECT_FLOAT_EQ(-0.5f, output_ptr[13]);
-    EXPECT_FLOAT_EQ(0.0f, output_ptr[14]);
-    EXPECT_FLOAT_EQ(-0.2f, output_ptr[15]);
+    ASSERT_FLOAT_EQ(0.5f, output_ptr[0]);
+    ASSERT_FLOAT_EQ(0.7f, output_ptr[1]);
+    ASSERT_FLOAT_EQ(0.2f, output_ptr[2]);
+    ASSERT_FLOAT_EQ(0.4f, output_ptr[3]);
+    ASSERT_FLOAT_EQ(1.0f, output_ptr[4]);
+    ASSERT_FLOAT_EQ(0.1f, output_ptr[5]);
+    ASSERT_FLOAT_EQ(0.3f, output_ptr[6]);
+    ASSERT_FLOAT_EQ(-0.5f, output_ptr[7]);
+    ASSERT_FLOAT_EQ(0.0f, output_ptr[8]);
+    ASSERT_FLOAT_EQ(-0.2f, output_ptr[9]);
+    ASSERT_FLOAT_EQ(1.0f, output_ptr[10]);
+    ASSERT_FLOAT_EQ(0.1f, output_ptr[11]);
+    ASSERT_FLOAT_EQ(0.3f, output_ptr[12]);
+    ASSERT_FLOAT_EQ(-0.5f, output_ptr[13]);
+    ASSERT_FLOAT_EQ(0.0f, output_ptr[14]);
+    ASSERT_FLOAT_EQ(-0.2f, output_ptr[15]);
 }
 
 TEST(concatenate_f32_gpu, test_concatenation_of_pool_and_unpool) {
@@ -265,7 +265,7 @@ TEST(concatenate_f32_gpu, test_concatenation_of_pool_and_unpool) {
     std::vector<float> out_ref = {6.4f, 8.f, 51.2f, 64.f};
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 4; i++) {
-        EXPECT_NEAR(output_ptr[i], out_ref[i], 1e-3);
+        ASSERT_NEAR(output_ptr[i], out_ref[i], 1e-3);
     }
 }
 
@@ -306,22 +306,22 @@ TEST(depth_concatenate_f32_gpu, test03_cascade_concat_opt) {
     ASSERT_TRUE(executed_primitives.count("depth2") == 0);
     ASSERT_TRUE(executed_primitives.count("depth3") == 0);
 
-    EXPECT_NEAR(1.4142f, output_ptr[0], 1e-3);
-    EXPECT_NEAR(1.5422f, output_ptr[1], 1e-3);
-    EXPECT_NEAR(1.8340f, output_ptr[2], 1e-3);
-    EXPECT_NEAR(2.0f, output_ptr[3], 1e-3);
-    EXPECT_NEAR(2.0f, output_ptr[4], 1e-3);
-    EXPECT_NEAR(2.3784f, output_ptr[5], 1e-3);
-    EXPECT_NEAR(3.3635f, output_ptr[6], 1e-3);
-    EXPECT_NEAR(4.0f, output_ptr[7], 1e-3);
-    EXPECT_NEAR(2.0f, output_ptr[8], 1e-3);
-    EXPECT_NEAR(2.3784f, output_ptr[9], 1e-3);
-    EXPECT_NEAR(3.3635f, output_ptr[10], 1e-3);
-    EXPECT_NEAR(4.0f, output_ptr[11], 1e-3);
-    EXPECT_NEAR(4.0f, output_ptr[12], 1e-3);
-    EXPECT_NEAR(5.6568f, output_ptr[13], 1e-3);
-    EXPECT_NEAR(11.3137f, output_ptr[14], 1e-3);
-    EXPECT_NEAR(16.0f, output_ptr[15], 1e-3);
+    ASSERT_NEAR(1.4142f, output_ptr[0], 1e-3);
+    ASSERT_NEAR(1.5422f, output_ptr[1], 1e-3);
+    ASSERT_NEAR(1.8340f, output_ptr[2], 1e-3);
+    ASSERT_NEAR(2.0f, output_ptr[3], 1e-3);
+    ASSERT_NEAR(2.0f, output_ptr[4], 1e-3);
+    ASSERT_NEAR(2.3784f, output_ptr[5], 1e-3);
+    ASSERT_NEAR(3.3635f, output_ptr[6], 1e-3);
+    ASSERT_NEAR(4.0f, output_ptr[7], 1e-3);
+    ASSERT_NEAR(2.0f, output_ptr[8], 1e-3);
+    ASSERT_NEAR(2.3784f, output_ptr[9], 1e-3);
+    ASSERT_NEAR(3.3635f, output_ptr[10], 1e-3);
+    ASSERT_NEAR(4.0f, output_ptr[11], 1e-3);
+    ASSERT_NEAR(4.0f, output_ptr[12], 1e-3);
+    ASSERT_NEAR(5.6568f, output_ptr[13], 1e-3);
+    ASSERT_NEAR(11.3137f, output_ptr[14], 1e-3);
+    ASSERT_NEAR(16.0f, output_ptr[15], 1e-3);
 }
 
 TEST(depth_concatenate_f32_gpu, test04_fused_relu) {
@@ -359,9 +359,9 @@ TEST(depth_concatenate_f32_gpu, test04_fused_relu) {
     unsigned int input_element_count = 300;
     for (unsigned int i = 0; i < 600; i++) {
         if (i < input_element_count)
-            EXPECT_FLOAT_EQ(input1_vec[i] < 0.0f ? 0.0f : input1_vec[i], output_ptr[i]);
+            ASSERT_FLOAT_EQ(input1_vec[i] < 0.0f ? 0.0f : input1_vec[i], output_ptr[i]);
         else
-            EXPECT_FLOAT_EQ(input2_vec[i - input_element_count] < 0.0f ? 0.0f : input2_vec[i - input_element_count], output_ptr[i]);
+            ASSERT_FLOAT_EQ(input2_vec[i - input_element_count] < 0.0f ? 0.0f : input2_vec[i - input_element_count], output_ptr[i]);
     }
 }
 
@@ -679,7 +679,7 @@ TEST(depth_concatenate_f32_gpu, concat_with_different_format_inputs) {
     for (unsigned i = 0; i < input1->count(); i++)
     {
         int value = i + 1;
-        EXPECT_FLOAT_EQ(float(value), output_ptr[out_offset++]);
+        ASSERT_FLOAT_EQ(float(value), output_ptr[out_offset++]);
 
         if ((value % input1_values_count) == 0)
         {
@@ -693,7 +693,7 @@ TEST(depth_concatenate_f32_gpu, concat_with_different_format_inputs) {
         for (unsigned j = 0; j < b; j++)
         {
             int value = i + input2_start_value + j * input2_batch_offset;
-            EXPECT_FLOAT_EQ(float(value), output_ptr[out_offset++]);
+            ASSERT_FLOAT_EQ(float(value), output_ptr[out_offset++]);
 
             if ((out_offset % all_values_count) == 0)
             {
@@ -738,7 +738,7 @@ TEST(depth_concatenate_f32_gpu, concat_with_reshape_input) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_FLOAT_EQ(values[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(values[i], output_ptr[i]);
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/depth_concatenate_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/depth_concatenate_gpu_test.cpp
@@ -73,8 +73,8 @@ TEST(depth_concatenate_f32_gpu, test01) {
     network.set_input_data("input2", input2);
 
     auto outputs = network.execute({});
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "depth1");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "depth1");
 
     auto output = outputs.at("depth1").get_memory();
 
@@ -136,7 +136,7 @@ void concat_basic_with_reorder() {
 
     auto outputs = network.execute({});
     ASSERT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "to_float");
+    ASSERT_EQ(outputs.begin()->first, "to_float");
 
     auto output = outputs.at("to_float").get_memory();
 
@@ -212,8 +212,8 @@ TEST(depth_concatenate_f32_gpu, test02) {
     network.set_input_data("input3", input3);
 
     auto outputs = network.execute({});
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "depth1");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "depth1");
 
     auto output = outputs.at("depth1").get_memory();
 
@@ -302,9 +302,9 @@ TEST(depth_concatenate_f32_gpu, test03_cascade_concat_opt) {
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
     auto executed_primitives = network.get_executed_primitives();
 
-    EXPECT_TRUE(executed_primitives.count("depth1") == 0);
-    EXPECT_TRUE(executed_primitives.count("depth2") == 0);
-    EXPECT_TRUE(executed_primitives.count("depth3") == 0);
+    ASSERT_TRUE(executed_primitives.count("depth1") == 0);
+    ASSERT_TRUE(executed_primitives.count("depth2") == 0);
+    ASSERT_TRUE(executed_primitives.count("depth3") == 0);
 
     EXPECT_NEAR(1.4142f, output_ptr[0], 1e-3);
     EXPECT_NEAR(1.5422f, output_ptr[1], 1e-3);
@@ -350,8 +350,8 @@ TEST(depth_concatenate_f32_gpu, test04_fused_relu) {
     network.set_input_data("input2", input2);
 
     auto outputs = network.execute({});
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "relu1");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "relu1");
 
     auto output = outputs.at("relu1").get_memory();
 
@@ -404,14 +404,14 @@ TEST(depth_concatenate_f32_gpu, test05_different_formats) {
     network.set_input_data("input2", input2);
 
     auto outputs = network.execute({});
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output = outputs.at("output").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     int cntr = 0;
     for (float val : output_ptr) {
-        EXPECT_EQ(val, out_ref[cntr++]);
+        ASSERT_EQ(val, out_ref[cntr++]);
     }
 }
 
@@ -464,16 +464,16 @@ TEST(depth_concatenate_f32_gpu, test06_padded_input) {
     network.set_input_data("input2", input2);
 
     auto outputs = network.execute({});
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
     // Check that all concatenations have been optimized out.
     auto executed_primitives = network.get_executed_primitives();
-    EXPECT_TRUE(executed_primitives.count("depth1") == 0);
-    EXPECT_TRUE(executed_primitives.count("depth2") == 0);
+    ASSERT_TRUE(executed_primitives.count("depth1") == 0);
+    ASSERT_TRUE(executed_primitives.count("depth2") == 0);
     // Check that convolution was able to use optimzed kernel.
     for (auto& info : network.get_primitives_info()) {
         if (info.original_id == "conv") {
-            EXPECT_TRUE(info.kernel_id.find("ref") == std::string::npos) << " selected kernel: " << info.kernel_id;
+            ASSERT_TRUE(info.kernel_id.find("ref") == std::string::npos) << " selected kernel: " << info.kernel_id;
         }
     }
 
@@ -490,7 +490,7 @@ TEST(depth_concatenate_f32_gpu, test06_padded_input) {
         else
             ref = static_cast<float>(input2_data[0][i % input_f][0][0]);
 
-        EXPECT_EQ(val, ref) << " at i=" << i;
+        ASSERT_EQ(val, ref) << " at i=" << i;
     }
 }
 
@@ -540,15 +540,15 @@ TEST(depth_concatenate_f32_gpu, test07_padded_output) {
     network.set_input_data("input2", input2);
 
     auto outputs = network.execute({});
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
     // Check that all concatenations have been optimized out.
     auto executed_primitives = network.get_executed_primitives();
-    EXPECT_TRUE(executed_primitives.count("depth1") == 0);
+    ASSERT_TRUE(executed_primitives.count("depth1") == 0);
     // Check that convolution was able to use optimzed kernel.
     for (auto& info : network.get_primitives_info()) {
         if (info.original_id == "conv") {
-            EXPECT_TRUE(info.kernel_id.find("ref") == std::string::npos) << " selected kernel: " << info.kernel_id;
+            ASSERT_TRUE(info.kernel_id.find("ref") == std::string::npos) << " selected kernel: " << info.kernel_id;
         }
     }
 
@@ -563,7 +563,7 @@ TEST(depth_concatenate_f32_gpu, test07_padded_output) {
         else
             ref = static_cast<float>(input2_data[0][i % input_f][0][0]);
 
-        EXPECT_EQ(val, ref) << " at i=" << i;
+        ASSERT_EQ(val, ref) << " at i=" << i;
     }
 }
 
@@ -599,11 +599,11 @@ TEST(depth_concatenate_f32_gpu, test07_concat_is_output) {
     network.set_input_data("input2", input2);
 
     auto outputs = network.execute({});
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "depth1");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "depth1");
     // Check that concatenation haven't been optimized out.
     auto executed_primitives = network.get_executed_primitives();
-    EXPECT_TRUE(executed_primitives.count("depth1") == 1);
+    ASSERT_TRUE(executed_primitives.count("depth1") == 1);
 
     auto output = outputs.at("depth1").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -616,7 +616,7 @@ TEST(depth_concatenate_f32_gpu, test07_concat_is_output) {
         else
             ref = 0.5f * input2_data[0][i % input_f][0][0];
 
-        EXPECT_EQ(val, ref) << " at i=" << i;
+        ASSERT_EQ(val, ref) << " at i=" << i;
     }
 }
 
@@ -665,7 +665,7 @@ TEST(depth_concatenate_f32_gpu, concat_with_different_format_inputs) {
 
     auto outputs = network.execute({});
     ASSERT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "depth4");
+    ASSERT_EQ(outputs.begin()->first, "depth4");
 
     auto output = outputs.at("depth4").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -729,8 +729,8 @@ TEST(depth_concatenate_f32_gpu, concat_with_reshape_input) {
     network.set_input_data("input1", input1);
 
     auto outputs = network.execute({});
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "depth2");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "depth2");
 
     auto output = outputs.at("depth2").get_memory();
 
@@ -765,7 +765,7 @@ TEST(depth_concatenate_i32_gpu, optimize_data01) {
 
     for (auto& it : outputs) {
         cldnn::mem_lock<int> output_ptr(it.second.get_memory(), get_test_stream());
-        EXPECT_EQ(output_ptr[0], out_data[0]);
+        ASSERT_EQ(output_ptr[0], out_data[0]);
     }
 }
 
@@ -832,7 +832,7 @@ TEST(depth_concatenate_i32_gpu, optimize_data02) {
     cldnn::mem_lock<int> output_concat6(outputs.at("concat6").get_memory(), get_test_stream());
 
     for (size_t i = 0; i < output_concat6.size(); i++) {
-        EXPECT_EQ(output_concat6[i], c6_data[i]);
+        ASSERT_EQ(output_concat6[i], c6_data[i]);
     }
 }
 
@@ -871,7 +871,7 @@ TEST(depth_concatenate_i32_gpu, optimize_data03) {
     for (auto& it : outputs) {
         cldnn::mem_lock<int> output_ptr(it.second.get_memory(), get_test_stream());
         for (size_t i = 0; i < output_ptr.size(); i++) {
-            EXPECT_EQ(output_ptr[i], output_data[i]);
+            ASSERT_EQ(output_ptr[i], output_data[i]);
         }
     }
 }
@@ -911,7 +911,7 @@ TEST(depth_concatenate_i32_gpu, optimize_data04) {
     for (auto& it : outputs) {
         cldnn::mem_lock<int> output_ptr(it.second.get_memory(), get_test_stream());
         for (size_t i = 0; i < output_ptr.size(); i++) {
-            EXPECT_EQ(output_ptr[i], output_data[i]);
+            ASSERT_EQ(output_ptr[i], output_data[i]);
         }
     }
 }
@@ -952,7 +952,7 @@ TEST(depth_concatenate_i32_gpu, optimize_data05) {
     cldnn::mem_lock<int> output_concat5(outputs.at("concat5").get_memory(), get_test_stream());
 
     for (size_t i = 0; i < output_concat5.size(); i++) {
-        EXPECT_EQ(output_concat5[i], c5_data[i]);
+        ASSERT_EQ(output_concat5[i], c5_data[i]);
     }
 }
 
@@ -1021,7 +1021,7 @@ void test_depth_concatenate_f32_gpu_basic_bfwzyx_along_w(bool is_caching_test) {
 
     ASSERT_EQ(output_concat.size(), expected_output.size());
     for (size_t i = 0; i < output_concat.size(); i++) {
-        EXPECT_EQ(output_concat[i], expected_output[i]);
+        ASSERT_EQ(output_concat[i], expected_output[i]);
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/detection_output_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/detection_output_test.cpp
@@ -89,7 +89,7 @@ public:
     void init_buffer_sort(cldnn::memory::ptr input_buff) {
         cldnn::mem_lock<T> input_data_ptr(input_buff, get_test_stream());
 
-        EXPECT_EQ((int)input_buff->count(), 128);
+        ASSERT_EQ((int)input_buff->count(), 128);
 
         T* input_data = input_data_ptr.data();
         input_data[0] = 8;
@@ -119,16 +119,16 @@ public:
         std::vector<std::string> items;
         std::istringstream iss(values);
         std::copy(std::istream_iterator<std::string>(iss), std::istream_iterator<std::string>(), back_inserter(items));
-        EXPECT_EQ((int)items.size(), 7);
+        ASSERT_EQ((int)items.size(), 7);
 
         // Check data.
         cldnn::mem_lock<T> out_ptr(output, get_test_stream());
         const T* data = out_ptr.data();
         for (int i = 0; i < 2; ++i) {
-            EXPECT_EQ(static_cast<int>((float)data[num * output->get_layout().spatial(0) + i]), atoi(items[i].c_str()));
+            ASSERT_EQ(static_cast<int>((float)data[num * output->get_layout().spatial(0) + i]), atoi(items[i].c_str()));
         }
         for (int i = 2; i < 7; ++i) {
-            EXPECT_TRUE(floating_point_equal(data[num * output->get_layout().spatial(0) + i], (T)(float)atof(items[i].c_str())));
+            ASSERT_TRUE(floating_point_equal(data[num * output->get_layout().spatial(0) + i], (T)(float)atof(items[i].c_str())));
         }
     }
 
@@ -157,13 +157,13 @@ public:
 
         auto outputs = network.execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "detection_output");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "detection_output");
 
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
     }
 
     void setup_two_layers() {
@@ -192,16 +192,16 @@ public:
 
         auto outputs = network.execute();
 
-        EXPECT_EQ(outputs.size(), size_t(2));
+        ASSERT_EQ(outputs.size(), size_t(2));
         unsigned i = 1;
         for (auto it = outputs.begin(); it != outputs.begin(); it++) {
 
-            EXPECT_EQ(it->first, "detection_output_" + std::to_string(i));
+            ASSERT_EQ(it->first, "detection_output_" + std::to_string(i));
 
-            EXPECT_EQ(it->second.get_memory()->get_layout().batch(), 1);
-            EXPECT_EQ(it->second.get_memory()->get_layout().feature(), 1);
-            EXPECT_EQ(it->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
-            EXPECT_EQ(it->second.get_memory()->get_layout().spatial(0), 7);
+            ASSERT_EQ(it->second.get_memory()->get_layout().batch(), 1);
+            ASSERT_EQ(it->second.get_memory()->get_layout().feature(), 1);
+            ASSERT_EQ(it->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
+            ASSERT_EQ(it->second.get_memory()->get_layout().spatial(0), 7);
             i++;
         }
     }
@@ -234,13 +234,13 @@ public:
 
         auto outputs = network.execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "detection_output");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "detection_output");
 
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
 
         auto output_prim = outputs.begin()->second.get_memory();
 
@@ -282,13 +282,13 @@ public:
 
         auto outputs = network.execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "detection_output");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "detection_output");
 
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
 
         auto output_prim = outputs.begin()->second.get_memory();
 
@@ -324,13 +324,13 @@ public:
 
         auto outputs = network.execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "detection_output");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "detection_output");
 
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
 
         auto output_prim = outputs.begin()->second.get_memory();
 
@@ -377,13 +377,13 @@ public:
 
         auto outputs = network.execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "detection_output");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "detection_output");
 
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
 
         auto output_prim = outputs.begin()->second.get_memory();
 
@@ -440,13 +440,13 @@ public:
 
         auto outputs = network.execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "detection_output");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "detection_output");
 
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
 
         auto output_prim = outputs.begin()->second.get_memory();
 
@@ -490,13 +490,13 @@ public:
 
         auto outputs = network.execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "detection_output");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "detection_output");
 
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
 
         auto output_prim = outputs.begin()->second.get_memory();
 
@@ -551,13 +551,13 @@ public:
 
         auto outputs = network.execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "detection_output");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "detection_output");
 
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
 
         auto output_prim = outputs.begin()->second.get_memory();
 
@@ -599,13 +599,13 @@ public:
 
         auto outputs = network.execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "detection_output");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "detection_output");
 
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
 
         auto output_prim = outputs.begin()->second.get_memory();
 
@@ -650,13 +650,13 @@ public:
 
         auto outputs = network.execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "detection_output");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "detection_output");
 
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
 
         auto output_prim = outputs.begin()->second.get_memory();
 
@@ -696,13 +696,13 @@ public:
 
         auto outputs = network.execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "detection_output");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "detection_output");
 
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
 
         auto output_prim = outputs.begin()->second.get_memory();
 
@@ -777,13 +777,13 @@ public:
 
         auto outputs = network->execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "detection_output");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "detection_output");
 
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
-        EXPECT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().batch(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().feature(), 1);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(1), keep_top_k * this->num_of_images);
+        ASSERT_EQ(outputs.begin()->second.get_memory()->get_layout().spatial(0), 7);
 
         auto output_prim = outputs.begin()->second.get_memory();
 

--- a/src/plugins/intel_gpu/tests/test_cases/dft_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/dft_gpu_test.cpp
@@ -2081,7 +2081,7 @@ TEST(dft_gpu_test, irdft_output_shape) {
             auto output = outputs.at("dft").get_memory();
             auto output_format = output->get_layout().format;
 
-            EXPECT_EQ(output_format, format::adjust_to_rank(blocked_format, p.output_shape.size()));
+            ASSERT_EQ(output_format, format::adjust_to_rank(blocked_format, p.output_shape.size()));
         }
 
         topology.add(reorder("out", input_info("dft"), format::bfwzyx, data_type));

--- a/src/plugins/intel_gpu/tests/test_cases/dft_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/dft_gpu_test.cpp
@@ -149,7 +149,7 @@ public:
         const auto expected_values = convert<T>(p.expected_values);
         ASSERT_EQ(output_ptr.size(), expected_values.size());
         for (size_t i = 0; i < output_ptr.size(); ++i) {
-            EXPECT_NEAR(expected_values[i], output_ptr[i], getThreshold<T>(type));
+            ASSERT_NEAR(expected_values[i], output_ptr[i], getThreshold<T>(type));
         }
     }
 
@@ -2099,7 +2099,7 @@ TEST(dft_gpu_test, irdft_output_shape) {
         const auto expected_values = convert<T>(p.expected_values);
         ASSERT_EQ(output_ptr.size(), expected_values.size());
         for (size_t i = 0; i < output_ptr.size(); ++i) {
-            EXPECT_NEAR(expected_values[i], output_ptr[i], getThreshold<T>(type));
+            ASSERT_NEAR(expected_values[i], output_ptr[i], getThreshold<T>(type));
         }
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/eltwise_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/eltwise_gpu_test.cpp
@@ -3509,7 +3509,7 @@ struct eltwise_same_input_test : testing::TestWithParam<eltwise_same_input_test_
                         auto input_out_val = input_ptr[opt_out_offset];
 
                         ASSERT_EQ((input_out_val+input_out_val), ref_out_val);
-                        // EXPECT_NEAR(static_cast<float>(opt_out_val), static_cast<float>(ref_out_val), 1.e-1f);
+                        // ASSERT_NEAR(static_cast<float>(opt_out_val), static_cast<float>(ref_out_val), 1.e-1f);
                     }
                 }
             }
@@ -4095,7 +4095,7 @@ struct eltwise_random_test : testing::TestWithParam<eltwise_random_test_params>
                         auto opt_out_val = opt_ptr[opt_out_offset];
 
                         ASSERT_EQ(opt_out_val, ref_out_val);
-                        // EXPECT_NEAR(static_cast<float>(opt_out_val), static_cast<float>(ref_out_val), 1.e-1f);
+                        // ASSERT_NEAR(static_cast<float>(opt_out_val), static_cast<float>(ref_out_val), 1.e-1f);
                     }
                 }
             }

--- a/src/plugins/intel_gpu/tests/test_cases/eltwise_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/eltwise_gpu_test.cpp
@@ -107,24 +107,24 @@ void generic_eltwise_test(cldnn::format test_input_fmt, int input_b, int input_f
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, out_id);
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, out_id);
 
     auto output_memory = outputs.at(out_id).get_memory();
     auto output_layout = output_memory->get_layout();
     cldnn::mem_lock<T> output_ptr(output_memory, get_test_stream());
 
     VVVVF<T> output_cpu = eltwise_reference<T>(input1_rnd, input2_rnd, mode, relu, slope, input_padding_y, input_padding_x, output_padding_y, output_padding_x);
-    EXPECT_EQ(output_layout.format.value, test_input_fmt.value);
+    ASSERT_EQ(output_layout.format.value, test_input_fmt.value);
     auto output_tensor = output_layout.get_padded_dims();
     int x_size = output_tensor[3];
     int y_size = output_tensor[2];
     int f_size = output_tensor[1];
     int b_size = output_tensor[0];
-    EXPECT_EQ(y_size, (int)output_cpu[0][0].size());
-    EXPECT_EQ(x_size, (int)output_cpu[0][0][0].size());
-    EXPECT_EQ(f_size, (int)output_cpu[0].size());
-    EXPECT_EQ(b_size, (int)output_cpu.size());
+    ASSERT_EQ(y_size, (int)output_cpu[0][0].size());
+    ASSERT_EQ(x_size, (int)output_cpu[0][0][0].size());
+    ASSERT_EQ(f_size, (int)output_cpu[0].size());
+    ASSERT_EQ(b_size, (int)output_cpu.size());
 
     bool test_is_correct = true;
     VF<T> output_cpu_vec = flatten_4d<T>(test_input_fmt, output_cpu);
@@ -134,7 +134,7 @@ void generic_eltwise_test(cldnn::format test_input_fmt, int input_b, int input_f
             break;
         }
     }
-    EXPECT_EQ(test_is_correct, true) << std::endl
+    ASSERT_EQ(test_is_correct, true) << std::endl
         << "failing test parameters:" << std::endl
         << "input_b = " << input_b << std::endl
         << "input_f = " << input_f << std::endl
@@ -245,25 +245,25 @@ void generic_eltwise_bool_test(cldnn::format test_input_fmt, int input_b, int in
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output_memory = outputs.at("eltwise").get_memory();
     auto output_layout = output_memory->get_layout();
     cldnn::mem_lock<int8_t> output_ptr(output_memory, get_test_stream());
 
     VVVVF<int8_t> output_cpu = eltwise_bool_reference<T>(input1_rnd, input2_rnd, mode, input_padding_y, input_padding_x, output_padding_y, output_padding_x);
-    EXPECT_EQ(output_layout.format.value, test_input_fmt.value);
+    ASSERT_EQ(output_layout.format.value, test_input_fmt.value);
     auto output_tensor = output_layout.get_padded_dims();
     int x_size = output_tensor[3];
     int y_size = output_tensor[2];
     int f_size = output_tensor[1];
     int b_size = output_tensor[0];
 
-    EXPECT_EQ(y_size, (int)output_cpu[0][0].size());
-    EXPECT_EQ(x_size, (int)output_cpu[0][0][0].size());
-    EXPECT_EQ(f_size, (int)output_cpu[0].size());
-    EXPECT_EQ(b_size, (int)output_cpu.size());
+    ASSERT_EQ(y_size, (int)output_cpu[0][0].size());
+    ASSERT_EQ(x_size, (int)output_cpu[0][0][0].size());
+    ASSERT_EQ(f_size, (int)output_cpu[0].size());
+    ASSERT_EQ(b_size, (int)output_cpu.size());
 
     bool test_is_correct = true;
     VF<int8_t> output_cpu_vec = flatten_4d<int8_t>(test_input_fmt, output_cpu);
@@ -273,7 +273,7 @@ void generic_eltwise_bool_test(cldnn::format test_input_fmt, int input_b, int in
             break;
         }
     }
-    EXPECT_EQ(test_is_correct, true) << std::endl
+    ASSERT_EQ(test_is_correct, true) << std::endl
         << "failing test parameters:" << std::endl
         << "input_b = " << input_b << std::endl
         << "input_f = " << input_f << std::endl
@@ -351,8 +351,8 @@ TEST(eltwise_gpu_f32, equal_in2_float_out1_int) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
     cldnn::mem_lock<int8_t> output_ptr(output, get_test_stream());
@@ -363,7 +363,7 @@ TEST(eltwise_gpu_f32, equal_in2_float_out1_int) {
                                     0, 1, 0, 0 };
 
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -421,8 +421,8 @@ TEST(eltwise_gpu_f32, not_equal_in2_float_out1_int) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
     cldnn::mem_lock<int8_t> output_ptr(output, get_test_stream());
@@ -433,7 +433,7 @@ TEST(eltwise_gpu_f32, not_equal_in2_float_out1_int) {
                                     1, 0, 1, 1 };
 
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -491,8 +491,8 @@ TEST(eltwise_gpu_f32, less_in2_float_out1_int) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
     cldnn::mem_lock<int8_t> output_ptr(output, get_test_stream());
@@ -503,7 +503,7 @@ TEST(eltwise_gpu_f32, less_in2_float_out1_int) {
                                     0, 0, 0, 0 };
 
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -561,8 +561,8 @@ TEST(eltwise_gpu_f32, less_equal_in2_float_out1_int) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
     cldnn::mem_lock<int8_t> output_ptr(output, get_test_stream());
@@ -573,7 +573,7 @@ TEST(eltwise_gpu_f32, less_equal_in2_float_out1_int) {
                                     0, 1, 0, 0 };
 
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -631,8 +631,8 @@ TEST(eltwise_gpu_f32, greater_in2_float_out1_int) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
     cldnn::mem_lock<int8_t> output_ptr(output, get_test_stream());
@@ -643,7 +643,7 @@ TEST(eltwise_gpu_f32, greater_in2_float_out1_int) {
                                     1, 0, 1, 1 };
 
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -701,8 +701,8 @@ TEST(eltwise_gpu_f32, greater_equal_in2_float_out1_int) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
     cldnn::mem_lock<int8_t> output_ptr(output, get_test_stream());
@@ -713,7 +713,7 @@ TEST(eltwise_gpu_f32, greater_equal_in2_float_out1_int) {
                                     1, 1, 1, 1 };
 
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -771,8 +771,8 @@ TEST(eltwise_gpu_f32, logicalAND_in2_float_out1_int) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
     cldnn::mem_lock<int8_t> output_ptr(output, get_test_stream());
@@ -783,7 +783,7 @@ TEST(eltwise_gpu_f32, logicalAND_in2_float_out1_int) {
                                     1, 0, 1, 1 };
 
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -858,8 +858,8 @@ TEST(eltwise_gpu_f32, logicalAND_in3_float_out1_int) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
     cldnn::mem_lock<int8_t> output_ptr(output, get_test_stream());
@@ -870,7 +870,7 @@ TEST(eltwise_gpu_f32, logicalAND_in3_float_out1_int) {
                                     1, 0, 1, 1 };
 
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -928,8 +928,8 @@ TEST(eltwise_gpu_f32, logicalOR_in2_float_out1_int) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
     cldnn::mem_lock<int8_t> output_ptr(output, get_test_stream());
@@ -940,7 +940,7 @@ TEST(eltwise_gpu_f32, logicalOR_in2_float_out1_int) {
                                     1, 0, 1, 1 };
 
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1015,8 +1015,8 @@ TEST(eltwise_gpu_f32, logicalOR_in3_float_out1_int) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
     cldnn::mem_lock<int8_t> output_ptr(output, get_test_stream());
@@ -1027,7 +1027,7 @@ TEST(eltwise_gpu_f32, logicalOR_in3_float_out1_int) {
                                     1, 1, 1, 1 };
 
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1085,8 +1085,8 @@ TEST(eltwise_gpu_f32, logicalXOR_in2_float_out1_int) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
     cldnn::mem_lock<int8_t> output_ptr(output, get_test_stream());
@@ -1097,7 +1097,7 @@ TEST(eltwise_gpu_f32, logicalXOR_in2_float_out1_int) {
                                     0, 0, 0, 0 };
 
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1141,8 +1141,8 @@ TEST(eltwise_gpu_f32, dynamic_kernel_no_broadcast) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -1154,7 +1154,7 @@ TEST(eltwise_gpu_f32, dynamic_kernel_no_broadcast) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (int i = 0; i < 16; i++) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1197,8 +1197,8 @@ TEST(eltwise_gpu_f32, dynamic_kernel_broadcast) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -1210,7 +1210,7 @@ TEST(eltwise_gpu_f32, dynamic_kernel_broadcast) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (int i = 0; i < 16; i++) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1267,8 +1267,8 @@ TEST(eltwise_gpu_f32, add_basic_in4x4x2x2) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -1281,7 +1281,7 @@ TEST(eltwise_gpu_f32, add_basic_in4x4x2x2) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1323,8 +1323,8 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_channel) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -1344,7 +1344,7 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_channel) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1392,8 +1392,8 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_x) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -1413,7 +1413,7 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_x) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1455,8 +1455,8 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_y) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -1476,7 +1476,7 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_y) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1520,8 +1520,8 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_batch) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -1541,7 +1541,7 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_batch) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1579,8 +1579,8 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_multiple_dims) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -1600,7 +1600,7 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_multiple_dims) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1636,8 +1636,8 @@ TEST(eltwise_gpu_f32, pow_in2x2x2x2_broadcast_all) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -1657,7 +1657,7 @@ TEST(eltwise_gpu_f32, pow_in2x2x2x2_broadcast_all) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1714,8 +1714,8 @@ TEST(eltwise_gpu_f32, add_basic_in2x2x2x2_broadcast_2_inputs_same_dim) {
     network.set_input_data("input3", input3);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -1735,7 +1735,7 @@ TEST(eltwise_gpu_f32, add_basic_in2x2x2x2_broadcast_2_inputs_same_dim) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1790,8 +1790,8 @@ TEST(eltwise_gpu_f32, add_basic_in2x2x2x2_broadcast_2_inputs_diff_dim) {
     network.set_input_data("input3", input3);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -1811,7 +1811,7 @@ TEST(eltwise_gpu_f32, add_basic_in2x2x2x2_broadcast_2_inputs_diff_dim) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1867,8 +1867,8 @@ TEST(eltwise_gpu_f32, max_basic_in4x4x4x4) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -1882,7 +1882,7 @@ TEST(eltwise_gpu_f32, max_basic_in4x4x4x4) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1938,8 +1938,8 @@ TEST(eltwise_gpu_f32, sub_basic_in4x4x4x4) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -1953,7 +1953,7 @@ TEST(eltwise_gpu_f32, sub_basic_in4x4x4x4) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -2009,7 +2009,7 @@ TEST(eltwise_gpu_int, basic_in4x4x4x4) {
             auto outputs = network.execute();
 
             ASSERT_EQ(outputs.size(), size_t(1));
-            EXPECT_EQ(outputs.begin()->first, "eltwise_reorder");
+            ASSERT_EQ(outputs.begin()->first, "eltwise_reorder");
 
             auto output = outputs.at("eltwise_reorder").get_memory();
 
@@ -2037,7 +2037,7 @@ TEST(eltwise_gpu_int, basic_in4x4x4x4) {
                     expected =  input_1_vec[i] - input_2_vec[i] * std::floor(input_1_vec[i] / divisor);
                 }
 
-                EXPECT_TRUE(are_equal(std::floor(expected), output_ptr[i]));
+                ASSERT_TRUE(are_equal(std::floor(expected), output_ptr[i]));
             }
         }
     }
@@ -2087,7 +2087,7 @@ TEST(eltwise_gpu_f32_int, basic_in4x4x4x4) {
             auto outputs = network.execute();
 
             ASSERT_EQ(outputs.size(), size_t(1));
-            EXPECT_EQ(outputs.begin()->first, "eltwise_reorder");
+            ASSERT_EQ(outputs.begin()->first, "eltwise_reorder");
 
             auto output = outputs.at("eltwise_reorder").get_memory();
 
@@ -2111,7 +2111,7 @@ TEST(eltwise_gpu_f32_int, basic_in4x4x4x4) {
                 else if (mode == eltwise_mode::mod)
                     expected = std::fmod(input_1_vec[i], input_2_vec[i]);
 
-                EXPECT_TRUE(are_equal(std::floor(expected), output_ptr[i]));
+                ASSERT_TRUE(are_equal(std::floor(expected), output_ptr[i]));
             }
         }
     }
@@ -2168,8 +2168,8 @@ TEST(eltwise_gpu_f32, prod_basic_in4x4x4x4) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -2183,7 +2183,7 @@ TEST(eltwise_gpu_f32, prod_basic_in4x4x4x4) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -2242,8 +2242,8 @@ TEST(eltwise_gpu_f32, max_basic_in4x4x4x4_input_padding) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -2257,7 +2257,7 @@ TEST(eltwise_gpu_f32, max_basic_in4x4x4x4_input_padding) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -2314,8 +2314,8 @@ TEST(eltwise_gpu_f32, add_basic_in4x4x2x2_with_coefficients) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -2328,7 +2328,7 @@ TEST(eltwise_gpu_f32, add_basic_in4x4x2x2_with_coefficients) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -2431,8 +2431,8 @@ TEST(eltwise_gpu_f32, add_basic_in4x4x2x2_with_coefficients_3inputs) {
     network.set_input_data("input3", input3);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -2445,7 +2445,7 @@ TEST(eltwise_gpu_f32, add_basic_in4x4x2x2_with_coefficients_3inputs) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -2521,8 +2521,8 @@ TEST(eltwise_gpu_f32, max_3inputs_in4x4x4x4_input_padding) {
     network.set_input_data("input3", input3);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -2536,7 +2536,7 @@ TEST(eltwise_gpu_f32, max_3inputs_in4x4x4x4_input_padding) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -2610,8 +2610,8 @@ TEST(eltwise_gpu_f32, stride_test_2x2) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -2625,7 +2625,7 @@ TEST(eltwise_gpu_f32, stride_test_2x2) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -2678,8 +2678,8 @@ TEST(eltwise_gpu_f32, broadcast_test_in4x4x2x2) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -2693,7 +2693,7 @@ TEST(eltwise_gpu_f32, broadcast_test_in4x4x2x2) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -2769,7 +2769,7 @@ TEST(eltwise_gpu_f16, fs_b_yx_fsv32_basic)
     ASSERT_EQ(golden_ptr.size(), FSV32_ptr.size());
 
     for (size_t i = 0; i < golden_ptr.size(); i++) {
-        EXPECT_EQ(float(golden_ptr[i]), float(FSV32_ptr[i]));
+        ASSERT_EQ(float(golden_ptr[i]), float(FSV32_ptr[i]));
     }
 }
 
@@ -2931,8 +2931,8 @@ TEST(eltwise_gpu_f32, broadcast_test_in4x4x2x2x2) {
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "eltwise");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "eltwise");
 
     auto output = outputs.at("eltwise").get_memory();
 
@@ -2951,7 +2951,7 @@ TEST(eltwise_gpu_f32, broadcast_test_in4x4x2x2x2) {
 
     for (int i = 0; i < 32; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -3029,10 +3029,10 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_basic)
     ASSERT_EQ(golden_ptr.size(), BYXF_OUTPUT_ptr.size());
 
     for (size_t i = 0; i < golden_ptr.size(); i++) {
-        EXPECT_EQ(float(golden_ptr[i]), float(FS_B_YX_FSV32_OUTPUT_ptr[i]));
+        ASSERT_EQ(float(golden_ptr[i]), float(FS_B_YX_FSV32_OUTPUT_ptr[i]));
     }
     for (size_t i = 0; i < golden_ptr.size(); i++) {
-        EXPECT_EQ(float(golden_ptr[i]), float(BYXF_OUTPUT_ptr[i]));
+        ASSERT_EQ(float(golden_ptr[i]), float(BYXF_OUTPUT_ptr[i]));
     }
 }
 
@@ -3111,10 +3111,10 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_output_padding) {
     ASSERT_EQ(golden_ptr.size(), BYXF_OUTPUT_ptr.size());
 
     for (size_t i = 0; i < golden_ptr.size(); i++) {
-        EXPECT_EQ(float(golden_ptr[i]), float(FS_B_YX_FSV32_OUTPUT_ptr[i]));
+        ASSERT_EQ(float(golden_ptr[i]), float(FS_B_YX_FSV32_OUTPUT_ptr[i]));
     }
     for (size_t i = 0; i < golden_ptr.size(); i++) {
-        EXPECT_EQ(float(golden_ptr[i]), float(BYXF_OUTPUT_ptr[i]));
+        ASSERT_EQ(float(golden_ptr[i]), float(BYXF_OUTPUT_ptr[i]));
     }
 }
 
@@ -3195,11 +3195,11 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_input_padding)
 
     for (size_t i = 0; i < golden_ptr.size(); i++)
     {
-        EXPECT_EQ(float(golden_ptr[i]), float(FS_B_YX_FSV32_OUTPUT_ptr[i]));
+        ASSERT_EQ(float(golden_ptr[i]), float(FS_B_YX_FSV32_OUTPUT_ptr[i]));
     }
     for (size_t i = 0; i < golden_ptr.size(); i++)
     {
-        EXPECT_EQ(float(golden_ptr[i]), float(BYXF_OUTPUT_ptr[i]));
+        ASSERT_EQ(float(golden_ptr[i]), float(BYXF_OUTPUT_ptr[i]));
     }
 }
 
@@ -3487,7 +3487,7 @@ struct eltwise_same_input_test : testing::TestWithParam<eltwise_same_input_test_
     }
 
     template <typename T>
-    bool compare_outputs(const memory::ptr out_ref, const memory::ptr input_ref) {
+    void compare_outputs(const memory::ptr out_ref, const memory::ptr input_ref) {
         auto output_lay = out_ref->get_layout();
         auto opt_output_lay = input_ref->get_layout();
 
@@ -3508,14 +3508,12 @@ struct eltwise_same_input_test : testing::TestWithParam<eltwise_same_input_test_
                         auto opt_out_offset = opt_output_lay.get_linear_offset(ref_out_coords);
                         auto input_out_val = input_ptr[opt_out_offset];
 
-                        EXPECT_EQ((input_out_val+input_out_val), ref_out_val);
+                        ASSERT_EQ((input_out_val+input_out_val), ref_out_val);
                         // EXPECT_NEAR(static_cast<float>(opt_out_val), static_cast<float>(ref_out_val), 1.e-1f);
                     }
                 }
             }
         }
-
-        return true;
     }
 
     void execute_same_input(const eltwise_same_input_test_params& params, bool check_result) {
@@ -3702,15 +3700,15 @@ TEST_P(eltwise_test, fsv16) {
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, out_id);
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, out_id);
 
     auto output_memory = outputs.at(out_id).get_memory();
     cldnn::mem_lock<float> output_ptr(output_memory, get_test_stream());
 
     VF<float> output_cpu_vec = eltwise_ref(input1_rnd, input2_rnd, in0_size, in1_size, mode);
     for (size_t i = 0; i < output_cpu_vec.size(); ++i) {
-        EXPECT_TRUE(!(std::isnan((float)output_cpu_vec[i]) && std::isnan((float)output_ptr[i])));
+        ASSERT_TRUE(!(std::isnan((float)output_cpu_vec[i]) && std::isnan((float)output_ptr[i])));
         ASSERT_FLOAT_EQ(output_cpu_vec[i], output_ptr[i]);
     }
 }
@@ -3808,15 +3806,15 @@ TEST_P(eltwise_test_6d, bfwzyx) {
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, out_id);
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, out_id);
 
     auto output_memory = outputs.at(out_id).get_memory();
     cldnn::mem_lock<float> output_ptr(output_memory, get_test_stream());
 
     VF<float> output_cpu_vec = eltwise_ref(input1_rnd, input2_rnd, in0_size, in1_size, mode);
     for (size_t i = 0; i < output_cpu_vec.size(); ++i) {
-        EXPECT_TRUE(!(std::isnan((float)output_cpu_vec[i]) && std::isnan((float)output_ptr[i])));
+        ASSERT_TRUE(!(std::isnan((float)output_cpu_vec[i]) && std::isnan((float)output_ptr[i])));
         ASSERT_FLOAT_EQ(output_cpu_vec[i], output_ptr[i]);
     }
 }
@@ -3893,15 +3891,15 @@ TEST_P(eltwise_test_mixed_precision, fsv16) {
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, out_id);
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, out_id);
 
     auto output_memory = outputs.at(out_id).get_memory();
     cldnn::mem_lock<float> output_ptr(output_memory, get_test_stream());
 
     VF<float> output_cpu_vec = eltwise_ref(input1_rnd, input2_rnd, in0_size, in1_size, mode);
     for (size_t i = 0; i < output_cpu_vec.size(); ++i) {
-        EXPECT_TRUE(!(std::isnan((float)output_cpu_vec[i]) && std::isnan((float)output_ptr[i])));
+        ASSERT_TRUE(!(std::isnan((float)output_cpu_vec[i]) && std::isnan((float)output_ptr[i])));
         ASSERT_FLOAT_EQ(output_cpu_vec[i], output_ptr[i]);
     }
 }
@@ -3988,17 +3986,17 @@ TEST_P(eltwise_test_mixed_layout, mixed_layout) {
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, out_id);
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, out_id);
 
-    EXPECT_TRUE(network.get_primitive_info("eltwise").find(selected_kernel) != std::string::npos);
+    ASSERT_TRUE(network.get_primitive_info("eltwise").find(selected_kernel) != std::string::npos);
 
     auto output_memory = outputs.at(out_id).get_memory();
     cldnn::mem_lock<float> output_ptr(output_memory, get_test_stream());
 
     VF<float> output_cpu_vec = eltwise_ref(input1_rnd, input2_rnd, in0_size, in1_size, mode);
     for (size_t i = 0; i < output_cpu_vec.size(); ++i) {
-        EXPECT_TRUE(!(std::isnan((float)output_cpu_vec[i]) && std::isnan((float)output_ptr[i])));
+        ASSERT_TRUE(!(std::isnan((float)output_cpu_vec[i]) && std::isnan((float)output_ptr[i])));
         ASSERT_FLOAT_EQ(output_cpu_vec[i], output_ptr[i]);
     }
 }
@@ -4075,7 +4073,7 @@ struct eltwise_random_test : testing::TestWithParam<eltwise_random_test_params>
     }
 
     template <typename T>
-    bool compare_outputs(const memory::ptr out_ref, const memory::ptr out_opt) {
+    void compare_outputs(const memory::ptr out_ref, const memory::ptr out_opt) {
         auto output_lay = out_ref->get_layout();
         auto opt_output_lay = out_opt->get_layout();
 
@@ -4096,14 +4094,12 @@ struct eltwise_random_test : testing::TestWithParam<eltwise_random_test_params>
                         auto opt_out_offset = opt_output_lay.get_linear_offset(ref_out_coords);
                         auto opt_out_val = opt_ptr[opt_out_offset];
 
-                        EXPECT_EQ(opt_out_val, ref_out_val);
+                        ASSERT_EQ(opt_out_val, ref_out_val);
                         // EXPECT_NEAR(static_cast<float>(opt_out_val), static_cast<float>(ref_out_val), 1.e-1f);
                     }
                 }
             }
         }
-
-        return true;
     }
 
     void execute_compare(const eltwise_random_test_params& params, bool check_result) {

--- a/src/plugins/intel_gpu/tests/test_cases/embedding_bag_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/embedding_bag_gpu_test.cpp
@@ -72,7 +72,7 @@ TEST(embedding_bag_fp16_gpu, packed_sum_basic) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
     }
 }
 
@@ -125,7 +125,7 @@ TEST(embedding_bag_fp16_gpu, packed_sum_basic_without_weights) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
     }
 }
 
@@ -219,7 +219,7 @@ TEST(embedding_bag_fp16_gpu, packed_sum_dim2) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]), static_cast<float>(1e-2))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]), static_cast<float>(1e-2))) << i;
     }
 }
 
@@ -360,7 +360,7 @@ TEST(embedding_bag_fp16_gpu, packed_sum_dim3) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]), static_cast<float>(1e-2))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]), static_cast<float>(1e-2))) << i;
     }
 }
 
@@ -424,7 +424,7 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_basic) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
     }
 }
 
@@ -489,7 +489,7 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_basic_first_empty) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
     }
 }
 
@@ -554,7 +554,7 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_basic_last_empty) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
     }
 }
 
@@ -612,7 +612,7 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_without_weights_and_def_index) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
     }
 }
 
@@ -758,7 +758,7 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_dim3) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]), static_cast<float>(1e-2))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]), static_cast<float>(1e-2))) << i;
     }
 }
 
@@ -823,7 +823,7 @@ TEST(embedding_bag_fp16_gpu, segments_sum_basic) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
     }
 }
 
@@ -888,7 +888,7 @@ TEST(embedding_bag_fp16_gpu, segments_sum_basic_first_empty) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
     }
 }
 
@@ -953,7 +953,7 @@ TEST(embedding_bag_fp16_gpu, segments_sum_basic_last_empty) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
     }
 }
 
@@ -1011,7 +1011,7 @@ TEST(embedding_bag_fp16_gpu, segments_sum_without_weights_and_def_index) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
     }
 }
 
@@ -1157,7 +1157,7 @@ TEST(embedding_bag_fp16_gpu, segments_sum_dim3) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]), static_cast<float>(1e-2))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]), static_cast<float>(1e-2))) << i;
     }
 }
 
@@ -1218,7 +1218,7 @@ TEST(embedding_bag_fp32_gpu, packed_sum_basic) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], output_ptr[i])) << i;
     }
 }
 
@@ -1359,7 +1359,7 @@ TEST(embedding_bag_fp32_gpu, packed_sum_dim3) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], output_ptr[i])) << i;
     }
 }
 
@@ -1433,7 +1433,7 @@ void test_embedding_bag_fp32_gpu_extended5_6(bool is_caching_test) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], output_ptr[i])) << i;
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_detection_output_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_detection_output_gpu_test.cpp
@@ -199,11 +199,11 @@ public:
         const auto& expected_scores = param.expected_scores;
         for (int i = 0; i < param.max_detections_per_image; ++i) {
             if (!is_caching_test) {
-                EXPECT_NEAR(expected_scores[i], output_scores_ptr[i], 0.001) << "i=" << i;
+                ASSERT_NEAR(expected_scores[i], output_scores_ptr[i], 0.001) << "i=" << i;
             }
             for (size_t coord = 0; coord < 4; ++coord) {
                 const auto roi_idx = i * 4 + coord;
-                EXPECT_NEAR(expected_boxes[roi_idx], output_boxes_ptr[roi_idx], getError<T>())
+                ASSERT_NEAR(expected_boxes[roi_idx], output_boxes_ptr[roi_idx], getError<T>())
                     << "i=" << i << ", coord=" << coord;
             }
             if (!is_caching_test) {

--- a/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_detection_output_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_detection_output_gpu_test.cpp
@@ -99,7 +99,7 @@ public:
         topology.add(input_layout(input_deltas_id, input_deltas->get_layout()));
         topology.add(input_layout(input_scores_id, input_scores->get_layout()));
         topology.add(input_layout(input_im_info_id, input_im_info->get_layout()));
-        
+
         const primitive_id b_input_boxes_id = "BlockedInputBoxes";
         const primitive_id b_input_deltas_id = "BlockedInputDeltas";
         const primitive_id b_input_scores_id = "BlockedInputScores";
@@ -207,7 +207,7 @@ public:
                     << "i=" << i << ", coord=" << coord;
             }
             if (!is_caching_test) {
-                EXPECT_EQ(expected_classes[i], output_classes_ptr[i]) << "i=" << i;
+                ASSERT_EQ(expected_classes[i], output_classes_ptr[i]) << "i=" << i;
             }
         }
     }

--- a/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_generate_proposals_single_image_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_generate_proposals_single_image_gpu_test.cpp
@@ -287,7 +287,7 @@ public:
         const auto &expected_rois = param.expected_rois;
         for (int64_t i = 0; i < param.post_nms_count; ++i) {
             if (!is_caching_test) {
-                EXPECT_NEAR(expected_roi_scores[i], roi_scores_ptr[i], 0.001) << "i=" << i;
+                ASSERT_NEAR(expected_roi_scores[i], roi_scores_ptr[i], 0.001) << "i=" << i;
             }
 
             // order of proposals with zero scores is not guaranteed (to be precise,
@@ -295,7 +295,7 @@ public:
             if (static_cast<float>(expected_roi_scores[i]) != 0.0f) {
                 for (size_t coord = 0; coord < 4; ++coord) {
                     const auto roi_idx = i * 4 + coord;
-                    EXPECT_NEAR(expected_rois[roi_idx], rois_ptr[roi_idx], getError<T>()) << "i=" << i << ", coord=" << coord;
+                    ASSERT_NEAR(expected_rois[roi_idx], rois_ptr[roi_idx], getError<T>()) << "i=" << i << ", coord=" << coord;
                 }
             }
         }

--- a/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_prior_grid_generator_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_prior_grid_generator_gpu_test.cpp
@@ -90,7 +90,7 @@ public:
 
         ASSERT_EQ(params.outputTensor.count(), out_ptr.size());
         for (size_t i = 0; i < params.expectedOutput.size(); ++i) {
-            EXPECT_NEAR(params.expectedOutput[i], out_ptr[i], 0.0001) << "at i = " << i;
+            ASSERT_NEAR(params.expectedOutput[i], out_ptr[i], 0.0001) << "at i = " << i;
         }
     }
 };

--- a/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_roi_feature_extractor_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_roi_feature_extractor_gpu_test.cpp
@@ -96,7 +96,7 @@ void test_experimental_detectron_roi_feature_extractor_gpu_fp32_one_level(bool i
     std::vector<T>& expected_second_output = rois;
 
     auto second_network_output = outputs.at(second_output_r_id).get_memory();
-    EXPECT_TRUE(engine.is_the_same_buffer(*second_output, *second_network_output));
+    ASSERT_TRUE(engine.is_the_same_buffer(*second_output, *second_network_output));
     cldnn::mem_lock<T> second_output_ptr(second_network_output, get_test_stream());
 
     ASSERT_EQ(expected_second_output.size(), second_output_ptr.size());
@@ -177,7 +177,7 @@ TEST(experimental_detectron_roi_feature_extractor_gpu_fp32, two_levels) {
     std::vector<float>& expected_second_output = rois;
 
     auto second_network_output = outputs.at(second_output_r_id).get_memory();
-    EXPECT_TRUE(engine.is_the_same_buffer(*second_output, *second_network_output));
+    ASSERT_TRUE(engine.is_the_same_buffer(*second_output, *second_network_output));
     cldnn::mem_lock<float> second_output_ptr(second_network_output, get_test_stream());
 
     ASSERT_EQ(expected_second_output.size(), second_output_ptr.size());
@@ -275,7 +275,7 @@ TEST(experimental_detectron_roi_feature_extractor_gpu_fp32, multiple_feature_ext
     std::vector<float>& expected_second_output_first_instance = rois_first_instance;
 
     auto second_network_output_first_instance = outputs.at(second_output_r_first_instance_id).get_memory();
-    EXPECT_TRUE(engine.is_the_same_buffer(*second_output_first_instance, *second_network_output_first_instance));
+    ASSERT_TRUE(engine.is_the_same_buffer(*second_output_first_instance, *second_network_output_first_instance));
     cldnn::mem_lock<float> second_output_ptr_first_instance(second_network_output_first_instance, get_test_stream());
 
     ASSERT_EQ(expected_second_output_first_instance.size(), second_output_ptr_first_instance.size());
@@ -299,7 +299,7 @@ TEST(experimental_detectron_roi_feature_extractor_gpu_fp32, multiple_feature_ext
     std::vector<float>& expected_second_output_second_instance = rois_second_instance;
 
     auto second_network_output_second_instance = outputs.at(second_output_r_second_instance_id).get_memory();
-    EXPECT_TRUE(engine.is_the_same_buffer(*second_output_second_instance, *second_network_output_second_instance));
+    ASSERT_TRUE(engine.is_the_same_buffer(*second_output_second_instance, *second_network_output_second_instance));
     cldnn::mem_lock<float> second_output_ptr_second_instance(second_network_output_second_instance, get_test_stream());
 
     ASSERT_EQ(expected_second_output_second_instance.size(), second_output_ptr_second_instance.size());

--- a/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_roi_feature_extractor_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_roi_feature_extractor_gpu_test.cpp
@@ -87,7 +87,7 @@ void test_experimental_detectron_roi_feature_extractor_gpu_fp32_one_level(bool i
 
     ASSERT_EQ(expected_first_output.size(), first_output_ptr.size());
     for (std::size_t i = 0; i < expected_first_output.size(); i++) {
-        EXPECT_FLOAT_EQ(expected_first_output[i], first_output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_first_output[i], first_output_ptr[i]);
     }
 
     if (is_caching_test)
@@ -101,7 +101,7 @@ void test_experimental_detectron_roi_feature_extractor_gpu_fp32_one_level(bool i
 
     ASSERT_EQ(expected_second_output.size(), second_output_ptr.size());
     for (std::size_t i = 0; i < expected_second_output.size(); i++) {
-        EXPECT_FLOAT_EQ(expected_second_output[i], second_output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_second_output[i], second_output_ptr[i]);
     }
 }
 
@@ -171,7 +171,7 @@ TEST(experimental_detectron_roi_feature_extractor_gpu_fp32, two_levels) {
 
     ASSERT_EQ(expected_first_output.size(), first_output_ptr.size());
     for (std::size_t i = 0; i < expected_first_output.size(); i++) {
-        EXPECT_FLOAT_EQ(expected_first_output[i], first_output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_first_output[i], first_output_ptr[i]);
     }
 
     std::vector<float>& expected_second_output = rois;
@@ -182,7 +182,7 @@ TEST(experimental_detectron_roi_feature_extractor_gpu_fp32, two_levels) {
 
     ASSERT_EQ(expected_second_output.size(), second_output_ptr.size());
     for (std::size_t i = 0; i < expected_second_output.size(); i++) {
-        EXPECT_FLOAT_EQ(expected_second_output[i], second_output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected_second_output[i], second_output_ptr[i]);
     }
 }
 
@@ -269,7 +269,7 @@ TEST(experimental_detectron_roi_feature_extractor_gpu_fp32, multiple_feature_ext
 
     ASSERT_EQ(expected_first_output_first_instance.size(), first_output_ptr_first_instance.size());
     for (std::size_t i = 0; i < expected_first_output_first_instance.size(); i++) {
-        EXPECT_FLOAT_EQ(expected_first_output_first_instance[i], first_output_ptr_first_instance[i]);
+        ASSERT_FLOAT_EQ(expected_first_output_first_instance[i], first_output_ptr_first_instance[i]);
     }
 
     std::vector<float>& expected_second_output_first_instance = rois_first_instance;
@@ -280,7 +280,7 @@ TEST(experimental_detectron_roi_feature_extractor_gpu_fp32, multiple_feature_ext
 
     ASSERT_EQ(expected_second_output_first_instance.size(), second_output_ptr_first_instance.size());
     for (std::size_t i = 0; i < expected_second_output_first_instance.size(); i++) {
-        EXPECT_FLOAT_EQ(expected_second_output_first_instance[i], second_output_ptr_first_instance[i]);
+        ASSERT_FLOAT_EQ(expected_second_output_first_instance[i], second_output_ptr_first_instance[i]);
     }
 
     std::vector<float> expected_first_output_second_instance {7.41662f,   7.7499523f, 8.0832853f,  8.41662f,   8.74995f,   9.0832853f, 9.16664f,   9.49998f,   9.83331f,
@@ -293,7 +293,7 @@ TEST(experimental_detectron_roi_feature_extractor_gpu_fp32, multiple_feature_ext
 
     ASSERT_EQ(expected_first_output_second_instance.size(), first_output_ptr_second_instance.size());
     for (std::size_t i = 0; i < expected_first_output_second_instance.size(); i++) {
-        EXPECT_FLOAT_EQ(expected_first_output_second_instance[i], first_output_ptr_second_instance[i]);
+        ASSERT_FLOAT_EQ(expected_first_output_second_instance[i], first_output_ptr_second_instance[i]);
     }
 
     std::vector<float>& expected_second_output_second_instance = rois_second_instance;
@@ -304,6 +304,6 @@ TEST(experimental_detectron_roi_feature_extractor_gpu_fp32, multiple_feature_ext
 
     ASSERT_EQ(expected_second_output_second_instance.size(), second_output_ptr_second_instance.size());
     for (std::size_t i = 0; i < expected_second_output_second_instance.size(); i++) {
-        EXPECT_FLOAT_EQ(expected_second_output_second_instance[i], second_output_ptr_second_instance[i]);
+        ASSERT_FLOAT_EQ(expected_second_output_second_instance[i], second_output_ptr_second_instance[i]);
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_topk_rois_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_topk_rois_gpu_test.cpp
@@ -34,7 +34,7 @@ struct experimental_detectron_topk_rois_gpu_test : public testing::Test {
         cldnn::mem_lock<input_type> out_ptr(mem, get_test_stream());
         ASSERT_EQ(expected_output.size(), out_ptr.size());
         for (size_t i = 0; i < expected_output.size(); ++i) {
-            EXPECT_NEAR(static_cast<input_type>(expected_output[i]), out_ptr[i], 0.0001) << "at i = " << i;
+            ASSERT_NEAR(static_cast<input_type>(expected_output[i]), out_ptr[i], 0.0001) << "at i = " << i;
         }
     }
 };
@@ -187,6 +187,6 @@ TEST(experimental_detectron_topk_rois_gpu_test, export_import) {
     cldnn::mem_lock<float> out_ptr(out_mem, get_test_stream());
     ASSERT_EQ(expected_output.size(), out_ptr.size());
     for (size_t i = 0; i < expected_output.size(); ++i) {
-        EXPECT_NEAR(static_cast<float>(expected_output[i]), out_ptr[i], 0.0001) << "at i = " << i;
+        ASSERT_NEAR(static_cast<float>(expected_output[i]), out_ptr[i], 0.0001) << "at i = " << i;
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/extract_image_patches_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/extract_image_patches_gpu_test.cpp
@@ -47,8 +47,8 @@ TEST(extract_image_patches_gpu, basic) {
     network.set_input_data("Input0", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "extract_image_patches");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "extract_image_patches");
 
     auto output = outputs.at("extract_image_patches").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -84,7 +84,7 @@ TEST(extract_image_patches_gpu, basic) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -121,8 +121,8 @@ TEST(extract_image_patches_gpu, basic2) {
     network.set_input_data("Input0", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "extract_image_patches");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "extract_image_patches");
 
     auto output = outputs.at("extract_image_patches").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -148,7 +148,7 @@ TEST(extract_image_patches_gpu, basic2) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -185,8 +185,8 @@ TEST(extract_image_patches_gpu, basic3) {
     network.set_input_data("Input0", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "extract_image_patches");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "extract_image_patches");
 
     auto output = outputs.at("extract_image_patches").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -243,7 +243,7 @@ TEST(extract_image_patches_gpu, basic3) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -280,8 +280,8 @@ TEST(extract_image_patches_gpu, basic3_same_lower) {
     network.set_input_data("Input0", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "extract_image_patches");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "extract_image_patches");
 
     auto output = outputs.at("extract_image_patches").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -338,7 +338,7 @@ TEST(extract_image_patches_gpu, basic3_same_lower) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -375,8 +375,8 @@ TEST(extract_image_patches_gpu, basic3_enough_space) {
     network.set_input_data("Input0", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "extract_image_patches");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "extract_image_patches");
 
     auto output = outputs.at("extract_image_patches").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -412,7 +412,7 @@ TEST(extract_image_patches_gpu, basic3_enough_space) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -449,8 +449,8 @@ TEST(extract_image_patches_gpu, basic4) {
     network.set_input_data("Input0", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "extract_image_patches");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "extract_image_patches");
 
     auto output = outputs.at("extract_image_patches").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -486,7 +486,7 @@ TEST(extract_image_patches_gpu, basic4) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -542,8 +542,8 @@ void test_extract_image_patches_gpu_basic5(bool is_caching_test) {
     network->set_input_data("Input0", input);
     auto outputs = network->execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "extract_image_patches");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "extract_image_patches");
 
     auto output = outputs.at("extract_image_patches").get_memory();
     cldnn::mem_lock<T> output_ptr(output, get_test_stream());
@@ -576,7 +576,7 @@ void test_extract_image_patches_gpu_basic5(bool is_caching_test) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/eye.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/eye.cpp
@@ -85,7 +85,7 @@ public:
             tp.add(reorder("output", input_info("eye"), oupput_fmt, type_to_data_type<OutputType>::value));
         }
 
-        cldnn::network::ptr network; 
+        cldnn::network::ptr network;
 
         if (is_caching_test) {
             membuf mem_buf;
@@ -106,8 +106,8 @@ public:
 
         auto outputs = network->execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, ouput_op_name);
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, ouput_op_name);
 
         auto output = outputs.at(ouput_op_name).get_memory();
 
@@ -115,7 +115,7 @@ public:
 
         ASSERT_EQ(output_ptr.size(), expected_values.size());
         for (size_t i = 0; i < output_ptr.size(); ++i)
-            EXPECT_TRUE(are_equal(expected_values[i], output_ptr[i], 2e-3));
+            ASSERT_TRUE(are_equal(expected_values[i], output_ptr[i], 2e-3));
     }
 
 protected:

--- a/src/plugins/intel_gpu/tests/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/fully_connected_gpu_test.cpp
@@ -114,7 +114,7 @@ void generic_fully_connected_test(cldnn::format test_input_fmt, cldnn::format te
     VF<T> output_cpu_vec = flatten_4d<T>(layout_4d(output_layout.format), output_cpu);
     for (size_t i = 0; i < output_cpu_vec.size(); ++i) {
         if (std::abs(float(output_cpu_vec[i]) - float(output_ptr[i])) > ulp) {
-            EXPECT_FLOAT_EQ(output_cpu_vec[i], output_ptr[i]); // to print the problematic values
+            ASSERT_FLOAT_EQ(output_cpu_vec[i], output_ptr[i]); // to print the problematic values
             test_is_correct = false;
             break;
         }
@@ -1407,7 +1407,7 @@ public:
 
         for (size_t bi = 0; bi < batch_num(); ++bi) {
             for (size_t fi = 0; fi < output_f(); ++fi) {
-                EXPECT_NEAR(out_ptr[bi * output_f() + fi], expected[bi][fi], 1) << "at b = " << bi << ", fi = " << fi;
+                ASSERT_NEAR(out_ptr[bi * output_f() + fi], expected[bi][fi], 1) << "at b = " << bi << ", fi = " << fi;
             }
         }
     }

--- a/src/plugins/intel_gpu/tests/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/fully_connected_gpu_test.cpp
@@ -94,19 +94,19 @@ void generic_fully_connected_test(cldnn::format test_input_fmt, cldnn::format te
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, out_id);
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, out_id);
 
     auto output_memory = outputs.at(out_id).get_memory();
     auto output_layout = output_memory->get_layout();
     cldnn::mem_lock<T> output_ptr(output_memory, get_test_stream());
 
-    //EXPECT_EQ(output_layout.format.value, test_input_fmt);
+    //ASSERT_EQ(output_layout.format.value, test_input_fmt);
     tensor output_tensor = output_layout.get_tensor();
     int b_size = output_tensor.batch[0];
     int x_size = output_tensor.feature[0];
-    EXPECT_EQ(b_size, input_b);
-    EXPECT_EQ(x_size, output_f);
+    ASSERT_EQ(b_size, input_b);
+    ASSERT_EQ(x_size, output_f);
     unsigned num_of_operations = f * x * y * 2;
     float ulp = (1.0f / 1024.0f) * num_of_operations;
     bool test_is_correct = true;
@@ -120,7 +120,7 @@ void generic_fully_connected_test(cldnn::format test_input_fmt, cldnn::format te
         }
     }
 
-    EXPECT_EQ(test_is_correct, true) << std::endl
+    ASSERT_EQ(test_is_correct, true) << std::endl
         << "failing test parameters:" << std::endl
         << "test_input_fmt = " << format::traits(test_input_fmt).order << std::endl
         << "test_weights_fmt = " << format::traits(test_weights_fmt).order << std::endl
@@ -215,17 +215,17 @@ TEST(fully_connected_gpu, no_biases) {
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "fc_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "fc_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(1.5f, output_ptr[0]);
-    EXPECT_EQ(0.75f, output_ptr[1]);
-    EXPECT_EQ(-2.25f, output_ptr[2]);
-    EXPECT_EQ(3.0f, output_ptr[3]);
+    ASSERT_EQ(1.5f, output_ptr[0]);
+    ASSERT_EQ(0.75f, output_ptr[1]);
+    ASSERT_EQ(-2.25f, output_ptr[2]);
+    ASSERT_EQ(3.0f, output_ptr[3]);
 }
 
 TEST(fully_connected_gpu, no_biases_int8) {
@@ -275,17 +275,17 @@ TEST(fully_connected_gpu, no_biases_int8) {
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder_to_float");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder_to_float");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(18.0f, output_ptr[0]);
-    EXPECT_EQ(-32.0f, output_ptr[1]);
-    EXPECT_EQ(12.0f, output_ptr[2]);
-    EXPECT_EQ(-52.0f, output_ptr[3]);
+    ASSERT_EQ(18.0f, output_ptr[0]);
+    ASSERT_EQ(-32.0f, output_ptr[1]);
+    ASSERT_EQ(12.0f, output_ptr[2]);
+    ASSERT_EQ(-52.0f, output_ptr[3]);
 }
 
 TEST(fully_connected_gpu, xb_f32_batch_1) {
@@ -334,17 +334,17 @@ TEST(fully_connected_gpu, xb_f32_batch_1) {
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "fc_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "fc_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(2.5f, output_ptr[0]);
-    EXPECT_EQ(2.75f, output_ptr[1]);
-    EXPECT_EQ(0.75f, output_ptr[2]);
-    EXPECT_EQ(7.0f, output_ptr[3]);
+    ASSERT_EQ(2.5f, output_ptr[0]);
+    ASSERT_EQ(2.75f, output_ptr[1]);
+    ASSERT_EQ(0.75f, output_ptr[2]);
+    ASSERT_EQ(7.0f, output_ptr[3]);
 }
 
 TEST(fully_connected_gpu, xb_f32_batch_2) {
@@ -394,21 +394,21 @@ TEST(fully_connected_gpu, xb_f32_batch_2) {
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "fc_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "fc_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(2.50f, output_ptr[0]);
-    EXPECT_EQ(4.00f, output_ptr[1]);
-    EXPECT_EQ(2.75f, output_ptr[2]);
-    EXPECT_EQ(1.00f, output_ptr[3]);
-    EXPECT_EQ(0.75f, output_ptr[4]);
-    EXPECT_EQ(2.75f, output_ptr[5]);
-    EXPECT_EQ(7.00f, output_ptr[6]);
-    EXPECT_EQ(5.00f, output_ptr[7]);
+    ASSERT_EQ(2.50f, output_ptr[0]);
+    ASSERT_EQ(4.00f, output_ptr[1]);
+    ASSERT_EQ(2.75f, output_ptr[2]);
+    ASSERT_EQ(1.00f, output_ptr[3]);
+    ASSERT_EQ(0.75f, output_ptr[4]);
+    ASSERT_EQ(2.75f, output_ptr[5]);
+    ASSERT_EQ(7.00f, output_ptr[6]);
+    ASSERT_EQ(5.00f, output_ptr[7]);
 }
 
 TEST(fully_connected_gpu, x_f32) {
@@ -456,17 +456,17 @@ TEST(fully_connected_gpu, x_f32) {
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "fc_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "fc_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(2.50f, output_ptr[0]);
-    EXPECT_EQ(2.75f, output_ptr[1]);
-    EXPECT_EQ(0.75f, output_ptr[2]);
-    EXPECT_EQ(7.00f, output_ptr[3]);
+    ASSERT_EQ(2.50f, output_ptr[0]);
+    ASSERT_EQ(2.75f, output_ptr[1]);
+    ASSERT_EQ(0.75f, output_ptr[2]);
+    ASSERT_EQ(7.00f, output_ptr[3]);
 }
 
 TEST(fully_connected_gpu, xb_f32_batch_1_relu) {
@@ -517,17 +517,17 @@ TEST(fully_connected_gpu, xb_f32_batch_1_relu) {
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(2.50f, output_ptr[0]);
-    EXPECT_EQ(0.00f, output_ptr[1]);
-    EXPECT_EQ(0.75f, output_ptr[2]);
-    EXPECT_EQ(0.00f, output_ptr[3]);
+    ASSERT_EQ(2.50f, output_ptr[0]);
+    ASSERT_EQ(0.00f, output_ptr[1]);
+    ASSERT_EQ(0.75f, output_ptr[2]);
+    ASSERT_EQ(0.00f, output_ptr[3]);
 }
 
 TEST(fully_connected_gpu, xb_f32_batch_2_relu) {
@@ -579,21 +579,21 @@ TEST(fully_connected_gpu, xb_f32_batch_2_relu) {
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(2.50f, output_ptr[0]);
-    EXPECT_EQ(4.00f, output_ptr[1]);
-    EXPECT_EQ(0.00f, output_ptr[2]);
-    EXPECT_EQ(0.00f, output_ptr[3]);
-    EXPECT_EQ(0.75f, output_ptr[4]);
-    EXPECT_EQ(2.75f, output_ptr[5]);
-    EXPECT_EQ(0.00f, output_ptr[6]);
-    EXPECT_EQ(0.00f, output_ptr[7]);
+    ASSERT_EQ(2.50f, output_ptr[0]);
+    ASSERT_EQ(4.00f, output_ptr[1]);
+    ASSERT_EQ(0.00f, output_ptr[2]);
+    ASSERT_EQ(0.00f, output_ptr[3]);
+    ASSERT_EQ(0.75f, output_ptr[4]);
+    ASSERT_EQ(2.75f, output_ptr[5]);
+    ASSERT_EQ(0.00f, output_ptr[6]);
+    ASSERT_EQ(0.00f, output_ptr[7]);
 }
 
 TEST(fully_connected_gpu, x_f32_relu) {
@@ -642,17 +642,17 @@ TEST(fully_connected_gpu, x_f32_relu) {
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(2.50f, output_ptr[0]);
-    EXPECT_EQ(0.00f, output_ptr[1]);
-    EXPECT_EQ(0.75f, output_ptr[2]);
-    EXPECT_EQ(0.00f, output_ptr[3]);
+    ASSERT_EQ(2.50f, output_ptr[0]);
+    ASSERT_EQ(0.00f, output_ptr[1]);
+    ASSERT_EQ(0.75f, output_ptr[2]);
+    ASSERT_EQ(0.00f, output_ptr[3]);
 }
 
 TEST(fully_connected_gpu, x_f32_relu_with_negative_slope) {
@@ -702,17 +702,17 @@ TEST(fully_connected_gpu, x_f32_relu_with_negative_slope) {
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(2.50f, output_ptr[0]);
-    EXPECT_EQ(-0.125f, output_ptr[1]);
-    EXPECT_EQ(0.75f, output_ptr[2]);
-    EXPECT_EQ(-0.1f, output_ptr[3]);
+    ASSERT_EQ(2.50f, output_ptr[0]);
+    ASSERT_EQ(-0.125f, output_ptr[1]);
+    ASSERT_EQ(0.75f, output_ptr[2]);
+    ASSERT_EQ(-0.1f, output_ptr[3]);
 }
 
 TEST(fully_connected_gpu, b_fs_yx_fsv4)
@@ -829,7 +829,7 @@ TEST(fully_connected_gpu, DISABLED_fs_byx_fsv32_b12) {
     if (!engine.get_device_info().supports_fp16)
     {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
     // Test parameters
@@ -889,7 +889,7 @@ TEST(fully_connected_gpu, DISABLED_fs_byx_fsv32_b12) {
             auto val = output_ptr[bi * output_f + fi];
             auto equal = floating_point_equal(ref_val, val);
 
-            EXPECT_TRUE(equal);
+            ASSERT_TRUE(equal);
             if (!equal)
             {
                 std::cout << "At b = " << bi << ", f = " << fi << std::endl;
@@ -905,7 +905,7 @@ TEST(fully_connected_gpu, DISABLED_fs_byx_fsv32_b34)
     if (!engine.get_device_info().supports_fp16)
     {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
     // Test parameters
@@ -965,7 +965,7 @@ TEST(fully_connected_gpu, DISABLED_fs_byx_fsv32_b34)
             auto val = output_ptr[bi * output_f + fi];
             auto equal = floating_point_equal(ref_val, val);
 
-            EXPECT_TRUE(equal);
+            ASSERT_TRUE(equal);
             if (!equal)
             {
                 std::cout << "At b = " << bi << ", f = " << fi << std::endl;
@@ -1694,17 +1694,17 @@ TEST(fully_connected_onednn_gpu, no_biases_int8) {
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder_to_float");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder_to_float");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(18.0f, output_ptr[0]);
-    EXPECT_EQ(-32.0f, output_ptr[1]);
-    EXPECT_EQ(12.0f, output_ptr[2]);
-    EXPECT_EQ(-52.0f, output_ptr[3]);
+    ASSERT_EQ(18.0f, output_ptr[0]);
+    ASSERT_EQ(-32.0f, output_ptr[1]);
+    ASSERT_EQ(12.0f, output_ptr[2]);
+    ASSERT_EQ(-52.0f, output_ptr[3]);
 }
 
 TEST(fully_connected_3d_onednn_gpu, no_biases_int8) {
@@ -1746,18 +1746,18 @@ TEST(fully_connected_3d_onednn_gpu, no_biases_int8) {
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder_to_float");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder_to_float");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
     for (int b = 0; b < output_b; b++) {
-        EXPECT_EQ(18.0f, output_ptr[b * output_f + 0]);
-        EXPECT_EQ(-32.0f, output_ptr[b * output_f + 1]);
-        EXPECT_EQ(12.0f, output_ptr[b * output_f + 2]);
-        EXPECT_EQ(-52.0f, output_ptr[b * output_f + 3]);
+        ASSERT_EQ(18.0f, output_ptr[b * output_f + 0]);
+        ASSERT_EQ(-32.0f, output_ptr[b * output_f + 1]);
+        ASSERT_EQ(12.0f, output_ptr[b * output_f + 2]);
+        ASSERT_EQ(-52.0f, output_ptr[b * output_f + 3]);
     }
 }
 #endif

--- a/src/plugins/intel_gpu/tests/test_cases/gather_elements_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/gather_elements_gpu_test.cpp
@@ -56,7 +56,7 @@ inline void DoTest(engine& engine,
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/gather_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/gather_gpu_test.cpp
@@ -107,7 +107,7 @@ public:
         auto planar_output = planar_network.execute().at("gather").get_memory();
         cldnn::mem_lock<T_dat> planar_output_ptr(planar_output, get_test_stream());
 
-        EXPECT_TRUE(
+        ASSERT_TRUE(
             !memcmp(reorder_output_ptr.data(), planar_output_ptr.data(), get_linear_size(shape_out) * sizeof(T_dat)));
     }
 };
@@ -397,7 +397,7 @@ TEST(gather8_gpu_fp16, d323_axisY_bdim_m1) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -487,7 +487,7 @@ TEST(gather7_gpu_fp16, d222_axisX_bdim_m1) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -615,7 +615,7 @@ TEST(gather7_gpu_fp16, d323_axisY_bdim_m1) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -709,7 +709,7 @@ TEST(gather7_gpu_fp16, d44_axisY_bdim1) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -772,7 +772,7 @@ TEST(gather7_gpu_fp16, d32_axisF_bdim_m1) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -834,7 +834,7 @@ TEST(gather7_gpu_fp16, d32_axisF_bdim1) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -905,7 +905,7 @@ TEST(gather7_gpu_fp16, d32_axisF_bdim0) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -963,7 +963,7 @@ TEST(gather_gpu_fp16, d14_axisB) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1025,7 +1025,7 @@ TEST(gather_gpu_fp16, d222_axisB) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1086,7 +1086,7 @@ TEST(gather_gpu_fp16, d22_axisY) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1147,7 +1147,7 @@ TEST(gather_gpu_fp16, d22_axisF) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1205,7 +1205,7 @@ TEST(gather_gpu_fp32, d14_axisB) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -1266,7 +1266,7 @@ TEST(gather_gpu_fp32, d222_axisB) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -1327,7 +1327,7 @@ TEST(gather_gpu_fp32, d22_axisY) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -1388,7 +1388,7 @@ TEST(gather_gpu_fp32, d22_axisF) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -1449,7 +1449,7 @@ TEST(gather_gpu_int32, d22_axisF) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -1507,7 +1507,7 @@ TEST(gather_gpu_int32, d14_axisB) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -1568,7 +1568,7 @@ TEST(gather_gpu_int32, d222_axisB) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -1629,7 +1629,7 @@ TEST(gather_gpu_int32, d22_axisY) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -1697,7 +1697,7 @@ TEST(gather_gpu_fp32, d41_axisB) {
 
     ASSERT_EQ(expected_results.size(), output_ptr.size());
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]) << " at i=" << i;
+        ASSERT_EQ(expected_results[i], output_ptr[i]) << " at i=" << i;
     }
 }
 
@@ -1758,7 +1758,7 @@ TEST(gather_gpu_fp32, d41_axisF) {
 
     ASSERT_EQ(expected_results.size(), output_ptr.size());
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]) << " at i=" << i;
+        ASSERT_EQ(expected_results[i], output_ptr[i]) << " at i=" << i;
     }
 }
 
@@ -1817,7 +1817,7 @@ TEST(gather_gpu_fp32, d2_axisX) {
 
     ASSERT_EQ(expected_results.size(), output_ptr.size());
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]) << " at i=" << i;
+        ASSERT_EQ(expected_results[i], output_ptr[i]) << " at i=" << i;
     }
 }
 
@@ -1866,7 +1866,7 @@ TEST(gather_gpu_fp32, 322_axisF) {
 
     ASSERT_EQ(expected_results.size(), output_ptr.size());
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]) << i;
+        ASSERT_EQ(expected_results[i], output_ptr[i]) << i;
     }
 }
 
@@ -1909,7 +1909,7 @@ TEST(gather_gpu_fp32, dynamic_322_axisF) {
 
     ASSERT_EQ(expected_results.size(), output_ptr.size());
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]) << i;
+        ASSERT_EQ(expected_results[i], output_ptr[i]) << i;
     }
 }
 
@@ -1970,7 +1970,7 @@ void test_gather_gpu_u8_322_axisF(bool is_caching_test) {
 
     ASSERT_EQ(expected_results.size(), output_ptr.size());
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]) << i;
+        ASSERT_EQ(expected_results[i], output_ptr[i]) << i;
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/gather_nd_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/gather_nd_gpu_test.cpp
@@ -67,7 +67,7 @@ inline void DoTestBase(engine& engine,
     auto output_format = output->get_layout().format;
     auto output_shape = output->get_layout().get_tensor();
 
-    EXPECT_EQ(fmt, output_format);
+    ASSERT_EQ(fmt, output_format);
 
     int32_t dim_size = 6;
     if (fmt == format::bfyx) {
@@ -78,13 +78,13 @@ inline void DoTestBase(engine& engine,
 
     for (int32_t i = 0; i < dim_size; i++)
     {
-        EXPECT_EQ(ts.sizes()[i], output_shape.sizes()[i]);
+        ASSERT_EQ(ts.sizes()[i], output_shape.sizes()[i]);
     }
 
     // Compare output value
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/gather_tree_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/gather_tree_gpu_test.cpp
@@ -247,7 +247,7 @@ public:
         ASSERT_EQ(params.final_id_tensor.count(), out_ptr.size());
 
         for (size_t i = 0; i < params.final_id.size(); ++i) {
-            EXPECT_NEAR(params.final_id[i], out_ptr[i], 0.005) << "at i = " << i;
+            ASSERT_NEAR(params.final_id[i], out_ptr[i], 0.005) << "at i = " << i;
         }
     }
 };

--- a/src/plugins/intel_gpu/tests/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/gemm_gpu_test.cpp
@@ -138,7 +138,7 @@ public:
         ASSERT_EQ(output_ptr.size(), out_data.size());
         const auto abs_error = type == data_types::f16 ? 0.1 : 0.0001;
         for (uint32_t i = 0; i < out_data.size(); ++i) {
-            EXPECT_NEAR(output_ptr[i], out_data[i], abs_error);
+            ASSERT_NEAR(output_ptr[i], out_data[i], abs_error);
         }
     }
 };
@@ -286,7 +286,7 @@ TEST(gemm_gpu, basic_bfyx_t2_inplace_crop_with_pad) {
 
     ASSERT_EQ(output_ptr.size(), (uint32_t)3);
     for (uint32_t i = 0; i < out_data.size(); ++i) {
-        EXPECT_FLOAT_EQ(output_ptr[i], out_data[i]);
+        ASSERT_FLOAT_EQ(output_ptr[i], out_data[i]);
     }
 }
 
@@ -340,7 +340,7 @@ TEST(gemm_gpu, dynamic) {
 
     ASSERT_EQ(output_ptr.size(), (uint32_t)3);
     for (uint32_t i = 0; i < out_data.size(); ++i) {
-        EXPECT_FLOAT_EQ(output_ptr[i], out_data[i]);
+        ASSERT_FLOAT_EQ(output_ptr[i], out_data[i]);
     }
 }
 
@@ -1135,15 +1135,15 @@ public:
         ASSERT_EQ(output_ptr.size(), (size_t)(p.b_out_num * p.f_out_num * p.m_size * p.n_size));
         if (sizeof(input0_type) == 1) {
             for (size_t i = 0; i < out_data.size(); ++i) {
-                EXPECT_NEAR(float(output_ptr[i]), float(out_data[i]), threshold_int8) << "index = " << i;
+                ASSERT_NEAR(float(output_ptr[i]), float(out_data[i]), threshold_int8) << "index = " << i;
             }
         } else if (sizeof(input0_type) == 2) {
             for (size_t i = 0; i < out_data.size(); ++i) {
-                EXPECT_NEAR(float(output_ptr[i]), float(out_data[i]), threshold_fp16) << "index = " << i;
+                ASSERT_NEAR(float(output_ptr[i]), float(out_data[i]), threshold_fp16) << "index = " << i;
             }
         } else {
             for (size_t i = 0; i < out_data.size(); ++i) {
-                EXPECT_NEAR(float(output_ptr[i]), float(out_data[i]), threshold_fp32) << "index = " << i;
+                ASSERT_NEAR(float(output_ptr[i]), float(out_data[i]), threshold_fp32) << "index = " << i;
             }
         }
     }

--- a/src/plugins/intel_gpu/tests/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/gemm_gpu_test.cpp
@@ -135,7 +135,7 @@ public:
         auto output = outputs.at("output").get_memory();
         cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
-        EXPECT_EQ(output_ptr.size(), out_data.size());
+        ASSERT_EQ(output_ptr.size(), out_data.size());
         const auto abs_error = type == data_types::f16 ? 0.1 : 0.0001;
         for (uint32_t i = 0; i < out_data.size(); ++i) {
             EXPECT_NEAR(output_ptr[i], out_data[i], abs_error);
@@ -284,7 +284,7 @@ TEST(gemm_gpu, basic_bfyx_t2_inplace_crop_with_pad) {
     auto output = outputs.at("output").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
-    EXPECT_EQ(output_ptr.size(), (uint32_t)3);
+    ASSERT_EQ(output_ptr.size(), (uint32_t)3);
     for (uint32_t i = 0; i < out_data.size(); ++i) {
         EXPECT_FLOAT_EQ(output_ptr[i], out_data[i]);
     }
@@ -338,7 +338,7 @@ TEST(gemm_gpu, dynamic) {
     auto output = outputs.at("gemm").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
-    EXPECT_EQ(output_ptr.size(), (uint32_t)3);
+    ASSERT_EQ(output_ptr.size(), (uint32_t)3);
     for (uint32_t i = 0; i < out_data.size(); ++i) {
         EXPECT_FLOAT_EQ(output_ptr[i], out_data[i]);
     }
@@ -1132,7 +1132,7 @@ public:
         const float threshold_fp16 = 1e-1;
         const float threshold_fp32 = 3e-4;
 
-        EXPECT_EQ(output_ptr.size(), (size_t)(p.b_out_num * p.f_out_num * p.m_size * p.n_size));
+        ASSERT_EQ(output_ptr.size(), (size_t)(p.b_out_num * p.f_out_num * p.m_size * p.n_size));
         if (sizeof(input0_type) == 1) {
             for (size_t i = 0; i < out_data.size(); ++i) {
                 EXPECT_NEAR(float(output_ptr[i]), float(out_data[i]), threshold_int8) << "index = " << i;

--- a/src/plugins/intel_gpu/tests/test_cases/generate_proposals_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/generate_proposals_gpu_test.cpp
@@ -421,12 +421,12 @@ public:
 
         for (auto i = 0; i < param.post_nms_count; ++i) {
             if (!is_caching_test) {
-                EXPECT_NEAR(expected_roi_scores[i], roi_scores_ptr[i], getError<T>()) << "i=" << i;
+                ASSERT_NEAR(expected_roi_scores[i], roi_scores_ptr[i], getError<T>()) << "i=" << i;
             }
             if (static_cast<float>(expected_roi_scores[i]) != 0.0f) {
                 for (size_t coord = 0; coord < 4; ++coord) {
                     const auto roi_idx = i * 4 + coord;
-                    EXPECT_NEAR(expected_rois[roi_idx], rois_ptr[roi_idx], getError<T>()) << "i=" << i << ", coord=" << coord;
+                    ASSERT_NEAR(expected_rois[roi_idx], rois_ptr[roi_idx], getError<T>()) << "i=" << i << ", coord=" << coord;
                 }
             }
         }

--- a/src/plugins/intel_gpu/tests/test_cases/generate_proposals_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/generate_proposals_gpu_test.cpp
@@ -415,7 +415,7 @@ public:
 
         if (!is_caching_test) {
             for (size_t j = 0; j < expected_rois_num.size(); ++j) {
-                EXPECT_EQ(expected_rois_num[j], rois_num_ptr[j]) << "j=" << j;
+                ASSERT_EQ(expected_rois_num[j], rois_num_ptr[j]) << "j=" << j;
             }
         }
 

--- a/src/plugins/intel_gpu/tests/test_cases/grid_sample_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/grid_sample_gpu_test.cpp
@@ -81,7 +81,7 @@ public:
 
         ASSERT_EQ(output_ptr.size(), p.expected_values.size());
         for (size_t i = 0; i < output_ptr.size(); ++i) {
-            EXPECT_NEAR(p.expected_values[i], output_ptr[i], getError<TD>());
+            ASSERT_NEAR(p.expected_values[i], output_ptr[i], getError<TD>());
         }
     }
 

--- a/src/plugins/intel_gpu/tests/test_cases/loop_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/loop_gpu_test.cpp
@@ -80,19 +80,19 @@ TEST(loop_gpu, basic_no_concat)
     network.set_input_data("initial_condition", initial_condition_mem);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), 1);
+    ASSERT_EQ(outputs.size(), 1);
     auto output = outputs.begin()->second.get_memory();
     auto output_layout = output->get_layout();
 
-    EXPECT_EQ(output_layout.batch(), 1);
-    EXPECT_EQ(output_layout.feature(), 1);
-    EXPECT_EQ(output_layout.spatial(0), 4);
-    EXPECT_EQ(output_layout.spatial(1), 5);
+    ASSERT_EQ(output_layout.batch(), 1);
+    ASSERT_EQ(output_layout.feature(), 1);
+    ASSERT_EQ(output_layout.spatial(0), 4);
+    ASSERT_EQ(output_layout.spatial(1), 5);
 
     // value check
     {
         mem_lock<float> output_ptr{ output, get_test_stream() };
-        EXPECT_EQ(output_ptr.size(), input_data.size());
+        ASSERT_EQ(output_ptr.size(), input_data.size());
         for (size_t i = 0, iend = input_data.size(); i < iend; ++i) {
             ASSERT_FLOAT_EQ(output_ptr[i], input_data[i] + eltwise_operand[i] * trip_count);
         }
@@ -111,11 +111,11 @@ TEST(loop_gpu, basic_no_concat)
     outputs = network.execute();
 
     // check everything once again
-    EXPECT_EQ(outputs.size(), 1);
+    ASSERT_EQ(outputs.size(), 1);
     auto output2 = outputs.begin()->second.get_memory();
     {
         mem_lock<float> output_ptr2{ output2, get_test_stream() };
-        EXPECT_EQ(output_ptr2.size(), input_data.size());
+        ASSERT_EQ(output_ptr2.size(), input_data.size());
         for (size_t i = 0, iend = input_data.size(); i < iend; ++i) {
             ASSERT_FLOAT_EQ(output_ptr2[i], input_data[i] + eltwise_operand[i] * trip_count);
         }
@@ -175,14 +175,14 @@ TEST(loop_gpu, basic_concat)
     network.set_input_data("initial_condition", initial_condition_mem);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), 1);
+    ASSERT_EQ(outputs.size(), 1);
     auto output = outputs.begin()->second.get_memory();
     auto output_layout = output->get_layout();
 
-    EXPECT_EQ(output_layout.batch(), 1);
-    EXPECT_EQ(output_layout.feature(), 1);
-    EXPECT_EQ(output_layout.spatial(0), 4);
-    EXPECT_EQ(output_layout.spatial(1), 5);
+    ASSERT_EQ(output_layout.batch(), 1);
+    ASSERT_EQ(output_layout.feature(), 1);
+    ASSERT_EQ(output_layout.spatial(0), 4);
+    ASSERT_EQ(output_layout.spatial(1), 5);
 
     // value check
     {
@@ -312,7 +312,7 @@ TEST(loop_gpu, basic_concat_nested)
     network.set_input_data("inner_initial_condition", inner_initial_condition_mem);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), 1);
+    ASSERT_EQ(outputs.size(), 1);
     auto output = outputs.begin()->second.get_memory();
     auto output_layout = output->get_layout();
 
@@ -333,13 +333,13 @@ TEST(loop_gpu, basic_concat_nested)
     /////////////////////////////////
     // compare
     /////////////////////////////////
-    EXPECT_EQ(output_layout.batch(), 1);
-    EXPECT_EQ(output_layout.feature(), 1);
-    EXPECT_EQ(output_layout.spatial(0), 4);
-    EXPECT_EQ(output_layout.spatial(1), 5);
+    ASSERT_EQ(output_layout.batch(), 1);
+    ASSERT_EQ(output_layout.feature(), 1);
+    ASSERT_EQ(output_layout.spatial(0), 4);
+    ASSERT_EQ(output_layout.spatial(1), 5);
 
     // check output values
-    EXPECT_EQ(output_layout.count(), expected.size());
+    ASSERT_EQ(output_layout.count(), expected.size());
     {
         mem_lock<float> output_ptr{ output, get_test_stream() };
         for (size_t i = 0; i < output_layout.count(); ++i) {

--- a/src/plugins/intel_gpu/tests/test_cases/lrn_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/lrn_gpu_test.cpp
@@ -58,7 +58,7 @@ TEST(lrn_fp32_gpu, basic) {
 
     ASSERT_EQ(output_ptr.size(), expected_results.size());
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], output_ptr[i])) << i;
     }
 }
 
@@ -107,7 +107,7 @@ TEST(lrn_fp32_gpu, basic2) {
 
     ASSERT_EQ(output_ptr.size(), expected_results.size());
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], output_ptr[i])) << i;
     }
 }
 
@@ -156,7 +156,7 @@ TEST(lrn_fp16_gpu, basic1) {
 
     ASSERT_EQ(output_ptr.size(), expected_results.size());
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
     }
 }
 
@@ -248,6 +248,6 @@ TEST(lrn_fp32_gpu, basic3) {
 
     ASSERT_EQ(output_ptr.size(), expected_results.size());
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(expected_results[i], output_ptr[i])) << i;
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/lru_caches_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/lru_caches_gpu_test.cpp
@@ -23,7 +23,7 @@ TEST(lru_cache, basic_data_type)
         input_values.push_back(std::make_pair(i, i + 10));
     }
 
-    EXPECT_EQ(ca.get_lru_element(), int());
+    ASSERT_EQ(ca.get_lru_element(), int());
 
     std::vector<bool> expected_hitted = {false, false, false, false, true, true, false};
     for (size_t i = 0; i < input_values.size(); i++) {
@@ -36,8 +36,8 @@ TEST(lru_cache, basic_data_type)
             ca.add(in.first, in.second);
             data = ca.get(in.first);
         }
-        EXPECT_EQ(data, in.second);
-        EXPECT_EQ(hitted, (bool)expected_hitted[i]);
+        ASSERT_EQ(data, in.second);
+        ASSERT_EQ(hitted, (bool)expected_hitted[i]);
     }
 
     std::vector<std::pair<int, int>> expected_value;
@@ -48,7 +48,7 @@ TEST(lru_cache, basic_data_type)
 
     int idx = expected_value.size() - 1;
     for (auto key : ca.get_all_keys()) {
-        EXPECT_EQ(key, expected_value[idx--].first);
+        ASSERT_EQ(key, expected_value[idx--].first);
     }
 }
 
@@ -95,7 +95,7 @@ TEST(lru_cache, custom_data_type) {
 
     std::vector<bool> expected_hitted = {false, false, false, false, true, true, true, false};
 
-    EXPECT_EQ(ca.get_lru_element(), std::shared_ptr<lru_cache_test_data>());
+    ASSERT_EQ(ca.get_lru_element(), std::shared_ptr<lru_cache_test_data>());
     for (size_t i = 0; i < inputs.size(); i++) {
         auto& in = inputs[i];
         std::shared_ptr<lru_cache_test_data> p_data;
@@ -106,11 +106,11 @@ TEST(lru_cache, custom_data_type) {
             ca.add(in->key, in);
             p_data = ca.get(in->key);
         }
-        EXPECT_EQ(p_data->key, in->key);
-        EXPECT_EQ(hitted, (bool)expected_hitted[i]);
+        ASSERT_EQ(p_data->key, in->key);
+        ASSERT_EQ(hitted, (bool)expected_hitted[i]);
     }
 
-    EXPECT_EQ(cap, ca.size());
+    ASSERT_EQ(cap, ca.size());
 
     std::vector<std::string> expected_keys;
     for (size_t i = cap; i > 0; i--) {
@@ -119,6 +119,6 @@ TEST(lru_cache, custom_data_type) {
 
     int idx = expected_keys.size() - 1;
     for (auto key : ca.get_all_keys()) {
-        EXPECT_EQ(key, expected_keys[idx--]);
+        ASSERT_EQ(key, expected_keys[idx--]);
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/lstm_dynamic_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/lstm_dynamic_gpu_test.cpp
@@ -287,7 +287,7 @@ struct lstm_dynamic_input_layer_test : public ::testing::Test
                 {
                     for (auto x = 0; x < out_layout.spatial(0); x++)
                     {
-                        EXPECT_NEAR(output_ref[b][len][dir][x], (float)out_ptr[i++], 1e-3f)
+                        ASSERT_NEAR(output_ref[b][len][dir][x], (float)out_ptr[i++], 1e-3f)
                             << "b:" << b << ", "
                             << "len:" << len << ", "
                             << "dir:" << dir << ", "
@@ -453,7 +453,7 @@ struct lstm_dynamic_single_layer_test : public ::testing::Test
                         //check hidden
                         if (len < dynamic_lengths[b])
                         {
-                            EXPECT_NEAR((float)ref_output_hidden[b][len][dir][x], (float)out_ptr[i++], epsilon)
+                            ASSERT_NEAR((float)ref_output_hidden[b][len][dir][x], (float)out_ptr[i++], epsilon)
                                 << "check hidden, "
                                 << "b:" << b << ", "
                                 << "len:" << len << ", "
@@ -463,7 +463,7 @@ struct lstm_dynamic_single_layer_test : public ::testing::Test
                         }
                         else
                         {
-                            EXPECT_NEAR(0.0f, (float)out_ptr[i++], epsilon)
+                            ASSERT_NEAR(0.0f, (float)out_ptr[i++], epsilon)
                                 << "check hidden, "
                                 << "b:" << b << ", "
                                 << "len:" << len << ", "
@@ -487,7 +487,7 @@ struct lstm_dynamic_single_layer_test : public ::testing::Test
                         }
                         else if (has_last_hidden_state && len == 0 && dynamic_lengths[b] == 0)
                         {
-                            EXPECT_NEAR(0.0f, (float)last_hidden_ptr[i_lh++], epsilon)
+                            ASSERT_NEAR(0.0f, (float)last_hidden_ptr[i_lh++], epsilon)
                                 << "check has_last_hidden_state, "
                                 << "b:" << b << ", "
                                 << "len:" << len << ", "
@@ -510,7 +510,7 @@ struct lstm_dynamic_single_layer_test : public ::testing::Test
                         }
                         else if (has_last_cell_state && len == 0 && dynamic_lengths[b] == 0)
                         {
-                            EXPECT_NEAR(0.0f, (float)last_cell_ptr[i_lc++], epsilon)
+                            ASSERT_NEAR(0.0f, (float)last_cell_ptr[i_lc++], epsilon)
                                 << "check has_last_cell_state, "
                                 << "b:" << b << ", "
                                 << "len:" << len << ", "

--- a/src/plugins/intel_gpu/tests/test_cases/lstm_dynamic_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/lstm_dynamic_gpu_test.cpp
@@ -476,7 +476,7 @@ struct lstm_dynamic_single_layer_test : public ::testing::Test
                         if(has_last_hidden_state && len == dynamic_lengths[b] - 1)
                         {
                             auto ratio = (float)ref_output_hidden[b][len][dir][x] / (float)last_hidden_ptr[i_lh++];
-                            EXPECT_TRUE(std::abs(1.0f - ratio) < 0.01f)
+                            ASSERT_TRUE(std::abs(1.0f - ratio) < 0.01f)
                             << "check has_last_hidden_state with ratio: " << ratio << ", "
                                 << "b:" << b << ", "
                                 << "len:" << len << ", "
@@ -500,7 +500,7 @@ struct lstm_dynamic_single_layer_test : public ::testing::Test
                         if(has_last_cell_state && len == dynamic_lengths[b] - 1)
                         {
                             auto ratio = (float)ref_output_cell[b][len][dir][x] / (float)last_cell_ptr[i_lc++];
-                            EXPECT_TRUE(std::abs(1.0f - ratio) < 0.01f)
+                            ASSERT_TRUE(std::abs(1.0f - ratio) < 0.01f)
                                 << "check has_last_cell_state with ratio: " << ratio << ", "
                                 << "b:" << b << ", "
                                 << "len:" << len << ", "

--- a/src/plugins/intel_gpu/tests/test_cases/lstm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/lstm_gpu_test.cpp
@@ -260,7 +260,7 @@ void generic_lstm_gemm_gpu_test(int sequence_len, int direction, int batch_size,
     int i = 0;
     for (int b = 0; b < batch_size; ++b) {
         for (int x = 0; x < 4 * hidden_size; ++x)
-            EXPECT_FLOAT_EQ(ref_output[b][0][0][x], output_ptr[i++]);
+            ASSERT_FLOAT_EQ(ref_output[b][0][0][x], output_ptr[i++]);
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/lstm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/lstm_gpu_test.cpp
@@ -253,7 +253,7 @@ void generic_lstm_gemm_gpu_test(int sequence_len, int direction, int batch_size,
     }
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.size(), size_t(1));
 
     auto output = outputs.begin()->second.get_memory();
     cldnn::mem_lock<T> output_ptr(output, get_test_stream());
@@ -316,7 +316,7 @@ void generic_lstm_elt_gpu_test(int /* sequence_len */, int direction, int batch_
     }
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.size(), size_t(1));
 
     auto output = outputs.begin()->second.get_memory();
     cldnn::mem_lock<T> output_ptr(output, get_test_stream());

--- a/src/plugins/intel_gpu/tests/test_cases/matrix_nms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/matrix_nms_gpu_test.cpp
@@ -126,12 +126,12 @@ public:
 
         ASSERT_EQ(test_inputs.expected_selected_boxes.size(), selected_boxes_ptr.size());
         for (size_t i = 0; i < test_inputs.expected_selected_boxes.size(); ++i) {
-            EXPECT_EQ(test_inputs.expected_selected_boxes[i], selected_boxes_ptr[i]);
+            ASSERT_EQ(test_inputs.expected_selected_boxes[i], selected_boxes_ptr[i]);
         }
 
         ASSERT_EQ(test_inputs.expected_valid_outputs.size(), valid_outputs_ptr.size());
         for (size_t i = 0; i < test_inputs.expected_valid_outputs.size(); ++i) {
-            EXPECT_EQ(test_inputs.expected_valid_outputs[i], valid_outputs_ptr[i]);
+            ASSERT_EQ(test_inputs.expected_valid_outputs[i], valid_outputs_ptr[i]);
         }
     }
 

--- a/src/plugins/intel_gpu/tests/test_cases/matrix_nms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/matrix_nms_gpu_test.cpp
@@ -121,7 +121,7 @@ public:
         const auto expected_output = convert<T>(test_inputs.expected_output);
         ASSERT_EQ(expected_output.size(), output_ptr.size());
         for (size_t i = 0; i < expected_output.size(); ++i) {
-            EXPECT_NEAR(expected_output[i], output_ptr[i], THRESHOLD);
+            ASSERT_NEAR(expected_output[i], output_ptr[i], THRESHOLD);
         }
 
         ASSERT_EQ(test_inputs.expected_selected_boxes.size(), selected_boxes_ptr.size());

--- a/src/plugins/intel_gpu/tests/test_cases/memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/memory_test.cpp
@@ -85,7 +85,7 @@ TEST(memory_pool, basic_non_padded_relu_pipe) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(engine->get_max_used_device_memory(), (uint64_t)64);
+    ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)64);
  }
 
 TEST(memory_pool, basic_non_padded_relu_and_pooling_pipe) {
@@ -117,7 +117,7 @@ TEST(memory_pool, basic_non_padded_relu_and_pooling_pipe) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(engine->get_max_used_device_memory(), (uint64_t)896);
+    ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)896);
 }
 
 TEST(memory_pool, multi_outputs_network) {
@@ -152,7 +152,7 @@ TEST(memory_pool, multi_outputs_network) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(engine->get_max_used_device_memory(), (uint64_t) 1536);
+    ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t) 1536);
 }
 
 TEST(memory_pool, oooq) {
@@ -190,7 +190,7 @@ TEST(memory_pool, oooq) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(engine->get_max_used_device_memory(), (uint64_t) 2560);
+    ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t) 2560);
 }
 
 TEST(memory_pool, DISABLED_shared_mem_pool_same_topology_twice) {
@@ -239,7 +239,7 @@ TEST(memory_pool, DISABLED_shared_mem_pool_same_topology_twice) {
     auto output_layout_first = output_memory_first->get_layout();
     cldnn::mem_lock<float> output_ptr_first(output_memory_first, get_test_stream());
 
-    EXPECT_EQ(engine->get_max_used_device_memory(), (uint64_t) 2560);
+    ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t) 2560);
 
     network network_second(*engine, topology, bo);
     network_second.set_input_data("input", input);
@@ -249,9 +249,9 @@ TEST(memory_pool, DISABLED_shared_mem_pool_same_topology_twice) {
     auto output_layout_second = output_memory_second->get_layout();
     cldnn::mem_lock<float> output_ptr_second(output_memory_second, get_test_stream());
 
-    EXPECT_EQ(engine->get_max_used_device_memory(), (uint64_t) 3328);
+    ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t) 3328);
 
-    EXPECT_EQ(output_layout_first, output_layout_second);
+    ASSERT_EQ(output_layout_first, output_layout_second);
 
     int y_size = output_layout_first.spatial(1);
     int x_size = output_layout_first.spatial(0);
@@ -268,7 +268,7 @@ TEST(memory_pool, DISABLED_shared_mem_pool_same_topology_twice) {
                 for (int x = 0; x < x_size; ++x)
                 {
                     int idx = b * b_offset + f * f_offset + y * x_size + x;
-                    EXPECT_EQ(output_ptr_first[idx], output_ptr_second[idx]);
+                    ASSERT_EQ(output_ptr_first[idx], output_ptr_second[idx]);
                 }
             }
         }
@@ -313,7 +313,7 @@ TEST(memory_pool, DISABLED_shared_mem_pool_same_topology_twice_weights) {
     uint64_t usm_result = 1208; // USM have a higher peak, since transfering memory to device adds temporay memory bytes allocated. Old memory is deallocated quickly, but max peak is higher.
     auto is_correct = engine->get_max_used_device_memory() == cl_mem_result
         || engine->get_max_used_device_memory() == usm_result;
-    EXPECT_TRUE(is_correct) << "Memory max peak is not correct";
+    ASSERT_TRUE(is_correct) << "Memory max peak is not correct";
 
     auto output_memory_first = outputs.at("softmax").get_memory();
     auto output_layout_first = output_memory_first->get_layout();
@@ -331,8 +331,8 @@ TEST(memory_pool, DISABLED_shared_mem_pool_same_topology_twice_weights) {
     usm_result = 1992; // USM have a higher peak, since transfering memory to device adds temporay memory bytes allocated. Old memory is deallocated quickly, but max peak is higher.
     is_correct = engine->get_max_used_device_memory() == cl_mem_result
         || engine->get_max_used_device_memory() == usm_result;
-    EXPECT_TRUE(is_correct) << "Memory max peak is not correct";
-    EXPECT_EQ(output_layout_first, output_layout_second);
+    ASSERT_TRUE(is_correct) << "Memory max peak is not correct";
+    ASSERT_EQ(output_layout_first, output_layout_second);
 
     int y_size = output_layout_first.spatial(1);
     int x_size = output_layout_first.spatial(0);
@@ -349,7 +349,7 @@ TEST(memory_pool, DISABLED_shared_mem_pool_same_topology_twice_weights) {
                 for (int x = 0; x < x_size; ++x)
                 {
                     int idx = b * b_offset + f * f_offset + y * x_size + x;
-                    EXPECT_EQ(output_ptr_first[idx], output_ptr_second[idx]);
+                    ASSERT_EQ(output_ptr_first[idx], output_ptr_second[idx]);
                 }
             }
         }
@@ -397,14 +397,14 @@ TEST(memory_pool, shared_mem_pool_diff_batches) {
     auto outputs = network_first.execute();
 
     auto dev_info = engine->get_device_info();
-    EXPECT_EQ(engine->get_max_used_device_memory(), (uint64_t)4744);
+    ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)4744);
 
     topo.change_input_layout("input", input_1->get_layout());//change input layout to batch=1
 
     network network_second(*engine, topo, bo);
     network_second.set_input_data("input", input_1);
     auto outputs_second = network_second.execute();
-    EXPECT_EQ(engine->get_max_used_device_memory(), (uint64_t)5912);
+    ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)5912);
 }
 
 TEST(memory_pool, shared_dep_two_output) {
@@ -450,7 +450,7 @@ TEST(memory_pool, shared_dep_two_output) {
 
     network network(*engine, topo, bo);
     auto outputs = network.execute();
-    EXPECT_EQ(engine->get_max_used_device_memory(), (uint64_t)192);
+    ASSERT_EQ(engine->get_max_used_device_memory(), (uint64_t)192);
 }
 
 TEST(memory_pool, non_opt_intermidate_opt_after) {
@@ -492,15 +492,15 @@ TEST(memory_pool, non_opt_intermidate_opt_after) {
     network.set_input_data("input1", input_memory1);
     network.set_input_data("input2", input_memory2);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), static_cast<size_t>(2));
+    ASSERT_EQ(outputs.size(), static_cast<size_t>(2));
 
     auto out1 = outputs.at("elt1");
     auto out2 = outputs.at("elt2");
 
     cldnn::mem_lock<float> out1_ptr(out1.get_memory(), get_test_stream());
     cldnn::mem_lock<float> out2_ptr(out2.get_memory(), get_test_stream());
-    EXPECT_EQ(out1_ptr[0], 1.0f);
-    EXPECT_EQ(out2_ptr[0], 2.0f);
+    ASSERT_EQ(out1_ptr[0], 1.0f);
+    ASSERT_EQ(out2_ptr[0], 2.0f);
 }
 
 TEST(memory_pool, add_mem_dep_test) {
@@ -540,20 +540,20 @@ TEST(memory_pool, add_mem_dep_test) {
     network network(engine, topology, bo);
     network.set_input_data("input1", input_memory1);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), static_cast<size_t>(2));
+    ASSERT_EQ(outputs.size(), static_cast<size_t>(2));
 
     auto out1 = outputs.at("out3");
     auto out2 = outputs.at("out4");
 
     cldnn::mem_lock<float> out1_ptr(out1.get_memory(), get_test_stream());
     cldnn::mem_lock<float> out2_ptr(out2.get_memory(), get_test_stream());
-    EXPECT_EQ(out1_ptr[0], 1.0f);
-    EXPECT_EQ(out1_ptr[1], 2.0f);
-    EXPECT_EQ(out1_ptr[2], 3.0f);
-    EXPECT_EQ(out1_ptr[3], 4.0f);
+    ASSERT_EQ(out1_ptr[0], 1.0f);
+    ASSERT_EQ(out1_ptr[1], 2.0f);
+    ASSERT_EQ(out1_ptr[2], 3.0f);
+    ASSERT_EQ(out1_ptr[3], 4.0f);
 
-    EXPECT_EQ(out2_ptr[0], 5.0f);
-    EXPECT_EQ(out2_ptr[1], 6.0f);
-    EXPECT_EQ(out2_ptr[2], 7.0f);
-    EXPECT_EQ(out2_ptr[3], 8.0f);
+    ASSERT_EQ(out2_ptr[0], 5.0f);
+    ASSERT_EQ(out2_ptr[1], 6.0f);
+    ASSERT_EQ(out2_ptr[2], 7.0f);
+    ASSERT_EQ(out2_ptr[3], 8.0f);
 }

--- a/src/plugins/intel_gpu/tests/test_cases/multiclass_nms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/multiclass_nms_gpu_test.cpp
@@ -219,7 +219,7 @@ public:
 
                 for (size_t j = 0; j < 6; ++j) {
                     const auto idx = box * 6 + j;
-                    EXPECT_NEAR(param.expected_selected_outputs[idx], output_boxes_ptr[idx], getError<T>())
+                    ASSERT_NEAR(param.expected_selected_outputs[idx], output_boxes_ptr[idx], getError<T>())
                                         << "format=" << fmt_to_str(target_format) << " box=" << box << ", j=" << j;
                 }
             }

--- a/src/plugins/intel_gpu/tests/test_cases/multiclass_nms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/multiclass_nms_gpu_test.cpp
@@ -210,12 +210,12 @@ public:
             ASSERT_EQ(output_selected_num_ptr.size(), param.num_batches) << "format=" << fmt_to_str(target_format);
 
             for (size_t i = 0; i < param.num_batches; ++i) {
-                EXPECT_EQ(param.expected_selected_num[i], output_selected_num_ptr[i])
+                ASSERT_EQ(param.expected_selected_num[i], output_selected_num_ptr[i])
                                     << "format=" << fmt_to_str(target_format) << " i=" << i;
             }
 
             for (size_t box = 0; box < dim; ++box) {
-                EXPECT_EQ(param.expected_selected_indices[box], output_selected_indices_ptr[box]) << "box=" << box;
+                ASSERT_EQ(param.expected_selected_indices[box], output_selected_indices_ptr[box]) << "box=" << box;
 
                 for (size_t j = 0; j < 6; ++j) {
                     const auto idx = box * 6 + j;

--- a/src/plugins/intel_gpu/tests/test_cases/multiple_streams_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/multiple_streams_gpu_test.cpp
@@ -67,7 +67,7 @@ TEST(multistream_gpu, basic) {
                 std::vector<int32_t> expected_results = {1, len, 512};
 
                 for (size_t out_idx = 0; out_idx < expected_results.size(); ++out_idx) {
-                    EXPECT_TRUE(are_equal(expected_results[out_idx], output_ptr[out_idx]));
+                    ASSERT_TRUE(are_equal(expected_results[out_idx], output_ptr[out_idx]));
                 }
             }
         });

--- a/src/plugins/intel_gpu/tests/test_cases/mvn_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/mvn_gpu_test.cpp
@@ -53,12 +53,12 @@ void mvn_compute_mean_across_channels(cldnn::memory::ptr output, bool normalize_
         }
         sum /= feature_size * y_size * x_size * z_size;
         T result_sum = static_cast<T>(sum);
-        EXPECT_NEAR(result_sum, 0.f, err_margin) << "at b=" << b;
+        ASSERT_NEAR(result_sum, 0.f, err_margin) << "at b=" << b;
 
         if (normalize_variance) {
             variance /= feature_size * y_size * x_size * z_size;
             T result_variance = static_cast<T>(variance);
-            EXPECT_NEAR(result_variance, 1.f, err_margin) << " at b=" << b;
+            ASSERT_NEAR(result_variance, 1.f, err_margin) << " at b=" << b;
         }
     }
 }
@@ -95,12 +95,12 @@ void mvn_compute_mean_within_channels(cldnn::memory::ptr output, bool normalize_
             }
             sum /= y_size * x_size * z_size;
             T result_sum = static_cast<T>(sum);
-            EXPECT_NEAR(result_sum, 0.f, err_margin) << "at b=" << b << ", f=" << f;
+            ASSERT_NEAR(result_sum, 0.f, err_margin) << "at b=" << b << ", f=" << f;
 
             if (normalize_variance) {
                 variance /= y_size * x_size * z_size;
                 T result_variance = static_cast<T>(variance);
-                EXPECT_NEAR(result_variance, 1.f, err_margin) << " at b=" << b << ", f=" << f;
+                ASSERT_NEAR(result_variance, 1.f, err_margin) << " at b=" << b << ", f=" << f;
             }
         }
     }
@@ -794,7 +794,7 @@ struct mvn_random_test_bsv32 : ::testing::TestWithParam<mvn_basic_test_params> {
     }
 
     template <typename T>
-    bool compare_outputs(const cldnn::memory::ptr out_ref, const cldnn::memory::ptr out_opt) {
+    void compare_outputs(const cldnn::memory::ptr out_ref, const cldnn::memory::ptr out_opt) {
         auto output_lay = out_ref->get_layout();
         auto opt_output_lay = out_opt->get_layout();
 
@@ -817,13 +817,11 @@ struct mvn_random_test_bsv32 : ::testing::TestWithParam<mvn_basic_test_params> {
                     for (size_t xi = 0; xi < x; ++xi) {
                         auto ref_out_val = ref_ptr[ref_out_offset + xi * ref_x_pitch];
                         auto opt_out_val = opt_ptr[opt_out_offset + xi * opt_x_pitch];
-                        EXPECT_NEAR(static_cast<float>(opt_out_val), static_cast<float>(ref_out_val), 1.e-1f);
+                        ASSERT_NEAR(static_cast<float>(opt_out_val), static_cast<float>(ref_out_val), 1.e-1f);
                     }
                 }
             }
         }
-
-        return true;
     }
 
     void execute(const mvn_basic_test_params& params) {

--- a/src/plugins/intel_gpu/tests/test_cases/mvn_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/mvn_gpu_test.cpp
@@ -126,8 +126,8 @@ TEST(mvn_gpu_test, mvn_test_across_channels_outside_sqrt_bfyx) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_across_channels<float>(output, false);
@@ -153,8 +153,8 @@ TEST(mvn_gpu_test, mvn_test_across_channels_inside_sqrt_bfyx) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_across_channels<float>(output, false);
@@ -180,8 +180,8 @@ TEST(mvn_gpu_test, mvn_test_across_channels_bfyx_outside_sqrt_fp16) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_across_channels<FLOAT16>(output, false);
@@ -207,8 +207,8 @@ TEST(mvn_gpu_test, mvn_test_across_channels_inside_sqrt_bfyx_fp16) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_across_channels<FLOAT16>(output, false);
@@ -234,8 +234,8 @@ TEST(mvn_gpu_test, mvn_test_across_channels_outside_sqrt_bfyx_normalize_variance
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_across_channels<float>(output, true);
@@ -261,8 +261,8 @@ TEST(mvn_gpu_test, mvn_test_across_channels_inside_sqrt_bfyx_normalize_variance)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_across_channels<float>(output, true);
@@ -288,8 +288,8 @@ TEST(mvn_gpu_test, mvn_test_across_channels_outside_sqrt_bfyx_normalize_variance
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_across_channels<FLOAT16>(output, true);
@@ -315,8 +315,8 @@ TEST(mvn_gpu_test, mvn_test_across_channels_inside_sqrt_bfyx_normalize_variance_
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_across_channels<FLOAT16>(output, true);
@@ -350,8 +350,8 @@ TEST(mvn_gpu_test, dynamic_across_channels_inside_sqrt_bfyx_normalize_variance_f
     ASSERT_TRUE(impl->is_dynamic());
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_across_channels<FLOAT16>(output, true);
@@ -377,8 +377,8 @@ TEST(mvn_gpu_test, mvn_test_within_channels_outside_sqrt_bfyx) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_within_channels<float>(output, false);
@@ -404,8 +404,8 @@ TEST(mvn_gpu_test, mvn_test_within_channels_inside_sqrt__bfyx) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_within_channels<float>(output, false);
@@ -431,8 +431,8 @@ TEST(mvn_gpu_test, mvn_test_within_channels_outside_sqrt_bfyx_fp16) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_within_channels<FLOAT16>(output, false);
@@ -458,8 +458,8 @@ TEST(mvn_gpu_test, mvn_test_within_channels_inside_sqrt_bfyx_fp16) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_within_channels<FLOAT16>(output, false);
@@ -485,8 +485,8 @@ TEST(mvn_gpu_test, mvn_test_within_channels_outside_sqrt_bfyx_normalize_variance
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_within_channels<float>(output, true);
@@ -512,8 +512,8 @@ TEST(mvn_gpu_test, mvn_test_within_channels_inside_sqrt_bfyx_normalize_variance)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_within_channels<float>(output, true);
@@ -539,8 +539,8 @@ TEST(mvn_gpu_test, mvn_test_within_channels_outside_sqrt_bfyx_normalize_variance
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_within_channels<FLOAT16>(output, true);
@@ -566,8 +566,8 @@ TEST(mvn_gpu_test, mvn_test_within_channels_inside_sqrt_bfyx_normalize_variance_
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "mvn");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "mvn");
 
     auto output = outputs.begin()->second.get_memory();
     mvn_compute_mean_within_channels<FLOAT16>(output, true);
@@ -667,8 +667,8 @@ struct mvn_random_test : ::testing::TestWithParam<mvn_basic_test_params> {
         net.set_input_data("input", input);
 
         auto outputs = net.execute();
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "mvn");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "mvn");
 
         auto output = outputs.begin()->second.get_memory();
         check_result(output, params.across_channels, params.normalize_variance);

--- a/src/plugins/intel_gpu/tests/test_cases/non_max_suppression_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/non_max_suppression_test.cpp
@@ -343,13 +343,13 @@ TYPED_TEST(non_max_suppression_basic, optional_outputs) {
         cldnn::mem_lock<float> second_output_ptr(plane_scores_mem, get_test_stream());
 
         for (size_t i = 0; i < expected_second_out.size(); ++i) {
-            EXPECT_FLOAT_EQ(expected_second_out[i], second_output_ptr[i]);
+            ASSERT_FLOAT_EQ(expected_second_out[i], second_output_ptr[i]);
         }
     } else {
         cldnn::mem_lock<half_t> second_output_ptr(plane_scores_mem, get_test_stream());
 
         for (size_t i = 0; i < expected_second_out.size(); ++i) {
-            EXPECT_NEAR(expected_second_out[i], half_to_float(second_output_ptr[i]), 0.0002f);
+            ASSERT_NEAR(expected_second_out[i], half_to_float(second_output_ptr[i]), 0.0002f);
         }
     }
 
@@ -463,13 +463,13 @@ TYPED_TEST(non_max_suppression_basic, multiple_outputs) {
         cldnn::mem_lock<float> second_output_ptr(plane_scores_mem, get_test_stream());
 
         for (size_t i = 0; i < expected_second_out.size(); ++i) {
-            EXPECT_FLOAT_EQ(expected_second_out[i], second_output_ptr[i]);
+            ASSERT_FLOAT_EQ(expected_second_out[i], second_output_ptr[i]);
         }
     } else {
         cldnn::mem_lock<half_t> second_output_ptr(plane_scores_mem, get_test_stream());
 
         for (size_t i = 0; i < expected_second_out.size(); ++i) {
-            EXPECT_NEAR(expected_second_out[i], half_to_float(second_output_ptr[i]), 0.0002f);
+            ASSERT_NEAR(expected_second_out[i], half_to_float(second_output_ptr[i]), 0.0002f);
         }
     }
 

--- a/src/plugins/intel_gpu/tests/test_cases/non_max_suppression_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/non_max_suppression_test.cpp
@@ -182,7 +182,7 @@ TYPED_TEST(non_max_suppression_basic, basic) {
 
     ASSERT_EQ(expected_out.size(), out_ptr.size());
     for (size_t i = 0; i < expected_out.size(); ++i) {
-        EXPECT_EQ(expected_out[i], out_ptr[i]) << "at i = " << i;
+        ASSERT_EQ(expected_out[i], out_ptr[i]) << "at i = " << i;
     }
 }
 
@@ -239,7 +239,7 @@ TYPED_TEST(non_max_suppression_basic, num_per_class) {
 
     ASSERT_EQ(expected_out.size(), out_ptr.size());
     for (size_t i = 0; i < expected_out.size(); ++i) {
-        EXPECT_EQ(expected_out[i], out_ptr[i]) << "at i = " << i;
+        ASSERT_EQ(expected_out[i], out_ptr[i]) << "at i = " << i;
     }
 }
 
@@ -326,7 +326,7 @@ TYPED_TEST(non_max_suppression_basic, optional_outputs) {
 
     ASSERT_EQ(expected_out.size(), out_ptr.size());
     for (size_t i = 0; i < expected_out.size(); ++i) {
-        EXPECT_EQ(expected_out[i], out_ptr[i]) << "at i = " << i;
+        ASSERT_EQ(expected_out[i], out_ptr[i]) << "at i = " << i;
     }
 
     topology second_output_topology;
@@ -445,7 +445,7 @@ TYPED_TEST(non_max_suppression_basic, multiple_outputs) {
 
     ASSERT_EQ(expected_out.size(), out_ptr.size());
     for (size_t i = 0; i < expected_out.size(); ++i) {
-        EXPECT_EQ(expected_out[i], out_ptr[i]) << "at i = " << i;
+        ASSERT_EQ(expected_out[i], out_ptr[i]) << "at i = " << i;
     }
 
 
@@ -526,7 +526,7 @@ TYPED_TEST(non_max_suppression_basic, iou_threshold) {
 
     ASSERT_EQ(expected_out.size(), out_ptr.size());
     for (size_t i = 0; i < expected_out.size(); ++i) {
-        EXPECT_EQ(expected_out[i], out_ptr[i]) << "at i = " << i;
+        ASSERT_EQ(expected_out[i], out_ptr[i]) << "at i = " << i;
     }
 }
 
@@ -583,7 +583,7 @@ TYPED_TEST(non_max_suppression_basic, score_threshold) {
 
     ASSERT_EQ(expected_out.size(), out_ptr.size());
     for (size_t i = 0; i < expected_out.size(); ++i) {
-        EXPECT_EQ(expected_out[i], out_ptr[i]) << "at i = " << i;
+        ASSERT_EQ(expected_out[i], out_ptr[i]) << "at i = " << i;
     }
 }
 
@@ -648,6 +648,6 @@ TYPED_TEST(non_max_suppression_basic, soft_nms_sigma) {
     outp.resize(36);
     ASSERT_EQ(expected_out.size(), out_ptr.size());
     for (size_t i = 0; i < expected_out.size(); ++i) {
-        EXPECT_EQ(expected_out[i], out_ptr[i]) << "at i = " << i;
+        ASSERT_EQ(expected_out[i], out_ptr[i]) << "at i = " << i;
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/non_zero_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/non_zero_gpu_test.cpp
@@ -34,7 +34,7 @@ void test_count_non_zero(layout in_layout, std::vector<T> in_data) {
     auto output = outputs.at("count_nonzero").get_memory();
 
     cldnn::mem_lock<int32_t> output_ptr(output, get_test_stream());
-    EXPECT_EQ(count_non_zero, output_ptr[0]);
+    ASSERT_EQ(count_non_zero, output_ptr[0]);
 }
 
 TEST(test_count_non_zero, 4d_fp32_1_2_1_5) {
@@ -87,7 +87,7 @@ void test_gather_non_zero(layout in_layout, std::vector<T> in_data) {
     cldnn::mem_lock<int32_t> shape_ptr(output_shape_mem, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -192,7 +192,7 @@ void test_non_zero(layout in_layout, std::vector<T> in_data) {
     cldnn::mem_lock<int32_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/normalizel2_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/normalizel2_gpu_test.cpp
@@ -185,7 +185,7 @@ TYPED_TEST(normalize_basic, basic) {
         cldnn::mem_lock<half_t> output_ptr(output, get_test_stream());
         auto expected_results = this->get_expected_result();
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_NEAR(expected_results[i], output_ptr[i], 0.001);
+            ASSERT_NEAR(expected_results[i], output_ptr[i], 0.001);
         }
     } else {
         cldnn::mem_lock<float> output_ptr(output, get_test_stream());

--- a/src/plugins/intel_gpu/tests/test_cases/normalizel2_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/normalizel2_gpu_test.cpp
@@ -46,7 +46,7 @@ struct normalize_basic : public testing::Test {
     const std::vector<output_type> get_expected_result() {
         return get_expected_result(std::integral_constant<bool, across_spatial>());
     }
-    
+
     const std::vector<input_type> get_input_values(unsigned b, unsigned f, unsigned y, unsigned x) {
         std::vector<input_type> inputVals(b * f * y * x);
         float n = 0;
@@ -191,7 +191,7 @@ TYPED_TEST(normalize_basic, basic) {
         cldnn::mem_lock<float> output_ptr(output, get_test_stream());
         auto expected_results = this->get_expected_result();
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_TRUE(are_equal(expected_results[i], output_ptr[i]));
+            ASSERT_TRUE(are_equal(expected_results[i], output_ptr[i]));
         }
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/one_hot_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/one_hot_gpu_test.cpp
@@ -89,24 +89,24 @@ void generic_one_hot_test_int(cldnn::format test_input_fmt, int input_b, int inp
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
     cldnn::mem_lock<T> output_ptr(output_memory, get_test_stream());
 
     VVVVF<T> output_cpu = one_hot_cpu<T>(input_rnd, one_hot_axis, one_hot_limit, input_padding_y, input_padding_x, output_padding_y, output_padding_x);
-    EXPECT_EQ(output_layout.format.value, test_input_fmt.value);
+    ASSERT_EQ(output_layout.format.value, test_input_fmt.value);
     tensor output_tensor = output_layout.get_buffer_size();
     int y_size = output_tensor.spatial[1];
     int x_size = output_tensor.spatial[0];
     int f_size = output_tensor.feature[0];
     int b_size = output_tensor.batch[0];
-    EXPECT_EQ(y_size, (int)output_cpu[0][0].size());
-    EXPECT_EQ(x_size, (int)output_cpu[0][0][0].size());
-    EXPECT_EQ(f_size, (int)output_cpu[0].size());
-    EXPECT_EQ(b_size, (int)output_cpu.size());
+    ASSERT_EQ(y_size, (int)output_cpu[0][0].size());
+    ASSERT_EQ(x_size, (int)output_cpu[0][0][0].size());
+    ASSERT_EQ(f_size, (int)output_cpu[0].size());
+    ASSERT_EQ(b_size, (int)output_cpu.size());
 
     bool test_is_correct = true;
     VF<T> output_cpu_vec = flatten_4d<T>(test_input_fmt, output_cpu);
@@ -117,7 +117,7 @@ void generic_one_hot_test_int(cldnn::format test_input_fmt, int input_b, int inp
             break;
         }
     }
-    EXPECT_EQ(test_is_correct, true) << std::endl
+    ASSERT_EQ(test_is_correct, true) << std::endl
         << "failing test parameters:" << std::endl
         << "input_b = " << input_b << std::endl
         << "input_f = " << input_f << std::endl
@@ -172,8 +172,8 @@ TEST(one_hot_gpu_i32, bfzyx_ax4) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -185,11 +185,11 @@ TEST(one_hot_gpu_i32, bfzyx_ax4) {
     int x_size = output_tensor.spatial[0];
     int f_size = output_tensor.feature[0];
     int b_size = output_tensor.batch[0];
-    EXPECT_EQ(z_size, 2);
-    EXPECT_EQ(y_size, 1);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(z_size, 2);
+    ASSERT_EQ(y_size, 1);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     bool test_is_correct = true;
 
@@ -201,7 +201,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax4) {
             test_is_correct = false;
         }
     }
-    EXPECT_EQ(test_is_correct, true);
+    ASSERT_EQ(test_is_correct, true);
 }
 
 TEST(one_hot_gpu_i64, bfzyx_ax4) {
@@ -231,8 +231,8 @@ TEST(one_hot_gpu_i64, bfzyx_ax4) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -244,11 +244,11 @@ TEST(one_hot_gpu_i64, bfzyx_ax4) {
     int x_size = output_tensor.spatial[0];
     int f_size = output_tensor.feature[0];
     int b_size = output_tensor.batch[0];
-    EXPECT_EQ(z_size, 2);
-    EXPECT_EQ(y_size, 1);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(z_size, 2);
+    ASSERT_EQ(y_size, 1);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     bool test_is_correct = true;
 
@@ -260,7 +260,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax4) {
             test_is_correct = false;
         }
     }
-    EXPECT_EQ(test_is_correct, true);
+    ASSERT_EQ(test_is_correct, true);
 }
 
 TEST(one_hot_gpu_i32_to_f32, bfyx_ax4) {
@@ -290,8 +290,8 @@ TEST(one_hot_gpu_i32_to_f32, bfyx_ax4) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -302,11 +302,11 @@ TEST(one_hot_gpu_i32_to_f32, bfyx_ax4) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(z_size, 2);
-    EXPECT_EQ(y_size, 1);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(z_size, 2);
+    ASSERT_EQ(y_size, 1);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     std::vector<float> output_cpu_vec = {1.f, 0.f, 0.f, 0.f, 0.f,
                                          0.f, 1.f, 0.f, 0.f, 0.f};
@@ -343,8 +343,8 @@ TEST(one_hot_gpu_i64_to_f32, bfyx_ax4) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -356,11 +356,11 @@ TEST(one_hot_gpu_i64_to_f32, bfyx_ax4) {
     int x_size = output_tensor.spatial[0];
     int f_size = output_tensor.feature[0];
     int b_size = output_tensor.batch[0];
-    EXPECT_EQ(z_size, 2);
-    EXPECT_EQ(y_size, 1);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(z_size, 2);
+    ASSERT_EQ(y_size, 1);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     std::vector<float> output_cpu_vec = {1.f, 0.f, 0.f, 0.f, 0.f,
                                          0.f, 1.f, 0.f, 0.f, 0.f};
@@ -394,8 +394,8 @@ TEST(one_hot_gpu_i32, bfzyx_ax0) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -407,11 +407,11 @@ TEST(one_hot_gpu_i32, bfzyx_ax0) {
     int x_size = output_tensor.spatial[0];
     int f_size = output_tensor.feature[0];
     int b_size = output_tensor.batch[0];
-    EXPECT_EQ(z_size, 1);
-    EXPECT_EQ(y_size, 1);
-    EXPECT_EQ(x_size, 2);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 3);
+    ASSERT_EQ(z_size, 1);
+    ASSERT_EQ(y_size, 1);
+    ASSERT_EQ(x_size, 2);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 3);
 
     bool test_is_correct = true;
 
@@ -422,7 +422,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax0) {
             test_is_correct = false;
         }
     }
-    EXPECT_EQ(test_is_correct, true);
+    ASSERT_EQ(test_is_correct, true);
 }
 
 TEST(one_hot_gpu_i64, bfzyx_ax0) {
@@ -449,8 +449,8 @@ TEST(one_hot_gpu_i64, bfzyx_ax0) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -462,11 +462,11 @@ TEST(one_hot_gpu_i64, bfzyx_ax0) {
     int x_size = output_tensor.spatial[0];
     int f_size = output_tensor.feature[0];
     int b_size = output_tensor.batch[0];
-    EXPECT_EQ(z_size, 1);
-    EXPECT_EQ(y_size, 1);
-    EXPECT_EQ(x_size, 2);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 3);
+    ASSERT_EQ(z_size, 1);
+    ASSERT_EQ(y_size, 1);
+    ASSERT_EQ(x_size, 2);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 3);
 
     bool test_is_correct = true;
 
@@ -477,7 +477,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax0) {
             test_is_correct = false;
         }
     }
-    EXPECT_EQ(test_is_correct, true);
+    ASSERT_EQ(test_is_correct, true);
 }
 
 TEST(one_hot_gpu_i32, bfzyx_ax1) {
@@ -504,8 +504,8 @@ TEST(one_hot_gpu_i32, bfzyx_ax1) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -517,11 +517,11 @@ TEST(one_hot_gpu_i32, bfzyx_ax1) {
     int x_size = output_tensor.spatial[0];
     int f_size = output_tensor.feature[0];
     int b_size = output_tensor.batch[0];
-    EXPECT_EQ(z_size, 1);
-    EXPECT_EQ(y_size, 1);
-    EXPECT_EQ(x_size, 2);
-    EXPECT_EQ(f_size, 3);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(z_size, 1);
+    ASSERT_EQ(y_size, 1);
+    ASSERT_EQ(x_size, 2);
+    ASSERT_EQ(f_size, 3);
+    ASSERT_EQ(b_size, 1);
 
     bool test_is_correct = true;
 
@@ -532,7 +532,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax1) {
             test_is_correct = false;
         }
     }
-    EXPECT_EQ(test_is_correct, true);
+    ASSERT_EQ(test_is_correct, true);
 }
 
 TEST(one_hot_gpu_i64, bfzyx_ax1) {
@@ -559,8 +559,8 @@ TEST(one_hot_gpu_i64, bfzyx_ax1) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -572,11 +572,11 @@ TEST(one_hot_gpu_i64, bfzyx_ax1) {
     int x_size = output_tensor.spatial[0];
     int f_size = output_tensor.feature[0];
     int b_size = output_tensor.batch[0];
-    EXPECT_EQ(z_size, 1);
-    EXPECT_EQ(y_size, 1);
-    EXPECT_EQ(x_size, 2);
-    EXPECT_EQ(f_size, 3);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(z_size, 1);
+    ASSERT_EQ(y_size, 1);
+    ASSERT_EQ(x_size, 2);
+    ASSERT_EQ(f_size, 3);
+    ASSERT_EQ(b_size, 1);
 
     bool test_is_correct = true;
 
@@ -587,7 +587,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax1) {
             test_is_correct = false;
         }
     }
-    EXPECT_EQ(test_is_correct, true);
+    ASSERT_EQ(test_is_correct, true);
 }
 
 TEST(one_hot_gpu_i32, bfzyx_ax2) {
@@ -614,8 +614,8 @@ TEST(one_hot_gpu_i32, bfzyx_ax2) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -627,11 +627,11 @@ TEST(one_hot_gpu_i32, bfzyx_ax2) {
     int x_size = output_tensor.spatial[0];
     int f_size = output_tensor.feature[0];
     int b_size = output_tensor.batch[0];
-    EXPECT_EQ(z_size, 3);
-    EXPECT_EQ(y_size, 1);
-    EXPECT_EQ(x_size, 2);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(z_size, 3);
+    ASSERT_EQ(y_size, 1);
+    ASSERT_EQ(x_size, 2);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     bool test_is_correct = true;
 
@@ -642,7 +642,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax2) {
             test_is_correct = false;
         }
     }
-    EXPECT_EQ(test_is_correct, true);
+    ASSERT_EQ(test_is_correct, true);
 }
 
 TEST(one_hot_gpu_i64, bfzyx_ax2) {
@@ -669,8 +669,8 @@ TEST(one_hot_gpu_i64, bfzyx_ax2) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -682,11 +682,11 @@ TEST(one_hot_gpu_i64, bfzyx_ax2) {
     int x_size = output_tensor.spatial[0];
     int f_size = output_tensor.feature[0];
     int b_size = output_tensor.batch[0];
-    EXPECT_EQ(z_size, 3);
-    EXPECT_EQ(y_size, 1);
-    EXPECT_EQ(x_size, 2);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(z_size, 3);
+    ASSERT_EQ(y_size, 1);
+    ASSERT_EQ(x_size, 2);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     bool test_is_correct = true;
 
@@ -697,7 +697,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax2) {
             test_is_correct = false;
         }
     }
-    EXPECT_EQ(test_is_correct, true);
+    ASSERT_EQ(test_is_correct, true);
 }
 
 TEST(one_hot_gpu_i32, bfzyx_ax3) {
@@ -724,8 +724,8 @@ TEST(one_hot_gpu_i32, bfzyx_ax3) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -737,11 +737,11 @@ TEST(one_hot_gpu_i32, bfzyx_ax3) {
     int x_size = output_tensor.spatial[0];
     int f_size = output_tensor.feature[0];
     int b_size = output_tensor.batch[0];
-    EXPECT_EQ(z_size, 1);
-    EXPECT_EQ(y_size, 3);
-    EXPECT_EQ(x_size, 2);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(z_size, 1);
+    ASSERT_EQ(y_size, 3);
+    ASSERT_EQ(x_size, 2);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     bool test_is_correct = true;
 
@@ -752,7 +752,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax3) {
             test_is_correct = false;
         }
     }
-    EXPECT_EQ(test_is_correct, true);
+    ASSERT_EQ(test_is_correct, true);
 }
 
 TEST(one_hot_gpu_i64, bfzyx_ax3) {
@@ -779,8 +779,8 @@ TEST(one_hot_gpu_i64, bfzyx_ax3) {
     network network(engine, topology);
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
 
     auto output_memory = outputs.at("output").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -791,11 +791,11 @@ TEST(one_hot_gpu_i64, bfzyx_ax3) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(z_size, 1);
-    EXPECT_EQ(y_size, 3);
-    EXPECT_EQ(x_size, 2);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(z_size, 1);
+    ASSERT_EQ(y_size, 3);
+    ASSERT_EQ(x_size, 2);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     bool test_is_correct = true;
 
@@ -806,7 +806,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax3) {
             test_is_correct = false;
         }
     }
-    EXPECT_EQ(test_is_correct, true);
+    ASSERT_EQ(test_is_correct, true);
 }
 
 TEST(one_hot_error, basic_error_wrong_axis) {

--- a/src/plugins/intel_gpu/tests/test_cases/permute_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/permute_gpu_test.cpp
@@ -126,7 +126,7 @@ TEST(permute_gpu_f32, basic_bfyx_permute_0_1_2_3)
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 24; i++)
     {
-        EXPECT_FLOAT_EQ(values[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(values[i], output_ptr[i]);
     }
 
 }
@@ -203,7 +203,7 @@ TEST(permute_gpu_f32, basic_bfyx_permute_0_1_3_2)
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 24; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 
 }
@@ -233,7 +233,7 @@ TEST(permute_gpu_f32, basic_yxfb_permute_1_0_2_3)
     cldnn::mem_lock<float> input_ptr(input_mem, get_test_stream());
     for (int i = 0; i < 6400; i++)
     {
-        EXPECT_FLOAT_EQ(input_ptr[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(input_ptr[i], output_ptr[i]);
     }
 
 }
@@ -312,7 +312,7 @@ TEST(permute_gpu_f32, basic_bfyx_permute_0_1_3_2_input_padding)
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 24; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 
 }
@@ -367,7 +367,7 @@ TEST(permute_gpu_f32, basic_yxfb_permute_batch_with_feature)
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 
 }
@@ -422,7 +422,7 @@ TEST(permute_gpu_f32, basic_bfyx_permute_batch_with_feature)
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 
 }
@@ -484,7 +484,7 @@ void permute_test_with_reorder()
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 24; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -586,8 +586,8 @@ TEST(permute_fuse_reorder_gpu_f32, basic_b_fs_yx_fsv4_permute_1_8_16_1)
 
     for (size_t i = 0; i < values.size(); i++)
     {
-        EXPECT_FLOAT_EQ(output_unfused_ptr[i], output_fused_ptr[i]);
-        EXPECT_FLOAT_EQ(output_unfused_ptr[i], values[i]);
+        ASSERT_FLOAT_EQ(output_unfused_ptr[i], output_fused_ptr[i]);
+        ASSERT_FLOAT_EQ(output_unfused_ptr[i], values[i]);
     }
 }
 
@@ -686,7 +686,7 @@ TEST(fc_permute_gpu, basic_permute_bfyx)
     cldnn::mem_lock<float> input_ptr(input_mem, get_test_stream());
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 5 * 256; i++)
-        EXPECT_NEAR(input_ptr[i], output_ptr[i], 1e-3f);
+        ASSERT_NEAR(input_ptr[i], output_ptr[i], 1e-3f);
 
 }
 
@@ -906,7 +906,7 @@ TEST(permute_gpu_f32, basic_bfzyx_permute_0_4_1_2_3)
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 48; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 
 }
@@ -969,7 +969,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, normal_bfyx_0_2_3_1) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1019,7 +1019,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, f_remainder_bfyx_0_2_3_1) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1075,7 +1075,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, x_remainder_bfyx_0_2_3_1) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1125,7 +1125,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, xf_remainder_bfyx_0_2_3_1) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1187,7 +1187,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, normal_bfzyx_0_2_3_4_1) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1241,7 +1241,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, f_remainder_bfzyx_0_2_3_4_1) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1295,7 +1295,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, x_remainder_bfzyx_0_2_3_4_1) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1349,7 +1349,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, xf_remainder_bfzyx_0_2_3_4_1) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1421,7 +1421,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, normal_bfwzyx_0_2_3_4_5_1) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1481,7 +1481,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, f_remainder_bfwzyx_0_2_3_4_5_1) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1541,7 +1541,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, x_remainder_bfwzyx_0_2_3_4_5_1) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1601,7 +1601,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, xf_remainder_bfwzyx_0_2_3_4_5_1) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1631,13 +1631,13 @@ public:
 
 template<>
 void TiledPermuteTest::compare_value(float a, float b) const {
-    EXPECT_FLOAT_EQ(a, b);
+    ASSERT_FLOAT_EQ(a, b);
 }
 
 // f16 format
 template<>
 void TiledPermuteTest::compare_value(FLOAT16 a, FLOAT16 b) const {
-    EXPECT_FLOAT_EQ(static_cast<float>(a), static_cast<float>(b));
+    ASSERT_FLOAT_EQ(static_cast<float>(a), static_cast<float>(b));
 }
 
 template<>
@@ -1899,6 +1899,6 @@ TEST(permute_gpu_f32_dynamic, bfyx_0_2_3_1) {
 
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++) {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/permute_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/permute_gpu_test.cpp
@@ -42,7 +42,7 @@ TEST(permute_gpu_f32, output_ordering_test)
     };
     std::vector<format> input_formats = { format::bfyx, format::yxfb };
 
-    auto get_permutation = [&](const std::vector<int32_t>& inp1, const std::vector<uint16_t>& order) {
+    auto get_permutation = [&](const std::vector<int32_t>& inp1, const std::vector<uint16_t>& order) -> std::vector<int32_t> {
         EXPECT_EQ(inp1.size(), order.size());
         std::vector<int32_t> output;
         for (auto const& o : order) {
@@ -64,13 +64,13 @@ TEST(permute_gpu_f32, output_ordering_test)
                 auto outputs = network.execute();
                 auto output = outputs.at("permute");
                 auto output_mem = output.get_memory();
-                EXPECT_EQ(outputs.size(), size_t(1));
+                ASSERT_EQ(outputs.size(), size_t(1));
                 auto ref_tensor = get_permutation(inp_t, perm);
                 auto dims = output_mem->get_layout().get_dims();
-                EXPECT_EQ(dims[0], ref_tensor[0]);
-                EXPECT_EQ(dims[1], ref_tensor[1]);
-                EXPECT_EQ(dims[2], ref_tensor[2]);
-                EXPECT_EQ(dims[3], ref_tensor[3]);
+                ASSERT_EQ(dims[0], ref_tensor[0]);
+                ASSERT_EQ(dims[1], ref_tensor[1]);
+                ASSERT_EQ(dims[2], ref_tensor[2]);
+                ASSERT_EQ(dims[3], ref_tensor[3]);
             }
         }
     }
@@ -118,8 +118,8 @@ TEST(permute_gpu_f32, basic_bfyx_permute_0_1_2_3)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -177,8 +177,8 @@ TEST(permute_gpu_f32, basic_bfyx_permute_0_1_3_2)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -224,8 +224,8 @@ TEST(permute_gpu_f32, basic_yxfb_permute_1_0_2_3)
     network.set_input_data("input", input_mem);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -286,8 +286,8 @@ TEST(permute_gpu_f32, basic_bfyx_permute_0_1_3_2_input_padding)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -343,15 +343,15 @@ TEST(permute_gpu_f32, basic_yxfb_permute_batch_with_feature)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
     auto l = output->get_layout();
-    EXPECT_EQ(l.batch(), 2);
-    EXPECT_EQ(l.feature(), 8);
-    EXPECT_EQ(l.spatial(0), 1);
-    EXPECT_EQ(l.spatial(1), 1);
+    ASSERT_EQ(l.batch(), 2);
+    ASSERT_EQ(l.feature(), 8);
+    ASSERT_EQ(l.spatial(0), 1);
+    ASSERT_EQ(l.spatial(1), 1);
 
     float answers[16] = {
         1.0f, 3.0f,
@@ -398,15 +398,15 @@ TEST(permute_gpu_f32, basic_bfyx_permute_batch_with_feature)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
     auto l = output->get_layout();
-    EXPECT_EQ(l.batch(), 8);
-    EXPECT_EQ(l.feature(), 2);
-    EXPECT_EQ(l.spatial(0), 1);
-    EXPECT_EQ(l.spatial(1), 1);
+    ASSERT_EQ(l.batch(), 8);
+    ASSERT_EQ(l.feature(), 2);
+    ASSERT_EQ(l.spatial(0), 1);
+    ASSERT_EQ(l.spatial(1), 1);
 
     float answers[16] = {
         1.0f, 3.0f,
@@ -459,7 +459,7 @@ void permute_test_with_reorder()
 
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder_out");
+    ASSERT_EQ(outputs.begin()->first, "reorder_out");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -579,10 +579,10 @@ TEST(permute_fuse_reorder_gpu_f32, basic_b_fs_yx_fsv4_permute_1_8_16_1)
     cldnn::mem_lock<float> output_fused_ptr(output_fused, get_test_stream());
     auto output_unfused = outputs_unfused.begin()->second.get_memory();
     cldnn::mem_lock<float> output_unfused_ptr(output_unfused, get_test_stream());
-    EXPECT_EQ(output_fused->get_layout().format, cldnn::format::bfyx);
-    EXPECT_EQ(output_unfused->get_layout().format, cldnn::format::bfyx);
-    EXPECT_EQ(fused.get_executed_primitives().size(), 4);
-    EXPECT_EQ(unfused.get_executed_primitives().size(), 5);
+    ASSERT_EQ(output_fused->get_layout().format, cldnn::format::bfyx);
+    ASSERT_EQ(output_unfused->get_layout().format, cldnn::format::bfyx);
+    ASSERT_EQ(fused.get_executed_primitives().size(), 4);
+    ASSERT_EQ(unfused.get_executed_primitives().size(), 5);
 
     for (size_t i = 0; i < values.size(); i++)
     {
@@ -607,16 +607,16 @@ TEST(fc_permute_crop_gpu, basic_permute_yxfb)
     network.set_input_data("input", input_mem);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
     auto l = output->get_layout();
-    EXPECT_EQ(l.batch(), 5);
-    EXPECT_EQ(l.feature(), 1);
-    EXPECT_EQ(l.spatial(0), 1);
-    EXPECT_EQ(l.spatial(1), 512);
-    EXPECT_EQ(output->get_layout().format, cldnn::format::yxfb);
+    ASSERT_EQ(l.batch(), 5);
+    ASSERT_EQ(l.feature(), 1);
+    ASSERT_EQ(l.spatial(0), 1);
+    ASSERT_EQ(l.spatial(1), 512);
+    ASSERT_EQ(output->get_layout().format, cldnn::format::yxfb);
 }
 
 TEST(fc_permute_crop_gpu, basic_0)
@@ -642,16 +642,16 @@ TEST(fc_permute_crop_gpu, basic_0)
     network.set_input_data("input", input_mem);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "crop");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "crop");
 
     auto output = outputs.begin()->second.get_memory();
     auto l = output->get_layout();
-    EXPECT_EQ(l.batch(), 1);
-    EXPECT_EQ(l.feature(), 1);
-    EXPECT_EQ(l.spatial(0), 1);
-    EXPECT_EQ(l.spatial(1), 512);
-    EXPECT_EQ(output->get_layout().format, cldnn::format::yxfb);
+    ASSERT_EQ(l.batch(), 1);
+    ASSERT_EQ(l.feature(), 1);
+    ASSERT_EQ(l.spatial(0), 1);
+    ASSERT_EQ(l.spatial(1), 512);
+    ASSERT_EQ(output->get_layout().format, cldnn::format::yxfb);
 }
 
 TEST(fc_permute_gpu, basic_permute_bfyx)
@@ -672,16 +672,16 @@ TEST(fc_permute_gpu, basic_permute_bfyx)
     network.set_input_data("input", input_mem);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
     auto l = output->get_layout();
-    EXPECT_EQ(l.batch(), 5);
-    EXPECT_EQ(l.feature(), 1);
-    EXPECT_EQ(l.spatial(0), 1);
-    EXPECT_EQ(l.spatial(1), 256);
-    EXPECT_EQ(output->get_layout().format, cldnn::format::bfyx);
+    ASSERT_EQ(l.batch(), 5);
+    ASSERT_EQ(l.feature(), 1);
+    ASSERT_EQ(l.spatial(0), 1);
+    ASSERT_EQ(l.spatial(1), 256);
+    ASSERT_EQ(output->get_layout().format, cldnn::format::bfyx);
 
     cldnn::mem_lock<float> input_ptr(input_mem, get_test_stream());
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -732,24 +732,24 @@ TEST(permute_gpu_f32, permute_bfwzyx)
     network.set_input_data("input", input_mem);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
     auto l = output->get_layout();
-    EXPECT_EQ(l.batch(), 2);
-    EXPECT_EQ(l.feature(), 1);
-    EXPECT_EQ(l.spatial(0), 6);
-    EXPECT_EQ(l.spatial(1), 5);
-    EXPECT_EQ(l.spatial(2), 4);
-    EXPECT_EQ(l.spatial(3), 3);
-    EXPECT_EQ(output->get_layout().format, cldnn::format::bfwzyx);
+    ASSERT_EQ(l.batch(), 2);
+    ASSERT_EQ(l.feature(), 1);
+    ASSERT_EQ(l.spatial(0), 6);
+    ASSERT_EQ(l.spatial(1), 5);
+    ASSERT_EQ(l.spatial(2), 4);
+    ASSERT_EQ(l.spatial(3), 3);
+    ASSERT_EQ(output->get_layout().format, cldnn::format::bfwzyx);
 
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < output_ptr.size(); ++i)
     {
-        EXPECT_EQ(expected_output[i], output_ptr[i]);
+        ASSERT_EQ(expected_output[i], output_ptr[i]);
     }
 }
 
@@ -824,8 +824,8 @@ TEST(permute_gpu_f32, 6D_reshape_permute_reshape)
     network.set_input_data("input", input_mem);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "output_4d");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output_4d");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -833,7 +833,7 @@ TEST(permute_gpu_f32, 6D_reshape_permute_reshape)
 
     for (size_t i = 0; i < output_ptr.size(); ++i)
     {
-        EXPECT_EQ(expected_out[i], output_ptr[i]);
+        ASSERT_EQ(expected_out[i], output_ptr[i]);
     }
 }
 TEST(permute_gpu_f32, basic_bfzyx_permute_0_4_1_2_3)
@@ -875,18 +875,18 @@ TEST(permute_gpu_f32, basic_bfzyx_permute_0_4_1_2_3)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
     auto l = output->get_layout();
-    EXPECT_EQ(l.batch(), 2);
-    EXPECT_EQ(l.feature(), 3);
-    EXPECT_EQ(l.spatial(0), 2);
-    EXPECT_EQ(l.spatial(1), 2);
-    EXPECT_EQ(l.spatial(2), 2);
+    ASSERT_EQ(l.batch(), 2);
+    ASSERT_EQ(l.feature(), 3);
+    ASSERT_EQ(l.spatial(0), 2);
+    ASSERT_EQ(l.spatial(1), 2);
+    ASSERT_EQ(l.spatial(2), 2);
 
-    EXPECT_EQ(output->get_layout().format, cldnn::format::bfzyx);
+    ASSERT_EQ(output->get_layout().format, cldnn::format::bfzyx);
 
     float answers[48] = {
         1.0f, 3.0f, 2.0f, 4.0f,
@@ -942,8 +942,8 @@ TEST(permute_gpu_f32_tile_8x8_4x4, normal_bfyx_0_2_3_1) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -998,8 +998,8 @@ TEST(permute_gpu_f32_tile_8x8_4x4, f_remainder_bfyx_0_2_3_1) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1054,8 +1054,8 @@ TEST(permute_gpu_f32_tile_8x8_4x4, x_remainder_bfyx_0_2_3_1) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1104,8 +1104,8 @@ TEST(permute_gpu_f32_tile_8x8_4x4, xf_remainder_bfyx_0_2_3_1) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1154,8 +1154,8 @@ TEST(permute_gpu_f32_tile_8x8_4x4, normal_bfzyx_0_2_3_4_1) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1216,8 +1216,8 @@ TEST(permute_gpu_f32_tile_8x8_4x4, f_remainder_bfzyx_0_2_3_4_1) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1270,8 +1270,8 @@ TEST(permute_gpu_f32_tile_8x8_4x4, x_remainder_bfzyx_0_2_3_4_1) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1324,8 +1324,8 @@ TEST(permute_gpu_f32_tile_8x8_4x4, xf_remainder_bfzyx_0_2_3_4_1) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1378,8 +1378,8 @@ TEST(permute_gpu_f32_tile_8x8_4x4, normal_bfwzyx_0_2_3_4_5_1) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1450,8 +1450,8 @@ TEST(permute_gpu_f32_tile_8x8_4x4, f_remainder_bfwzyx_0_2_3_4_5_1) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1510,8 +1510,8 @@ TEST(permute_gpu_f32_tile_8x8_4x4, x_remainder_bfwzyx_0_2_3_4_5_1) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1570,8 +1570,8 @@ TEST(permute_gpu_f32_tile_8x8_4x4, xf_remainder_bfwzyx_0_2_3_4_5_1) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1617,7 +1617,7 @@ public:
 
     template<typename T>
     void compare_value(T a, T b) const {
-        EXPECT_EQ(a, b);
+        ASSERT_EQ(a, b);
     }
 
     template<typename T>
@@ -1879,8 +1879,8 @@ TEST(permute_gpu_f32_dynamic, bfyx_0_2_3_1) {
     ASSERT_TRUE(impl->is_dynamic());
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "permute");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "permute");
 
     auto output = outputs.begin()->second.get_memory();
 

--- a/src/plugins/intel_gpu/tests/test_cases/pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/pooling_gpu_test.cpp
@@ -225,13 +225,13 @@ TEST(pooling_forward_gpu, basic_max_byxf_f32_wsiz3x3_wstr1x1_i1x3x3x8_nopad) {
     network.set_input_data("input_prim", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "pool_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
-    EXPECT_EQ(4.0f, output_ptr[3]);
+    ASSERT_EQ(4.0f, output_ptr[3]);
 }
 
 TEST(pooling_forward_gpu, basic_max_yxfb_f32_wsiz3x3_wstr1x1_i3x3x1x1_nopad) {
@@ -263,14 +263,14 @@ TEST(pooling_forward_gpu, basic_max_yxfb_f32_wsiz3x3_wstr1x1_i3x3x1x1_nopad) {
     network.set_input_data("input_prim", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "pool_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(2.0f, output_ptr[0]);
+    ASSERT_EQ(2.0f, output_ptr[0]);
 }
 
 TEST(pooling_forward_gpu, basic_max_pooling_int8) {
@@ -315,7 +315,7 @@ TEST(pooling_forward_gpu, basic_max_pooling_int8) {
     unsigned int cntr = 0;
     for (const auto& exp : final_results)
     {
-        EXPECT_EQ(exp, interm_ptr[cntr++]);
+        ASSERT_EQ(exp, interm_ptr[cntr++]);
     }
 }
 
@@ -364,7 +364,7 @@ TEST(pooling_forward_gpu, basic_avg_pooling_int8) {
 
     auto interm = outputs.at("reorder2").get_memory();
     cldnn::mem_lock<float> interm_ptr(interm, get_test_stream());
-    EXPECT_EQ(final_result, interm_ptr[0]);
+    ASSERT_EQ(final_result, interm_ptr[0]);
 }
 
 TEST(pooling_forward_gpu, basic_max_yxfb_f32_wsiz2x2_wstr1x1_i3x3x1x1_nopad) {
@@ -397,17 +397,17 @@ TEST(pooling_forward_gpu, basic_max_yxfb_f32_wsiz2x2_wstr1x1_i3x3x1x1_nopad) {
     network.set_input_data("input_prim", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "pool_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(2.0f, output_ptr[0]);
-    EXPECT_EQ(1.5f, output_ptr[1]);
-    EXPECT_EQ(2.0f, output_ptr[2]);
-    EXPECT_EQ(1.5f, output_ptr[3]);
+    ASSERT_EQ(2.0f, output_ptr[0]);
+    ASSERT_EQ(1.5f, output_ptr[1]);
+    ASSERT_EQ(2.0f, output_ptr[2]);
+    ASSERT_EQ(1.5f, output_ptr[3]);
 }
 
 TEST(pooling_forward_gpu, basic_max_yxfb_f32_wsiz2x2_wstr2x2_i4x4x1x1_nopad) {
@@ -441,17 +441,17 @@ TEST(pooling_forward_gpu, basic_max_yxfb_f32_wsiz2x2_wstr2x2_i4x4x1x1_nopad) {
     network.set_input_data("input_prim", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "pool_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(2.0f, output_ptr[0]);
-    EXPECT_EQ(0.5f, output_ptr[1]);
-    EXPECT_EQ(0.5f, output_ptr[2]);
-    EXPECT_EQ(0.5f, output_ptr[3]);
+    ASSERT_EQ(2.0f, output_ptr[0]);
+    ASSERT_EQ(0.5f, output_ptr[1]);
+    ASSERT_EQ(0.5f, output_ptr[2]);
+    ASSERT_EQ(0.5f, output_ptr[3]);
 }
 
 TEST(pooling_forward_gpu, basic_max_yxfb_f32_wsiz2x2_wstr1x1_i3x3x2x2_nopad) {
@@ -495,22 +495,22 @@ TEST(pooling_forward_gpu, basic_max_yxfb_f32_wsiz2x2_wstr1x1_i3x3x2x2_nopad) {
     network.set_input_data("input_prim", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "pool_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(1.0f, output_ptr[0]); EXPECT_EQ(0.0f, output_ptr[2]);
-    EXPECT_EQ(0.5f, output_ptr[4]); EXPECT_EQ(1.5f, output_ptr[6]);
-    EXPECT_EQ(1.0f, output_ptr[8]); EXPECT_EQ(1.0f, output_ptr[10]);
-    EXPECT_EQ(-0.5f, output_ptr[12]); EXPECT_EQ(1.5f, output_ptr[14]);
+    ASSERT_EQ(1.0f, output_ptr[0]); ASSERT_EQ(0.0f, output_ptr[2]);
+    ASSERT_EQ(0.5f, output_ptr[4]); ASSERT_EQ(1.5f, output_ptr[6]);
+    ASSERT_EQ(1.0f, output_ptr[8]); ASSERT_EQ(1.0f, output_ptr[10]);
+    ASSERT_EQ(-0.5f, output_ptr[12]); ASSERT_EQ(1.5f, output_ptr[14]);
 
-    EXPECT_EQ(0.5f,  output_ptr[1]);  EXPECT_EQ(1.0f, output_ptr[3]);
-    EXPECT_EQ(1.0f,  output_ptr[5]);  EXPECT_EQ(0.5f, output_ptr[7]);
-    EXPECT_EQ(-0.5f, output_ptr[9]);  EXPECT_EQ(1.0f, output_ptr[11]);
-    EXPECT_EQ(1.5f,  output_ptr[13]); EXPECT_EQ(0.0f, output_ptr[15]);
+    ASSERT_EQ(0.5f,  output_ptr[1]);  ASSERT_EQ(1.0f, output_ptr[3]);
+    ASSERT_EQ(1.0f,  output_ptr[5]);  ASSERT_EQ(0.5f, output_ptr[7]);
+    ASSERT_EQ(-0.5f, output_ptr[9]);  ASSERT_EQ(1.0f, output_ptr[11]);
+    ASSERT_EQ(1.5f,  output_ptr[13]); ASSERT_EQ(0.0f, output_ptr[15]);
 }
 
 TEST(pooling_forward_gpu, offsets_max_yxfb_f32_wsiz2x2_wstr2x2_i2x2x1x1_zeropad) {
@@ -545,16 +545,16 @@ TEST(pooling_forward_gpu, offsets_max_yxfb_f32_wsiz2x2_wstr2x2_i2x2x1x1_zeropad)
     network.set_input_data("input_prim", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "pool_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
-    EXPECT_EQ( 1.5f, output_ptr[0]);
-    EXPECT_EQ(-0.5f, output_ptr[1]);
-    EXPECT_EQ(-1.0f, output_ptr[2]);
-    EXPECT_EQ( 0.5f, output_ptr[3]);
+    ASSERT_EQ( 1.5f, output_ptr[0]);
+    ASSERT_EQ(-0.5f, output_ptr[1]);
+    ASSERT_EQ(-1.0f, output_ptr[2]);
+    ASSERT_EQ( 0.5f, output_ptr[3]);
 }
 
 TEST(pooling_forward_gpu, offsets_max_yxfb_f32_wsiz2x2_wstr2x2_i3x3x1x1_zeropad) {
@@ -596,17 +596,17 @@ TEST(pooling_forward_gpu, offsets_max_yxfb_f32_wsiz2x2_wstr2x2_i3x3x1x1_zeropad)
     network.set_input_data("input_prim", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "pool_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
-    EXPECT_EQ((int)output_prim->get_layout().count(), 4);
+    ASSERT_EQ((int)output_prim->get_layout().count(), 4);
 
     cldnn::mem_lock<float> output_ptr(output_prim, get_test_stream());
-    EXPECT_EQ(1.5f, output_ptr[0]);
-    EXPECT_EQ(-0.5f, output_ptr[1]);
-    EXPECT_EQ(1.0f, output_ptr[2]);
-    EXPECT_EQ(-0.5f, output_ptr[3]);
+    ASSERT_EQ(1.5f, output_ptr[0]);
+    ASSERT_EQ(-0.5f, output_ptr[1]);
+    ASSERT_EQ(1.0f, output_ptr[2]);
+    ASSERT_EQ(-0.5f, output_ptr[3]);
 }
 
 TEST(pooling_forward_gpu, basic_avg_yxfb_f32_wsiz2x2_wstr1x1_i3x3x1x1_nopad) {
@@ -639,17 +639,17 @@ TEST(pooling_forward_gpu, basic_avg_yxfb_f32_wsiz2x2_wstr1x1_i3x3x1x1_nopad) {
     network.set_input_data("input_prim", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "pool_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_EQ(1.0f,   output_ptr[0]);
-    EXPECT_EQ(0.625f, output_ptr[1]);
-    EXPECT_EQ(1.625f, output_ptr[2]);
-    EXPECT_EQ(0.875f, output_ptr[3]);
+    ASSERT_EQ(1.0f,   output_ptr[0]);
+    ASSERT_EQ(0.625f, output_ptr[1]);
+    ASSERT_EQ(1.625f, output_ptr[2]);
+    ASSERT_EQ(0.875f, output_ptr[3]);
 }
 
 TEST(pooling_forward_gpu, offsets_avg_yxfb_f32_wsiz2x2_wstr2x2_i2x2x1x1_zeropad) {
@@ -684,16 +684,16 @@ TEST(pooling_forward_gpu, offsets_avg_yxfb_f32_wsiz2x2_wstr2x2_i2x2x1x1_zeropad)
     network.set_input_data("input_prim", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "pool_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
-    EXPECT_EQ(0.375f,  output_ptr[0]);
-    EXPECT_EQ(-0.125f, output_ptr[1]);
-    EXPECT_EQ(-0.25f,  output_ptr[2]);
-    EXPECT_EQ(0.125f,  output_ptr[3]);
+    ASSERT_EQ(0.375f,  output_ptr[0]);
+    ASSERT_EQ(-0.125f, output_ptr[1]);
+    ASSERT_EQ(-0.25f,  output_ptr[2]);
+    ASSERT_EQ(0.125f,  output_ptr[3]);
 }
 
 TEST(pooling_forward_gpu, offsets_avg_bfyx_f32_wsiz3x3_wstr3x3_i1x1x3x3_zeropad) {
@@ -732,8 +732,8 @@ TEST(pooling_forward_gpu, offsets_avg_bfyx_f32_wsiz3x3_wstr3x3_i1x1x3x3_zeropad)
     network.set_input_data("input_prim", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "pool_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -777,17 +777,17 @@ TEST(pooling_forward_gpu, offsets_avg_yxfb_f32_wsiz2x2_wstr2x2_i3x3x1x1_zeropad)
     network.set_input_data("input_prim", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "pool_prim");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
     auto output_prim = outputs.begin()->second.get_memory();
-    EXPECT_EQ((int)output_prim->get_layout().count(), 4);
+    ASSERT_EQ((int)output_prim->get_layout().count(), 4);
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
-    EXPECT_EQ(0.375f,  output_ptr[0]);
-    EXPECT_EQ(0.5f,    output_ptr[1]);
-    EXPECT_EQ(-0.125f, output_ptr[2]);
-    EXPECT_EQ(-1.125f, output_ptr[3]);
+    ASSERT_EQ(0.375f,  output_ptr[0]);
+    ASSERT_EQ(0.5f,    output_ptr[1]);
+    ASSERT_EQ(-0.125f, output_ptr[2]);
+    ASSERT_EQ(-1.125f, output_ptr[3]);
 }
 
 TEST(pooling_forward_gpu, offsets_avg_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i2x2x1x1_outpad2) {
@@ -841,13 +841,13 @@ TEST(pooling_forward_gpu, offsets_avg_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i2x2x1x1_out
         };
 
         auto outputs = network.execute();
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "pool_prim");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
         auto output_prim = outputs.begin()->second.get_memory();
         cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
         for (size_t i = 0; i < expected.size(); ++i) {
-            EXPECT_EQ(expected[i], output_ptr[i]);
+            ASSERT_EQ(expected[i], output_ptr[i]);
         }
     }
 }
@@ -906,16 +906,16 @@ TEST(pooling_forward_gpu, offsets_max_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i3x3x1x1_out
         };
 
         auto outputs = network.execute();
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "pool_prim");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
         auto output_prim = outputs.begin()->second.get_memory();
-        EXPECT_EQ((int)output_prim->get_layout().count(), 4);
-        EXPECT_EQ((int)output_prim->get_layout().get_buffer_size().count(), 16);
+        ASSERT_EQ((int)output_prim->get_layout().count(), 4);
+        ASSERT_EQ((int)output_prim->get_layout().get_buffer_size().count(), 16);
 
         cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
         for (size_t i = 0; i < expected.size(); ++i) {
-            EXPECT_EQ(expected[i], output_ptr[i]);
+            ASSERT_EQ(expected[i], output_ptr[i]);
         }
     }
 }
@@ -973,13 +973,13 @@ TEST(pooling_forward_gpu, offsets_avg_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i2x2x1x1_inp
         };
 
         auto outputs = network.execute();
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "pool_prim");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
         auto output_prim = outputs.begin()->second.get_memory();
         cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
         for (size_t i = 0; i < expected.size(); ++i) {
-            EXPECT_EQ(expected[i], output_ptr[i]);
+            ASSERT_EQ(expected[i], output_ptr[i]);
         }
     }
 }
@@ -1040,16 +1040,16 @@ TEST(pooling_forward_gpu, offsets_max_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i3x3x1x1_inp
         };
 
         auto outputs = network.execute();
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "pool_prim");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
         auto output_prim = outputs.begin()->second.get_memory();
-        EXPECT_EQ((int)output_prim->get_layout().count(), 4);
-        EXPECT_EQ((int)output_prim->get_layout().get_buffer_size().count(), 16);
+        ASSERT_EQ((int)output_prim->get_layout().count(), 4);
+        ASSERT_EQ((int)output_prim->get_layout().get_buffer_size().count(), 16);
 
         cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
         for (size_t i = 0; i < expected.size(); ++i) {
-            EXPECT_EQ(expected[i], output_ptr[i]);
+            ASSERT_EQ(expected[i], output_ptr[i]);
         }
     }
 }
@@ -1111,13 +1111,13 @@ TEST(pooling_forward_gpu, avg_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i2x2x1x1_inpad2x1_ou
         };
 
         auto outputs = network.execute();
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "pool_prim");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
         auto output_prim = outputs.begin()->second.get_memory();
         cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
         for (size_t i = 0; i < expected.size(); ++i) {
-            EXPECT_EQ(expected[i], output_ptr[i]);
+            ASSERT_EQ(expected[i], output_ptr[i]);
         }
     }
 }
@@ -1182,16 +1182,16 @@ TEST(pooling_forward_gpu, max_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i3x3x1x1_inpad2x1_ou
         };
 
         auto outputs = network.execute();
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "pool_prim");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "pool_prim");
 
         auto output_prim = outputs.begin()->second.get_memory();
-        EXPECT_EQ((int)output_prim->get_layout().count(), 9);
-        EXPECT_EQ((int)output_prim->get_layout().get_buffer_size().count(), 25);
+        ASSERT_EQ((int)output_prim->get_layout().count(), 9);
+        ASSERT_EQ((int)output_prim->get_layout().get_buffer_size().count(), 25);
 
         cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
         for (size_t i = 0; i < expected.size(); ++i) {
-            EXPECT_EQ(expected[i], output_ptr[i]);
+            ASSERT_EQ(expected[i], output_ptr[i]);
         }
     }
 }
@@ -1234,7 +1234,7 @@ static void generic_average_wo_padding_test(format fmt, tensor output, tensor in
     auto output_mem = net.execute().at("pool").get_memory();
 
     ASSERT_EQ(output_mem->count(), expected_output.size());
-    EXPECT_EQ(output_mem->get_layout().get_tensor(), output);
+    ASSERT_EQ(output_mem->get_layout().get_tensor(), output);
     cldnn::mem_lock<DataType> out_ptr(output_mem, get_test_stream());
 
     for (size_t i = 0; i < expected_output.size(); ++i)
@@ -1536,17 +1536,17 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_avg_3x3_input_2x2_pool_1x1_stride_2x2_ou
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder_after_pooling");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder_after_pooling");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
     cldnn::mem_lock<FLOAT16> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_EQ(1.0f, float(output_ptr[0]));
-    EXPECT_EQ(0.625f, float(output_ptr[1]));
-    EXPECT_EQ(1.625f, float(output_ptr[2]));
-    EXPECT_EQ(0.875f, float(output_ptr[3]));
+    ASSERT_EQ(1.0f, float(output_ptr[0]));
+    ASSERT_EQ(0.625f, float(output_ptr[1]));
+    ASSERT_EQ(1.625f, float(output_ptr[2]));
+    ASSERT_EQ(0.875f, float(output_ptr[3]));
 
 }
 
@@ -1588,17 +1588,17 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_avg_3x3_input_2x2_pool_2x2_stride)
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder_after_pooling");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder_after_pooling");
 
     auto output_prim = outputs.begin()->second.get_memory();
     cldnn::mem_lock<FLOAT16> output_ptr(output_prim, get_test_stream());
 
-    EXPECT_EQ(1.0f, float(output_ptr[0]));
-    EXPECT_EQ(0.f, float(output_ptr[1]));
+    ASSERT_EQ(1.0f, float(output_ptr[0]));
+    ASSERT_EQ(0.f, float(output_ptr[1]));
 
-    EXPECT_EQ(1.5f, float(output_ptr[2]));
-    EXPECT_EQ(3.5f, float(output_ptr[3]));
+    ASSERT_EQ(1.5f, float(output_ptr[2]));
+    ASSERT_EQ(3.5f, float(output_ptr[3]));
 
 }
 
@@ -1657,8 +1657,8 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_avg_2x2x3x3_input_2x2_pool_2x2_stride)
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder_after_pooling");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder_after_pooling");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -1673,11 +1673,11 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_avg_2x2x3x3_input_2x2_pool_2x2_stride)
         {
             const int f_pitch = out_x * out_y;
             const int bf_offset = b * (f_pitch * features_count) + f * f_pitch;
-            EXPECT_EQ(1.0f, float(output_ptr[bf_offset + 0])); // X0Y0
-            EXPECT_EQ(0.f,  float(output_ptr[bf_offset + 1])); // X1Y0
+            ASSERT_EQ(1.0f, float(output_ptr[bf_offset + 0])); // X0Y0
+            ASSERT_EQ(0.f,  float(output_ptr[bf_offset + 1])); // X1Y0
 
-            EXPECT_EQ(1.5f, float(output_ptr[bf_offset + 2])); // X0Y1
-            EXPECT_EQ(3.5f, float(output_ptr[bf_offset + 3])); // X1Y1
+            ASSERT_EQ(1.5f, float(output_ptr[bf_offset + 2])); // X0Y1
+            ASSERT_EQ(3.5f, float(output_ptr[bf_offset + 3])); // X1Y1
         }
     }
 }
@@ -1738,17 +1738,17 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_max_1x1x3x3_input_2x2_pool_2x2_stride_2x
         };
 
         auto outputs = network.execute();
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "reorder_pooling");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "reorder_pooling");
 
         auto output_prim = outputs.begin()->second.get_memory();
-        EXPECT_EQ((int)output_prim->get_layout().count(), 4);
-        EXPECT_EQ((int)output_prim->get_layout().get_buffer_size().count(), 16);
+        ASSERT_EQ((int)output_prim->get_layout().count(), 4);
+        ASSERT_EQ((int)output_prim->get_layout().get_buffer_size().count(), 16);
 
         cldnn::mem_lock<FLOAT16> output_ptr(output_prim, get_test_stream());
 
         for (size_t i = 0; i < expected.size(); ++i) {
-            EXPECT_EQ(expected[i], float(output_ptr[i]));
+            ASSERT_EQ(expected[i], float(output_ptr[i]));
         }
 
 }
@@ -1814,17 +1814,17 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_max_1x1x5x5_input_2x2_pool_2x2_stride_2x
     };
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder_pooling");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder_pooling");
 
     auto output_prim = outputs.begin()->second.get_memory();
-    EXPECT_EQ((int)output_prim->get_layout().count(), 9);
-    EXPECT_EQ((int)output_prim->get_layout().get_buffer_size().count(), 25);
+    ASSERT_EQ((int)output_prim->get_layout().count(), 9);
+    ASSERT_EQ((int)output_prim->get_layout().get_buffer_size().count(), 25);
 
     cldnn::mem_lock<FLOAT16> output_ptr(output_prim, get_test_stream());
 
     for (size_t i = 0; i < expected.size(); ++i) {
-        EXPECT_EQ(expected[i], float(output_ptr[i]));
+        ASSERT_EQ(expected[i], float(output_ptr[i]));
     }
 }
 
@@ -1999,7 +1999,7 @@ public:
                                 ASSERT_NEAR(ref_val, actual_val, tolerance)
                                     << "at b= " << bi << ", f= " << fi << ", z= " << zi << ", y= " << yi << ", x= " << xi;
                             } else {
-                                EXPECT_TRUE(are_equal(ref_val, actual_val))
+                                ASSERT_TRUE(are_equal(ref_val, actual_val))
                                     << "at b= " << bi << ", f= " << fi << ", z= " << zi << ", y= " << yi << ", x= " << xi;
                             }
                         }
@@ -2359,7 +2359,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_16x16x8x8_input_2x2_pool_2x2_stride)
     for (size_t i = 0; i < golden_results.size(); i++)
     {
         auto equal = are_equal(golden_results[i], bsv16_fsv16_results[i]);
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal)
         {
             std::cout << "Difference at idx = " << i << std::endl;
@@ -2442,7 +2442,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_16x16x2x2_input_4x4_pool_1x1_stride_1x
     for (size_t i = 0; i < golden_results.size(); i++)
     {
         auto equal = are_equal(golden_results[i], bsv16_fsv16_results[i]);
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal)
         {
             std::cout << "Difference at idx = " << i << std::endl;
@@ -2526,7 +2526,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_avg_16x16x20x20_input_5x5_pool_3x3_stride)
     for (size_t i = 0; i < golden_results.size(); i++)
     {
         auto equal = are_equal(golden_results[i], bsv16_fsv16_results[i]);
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal)
         {
             std::cout << "Difference at idx = " << i << std::endl;
@@ -2609,7 +2609,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_avg_16x16x20x20_input_5x5_pool_3x1_stride)
     for (size_t i = 0; i < golden_results.size(); i++)
     {
         auto equal = are_equal(golden_results[i], bsv16_fsv16_results[i]);
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal)
         {
             std::cout << "Difference at idx = " << i << std::endl;
@@ -2694,7 +2694,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_16x16x20x20_input_5x5_pool_3x1_stride)
     for (size_t i = 0; i < golden_results.size(); i++)
     {
         auto equal = are_equal(golden_results[i], bsv16_fsv16_results[i]);
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal)
         {
             std::cout << "Difference at idx = " << i << std::endl;
@@ -2779,7 +2779,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_32x32x20x20_input_5x5_pool_3x1_stride)
     for (size_t i = 0; i < golden_results.size(); i++)
     {
         auto equal = are_equal(golden_results[i], bsv16_fsv16_results[i]);
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal)
         {
             std::cout << "Difference at idx = " << i << std::endl;
@@ -2868,7 +2868,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_32x16x20x20_input_5x5_pool_3x1_stride)
     for (size_t i = 0; i < golden_results.size(); i++)
     {
         auto equal = are_equal(golden_results[i], bsv16_fsv16_results[i]);
-        EXPECT_TRUE(equal);
+        ASSERT_TRUE(equal);
         if (!equal)
         {
             std::cout << "Difference at idx = " << i << std::endl;
@@ -3249,7 +3249,7 @@ TEST(pooling_forward_gpu_onednn, basic_max_pooling_int8) {
     unsigned int cntr = 0;
     for (const auto& exp : final_results)
     {
-        EXPECT_EQ(exp, interm_ptr[cntr++]);
+        ASSERT_EQ(exp, interm_ptr[cntr++]);
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/pooling_gpu_test.cpp
@@ -739,10 +739,10 @@ TEST(pooling_forward_gpu, offsets_avg_bfyx_f32_wsiz3x3_wstr3x3_i1x1x3x3_zeropad)
 
     cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
 
-    EXPECT_NEAR(output_ptr[0], 0.177777f, 1e-05F);
-    EXPECT_NEAR(output_ptr[1], -0.133333f, 1e-05F);
-    EXPECT_NEAR(output_ptr[2], 0.333333f, 1e-05F);
-    EXPECT_NEAR(output_ptr[3], 0.55f, 1e-05F);
+    ASSERT_NEAR(output_ptr[0], 0.177777f, 1e-05F);
+    ASSERT_NEAR(output_ptr[1], -0.133333f, 1e-05F);
+    ASSERT_NEAR(output_ptr[2], 0.333333f, 1e-05F);
+    ASSERT_NEAR(output_ptr[3], 0.55f, 1e-05F);
 }
 
 TEST(pooling_forward_gpu, offsets_avg_yxfb_f32_wsiz2x2_wstr2x2_i3x3x1x1_zeropad) {
@@ -1238,7 +1238,7 @@ static void generic_average_wo_padding_test(format fmt, tensor output, tensor in
     cldnn::mem_lock<DataType> out_ptr(output_mem, get_test_stream());
 
     for (size_t i = 0; i < expected_output.size(); ++i)
-        EXPECT_FLOAT_EQ(out_ptr[i], expected_output[i]);
+        ASSERT_FLOAT_EQ(out_ptr[i], expected_output[i]);
 }
 
 //bfyx fp32
@@ -1901,7 +1901,7 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_avg_65x5x6x7_input_3x3_pool_4x4_stride_3
     ASSERT_EQ(fsv32_results.size(), golden_results.size());
     for (size_t i = 0; i < golden_results.size(); i++)
     {
-        EXPECT_NEAR(golden_results[i], fsv32_results[i], 0.001f);
+        ASSERT_NEAR(golden_results[i], fsv32_results[i], 0.001f);
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/prior_box_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/prior_box_gpu_test.cpp
@@ -100,7 +100,7 @@ public:
 
         ASSERT_EQ(output_ptr.size(), expected_values.size());
         for (size_t i = 0; i < output_ptr.size(); ++i) {
-            EXPECT_NEAR(output_ptr[i], expected_values[i], 2e-3)
+            ASSERT_NEAR(output_ptr[i], expected_values[i], 2e-3)
                 << "target_format=" << fmt_to_str(target_format) << ", i=" << i;
         }
     }

--- a/src/plugins/intel_gpu/tests/test_cases/propagate_constants_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/propagate_constants_gpu_test.cpp
@@ -45,6 +45,6 @@ TEST(propagate_constants, copy_dependecies_from_nodes) {
     float epsilon = 1e-2f;
     for (auto& it : outputs) {
         cldnn::mem_lock<float> output(it.second.get_memory(), get_test_stream());
-        EXPECT_NEAR(7.8f, output[0], epsilon);
+        ASSERT_NEAR(7.8f, output[0], epsilon);
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/proposal_cpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/proposal_cpu_test.cpp
@@ -129,7 +129,7 @@ TEST(proposal, basic) {
     cldnn::mem_lock<float> f(output, get_test_stream());
 
     for (size_t i = 0; i < proposal_ref_size; i++) {
-        EXPECT_NEAR(f[i], proposal_ref[i], epsilon);
+        ASSERT_NEAR(f[i], proposal_ref[i], epsilon);
     }
 }
 
@@ -146,7 +146,7 @@ TEST(proposal, fp16) {
 
     for (size_t i = 0; i < proposal_ref_size; i++) {
         FLOAT16 ref(proposal_ref[i]);
-        EXPECT_NEAR((float)d[i], (float)ref, epsilon_fp16);
+        ASSERT_NEAR((float)d[i], (float)ref, epsilon_fp16);
     }
 }
 
@@ -163,7 +163,7 @@ TEST(proposal, scores_fp16_im_info_fp32) {
 
     for (size_t i = 0; i < proposal_ref_size; i++) {
         FLOAT16 ref(proposal_ref[i]);
-        EXPECT_NEAR((float)d[i], (float)ref, epsilon_fp16);
+        ASSERT_NEAR((float)d[i], (float)ref, epsilon_fp16);
     }
 }
 
@@ -180,7 +180,7 @@ TEST(proposal, scores_fp32_im_info_fp16) {
 
     for (size_t i = 0; i < proposal_ref_size; i++) {
         float ref(proposal_ref[i]);
-        EXPECT_NEAR((float)d[i], (float)ref, epsilon);
+        ASSERT_NEAR((float)d[i], (float)ref, epsilon);
     }
 }
 
@@ -196,7 +196,7 @@ TEST(proposal, img_info_batched) {
     cldnn::mem_lock<float> f(output, get_test_stream());
 
     for (size_t i = 0; i < proposal_ref_size; i++) {
-        EXPECT_NEAR(f[i], proposal_ref[i], epsilon);
+        ASSERT_NEAR(f[i], proposal_ref[i], epsilon);
     }
 }
 
@@ -212,6 +212,6 @@ TEST(proposal, img_info_batch_only) {
     cldnn::mem_lock<float> f(output, get_test_stream());
 
     for (size_t i = 0; i < proposal_ref_size; i++) {
-        EXPECT_NEAR(f[i], proposal_ref[i], epsilon);
+        ASSERT_NEAR(f[i], proposal_ref[i], epsilon);
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/pyramid_roi_align_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/pyramid_roi_align_gpu_test.cpp
@@ -127,6 +127,6 @@ TYPED_TEST(pyramid_roi_align_typed_test, smoke_4levels) {
 
     ASSERT_EQ(expected_out.size(), out_ptr.size());
     for (size_t i = 0; i < expected_out.size(); ++i) {
-        EXPECT_EQ(expected_out[i], static_cast<float>(out_ptr[i])) << "at i = " << i;
+        ASSERT_EQ(expected_out[i], static_cast<float>(out_ptr[i])) << "at i = " << i;
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/quantize_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/quantize_gpu_test.cpp
@@ -99,7 +99,7 @@ TEST(quantize_gpu, quantize_levels_2_output_broadcast_inputs_1) {
     ASSERT_EQ(output->size(), ref_data.size() * sizeof(uint32_t));
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_EQ(output_ptr[i], ref_data[i]) << " index = " << i;
+        ASSERT_EQ(output_ptr[i], ref_data[i]) << " index = " << i;
     }
 }
 
@@ -163,7 +163,7 @@ TEST(quantize_gpu, quantize_levels_2_output_broadcast_inputs_1_ch8) {
     ASSERT_EQ(output->size(), ref_data.size() * sizeof(uint32_t));
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_EQ(output_ptr[i], ref_data[i]) << " index = " << i;
+        ASSERT_EQ(output_ptr[i], ref_data[i]) << " index = " << i;
     }
 }
 
@@ -229,7 +229,7 @@ TEST(quantize_gpu, quantize_levels_2_output_broadcast_inputs_1_ch8_binary_pack) 
     ASSERT_EQ(output->size(), ref_data.size() * sizeof(uint32_t));
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_EQ(output_ptr[i], ref_data[i]) << " index = " << i;
+        ASSERT_EQ(output_ptr[i], ref_data[i]) << " index = " << i;
     }
 }
 
@@ -307,7 +307,7 @@ TEST(quantize_gpu, quantize_levels_2_output_broadcast_inputs_2) {
     ASSERT_EQ(output->size(), ref_data.size() * sizeof(float));
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_EQ(output_ptr[i], ref_data[i]) << " index = " << i;
+        ASSERT_EQ(output_ptr[i], ref_data[i]) << " index = " << i;
     }
 }
 
@@ -397,7 +397,7 @@ TEST(quantize_gpu, quantize_levels_3) {
     ASSERT_EQ(output->size(), ref_data.size() * sizeof(float));
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_EQ(output_ptr[i], ref_data[i]) << " i=" << i;
+        ASSERT_EQ(output_ptr[i], ref_data[i]) << " i=" << i;
     }
 }
 
@@ -488,7 +488,7 @@ TEST(quantize_gpu, quantize_levels_256_2d_unsigned) {
     ASSERT_EQ(output->size(), ref_data.size() * sizeof(uint8_t));
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_EQ(output_ptr[i], ref_data[i]) << " i=" << i;
+        ASSERT_EQ(output_ptr[i], ref_data[i]) << " i=" << i;
     }
 }
 
@@ -580,7 +580,7 @@ TEST(quantize_gpu, quantize_levels_256_3d_unsigned) {
     ASSERT_EQ(output->size(), ref_data.size() * sizeof(uint8_t));
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_EQ(output_ptr[i], ref_data[i]) << " i=" << i;
+        ASSERT_EQ(output_ptr[i], ref_data[i]) << " i=" << i;
     }
 }
 
@@ -666,7 +666,7 @@ struct quantize_random_test : testing::TestWithParam<quantize_random_test_params
     }
 
     template <typename T>
-    bool compare_outputs(const memory::ptr out_ref, const memory::ptr out_opt) {
+    void compare_outputs(const memory::ptr out_ref, const memory::ptr out_opt) {
         auto output_lay = out_ref->get_layout();
         auto opt_output_lay = out_opt->get_layout();
 
@@ -687,13 +687,11 @@ struct quantize_random_test : testing::TestWithParam<quantize_random_test_params
                         auto opt_out_offset = opt_output_lay.get_linear_offset(ref_out_coords);
                         auto opt_out_val = opt_ptr[opt_out_offset];
 
-                        EXPECT_EQ(opt_out_val, ref_out_val);
+                        ASSERT_EQ(opt_out_val, ref_out_val);
                     }
                 }
             }
         }
-
-        return true;
     }
 
     void execute_compare(const quantize_random_test_params& params, bool check_result) {

--- a/src/plugins/intel_gpu/tests/test_cases/random_uniform_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/random_uniform_gpu_test.cpp
@@ -69,7 +69,7 @@ public:
 
         ASSERT_EQ(params.expected_out.size(), out_ptr.size());
         for (size_t i = 0; i < params.expected_out.size(); ++i) {
-            EXPECT_NEAR(params.expected_out[i], out_ptr[i], 0.0001) << "at i = " << i;
+            ASSERT_NEAR(params.expected_out[i], out_ptr[i], 0.0001) << "at i = " << i;
         }
     }
 };

--- a/src/plugins/intel_gpu/tests/test_cases/range_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/range_gpu_test.cpp
@@ -90,7 +90,7 @@ void doSmokeRange(range_test_params& params) {
     mem_lock<T> output_ptr { output, tests::get_test_stream() };
 
     for (std::size_t i = 0; i < static_cast<size_t>(outLen); ++i) {
-        EXPECT_EQ(start_val + i * step_val, output_ptr[i]);
+        ASSERT_EQ(start_val + i * step_val, output_ptr[i]);
     }
 }
 
@@ -112,7 +112,7 @@ void doSmokeRange_fp16(range_test_params& params) {
     mem_lock<uint16_t> output_ptr { output, tests::get_test_stream() };
 
     for (std::size_t i = 0; i < static_cast<size_t>(outLen); ++i) {
-        EXPECT_EQ(start_val + i * step_val, half_to_float(output_ptr[i]));
+        ASSERT_EQ(start_val + i * step_val, half_to_float(output_ptr[i]));
     }
 }
 
@@ -219,7 +219,7 @@ TEST(range_gpu_test, range_with_select) {
     mem_lock<int32_t> output_ptr { output, tests::get_test_stream() };
 
     for (size_t i = 0; i < static_cast<size_t>(expected_dim); ++i) {
-        EXPECT_EQ(start_val + i * step_val, output_ptr[i]);
+        ASSERT_EQ(start_val + i * step_val, output_ptr[i]);
     }
 }
 }  // namespace

--- a/src/plugins/intel_gpu/tests/test_cases/reduce_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reduce_gpu_test.cpp
@@ -562,7 +562,7 @@ public:
                                               << " y: " << yi << " x: " << xi << " = " << val_ref << " Val = " << val
                                               << std::endl;
 
-                                EXPECT_TRUE(equal);
+                                ASSERT_TRUE(equal);
 
                                 if (!equal)
                                     break;
@@ -785,8 +785,8 @@ TEST(reduce_gpu, common_bfyx) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -795,7 +795,7 @@ TEST(reduce_gpu, common_bfyx) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -815,8 +815,8 @@ TEST(reduce_gpu, common_bfyx_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -825,7 +825,7 @@ TEST(reduce_gpu, common_bfyx_keepdims) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -845,8 +845,8 @@ TEST(reduce_gpu, regr_bfyx_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -855,7 +855,7 @@ TEST(reduce_gpu, regr_bfyx_keepdims) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -875,8 +875,8 @@ TEST(reduce_gpu, common_bfzyx) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -885,7 +885,7 @@ TEST(reduce_gpu, common_bfzyx) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -905,8 +905,8 @@ TEST(reduce_gpu, common_bfzyx_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -915,7 +915,7 @@ TEST(reduce_gpu, common_bfzyx_keepdims) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -935,8 +935,8 @@ TEST(reduce_gpu, common_bfwzyx) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -945,7 +945,7 @@ TEST(reduce_gpu, common_bfwzyx) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -965,8 +965,8 @@ TEST(reduce_gpu, common_bfwzyx_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -975,7 +975,7 @@ TEST(reduce_gpu, common_bfwzyx_keepdims) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -996,8 +996,8 @@ TEST(reduce_gpu, common_bfwzyx_max_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1006,7 +1006,7 @@ TEST(reduce_gpu, common_bfwzyx_max_keepdims) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1026,8 +1026,8 @@ TEST(reduce_gpu, common_bfwzyx_min) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1036,7 +1036,7 @@ TEST(reduce_gpu, common_bfwzyx_min) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1056,8 +1056,8 @@ TEST(reduce_gpu, common_bfwzyx_min_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1066,7 +1066,7 @@ TEST(reduce_gpu, common_bfwzyx_min_keepdims) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1086,8 +1086,8 @@ TEST(reduce_gpu, common_bfwzyx_mean) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1096,7 +1096,7 @@ TEST(reduce_gpu, common_bfwzyx_mean) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1116,8 +1116,8 @@ TEST(reduce_gpu, common_bfwzyx_mean_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1126,7 +1126,7 @@ TEST(reduce_gpu, common_bfwzyx_mean_keepdims) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1146,8 +1146,8 @@ TEST(reduce_gpu, common_bfwzyx_prod) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1156,7 +1156,7 @@ TEST(reduce_gpu, common_bfwzyx_prod) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1176,8 +1176,8 @@ TEST(reduce_gpu, common_bfwzyx_prod_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1186,7 +1186,7 @@ TEST(reduce_gpu, common_bfwzyx_prod_keepdims) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1207,8 +1207,8 @@ TEST(reduce_gpu, common_bfwzyx_sum_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1217,7 +1217,7 @@ TEST(reduce_gpu, common_bfwzyx_sum_keepdims) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1237,8 +1237,8 @@ TEST(reduce_gpu, common_bfwzyx_logical_and) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1247,7 +1247,7 @@ TEST(reduce_gpu, common_bfwzyx_logical_and) {
     cldnn::mem_lock<char> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1267,8 +1267,8 @@ TEST(reduce_gpu, common_bfwzyx_logical_and_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1277,7 +1277,7 @@ TEST(reduce_gpu, common_bfwzyx_logical_and_keepdims) {
     cldnn::mem_lock<char> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1297,8 +1297,8 @@ TEST(reduce_gpu, common_bfwzyx_logical_or) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1307,7 +1307,7 @@ TEST(reduce_gpu, common_bfwzyx_logical_or) {
     cldnn::mem_lock<char> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1327,8 +1327,8 @@ TEST(reduce_gpu, common_bfwzyx_logical_or_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1337,7 +1337,7 @@ TEST(reduce_gpu, common_bfwzyx_logical_or_keepdims) {
     cldnn::mem_lock<char> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1357,8 +1357,8 @@ TEST(reduce_gpu, common_bfwzyx_sum_square) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1367,7 +1367,7 @@ TEST(reduce_gpu, common_bfwzyx_sum_square) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1387,8 +1387,8 @@ TEST(reduce_gpu, common_bfwzyx_sum_square_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1397,7 +1397,7 @@ TEST(reduce_gpu, common_bfwzyx_sum_square_keepdims) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1417,8 +1417,8 @@ TEST(reduce_gpu, common_bfwzyx_l1) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1427,7 +1427,7 @@ TEST(reduce_gpu, common_bfwzyx_l1) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1447,8 +1447,8 @@ TEST(reduce_gpu, common_bfwzyx_l1_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1457,7 +1457,7 @@ TEST(reduce_gpu, common_bfwzyx_l1_keepdims) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1477,8 +1477,8 @@ TEST(reduce_gpu, common_bfwzyx_l2) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1487,7 +1487,7 @@ TEST(reduce_gpu, common_bfwzyx_l2) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1507,8 +1507,8 @@ TEST(reduce_gpu, common_bfwzyx_l2_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1517,7 +1517,7 @@ TEST(reduce_gpu, common_bfwzyx_l2_keepdims) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1537,8 +1537,8 @@ TEST(reduce_gpu, common_bfwzyx_log_sum) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1547,7 +1547,7 @@ TEST(reduce_gpu, common_bfwzyx_log_sum) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1567,8 +1567,8 @@ TEST(reduce_gpu, common_bfwzyx_log_sum_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1577,7 +1577,7 @@ TEST(reduce_gpu, common_bfwzyx_log_sum_keepdims) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1597,8 +1597,8 @@ TEST(reduce_gpu, common_bfwzyx_log_sum_exp) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1607,7 +1607,7 @@ TEST(reduce_gpu, common_bfwzyx_log_sum_exp) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1627,8 +1627,8 @@ TEST(reduce_gpu, common_bfwzyx_log_sum_exp_keepdims) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reduce");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reduce");
 
     auto output = outputs.at("reduce").get_memory();
 
@@ -1637,7 +1637,7 @@ TEST(reduce_gpu, common_bfwzyx_log_sum_exp_keepdims) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < ref_data.size(); ++i) {
-        EXPECT_TRUE(are_equal(ref_data[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(ref_data[i], output_ptr[i]));
     }
 }
 
@@ -1779,7 +1779,7 @@ public:
                                                 << " y: " << yi << " x: " << xi << " = " << val_ref << " Val = " << val
                                                 << std::endl;
 
-                                    EXPECT_TRUE(equal);
+                                    ASSERT_TRUE(equal);
 
                                     if (!equal)
                                         break;
@@ -1930,7 +1930,7 @@ public:
                                               << " y: " << yi << " x: " << xi << " = " << static_cast<float>(val_ref) << " Val = " << static_cast<float>(val)
                                               << std::endl;
 
-                                EXPECT_TRUE(equal);
+                                ASSERT_TRUE(equal);
 
                                 if (!equal)
                                     break;

--- a/src/plugins/intel_gpu/tests/test_cases/region_yolo_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/region_yolo_gpu_test.cpp
@@ -84,7 +84,7 @@ void region_yolo_ref(const T* input,
                      const uint32_t regions,
                      const bool do_softmax,
                      const std::vector<int64_t>& mask) {
-    EXPECT_EQ(input_shape.size(), 4);
+    ASSERT_EQ(input_shape.size(), 4);
 
     const uint32_t batches = input_shape[0];
     //const uint32_t channels = input_shape[1];

--- a/src/plugins/intel_gpu/tests/test_cases/region_yolo_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/region_yolo_gpu_test.cpp
@@ -195,7 +195,7 @@ void runRegionTest(region_yolo_test_params& params) {
 
     /// compare values
     for (size_t i = 0; i < inputData.size(); ++i) {
-        EXPECT_NEAR(refOutputData[i], outputData[i], 0.01);
+        ASSERT_NEAR(refOutputData[i], outputData[i], 0.01);
     }
 }
 }  // namespace

--- a/src/plugins/intel_gpu/tests/test_cases/removing_output_node_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/removing_output_node_test.cpp
@@ -75,7 +75,7 @@ TEST(removing_output_node, multiple_outputs) {
     ASSERT_TRUE(output->get_layout().get_tensor() == after_reshape);
 
     for (size_t i = 0; i < out_vec.size(); i++)
-        EXPECT_EQ(output_ptr[i], out_vec[i]);
+        ASSERT_EQ(output_ptr[i], out_vec[i]);
 
     // checking the output node has the same name after output node deleting due to StridedSlice optimization
     ASSERT_TRUE(outputs.find("strided_slice") != outputs.end());
@@ -85,7 +85,7 @@ TEST(removing_output_node, multiple_outputs) {
     ASSERT_TRUE(output2->get_layout().get_tensor() == after_strided_slice);
 
     for (size_t i = 0; i < out_vec.size(); i++)
-        EXPECT_EQ(output_ptr2[i], out_vec[i]);
+        ASSERT_EQ(output_ptr2[i], out_vec[i]);
 }
 
 TEST(removing_output_node, output_node_optimization) {
@@ -130,8 +130,8 @@ TEST(removing_output_node, output_node_optimization) {
 
     // checking the output node has the same name after output node deleting due to ReLU optimization
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "relu");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "relu");
 
     auto output_memory = outputs.at("relu").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -141,14 +141,14 @@ TEST(removing_output_node, output_node_optimization) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
-            EXPECT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
         }
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reorder_gpu_test.cpp
@@ -299,7 +299,7 @@ TEST(reorder_gpu_optimization, bfyx_to_fsv16_without_f_remainder) {
             for (int32_t y = 0; y < y_in; y++) {
                 for (int32_t x = 0; x < x_in; x++) {
                     int32_t b_fs_yx_fsv16_index = get_fsv16_index(b_in, f_in, y_in, x_in, b, f, y, x);
-                    EXPECT_FLOAT_EQ(input_ptr[linear_index++], output_ptr[b_fs_yx_fsv16_index]);
+                    ASSERT_FLOAT_EQ(input_ptr[linear_index++], output_ptr[b_fs_yx_fsv16_index]);
                 }
             }
         }
@@ -380,7 +380,7 @@ TEST(reorder_gpu_f32, basic) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -472,7 +472,7 @@ TEST(reorder_gpu_f32, basic_subtract) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1069,7 +1069,7 @@ TEST(reorder_gpu_f32, basic_yxfb_to_bfyx_input_padding)
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 
 }
@@ -1150,7 +1150,7 @@ TEST(reorder_gpu_f32, basic_bfyx_to_yxfb_input_padding)
     for (int i = 0; i < 16; i++)
     {
         out.push_back(output_ptr[i]);
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 
 }
@@ -1215,7 +1215,7 @@ TEST(reorder_gpu_f32, basic_bfyx_to_bfzyx)
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1346,7 +1346,7 @@ TEST(reorder_gpu_f32, basic_yxfb_to_bfzyx)
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1434,7 +1434,7 @@ TEST(reorder_gpu_f32, basic_bfzyx_to_bfyx)
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1485,8 +1485,8 @@ TEST(reorder_gpu_opt, remove_redundant_activation_fuse)
     net.set_input_data("in", in);
     auto outputs = net.execute();
     cldnn::mem_lock<float> out_ptr(outputs.begin()->second.get_memory(), get_test_stream());
-    EXPECT_FLOAT_EQ(out_ptr[0], -0.02f);
-    EXPECT_FLOAT_EQ(out_ptr[1], -0.02f);
+    ASSERT_FLOAT_EQ(out_ptr[0], -0.02f);
+    ASSERT_FLOAT_EQ(out_ptr[1], -0.02f);
 }
 
 TEST(reorder_gpu_opt, basic_remove_redundant_output_due_to_implicit_reorders)
@@ -1604,7 +1604,7 @@ TEST(reorder_gpu_opt, mean_mul)
     cldnn::mem_lock<float> ptr(output, get_test_stream());
     float* a_ptr = answers;
     for (auto& val : ptr)
-        EXPECT_FLOAT_EQ(*(a_ptr++), val);
+        ASSERT_FLOAT_EQ(*(a_ptr++), val);
 
 }
 
@@ -1639,7 +1639,7 @@ TEST(reorder_gpu_opt, mean_div)
     cldnn::mem_lock<float> ptr(output, get_test_stream());
     float* a_ptr = answers;
     for (auto& val : ptr)
-        EXPECT_FLOAT_EQ(*(a_ptr++), val);
+        ASSERT_FLOAT_EQ(*(a_ptr++), val);
 
 }
 
@@ -1670,7 +1670,7 @@ TEST(reorder_gpu_opt, mean_mul_val)
     cldnn::mem_lock<float> ptr(output, get_test_stream());
     float* a_ptr = answers;
     for (auto& val : ptr)
-        EXPECT_FLOAT_EQ(*(a_ptr++), val);
+        ASSERT_FLOAT_EQ(*(a_ptr++), val);
 }
 
 TEST(reorder_gpu_opt, mean_mul_val_float_to_int)
@@ -1952,7 +1952,7 @@ TEST(reorder_gpu_f32, bfwzyx_bfyx_chain)
 
     for (size_t i = 0; i < expected.size(); i++)
     {
-        EXPECT_FLOAT_EQ(expected[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(expected[i], output_ptr[i]);
     }
 }
 
@@ -2025,7 +2025,7 @@ TEST(reorder_gpu_f32, bfzyx_to_bsv16_fsv16)
                                                                           0, z, 0,
                                                                           0, y, 0,
                                                                           0, x, 0);
-                        EXPECT_FLOAT_EQ(input_ptr[linear_index++], output_ptr[bsv16_fsv16_index]);
+                        ASSERT_FLOAT_EQ(input_ptr[linear_index++], output_ptr[bsv16_fsv16_index]);
                     }
                 }
             }
@@ -2107,7 +2107,7 @@ TEST(reorder_gpu_f32, bfzyx_to_bsv16_fsv16_padded)
                                                                           z_pad, z, z_pad,
                                                                           y_pad, y, y_pad,
                                                                           x_pad, x, x_pad);
-                        EXPECT_FLOAT_EQ(input_ptr[linear_index++], output_ptr[bsv16_fsv16_index]);
+                        ASSERT_FLOAT_EQ(input_ptr[linear_index++], output_ptr[bsv16_fsv16_index]);
                     }
                 }
             }
@@ -2155,7 +2155,7 @@ TEST(reorder_gpu_f32, b_fs_yx_fsv16_to_bfyx_opt_allowed)
     ASSERT_EQ(output_ptr.size(), 24);
     for (size_t i = 0; i < output_ptr.size(); i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]) << "i=" << i;
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]) << "i=" << i;
     }
 }
 
@@ -2198,7 +2198,7 @@ TEST(reorder_gpu_f32, b_fs_yx_fsv16_to_bfyx_opt_not_allowed)
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 1; i++)
     {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]) << "i=" << i;
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]) << "i=" << i;
     }
 }
 
@@ -2257,7 +2257,7 @@ TEST(reorder_gpu_f32, b_fs_yx_fsv16_to_bfyx_opt_padded)
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     ASSERT_EQ(output_ptr.size(), 8);
     for (size_t i = 0; i < output_ptr.size(); i++) {
-        EXPECT_FLOAT_EQ(answers[i], output_ptr[i]) << "i=" << i;
+        ASSERT_FLOAT_EQ(answers[i], output_ptr[i]) << "i=" << i;
     }
 }
 
@@ -2326,7 +2326,7 @@ TEST(reorder_image2d_rgba_to_bfyx_gpu, basic)
     cldnn::mem_lock<FLOAT16> output_ptr (output, get_test_stream());
     for (int i = 0; i < 12; i++)
     {
-        EXPECT_NEAR(FLOAT16(answers[i] / 255.f), output_ptr[i], 1e-3f);
+        ASSERT_NEAR(FLOAT16(answers[i] / 255.f), output_ptr[i], 1e-3f);
     }
 
 }

--- a/src/plugins/intel_gpu/tests/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reorder_gpu_test.cpp
@@ -36,7 +36,7 @@ static void compare_result(std::map<cldnn::primitive_id, cldnn::network_output> 
     const size_t output_size = output_ref_ptr.size();
     for (size_t i = 0; i < output_size; i++)
     {
-        EXPECT_EQ(output_ref_ptr[i], output_opt_ptr[i]);
+        ASSERT_EQ(output_ref_ptr[i], output_opt_ptr[i]);
     }
 }
 
@@ -271,8 +271,8 @@ TEST(reorder_gpu_optimization, bfyx_to_fsv16_without_f_remainder) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
     mem_lock<float> output_ptr{output, get_test_stream()};
@@ -358,8 +358,8 @@ TEST(reorder_gpu_f32, basic) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -451,8 +451,8 @@ TEST(reorder_gpu_f32, basic_subtract) {
     network.set_input_data("subtract", subtract);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -532,8 +532,8 @@ TEST(reorder_gpu_f32, basic_subtract_value) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -553,7 +553,7 @@ TEST(reorder_gpu_f32, basic_subtract_value) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -594,7 +594,7 @@ TEST(reorder_gpu_f16, basic_subtract_f32_output_f32) {
     if (!engine.get_device_info().supports_fp16)
     {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -630,8 +630,8 @@ TEST(reorder_gpu_f16, basic_subtract_f32_output_f32) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -651,7 +651,7 @@ TEST(reorder_gpu_f16, basic_subtract_f32_output_f32) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -688,7 +688,7 @@ TEST(reorder_gpu_f16, basic_subtract_value) {
     if (!engine.get_device_info().supports_fp16)
     {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -718,8 +718,8 @@ TEST(reorder_gpu_f16, basic_subtract_value) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -739,7 +739,7 @@ TEST(reorder_gpu_f16, basic_subtract_value) {
     cldnn::mem_lock<half_t> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(static_cast<uint16_t>(answers[i]), static_cast<uint16_t>(output_ptr[i])));
+        ASSERT_TRUE(are_equal(static_cast<uint16_t>(answers[i]), static_cast<uint16_t>(output_ptr[i])));
     }
 }
 
@@ -758,7 +758,7 @@ TEST(reorder_gpu, basic_convert_f16_f32_f16) {
     if (!engine.get_device_info().supports_fp16)
     {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -797,36 +797,36 @@ TEST(reorder_gpu, basic_convert_f16_f32_f16) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(2));
-    EXPECT_TRUE(outputs.find("reorder_f16_f32") != outputs.end());
-    EXPECT_TRUE(outputs.find("reorder_f32_f16") != outputs.end());
+    ASSERT_EQ(outputs.size(), size_t(2));
+    ASSERT_TRUE(outputs.find("reorder_f16_f32") != outputs.end());
+    ASSERT_TRUE(outputs.find("reorder_f32_f16") != outputs.end());
 
     auto interm = outputs.at("reorder_f16_f32").get_memory();
     cldnn::mem_lock<float> interm_ptr(interm, get_test_stream());
 
     // Sample positive.
-    EXPECT_TRUE(are_equal(interm_ptr[0x3400], 0.25f));
-    EXPECT_TRUE(are_equal(interm_ptr[0x3800], 0.5f));
-    EXPECT_TRUE(are_equal(interm_ptr[0x3C00], 1.0f));
-    EXPECT_TRUE(are_equal(interm_ptr[0x4000], 2.0f));
-    EXPECT_TRUE(are_equal(interm_ptr[0x4400], 4.0f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x3400], 0.25f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x3800], 0.5f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x3C00], 1.0f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x4000], 2.0f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x4400], 4.0f));
     // Sample negative.
-    EXPECT_TRUE(are_equal(interm_ptr[0x3400 + 0x7C00], -0.25f));
-    EXPECT_TRUE(are_equal(interm_ptr[0x3800 + 0x7C00], -0.5f));
-    EXPECT_TRUE(are_equal(interm_ptr[0x3C00 + 0x7C00], -1.0f));
-    EXPECT_TRUE(are_equal(interm_ptr[0x4000 + 0x7C00], -2.0f));
-    EXPECT_TRUE(are_equal(interm_ptr[0x4400 + 0x7C00], -4.0f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x3400 + 0x7C00], -0.25f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x3800 + 0x7C00], -0.5f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x3C00 + 0x7C00], -1.0f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x4000 + 0x7C00], -2.0f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x4400 + 0x7C00], -4.0f));
     // Special values.
-    EXPECT_TRUE(are_equal(interm_ptr[0xF800], std::numeric_limits<float>::infinity()));
-    EXPECT_TRUE(are_equal(interm_ptr[0xF801], -std::numeric_limits<float>::infinity()));
-    EXPECT_TRUE(are_equal(interm_ptr[0xF802], -0.0f));
-    EXPECT_TRUE(std::isnan(interm_ptr[0xF803]));
+    ASSERT_TRUE(are_equal(interm_ptr[0xF800], std::numeric_limits<float>::infinity()));
+    ASSERT_TRUE(are_equal(interm_ptr[0xF801], -std::numeric_limits<float>::infinity()));
+    ASSERT_TRUE(are_equal(interm_ptr[0xF802], -0.0f));
+    ASSERT_TRUE(std::isnan(interm_ptr[0xF803]));
 
     auto output = outputs.at("reorder_f32_f16").get_memory();
     cldnn::mem_lock<half_t> output_ptr(output, get_test_stream());
     for (int i = 0; i < 0xF802; ++i) // NOTE: do not test for possibly ambiguous values of floating point (-0, NaNs).
     {
-        EXPECT_TRUE(are_equal(static_cast<uint16_t>(expected_values[i]), static_cast<uint16_t>(output_ptr[i])));
+        ASSERT_TRUE(are_equal(static_cast<uint16_t>(expected_values[i]), static_cast<uint16_t>(output_ptr[i])));
     }
 }
 
@@ -874,7 +874,7 @@ TEST(reorder_gpu, basic_convert_int8) {
     unsigned int cntr = 0;
     for (const auto& exp : final_results)
     {
-        EXPECT_EQ(exp, interm_ptr[cntr++]);
+        ASSERT_EQ(exp, interm_ptr[cntr++]);
     }
 }
 
@@ -894,7 +894,7 @@ TEST(reorder_gpu, basic_convert_uint8rgbabyxf_to_fp32_bfyx) {
     if (!engine.get_device_info().supports_fp16)
     {
         std::cout << "[ SKIPPED ] The test is skipped (cl_khr_fp16 is not supported)." << std::endl;
-        EXPECT_EQ(1, 1);
+        ASSERT_EQ(1, 1);
         return;
     }
 
@@ -951,17 +951,17 @@ TEST(reorder_gpu, basic_convert_uint8rgbabyxf_to_fp32_bfyx) {
     network.set_input_data("input", input_memory);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(2));
-    EXPECT_TRUE(outputs.find("reorder_input") != outputs.end());
-    EXPECT_TRUE(outputs.find("crop") != outputs.end());
+    ASSERT_EQ(outputs.size(), size_t(2));
+    ASSERT_TRUE(outputs.find("reorder_input") != outputs.end());
+    ASSERT_TRUE(outputs.find("crop") != outputs.end());
 
     auto interm = outputs.at("reorder_input").get_memory();
     cldnn::mem_lock<float> interm_ptr(interm, get_test_stream());
     auto interm_size = outputs.at("reorder_input").get_memory()->count();
-    EXPECT_EQ(interm_size,(size_t) (1*feature_size*kernel_size*kernel_size));
+    ASSERT_EQ(interm_size,(size_t) (1*feature_size*kernel_size*kernel_size));
 
     // Sample positive.
-    EXPECT_TRUE(are_equal(interm_ptr[0], 1.0f));
+    ASSERT_TRUE(are_equal(interm_ptr[0], 1.0f));
     size_t source_index = 0;
     size_t target_index = 0;
     std::vector<uint8_t> testinput;// This will be used to direct access elements of test input in the next test
@@ -974,14 +974,14 @@ TEST(reorder_gpu, basic_convert_uint8rgbabyxf_to_fp32_bfyx) {
         size_t current_x = (source_index / feature_size) % kernel_size;
         size_t current_y = (source_index / (feature_size * kernel_size));
         target_index = current_x + current_y*kernel_size + current_feature*(kernel_size*kernel_size);
-        EXPECT_TRUE(are_equal(val, interm_ptr[target_index]));
+        ASSERT_TRUE(are_equal(val, interm_ptr[target_index]));
         source_index++;
     }
 
     auto output = outputs.at("crop").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     auto output_size = output->count();
-    EXPECT_EQ(output_size,(size_t) (1 * (feature_size-1)*kernel_size*kernel_size));
+    ASSERT_EQ(output_size,(size_t) (1 * (feature_size-1)*kernel_size*kernel_size));
 
     for (target_index = 0; target_index < output_size; target_index++)
     {
@@ -991,7 +991,7 @@ TEST(reorder_gpu, basic_convert_uint8rgbabyxf_to_fp32_bfyx) {
         size_t current_feature = target_index / (kernel_size*kernel_size);
 
         source_index = current_x*feature_size + current_y*(kernel_size*feature_size) + current_feature;
-        EXPECT_TRUE(are_equal(output_val, testinput[source_index]));
+        ASSERT_TRUE(are_equal(output_val, testinput[source_index]));
     }
 
 }
@@ -1048,8 +1048,8 @@ TEST(reorder_gpu_f32, basic_yxfb_to_bfyx_input_padding)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder2");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder2");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1127,8 +1127,8 @@ TEST(reorder_gpu_f32, basic_bfyx_to_yxfb_input_padding)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder2");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder2");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1186,17 +1186,17 @@ TEST(reorder_gpu_f32, basic_bfyx_to_bfzyx)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
-    EXPECT_TRUE(output->get_layout().format == format::bfzyx);
+    ASSERT_TRUE(output->get_layout().format == format::bfzyx);
     auto l = output->get_layout();
-    EXPECT_TRUE(l.batch() == 2);
-    EXPECT_TRUE(l.feature() == 2);
-    EXPECT_TRUE(l.spatial(0) == 2);
-    EXPECT_TRUE(l.spatial(1) == 2);
-    EXPECT_TRUE(l.spatial(2) == 1);
+    ASSERT_TRUE(l.batch() == 2);
+    ASSERT_TRUE(l.feature() == 2);
+    ASSERT_TRUE(l.spatial(0) == 2);
+    ASSERT_TRUE(l.spatial(1) == 2);
+    ASSERT_TRUE(l.spatial(2) == 1);
 
     float answers[16] = {
         1.f, 0.f,
@@ -1257,14 +1257,14 @@ TEST(reorder_gpu_f32, dynamic_bfyx_to_bfzyx) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
-    EXPECT_TRUE(output->get_layout().format == format::bfzyx);
+    ASSERT_TRUE(output->get_layout().format == format::bfzyx);
     auto l = output->get_layout();
     auto expected_shape = ov::PartialShape(in_shape);
-    EXPECT_EQ(l.get_partial_shape(), expected_shape);
+    ASSERT_EQ(l.get_partial_shape(), expected_shape);
 
     float answers[16] = {
         1.f, 0.f,
@@ -1317,17 +1317,17 @@ TEST(reorder_gpu_f32, basic_yxfb_to_bfzyx)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
-    EXPECT_TRUE(output->get_layout().format == format::bfzyx);
+    ASSERT_TRUE(output->get_layout().format == format::bfzyx);
     auto l = output->get_layout();
-    EXPECT_TRUE(l.batch() == 2);
-    EXPECT_TRUE(l.feature() == 2);
-    EXPECT_TRUE(l.spatial(0) == 2);
-    EXPECT_TRUE(l.spatial(1) == 2);
-    EXPECT_TRUE(l.spatial(2) == 1);
+    ASSERT_TRUE(l.batch() == 2);
+    ASSERT_TRUE(l.feature() == 2);
+    ASSERT_TRUE(l.spatial(0) == 2);
+    ASSERT_TRUE(l.spatial(1) == 2);
+    ASSERT_TRUE(l.spatial(2) == 1);
 
     float answers[16] = {
         1.0f,  2.0f,
@@ -1393,17 +1393,17 @@ TEST(reorder_gpu_f32, basic_bfzyx_to_bfyx)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
-    EXPECT_TRUE(output->get_layout().format == format::bfyx);
+    ASSERT_TRUE(output->get_layout().format == format::bfyx);
     auto l = output->get_layout();
-    EXPECT_TRUE(l.batch() == 2);
-    EXPECT_TRUE(l.feature() == 2);
-    EXPECT_TRUE(l.spatial(0) == 2);
-    EXPECT_TRUE(l.spatial(1) == 4);
-    EXPECT_TRUE(l.spatial(2) == 1);
+    ASSERT_TRUE(l.batch() == 2);
+    ASSERT_TRUE(l.feature() == 2);
+    ASSERT_TRUE(l.spatial(0) == 2);
+    ASSERT_TRUE(l.spatial(1) == 4);
+    ASSERT_TRUE(l.spatial(2) == 1);
 
     float answers[32] = {
         1.f, 0.f,
@@ -1457,9 +1457,9 @@ TEST(reorder_gpu_opt, basic_remove_redundant)
     auto outputs = net.execute();
     auto executed_primitives = net.get_executed_primitives();
 
-    EXPECT_TRUE(executed_primitives.count("r1") == 0);
+    ASSERT_TRUE(executed_primitives.count("r1") == 0);
     ASSERT_TRUE(outputs.count("r2") == 1);
-    EXPECT_TRUE(outputs.at("r2").get_memory()->get_layout().format == format::yxfb);
+    ASSERT_TRUE(outputs.at("r2").get_memory()->get_layout().format == format::yxfb);
 }
 
 TEST(reorder_gpu_opt, remove_redundant_activation_fuse)
@@ -1512,9 +1512,9 @@ TEST(reorder_gpu_opt, basic_remove_redundant_output_due_to_implicit_reorders)
     net.set_input_data("in", in);
     auto outputs = net.execute();
 
-    EXPECT_TRUE(outputs.count("conv") == 0);
+    ASSERT_TRUE(outputs.count("conv") == 0);
     ASSERT_TRUE(outputs.count("r1") == 1);
-    EXPECT_TRUE(outputs.at("r1").get_memory()->get_layout().format == format::bfyx);
+    ASSERT_TRUE(outputs.at("r1").get_memory()->get_layout().format == format::bfyx);
 }
 
 TEST(reorder_gpu_opt, basic_remove_redundant_due_to_implicit_reorders)
@@ -1540,10 +1540,10 @@ TEST(reorder_gpu_opt, basic_remove_redundant_due_to_implicit_reorders)
     auto executed_primitives = net.get_executed_primitives();
 
     //remove redundant reorder optimization should remove r1 node
-    EXPECT_TRUE(executed_primitives.count("r1") == 0);
+    ASSERT_TRUE(executed_primitives.count("r1") == 0);
     //all pirmitives in this test needs to be executed
     ASSERT_TRUE(outputs.count("output") == 1);
-    EXPECT_TRUE(outputs.at("output").get_memory()->get_layout().format == format::bfyx);
+    ASSERT_TRUE(outputs.at("output").get_memory()->get_layout().format == format::bfyx);
 }
 
 TEST(reorder_gpu_opt, non_trivial_remove_redundant)
@@ -1568,9 +1568,9 @@ TEST(reorder_gpu_opt, non_trivial_remove_redundant)
 
     ASSERT_TRUE(executed_primitives.count("in") == 1);
     //ASSERT_TRUE(all_primitives.at("r1") == "_optimized_");
-    EXPECT_TRUE(executed_primitives.at("in") != outputs.at("r1").get_event());
+    ASSERT_TRUE(executed_primitives.at("in") != outputs.at("r1").get_event());
     ASSERT_TRUE(outputs.count("r1") == 1);
-    EXPECT_TRUE(outputs.at("r1").get_memory()->get_layout().format == format::bfyx);
+    ASSERT_TRUE(outputs.at("r1").get_memory()->get_layout().format == format::bfyx);
 }
 
 TEST(reorder_gpu_opt, mean_mul)
@@ -1700,7 +1700,7 @@ TEST(reorder_gpu_opt, mean_mul_val_float_to_int)
     cldnn::mem_lock<char> ptr(output, get_test_stream());
     char* a_ptr = answers;
     for (auto& val : ptr)
-        EXPECT_EQ(*(a_ptr++), val);
+        ASSERT_EQ(*(a_ptr++), val);
 }
 
 TEST(reorder_gpu_i32, basic)
@@ -1726,8 +1726,8 @@ TEST(reorder_gpu_i32, basic)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1741,7 +1741,7 @@ TEST(reorder_gpu_i32, basic)
     int32_t* a_ptr = answers;
     cldnn::mem_lock<int32_t> output_ptr(output, get_test_stream());
     for (auto& val : output_ptr)
-        EXPECT_EQ(*(a_ptr++), val);
+        ASSERT_EQ(*(a_ptr++), val);
 }
 
 TEST(reorder_gpu_i64, basic)
@@ -1767,8 +1767,8 @@ TEST(reorder_gpu_i64, basic)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -1782,7 +1782,7 @@ TEST(reorder_gpu_i64, basic)
     int64_t* a_ptr = answers;
     cldnn::mem_lock<int64_t> output_ptr(output, get_test_stream());
     for (auto& val : output_ptr)
-        EXPECT_EQ(*(a_ptr++), val);
+        ASSERT_EQ(*(a_ptr++), val);
 }
 
 TEST(reorder_gpu_binary, binary_output)
@@ -1812,8 +1812,8 @@ TEST(reorder_gpu_binary, binary_output)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
     cldnn::mem_lock<uint32_t> output_ptr(output, get_test_stream());
@@ -1829,7 +1829,7 @@ TEST(reorder_gpu_binary, binary_output)
     ASSERT_EQ(output->size(), answers.size() * sizeof(uint32_t));
 
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_EQ(answers[i], output_ptr[i]) << "index: " << i;
+        ASSERT_EQ(answers[i], output_ptr[i]) << "index: " << i;
     }
 }
 
@@ -1863,8 +1863,8 @@ TEST(reorder_gpu_binary, binary_input)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -1876,7 +1876,7 @@ TEST(reorder_gpu_binary, binary_input)
     ASSERT_EQ(output->size(), answers.size() * sizeof(float));
 
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_EQ(answers[i], output_ptr[i]) << "index: " << i;
+        ASSERT_EQ(answers[i], output_ptr[i]) << "index: " << i;
     }
 }
 
@@ -1935,17 +1935,17 @@ TEST(reorder_gpu_f32, bfwzyx_bfyx_chain)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "out_reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out_reorder");
 
     auto output = outputs.begin()->second.get_memory();
-    EXPECT_TRUE(output->get_layout().format == format::bfwzyx);
+    ASSERT_TRUE(output->get_layout().format == format::bfwzyx);
     auto l = output->get_layout();
-    EXPECT_EQ(l.batch(), 1);
-    EXPECT_EQ(l.feature(), 4);
-    EXPECT_EQ(l.spatial(0), 2);
-    EXPECT_EQ(l.spatial(1), 2);
-    EXPECT_EQ(l.spatial(2), 1);
+    ASSERT_EQ(l.batch(), 1);
+    ASSERT_EQ(l.feature(), 4);
+    ASSERT_EQ(l.spatial(0), 2);
+    ASSERT_EQ(l.spatial(1), 2);
+    ASSERT_EQ(l.spatial(2), 1);
 
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     ASSERT_EQ(output_ptr.size(), expected.size());
@@ -1978,8 +1978,8 @@ TEST(reorder_gpu_f32, bfzyx_to_bsv16_fsv16)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -2060,8 +2060,8 @@ TEST(reorder_gpu_f32, bfzyx_to_bsv16_fsv16_padded)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -2140,9 +2140,9 @@ TEST(reorder_gpu_f32, b_fs_yx_fsv16_to_bfyx_opt_allowed)
 
     auto executed_prims = network.get_executed_primitives();
 
-    EXPECT_TRUE(executed_prims.find(reorder_name) == executed_prims.end());
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "second_activation");
+    ASSERT_TRUE(executed_prims.find(reorder_name) == executed_prims.end());
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "second_activation");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -2188,8 +2188,8 @@ TEST(reorder_gpu_f32, b_fs_yx_fsv16_to_bfyx_opt_not_allowed)
     auto executed_prims = network.get_executed_primitive_ids();
 
     EXPECT_FALSE(std::find(executed_prims.begin(), executed_prims.end(), reorder_primitive_name) != executed_prims.end());
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "convolution");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "convolution");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -2243,9 +2243,9 @@ TEST(reorder_gpu_f32, b_fs_yx_fsv16_to_bfyx_opt_padded)
 
     auto executed_prims = network.get_executed_primitives();
 
-    EXPECT_TRUE(executed_prims.find(reorder_name) == executed_prims.end());
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "activation");
+    ASSERT_TRUE(executed_prims.find(reorder_name) == executed_prims.end());
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "activation");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -2281,7 +2281,7 @@ TEST(reorder_gpu, any_format) {
     cldnn::mem_lock<float> output(out_mem, get_test_stream());
 
     for (size_t i = 0; i < data.size(); ++i) {
-        EXPECT_EQ(output[i], data[i]) << "i = " << i;
+        ASSERT_EQ(output[i], data[i]) << "i = " << i;
     }
 }
 
@@ -2307,8 +2307,8 @@ TEST(reorder_image2d_rgba_to_bfyx_gpu, basic)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -2357,8 +2357,8 @@ TEST(reorder_bfyx_to_image2d_rgba_gpu, basic)
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -2372,7 +2372,7 @@ TEST(reorder_bfyx_to_image2d_rgba_gpu, basic)
     cldnn::mem_lock<unsigned char> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 
 }
@@ -2621,7 +2621,7 @@ TEST_P(testing_removal_reorder, removal_reorder_1d_along_f) {
 
     execute(p);
 
-    EXPECT_EQ(check_optimized_out(p, "reorder_bias1"), true);
+    ASSERT_EQ(check_optimized_out(p, "reorder_bias1"), true);
 }
 
 // Testing bugfix not to remove reorder in front of conv has deep depth input
@@ -2644,7 +2644,7 @@ TEST_P(testing_removal_reorder, only_remove_reorder_shallow_depth_input) {
 
     execute(p);
 
-    EXPECT_EQ(check_optimized_out(p, "reorder_conv"), false);
+    ASSERT_EQ(check_optimized_out(p, "reorder_conv"), false);
 }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
@@ -2674,7 +2674,7 @@ TEST_P(testing_removal_reorder, removal_no_padded_reorder) {
 
     execute(p);
 
-    EXPECT_EQ(check_optimized_out(p, "reorder_conv"), true);
+    ASSERT_EQ(check_optimized_out(p, "reorder_conv"), true);
 }
 
 // Check not to remove reorder between onednn and cldnn conv if the reorder has padded output
@@ -2703,7 +2703,7 @@ TEST_P(testing_removal_reorder, removal_padded_reorder) {
 
     execute(p);
 
-    EXPECT_EQ(check_optimized_out(p, "reorder_conv"), false);
+    ASSERT_EQ(check_optimized_out(p, "reorder_conv"), false);
 }
 #endif // ENABLE_ONEDNN_FOR_GPU
 
@@ -2763,7 +2763,7 @@ TEST(reorder_onednn_gpu, basic_convert_int8) {
     unsigned int cntr = 0;
     for (const auto& exp : final_results)
     {
-        EXPECT_EQ(exp, interm_ptr[cntr++]);
+        ASSERT_EQ(exp, interm_ptr[cntr++]);
     }
 }
 #endif // ENABLE_ONEDNN_FOR_GPU

--- a/src/plugins/intel_gpu/tests/test_cases/reorg_yolo_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reorg_yolo_gpu_test.cpp
@@ -329,7 +329,7 @@ private:
 
         ASSERT_EQ(params.expected.size(), out_ptr.size());
         for (size_t i = 0; i < params.expected.size(); ++i) {
-            EXPECT_NEAR(params.expected[i], out_ptr[i], getError<T>()) << "format=" << target_format << ", i= " << i;
+            ASSERT_NEAR(params.expected[i], out_ptr[i], getError<T>()) << "format=" << target_format << ", i= " << i;
         }
     }
 };

--- a/src/plugins/intel_gpu/tests/test_cases/resample_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/resample_gpu_test.cpp
@@ -134,7 +134,7 @@ TEST(resample_gpu, basic_in2x3x2x2_bilinear) {
     for (int k = 0; k < 4; ++k) { // Y
         for (int l = 0; l < 4; ++l) { // X
             auto linear_id = l + k * 4;
-            EXPECT_NEAR(answers[linear_id], output_ptr[linear_id], 1e-05F);
+            ASSERT_NEAR(answers[linear_id], output_ptr[linear_id], 1e-05F);
         }
     }
 }
@@ -185,7 +185,7 @@ TEST(resample_gpu, nearest_asymmetric) {
     for (int k = 0; k < 4; ++k) { // Y
         for (int l = 0; l < 5; ++l) { // X
             auto linear_id = l + k * 5;
-            EXPECT_NEAR(answers[linear_id], output_ptr[linear_id], 1e-05F);
+            ASSERT_NEAR(answers[linear_id], output_ptr[linear_id], 1e-05F);
         }
     }
 }
@@ -287,7 +287,7 @@ TEST(resample_gpu, bilinear_asymmetric) {
     for (int k = 0; k < 4; ++k) { // Y
         for (int l = 0; l < 6; ++l) { // X
             auto linear_id = l + k * 6;
-            EXPECT_NEAR(answers[linear_id], output_ptr[linear_id], 5e-03F) << l << " " << k;
+            ASSERT_NEAR(answers[linear_id], output_ptr[linear_id], 5e-03F) << l << " " << k;
         }
     }
 }
@@ -1852,7 +1852,7 @@ TYPED_TEST(onnx_5d_format, interpolate_linear_onnx5d)
         ASSERT_EQ(this->expected_results[i].size(), output_ptr.size());
         for (size_t j = 0; j < this->expected_results[i].size(); ++j) {
             //ASSERT_TRUE(are_equal(expected_results[i][j], output_ptr[i])) << i;
-            EXPECT_NEAR(this->expected_results[i][j], output_ptr[j], 0.001) << j;
+            ASSERT_NEAR(this->expected_results[i][j], output_ptr[j], 0.001) << j;
         }
 
         ++i;

--- a/src/plugins/intel_gpu/tests/test_cases/resample_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/resample_gpu_test.cpp
@@ -81,7 +81,7 @@ TEST(resample_gpu, basic_in2x3x2x2_nearest) {
             for (int k = 0; k < 4; ++k) { // Y
                 for (int l = 0; l < 6; ++l) { // X
                     auto linear_id = l + k * 6 + j * 4 * 6 + i * 2 * 4 * 6;
-                    EXPECT_TRUE(are_equal(answers[linear_id], output_ptr[linear_id]));
+                    ASSERT_TRUE(are_equal(answers[linear_id], output_ptr[linear_id]));
                 }
             }
         }
@@ -122,7 +122,7 @@ TEST(resample_gpu, basic_in2x3x2x2_bilinear) {
     auto output = outputs.at("upsampling").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
-    EXPECT_EQ(output->get_layout().get_linear_size(), (size_t) 16);
+    ASSERT_EQ(output->get_layout().get_linear_size(), (size_t) 16);
 
     float answers[16] = {
         1.f, 1.25f, 1.75f, 2.f,
@@ -173,7 +173,7 @@ TEST(resample_gpu, nearest_asymmetric) {
     auto output = outputs.at("upsampling").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
-    EXPECT_EQ(output->get_layout().get_linear_size(), (size_t)20);
+    ASSERT_EQ(output->get_layout().get_linear_size(), (size_t)20);
 
     float answers[20] = {
         1.f, 1.f, 1.f, 2.f, 2.f,
@@ -224,7 +224,7 @@ TEST(resample_gpu, nearest_asymmetric_i8) {
     auto output = outputs.at("upsampling").get_memory();
     cldnn::mem_lock<int8_t> output_ptr(output, get_test_stream());
 
-    EXPECT_EQ(output->get_layout().get_linear_size(), (size_t)20);
+    ASSERT_EQ(output->get_layout().get_linear_size(), (size_t)20);
 
     int8_t answers[20] = {
             1, 1, 1, 2, 2,
@@ -236,7 +236,7 @@ TEST(resample_gpu, nearest_asymmetric_i8) {
     for (int k = 0; k < 4; ++k) { // Y
         for (int l = 0; l < 5; ++l) { // X
             auto linear_id = l + k * 5;
-            EXPECT_EQ(answers[linear_id], output_ptr[linear_id]);
+            ASSERT_EQ(answers[linear_id], output_ptr[linear_id]);
         }
     }
 }
@@ -275,7 +275,7 @@ TEST(resample_gpu, bilinear_asymmetric) {
     auto output = outputs.at("upsampling").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
-    EXPECT_EQ(output->get_layout().get_linear_size(), (size_t)24);
+    ASSERT_EQ(output->get_layout().get_linear_size(), (size_t)24);
 
     float answers[24] = {
         1.f, 1.f, 1.33333f, 1.66667f, 2.f, 2.f,
@@ -373,7 +373,7 @@ struct resample_random_test : testing::TestWithParam<resample_random_test_params
                         auto out_coords = tensor(batch(bi), feature(fi), spatial(xi, yi, 0, 0));
                         auto out_offset = output->get_layout().get_linear_offset(out_coords);
                         auto out_val = out_ptr[out_offset];
-                        EXPECT_EQ(in_val, out_val) << " at bi=" << bi << ", fi=" << fi << ", xi=" << xi << ", yi=" << yi;
+                        ASSERT_EQ(in_val, out_val) << " at bi=" << bi << ", fi=" << fi << ", xi=" << xi << ", yi=" << yi;
                     }
                 }
             }
@@ -586,7 +586,7 @@ struct caffe_resample_random_test : testing::TestWithParam<caffe_resample_random
     }
 
     template <typename T>
-    bool compare_outputs(const memory::ptr out_ref, const memory::ptr out_opt) {
+    void compare_outputs(const memory::ptr out_ref, const memory::ptr out_opt) {
         auto output_lay = out_ref->get_layout();
         auto opt_output_lay = out_opt->get_layout();
 
@@ -607,15 +607,12 @@ struct caffe_resample_random_test : testing::TestWithParam<caffe_resample_random
                         auto opt_out_offset = opt_output_lay.get_linear_offset(ref_out_coords);
                         auto opt_out_val = opt_ptr[opt_out_offset];
 
-                        EXPECT_EQ(ref_out_offset, opt_out_offset);
-                        EXPECT_EQ(opt_out_val, ref_out_val);
-                        // EXPECT_NEAR(static_cast<float>(opt_out_val), static_cast<float>(ref_out_val), 1.e-1f);
+                        ASSERT_EQ(ref_out_offset, opt_out_offset);
+                        ASSERT_EQ(opt_out_val, ref_out_val);
                     }
                 }
             }
         }
-
-        return true;
     }
 
     void execute_compare(const caffe_resample_random_test_params& params, bool check_result) {
@@ -803,7 +800,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_nearest1) {
             for (int k = 0; k < 4; ++k) { // Y
                 for (int l = 0; l < 6; ++l) { // X
                     auto linear_id = l + k * 6 + j * 4 * 6 + i * 2 * 4 * 6;
-                    EXPECT_TRUE(are_equal(answers[linear_id], output_ptr[linear_id])) << linear_id;
+                    ASSERT_TRUE(are_equal(answers[linear_id], output_ptr[linear_id])) << linear_id;
                 }
             }
         }
@@ -893,7 +890,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_nearest2) {
             for (int k = 0; k < 4; ++k) { // Y
                 for (int l = 0; l < 6; ++l) { // X
                     auto linear_id = l + k * 6 + j * 4 * 6 + i * 2 * 4 * 6;
-                    EXPECT_TRUE(are_equal(answers[linear_id], output_ptr[linear_id])) << linear_id;
+                    ASSERT_TRUE(are_equal(answers[linear_id], output_ptr[linear_id])) << linear_id;
                 }
             }
         }
@@ -983,7 +980,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_nearest3) {
             for (int k = 0; k < 4; ++k) { // Y
                 for (int l = 0; l < 6; ++l) { // X
                     auto linear_id = l + k * 6 + j * 4 * 6 + i * 2 * 4 * 6;
-                    EXPECT_TRUE(are_equal(answers[linear_id], output_ptr[linear_id])) << linear_id;
+                    ASSERT_TRUE(are_equal(answers[linear_id], output_ptr[linear_id])) << linear_id;
                 }
             }
         }
@@ -1073,7 +1070,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_nearest4) {
             for (int k = 0; k < 4; ++k) { // Y
                 for (int l = 0; l < 6; ++l) { // X
                     auto linear_id = l + k * 6 + j * 4 * 6 + i * 2 * 4 * 6;
-                    EXPECT_TRUE(are_equal(answers[linear_id], output_ptr[linear_id])) << linear_id;
+                    ASSERT_TRUE(are_equal(answers[linear_id], output_ptr[linear_id])) << linear_id;
                 }
             }
         }
@@ -1163,7 +1160,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_nearest5) {
             for (int k = 0; k < 4; ++k) { // Y
                 for (int l = 0; l < 6; ++l) { // X
                     auto linear_id = l + k * 6 + j * 4 * 6 + i * 2 * 4 * 6;
-                    EXPECT_TRUE(are_equal(answers[linear_id], output_ptr[linear_id])) << linear_id;
+                    ASSERT_TRUE(are_equal(answers[linear_id], output_ptr[linear_id])) << linear_id;
                 }
             }
         }
@@ -1236,7 +1233,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_coord_transform_mode1) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -1300,7 +1297,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_coord_transform_mode2) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -1370,7 +1367,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_coord_transform_mode3) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -1440,7 +1437,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_coord_transform_mode4) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -1510,7 +1507,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_coord_transform_mode5) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -1578,7 +1575,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_cubic) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -1631,7 +1628,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_cubic2) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -1699,7 +1696,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_linear) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -1854,7 +1851,7 @@ TYPED_TEST(onnx_5d_format, interpolate_linear_onnx5d)
 
         ASSERT_EQ(this->expected_results[i].size(), output_ptr.size());
         for (size_t j = 0; j < this->expected_results[i].size(); ++j) {
-            //EXPECT_TRUE(are_equal(expected_results[i][j], output_ptr[i])) << i;
+            //ASSERT_TRUE(are_equal(expected_results[i][j], output_ptr[i])) << i;
             EXPECT_NEAR(this->expected_results[i][j], output_ptr[j], 0.001) << j;
         }
 
@@ -1911,7 +1908,7 @@ TEST(resample_gpu, interpolate_in1x1x2x4_linear_scale) {
 
     ASSERT_EQ(answers.size(), output_ptr.size());
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i])) << i;
     }
 }
 
@@ -1977,7 +1974,7 @@ struct resample_opt_random_test : testing::TestWithParam<resample_opt_random_tes
     }
 
     template <typename T>
-    bool compare_outputs(const memory::ptr out_ref, const memory::ptr out_opt) {
+    void compare_outputs(const memory::ptr out_ref, const memory::ptr out_opt) {
         auto output_lay = out_ref->get_layout();
         auto opt_output_lay = out_opt->get_layout();
 
@@ -1998,19 +1995,17 @@ struct resample_opt_random_test : testing::TestWithParam<resample_opt_random_tes
                             auto ref_out_val = ref_ptr[ref_out_offset];
                             auto opt_out_offset = opt_output_lay.get_linear_offset(ref_out_coords);
                             auto opt_out_val = opt_ptr[opt_out_offset];
-                            EXPECT_EQ(ref_out_offset, opt_out_offset);
+                            ASSERT_EQ(ref_out_offset, opt_out_offset);
                             if (std::is_same<T, FLOAT16>::value) {
-                                EXPECT_NEAR(static_cast<float>(opt_out_val), static_cast<float>(ref_out_val), 1.e-1f);
+                                ASSERT_NEAR(static_cast<float>(opt_out_val), static_cast<float>(ref_out_val), 1.e-1f);
                             } else {
-                                EXPECT_EQ(opt_out_val, ref_out_val);
+                                ASSERT_EQ(opt_out_val, ref_out_val);
                             }
                         }
                     }
                 }
             }
         }
-
-        return true;
     }
 
     void execute_compare(const resample_opt_random_test_params& params, bool check_result, const std::string& kernel = "resample_opt") {
@@ -2078,7 +2073,6 @@ struct resample_opt_random_test : testing::TestWithParam<resample_opt_random_tes
             }
         }
     }
-
 };
 
 struct resample_opt_random_test_ext : resample_opt_random_test

--- a/src/plugins/intel_gpu/tests/test_cases/reshape_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reshape_gpu_test.cpp
@@ -18,7 +18,7 @@ using namespace testing;
 
 namespace {
 void verify_float(const float& output_value, const float& value) {
-    EXPECT_FLOAT_EQ(output_value, value);
+    ASSERT_FLOAT_EQ(output_value, value);
 }
 
 void verify_int(const int32_t& output_value, const int32_t& value) {

--- a/src/plugins/intel_gpu/tests/test_cases/reshape_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reshape_gpu_test.cpp
@@ -22,7 +22,7 @@ void verify_float(const float& output_value, const float& value) {
 }
 
 void verify_int(const int32_t& output_value, const int32_t& value) {
-    EXPECT_EQ(output_value, value);
+    ASSERT_EQ(output_value, value);
 }
 
 template <class ElemType>
@@ -78,8 +78,8 @@ void generic_reshape_test(format fmt, tensor const& input_size, tensor const& re
     auto net_input = outputs.at(reshape_input).get_memory();
     auto output = outputs.at("reshape").get_memory();
 
-    EXPECT_EQ(output->get_layout().data_type, input->get_layout().data_type);        //reshape should not change data_type
-    EXPECT_TRUE(output->get_layout().format.value == input->get_layout().format.value);  //reshape should not change format
+    ASSERT_EQ(output->get_layout().data_type, input->get_layout().data_type);        //reshape should not change data_type
+    ASSERT_TRUE(output->get_layout().format.value == input->get_layout().format.value);  //reshape should not change format
 
     //output size should be equal to requested plus output padding
     ASSERT_TRUE(output->get_layout().get_tensor() == reshape_size);
@@ -467,13 +467,13 @@ TEST(reshape_gpu_f32, multiple_users_with_reorder) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < out1.size(); i++)
-        EXPECT_EQ(output_ptr[i], out1[i]);
+        ASSERT_EQ(output_ptr[i], out1[i]);
 
     auto output_2 = outputs.at("relu2").get_memory();
     cldnn::mem_lock<float> output_ptr_2(output_2, get_test_stream());
 
     for (size_t i = 0; i < out2.size(); i++)
-        EXPECT_EQ(output_ptr_2[i], out2[i]);
+        ASSERT_EQ(output_ptr_2[i], out2[i]);
 }
 
 TEST(reshape_gpu_f32, calc_output_shape) {
@@ -501,13 +501,13 @@ TEST(reshape_gpu_f32, calc_output_shape) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reshape");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reshape");
 
     auto output = outputs.at("reshape").get_memory();
 
-    EXPECT_EQ(output->get_layout().data_type, input->get_layout().data_type);
-    EXPECT_EQ(output->get_layout().format, input->get_layout().format);
+    ASSERT_EQ(output->get_layout().data_type, input->get_layout().data_type);
+    ASSERT_EQ(output->get_layout().format, input->get_layout().format);
 
     ASSERT_TRUE(output->get_layout().get_tensor() == tensor(1, 1, 1, 4));
 
@@ -515,7 +515,7 @@ TEST(reshape_gpu_f32, calc_output_shape) {
 
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     for (int i = 0; i < 4; i++) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -568,19 +568,19 @@ TEST(reshape_gpu_f32, basic_bfwzyx) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reshape");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reshape");
 
     auto output = outputs.at("reshape").get_memory();
 
-    EXPECT_EQ(output->get_layout().data_type, input->get_layout().data_type);
-    EXPECT_EQ(output->get_layout().format, input->get_layout().format);
+    ASSERT_EQ(output->get_layout().data_type, input->get_layout().data_type);
+    ASSERT_EQ(output->get_layout().format, input->get_layout().format);
 
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     ASSERT_EQ(output_ptr.size(), expected_out.size());
 
     for (size_t i = 0; i < expected_out.size(); i++) {
-        EXPECT_TRUE(are_equal(expected_out[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(expected_out[i], output_ptr[i]));
     }
 }
 
@@ -625,7 +625,7 @@ TEST(reshape_gpu_f32, shrink_chain_partial) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < out.size(); i++)
-        EXPECT_EQ(output_ptr[i], out[i]) << " i=" << i;
+        ASSERT_EQ(output_ptr[i], out[i]) << " i=" << i;
 }
 
 TEST(reshape_gpu_f32, shrink_chain_full) {
@@ -665,7 +665,7 @@ TEST(reshape_gpu_f32, shrink_chain_full) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < out.size(); i++)
-        EXPECT_EQ(output_ptr[i], out[i]) << " i=" << i;
+        ASSERT_EQ(output_ptr[i], out[i]) << " i=" << i;
 }
 
 TEST(reshape_gpu_f32, shrink_chain_out) {
@@ -700,7 +700,7 @@ TEST(reshape_gpu_f32, shrink_chain_out) {
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < out.size(); i++)
-        EXPECT_EQ(output_ptr[i], out[i]) << " i=" << i;
+        ASSERT_EQ(output_ptr[i], out[i]) << " i=" << i;
 }
 
 TEST(reshape_gpu_f32, basic_runtime_static_shape) {
@@ -735,13 +735,13 @@ TEST(reshape_gpu_f32, basic_runtime_static_shape) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reshape");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reshape");
 
     auto output = outputs.at("reshape").get_memory();
 
-    EXPECT_EQ(output->get_layout().data_type, input->get_layout().data_type);
-    EXPECT_EQ(output->get_layout().format, format::bfyx);
+    ASSERT_EQ(output->get_layout().data_type, input->get_layout().data_type);
+    ASSERT_EQ(output->get_layout().format, format::bfyx);
 
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     ASSERT_EQ(output_ptr.size(), input_data.size());
@@ -784,13 +784,13 @@ TEST(reshape_gpu_f32, basic_runtime_dynamic_shape) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reshape");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reshape");
 
     auto output = outputs.at("reshape").get_memory();
 
-    EXPECT_EQ(output->get_layout().data_type, input->get_layout().data_type);
-    EXPECT_EQ(output->get_layout().format, format::bfyx);
+    ASSERT_EQ(output->get_layout().data_type, input->get_layout().data_type);
+    ASSERT_EQ(output->get_layout().format, format::bfyx);
 
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     ASSERT_EQ(output_ptr.size(), input_data.size());
@@ -835,18 +835,18 @@ TEST(reshape_gpu_f32, basic_runtime_dynamic_shape_with_const) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reshape");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reshape");
 
     auto output = outputs.at("reshape").get_memory();
 
-    EXPECT_EQ(output->get_layout().data_type, input->get_layout().data_type);
-    EXPECT_EQ(output->get_layout().format, format::bfyx);
-    EXPECT_TRUE(output->get_layout().is_static());
+    ASSERT_EQ(output->get_layout().data_type, input->get_layout().data_type);
+    ASSERT_EQ(output->get_layout().format, format::bfyx);
+    ASSERT_TRUE(output->get_layout().is_static());
     std::vector<int32_t> ref_dims = {12, 3, 1, 1};
-    EXPECT_EQ(output->get_layout().get_dims(), ref_dims);
+    ASSERT_EQ(output->get_layout().get_dims(), ref_dims);
     ov::PartialShape ref_pshape = {12, 3};
-    EXPECT_EQ(output->get_layout().get_partial_shape(), ref_pshape);
+    ASSERT_EQ(output->get_layout().get_partial_shape(), ref_pshape);
 
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     ASSERT_EQ(output_ptr.size(), input_data.size());
@@ -892,18 +892,18 @@ TEST(reshape_gpu_f32, basic_runtime_dynamic_shape_with_const_optimized_out) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "reorder");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
 
     auto output = outputs.at("reorder").get_memory();
 
-    EXPECT_EQ(output->get_layout().data_type, input->get_layout().data_type);
-    EXPECT_EQ(output->get_layout().format, format::bfyx);
-    EXPECT_TRUE(output->get_layout().is_static());
+    ASSERT_EQ(output->get_layout().data_type, input->get_layout().data_type);
+    ASSERT_EQ(output->get_layout().format, format::bfyx);
+    ASSERT_TRUE(output->get_layout().is_static());
     std::vector<int32_t> ref_dims = {12, 3, 1, 1};
-    EXPECT_EQ(output->get_layout().get_dims(), ref_dims);
+    ASSERT_EQ(output->get_layout().get_dims(), ref_dims);
     ov::PartialShape ref_pshape = {12, 3};
-    EXPECT_EQ(output->get_layout().get_partial_shape(), ref_pshape);
+    ASSERT_EQ(output->get_layout().get_partial_shape(), ref_pshape);
 
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     ASSERT_EQ(output_ptr.size(), input_data.size());

--- a/src/plugins/intel_gpu/tests/test_cases/reverse_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reverse_gpu_test.cpp
@@ -86,7 +86,7 @@ public:
 
         ASSERT_EQ(params.expected_out.size(), out_ptr.size());
         for (size_t i = 0; i < params.expected_out.size(); ++i) {
-            EXPECT_NEAR(params.expected_out[i], out_ptr[i], 0.0001) << "at i = " << i;
+            ASSERT_NEAR(params.expected_out[i], out_ptr[i], 0.0001) << "at i = " << i;
         }
     }
 };

--- a/src/plugins/intel_gpu/tests/test_cases/reverse_sequence_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reverse_sequence_gpu_test.cpp
@@ -52,7 +52,7 @@ TEST(reverese_sequence_gpu_test, fp32_d2_2_ba1_sa0) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -98,7 +98,7 @@ TEST(reverese_sequence_gpu_test, fp32_d3_3_3_ba0_sa1) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -144,7 +144,7 @@ TEST(reverese_sequence_gpu_test, fp32_d3_3_3_ba2_sa0) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -191,7 +191,7 @@ TEST(reverese_sequence_gpu_test, fp32_d2_2_3_2ba0_sa3) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -238,7 +238,7 @@ TEST(reverese_sequence_gpu_test, fp32_d2_2_3_2ba0_sa2) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -285,7 +285,7 @@ TEST(reverese_sequence_gpu_test, fp32_d2_2_3_2ba2_sa0) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -327,7 +327,7 @@ TEST(reverese_sequence_gpu_test, fp16_d2_2_ba1_sa0) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -369,7 +369,7 @@ TEST(reverese_sequence_gpu_test, fp16x2_d2_2_ba1_sa0) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -415,7 +415,7 @@ TEST(reverese_sequence_gpu_test, fp16_d3_3_3_ba0_sa1) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -461,7 +461,7 @@ TEST(reverese_sequence_gpu_test, fp16_d3_3_3_ba2_sa0) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -508,7 +508,7 @@ TEST(reverese_sequence_gpu_test, fp16_d2_2_3_2ba0_sa3) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -555,7 +555,7 @@ TEST(reverese_sequence_gpu_test, fp16_d2_2_3_2ba0_sa2) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -602,6 +602,6 @@ TEST(reverese_sequence_gpu_test, fp16_d2_2_3_2ba2_sa0) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/roi_align_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/roi_align_gpu_test.cpp
@@ -104,7 +104,7 @@ struct roi_align_test : public testing::Test {
 
         ASSERT_EQ(output_ptr.size(), expected_output.size());
         for (uint32_t i = 0; i < expected_output.size(); ++i) {
-            EXPECT_NEAR(output_ptr[i], expected_output[i], 0.01);
+            ASSERT_NEAR(output_ptr[i], expected_output[i], 0.01);
         }
     }
 };

--- a/src/plugins/intel_gpu/tests/test_cases/roi_pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/roi_pooling_gpu_test.cpp
@@ -191,8 +191,8 @@ public:
         }
         const auto outputs = network.execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "reordered_roi_pooling");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "reordered_roi_pooling");
 
         auto output = outputs.at("reordered_roi_pooling").get_memory();
         cldnn::mem_lock<T> output_ptr(output, get_test_stream());

--- a/src/plugins/intel_gpu/tests/test_cases/roi_pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/roi_pooling_gpu_test.cpp
@@ -199,7 +199,7 @@ public:
 
         ASSERT_EQ(output_ptr.size(), p.output_values.size());
         for (size_t i = 0; i < output_ptr.size(); ++i) {
-            EXPECT_NEAR(p.output_values[i], output_ptr[i], threshold);
+            ASSERT_NEAR(p.output_values[i], output_ptr[i], threshold);
         }
     }
 

--- a/src/plugins/intel_gpu/tests/test_cases/roll_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/roll_gpu_test.cpp
@@ -63,7 +63,7 @@ struct roll_test : testing::TestWithParam<roll_test_params<T>> {
 
         ASSERT_EQ(output_ptr.size(), p.expected_values.size());
         for (size_t i = 0; i < output_ptr.size(); ++i) {
-            EXPECT_NEAR(p.expected_values[i], output_ptr[i], 1e-5f);
+            ASSERT_NEAR(p.expected_values[i], output_ptr[i], 1e-5f);
         }
     }
 

--- a/src/plugins/intel_gpu/tests/test_cases/scatter_elements_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/scatter_elements_update_gpu_test.cpp
@@ -304,7 +304,7 @@ public:
         ASSERT_EQ(params.data.size(), output_ptr.size());
         ASSERT_EQ(params.expected.size(), output_ptr.size());
         for (uint32_t i = 0; i < output_ptr.size(); i++) {
-            EXPECT_NEAR(output_ptr[i], params.expected[i], getError<T>())
+            ASSERT_NEAR(output_ptr[i], params.expected[i], getError<T>())
                                 << "format=" << fmt_to_str(target_data_format) << ", i=" << i;
         }
     }

--- a/src/plugins/intel_gpu/tests/test_cases/scatter_elements_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/scatter_elements_update_gpu_test.cpp
@@ -87,7 +87,7 @@ TEST(scatter_elements_update_gpu_fp16, d2411_axisF) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/scatter_nd_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/scatter_nd_update_gpu_test.cpp
@@ -164,7 +164,7 @@ struct scatter_nd_update_random_test : testing::TestWithParam<scatter_nd_update_
                                                                   ov::Shape(updates_vec.begin(), updates_vec.end()));
 
         for (size_t i = 0; i < outputs_ref.size(); ++i) {
-            EXPECT_EQ(outputs_ref[i], half_to_float(outputs_ptr[i]));
+            ASSERT_EQ(outputs_ref[i], half_to_float(outputs_ptr[i]));
         }
     }
 
@@ -234,7 +234,7 @@ struct scatter_nd_update_random_test : testing::TestWithParam<scatter_nd_update_
                                                           ov::Shape(updates_vec.begin(), updates_vec.end()));
 
         for (size_t i = 0; i < outputs_ref.size(); ++i) {
-            EXPECT_EQ(outputs_ref[i], outputs_ptr[i]);
+            ASSERT_EQ(outputs_ref[i], outputs_ptr[i]);
         }
     }
 };
@@ -581,7 +581,7 @@ TEST(scatter_nd_update_gpu_fp16_test15, data5_indice3_update5) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -665,7 +665,7 @@ TEST(scatter_nd_update_gpu_fp16_test14, data5_indice2_update3) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -729,7 +729,7 @@ TEST(scatter_nd_update_gpu_fp16_test13, data4_indice2_update2) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -800,7 +800,7 @@ TEST(scatter_nd_update_gpu_fp16_test12, data3_indice3_update1) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -930,7 +930,7 @@ TEST(scatter_nd_update_gpu_fp16_test11, data6_indice1_update6) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1026,7 +1026,7 @@ TEST(scatter_nd_update_gpu_fp16_test10, data5_indice1_update5) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1104,7 +1104,7 @@ TEST(scatter_nd_update_gpu_fp16_test9, data4_indice1_update4) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1202,7 +1202,7 @@ TEST(scatter_nd_update_gpu_fp16_test8, data6_indice2_update5) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1270,7 +1270,7 @@ TEST(scatter_nd_update_gpu_fp16_test7, data5_indice2_update4) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1336,7 +1336,7 @@ TEST(scatter_nd_update_gpu_fp16_test6, data4_indice2_update3) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1401,7 +1401,7 @@ TEST(scatter_nd_update_gpu_fp16_test5, data3_indice2_update2) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1456,7 +1456,7 @@ TEST(scatter_nd_update_gpu_fp16_test4, data2_indice2_update1) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1531,7 +1531,7 @@ TEST(scatter_nd_update_gpu_fp16_test3, data3_indice1_update3) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1586,7 +1586,7 @@ TEST(scatter_nd_update_gpu_fp16_test2, data2_indice1_update2) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1635,7 +1635,7 @@ TEST(scatter_nd_update_gpu_fp16_test1, data1_indice1_update1) {
     cldnn::mem_lock<uint16_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1775,7 +1775,7 @@ TEST(scatter_nd_update_gpu_fp16, d6661_i2311) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -1914,7 +1914,7 @@ TEST(scatter_nd_update_gpu_fp16, d6661_i2211) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -2064,7 +2064,7 @@ TEST(scatter_nd_update_gpu_fp16, d6661_i2111) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -2167,7 +2167,7 @@ TEST(scatter_nd_update_gpu_fp16, d3232_i2411) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -2270,7 +2270,7 @@ TEST(scatter_nd_update_gpu_fp16, d3232_i2311) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -2379,7 +2379,7 @@ TEST(scatter_nd_update_gpu_fp16, d3232_i2211) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -2496,7 +2496,7 @@ TEST(scatter_nd_update_gpu_fp16, d3232_i2111) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -2662,7 +2662,7 @@ TEST(scatter_nd_update_gpu_fp16, d32323_i25111) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -2830,7 +2830,7 @@ TEST(scatter_nd_update_gpu_fp16, d32323_i24111) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -3001,7 +3001,7 @@ TEST(scatter_nd_update_gpu_fp16, d32323_i23111) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -3184,7 +3184,7 @@ TEST(scatter_nd_update_gpu_fp16, d32323_i22111) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -3385,7 +3385,7 @@ TEST(scatter_nd_update_gpu_fp16, d32323_i21111) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -3537,7 +3537,7 @@ TEST(scatter_nd_update_gpu_fp16, d222222_i261111) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -3690,7 +3690,7 @@ TEST(scatter_nd_update_gpu_fp16, d222222_i251111) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -3846,7 +3846,7 @@ TEST(scatter_nd_update_gpu_fp16, d222222_i241111) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -4009,7 +4009,7 @@ TEST(scatter_nd_update_gpu_fp16, d222222_i231111) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -4183,7 +4183,7 @@ TEST(scatter_nd_update_gpu_fp16, d222222_i221111) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -4380,6 +4380,6 @@ TEST(scatter_nd_update_gpu_fp16, d222222_i211111) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/scatter_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/scatter_update_gpu_test.cpp
@@ -112,7 +112,7 @@ TEST(scatter_update_gpu_fp16, d2411_axisB) {
         };
 
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]))
+            ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]))
                 << "i=" << i << ", target_format=" << target_format;
         }
     }
@@ -188,7 +188,7 @@ TEST(scatter_update_gpu_fp32, d8111_axisB) {
         };
 
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_EQ(expected_results[i], output_ptr[i])
+            ASSERT_EQ(expected_results[i], output_ptr[i])
                                 << "i=" << i << ", target_format=" << target_format;
         }
     }
@@ -284,7 +284,7 @@ TEST(scatter_update_gpu_fp16, d4311_axisB) {
         };
 
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]))
+            ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]))
                 << "i=" << i << ", target_format=" << target_format;
         }
     }
@@ -418,7 +418,7 @@ TEST(scatter_update_gpu_fp16, d2521_axisF) {
         };
 
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]))
+            ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]))
                                 << "i=" << i << ", target_format=" << target_format;
         }
     }
@@ -525,7 +525,7 @@ TEST(scatter_update_gpu_fp16, d2241_axisY) {
 
 
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]))
+            ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]))
                                 << "i=" << i << ", target_format=" << target_format;
         }
     }
@@ -716,7 +716,7 @@ TEST(scatter_update_gpu_fp16, d8x2x20x1_axisB) {
         };
 
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]))
+            ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]))
                                 << "i=" << i << ", target_format=" << target_format;
         }
     }
@@ -812,7 +812,7 @@ TEST(scatter_update_gpu_fp32, d2214_axisX) {
 
 
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_EQ(expected_results[i], output_ptr[i])
+            ASSERT_EQ(expected_results[i], output_ptr[i])
                                 << "i=" << i << ", target_format=" << target_format;
         }
     }
@@ -915,7 +915,7 @@ TEST(scatter_update_gpu_int32, d6211_axisB) {
         };
 
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_EQ(expected_results[i], output_ptr[i])
+            ASSERT_EQ(expected_results[i], output_ptr[i])
                                 << "i=" << i << ", target_format=" << target_format;
         }
     }
@@ -1011,7 +1011,7 @@ TEST(scatter_update_gpu_int32, d3151_axisY) {
         };
 
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_EQ(expected_results[i], output_ptr[i])
+            ASSERT_EQ(expected_results[i], output_ptr[i])
                 << "i=" << i << ", target_format=" << target_format;
         }
     }
@@ -1094,7 +1094,7 @@ TEST(scatter_update_gpu_fp32, d24111_axisF_bfzyx) {
             };
 
             for (size_t i = 0; i < expected_results.size(); ++i) {
-                EXPECT_EQ(expected_results[i], output_ptr[i])
+                ASSERT_EQ(expected_results[i], output_ptr[i])
                                     << "i=" << i
                                     << ", target_format_2d=" << target_format
                                     << ", target_format_3d=" << target_format_3d;
@@ -1202,7 +1202,7 @@ TEST(scatter_update_gpu_int32, d121251_bfwzyx_axisB) {
         };
 
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_EQ(expected_results[i], output_ptr[i])
+            ASSERT_EQ(expected_results[i], output_ptr[i])
                 << "i=" << i << ", target_format=" << target_format;
         }
     }
@@ -1292,7 +1292,7 @@ TEST(scatter_update_gpu_fp32, d21511_bfzyx_axisX) {
             };
 
             for (size_t i = 0; i < expected_results.size(); ++i) {
-                EXPECT_EQ(expected_results[i], output_ptr[i])
+                ASSERT_EQ(expected_results[i], output_ptr[i])
                                     << "i=" << i
                                     << ", target_format_2d=" << target_format
                                     << ", target_format_3d=" << target_format_3d;
@@ -1397,7 +1397,7 @@ TEST(scatter_update_gpu_fp32, d1252_axisY_bfwzyx) {
         };
 
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_EQ(expected_results[i], output_ptr[i])
+            ASSERT_EQ(expected_results[i], output_ptr[i])
                                 << "i=" << i << ", target_format=" << target_format;
         }
     }
@@ -1487,7 +1487,7 @@ TEST(scatter_update_gpu_int32, d2115_axisX_bfwzyx) {
         };
 
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_EQ(expected_results[i], output_ptr[i])
+            ASSERT_EQ(expected_results[i], output_ptr[i])
                                 << "i=" << i << ", target_format=" << target_format;
         }
     }
@@ -1582,7 +1582,7 @@ TEST(scatter_update_gpu_fp16, d21214_bfzyx_axisX_bfwzyx) {
             };
 
             for (size_t i = 0; i < expected_results.size(); ++i) {
-                EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]))
+                ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]))
                                     << "i=" << i
                                     << ", target_format_2d=" << target_format
                                     << ", target_format_3d=" << target_format_3d;

--- a/src/plugins/intel_gpu/tests/test_cases/select_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/select_gpu_test.cpp
@@ -63,7 +63,7 @@ TEST(select_gpu_f32, select_basic) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -117,7 +117,7 @@ TEST(select_gpu_f32, select_basic_negative) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -203,7 +203,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_mask_2x2x1x2) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -279,7 +279,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_mask_1x1x1x1) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -359,7 +359,7 @@ TEST(select_gpu_f32, select_basic_comma_byxf_2x2x2x2_bcast_mask_2x2x2x1) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -445,7 +445,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_in2_2x2x1x2) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -527,7 +527,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_in1_2x2x2x1_bcast_in2_2x2x1
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -601,7 +601,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_mask_2x1x2x2_in1_1x2x2x2_in
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -677,7 +677,7 @@ TEST(select_gpu_f32, select_basic_comma_byxf_2x2x2x2_bcast_mask_2x1x2x2_in1_2x2x
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -753,7 +753,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_in2_1x1x1x1) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -833,7 +833,7 @@ TEST(select_gpu_f32, select_basic_comma_byxf_2x2x2x2_bcast_in2_2x2x2x1) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -919,7 +919,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_in1_2x2x1x2) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -995,7 +995,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_in1_1x1x1x1) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1075,7 +1075,7 @@ TEST(select_gpu_f32, select_basic_comma_byxf_2x2x2x2_bcast_in1_2x2x2x1) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1155,7 +1155,7 @@ TEST(select_gpu_f32, select_basic_comma_byxf_2x2x2x2_bcast_mask_2x1x2x2_in1_2x2x
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1209,7 +1209,7 @@ TEST(select_gpu_f32, select_basic_comma) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1326,7 +1326,7 @@ TEST(select_gpu_f32, select_basic_byxf) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1380,7 +1380,7 @@ TEST(select_gpu_f32, select_basic_mask_f16) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1434,7 +1434,7 @@ TEST(select_gpu_f32, select_basic_mask_i8) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1488,7 +1488,7 @@ TEST(select_gpu_f32, select_basic_mask_u8) {
 
     for (int i = 0; i < 16; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1534,7 +1534,7 @@ TEST(select_gpu_f32, select_basic_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1584,7 +1584,7 @@ TEST(select_gpu_f32, select_basic_bfyx_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1634,7 +1634,7 @@ TEST(select_gpu_f32, select_basic_byxf_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1685,7 +1685,7 @@ TEST(select_gpu_f16, select_basic_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1735,7 +1735,7 @@ TEST(select_gpu_f16, select_basic_mask_f32_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1785,7 +1785,7 @@ TEST(select_gpu_f16, select_basic_mask_i8_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1835,7 +1835,7 @@ TEST(select_gpu_f16, select_basic_mask_u8_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1886,7 +1886,7 @@ TEST(select_gpu_i8, select_basic_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1936,7 +1936,7 @@ TEST(select_gpu_i8, select_basic_mask_f32_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -1986,7 +1986,7 @@ TEST(select_gpu_i8, select_basic_mask_f16_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -2036,7 +2036,7 @@ TEST(select_gpu_i8, select_basic_mask_u8_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -2087,7 +2087,7 @@ TEST(select_gpu_u8, select_basic_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -2137,7 +2137,7 @@ TEST(select_gpu_u8, select_basic_mask_f32_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -2187,7 +2187,7 @@ TEST(select_gpu_u8, select_basic_mask_f16_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -2237,7 +2237,7 @@ TEST(select_gpu_u8, select_basic_mask_i8_1x1x2x2) {
 
     for (int i = 0; i < 4; i++)
     {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }
 
@@ -2291,6 +2291,6 @@ TEST(select_gpu_fp32, select_numpy_broadcast_mask_u8_1x1x3) {
 
     for (int i = 0; i < 27; i++)
     {
-        EXPECT_EQ(answers[i], output_ptr[i]);
+        ASSERT_EQ(answers[i], output_ptr[i]);
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/set_output_memory_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/set_output_memory_gpu_test.cpp
@@ -55,12 +55,12 @@ TEST(set_output_memory_gpu, basic) {
     auto outputs = network.execute();
 
     auto output = outputs.at("reorder").get_memory();
-    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *output));
+    ASSERT_TRUE(engine.is_the_same_buffer(*output_mem, *output));
 
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < inputVals.size(); ++i) {
-        EXPECT_TRUE(are_equal(inputVals[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(inputVals[i], output_ptr[i])) << i;
     }
 }
 
@@ -101,17 +101,17 @@ TEST(set_output_memory_gpu, basic_const) {
 
     auto output_dyn = outputs.at("reorder_dyn").get_memory();
     auto output_const = outputs.at("reorder_const").get_memory();
-    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *output_dyn));
+    ASSERT_TRUE(engine.is_the_same_buffer(*output_mem, *output_dyn));
 
     cldnn::mem_lock<float> output_dyn_ptr(output_dyn, get_test_stream());
     cldnn::mem_lock<float> output_const_ptr(output_const, get_test_stream());
 
     for (size_t i = 0; i < inputVals.size(); ++i) {
-        EXPECT_TRUE(are_equal(inputVals[i], output_dyn_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(inputVals[i], output_dyn_ptr[i])) << i;
     }
 
     for (size_t i = 0; i < inputVals.size(); ++i) {
-        EXPECT_TRUE(are_equal(inputVals[i], output_const_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(inputVals[i], output_const_ptr[i])) << i;
     }
 }
 
@@ -150,18 +150,18 @@ TEST(set_output_memory_gpu, basic_mutable) {
 
     auto output_dyn = outputs.at("reorder_dyn").get_memory();
     auto output_mutable = outputs.at("reorder_mutable").get_memory();
-    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *output_dyn));
-    EXPECT_TRUE(engine.is_the_same_buffer(*output_mutable_mem, *output_mutable));
+    ASSERT_TRUE(engine.is_the_same_buffer(*output_mem, *output_dyn));
+    ASSERT_TRUE(engine.is_the_same_buffer(*output_mutable_mem, *output_mutable));
 
     cldnn::mem_lock<float> output_dyn_ptr(output_dyn, get_test_stream());
     cldnn::mem_lock<float> output_mutable_mem_ptr(output_mutable_mem, get_test_stream());
 
     for (size_t i = 0; i < inputVals.size(); ++i) {
-        EXPECT_TRUE(are_equal(inputVals[i], output_dyn_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(inputVals[i], output_dyn_ptr[i])) << i;
     }
 
     for (size_t i = 0; i < inputVals.size(); ++i) {
-        EXPECT_TRUE(are_equal(inputVals[i], output_mutable_mem_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(inputVals[i], output_mutable_mem_ptr[i])) << i;
     }
 }
 
@@ -200,13 +200,13 @@ TEST(set_output_memory_gpu, top_k1) {
     auto outputs = network.execute();
 
     auto output = outputs.at("reorder").get_memory();
-    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *output));
+    ASSERT_TRUE(engine.is_the_same_buffer(*output_mem, *output));
 
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     cldnn::mem_lock<float> output_mem_ptr(output_mem, get_test_stream());
 
     for (size_t i = 0; i < output_ptr.size(); ++i) {
-        EXPECT_TRUE(are_equal(output_mem_ptr[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(output_mem_ptr[i], output_ptr[i])) << i;
     }
 }
 
@@ -246,13 +246,13 @@ TEST(set_output_memory_gpu, top_k2) {
     auto outputs = network.execute();
 
     auto output = outputs.at("reorder").get_memory();
-    EXPECT_TRUE(engine.is_the_same_buffer(*second_output_mem, *output));
+    ASSERT_TRUE(engine.is_the_same_buffer(*second_output_mem, *output));
 
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
     cldnn::mem_lock<float> output_mem_ptr(second_output_mem, get_test_stream());
 
     for (size_t i = 0; i < output_ptr.size(); ++i) {
-        EXPECT_TRUE(are_equal(output_mem_ptr[i], output_ptr[i])) << i;
+        ASSERT_TRUE(are_equal(output_mem_ptr[i], output_ptr[i])) << i;
     }
 }
 
@@ -330,16 +330,16 @@ TEST(set_output_memory_gpu, basic_opt) {
     auto outputs = network.execute();
     auto output = outputs.at(outputID).get_memory();
     //  check for correct output memory setting
-    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *output));
+    ASSERT_TRUE(engine.is_the_same_buffer(*output_mem, *output));
     //  check for memory set propagation
-    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *network.get_output_memory("concat")));
-    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *network.get_output_memory("clamp1")));
-    EXPECT_TRUE(engine.is_the_same_buffer(*output_mem, *network.get_output_memory("clamp2")));
+    ASSERT_TRUE(engine.is_the_same_buffer(*output_mem, *network.get_output_memory("concat")));
+    ASSERT_TRUE(engine.is_the_same_buffer(*output_mem, *network.get_output_memory("clamp1")));
+    ASSERT_TRUE(engine.is_the_same_buffer(*output_mem, *network.get_output_memory("clamp2")));
 
     //  check for correct result
     cldnn::mem_lock<float> output_ptr(output_mem, get_test_stream());
     for (size_t i = 0; i < output_ptr.size(); ++i) {
-        EXPECT_TRUE(are_equal(output_ptr[i], output_vec[i])) << i;
+        ASSERT_TRUE(are_equal(output_ptr[i], output_vec[i])) << i;
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/shape_of_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/shape_of_gpu_test.cpp
@@ -39,7 +39,7 @@ TEST(shape_of_gpu, bfyx) {
     std::vector<int32_t> expected_results = {1, 2, 3, 3};
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(expected_results[i], output_ptr[i]));
     }
 }
 
@@ -64,7 +64,7 @@ TEST(shape_of_gpu, bfyx_i64) {
     std::vector<int64_t> expected_results = {1, 2, 3, 3};
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(expected_results[i], output_ptr[i]));
     }
 }
 
@@ -89,7 +89,7 @@ TEST(shape_of_gpu, yxfb) {
     std::vector<int32_t> expected_results = {1, 2, 3, 3};
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(expected_results[i], output_ptr[i]));
     }
 }
 
@@ -114,7 +114,7 @@ TEST(shape_of_gpu, bfzyx) {
     std::vector<int32_t> expected_results = {1, 2, 4, 3, 3};
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_TRUE(are_equal(expected_results[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(expected_results[i], output_ptr[i]));
     }
 }
 
@@ -151,7 +151,7 @@ TEST(shape_of_gpu, dynamic) {
         std::vector<int32_t> expected_results = {1, 2, 3, 4};
 
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_TRUE(are_equal(expected_results[i], output_ptr[i]));
+            ASSERT_TRUE(are_equal(expected_results[i], output_ptr[i]));
         }
     }
 
@@ -166,7 +166,7 @@ TEST(shape_of_gpu, dynamic) {
         std::vector<int32_t> expected_results = {4, 3, 2, 1};
 
         for (size_t i = 0; i < expected_results.size(); ++i) {
-            EXPECT_TRUE(are_equal(expected_results[i], output_ptr[i]));
+            ASSERT_TRUE(are_equal(expected_results[i], output_ptr[i]));
         }
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/shuffle_channels_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/shuffle_channels_test.cpp
@@ -52,7 +52,7 @@ TEST(shuffle_channels_fp32_gpu, d1_15_2_2_ax1_g5) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -94,7 +94,7 @@ TEST(shuffle_channels_fp32_gpu, d1_15_2_2_axm3_g5) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -136,7 +136,7 @@ TEST(shuffle_channels_fp32_gpu, d15_2_2_ax0_g5) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -178,7 +178,7 @@ TEST(shuffle_channels_fp32_gpu, d15_2_2_axm4_g5) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -216,7 +216,7 @@ TEST(shuffle_channels_fp32_gpu, d2_2_6_axm2_g3) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -254,7 +254,7 @@ TEST(shuffle_channels_fp32_gpu, d2_6_2_axm3_g3) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -292,7 +292,7 @@ TEST(shuffle_channels_fp32_gpu, d2_2_6_axm2_g2) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -330,7 +330,7 @@ TEST(shuffle_channels_fp32_gpu, d2_6_2_axm3_g2) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -365,6 +365,6 @@ TEST(shuffle_channels_fp32_gpu, d6_axm0_g2) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/slice.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/slice.cpp
@@ -51,8 +51,8 @@ public:
 
         auto outputs = network.execute();
 
-        EXPECT_EQ(outputs.size(), size_t(1));
-        EXPECT_EQ(outputs.begin()->first, "slice");
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "slice");
 
         auto output = outputs.at("slice").get_memory();
 
@@ -60,7 +60,7 @@ public:
 
         ASSERT_EQ(output_ptr.size(), expected_output_.size());
         for (size_t i = 0; i < output_ptr.size(); ++i)
-            EXPECT_TRUE(are_equal(expected_output_[i], output_ptr[i], 2e-3));
+            ASSERT_TRUE(are_equal(expected_output_[i], output_ptr[i], 2e-3));
     }
 
     data_types DataType() const;

--- a/src/plugins/intel_gpu/tests/test_cases/softmax_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/softmax_gpu_test.cpp
@@ -931,7 +931,7 @@ public:
 
         ASSERT_EQ(params.input_tensor.count(), output_ptr.size());
         for (uint32_t i = 0; i < output_ptr.size(); i++) {
-            EXPECT_NEAR(output_ptr[i], params.expected[i], getError<T>()) << "target_format=" << target_format << ", i=" << i;
+            ASSERT_NEAR(output_ptr[i], params.expected[i], getError<T>()) << "target_format=" << target_format << ", i=" << i;
         }
     }
 };

--- a/src/plugins/intel_gpu/tests/test_cases/softmax_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/softmax_gpu_test.cpp
@@ -38,7 +38,7 @@ public:
     void compare_out_buffer_with_expected() {
         for(size_t i = 0; i < out_size; ++i) {
             // does output have expected values
-            EXPECT_TRUE(are_equal(out_buffer[i], expected_buffer[i]))
+            ASSERT_TRUE(are_equal(out_buffer[i], expected_buffer[i]))
                 << "At ["<< i <<  "] Expected : " << expected_buffer[i] << " actual : " << out_buffer[i];
         }
     }
@@ -50,11 +50,11 @@ public:
                 auto idx = b+x*output_b;
                 batch_wise_sum += out_buffer[idx];
                 // does output have expected values
-                EXPECT_TRUE(are_equal(out_buffer[idx], expected_buffer[idx]))
+                ASSERT_TRUE(are_equal(out_buffer[idx], expected_buffer[idx]))
                     << "At ["<< idx <<  "] Expected : " << expected_buffer[idx] << " actual : " << out_buffer[idx];
             }
             // does it sum to 1 batch wise
-            EXPECT_TRUE(are_equal(batch_wise_sum, 1.0f))
+            ASSERT_TRUE(are_equal(batch_wise_sum, 1.0f))
                 << "Expected : " << 1.0f << " actual : " << batch_wise_sum;
         }
     }
@@ -74,8 +74,8 @@ TEST_F(softmax_gpu_xb_f32_test_fixture, input_same_values) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "softmax");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "softmax");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -103,8 +103,8 @@ TEST_F(softmax_gpu_xb_f32_test_fixture, input_same_values_batch_wise) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "softmax");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "softmax");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -157,8 +157,8 @@ TEST_F(softmax_gpu_xb_f32_test_fixture, values_batch_wise) {
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "softmax");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "softmax");
 
     auto output_prim = outputs.begin()->second.get_memory();
 
@@ -217,8 +217,8 @@ TEST(softmax_gpu_bfyx_f32, normalize_y) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "softmax");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "softmax");
 
     auto output = outputs.at("softmax").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -244,11 +244,11 @@ TEST(softmax_gpu_bfyx_f32, normalize_y) {
                     }
                     sum += out_buffer[index];
                 }
-                EXPECT_EQ(true, are_equal(temp_max, expected_max_values[max_value_buffer_index]));
+                ASSERT_EQ(true, are_equal(temp_max, expected_max_values[max_value_buffer_index]));
                 temp_max = 0;
                 max_value_buffer_index++;
 
-                EXPECT_EQ(true, are_equal(sum, expected_sum));
+                ASSERT_EQ(true, are_equal(sum, expected_sum));
                 sum = 0.0f;
             }
         }
@@ -297,8 +297,8 @@ TEST(softmax_gpu_bfyx_f32, normalize_f) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "softmax");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "softmax");
 
     auto output = outputs.at("softmax").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -328,11 +328,11 @@ TEST(softmax_gpu_bfyx_f32, normalize_f) {
                     }
                     sum += out_buffer[index];
                 }
-                EXPECT_EQ(true, are_equal(temp_max, expected_max_values[max_value_buffer_index]));
+                ASSERT_EQ(true, are_equal(temp_max, expected_max_values[max_value_buffer_index]));
                 temp_max = 0;
                 max_value_buffer_index++;
 
-                EXPECT_EQ(true, are_equal(sum, expected_sum));
+                ASSERT_EQ(true, are_equal(sum, expected_sum));
                 sum = 0.0f;
             }
         }
@@ -382,8 +382,8 @@ TEST(softmax_gpu_bfzyx_f32, normalize_z) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "softmax");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "softmax");
 
     auto output = outputs.at("softmax").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -411,10 +411,10 @@ TEST(softmax_gpu_bfzyx_f32, normalize_z) {
                         }
                         sum += out_buffer[index];
                     }
-                    EXPECT_EQ(true, are_equal(temp_max, expected_max_values[max_value_buffer_index]));
+                    ASSERT_EQ(true, are_equal(temp_max, expected_max_values[max_value_buffer_index]));
                     temp_max = 0;
                     max_value_buffer_index++;
-                    EXPECT_EQ(true, are_equal(sum, expected_sum));
+                    ASSERT_EQ(true, are_equal(sum, expected_sum));
                     sum = 0.0f;
                 }
             }
@@ -465,8 +465,8 @@ TEST(softmax_gpu_bfyx_f32, normalize_b) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "softmax");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "softmax");
 
     auto output = outputs.at("softmax").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -492,11 +492,11 @@ TEST(softmax_gpu_bfyx_f32, normalize_b) {
                     }
                     sum += out_buffer[index];
                 }
-                EXPECT_EQ(true, are_equal(temp_max, expected_max_values[max_value_buffer_index]));
+                ASSERT_EQ(true, are_equal(temp_max, expected_max_values[max_value_buffer_index]));
                 temp_max = 0;
                 max_value_buffer_index++;
 
-                EXPECT_EQ(true, are_equal(sum, expected_sum));
+                ASSERT_EQ(true, are_equal(sum, expected_sum));
                 sum = 0.0f;
             }
         }
@@ -1033,8 +1033,8 @@ TEST(softmax_gpu_bfyx_f32, normalize_f_dynamic) {
     ASSERT_TRUE(impl->is_dynamic());
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "softmax");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "softmax");
 
     auto output = outputs.at("softmax").get_memory();
     cldnn::mem_lock<float> output_ptr(output, get_test_stream());
@@ -1060,11 +1060,11 @@ TEST(softmax_gpu_bfyx_f32, normalize_f_dynamic) {
                     }
                     sum += out_buffer[index];
                 }
-                EXPECT_TRUE(are_equal(temp_max, expected_max_values[max_value_buffer_index]));
+                ASSERT_TRUE(are_equal(temp_max, expected_max_values[max_value_buffer_index]));
                 temp_max = 0;
                 max_value_buffer_index++;
 
-                EXPECT_TRUE(are_equal(sum, expected_sum));
+                ASSERT_TRUE(are_equal(sum, expected_sum));
                 sum = 0.0f;
             }
         }

--- a/src/plugins/intel_gpu/tests/test_cases/space_to_batch_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/space_to_batch_gpu_test.cpp
@@ -55,7 +55,7 @@ TEST(space_to_batch_fp16_gpu, i1222_bs1222_pb0000_pe0000) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -102,7 +102,7 @@ TEST(space_to_batch_fp16_gpu, i1242_bs1221_pb0020_pe0000) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -148,7 +148,7 @@ TEST(space_to_batch_fp16_gpu, i2132_bs1222_pb0010_pe0100) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -192,7 +192,7 @@ TEST(space_to_batch_fp16_gpu, i12132_bs12122_pb00010_pe00000) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -246,7 +246,7 @@ TEST(space_to_batch_fp16_gpu, i134121_bs142121_pb010100_pe000000) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -299,7 +299,7 @@ TEST(space_to_batch_fp16_gpu, i11611_bs1222_pb0010_pe0001_b_fs_yx_fsv16) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -348,7 +348,7 @@ TEST(space_to_batch_fp16_gpu, i1812_bs1221_pb0010_pe0200_b_fs_yx_fsv16) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -390,7 +390,7 @@ TEST(space_to_batch_fp32_gpu, i1222_bs1222_pb0000_pe0000) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -437,7 +437,7 @@ TEST(space_to_batch_fp32_gpu, i1242_bs1221_pb0020_pe0000) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -483,7 +483,7 @@ TEST(space_to_batch_fp32_gpu, i2132_bs1222_pb0010_pe0100) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -527,7 +527,7 @@ TEST(space_to_batch_fp32_gpu, i12132_bs12122_pb00010_pe00000) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -579,7 +579,7 @@ TEST(space_to_batch_fp32_gpu, i134121_bs142121_pb010100_pe000000) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -636,7 +636,7 @@ TEST(space_to_batch_fp32_gpu, i11622_bs1421_pb0000_pe0000_b_fs_yx_fsv16) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -688,6 +688,6 @@ TEST(space_to_batch_fp32_gpu, i1623_bs1312_pb0001_pe0000_b_fs_yx_fsv16) {
     ASSERT_EQ(output_ptr.size(), expected_results.size());
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/space_to_depth_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/space_to_depth_gpu_test.cpp
@@ -54,7 +54,7 @@ TEST(space_to_depth_fp16_gpu, d1122_bs2_mbf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -96,7 +96,7 @@ TEST(space_to_depth_fp16_gpu, d1142_bs2_mbf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -151,7 +151,7 @@ TEST(space_to_depth_fp16_gpu, d1264_bs2_mbf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -214,7 +214,7 @@ TEST(space_to_depth_fp16_gpu, d1199_bs3_mbf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -253,7 +253,7 @@ TEST(space_to_depth_fp32_gpu, d1122_bs2_mbf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -292,7 +292,7 @@ TEST(space_to_depth_fp32_gpu, d1142_bs2_mbf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -347,7 +347,7 @@ TEST(space_to_depth_fp32_gpu, d1264_bs2_mbf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -402,7 +402,7 @@ TEST(space_to_depth_fp32_gpu, d1199_bs3_mbf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -446,7 +446,7 @@ TEST(space_to_depth_fp16_gpu, d1122_bs2_mdf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -488,7 +488,7 @@ TEST(space_to_depth_fp16_gpu, d1142_bs2_mdf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -543,7 +543,7 @@ TEST(space_to_depth_fp16_gpu, d1264_bs2_mdf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -606,7 +606,7 @@ TEST(space_to_depth_fp16_gpu, d1199_bs3_mdf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], half_to_float(output_ptr[i]));
+        ASSERT_EQ(expected_results[i], half_to_float(output_ptr[i]));
     }
 }
 
@@ -645,7 +645,7 @@ TEST(space_to_depth_fp32_gpu, d1122_bs2_mdf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -684,7 +684,7 @@ TEST(space_to_depth_fp32_gpu, d1142_bs2_mdf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -739,7 +739,7 @@ TEST(space_to_depth_fp32_gpu, d1264_bs2_mdf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -794,7 +794,7 @@ TEST(space_to_depth_fp32_gpu, d1199_bs3_mdf) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -849,7 +849,7 @@ TEST(space_to_depth_fp32_gpu, d1199_bs3_mdf_fsv16) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }
 
@@ -904,6 +904,6 @@ TEST(space_to_depth_fp32_gpu, d1199_bs3_mdf_fsv4) {
     };
 
     for (size_t i = 0; i < expected_results.size(); ++i) {
-        EXPECT_EQ(expected_results[i], output_ptr[i]);
+        ASSERT_EQ(expected_results[i], output_ptr[i]);
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/spatial_concatenate_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/spatial_concatenate_gpu_test.cpp
@@ -60,7 +60,7 @@ TEST(spatial_concatenate_f32_gpu, test01) {
         size_t idx = 0;
         for (auto const& value : out_ptr)
         {
-            EXPECT_FLOAT_EQ(value, expected_output[idx++]);
+            ASSERT_FLOAT_EQ(value, expected_output[idx++]);
         }
     }
 }
@@ -115,7 +115,7 @@ TEST(spatial_concatenate_f32_gpu, test02) {
         size_t idx = 0;
         for (auto const& value : out_ptr)
         {
-            EXPECT_FLOAT_EQ(value, expected_output[idx++]);
+            ASSERT_FLOAT_EQ(value, expected_output[idx++]);
         }
     }
 }
@@ -172,7 +172,7 @@ TEST(spatial_concatenate_f32_gpu, test03) {
         size_t idx = 0;
         for (auto const& value : out_ptr)
         {
-            EXPECT_FLOAT_EQ(value, expected_output[idx++]);
+            ASSERT_FLOAT_EQ(value, expected_output[idx++]);
         }
     }
 }
@@ -227,7 +227,7 @@ TEST(spatial_concatenate_f32_gpu, test04) {
         size_t idx = 0;
         for (auto const& value : out_ptr)
         {
-            EXPECT_FLOAT_EQ(value, expected_output[idx++]);
+            ASSERT_FLOAT_EQ(value, expected_output[idx++]);
         }
     }
 }
@@ -288,7 +288,7 @@ TEST(spatial_concatenate_f32_gpu, inputs_3) {
         size_t idx = 0;
         for (auto const& value : out_ptr)
         {
-            EXPECT_FLOAT_EQ(value, expected_output[idx++]);
+            ASSERT_FLOAT_EQ(value, expected_output[idx++]);
         }
     }
 }
@@ -376,7 +376,7 @@ TEST(spatial_concatenate_f32_gpu, inputs_3_uneven_axis_b) {
         size_t idx = 0;
         for (auto const& value : out_ptr)
         {
-            EXPECT_FLOAT_EQ(value, expected_output[idx++]);
+            ASSERT_FLOAT_EQ(value, expected_output[idx++]);
         }
     }
 }
@@ -436,7 +436,7 @@ TEST(spatial_concatenate_f32_gpu, inputs3d_axis_x) {
         size_t idx = 0;
         for (auto const& value : out_ptr)
         {
-            EXPECT_FLOAT_EQ(value, expected_output[idx++]);
+            ASSERT_FLOAT_EQ(value, expected_output[idx++]);
         }
     }
 }
@@ -500,7 +500,7 @@ TEST(spatial_concatenate_f32_gpu, inputs3d_axis_y) {
         size_t idx = 0;
         for (auto const& value : out_ptr)
         {
-            EXPECT_FLOAT_EQ(value, expected_output[idx++]);
+            ASSERT_FLOAT_EQ(value, expected_output[idx++]);
         }
     }
 }
@@ -564,7 +564,7 @@ TEST(spatial_concatenate_f32_gpu, inputs3d_axis_z) {
         size_t idx = 0;
         for (auto const& value : out_ptr)
         {
-            EXPECT_FLOAT_EQ(value, expected_output[idx++]);
+            ASSERT_FLOAT_EQ(value, expected_output[idx++]);
         }
     }
 }
@@ -639,7 +639,7 @@ TEST(spatial_concatenate_f32_gpu, inputs3d_axis_b) {
         size_t idx = 0;
         for (auto const& value : out_ptr)
         {
-            EXPECT_FLOAT_EQ(value, expected_output[idx++]);
+            ASSERT_FLOAT_EQ(value, expected_output[idx++]);
         }
     }
 }
@@ -770,7 +770,7 @@ TEST(spatial_concatenate_f32_gpu, inputs3d_3_uneven_axis_b) {
         size_t idx = 0;
         for (auto const& value : out_ptr)
         {
-            EXPECT_FLOAT_EQ(value, expected_output[idx++]);
+            ASSERT_FLOAT_EQ(value, expected_output[idx++]);
         }
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/split_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/split_gpu_test.cpp
@@ -35,7 +35,7 @@ void check_feature_map(T* output_ptr, std::vector<T> &input_vec, size_t batch_nu
             for (size_t x = 0; x < x_size; ++x) { //X
                 auto linear_id = x + x_size * (y + y_size * (feature_id + feature_num * b));
                 auto output_linear_id = x + x_size * (y + y_size * b);
-                EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id] * factor);
+                ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id] * factor);
             }
         }
     }
@@ -78,7 +78,7 @@ void split_test(int batch_num, int feature_num, int x_size, int y_size, std::vec
     auto outputs = network.execute();
 
     // The number of splits should match the expected number of splits
-    EXPECT_EQ(outputs.size(), size_t(split_offsets.size()));
+    ASSERT_EQ(outputs.size(), size_t(split_offsets.size()));
 
     std::vector<cldnn::tensor> expected_sizes;
     for (size_t splitNum = 0; splitNum < split_offsets.size(); splitNum++)  // Calculate the expected sizes
@@ -111,7 +111,7 @@ void split_test(int batch_num, int feature_num, int x_size, int y_size, std::vec
         primitive_id split_id = "split:" + create_split_id(splitNum);
         cldnn::memory::ptr output = outputs.at(split_id).get_memory();
         auto prim = output->get_layout();
-        EXPECT_EQ(prim.get_tensor(), expected_sizes[splitNum]);
+        ASSERT_EQ(prim.get_tensor(), expected_sizes[splitNum]);
         cldnn::mem_lock<T> output_ptr(output, get_test_stream());
 
         // Output tensor size
@@ -147,7 +147,7 @@ void split_test(int batch_num, int feature_num, int x_size, int y_size, std::vec
                     for (auto x = 0; x < output_x; x++) {  // X
                         auto linear_id = input_x_itr + x_size * (input_y_itr + y_size * (input_feature_itr + feature_num * input_batch_itr)); // index in input
                         auto output_linear_id = x + output_x * (y + output_y * (f + output_feature * b)); // index in output
-                        EXPECT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
+                        ASSERT_EQ(output_ptr[output_linear_id], input_vec[linear_id]);
                         input_x_itr++;  // update the input x iterator
                     }
                     input_y_itr++;  // update the input y iterator
@@ -237,7 +237,7 @@ TEST(split_gpu_f32, basic_split_concat_optimization) {
 
     for (int i = 0; i < 25*256; ++i)
     {
-        EXPECT_EQ(output_ptr[i], input_ptr[i]);
+        ASSERT_EQ(output_ptr[i], input_ptr[i]);
     }
 }
 
@@ -277,7 +277,7 @@ TEST(split_gpu_i64, basic_split_concat_optimization) {
 
     for (int i = 0; i < 25*256; ++i)
     {
-        EXPECT_EQ(output_ptr[i], input_ptr[i]);
+        ASSERT_EQ(output_ptr[i], input_ptr[i]);
     }
 }
 
@@ -544,7 +544,7 @@ TEST(split_gpu_f32, basic_in2x3x2x2_split_feature_bfyx) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(3));
+    ASSERT_EQ(outputs.size(), size_t(3));
 
     for (unsigned int i = 0; i < 3; i++)
     {
@@ -590,7 +590,7 @@ TEST(split_gpu_i64, basic_in2x3x2x2_split_feature_bfyx) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(3));
+    ASSERT_EQ(outputs.size(), size_t(3));
 
     for (unsigned int i = 0; i < 3; i++)
     {
@@ -656,7 +656,7 @@ TEST(split_gpu_f32, basic_in2x3x2x2_split_scale_feature_bfyx) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(3));
+    ASSERT_EQ(outputs.size(), size_t(3));
 
     for (unsigned int i = 0; i < 3; i++)
     {

--- a/src/plugins/intel_gpu/tests/test_cases/streams_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/streams_test.cpp
@@ -51,7 +51,7 @@ TEST(gpu_streams, can_create_networks_for_stream) {
     ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
-        EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
+        ASSERT_FLOAT_EQ(output_vec[i], output_ptr[i]);
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/streams_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/streams_test.cpp
@@ -33,8 +33,8 @@ TEST(gpu_streams, can_create_networks_for_stream) {
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "relu");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "relu");
 
     auto output_memory = outputs.at("relu").get_memory();
     auto output_layout = output_memory->get_layout();
@@ -44,11 +44,11 @@ TEST(gpu_streams, can_create_networks_for_stream) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 4);
-    EXPECT_EQ(x_size, 5);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 4);
+    ASSERT_EQ(x_size, 5);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
         EXPECT_FLOAT_EQ(output_vec[i], output_ptr[i]);
@@ -86,10 +86,10 @@ TEST(gpu_streams, check_networks_can_use_the_same_weights) {
 
     auto outputs0 = network0.execute();
     auto outputs1 = network1.execute();
-    EXPECT_EQ(outputs0.size(), size_t(1));
-    EXPECT_EQ(outputs1.size(), size_t(1));
-    EXPECT_EQ(outputs0.begin()->first, "conv");
-    EXPECT_EQ(outputs1.begin()->first, "conv");
+    ASSERT_EQ(outputs0.size(), size_t(1));
+    ASSERT_EQ(outputs1.size(), size_t(1));
+    ASSERT_EQ(outputs0.begin()->first, "conv");
+    ASSERT_EQ(outputs1.begin()->first, "conv");
 
     auto output_memory0 = outputs0.at("conv").get_memory();
     auto output_memory1 = outputs1.at("conv").get_memory();
@@ -106,15 +106,15 @@ TEST(gpu_streams, check_networks_can_use_the_same_weights) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::yxfb);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::yxfb);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
-            EXPECT_EQ(output_vec[y][x], output_ptr0[y * x_size + x]);
-            EXPECT_EQ(output_vec[y][x], output_ptr1[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr0[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr1[y * x_size + x]);
         }
     }
 }
@@ -150,10 +150,10 @@ TEST(gpu_streams, check_networks_use_unique_mutable_data_per_stream) {
 
     auto outputs0 = network0.execute();
     auto outputs1 = network1.execute();
-    EXPECT_EQ(outputs0.size(), size_t(1));
-    EXPECT_EQ(outputs1.size(), size_t(1));
-    EXPECT_EQ(outputs0.begin()->first, "conv");
-    EXPECT_EQ(outputs1.begin()->first, "conv");
+    ASSERT_EQ(outputs0.size(), size_t(1));
+    ASSERT_EQ(outputs1.size(), size_t(1));
+    ASSERT_EQ(outputs0.begin()->first, "conv");
+    ASSERT_EQ(outputs1.begin()->first, "conv");
 
     auto output_memory0 = outputs0.at("conv").get_memory();
     auto output_memory1 = outputs1.at("conv").get_memory();
@@ -174,15 +174,15 @@ TEST(gpu_streams, check_networks_use_unique_mutable_data_per_stream) {
     int x_size = output_layout.spatial(0);
     int f_size = output_layout.feature();
     int b_size = output_layout.batch();
-    EXPECT_EQ(output_layout.format, format::bfyx);
-    EXPECT_EQ(y_size, 2);
-    EXPECT_EQ(x_size, 3);
-    EXPECT_EQ(f_size, 1);
-    EXPECT_EQ(b_size, 1);
+    ASSERT_EQ(output_layout.format, format::bfyx);
+    ASSERT_EQ(y_size, 2);
+    ASSERT_EQ(x_size, 3);
+    ASSERT_EQ(f_size, 1);
+    ASSERT_EQ(b_size, 1);
     for (int y = 0; y < y_size; ++y) {
         for (int x = 0; x < x_size; ++x) {
-            EXPECT_EQ(output_vec[y][x], output_ptr0[y * x_size + x]);
-            EXPECT_EQ(output_vec[y][x], output_ptr1[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr0[y * x_size + x]);
+            ASSERT_EQ(output_vec[y][x], output_ptr1[y * x_size + x]);
         }
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/strided_slice_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/strided_slice_gpu_test.cpp
@@ -53,8 +53,8 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x2x2_full) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -66,7 +66,7 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x2x2_full) {
     ASSERT_EQ(output_ptr.size(), answers.size());
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -110,8 +110,8 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_full) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -123,7 +123,7 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_full) {
     ASSERT_EQ(output_ptr.size(), answers.size());
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -167,8 +167,8 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x2x2_ignore) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -182,7 +182,7 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x2x2_ignore) {
     ASSERT_EQ(output_ptr.size(), answers.size());
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -226,8 +226,8 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_ignore) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -241,7 +241,7 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_ignore) {
     ASSERT_EQ(output_ptr.size(), answers.size());
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -285,8 +285,8 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x2x2_single) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -297,7 +297,7 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x2x2_single) {
     ASSERT_EQ(output_ptr.size(), answers.size());
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -341,8 +341,8 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_single) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -353,7 +353,7 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_single) {
     ASSERT_EQ(output_ptr.size(), answers.size());
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -401,8 +401,8 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x4x3_stride) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -416,7 +416,7 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x4x3_stride) {
     ASSERT_EQ(output_ptr.size(), answers.size());
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -464,8 +464,8 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x4x3_stride) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -479,7 +479,7 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x4x3_stride) {
     ASSERT_EQ(output_ptr.size(), answers.size());
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -540,8 +540,8 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x4x4_part_stride) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -562,7 +562,7 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x4x4_part_stride) {
     ASSERT_EQ(output_ptr.size(), answers.size());
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -623,8 +623,8 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x4x4_part_stride) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -645,7 +645,7 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x4x4_part_stride) {
     ASSERT_EQ(output_ptr.size(), answers.size());
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -687,8 +687,8 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x4x1_new_axis_mask) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -701,7 +701,7 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x4x1_new_axis_mask) {
 
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -743,8 +743,8 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x4x1_new_axis_mask) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -757,7 +757,7 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x4x1_new_axis_mask) {
 
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -798,8 +798,8 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x1x1_new_axis_mask_2) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -811,7 +811,7 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x1x1_new_axis_mask_2) {
 
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -852,8 +852,8 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x1x1_new_axis_mask_2) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -865,7 +865,7 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x1x1_new_axis_mask_2) {
 
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -905,8 +905,8 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x1x1) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -918,7 +918,7 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x1x1) {
 
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -958,8 +958,8 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x1x1) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -971,7 +971,7 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x1x1) {
 
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1011,8 +1011,8 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x2x1x1) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -1024,7 +1024,7 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x2x1x1) {
 
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1064,8 +1064,8 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -1077,7 +1077,7 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1) {
 
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1118,8 +1118,8 @@ TEST(strided_slice_gpu_i8_i64, test_2x2x2x1x1) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -1130,7 +1130,7 @@ TEST(strided_slice_gpu_i8_i64, test_2x2x2x1x1) {
     cldnn::mem_lock<int8_t> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < answers.size(); ++i) {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1170,8 +1170,8 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x2x1x1_2) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -1183,7 +1183,7 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x2x1x1_2) {
 
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1223,8 +1223,8 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1_2) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -1236,7 +1236,7 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1_2) {
 
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1280,8 +1280,8 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x2x2_full_negative_stride) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -1293,7 +1293,7 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x2x2_full_negative_stride) {
     ASSERT_EQ(output_ptr.size(), answers.size());
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1337,8 +1337,8 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_full_negative_stride) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -1350,7 +1350,7 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x2_full_negative_stride) {
     ASSERT_EQ(output_ptr.size(), answers.size());
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1390,8 +1390,8 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x2x1x1_2_negative_all) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -1403,7 +1403,7 @@ TEST(strided_slice_gpu_f32_i32, test_2x2x2x1x1_2_negative_all) {
 
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1443,8 +1443,8 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1_2_negative_all) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -1456,7 +1456,7 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1_2_negative_all) {
 
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1493,8 +1493,8 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1_2_negative_all_dynamic) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -1506,7 +1506,7 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1_2_negative_all_dynamic) {
 
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }
 
@@ -1537,8 +1537,8 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1_2_negative_all_dynamic_begin) {
 
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), size_t(1));
-    EXPECT_EQ(outputs.begin()->first, "strided_slice");
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "strided_slice");
 
     auto output = outputs.at("strided_slice").get_memory();
 
@@ -1550,6 +1550,6 @@ TEST(strided_slice_gpu_f32_i64, test_2x2x2x1x1_2_negative_all_dynamic_begin) {
 
     for (size_t i = 0; i < answers.size(); ++i)
     {
-        EXPECT_TRUE(are_equal(answers[i], output_ptr[i]));
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i]));
     }
 }

--- a/src/plugins/intel_gpu/tests/test_cases/tensor_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/tensor_test.cpp
@@ -9,22 +9,22 @@ TEST(tensor_api, order_new_notation)
     cldnn::tensor test{ cldnn::feature(3), cldnn::batch(4), cldnn::spatial(2, 1) };
 
     //sizes
-    EXPECT_EQ(test.batch.size(), size_t(1));
-    EXPECT_EQ(test.feature.size(), size_t(1));
-    EXPECT_EQ(test.spatial.size(), size_t(cldnn::tensor_spatial_dim_max));
+    ASSERT_EQ(test.batch.size(), size_t(1));
+    ASSERT_EQ(test.feature.size(), size_t(1));
+    ASSERT_EQ(test.spatial.size(), size_t(cldnn::tensor_spatial_dim_max));
 
     //passed values
-    EXPECT_EQ(test.spatial[0], cldnn::tensor::value_type(2));
-    EXPECT_EQ(test.spatial[1], cldnn::tensor::value_type(1));
-    EXPECT_EQ(test.feature[0], cldnn::tensor::value_type(3));
-    EXPECT_EQ(test.batch[0], cldnn::tensor::value_type(4));
+    ASSERT_EQ(test.spatial[0], cldnn::tensor::value_type(2));
+    ASSERT_EQ(test.spatial[1], cldnn::tensor::value_type(1));
+    ASSERT_EQ(test.feature[0], cldnn::tensor::value_type(3));
+    ASSERT_EQ(test.batch[0], cldnn::tensor::value_type(4));
 
     //reverse
     auto sizes = test.sizes();
-    EXPECT_EQ(sizes[0], cldnn::tensor::value_type(4));
-    EXPECT_EQ(sizes[1], cldnn::tensor::value_type(3));
-    EXPECT_EQ(sizes[2], cldnn::tensor::value_type(2));
-    EXPECT_EQ(sizes[3], cldnn::tensor::value_type(1));
+    ASSERT_EQ(sizes[0], cldnn::tensor::value_type(4));
+    ASSERT_EQ(sizes[1], cldnn::tensor::value_type(3));
+    ASSERT_EQ(sizes[2], cldnn::tensor::value_type(2));
+    ASSERT_EQ(sizes[3], cldnn::tensor::value_type(1));
 }
 
 TEST(tensor_api, order_new_notation_feature_default)
@@ -32,22 +32,22 @@ TEST(tensor_api, order_new_notation_feature_default)
     cldnn::tensor test{ cldnn::feature(3), cldnn::spatial(2) };
 
     //sizes
-    EXPECT_EQ(test.batch.size(), size_t(1));
-    EXPECT_EQ(test.feature.size(), size_t(1));
-    EXPECT_EQ(test.spatial.size(), size_t(cldnn::tensor_spatial_dim_max));
+    ASSERT_EQ(test.batch.size(), size_t(1));
+    ASSERT_EQ(test.feature.size(), size_t(1));
+    ASSERT_EQ(test.spatial.size(), size_t(cldnn::tensor_spatial_dim_max));
 
     //passed values
-    EXPECT_EQ(test.spatial[0], cldnn::tensor::value_type(2));
-    EXPECT_EQ(test.spatial[1], cldnn::tensor::value_type(1));
-    EXPECT_EQ(test.feature[0], cldnn::tensor::value_type(3));
-    EXPECT_EQ(test.batch[0], cldnn::tensor::value_type(1));
+    ASSERT_EQ(test.spatial[0], cldnn::tensor::value_type(2));
+    ASSERT_EQ(test.spatial[1], cldnn::tensor::value_type(1));
+    ASSERT_EQ(test.feature[0], cldnn::tensor::value_type(3));
+    ASSERT_EQ(test.batch[0], cldnn::tensor::value_type(1));
 
     //reverse
     auto sizes = test.sizes();
-    EXPECT_EQ(sizes[0], cldnn::tensor::value_type(1));
-    EXPECT_EQ(sizes[1], cldnn::tensor::value_type(3));
-    EXPECT_EQ(sizes[2], cldnn::tensor::value_type(2));
-    EXPECT_EQ(sizes[3], cldnn::tensor::value_type(1));
+    ASSERT_EQ(sizes[0], cldnn::tensor::value_type(1));
+    ASSERT_EQ(sizes[1], cldnn::tensor::value_type(3));
+    ASSERT_EQ(sizes[2], cldnn::tensor::value_type(2));
+    ASSERT_EQ(sizes[3], cldnn::tensor::value_type(1));
 }
 
 TEST(tensor_api, order)
@@ -55,27 +55,27 @@ TEST(tensor_api, order)
     cldnn::tensor test{ 1, 2, 3, 4 };
 
     //sizes
-    EXPECT_EQ(test.batch.size(), size_t(1));
-    EXPECT_EQ(test.feature.size(), size_t(1));
-    EXPECT_EQ(test.spatial.size(), size_t(cldnn::tensor_spatial_dim_max));
+    ASSERT_EQ(test.batch.size(), size_t(1));
+    ASSERT_EQ(test.feature.size(), size_t(1));
+    ASSERT_EQ(test.spatial.size(), size_t(cldnn::tensor_spatial_dim_max));
 
     //passed values
-    EXPECT_EQ(test.spatial[1], cldnn::tensor::value_type(4));
-    EXPECT_EQ(test.spatial[0], cldnn::tensor::value_type(3));
-    EXPECT_EQ(test.feature[0], cldnn::tensor::value_type(2));
-    EXPECT_EQ(test.batch[0], cldnn::tensor::value_type(1));
+    ASSERT_EQ(test.spatial[1], cldnn::tensor::value_type(4));
+    ASSERT_EQ(test.spatial[0], cldnn::tensor::value_type(3));
+    ASSERT_EQ(test.feature[0], cldnn::tensor::value_type(2));
+    ASSERT_EQ(test.batch[0], cldnn::tensor::value_type(1));
 
     //reverse
     auto sizes = test.sizes();
-    EXPECT_EQ(sizes[0], cldnn::tensor::value_type(1));
-    EXPECT_EQ(sizes[1], cldnn::tensor::value_type(2));
-    EXPECT_EQ(sizes[2], cldnn::tensor::value_type(3));
-    EXPECT_EQ(sizes[3], cldnn::tensor::value_type(4));
+    ASSERT_EQ(sizes[0], cldnn::tensor::value_type(1));
+    ASSERT_EQ(sizes[1], cldnn::tensor::value_type(2));
+    ASSERT_EQ(sizes[2], cldnn::tensor::value_type(3));
+    ASSERT_EQ(sizes[3], cldnn::tensor::value_type(4));
 }
 
 static void test_tensor_offset(cldnn::tensor shape, cldnn::tensor coord, cldnn::format fmt, size_t ref_offset) {
     auto offset = shape.get_linear_offset(coord, fmt);
-    EXPECT_EQ(ref_offset, offset)
+    ASSERT_EQ(ref_offset, offset)
         << "format: " << fmt << ", shape: " << shape << ", coord: " << coord;
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/tile_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/tile_gpu_test.cpp
@@ -81,7 +81,7 @@ TEST(tile_gpu, basic_in1x2x2x2_axis_b) {
     cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
 
     for (unsigned int i = 0; i < output_ref->count(); ++i) {
-        EXPECT_EQ(output_ptr[i], output_ref_ptr[i]) << "Index=" << i;
+        ASSERT_EQ(output_ptr[i], output_ref_ptr[i]) << "Index=" << i;
     }
 }
 
@@ -113,7 +113,7 @@ TEST(tile_gpu, basic_in1x2x2x2_axis_f) {
     cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
 
     for (unsigned int i = 0; i < output_ref->count(); ++i) {
-        EXPECT_EQ(output_ptr[i], output_ref_ptr[i]) << "Index=" << i;
+        ASSERT_EQ(output_ptr[i], output_ref_ptr[i]) << "Index=" << i;
     }
 }
 
@@ -149,7 +149,7 @@ TEST(tile_gpu, basic_in1x2x2x2_axis_y) {
     cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
 
     for (unsigned int i = 0; i < output_ref->count(); ++i) {
-        EXPECT_EQ(output_ptr[i], output_ref_ptr[i]) << "Index=" << i;
+        ASSERT_EQ(output_ptr[i], output_ref_ptr[i]) << "Index=" << i;
     }
 }
 
@@ -181,7 +181,7 @@ TEST(tile_gpu, basic_in1x2x2x2_axis_x) {
     cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
 
     for (unsigned int i = 0; i < output_ref->count(); ++i) {
-        EXPECT_EQ(output_ptr[i], output_ref_ptr[i]) << "Index=" << i;
+        ASSERT_EQ(output_ptr[i], output_ref_ptr[i]) << "Index=" << i;
     }
 }
 
@@ -209,7 +209,7 @@ TEST(tile_gpu, basic_in1x2x2x2_axis_x_dense) {
     cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
 
     for (unsigned int i = 0; i < output_ref->count(); ++i) {
-        EXPECT_EQ(output_ptr[i], output_ref_ptr[i]) << "Index=" << i;
+        ASSERT_EQ(output_ptr[i], output_ref_ptr[i]) << "Index=" << i;
     }
 }
 
@@ -246,7 +246,7 @@ TEST(tile_gpu, basic_in1x2x2x2_axis_z) {
     cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
 
     for (unsigned int i = 0; i < output_ref->count(); ++i) {
-        EXPECT_EQ(output_ptr[i], output_ref_ptr[i]) << "Index=" << i;
+        ASSERT_EQ(output_ptr[i], output_ref_ptr[i]) << "Index=" << i;
     }
 }
 

--- a/src/plugins/intel_gpu/tests/test_cases/tile_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/tile_gpu_test.cpp
@@ -612,7 +612,7 @@ public:
         ASSERT_EQ(params.output_tensor.count(), out_ptr.size());
 
         for (size_t i = 0; i < params.outputs.size(); ++i) {
-            EXPECT_NEAR(params.outputs[i], out_ptr[i], 0.005) << "at i = " << i;
+            ASSERT_NEAR(params.outputs[i], out_ptr[i], 0.005) << "at i = " << i;
         }
     }
 };

--- a/src/plugins/intel_gpu/tests/test_cases/trim_to_outputs_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/trim_to_outputs_gpu_test.cpp
@@ -60,7 +60,7 @@ TEST(trim_to_outputs, one_node_to_eliminate_case1) {
         cldnn::mem_lock<float> output_ptr(it.second.get_memory(), get_test_stream());
         for (size_t cntr = 0; cntr < out_data.size(); cntr++)
         {
-            EXPECT_NEAR(output_ptr[cntr], out_data[cntr], 1e-4);
+            ASSERT_NEAR(output_ptr[cntr], out_data[cntr], 1e-4);
         }
         ASSERT_EQ(it.first, "conv1");
     }
@@ -116,7 +116,7 @@ TEST(trim_to_outputs, one_node_to_eliminate_case2) {
 
         for (size_t cntr = 0; cntr < out_data.size(); cntr++)
         {
-            EXPECT_NEAR(output_ptr[cntr], out_data[cntr], 1e-4);
+            ASSERT_NEAR(output_ptr[cntr], out_data[cntr], 1e-4);
         }
         ASSERT_EQ(it.first, "conv1");
     }
@@ -175,7 +175,7 @@ TEST(trim_to_outputs, two_nodes_to_eliminate_case1) {
 
         for (size_t cntr = 0; cntr < out_data.size(); cntr++)
         {
-            EXPECT_NEAR(output_ptr[cntr], out_data[cntr], 1e-4);
+            ASSERT_NEAR(output_ptr[cntr], out_data[cntr], 1e-4);
         }
         ASSERT_EQ(it.first, "conv4");
     }

--- a/src/plugins/intel_gpu/tests/test_cases/trim_to_outputs_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/trim_to_outputs_gpu_test.cpp
@@ -51,9 +51,9 @@ TEST(trim_to_outputs, one_node_to_eliminate_case1) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), (size_t)1); // there is only one output
-    EXPECT_EQ(network.get_executed_primitives().size(), (size_t)2);   // input and conv1 where executed
-    EXPECT_EQ(network.get_all_primitive_ids().size(), (size_t)4);     // also bias and weights still exist
+    ASSERT_EQ(outputs.size(), (size_t)1); // there is only one output
+    ASSERT_EQ(network.get_executed_primitives().size(), (size_t)2);   // input and conv1 where executed
+    ASSERT_EQ(network.get_all_primitive_ids().size(), (size_t)4);     // also bias and weights still exist
 
     for (auto& it : outputs)
     {
@@ -62,7 +62,7 @@ TEST(trim_to_outputs, one_node_to_eliminate_case1) {
         {
             EXPECT_NEAR(output_ptr[cntr], out_data[cntr], 1e-4);
         }
-        EXPECT_EQ(it.first, "conv1");
+        ASSERT_EQ(it.first, "conv1");
     }
 }
 
@@ -106,9 +106,9 @@ TEST(trim_to_outputs, one_node_to_eliminate_case2) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), (size_t)1); // there is only one output
-    EXPECT_EQ(network.get_executed_primitives().size(), (size_t)2);   // input and conv1 where executed
-    EXPECT_EQ(network.get_all_primitive_ids().size(), (size_t)4);     // also bias1 and weights1 still exist
+    ASSERT_EQ(outputs.size(), (size_t)1); // there is only one output
+    ASSERT_EQ(network.get_executed_primitives().size(), (size_t)2);   // input and conv1 where executed
+    ASSERT_EQ(network.get_all_primitive_ids().size(), (size_t)4);     // also bias1 and weights1 still exist
 
     for (auto& it : outputs)
     {
@@ -118,7 +118,7 @@ TEST(trim_to_outputs, one_node_to_eliminate_case2) {
         {
             EXPECT_NEAR(output_ptr[cntr], out_data[cntr], 1e-4);
         }
-        EXPECT_EQ(it.first, "conv1");
+        ASSERT_EQ(it.first, "conv1");
     }
 }
 
@@ -165,9 +165,9 @@ TEST(trim_to_outputs, two_nodes_to_eliminate_case1) {
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
-    EXPECT_EQ(outputs.size(), (size_t)1); // there is only one output
-    EXPECT_EQ(network.get_executed_primitives().size(), (size_t)3);   // input, conv1 and conv4  where executed
-    EXPECT_EQ(network.get_all_primitive_ids().size(), (size_t)6);     // also bias weights1 and weights4 still exist
+    ASSERT_EQ(outputs.size(), (size_t)1); // there is only one output
+    ASSERT_EQ(network.get_executed_primitives().size(), (size_t)3);   // input, conv1 and conv4  where executed
+    ASSERT_EQ(network.get_all_primitive_ids().size(), (size_t)6);     // also bias weights1 and weights4 still exist
 
     for (auto& it : outputs)
     {
@@ -177,6 +177,6 @@ TEST(trim_to_outputs, two_nodes_to_eliminate_case1) {
         {
             EXPECT_NEAR(output_ptr[cntr], out_data[cntr], 1e-4);
         }
-        EXPECT_EQ(it.first, "conv4");
+        ASSERT_EQ(it.first, "conv4");
     }
 }

--- a/src/plugins/intel_gpu/tests/test_utils/network_test.h
+++ b/src/plugins/intel_gpu/tests/test_utils/network_test.h
@@ -77,7 +77,7 @@ struct reference_tensor_typed<T, 1> : reference_tensor {
             size_t offset = actual->get_layout().get_linear_offset(coords);
             auto& ref = reference[bi];
             auto& val = ptr[offset];
-            TYPED_EXPECT_EQ(ref, val) << " at bi=" << bi;
+            TYPED_ASSERT_EQ(ref, val) << " at bi=" << bi;
         }
     }
 
@@ -110,7 +110,7 @@ struct reference_tensor_typed<T, 2> : reference_tensor {
                 size_t offset = actual->get_layout().get_linear_offset(coords);
                 auto& ref = reference[bi][fi];
                 auto& val = ptr[offset];
-                TYPED_EXPECT_EQ(ref, val) << "at bi=" << bi << " fi=" << fi;
+                TYPED_ASSERT_EQ(ref, val) << "at bi=" << bi << " fi=" << fi;
             }
         }
     }
@@ -147,7 +147,7 @@ struct reference_tensor_typed<T, 4> : reference_tensor {
                         size_t offset = actual->get_layout().get_linear_offset(coords);
                         auto& ref = reference[bi][fi][yi][xi];
                         auto& val = ptr[offset];
-                        TYPED_EXPECT_EQ(ref, val) << "at bi=" << bi << " fi=" << fi << " yi=" << yi << " xi=" << xi;
+                        TYPED_ASSERT_EQ(ref, val) << "at bi=" << bi << " fi=" << fi << " yi=" << yi << " xi=" << xi;
                     }
                 }
             }

--- a/src/plugins/intel_gpu/tests/test_utils/test_utils.cpp
+++ b/src/plugins/intel_gpu/tests/test_utils/test_utils.cpp
@@ -100,7 +100,7 @@ void generic_test::run_single_test() {
     }
 
     auto outputs = network.execute();
-    EXPECT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.size(), size_t(1));
 
     auto output = outputs.begin()->second.get_memory();
 
@@ -118,11 +118,11 @@ void generic_test::compare_buffers(const memory::ptr out, const memory::ptr ref)
     auto out_layout = out->get_layout();
     auto ref_layout = ref->get_layout();
 
-    EXPECT_EQ(out_layout.get_tensor(), ref_layout.get_tensor());
-    EXPECT_EQ(out_layout.data_type, ref_layout.data_type);
-    EXPECT_EQ(get_expected_output_tensor(), out_layout.get_tensor());
-    EXPECT_EQ(out_layout.get_linear_size(), ref_layout.get_linear_size());
-    EXPECT_EQ(out_layout.data_padding, ref_layout.data_padding);
+    ASSERT_EQ(out_layout.get_tensor(), ref_layout.get_tensor());
+    ASSERT_EQ(out_layout.data_type, ref_layout.data_type);
+    ASSERT_EQ(get_expected_output_tensor(), out_layout.get_tensor());
+    ASSERT_EQ(out_layout.get_linear_size(), ref_layout.get_linear_size());
+    ASSERT_EQ(out_layout.data_padding, ref_layout.data_padding);
 
     int batch_size = out_layout.batch();
     int feature_size = out_layout.feature();
@@ -142,7 +142,7 @@ void generic_test::compare_buffers(const memory::ptr out, const memory::ptr ref)
                     size_t res_index = get_linear_index(out_layout, b, f, y, x, out_desc);
                     size_t ref_index = get_linear_index(ref_layout, b, f, y, x, ref_desc);
 
-                    EXPECT_TRUE(floating_point_equal(res_data[res_index], ref_data[ref_index], max_ulps_diff_allowed))
+                    ASSERT_TRUE(floating_point_equal(res_data[res_index], ref_data[ref_index], max_ulps_diff_allowed))
                         << "Expected " << (float)res_data[res_index] << " to be almost equal (within "
                         << max_ulps_diff_allowed << " ULP's) to " << (float)ref_data[ref_index]
                         << " (ref index = " << ref_index << ", B " << b << ", F "<< f << ", Y " << y << ", X " << x << ")!";


### PR DESCRIPTION
### Details:
 - Use ASSERT macro in cldnn unit tests to avoid huge log files in case of massive failures