### PR TITLE
Bugfix for byx reduction

### DIFF
--- a/src/common/transformations/include/transformations/op_conversions/reduce_modification_for_false_keepdims.hpp
+++ b/src/common/transformations/include/transformations/op_conversions/reduce_modification_for_false_keepdims.hpp
@@ -1,0 +1,144 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <openvino/core/rt_info.hpp>
+#include <openvino/opsets/opset10.hpp>
+#include <openvino/pass/graph_rewrite.hpp>
+#include <transformations_visibility.hpp>
+#include <vector>
+
+namespace ov {
+namespace pass {
+
+// Modify reduce if keep_dims is false and it reduces batch and spatial axes
+class TRANSFORMATIONS_API ModifyReduceForFalseKeepDims;
+class TRANSFORMATIONS_API ModifyReduceMeanForFalseKeepDims;
+class TRANSFORMATIONS_API ModifyReduceSumForFalseKeepDims;
+class TRANSFORMATIONS_API ModifyReduceMaxForFalseKeepDims;
+class TRANSFORMATIONS_API ModifyReduceMinForFalseKeepDims;
+class TRANSFORMATIONS_API ModifyReduceLogicalAndForFalseKeepDims;
+class TRANSFORMATIONS_API ModifyReduceLogicalOrForFalseKeepDims;
+
+}  // namespace pass
+}  // namespace ov
+
+// Add Reshape to modify output of Reduce and update keep_dims to true : reduce-reshape
+// A clDNN Reduce reorders un-reduced axes of its output tensor to b-f and spatial order when keep_dims is false.
+// oneDNN reduction does not allow this. And clDNN execution shows a hug perf drop for blocked formats.
+class ModifyReduceBase : public ov::pass::MatcherPass {
+public:
+    template <class T>
+    ov::matcher_pass_callback modify_reduce_for_false_keepdims();
+
+    bool is_unsupported_reordered_axes(std::vector<int64_t> reduce_axes, size_t num_dim, size_t num_spatial);
+};
+
+class ov::pass::ModifyReduceMeanForFalseKeepDims : public ModifyReduceBase {
+public:
+    OPENVINO_RTTI("ModifyReduceMeanForFalseKeepDims", "0");
+    ModifyReduceMeanForFalseKeepDims();
+};
+
+class ov::pass::ModifyReduceSumForFalseKeepDims : public ModifyReduceBase {
+public:
+    OPENVINO_RTTI("ModifyReduceSumForFalseKeepDims", "0");
+    ModifyReduceSumForFalseKeepDims();
+};
+
+class ov::pass::ModifyReduceMaxForFalseKeepDims : public ModifyReduceBase {
+public:
+    OPENVINO_RTTI("ModifyReduceMaxForFalseKeepDims", "0");
+    ModifyReduceMaxForFalseKeepDims();
+};
+
+class ov::pass::ModifyReduceMinForFalseKeepDims : public ModifyReduceBase {
+public:
+    OPENVINO_RTTI("ModifyReduceMinForFalseKeepDims", "0");
+    ModifyReduceMinForFalseKeepDims();
+};
+
+class ov::pass::ModifyReduceLogicalAndForFalseKeepDims : public ModifyReduceBase {
+public:
+    OPENVINO_RTTI("ModifyReduceLogicalAndForFalseKeepDims", "0");
+    ModifyReduceLogicalAndForFalseKeepDims();
+};
+
+class ov::pass::ModifyReduceLogicalOrForFalseKeepDims : public ModifyReduceBase {
+public:
+    OPENVINO_RTTI("ModifyReduceLogicalOrForFalseKeepDims", "0");
+    ModifyReduceLogicalOrForFalseKeepDims();
+};
+
+class ov::pass::ModifyReduceForFalseKeepDims : public ov::pass::GraphRewrite {
+public:
+    OPENVINO_RTTI("ModifyReduceForFalseKeepDims", "0");
+    ModifyReduceForFalseKeepDims() {
+        add_matcher<ModifyReduceMeanForFalseKeepDims>();
+        add_matcher<ModifyReduceSumForFalseKeepDims>();
+        add_matcher<ModifyReduceMaxForFalseKeepDims>();
+        add_matcher<ModifyReduceMinForFalseKeepDims>();
+        add_matcher<ModifyReduceLogicalAndForFalseKeepDims>();
+        add_matcher<ModifyReduceLogicalOrForFalseKeepDims>();
+    }
+};
+
+template <class T>
+ov::matcher_pass_callback ModifyReduceBase::modify_reduce_for_false_keepdims() {
+    return [&](ov::pass::pattern::Matcher& m) {
+        auto reduce = std::dynamic_pointer_cast<T>(m.get_match_root());
+        if (!reduce)
+            return false;
+
+        auto input = reduce->input_value(0);
+        const auto input_shape = input.get_shape();
+        const auto reduce_shape = reduce->output(0).get_shape();
+        const auto input_rank = input.get_partial_shape().rank().get_length();
+
+        auto axes_vector = reduce->get_reduction_axes().to_vector();
+        std::sort(axes_vector.begin(), axes_vector.end());
+
+        if (is_unsupported_reordered_axes(axes_vector, input_rank, (input_rank - 2)) && input_shape.size() < 6) {
+            ngraph::NodeVector new_ops;
+
+            // Reduce
+            auto reduce_const =
+                ov::opset10::Constant::create(ov::element::i64, ov::Shape{axes_vector.size()}, axes_vector);
+            input = std::make_shared<T>(input, reduce_const, true);
+            input.get_node_shared_ptr()->set_friendly_name(reduce->get_friendly_name());
+            new_ops.push_back(input.get_node_shared_ptr());
+
+            // Reshape
+            auto reshape_shape = ov::Shape(input_shape.size(), 1);
+            // Expected that a feature axis is only un-reduced.
+            reshape_shape[0] = reduce_shape[0];
+            input = std::make_shared<ov::opset10::Reshape>(
+                input,
+                ov::opset10::Constant::create(ov::element::i64, ov::Shape{reshape_shape.size()}, reshape_shape),
+                false);
+
+            input.get_node_shared_ptr()->set_friendly_name(reduce->get_friendly_name() + "_reshape_false_keepdims");
+            new_ops.push_back(input.get_node_shared_ptr());
+
+            copy_runtime_info(reduce, new_ops);
+            reduce->output(0).replace(input);
+            return true;
+        }
+
+        return false;
+    };
+}
+
+namespace pass {
+using ov::pass::ModifyReduceForFalseKeepDims;
+using ov::pass::ModifyReduceLogicalAndForFalseKeepDims;
+using ov::pass::ModifyReduceLogicalOrForFalseKeepDims;
+using ov::pass::ModifyReduceMaxForFalseKeepDims;
+using ov::pass::ModifyReduceMeanForFalseKeepDims;
+using ov::pass::ModifyReduceMinForFalseKeepDims;
+using ov::pass::ModifyReduceSumForFalseKeepDims;
+}  // namespace pass

