### PR TITLE
[GPU] fix strided_slice_optimize for 5d new axis output, typo in strided_slice cl kernal, update output layout of current node for 5d->4d case

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/handle_reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/handle_reshape.cpp
@@ -85,7 +85,6 @@ void handle_reshape::run(program& p) {
                     reorder_node_to_split.push_back(user);
             }
 
-            bool update_node_output_layout = false;
             if (!reorder_node_to_split.empty()) {
                 auto& prim_node = node->as<reshape>();
                 const auto& prim = prim_node.get_primitive();
@@ -125,7 +124,6 @@ void handle_reshape::run(program& p) {
                     auto& reorder_reshape_node = reorder_reshape_nodes[reshape_reorder_id];
                     auto reshape_in_layout = reorder_node->get_output_layout();
                     auto dims = cldnn::format::dimension(reshape_in_layout.format);
-                    auto dims_reorder_reshape_node = cldnn::format::dimension(reorder_reshape_node->get_output_layout().format);
                     auto format = cldnn::format::bfyx;
                     if (dims == 5)
                         format = cldnn::format::bfzyx;
@@ -143,14 +141,7 @@ void handle_reshape::run(program& p) {
                                        reshape_input_node.get_dependencies().empty());
                     reshape_reorder_id++;
                     reshape_input_node.recalc_output_layout();
-                    if (dims_reorder_reshape_node > dims)
-                        update_node_output_layout = true;
                 }
-            }
-
-            if (update_node_output_layout) {
-                auto node_new_layout = node->get_dependency(0).get_output_layout();
-                node->set_output_layout(node_new_layout);
             }
 
             auto reshape_layout = node->get_output_layout();

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/strided_slice_optimize.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/strided_slice_optimize.cpp
@@ -26,12 +26,16 @@ void strided_slice_optimize::run(program& p) {
             if (std::find(new_axis_mask.begin(), new_axis_mask.end(), 1) == new_axis_mask.end())
                 continue;
 
+            auto node_layout = strided_slice_node.get_output_layout();
+            // only 4D or less dimension output runs optimization
+            if (node_layout.get_rank() > 4)
+                continue;
+
             auto& deps = node->get_dependencies();
             for (size_t i = deps.size(); i--;)
                 if (deps[i].first->is_type<data>())
                     node->remove_dependency(i);
 
-            auto node_layout = strided_slice_node.get_output_layout();
             auto node_size = node_layout.get_tensor().sizes(format::bfyx);
 
             auto is_shift_possible = [&](const std::vector<int32_t>& dims) -> bool {

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/strided_slice_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/strided_slice_ref.cl
@@ -19,8 +19,8 @@ KERNEL(strided_slice_ref)(const __global INPUT0_TYPE* input, __global OUTPUT_TYP
 #elif OUTPUT_LAYOUT_BFZYX
     const uint yx_input = (uint)get_global_id(2) % (INPUT0_SIZE_X * INPUT0_SIZE_Y);
     const uint z_input = (uint)get_global_id(2) / (INPUT0_SIZE_X * INPUT0_SIZE_Y);
-    const uint y_input = yx / INPUT0_SIZE_X;
-    const uint x_input = yx % INPUT0_SIZE_X;
+    const uint y_input = yx_input / INPUT0_SIZE_X;
+    const uint x_input = yx_input % INPUT0_SIZE_X;
 #endif
     const uint input_index = INPUT0_OFFSET +
         batch * INPUT0_BATCH_PITCH +


### PR DESCRIPTION
### Details:
 - Avoid strided_slice_optimize() for 5d new axis case
 - Fix typo error in strided slice cl kernel
 - update output layout of current node for 5d->4d case in reshape_handle

### Tickets:
 - 97904
