### PR TITLE
Fix LogicalNot evaluate when created with dynamic input

### DIFF
--- a/src/core/src/op/logical_not.cpp
+++ b/src/core/src/op/logical_not.cpp
@@ -64,7 +64,7 @@ bool evaluate_not(const HostTensorPtr& arg0, const HostTensorPtr& out, const siz
 bool op::v1::LogicalNot::evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const {
     OV_OP_SCOPE(v1_LogicalNot_evaluate);
     NGRAPH_CHECK(validate_host_tensor_vector(outputs, 1) && validate_host_tensor_vector(inputs, 1));
-    return notop::evaluate_not(inputs[0], outputs[0], shape_size(get_output_shape(0)));
+    return notop::evaluate_not(inputs[0], outputs[0], inputs[0]->get_element_count());
 }
 
 bool op::v1::LogicalNot::has_evaluate() const {

--- a/src/core/tests/eval.cpp
+++ b/src/core/tests/eval.cpp
@@ -1090,6 +1090,18 @@ TEST(eval, evaluate_tanh) {
     ASSERT_FLOAT_VECTORS_EQ(input, result_val);
 }
 
+TEST(eval, evaluate_logical_not_dynamic_input_shape) {
+    const auto a = make_shared<op::Parameter>(element::boolean, PartialShape::dynamic());
+    const auto op = make_shared<op::v1::LogicalNot>(a);
+    const auto f = make_shared<Function>(OutputVector{op}, ParameterVector{a});
+    const auto result = make_shared<HostTensor>();
+
+    ASSERT_TRUE(f->evaluate({result}, {make_host_tensor<element::Type_t::boolean>(Shape{2, 1, 2}, {0, 0, 1, 1})}));
+    EXPECT_EQ(result->get_element_type(), element::boolean);
+    EXPECT_EQ(result->get_shape(), Shape({2, 1, 2}));
+    EXPECT_THAT(read_vector<char>(result), ElementsAre(1, 1, 0, 0));
+}
+
 TEST(eval, evaluate_logical_not) {
     auto p = make_shared<op::Parameter>(element::boolean, Shape{2, 2});
     auto logical_not = make_shared<op::v1::LogicalNot>(p);


### PR DESCRIPTION
### Details:
 - Exception that tries to get element count from dynamic shape will be not thrown as count is taken from input tensor instead 
operator input which can be dynamic.

### Tickets:
 - 98450