--- a/src/common/transformations/src/transformations/op_conversions/reduce_modification_for_false_keepdims.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/reduce_modification_for_false_keepdims.cpp
@@ -1,0 +1,89 @@
+// Copyright (C) 2018-2022 Intel Corporationc
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/op_conversions/reduce_modification_for_false_keepdims.hpp"
+
+#include "itt.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+
+bool ModifyReduceBase::is_unsupported_reordered_axes(std::vector<int64_t> reduce_axes,
+                                                     size_t num_dim,
+                                                     size_t num_spatial) {
+    bool is_remains_feature_axis = false;
+
+    // Case to reduce batch axis and spatial axes
+    if (reduce_axes.size() > 1 && count(reduce_axes.begin(), reduce_axes.end(), 0) != 0 &&
+        count(reduce_axes.begin(), reduce_axes.end(), 1) == 0) {
+        is_remains_feature_axis = true;
+        // Check if it reduces all spatial axes
+        for (size_t idx_spatial = (num_dim - num_spatial); idx_spatial < num_dim; idx_spatial++) {
+            if (count(reduce_axes.begin(), reduce_axes.end(), idx_spatial) == 0) {
+                is_remains_feature_axis = false;
+                break;
+            }
+        }
+    }
+
+    return is_remains_feature_axis;
+}
+
+ov::pass::ModifyReduceMeanForFalseKeepDims::ModifyReduceMeanForFalseKeepDims() {
+    MATCHER_SCOPE(ModifyReduceMeanForFalseKeepDims);
+    auto m = std::make_shared<pattern::Matcher>(
+        pattern::wrap_type<opset10::ReduceMean>(
+            {pattern::any_input(pattern::has_static_shape()), pattern::wrap_type<opset10::Constant>()},
+            pattern::has_static_shape()),
+        matcher_name);
+    register_matcher(m, modify_reduce_for_false_keepdims<opset10::ReduceMean>());
+}
+
+ov::pass::ModifyReduceSumForFalseKeepDims::ModifyReduceSumForFalseKeepDims() {
+    MATCHER_SCOPE(ModifyReduceSumForFalseKeepDims);
+    auto m = std::make_shared<pattern::Matcher>(
+        pattern::wrap_type<opset10::ReduceSum>(
+            {pattern::any_input(pattern::has_static_shape()), pattern::wrap_type<opset10::Constant>()},
+            pattern::has_static_shape()),
+        matcher_name);
+    register_matcher(m, modify_reduce_for_false_keepdims<opset10::ReduceSum>());
+}
+
+ov::pass::ModifyReduceMaxForFalseKeepDims::ModifyReduceMaxForFalseKeepDims() {
+    MATCHER_SCOPE(ModifyReduceMaxForFalseKeepDims);
+    auto m = std::make_shared<pattern::Matcher>(
+        pattern::wrap_type<opset10::ReduceMax>(
+            {pattern::any_input(pattern::has_static_shape()), pattern::wrap_type<opset10::Constant>()},
+            pattern::has_static_shape()),
+        matcher_name);
+    register_matcher(m, modify_reduce_for_false_keepdims<opset10::ReduceMax>());
+}
+
+ov::pass::ModifyReduceMinForFalseKeepDims::ModifyReduceMinForFalseKeepDims() {
+    MATCHER_SCOPE(ModifyReduceMinForFalseKeepDims);
+    auto m = std::make_shared<pattern::Matcher>(
+        pattern::wrap_type<opset10::ReduceMin>(
+            {pattern::any_input(pattern::has_static_shape()), pattern::wrap_type<opset10::Constant>()},
+            pattern::has_static_shape()),
+        matcher_name);
+    register_matcher(m, modify_reduce_for_false_keepdims<opset10::ReduceMin>());
+}
+
+ov::pass::ModifyReduceLogicalAndForFalseKeepDims::ModifyReduceLogicalAndForFalseKeepDims() {
+    MATCHER_SCOPE(ModifyReduceLogicalAndForFalseKeepDims);
+    auto m = std::make_shared<pattern::Matcher>(
+        pattern::wrap_type<opset10::ReduceLogicalAnd>(
+            {pattern::any_input(pattern::has_static_shape()), pattern::wrap_type<opset10::Constant>()},
+            pattern::has_static_shape()),
+        matcher_name);
+    register_matcher(m, modify_reduce_for_false_keepdims<opset10::ReduceLogicalAnd>());
+}
+
+ov::pass::ModifyReduceLogicalOrForFalseKeepDims::ModifyReduceLogicalOrForFalseKeepDims() {
+    MATCHER_SCOPE(ModifyReduceLogicalOrForFalseKeepDims);
+    auto m = std::make_shared<pattern::Matcher>(
+        pattern::wrap_type<opset10::ReduceLogicalOr>(
+            {pattern::any_input(pattern::has_static_shape()), pattern::wrap_type<opset10::Constant>()},
+            pattern::has_static_shape()),
+        matcher_name);
+    register_matcher(m, modify_reduce_for_false_keepdims<opset10::ReduceLogicalOr>());
+}

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reduction_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reduction_onednn.cpp
@@ -9,33 +9,13 @@
 #include "kernel_selector_common.h"
 #include "kernel_base.h"
 
