### PR TITLE
Disable clang format for inference tests to fix CI

### DIFF
--- a/src/inference/tests/functional/CMakeLists.txt
+++ b/src/inference/tests/functional/CMakeLists.txt
@@ -64,7 +64,6 @@ ov_add_test_target(
             funcTestUtils
         INCLUDES
             $<TARGET_PROPERTY:inference_engine_obj,SOURCE_DIR>/src
-        ADD_CLANG_FORMAT
         LABELS
             OV
 )

--- a/src/inference/tests/unit/CMakeLists.txt
+++ b/src/inference/tests/unit/CMakeLists.txt
@@ -32,7 +32,6 @@ ov_add_test_target(
         LINK_LIBRARIES
             unitTestUtils
         INCLUDES
-        ADD_CLANG_FORMAT
         LABELS
             OV
 )


### PR DESCRIPTION
### Details:
 - Disable clang format for inference tests to fix CI

### Tickets:
 - *ticket-id*
