### PR TITLE
[Offline Transformations] Avoid VC warnings

### DIFF
--- a/src/common/offline_transformations/CMakeLists.txt
+++ b/src/common/offline_transformations/CMakeLists.txt
@@ -4,11 +4,6 @@
 
 set(TARGET_NAME "offline_transformations")
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    ie_add_compiler_flags(/wd4244)
-    ie_add_compiler_flags(/wd4267)
-endif()
-
 file(GLOB_RECURSE LIBRARY_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 file(GLOB_RECURSE PUBLIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp)
 

--- a/src/common/offline_transformations/src/pruning/shrink_weights.cpp
+++ b/src/common/offline_transformations/src/pruning/shrink_weights.cpp
@@ -40,10 +40,13 @@ static bool is_static_reshape_op(std::shared_ptr<ov::Node> node) {
     if (!output_shape_const_op)
         return false;
 
-    const auto input_shape = input.get_shape();
+    const auto& input_shape = input.get_shape();
     const auto output_shape = output_shape_const_op->cast_vector<int64_t>();
-    const auto input_elems = std::accumulate(input_shape.begin(), input_shape.end(), 1, std::multiplies<int64_t>());
-    const auto output_elems = std::accumulate(output_shape.begin(), output_shape.end(), 1, std::multiplies<int64_t>());
+    // below casts are needed due to VC warning C4244, literals are not enough in this case
+    const auto input_elems =
+        std::accumulate(input_shape.begin(), input_shape.end(), static_cast<size_t>(1), std::multiplies<size_t>());
+    const auto output_elems =
+        std::accumulate(output_shape.begin(), output_shape.end(), static_cast<int64_t>(1), std::multiplies<int64_t>());
     if (output_elems <= 0 || input_elems == output_elems)
         return false;
     return true;


### PR DESCRIPTION
### Details:
 - Removes MSVC warnings suppression from Offline Transformations
 - Fixes the warnings

### Tickets:
- 95170
