### PR TITLE
[TF FE] Support models with topologically unsorted nodes

### DIFF
--- a/src/frontends/tensorflow/src/input_model.cpp
+++ b/src/frontends/tensorflow/src/input_model.cpp
@@ -79,7 +79,7 @@ public:
 
 private:
     void loadPlaces();
-    std::vector<std::shared_ptr<OpPlace>> determine_cut_nodes() const;
+    std::vector<std::shared_ptr<OpPlace>> topologically_sort_op_nodes() const;
 
     std::vector<std::shared_ptr<OpPlace>> m_op_places;
     std::map<std::string, std::shared_ptr<OpPlace>> m_op_places_map;
@@ -198,13 +198,10 @@ void InputModel::InputModelTFImpl::loadPlaces() {
 }
 
 std::vector<std::shared_ptr<OpPlace>> InputModel::InputModelTFImpl::get_op_places() const {
-    if (m_graph_changed) {
-        return determine_cut_nodes();
-    }
-    return m_op_places;
+    return topologically_sort_op_nodes();    
 }
 
-std::vector<std::shared_ptr<OpPlace>> InputModel::InputModelTFImpl::determine_cut_nodes() const {
+std::vector<std::shared_ptr<OpPlace>> InputModel::InputModelTFImpl::topologically_sort_op_nodes() const {
     std::vector<std::shared_ptr<OpPlace>> topologically_sorted_ops;
     std::stack<std::shared_ptr<OpPlace>> ops_to_do;
     std::unordered_set<std::shared_ptr<OpPlace>> ops_done;

--- a/src/frontends/tensorflow/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow/tests/convert_tricky_models.cpp
@@ -5,6 +5,8 @@
 #include <openvino/frontend/exception.hpp>
 #include <openvino/frontend/manager.hpp>
 
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include "gtest/gtest.h"
 #include "test_common.hpp"
 #include "tf_utils.hpp"
 #include "utils.hpp"
@@ -68,4 +70,9 @@ TEST(FrontEndConvertTrickyModels, model_with_output_shapes) {
             ASSERT_TRUE(node->get_output_partial_shape(0).same_scheme(ov::PartialShape{2, 3}));
         }
     }
+}
+
+TEST_F(TransformationTestsF, UnsortedNodes) {
+    { function = convert_model("forward_edge_model_unsorted/forward_edge_model_unsorted.pb"); }
+    { function_ref = convert_model("forward_edge_model/forward_edge_model.pb"); }
 }

--- a/src/frontends/tensorflow/tests/test_models/models_pbtxt/forward_edge_model_unsorted.pbtxt
+++ b/src/frontends/tensorflow/tests/test_models/models_pbtxt/forward_edge_model_unsorted.pbtxt
@@ -1,0 +1,79 @@
+node {
+  name: "Relu"
+  op: "Relu"
+  input: "x"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "Mul"
+  op: "Mul"
+  input: "add"
+  input: "Relu"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "x"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 2
+        }
+        dim {
+          size: 3
+        }
+      }
+    }
+  }
+}
+node {
+  name: "add"
+  op: "AddV2"
+  input: "Relu"
+  input: "Const"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "Const"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 2.0
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Details:** Always topologically sort nodes because it is not guaranteed in the original model.

**Ticket:** 89078

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
