### PR TITLE
Fix CC tests static build

### DIFF
--- a/src/common/conditional_compilation/tests/CMakeLists.txt
+++ b/src/common/conditional_compilation/tests/CMakeLists.txt
@@ -11,8 +11,10 @@ ov_add_test_target(
         LINK_LIBRARIES
             gmock
             funcTestUtils
+            commonTestUtils
         INCLUDES
             "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../../itt/include"
         ADD_CLANG_FORMAT
         LABELS
             OV


### PR DESCRIPTION
After https://github.com/openvinotoolkit/openvino/commit/1cc855051221e1a8dfea9f4083b51c49e76756f6 `cmake -DBUILD_SHARED_LIBS=OFF ..` failed due `<openvino/itt.hpp> not found`