### PR TITLE
Disable clang format for transformation test for fix CI

### DIFF
--- a/src/common/transformations/tests/CMakeLists.txt
+++ b/src/common/transformations/tests/CMakeLists.txt
@@ -41,7 +41,6 @@ ov_add_test_target(
         sharedTestClasses
     INCLUDES
         $<TARGET_PROPERTY:inference_engine_obj,SOURCE_DIR>/src
-    ADD_CLANG_FORMAT
     LABELS
         TRANSFORMATIONS
 )


### PR DESCRIPTION
### Details:
 - Disable clang format for transformation test for fix CI

### Tickets:
 - *ticket-id*