+#include <impls/onednn/utils.hpp>
 #include <oneapi/dnnl/dnnl.hpp>
 
 #include <algorithm>
 #include <memory>
 namespace cldnn {
 namespace onednn {
-
-static void reorder_unreduced_axis_no_fusion(const cldnn::layout& input_layout, cldnn::layout& output_layout, std::vector<int64_t> axes) {
-    auto in_dims = input_layout.get_tensor().sizes();
-    auto num_dims = input_layout.format.dimension();
-    auto num_spatial = format::spatial_num(input_layout.format);
-    size_t num_others = num_dims - num_spatial;
-
-    for (size_t idx = 0; idx < axes.size(); idx++) {
-        if (axes[idx] < static_cast<int64_t>(num_others))
-            in_dims[axes[idx]] = 1;
-        else
-            in_dims[(num_dims - axes[idx] - 1 + num_others)] = 1;
-    }
-
-    auto output_tensor = output_layout.get_tensor();
-    for (size_t idx = 0; idx < output_layout.get_rank(); idx++) {
-        output_tensor.raw[idx] = in_dims[idx];
-    }
-
-    output_layout.set_tensor(output_tensor);
-}
 
 struct reduction_onednn : typed_primitive_onednn_impl<reduce, dnnl::reduction::desc> {
     using parent = typed_primitive_onednn_impl<reduce, dnnl::reduction::desc>;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -250,6 +250,27 @@ void combine_bf_with_first_spatial_dim(cldnn::layout& l) {
     l.set_partial_shape(new_shape);
 }
 
+void reorder_unreduced_axis_no_fusion(const cldnn::layout& input_layout, cldnn::layout& output_layout, std::vector<int64_t> axes) {
+    auto in_dims = input_layout.get_tensor().sizes();
+    auto num_dims = input_layout.format.dimension();
+    auto num_spatial = format::spatial_num(input_layout.format);
+    size_t num_others = num_dims - num_spatial;
+
+    for (size_t idx = 0; idx < axes.size(); idx++) {
+        if (axes[idx] < static_cast<int64_t>(num_others))
+            in_dims[axes[idx]] = 1;
+        else
+            in_dims[(num_dims - axes[idx] - 1 + num_others)] = 1;
+    }
+
+    auto output_tensor = output_layout.get_tensor();
+    for (size_t idx = 0; idx < output_layout.get_rank(); idx++) {
+        output_tensor.raw[idx] = in_dims[idx];
+    }
+
+    output_layout.set_tensor(output_tensor);
+}
+
 int64_t get_f_offset(cldnn::layout&& l, dnnl::memory::desc&& desc) {
     int64_t offset = 0;
     auto f_padding = l.data_padding.lower_size().feature[0];

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
@@ -20,6 +20,7 @@ template <typename T>
 cldnn::memory::ptr convert_zp_data_to_s32(const memory::ptr zp_memory);
 cldnn::format default_fmt_for_dims(size_t dims, bool is_grouped = false);
 void combine_bf_with_first_spatial_dim(cldnn::layout& l);
+void reorder_unreduced_axis_no_fusion(const cldnn::layout& input_layout, cldnn::layout& output_layout, std::vector<int64_t> axes);
 
 // cldnn -> onednn
 dnnl::memory::dims convert_tensor(cldnn::tensor t, size_t dims = 2, bool is_grouped = false);

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -83,6 +83,7 @@
 #include <transformations/op_conversions/gelu7_downgrade.hpp>
 #include <transformations/op_conversions/convert_softmax_downgrade.hpp>
 #include <transformations/op_conversions/convert_prior_box_v8_to_v0.hpp>
+#include <transformations/op_conversions/reduce_modification_for_false_keepdims.hpp>
 #include <transformations/convert_precision.hpp>
 #include <transformations/init_node_info.hpp>
 #include <transformations/rt_info/fused_names_attribute.hpp>
@@ -261,6 +262,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             pass_config->disable<ngraph::pass::ConvertReduceMeanToPooling>();
             pass_config->disable<ngraph::pass::ConvertReduceMaxToPooling>();
             manager.register_pass<ConvertAvgPoolingToReduce>();
+            manager.register_pass<pass::ModifyReduceForFalseKeepDims>();
         } else {
             pass_config->set_callback<ngraph::pass::ConvertReduceSumToPooling>(
             [](const_node_ptr &node) -> bool {


### PR DESCRIPTION
+ Fix accuracy issue of oneDNN reduction when it reduces byx axes
+ Add Reshape to modify output of Reduce and update keep_dims to true : reduce-reshape

Signed-off-by: Min, Byungil <byungil.min@intel.com>

### Details:
 - A clDNN Reduce reorders un-reduced axes of its output tensor to b-f and spatial order when keep_dims is false. oneDNN reduction does not allow this. And clDNN execution shows a hug perf drop for blocked formats
- Resolve accuracy issue of deblurgan-v2 model.

### Tickets:
 - 98612
