### PR TITLE
Enable clang-format for tests

### DIFF
--- a/src/common/low_precision_transformations/tests/CMakeLists.txt
+++ b/src/common/low_precision_transformations/tests/CMakeLists.txt
@@ -25,17 +25,18 @@ if(NOT MSVC)
 endif()
 
 ov_add_test_target(
-        NAME ${TARGET_NAME}
-        ROOT ${CMAKE_CURRENT_SOURCE_DIR}
-        DEPENDENCIES
-        LINK_LIBRARIES
-            gtest
-            gtest_main
-            openvino::runtime::dev
-            commonTestUtils
-            lptNgraphFunctions
-            gmock
-        INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}
-        LABELS
-            LP_TRANSFORMATIONS
+    NAME ${TARGET_NAME}
+    ROOT ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDENCIES
+    LINK_LIBRARIES
+        gtest
+        gtest_main
+        openvino::runtime::dev
+        commonTestUtils
+        lptNgraphFunctions
+        gmock
+    ADD_CLANG_FORMAT
+    INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}
+    LABELS
+        LP_TRANSFORMATIONS
 )

--- a/src/common/transformations/tests/CMakeLists.txt
+++ b/src/common/transformations/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ ov_add_test_target(
         offline_transformations
         sharedTestClasses
         lptNgraphFunctions
+    ADD_CLANG_FORMAT
     INCLUDES
         $<TARGET_PROPERTY:inference_engine_obj,SOURCE_DIR>/src
     LABELS


### PR DESCRIPTION
### Details:
 - Enable clang-format for ov_transformations_tests & ov_lp_transformations_teststests

### Tickets:
 - CVS-99422
