### PR TITLE
Disable clang format for lp transformation test for fix CI

### DIFF
--- a/src/common/low_precision_transformations/tests/CMakeLists.txt
+++ b/src/common/low_precision_transformations/tests/CMakeLists.txt
@@ -36,7 +36,6 @@ ov_add_test_target(
             lptNgraphFunctions
             gmock
         INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}
-        ADD_CLANG_FORMAT
         LABELS
             LP_TRANSFORMATIONS
 )


### PR DESCRIPTION
### Details:
 - Disable clang format for lp transformation test for fix CI
 - *...*

### Tickets:
 - *ticket-id*
