### PR TITLE
Transpose sinking binary/split/concat mult consumers case + PRelu

### DIFF
--- a/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_binary.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_binary.hpp
@@ -11,20 +11,20 @@
 namespace ov {
 namespace pass {
 
-class TRANSFORMATIONS_API TransposeSinkingBinaryElementwiseForward;
-class TRANSFORMATIONS_API TransposeSinkingBinaryElementwiseBackward;
+class TRANSFORMATIONS_API TransposeSinkingBinaryForward;
+class TRANSFORMATIONS_API TransposeSinkingBinaryBackward;
 
 }  // namespace pass
 }  // namespace ov
 
-class ov::pass::TransposeSinkingBinaryElementwiseForward : public ov::pass::MatcherPass {
+class ov::pass::TransposeSinkingBinaryForward : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::pass::TransposeSinkingBinaryElementwiseForward", "0");
-    TransposeSinkingBinaryElementwiseForward();
+    OPENVINO_RTTI("ov::pass::TransposeSinkingBinaryForward", "0");
+    TransposeSinkingBinaryForward();
 };
 
-class ov::pass::TransposeSinkingBinaryElementwiseBackward : public ov::pass::MatcherPass {
+class ov::pass::TransposeSinkingBinaryBackward : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::pass::TransposeSinkingBinaryElementwiseBackward", "0");
-    TransposeSinkingBinaryElementwiseBackward();
+    OPENVINO_RTTI("ov::pass::TransposeSinkingBinaryBackward", "0");
+    TransposeSinkingBinaryBackward();
 };

--- a/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_unary.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_unary.hpp
@@ -11,6 +11,8 @@ namespace ov {
 namespace pass {
 
 class TRANSFORMATIONS_API TransposeSinkingUnaryForward;
+class TRANSFORMATIONS_API TransposeSinkingUnaryBackwardSingleConsumer;
+class TRANSFORMATIONS_API TransposeSinkingUnaryBackwardMultiConsumers;
 class TRANSFORMATIONS_API TransposeSinkingUnaryBackward;
 
 }  // namespace pass
@@ -22,7 +24,19 @@ public:
     TransposeSinkingUnaryForward();
 };
 
-class ov::pass::TransposeSinkingUnaryBackward : public ov::pass::MatcherPass {
+class ov::pass::TransposeSinkingUnaryBackwardSingleConsumer : public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("TransposeSinkingUnaryBackwardSingleConsumer", "0");
+    TransposeSinkingUnaryBackwardSingleConsumer();
+};
+
+class ov::pass::TransposeSinkingUnaryBackwardMultiConsumers : public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("TransposeSinkingUnaryBackwardMultiConsumers", "0");
+    TransposeSinkingUnaryBackwardMultiConsumers();
+};
+
+class ov::pass::TransposeSinkingUnaryBackward : public ov::pass::GraphRewrite {
 public:
     OPENVINO_RTTI("TransposeSinkingUnaryBackward", "0");
     TransposeSinkingUnaryBackward();

--- a/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
@@ -100,7 +100,7 @@ void UpdateForwardSinkingAbility(std::shared_ptr<ov::Node>);
  *  @brief Checks if @arg has consumers that all are the same transpose operation. If no consumers at all
  *  returns false.
  */
-bool HasSameOutputTransposeNodes(std::shared_ptr<ov::Node>);
+bool HasSameOutputTransposeNodes(const ov::Output<ov::Node>&);
 
 /**
  * Removes all direct node consumers that have one output

--- a/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
@@ -65,7 +65,7 @@ void SwapNames(std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>);
  * @brief Clone @arg node with the same inputs as original. Reconnect all output consumers to a cloned node
  * except consumers specified as @args consumers.
  */
-std::shared_ptr<ov::Node> CloneNodeWithoutConsumers(std::shared_ptr<ov::Node> node, ov::NodeVector consumers);
+std::shared_ptr<ov::Node> CloneNodeWithoutConsumers(std::shared_ptr<ov::Node> node, const ov::NodeVector& consumers);
 
 namespace sink_forward {
 // insert input reversed transposes, remove first input tranpose

--- a/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
@@ -70,7 +70,8 @@ std::shared_ptr<ov::Node> CloneNodeWithoutConsumers(std::shared_ptr<ov::Node> no
 namespace sink_forward {
 // insert input reversed transposes, remove first input tranpose
 /**
- * @brief Insert reversed transposed on @args main_node inputs. Remove input transpose specified in @arg transpose_input_info
+ * @brief Insert reversed transposed on @args main_node inputs. Remove input transpose specified in @arg
+ * transpose_input_info
  */
 void UpdateInputTransposes(std::shared_ptr<ov::Node> main_node, TransposeInputsInfo& transpose_input_info);
 

--- a/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
@@ -29,66 +29,65 @@ struct TransposeInputsInfo {
 };
 
 /**
- * @brief Find node first input that is a transpose operation and return filled TransposeInputsInfo
+ * @brief Finds node first input that is a transpose operation and returns filled TransposeInputsInfo
  * for it
  */
 TransposeInputsInfo GetFirstTransposeInput(std::shared_ptr<ov::Node>);
 
 /**
- * @brief Check if @arg has any input node that is a transpose operation
+ * @brief Checks if @arg has any input node that is a transpose operation
  */
 bool IfNodeHasTransposeInputs(const ov::Output<ov::Node>&);
 
 /**
- * @brief Reverse order of transpose operation. Do it in a such way that if we had couple following one after
+ * @brief Reverses order of transpose operation. Do it in a such way that if we had couple following one after
  * another transposes (one would be reversed version of another) we will have no transpose as a result of that
  * couple of transposes.
  */
 ov::AxisVector ReverseTransposeOrder(const ov::AxisVector&);
 
 /**
- * @brief Swap @args output tensor names
+ * @brief Swaps @args output tensor names
  */
 void SwapOutputNames(ov::Output<ov::Node>, ov::Output<ov::Node>);
 
 /**
- * @brief Swap @args friendly names
+ * @brief Swaps @args friendly names
  */
 void SwapFriendlyNames(std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>);
 
 /**
- * @brief Swap @args output tensor names and friendly names
+ * @brief Swaps @args output tensor names and friendly names
  */
 void SwapNames(std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>);
 
 /**
- * @brief Clone @arg node with the same inputs as original. Reconnect all output consumers to a cloned node
+ * @brief Clones @arg node with the same inputs as original. Reconnects all output consumers to a cloned node
  * except consumers specified as @args consumers.
  */
 std::shared_ptr<ov::Node> CloneNodeWithoutConsumers(std::shared_ptr<ov::Node> node, const ov::NodeVector& consumers);
 
 namespace sink_forward {
-// insert input reversed transposes, remove first input tranpose
 /**
- * @brief Insert reversed transposed on @args main_node inputs. Remove input transpose specified in @arg
+ * @brief Inserts reversed transposed on @args main_node inputs. Removes input transpose specified in @arg
  * transpose_input_info
  */
 void UpdateInputTransposes(std::shared_ptr<ov::Node> main_node, TransposeInputsInfo& transpose_input_info);
 
 /**
- * @brief Remove @arg input node
+ * @brief Removes @arg input node
  */
 void RemoveInputNode(std::shared_ptr<ov::Node>, size_t input_idx);
 
 /**
- * @brief Insert transposes on each main_node output with the order specified in @arg transpose_input_info
+ * @brief Inserts transposes on each main_node output with the order specified in @arg transpose_input_info
  */
 ov::NodeVector InsertOutputTransposes(std::shared_ptr<ov::Node> main_node, TransposeInputsInfo& transpose_input_info);
 }  // namespace sink_forward
 
 namespace sink_backward {
 /**
- * @brief Insert transposes on each input of @arg main_node with the order specified in @arg transpose_const
+ * @brief Inserts transposes on each input of @arg main_node with the order specified in @arg transpose_const
  */
 ov::NodeVector InsertTransposeBeforeNode(std::shared_ptr<ov::Node> main_node,
                                          std::shared_ptr<ov::opset9::Constant> transpose_const);

--- a/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
@@ -103,8 +103,8 @@ void UpdateForwardSinkingAbility(std::shared_ptr<ov::Node>);
 bool HasSameOutputTransposeNodes(std::shared_ptr<ov::Node>);
 
 /**
- * Removes all direct node consumers
+ * Removes all direct node consumers that have one output
  */
-void RemoveConsumers(std::shared_ptr<ov::Node>);
+void RemoveSingleOutputConsumers(std::shared_ptr<ov::Node>);
 
 }  // namespace transpose_sinking

--- a/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
@@ -96,4 +96,15 @@ ov::NodeVector InsertTransposeBeforeNode(std::shared_ptr<ov::Node> main_node,
 
 void UpdateForwardSinkingAbility(std::shared_ptr<ov::Node>);
 
+/**
+ *  @brief Checks if @arg has consumers that all are the same transpose operation. If no consumers at all
+ *  returns false.
+ */
+bool HasSameOutputTransposeNodes(std::shared_ptr<ov::Node>);
+
+/**
+ * Removes all direct node consumers
+ */
+void RemoveConsumers(std::shared_ptr<ov::Node>);
+
 }  // namespace transpose_sinking

--- a/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
@@ -34,6 +34,7 @@ ov::AxisVector ReverseTransposeOrder(const ov::AxisVector& axis_order);
 void SwapOutputNames(ov::Output<ov::Node> output1, ov::Output<ov::Node> output2);
 void SwapFriendlyNames(std::shared_ptr<ov::Node> node1, std::shared_ptr<ov::Node> node2);
 void SwapNames(std::shared_ptr<ov::Node> node1, std::shared_ptr<ov::Node> node2);
+std::shared_ptr<ov::Node> CloneNodeWithoutConsumers(std::shared_ptr<ov::Node> node, ov::NodeVector consumers);
 
 namespace sink_forward {
 // insert input reversed transposes, remove first input tranpose

--- a/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
@@ -28,22 +28,67 @@ struct TransposeInputsInfo {
     }
 };
 
-TransposeInputsInfo GetFirstTransposeInput(std::shared_ptr<ov::Node> node);
-bool IfNodeHasTransposeInputs(const ov::Output<ov::Node>& output);
-ov::AxisVector ReverseTransposeOrder(const ov::AxisVector& axis_order);
-void SwapOutputNames(ov::Output<ov::Node> output1, ov::Output<ov::Node> output2);
-void SwapFriendlyNames(std::shared_ptr<ov::Node> node1, std::shared_ptr<ov::Node> node2);
-void SwapNames(std::shared_ptr<ov::Node> node1, std::shared_ptr<ov::Node> node2);
+/**
+ * @brief Find node first input that is a transpose operation and return filled TransposeInputsInfo
+ * for it
+ */
+TransposeInputsInfo GetFirstTransposeInput(std::shared_ptr<ov::Node>);
+
+/**
+ * @brief Check if @arg has any input node that is a transpose operation
+ */
+bool IfNodeHasTransposeInputs(const ov::Output<ov::Node>&);
+
+/**
+ * @brief Reverse order of transpose operation. Do it in a such way that if we had couple following one after
+ * another transposes (one would be reversed version of another) we will have no transpose as a result of that
+ * couple of transposes.
+ */
+ov::AxisVector ReverseTransposeOrder(const ov::AxisVector&);
+
+/**
+ * @brief Swap @args output tensor names
+ */
+void SwapOutputNames(ov::Output<ov::Node>, ov::Output<ov::Node>);
+
+/**
+ * @brief Swap @args friendly names
+ */
+void SwapFriendlyNames(std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>);
+
+/**
+ * @brief Swap @args output tensor names and friendly names
+ */
+void SwapNames(std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>);
+
+/**
+ * @brief Clone @arg node with the same inputs as original. Reconnect all output consumers to a cloned node
+ * except consumers specified as @args consumers.
+ */
 std::shared_ptr<ov::Node> CloneNodeWithoutConsumers(std::shared_ptr<ov::Node> node, ov::NodeVector consumers);
 
 namespace sink_forward {
 // insert input reversed transposes, remove first input tranpose
+/**
+ * @brief Insert reversed transposed on @args main_node inputs. Remove input transpose specified in @arg transpose_input_info
+ */
 void UpdateInputTransposes(std::shared_ptr<ov::Node> main_node, TransposeInputsInfo& transpose_input_info);
-void RemoveZeroInputNode(std::shared_ptr<ov::Node> main_node);
+
+/**
+ * @brief Remove @arg input node
+ */
+void RemoveInputNode(std::shared_ptr<ov::Node>, size_t input_idx);
+
+/**
+ * @brief Insert transposes on each main_node output with the order specified in @arg transpose_input_info
+ */
 ov::NodeVector InsertOutputTransposes(std::shared_ptr<ov::Node> main_node, TransposeInputsInfo& transpose_input_info);
 }  // namespace sink_forward
 
 namespace sink_backward {
+/**
+ * @brief Insert transposes on each input of @arg main_node with the order specified in @arg transpose_const
+ */
 ov::NodeVector InsertTransposeBeforeNode(std::shared_ptr<ov::Node> main_node,
                                          std::shared_ptr<ov::opset9::Constant> transpose_const);
 }  // namespace sink_backward

--- a/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
@@ -72,7 +72,7 @@ namespace sink_forward {
  * @brief Inserts reversed transposed on @args main_node inputs. Removes input transpose specified in @arg
  * transpose_input_info
  */
-void UpdateInputTransposes(std::shared_ptr<ov::Node> main_node, TransposeInputsInfo& transpose_input_info);
+void UpdateInputTransposes(std::shared_ptr<ov::Node> main_node, const TransposeInputsInfo& transpose_input_info);
 
 /**
  * @brief Removes @arg input node
@@ -82,7 +82,7 @@ void RemoveInputNode(std::shared_ptr<ov::Node>, size_t input_idx);
 /**
  * @brief Inserts transposes on each main_node output with the order specified in @arg transpose_input_info
  */
-ov::NodeVector InsertOutputTransposes(std::shared_ptr<ov::Node> main_node, TransposeInputsInfo& transpose_input_info);
+ov::NodeVector InsertOutputTransposes(std::shared_ptr<ov::Node> main_node, const TransposeInputsInfo& transpose_input_info);
 }  // namespace sink_forward
 
 namespace sink_backward {

--- a/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
@@ -82,7 +82,8 @@ void RemoveInputNode(std::shared_ptr<ov::Node>, size_t input_idx);
 /**
  * @brief Inserts transposes on each main_node output with the order specified in @arg transpose_input_info
  */
-ov::NodeVector InsertOutputTransposes(std::shared_ptr<ov::Node> main_node, const TransposeInputsInfo& transpose_input_info);
+ov::NodeVector InsertOutputTransposes(std::shared_ptr<ov::Node> main_node,
+                                      const TransposeInputsInfo& transpose_input_info);
 }  // namespace sink_forward
 
 namespace sink_backward {

--- a/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/transpose_sinking_utils.hpp
@@ -61,12 +61,6 @@ void SwapFriendlyNames(std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>);
  */
 void SwapNames(std::shared_ptr<ov::Node>, std::shared_ptr<ov::Node>);
 
-/**
- * @brief Clones @arg node with the same inputs as original. Reconnects all output consumers to a cloned node
- * except consumers specified as @args consumers.
- */
-std::shared_ptr<ov::Node> CloneNodeWithoutConsumers(std::shared_ptr<ov::Node> node, const ov::NodeVector& consumers);
-
 namespace sink_forward {
 /**
  * @brief Inserts reversed transposed on @args main_node inputs. Removes input transpose specified in @arg

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_binary.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_binary.cpp
@@ -23,7 +23,7 @@ using namespace transpose_sinking;
 ov::pass::TransposeSinkingBinaryForward::TransposeSinkingBinaryForward() {
     MATCHER_SCOPE(TransposeSinkingBinaryForward);
 
-    auto main_node_label = wrap_type<op::util::BinaryElementwiseArithmetic>(IfNodeHasTransposeInputs);
+    auto main_node_label = wrap_type<op::util::BinaryElementwiseArithmetic, PRelu>(IfNodeHasTransposeInputs);
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
@@ -46,10 +46,10 @@ ov::pass::TransposeSinkingBinaryForward::TransposeSinkingBinaryForward() {
     register_matcher(m, matcher_pass_callback);
 }
 
-pass::TransposeSinkingBinaryBackward::TransposeSinkingBinaryBackward() {
+ov::pass::TransposeSinkingBinaryBackward::TransposeSinkingBinaryBackward() {
     MATCHER_SCOPE(TransposeSinkingBinaryBackward);
 
-    auto main_node_label = wrap_type<op::util::BinaryElementwiseArithmetic>(has_static_rank());
+    auto main_node_label = wrap_type<op::util::BinaryElementwiseArithmetic, PRelu>(has_static_rank());
 
     auto transpose_const_label = wrap_type<Constant>();
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_binary.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_binary.cpp
@@ -49,7 +49,9 @@ ov::pass::TransposeSinkingBinaryForward::TransposeSinkingBinaryForward() {
 ov::pass::TransposeSinkingBinaryBackward::TransposeSinkingBinaryBackward() {
     MATCHER_SCOPE(TransposeSinkingBinaryBackward);
 
-    auto main_node_label = wrap_type<op::util::BinaryElementwiseArithmetic, PRelu>(has_static_rank());
+    auto main_node_label = wrap_type<op::util::BinaryElementwiseArithmetic, PRelu>([](const Output<Node>& output) -> bool {
+            return has_static_rank()(output) && HasSameOutputTransposeNodes(output.get_node_shared_ptr());
+        });
 
     auto transpose_const_label = wrap_type<Constant>();
 
@@ -64,17 +66,12 @@ ov::pass::TransposeSinkingBinaryBackward::TransposeSinkingBinaryBackward() {
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto main_node = pattern_to_output.at(main_node_label).get_node_shared_ptr();
 
-        if (main_node->output(0).get_target_inputs().size() > 1) {
-            auto new_node = CloneNodeWithoutConsumers(main_node, NodeVector{transpose});
-            register_new_node(new_node);
-        }
-
         for (auto& new_node : sink_backward::InsertTransposeBeforeNode(main_node, transpose_const)) {
             register_new_node(new_node);
         }
 
-        // remove transpose after main node
-        transpose->output(0).replace(main_node);
+        // remove output transposes
+        RemoveConsumers(main_node);
 
         SwapNames(transpose, main_node);
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_binary.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_binary.cpp
@@ -64,18 +64,9 @@ ov::pass::TransposeSinkingBinaryElementwiseBackward::TransposeSinkingBinaryEleme
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto main_node = pattern_to_output.at(main_node_label).get_node_shared_ptr();
 
-        if (main_node->output(0).get_target_inputs().size() > 1) { // FIXME: move to a separate function
-            // reconnect consumers except transpose to new cloned main_node
-            auto new_main_node = main_node->clone_with_new_inputs(main_node->input_values());
-            for (size_t i = 0; i < main_node->get_output_size(); ++i) {
-                for (auto main_node_consumer : main_node->output(i).get_target_inputs()) {
-                    if (transpose->get_instance_id() == main_node_consumer.get_node()->get_instance_id())
-                        continue;
-                    main_node_consumer.replace_source_output(new_main_node);
-                }
-            }
-            copy_runtime_info(main_node, new_main_node);
-            register_new_node(new_main_node);
+        if (main_node->output(0).get_target_inputs().size() > 1) {
+            auto new_node = CloneNodeWithoutConsumers(main_node, NodeVector{transpose});
+            register_new_node(new_node);
         }
 
         for (auto& new_node : sink_backward::InsertTransposeBeforeNode(main_node, transpose_const)) {

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_binary.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_binary.cpp
@@ -71,7 +71,7 @@ ov::pass::TransposeSinkingBinaryBackward::TransposeSinkingBinaryBackward() {
         }
 
         // remove output transposes
-        RemoveConsumers(main_node);
+        RemoveSingleOutputConsumers(main_node);
 
         SwapNames(transpose, main_node);
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_binary.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_binary.cpp
@@ -20,8 +20,8 @@ using namespace ov;
 using namespace ov::opset9;
 using namespace transpose_sinking;
 
-ov::pass::TransposeSinkingBinaryElementwiseForward::TransposeSinkingBinaryElementwiseForward() {
-    MATCHER_SCOPE(TransposeSinkingBinaryElementwiseForward);
+ov::pass::TransposeSinkingBinaryForward::TransposeSinkingBinaryForward() {
+    MATCHER_SCOPE(TransposeSinkingBinaryForward);
 
     auto main_node_label = wrap_type<op::util::BinaryElementwiseArithmetic>(IfNodeHasTransposeInputs);
 
@@ -46,8 +46,8 @@ ov::pass::TransposeSinkingBinaryElementwiseForward::TransposeSinkingBinaryElemen
     register_matcher(m, matcher_pass_callback);
 }
 
-ov::pass::TransposeSinkingBinaryElementwiseBackward::TransposeSinkingBinaryElementwiseBackward() {
-    MATCHER_SCOPE(TransposeSinkingBinaryElementwiseBackward);
+pass::TransposeSinkingBinaryBackward::TransposeSinkingBinaryBackward() {
+    MATCHER_SCOPE(TransposeSinkingBinaryBackward);
 
     auto main_node_label = wrap_type<op::util::BinaryElementwiseArithmetic>(has_static_rank());
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_binary.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_binary.cpp
@@ -50,7 +50,7 @@ ov::pass::TransposeSinkingBinaryBackward::TransposeSinkingBinaryBackward() {
     MATCHER_SCOPE(TransposeSinkingBinaryBackward);
 
     auto main_node_label = wrap_type<op::util::BinaryElementwiseArithmetic, PRelu>([](const Output<Node>& output) -> bool {
-            return has_static_rank()(output) && HasSameOutputTransposeNodes(output.get_node_shared_ptr());
+            return has_static_rank()(output) && HasSameOutputTransposeNodes(output);
         });
 
     auto transpose_const_label = wrap_type<Constant>();

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_binary.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_binary.cpp
@@ -49,7 +49,8 @@ ov::pass::TransposeSinkingBinaryForward::TransposeSinkingBinaryForward() {
 ov::pass::TransposeSinkingBinaryBackward::TransposeSinkingBinaryBackward() {
     MATCHER_SCOPE(TransposeSinkingBinaryBackward);
 
-    auto main_node_label = wrap_type<op::util::BinaryElementwiseArithmetic, PRelu>([](const Output<Node>& output) -> bool {
+    auto main_node_label =
+        wrap_type<op::util::BinaryElementwiseArithmetic, PRelu>([](const Output<Node>& output) -> bool {
             return has_static_rank()(output) && HasSameOutputTransposeNodes(output);
         });
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_concat.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_concat.cpp
@@ -55,8 +55,8 @@ ov::pass::TransposeSinkingConcatBackward::TransposeSinkingConcatBackward() {
     MATCHER_SCOPE(TransposeSinkingConcatBackward);
 
     auto main_node_label = wrap_type<Concat>([](const Output<Node>& output) -> bool {
-            return has_static_rank()(output) && HasSameOutputTransposeNodes(output);
-        });
+        return has_static_rank()(output) && HasSameOutputTransposeNodes(output);
+    });
 
     auto transpose_const_label = wrap_type<Constant>();
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_concat.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_concat.cpp
@@ -76,7 +76,7 @@ ov::pass::TransposeSinkingConcatBackward::TransposeSinkingConcatBackward() {
         }
 
         // remove output transposes
-        RemoveConsumers(main_node);
+        RemoveSingleOutputConsumers(main_node);
 
         SwapNames(transpose, main_node);
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_concat.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_concat.cpp
@@ -55,7 +55,7 @@ ov::pass::TransposeSinkingConcatBackward::TransposeSinkingConcatBackward() {
     MATCHER_SCOPE(TransposeSinkingConcatBackward);
 
     auto main_node_label = wrap_type<Concat>([](const Output<Node>& output) -> bool {
-            return has_static_rank()(output) && HasSameOutputTransposeNodes(output.get_node_shared_ptr());
+            return has_static_rank()(output) && HasSameOutputTransposeNodes(output);
         });
 
     auto transpose_const_label = wrap_type<Constant>();

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_concat.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_concat.cpp
@@ -54,15 +54,13 @@ ov::pass::TransposeSinkingConcatForward::TransposeSinkingConcatForward() {
 ov::pass::TransposeSinkingConcatBackward::TransposeSinkingConcatBackward() {
     MATCHER_SCOPE(TransposeSinkingConcatBackward);
 
-    auto main_node_label = wrap_type<Concat>([](const Output<Node>& output) -> bool {
-        return consumers_count(1)(output) && has_static_rank()(output);
-    });
+    auto main_node_label = wrap_type<Concat>(has_static_rank());
 
-    auto transpose_const_label = wrap_type<Constant>(consumers_count(1));
+    auto transpose_const_label = wrap_type<Constant>();
 
     auto transpose_label =
         wrap_type<Transpose>({main_node_label, transpose_const_label}, [](const Output<Node>& output) -> bool {
-            return consumers_count(1)(output) && has_static_rank()(output) && is_sinking_node(output);
+            return has_static_rank()(output) && is_sinking_node(output);
         });
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
@@ -70,6 +68,11 @@ ov::pass::TransposeSinkingConcatBackward::TransposeSinkingConcatBackward() {
         auto transpose_const = as_type_ptr<Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto main_node = pattern_to_output.at(main_node_label).get_node_shared_ptr();
+
+        if (main_node->output(0).get_target_inputs().size() > 1) {
+            auto new_node = CloneNodeWithoutConsumers(main_node, NodeVector{transpose});
+            register_new_node(new_node);
+        }
 
         for (auto& new_node : sink_backward::InsertTransposeBeforeNode(main_node, transpose_const)) {
             register_new_node(new_node);

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_general.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_general.cpp
@@ -21,7 +21,7 @@
 ov::pass::TransposeSinkingGeneralForward::TransposeSinkingGeneralForward() {
     MATCHER_SCOPE(TransposeSinkingGeneralForward);
     add_matcher<ov::pass::TransposeSinkingUnaryForward>();
-    add_matcher<ov::pass::TransposeSinkingBinaryElementwiseForward>();
+    add_matcher<ov::pass::TransposeSinkingBinaryForward>();
     add_matcher<ov::pass::TransposeSinkingConcatForward>();
     add_matcher<ov::pass::TransposeSinkingSplitForward>();
     add_matcher<ngraph::pass::TransposeFuse>();
@@ -30,7 +30,7 @@ ov::pass::TransposeSinkingGeneralForward::TransposeSinkingGeneralForward() {
 ov::pass::TransposeSinkingGeneralBackward::TransposeSinkingGeneralBackward() {
     MATCHER_SCOPE(TransposeSinkingGeneralBackward);
     add_matcher<ov::pass::TransposeSinkingUnaryBackward>();
-    add_matcher<ov::pass::TransposeSinkingBinaryElementwiseBackward>();
+    add_matcher<ov::pass::TransposeSinkingBinaryBackward>();
     add_matcher<ov::pass::TransposeSinkingConcatBackward>();
     add_matcher<ov::pass::TransposeSinkingSplitBackward>();
     add_matcher<ngraph::pass::TransposeFuse>();

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_split.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_split.cpp
@@ -90,13 +90,13 @@ bool IsSplitSinked(const Output<Node>& output) {
  * Consider case Split (1) -> Split (2) -> Transpose
  * If specify Split as main searched node after first transformation work we will have
  * Split (1) -> Transpose -> Split(2)
- * Matcher pass will not call TransposeSinkingSplitBackward since 
+ * Matcher pass will not call TransposeSinkingSplitBackward since
  * - matcher pattern has no Transpose label
  * - Split (1) has already been proceeded
  * Adding Split(2) into the working queue as register_new_node(split)
  * cannot help us. We just can try to find all input Split operations and add them with
  * register_new_node(). Implemented way is simpler.
- * 
+ *
  * We sink Transpose through Split operation in a backward way only if all the output
  * nodes are the same Transpose. We can:
  * - clone Split with all outputs except Transpose
@@ -108,8 +108,7 @@ ov::pass::TransposeSinkingSplitBackward::TransposeSinkingSplitBackward() {
     MATCHER_SCOPE(TransposeSinkingSplitBackward);
 
     auto transpose_const_label = wrap_type<Constant>();
-    auto transpose_label =
-        wrap_type<Transpose>({any_input(), transpose_const_label}, IsSplitSinked);
+    auto transpose_label = wrap_type<Transpose>({any_input(), transpose_const_label}, IsSplitSinked);
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_split.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_split.cpp
@@ -153,7 +153,7 @@ ov::pass::TransposeSinkingSplitBackward::TransposeSinkingSplitBackward() {
                           new_split_axis_const);
 
         // remove split output transposes
-        RemoveConsumers(split);
+        RemoveSingleOutputConsumers(split);
 
         return true;
     };

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_split.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_split.cpp
@@ -186,7 +186,7 @@ ov::pass::TransposeSinkingSplitForward::TransposeSinkingSplitForward() {
 
         TransposeInputsInfo transpose_input_info = GetFirstTransposeInput(main_node);
 
-        sink_forward::RemoveZeroInputNode(main_node);
+        sink_forward::RemoveInputNode(main_node, /* input_idx */ 0);
         for (auto& new_node : sink_forward::InsertOutputTransposes(main_node, transpose_input_info)) {
             register_new_node(new_node);
             transpose_sinking::UpdateForwardSinkingAbility(new_node);

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_split.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_split.cpp
@@ -115,7 +115,7 @@ bool HasInputSplitAndTransposeSiblings(const Output<Node>& output) {
 ov::pass::TransposeSinkingSplitBackward::TransposeSinkingSplitBackward() {
     MATCHER_SCOPE(TransposeSinkingSplitBackward);
 
-    auto transpose_const_label = wrap_type<Constant>(consumers_count(1));
+    auto transpose_const_label = wrap_type<Constant>();
     auto transpose_label =
         wrap_type<Transpose>({any_input(), transpose_const_label}, HasInputSplitAndTransposeSiblings);
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_unary.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_unary.cpp
@@ -161,7 +161,7 @@ ov::pass::TransposeSinkingUnaryBackwardMultiConsumers::TransposeSinkingUnaryBack
     MATCHER_SCOPE(TransposeSinkingUnaryBackwardMultiConsumers);
 
     auto unary_restrictions = [](const Output<Node>& output) -> bool {
-        return consumers_more_than(1) && HasSameOutputTransposeNodes(output);
+        return consumers_more_than(1)(output) && HasSameOutputTransposeNodes(output);
     };
 
     auto unary_label =

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_unary.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_unary.cpp
@@ -127,13 +127,14 @@ bool IfSinkingEnabled(const Output<Node>& output) {
 ov::pass::TransposeSinkingUnaryBackward::TransposeSinkingUnaryBackward() {
     MATCHER_SCOPE(TransposeSinkingUnaryBackward);
 
-    auto unary_label = ov::pass::pattern::wrap_type<ov::op::util::UnaryElementwiseArithmetic,
-                                                    ov::opset9::Clamp,
-                                                    ov::opset9::Elu,
-                                                    ov::opset9::SoftPlus,
-                                                    ov::opset9::LogicalNot,
-                                                    ov::opset9::Convert>({ov::pass::pattern::any_input()},
-                                                    transpose_sinking::HasSameOutputTransposeNodes);
+    auto unary_label =
+        ov::pass::pattern::wrap_type<ov::op::util::UnaryElementwiseArithmetic,
+                                     ov::opset9::Clamp,
+                                     ov::opset9::Elu,
+                                     ov::opset9::SoftPlus,
+                                     ov::opset9::LogicalNot,
+                                     ov::opset9::Convert>({ov::pass::pattern::any_input()},
+                                                          transpose_sinking::HasSameOutputTransposeNodes);
 
     auto transpose_label =
         ov::pass::pattern::wrap_type<ov::opset9::Transpose>({unary_label, ov::pass::pattern::any_input()},

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_unary.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_unary.cpp
@@ -132,7 +132,8 @@ ov::pass::TransposeSinkingUnaryBackward::TransposeSinkingUnaryBackward() {
                                                     ov::opset9::Elu,
                                                     ov::opset9::SoftPlus,
                                                     ov::opset9::LogicalNot,
-                                                    ov::opset9::Convert>({ov::pass::pattern::any_input()});
+                                                    ov::opset9::Convert>({ov::pass::pattern::any_input()},
+                                                    transpose_sinking::HasSameOutputTransposeNodes);
 
     auto transpose_label =
         ov::pass::pattern::wrap_type<ov::opset9::Transpose>({unary_label, ov::pass::pattern::any_input()},

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
@@ -363,10 +363,13 @@ bool HasSameOutputTransposeNodes(NodePtr main_node) {
     return true;
 }
 
-void RemoveConsumers(NodePtr node) {
+void RemoveSingleOutputConsumers(NodePtr node) {
     for (size_t output_idx = 0; output_idx < node->get_output_size(); ++output_idx) {
         for (auto& input : node->get_output_target_inputs(output_idx)) {
-            input.get_node()->output(0).replace(node->output(output_idx));
+            Node* consumer = input.get_node();
+            if (consumer->get_output_size() != 1)
+                continue;
+            consumer->output(0).replace(node->output(output_idx));
         }
     }
 }

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
@@ -114,8 +114,9 @@ ov::Output<ov::Node> FixInputNodeRank(ov::Output<ov::Node> input_node, ov::Rank:
 std::set<size_t> GetNodeIds(NodeVector nodes) {
     std::set<size_t> node_ids;
 
-    std::transform(nodes.begin(), nodes.end(), std::inserter(node_ids, node_ids.begin()),
-                   [](NodePtr node) -> size_t { return node->get_instance_id(); });
+    std::transform(nodes.begin(), nodes.end(), std::inserter(node_ids, node_ids.begin()), [](NodePtr node) -> size_t {
+        return node->get_instance_id();
+    });
 
     return node_ids;
 }

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
@@ -111,7 +111,7 @@ ov::Output<ov::Node> FixInputNodeRank(ov::Output<ov::Node> input_node, ov::Rank:
     return InsertUnsqueeze(input_node, required_rank - output_rank)->output(0);
 }
 
-std::set<size_t> GetNodeIds(NodeVector nodes) {
+std::set<size_t> GetNodeIds(const NodeVector& nodes) {
     std::set<size_t> node_ids;
 
     std::transform(nodes.begin(), nodes.end(), std::inserter(node_ids, node_ids.begin()), [](NodePtr node) -> size_t {
@@ -123,7 +123,7 @@ std::set<size_t> GetNodeIds(NodeVector nodes) {
 
 }  // namespace
 
-NodePtr CloneNodeWithoutConsumers(NodePtr node, NodeVector consumers) {
+NodePtr CloneNodeWithoutConsumers(NodePtr node, const NodeVector& consumers) {
     const auto consumer_ids = GetNodeIds(consumers);
 
     auto new_node = node->clone_with_new_inputs(node->input_values());

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
@@ -140,7 +140,6 @@ NodePtr CloneNodeWithoutConsumers(NodePtr node, NodeVector consumers) {
 
 namespace sink_forward {
 
-// insert input reversed transposes, remove first input tranpose
 void UpdateInputTransposes(NodePtr main_node, TransposeInputsInfo& transpose_input_info) {
     if (transpose_input_info.isEmpty() || HasDynamicRankInput(main_node))
         return;
@@ -174,12 +173,12 @@ void UpdateInputTransposes(NodePtr main_node, TransposeInputsInfo& transpose_inp
     }
 }
 
-void RemoveZeroInputNode(NodePtr main_node) {
-    auto input_node = main_node->input_value(0);
-    if (input_node.get_node()->get_input_size() < 1)
+void RemoveInputNode(NodePtr main_node, size_t input_idx) {
+    auto input_node = main_node->input_value(input_idx);
+    if (input_node.get_node()->get_input_size() < (input_idx + 1))
         return;
-    auto parent_node = input_node.get_node()->input_value(0);
-    main_node->input(0).replace_source_output(parent_node);
+    auto parent_node = input_node.get_node()->input_value(input_idx);
+    main_node->input(input_idx).replace_source_output(parent_node);
 }
 
 NodeVector InsertOutputTransposes(NodePtr main_node, TransposeInputsInfo& transpose_input_info) {

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
@@ -111,33 +111,7 @@ ov::Output<ov::Node> FixInputNodeRank(ov::Output<ov::Node> input_node, ov::Rank:
     return InsertUnsqueeze(input_node, required_rank - output_rank)->output(0);
 }
 
-std::set<size_t> GetNodeIds(const NodeVector& nodes) {
-    std::set<size_t> node_ids;
-
-    std::transform(nodes.begin(), nodes.end(), std::inserter(node_ids, node_ids.begin()), [](NodePtr node) -> size_t {
-        return node->get_instance_id();
-    });
-
-    return node_ids;
-}
-
 }  // namespace
-
-NodePtr CloneNodeWithoutConsumers(NodePtr node, const NodeVector& consumers) {
-    const auto consumer_ids = GetNodeIds(consumers);
-
-    auto new_node = node->clone_with_new_inputs(node->input_values());
-    for (size_t i = 0; i < node->get_output_size(); ++i) {
-        for (auto& orig_node_consumer : node->output(i).get_target_inputs()) {
-            if (consumer_ids.find(orig_node_consumer.get_node()->get_instance_id()) != consumer_ids.end())
-                continue;
-            orig_node_consumer.replace_source_output(new_node->output(i));
-        }
-    }
-    copy_runtime_info(node, new_node);
-
-    return new_node;
-}
 
 namespace sink_forward {
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
@@ -270,18 +270,6 @@ void UpdateForwardSinkingAbility(NodePtr node) {
 
 namespace {
 
-std::shared_ptr<Constant> GetTransposeConstant(Input<Node> input) {
-    auto transpose_node = dynamic_cast<Transpose*>(input.get_node());
-    if (!transpose_node)
-        return {};
-
-    auto constant_node = as_type_ptr<Constant>(transpose_node->input_value(1).get_node_shared_ptr());
-    if (!constant_node)
-        return {};
-
-    return constant_node;
-}
-
 std::shared_ptr<Constant> GetTransposeConstant(Node* node) {
     auto transpose_node = dynamic_cast<Transpose*>(node);
     if (!transpose_node)
@@ -318,7 +306,7 @@ bool HasSameOutputTransposeNodes(NodePtr main_node) {
 
     for (size_t output_idx = 0; output_idx < main_node->get_output_size(); ++output_idx) {
         for (auto& input : main_node->get_output_target_inputs(output_idx)) {
-            auto constant_node = GetTransposeConstant(input);
+            auto constant_node = GetTransposeConstant(input.get_node());
             if (!constant_node)
                 return false;
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
@@ -271,6 +271,7 @@ bool CanPropagateForwardThrough(Node* node) {
     CHECK_TRANSPOSE_SINKING_SUPPORTED(Concat, node);
     CHECK_TRANSPOSE_SINKING_SUPPORTED(Split, node);
     CHECK_TRANSPOSE_SINKING_SUPPORTED(Transpose, node);
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(PRelu, node);
 
     return false;
 }

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
@@ -111,7 +111,32 @@ ov::Output<ov::Node> FixInputNodeRank(ov::Output<ov::Node> input_node, ov::Rank:
     return InsertUnsqueeze(input_node, required_rank - output_rank)->output(0);
 }
 
+std::set<size_t> GetNodeIds(NodeVector nodes) {
+    std::set<size_t> node_ids;
+
+    std::transform(nodes.begin(), nodes.end(), std::inserter(node_ids, node_ids.begin()),
+                   [](NodePtr node) -> size_t { return node->get_instance_id(); });
+
+    return node_ids;
+}
+
 }  // namespace
+
+NodePtr CloneNodeWithoutConsumers(NodePtr node, NodeVector consumers) {
+    const auto consumer_ids = GetNodeIds(consumers);
+
+    auto new_node = node->clone_with_new_inputs(node->input_values());
+    for (size_t i = 0; i < node->get_output_size(); ++i) {
+        for (auto& orig_node_consumer : node->output(i).get_target_inputs()) {
+            if (consumer_ids.find(orig_node_consumer.get_node()->get_instance_id()) != consumer_ids.end())
+                continue;
+            orig_node_consumer.replace_source_output(new_node->output(i));
+        }
+    }
+    copy_runtime_info(node, new_node);
+
+    return new_node;
+}
 
 namespace sink_forward {
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
@@ -330,8 +330,6 @@ Node* FindFirstConsumer(NodePtr node) {
     return nullptr;
 }
 
-}  // namespace
-
 bool HasSameOutputTransposeNodes(NodePtr main_node) {
     AxisVector first_transpose_axis_order;
     {
@@ -361,6 +359,12 @@ bool HasSameOutputTransposeNodes(NodePtr main_node) {
     }
 
     return true;
+}
+
+}  // namespace
+
+bool HasSameOutputTransposeNodes(const Output<Node>& output) {
+    return HasSameOutputTransposeNodes(output.get_node_shared_ptr());
 }
 
 void RemoveSingleOutputConsumers(NodePtr node) {

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking_utils.cpp
@@ -141,7 +141,7 @@ NodePtr CloneNodeWithoutConsumers(NodePtr node, const NodeVector& consumers) {
 
 namespace sink_forward {
 
-void UpdateInputTransposes(NodePtr main_node, TransposeInputsInfo& transpose_input_info) {
+void UpdateInputTransposes(NodePtr main_node, const TransposeInputsInfo& transpose_input_info) {
     if (transpose_input_info.isEmpty() || HasDynamicRankInput(main_node))
         return;
 
@@ -182,7 +182,7 @@ void RemoveInputNode(NodePtr main_node, size_t input_idx) {
     main_node->input(input_idx).replace_source_output(parent_node);
 }
 
-NodeVector InsertOutputTransposes(NodePtr main_node, TransposeInputsInfo& transpose_input_info) {
+NodeVector InsertOutputTransposes(NodePtr main_node, const TransposeInputsInfo& transpose_input_info) {
     if (transpose_input_info.isEmpty())
         return {};
     const auto transpose_axis_order = transpose_input_info.transpose_const->get_axis_vector_val();

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -15,6 +15,8 @@
 using namespace ov;
 using namespace ov::opset9;
 
+namespace transpose_sinking_binary_eltwise {
+
 namespace {
 
 using NodePtr = std::shared_ptr<ov::Node>;
@@ -1166,6 +1168,8 @@ std::vector<CreateGraphFunctionDesc> backward_subtests = {
     SUBTEST(backward::output_transpose_mult_consumers, "backward_output_transpose_mult_consumers")
 };
 
+#undef SUBTEST
+
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingBinaryForwardMultiConsumersTestSuite,
     TransposeSinkingFixture,
@@ -1187,3 +1191,5 @@ INSTANTIATE_TEST_SUITE_P(
                        TransposeSinkingFixture::get_test_name);
 
 } // namespace mult_consumers
+
+} // namespace transpose_sinking_binary_eltwise

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -1127,7 +1127,6 @@ std::vector<CreateGraphFunctionDesc> backward_subtests = {
 
 #undef SUBTEST
 
-
 INSTANTIATE_TEST_SUITE_P(TransposeSinkingBinaryForwardMultiConsumersTestSuite,
                          TransposeBinaryMultiSinkingFixture,
                          ::testing::Combine(::testing::ValuesIn(binary_factories),
@@ -1150,8 +1149,7 @@ namespace no_sinking {
 
 struct CreateGraphFunctionDesc {
     CreateGraphFunctionDesc() = default;
-    CreateGraphFunctionDesc(CreateGraphF a_model_factory,
-                            std::string a_subtest_name)
+    CreateGraphFunctionDesc(CreateGraphF a_model_factory, std::string a_subtest_name)
         : model_factory(a_model_factory),
           subtest_name(a_subtest_name) {}
     CreateGraphF model_factory;
@@ -1165,7 +1163,7 @@ using TestBinaryParams = std::tuple<BinaryFactoryPtr,
                                     size_t>;       /*binary_transpose_input_idx*/
 
 class TransposeBinaryMultiSinkingBinaryMultiConsumersFixture : public ::testing::WithParamInterface<TestBinaryParams>,
-                                           public TransformationTestsF {
+                                                               public TransformationTestsF {
 public:
     static std::string get_test_name(const testing::TestParamInfo<TestBinaryParams>& obj) {
         BinaryFactoryPtr binary_factory;
@@ -1198,19 +1196,17 @@ TEST_P(TransposeBinaryMultiSinkingBinaryMultiConsumersFixture, CompareFunctions)
 
     model = function_desc.model_factory(binary_factory, input_type, binary_transpose_input_idx);
     model_ref = model->clone();
-    //model_ref = function_desc.model_factory(binary_factory, input_type, binary_transpose_input_idx);
+    // model_ref = function_desc.model_factory(binary_factory, input_type, binary_transpose_input_idx);
     pass_factory->registerPass(manager);
 }
 
-#define SUBTEST(nmspace, subtest_name) \
-    CreateGraphFunctionDesc(nmspace::CreateFunction, subtest_name)
+#define SUBTEST(nmspace, subtest_name) CreateGraphFunctionDesc(nmspace::CreateFunction, subtest_name)
 
 std::vector<CreateGraphFunctionDesc> backward_subtests_binary_consumers = {
     SUBTEST(backward::output_consumers::one_binary, "backwardOutputConsumersOneBinary"),
     SUBTEST(backward::output_consumers::multiple_binaries, "backwardOutputConsumersMultipleBinaries"),
 };
 #undef SUBTEST
-
 
 INSTANTIATE_TEST_SUITE_P(TransposeSinkingBinaryBackwardBinaryMultiConsumersTestSuite,
                          TransposeBinaryMultiSinkingBinaryMultiConsumersFixture,
@@ -1221,7 +1217,7 @@ INSTANTIATE_TEST_SUITE_P(TransposeSinkingBinaryBackwardBinaryMultiConsumersTestS
                                             ::testing::ValuesIn(binary_transpose_input_indexes)),
                          TransposeBinaryMultiSinkingBinaryMultiConsumersFixture::get_test_name);
 
-} // namespace no_sinking
+}  // namespace no_sinking
 
 }  // namespace mult_consumers
 

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -234,7 +234,28 @@ using TestBinaryTwoTransposeInputsParams = std::tuple<BinaryFactoryPtr,
 
 class TransposeSinkingBinaryTwoTransposeInputsTestFixture
     : public ::testing::WithParamInterface<TestBinaryTwoTransposeInputsParams>,
-                                          public TransformationTestsF {};
+                                          public TransformationTestsF {
+public:
+    static std::string get_test_name(const testing::TestParamInfo<TestBinaryTwoTransposeInputsParams>& obj) {
+        BinaryFactoryPtr unary_factory;
+        PassFactoryPtr pass_factory;
+        size_t num_binary_ops;
+        CreateGraphBinaryTwoTransposeInputsF model_factory;
+        CreateGraphBinaryTwoTransposeInputsF reference_model_factory;
+        element::Type input_type;
+
+        std::tie(unary_factory, pass_factory, num_binary_ops, model_factory, reference_model_factory, input_type) =
+            obj.param;
+
+        std::ostringstream test_name;
+        test_name << "binary_factory=" << unary_factory->getTypeName() << "_";
+        test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
+        test_name << "num_binary_ops=" << num_binary_ops << "_";
+        test_name << "input_type=" << input_type;
+
+        return test_name.str();
+    }
+};
 
 TEST_P(TransposeSinkingBinaryTwoTransposeInputsTestFixture, CompareFunctions) {
     BinaryFactoryPtr unary_factory;
@@ -260,7 +281,8 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::ValuesIn(binary_operations_numbers),
                        ::testing::Values(CreateFunction),
                        ::testing::Values(CreateReferenceFunction),
-                       ::testing::Values(element::f32)));
+                       ::testing::Values(element::f32)),
+                       TransposeSinkingBinaryTwoTransposeInputsTestFixture::get_test_name);
 
 
 }  // namespace double_transpose

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -279,7 +279,7 @@ INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingBinaryTwoTransposeInputsForwardTestSuite,
     TransposeSinkingBinaryTwoTransposeInputsTestFixture,
     ::testing::Combine(::testing::ValuesIn(binary_factories),
-                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryElementwiseForward)),
+                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryForward)),
                        ::testing::ValuesIn(binary_operations_numbers),
                        ::testing::Values(CreateFunction),
                        ::testing::Values(CreateReferenceFunction),
@@ -414,7 +414,7 @@ INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingBinaryTestFixture,
     ::testing::Combine(
         ::testing::ValuesIn(binary_factories),
-        ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryElementwiseForward)),
+        ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryForward)),
         ::testing::ValuesIn(binary_operations_numbers),
         ::testing::Values(single_consumer::forward::one_input_transpose::CreateFunction),
         ::testing::Values(single_consumer::forward::one_input_transpose::CreateReferenceFunction),
@@ -427,7 +427,7 @@ INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingBinaryTestFixture,
     ::testing::Combine(
         ::testing::ValuesIn(binary_factories),
-        ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryElementwiseBackward)),
+        ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryBackward)),
         ::testing::ValuesIn(binary_operations_numbers),
         ::testing::Values(single_consumer::backward::one_input_transpose::CreateFunction),
         ::testing::Values(single_consumer::backward::one_input_transpose::CreateReferenceFunction),
@@ -635,7 +635,7 @@ INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingBinaryIncompatShapesBackwardTestSuite,
     TransposeSinkingBinaryIncompatShapesTestFixture,
     ::testing::Combine(::testing::ValuesIn(binary_factories),
-                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryElementwiseBackward)),
+                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryBackward)),
                        ::testing::Values(ov::Shape{1, 96, 55, 55}),
                        ::testing::ValuesIn(binary::single_consumer::backward::incompat_shapes::constant_shapes),
                        ::testing::Values(binary::single_consumer::backward::incompat_shapes::CreateFunction),
@@ -648,7 +648,7 @@ INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingBinaryIncompatShapesForwardTestSuite,
     TransposeSinkingBinaryIncompatShapesTestFixture,
     ::testing::Combine(::testing::ValuesIn(binary_factories),
-                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryElementwiseForward)),
+                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryForward)),
                        ::testing::Values(ov::Shape{1, 96, 55, 55}),
                        ::testing::ValuesIn(binary::single_consumer::forward::incompat_shapes::constant_shapes),
                        ::testing::Values(binary::single_consumer::forward::incompat_shapes::CreateFunction),
@@ -1163,36 +1163,35 @@ std::vector<CreateGraphFunctionDesc> forward_subtests = {
     SUBTEST(forward::output_consumers::one_binary, "forward_output_consumers"),
     SUBTEST(forward::input_node_consumers, "forward_input_node_consumers")
 };
-#if 0
+
 std::vector<CreateGraphFunctionDesc> backward_subtests = {
     SUBTEST(backward::output_consumers::one_binary, "backward_output_consumers_one_binary"),
     SUBTEST(backward::output_consumers::multiple_binaries, "backward_output_consumers_multiple_binaries"),
     SUBTEST(backward::input_node_consumers, "backward_input_node_consumers"),
     SUBTEST(backward::output_transpose_mult_consumers, "backward_output_transpose_mult_consumers")
 };
-#endif
+
 #undef SUBTEST
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingBinaryForwardMultiConsumersTestSuite,
     TransposeBinaryMultiSinkingFixture,
     ::testing::Combine(::testing::ValuesIn(binary_factories),
-                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryElementwiseForward)),
+                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryForward)),
                        ::testing::ValuesIn(forward_subtests),
                        ::testing::Values(element::f32),
                        ::testing::ValuesIn(binary_transpose_input_indexes)),
                        TransposeBinaryMultiSinkingFixture::get_test_name);
-#if 0
+
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingBinaryBackwardMultiConsumersTestSuite,
     TransposeBinaryMultiSinkingFixture,
     ::testing::Combine(::testing::ValuesIn(binary_factories),
-                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryElementwiseBackward)),
+                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryBackward)),
                        ::testing::ValuesIn(backward_subtests),
                        ::testing::Values(element::f32),
                        ::testing::ValuesIn(binary_transpose_input_indexes)),
                        TransposeBinaryMultiSinkingFixture::get_test_name);
-#endif
 } // namespace mult_consumers
 
 } // namespace transpose_sinking_binary_eltwise

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -362,8 +362,9 @@ public:
         size_t num_binary_ops;
         CreateGraphBinaryF model_factory;
         CreateGraphBinaryF reference_model_factory;
-        ov::element::Type input_type;
+        element::Type input_type;
         size_t binary_transpose_input_idx;
+
         std::tie(binary_factory,
                  pass_factory,
                  num_binary_ops,

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -906,43 +906,6 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
     return std::make_shared<Model>(ov::OutputVector{transpose0, tanh}, ov::ParameterVector{X});
 }
 
-#if 0
-std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
-                                               element::Type input_type,
-                                               size_t binary_transpose_input_idx) {
-    const Shape input_shape{1, 96, 55, 55};
-
-    auto X = std::make_shared<Parameter>(input_type, input_shape);
-
-    auto tanh0 = std::make_shared<Tanh>(X);
-
-    NodePtr binary0;
-    auto in_constant0 = std::make_shared<Constant>(input_type, input_shape, Shape{1});
-    if (!binary_transpose_input_idx)
-        binary0 = binary_factory->create(tanh0, in_constant0);
-    else
-        binary0 = binary_factory->create(in_constant0, tanh0);
-
-    auto tanh1 = std::make_shared<Tanh>(binary0);
-
-    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<Transpose>(tanh0, ng_order0);
-
-    auto in_constant = std::make_shared<Constant>(input_type, input_shape, Shape{1});
-
-    auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
-    auto transpose = std::make_shared<Transpose>(in_constant, ng_order);
-
-    NodePtr binary1;
-    if (!binary_transpose_input_idx)
-        binary1 = binary_factory->create(transpose0, transpose);
-    else
-        binary1 = binary_factory->create(transpose, transpose0);
-
-    return std::make_shared<Model>(ov::OutputVector{binary1, tanh1}, ov::ParameterVector{X});
-}
-#endif
-
 }  // namespace one_binary
 
 namespace multiple_binaries {
@@ -973,48 +936,6 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
 
     return std::make_shared<Model>(ov::OutputVector{transpose0, tanh}, ov::ParameterVector{X});
 }
-
-#if 0
-std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
-                                               element::Type input_type,
-                                               size_t binary_transpose_input_idx) {
-    const Shape input_shape{1, 96, 55, 55};
-    const size_t n_binaries = 10;
-
-    auto X = std::make_shared<Parameter>(input_type, input_shape);
-
-    auto tanh0 = std::make_shared<Tanh>(X);
-
-    // left branch
-    NodePtr in_op = tanh0;
-    for (size_t i = 0; i < n_binaries; ++i) {
-        auto in_constant = std::make_shared<Constant>(input_type, input_shape, Shape{1});
-        if (!binary_transpose_input_idx)
-            in_op = binary_factory->create(in_op, in_constant);
-        else
-            in_op = binary_factory->create(in_constant, in_op);
-    }
-
-    auto tanh1 = std::make_shared<Tanh>(in_op);
-
-    // right branch
-    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<Transpose>(tanh0, ng_order0);
-
-    in_op = transpose0;
-    for (size_t i = 0; i < n_binaries; ++i) {
-        auto in_constant = std::make_shared<Constant>(input_type, input_shape, Shape{1});
-        auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
-        auto transpose = std::make_shared<Transpose>(in_constant, ng_order);
-        if (!binary_transpose_input_idx)
-            in_op = binary_factory->create(in_op, transpose);
-        else
-            in_op = binary_factory->create(transpose, in_op);
-    }
-
-    return std::make_shared<Model>(ov::OutputVector{in_op, tanh1}, ov::ParameterVector{X});
-}
-#endif
 
 }  // namespace multiple_binaries
 

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -778,6 +778,8 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
     return std::make_shared<Model>(ov::OutputVector{tanh1, tanh2}, ov::ParameterVector{X});
 }
 
+} // namespace one_binary
+
 } // namespace output_consumers
 
 namespace input_node_consumers {
@@ -838,12 +840,13 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
 
 } // namespace input_node_consumers
 
-
 } // namespace forward
 
 namespace backward {
 
 namespace output_consumers {
+
+namespace one_binary {
 
 std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
                                           element::Type input_type,
@@ -1113,7 +1116,7 @@ using TestBinaryParams = std::tuple<BinaryFactoryPtr,
                                     element::Type, /* input type */
                                     size_t>;       /*binary_transpose_input_idx*/
 
-class TransposeSinkingFixture
+class TransposeBinaryMultiSinkingFixture
     : public ::testing::WithParamInterface<TestBinaryParams>,
                                           public TransformationTestsF {
 public:
@@ -1138,7 +1141,7 @@ public:
     }
 };
 
-TEST_P(TransposeSinkingFixture, CompareFunctions) {
+TEST_P(TransposeBinaryMultiSinkingFixture, CompareFunctions) {
     BinaryFactoryPtr binary_factory;
     PassFactoryPtr pass_factory;
     CreateGraphFunctionDesc function_desc;
@@ -1157,39 +1160,39 @@ TEST_P(TransposeSinkingFixture, CompareFunctions) {
 
 std::vector<CreateGraphFunctionDesc> forward_subtests = {
     SUBTEST(forward::input_transpose_consumers, "forward_input_transpose_consumers"),
-    SUBTEST(forward::output_consumers, "forward_output_consumers"),
+    SUBTEST(forward::output_consumers::one_binary, "forward_output_consumers"),
     SUBTEST(forward::input_node_consumers, "forward_input_node_consumers")
 };
-
+#if 0
 std::vector<CreateGraphFunctionDesc> backward_subtests = {
     SUBTEST(backward::output_consumers::one_binary, "backward_output_consumers_one_binary"),
     SUBTEST(backward::output_consumers::multiple_binaries, "backward_output_consumers_multiple_binaries"),
     SUBTEST(backward::input_node_consumers, "backward_input_node_consumers"),
     SUBTEST(backward::output_transpose_mult_consumers, "backward_output_transpose_mult_consumers")
 };
-
+#endif
 #undef SUBTEST
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingBinaryForwardMultiConsumersTestSuite,
-    TransposeSinkingFixture,
+    TransposeBinaryMultiSinkingFixture,
     ::testing::Combine(::testing::ValuesIn(binary_factories),
                        ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryElementwiseForward)),
                        ::testing::ValuesIn(forward_subtests),
                        ::testing::Values(element::f32),
                        ::testing::ValuesIn(binary_transpose_input_indexes)),
-                       TransposeSinkingFixture::get_test_name);
-
+                       TransposeBinaryMultiSinkingFixture::get_test_name);
+#if 0
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingBinaryBackwardMultiConsumersTestSuite,
-    TransposeSinkingFixture,
+    TransposeBinaryMultiSinkingFixture,
     ::testing::Combine(::testing::ValuesIn(binary_factories),
                        ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryElementwiseBackward)),
                        ::testing::ValuesIn(backward_subtests),
                        ::testing::Values(element::f32),
                        ::testing::ValuesIn(binary_transpose_input_indexes)),
-                       TransposeSinkingFixture::get_test_name);
-
+                       TransposeBinaryMultiSinkingFixture::get_test_name);
+#endif
 } // namespace mult_consumers
 
 } // namespace transpose_sinking_binary_eltwise

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -223,7 +223,7 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
 }
 
 using CreateGraphBinaryTwoTransposeInputsF = std::function<
-    std::shared_ptr<Model>(BinaryFactoryPtr unary_factory, size_t num_binary_ops, element::Type input_type)>;
+    std::shared_ptr<Model>(BinaryFactoryPtr binary_factory, size_t num_binary_ops, element::Type input_type)>;
 
 using TestBinaryTwoTransposeInputsParams = std::tuple<BinaryFactoryPtr,
                                     PassFactoryPtr,
@@ -237,18 +237,18 @@ class TransposeSinkingBinaryTwoTransposeInputsTestFixture
                                           public TransformationTestsF {
 public:
     static std::string get_test_name(const testing::TestParamInfo<TestBinaryTwoTransposeInputsParams>& obj) {
-        BinaryFactoryPtr unary_factory;
+        BinaryFactoryPtr binary_factory;
         PassFactoryPtr pass_factory;
         size_t num_binary_ops;
         CreateGraphBinaryTwoTransposeInputsF model_factory;
         CreateGraphBinaryTwoTransposeInputsF reference_model_factory;
         element::Type input_type;
 
-        std::tie(unary_factory, pass_factory, num_binary_ops, model_factory, reference_model_factory, input_type) =
+        std::tie(binary_factory, pass_factory, num_binary_ops, model_factory, reference_model_factory, input_type) =
             obj.param;
 
         std::ostringstream test_name;
-        test_name << "binary_factory=" << unary_factory->getTypeName() << "_";
+        test_name << "binary_factory=" << binary_factory->getTypeName() << "_";
         test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
         test_name << "num_binary_ops=" << num_binary_ops << "_";
         test_name << "input_type=" << input_type;
@@ -258,18 +258,18 @@ public:
 };
 
 TEST_P(TransposeSinkingBinaryTwoTransposeInputsTestFixture, CompareFunctions) {
-    BinaryFactoryPtr unary_factory;
+    BinaryFactoryPtr binary_factory;
     PassFactoryPtr pass_factory;
     size_t num_binary_ops;
     CreateGraphBinaryTwoTransposeInputsF model_factory;
     CreateGraphBinaryTwoTransposeInputsF reference_model_factory;
     element::Type input_type;
 
-    std::tie(unary_factory, pass_factory, num_binary_ops, model_factory, reference_model_factory, input_type) =
+    std::tie(binary_factory, pass_factory, num_binary_ops, model_factory, reference_model_factory, input_type) =
         this->GetParam();
 
-    model = model_factory(unary_factory, num_binary_ops, input_type);
-    model_ref = reference_model_factory(unary_factory, num_binary_ops, input_type);
+    model = model_factory(binary_factory, num_binary_ops, input_type);
+    model_ref = reference_model_factory(binary_factory, num_binary_ops, input_type);
     pass_factory->registerPass(manager);
 }
 
@@ -340,7 +340,7 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
     return std::make_shared<Model>(ov::OutputVector{in_op}, ov::ParameterVector{X});
 }
 
-using CreateGraphBinaryF = std::function<std::shared_ptr<Model>(BinaryFactoryPtr unary_factory,
+using CreateGraphBinaryF = std::function<std::shared_ptr<Model>(BinaryFactoryPtr binary_factory,
                                                                     size_t num_binary_ops,
                                                                     element::Type input_type,
                                                                     size_t binary_transpose_input_idx)>;

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -12,6 +12,9 @@
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "gtest/gtest.h"
 
+using namespace ov;
+using namespace ov::opset9;
+
 namespace {
 
 using NodePtr = std::shared_ptr<ov::Node>;
@@ -114,21 +117,21 @@ namespace single_consumer {
 namespace forward {
 namespace one_input_transpose {
 
-std::shared_ptr<ov::Model> CreateFunction(BinaryFactoryPtr binary_factory,
+std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
                                           size_t num_binary_ops,
-                                          ov::element::Type input_type,
+                                          element::Type input_type,
                                           size_t binary_transpose_input_idx) {
-    const ov::Shape input_shape{1, 96, 55, 55};
-    const ov::Shape const_shape{1, 55, 55, 96};
+    const Shape input_shape{1, 96, 55, 55};
+    const Shape const_shape{1, 55, 55, 96};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(X, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
     NodePtr in_op = transpose0;
     for (size_t i = 0; i < num_binary_ops; ++i) {
-        auto in_constant = std::make_shared<ov::opset9::Constant>(input_type, const_shape, ov::Shape{1});
+        auto in_constant = std::make_shared<Constant>(input_type, const_shape, Shape{1});
         if (!binary_transpose_input_idx)
             in_op = binary_factory->create(in_op, in_constant);
         else
@@ -140,20 +143,20 @@ std::shared_ptr<ov::Model> CreateFunction(BinaryFactoryPtr binary_factory,
 
 std::shared_ptr<ov::Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
                                                    size_t num_binary_ops,
-                                                   ov::element::Type input_type,
+                                                   element::Type input_type,
                                                    size_t binary_transpose_input_idx) {
-    const ov::Shape input_shape{1, 96, 55, 55};
-    const ov::Shape const_shape{1, 55, 55, 96};
+    const Shape input_shape{1, 96, 55, 55};
+    const Shape const_shape{1, 55, 55, 96};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     NodePtr in_op = X;
     for (size_t i = 0; i < num_binary_ops; ++i) {
-        auto in_constant = std::make_shared<ov::opset9::Constant>(input_type, const_shape, ov::Shape{1});
+        auto in_constant = std::make_shared<Constant>(input_type, const_shape, Shape{1});
 
         auto transpose_reversed_const =
-            std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-        auto transpose_reversed = std::make_shared<ov::opset9::Transpose>(in_constant, transpose_reversed_const);
+            std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+        auto transpose_reversed = std::make_shared<Transpose>(in_constant, transpose_reversed_const);
 
         if (!binary_transpose_input_idx)
             in_op = binary_factory->create(in_op, transpose_reversed);
@@ -161,8 +164,8 @@ std::shared_ptr<ov::Model> CreateReferenceFunction(BinaryFactoryPtr binary_facto
             in_op = binary_factory->create(transpose_reversed, in_op);
     }
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(in_op, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
 
     return std::make_shared<ov::Model>(ov::OutputVector{transpose0}, ov::ParameterVector{X});
 }
@@ -172,19 +175,19 @@ std::shared_ptr<ov::Model> CreateReferenceFunction(BinaryFactoryPtr binary_facto
 namespace double_transpose {
 std::shared_ptr<ov::Model> CreateFunction(BinaryFactoryPtr binary_factory,
                                           size_t num_binary_ops,
-                                          ov::element::Type input_type) {
-    const ov::Shape input_shape{1, 96, 55, 55};
+                                          element::Type input_type) {
+    const Shape input_shape{1, 96, 55, 55};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(X, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
     NodePtr in_op = transpose0;
     for (size_t i = 0; i < num_binary_ops; ++i) {
-        auto in_constant = std::make_shared<ov::opset9::Constant>(input_type, input_shape, ov::Shape{1});
-        auto ng_order1 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-        auto transpose1 = std::make_shared<ov::opset9::Transpose>(in_constant, ng_order1);
+        auto in_constant = std::make_shared<Constant>(input_type, input_shape, Shape{1});
+        auto ng_order1 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+        auto transpose1 = std::make_shared<Transpose>(in_constant, ng_order1);
 
         in_op = binary_factory->create(in_op, transpose1);
     }
@@ -194,40 +197,40 @@ std::shared_ptr<ov::Model> CreateFunction(BinaryFactoryPtr binary_factory,
 
 std::shared_ptr<ov::Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
                                                    size_t num_binary_ops,
-                                                   ov::element::Type input_type) {
-    const ov::Shape input_shape{1, 96, 55, 55};
+                                                   element::Type input_type) {
+    const Shape input_shape{1, 96, 55, 55};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     NodePtr in_op = X;
     for (size_t i = 0; i < num_binary_ops; ++i) {
-        auto in_constant = std::make_shared<ov::opset9::Constant>(input_type, input_shape, ov::Shape{1});
+        auto in_constant = std::make_shared<Constant>(input_type, input_shape, Shape{1});
 
-        auto ng_order1 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-        auto transpose1 = std::make_shared<ov::opset9::Transpose>(in_constant, ng_order1);
+        auto ng_order1 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+        auto transpose1 = std::make_shared<Transpose>(in_constant, ng_order1);
 
         auto transpose_reversed_const =
-            std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-        auto transpose_reversed = std::make_shared<ov::opset9::Transpose>(transpose1, transpose_reversed_const);
+            std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+        auto transpose_reversed = std::make_shared<Transpose>(transpose1, transpose_reversed_const);
 
         in_op = binary_factory->create(in_op, transpose_reversed);
     }
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(in_op, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
 
     return std::make_shared<ov::Model>(ov::OutputVector{transpose0}, ov::ParameterVector{X});
 }
 
 using CreateGraphBinaryTwoTransposeInputsF = std::function<
-    std::shared_ptr<ov::Model>(BinaryFactoryPtr unary_factory, size_t num_binary_ops, ov::element::Type input_type)>;
+    std::shared_ptr<ov::Model>(BinaryFactoryPtr unary_factory, size_t num_binary_ops, element::Type input_type)>;
 
 using TestBinaryTwoTransposeInputsParams = std::tuple<BinaryFactoryPtr,
                                     PassFactoryPtr,
                                     size_t,                                  /* num_binary_ops */
                                     CreateGraphBinaryTwoTransposeInputsF,    /* model_factory */
                                     CreateGraphBinaryTwoTransposeInputsF, /* reference_model_factory */
-                                    ov::element::Type>;                      /* input type */
+                                    element::Type>;                      /* input type */
 
 class TransposeSinkingBinaryTwoTransposeInputsTestFixture
     : public ::testing::WithParamInterface<TestBinaryTwoTransposeInputsParams>,
@@ -239,7 +242,7 @@ TEST_P(TransposeSinkingBinaryTwoTransposeInputsTestFixture, CompareFunctions) {
     size_t num_binary_ops;
     CreateGraphBinaryTwoTransposeInputsF model_factory;
     CreateGraphBinaryTwoTransposeInputsF reference_model_factory;
-    ov::element::Type input_type;
+    element::Type input_type;
 
     std::tie(unary_factory, pass_factory, num_binary_ops, model_factory, reference_model_factory, input_type) =
         this->GetParam();
@@ -257,7 +260,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::ValuesIn(binary_operations_numbers),
                        ::testing::Values(CreateFunction),
                        ::testing::Values(CreateReferenceFunction),
-                       ::testing::Values(ov::element::f32)));
+                       ::testing::Values(element::f32)));
 
 
 }  // namespace double_transpose
@@ -267,44 +270,44 @@ namespace backward {
 namespace one_input_transpose {
 std::shared_ptr<ov::Model> CreateFunction(BinaryFactoryPtr binary_factory,
                                           size_t num_binary_ops,
-                                          ov::element::Type input_type,
+                                          element::Type input_type,
                                           size_t binary_transpose_input_idx) {
-    const ov::Shape input_shape{1, 96, 55, 55};
+    const Shape input_shape{1, 96, 55, 55};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     NodePtr in_op = X;
     for (size_t i = 0; i < num_binary_ops; ++i) {
-        auto in_constant = std::make_shared<ov::opset9::Constant>(input_type, input_shape, ov::Shape{1});
+        auto in_constant = std::make_shared<Constant>(input_type, input_shape, Shape{1});
         if (!binary_transpose_input_idx)
             in_op = binary_factory->create(in_op, in_constant);
         else
             in_op = binary_factory->create(in_constant, in_op);
     }
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(in_op, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
 
     return std::make_shared<ov::Model>(ov::OutputVector{transpose0}, ov::ParameterVector{X});
 }
 
 std::shared_ptr<ov::Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
                                                    size_t num_binary_ops,
-                                                   ov::element::Type input_type,
+                                                   element::Type input_type,
                                                    size_t binary_transpose_input_idx) {
-    const ov::Shape input_shape{1, 96, 55, 55};
+    const Shape input_shape{1, 96, 55, 55};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(X, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
     NodePtr in_op = transpose0;
     for (size_t i = 0; i < num_binary_ops; ++i) {
-        auto in_constant = std::make_shared<ov::opset9::Constant>(input_type, input_shape, ov::Shape{1});
+        auto in_constant = std::make_shared<Constant>(input_type, input_shape, Shape{1});
 
-        auto ng_order = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-        auto transpose = std::make_shared<ov::opset9::Transpose>(in_constant, ng_order);
+        auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+        auto transpose = std::make_shared<Transpose>(in_constant, ng_order);
 
         if (!binary_transpose_input_idx)
             in_op = binary_factory->create(in_op, transpose);
@@ -317,7 +320,7 @@ std::shared_ptr<ov::Model> CreateReferenceFunction(BinaryFactoryPtr binary_facto
 
 using CreateGraphBinaryF = std::function<std::shared_ptr<ov::Model>(BinaryFactoryPtr unary_factory,
                                                                     size_t num_binary_ops,
-                                                                    ov::element::Type input_type,
+                                                                    element::Type input_type,
                                                                     size_t binary_transpose_input_idx)>;
 
 using TestBinaryParams = std::tuple<BinaryFactoryPtr,
@@ -325,7 +328,7 @@ using TestBinaryParams = std::tuple<BinaryFactoryPtr,
                                     size_t,             /* num_binary_ops */
                                     CreateGraphBinaryF, /* model_factory */
                                     CreateGraphBinaryF, /* reference_model_factory */
-                                    ov::element::Type,  /* input type */
+                                    element::Type,  /* input type */
                                     size_t>;            /* binary_transpose_input_idx */
 
 class TransposeSinkingBinaryTestFixture : public ::testing::WithParamInterface<TestBinaryParams>,
@@ -364,7 +367,7 @@ TEST_P(TransposeSinkingBinaryTestFixture, CompareFunctions) {
     size_t num_binary_ops;
     CreateGraphBinaryF model_factory;
     CreateGraphBinaryF reference_model_factory;
-    ov::element::Type input_type;
+    element::Type input_type;
     size_t binary_transpose_input_idx;
     std::tie(binary_factory,
              pass_factory,

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -98,18 +98,16 @@ public:
 
 #undef CREATE_BINARY_FACTORY
 #define CREATE_BINARY_FACTORY(type_name) CreateBinaryFactory<ov::opset9::type_name>(#type_name)
-std::vector<BinaryFactoryPtr> binary_factories = {
-    CREATE_BINARY_FACTORY(Add),
-    CREATE_BINARY_FACTORY(Divide),
-    CREATE_BINARY_FACTORY(Maximum),
-    CREATE_BINARY_FACTORY(Minimum),
-    CREATE_BINARY_FACTORY(Mod),
-    CREATE_BINARY_FACTORY(Multiply),
-    CREATE_BINARY_FACTORY(Power),
-    CREATE_BINARY_FACTORY(SquaredDifference),
-    CREATE_BINARY_FACTORY(Subtract),
-    CREATE_BINARY_FACTORY(PRelu)
-};
+std::vector<BinaryFactoryPtr> binary_factories = {CREATE_BINARY_FACTORY(Add),
+                                                  CREATE_BINARY_FACTORY(Divide),
+                                                  CREATE_BINARY_FACTORY(Maximum),
+                                                  CREATE_BINARY_FACTORY(Minimum),
+                                                  CREATE_BINARY_FACTORY(Mod),
+                                                  CREATE_BINARY_FACTORY(Multiply),
+                                                  CREATE_BINARY_FACTORY(Power),
+                                                  CREATE_BINARY_FACTORY(SquaredDifference),
+                                                  CREATE_BINARY_FACTORY(Subtract),
+                                                  CREATE_BINARY_FACTORY(PRelu)};
 #undef CREATE_BINARY_FACTORY
 
 std::vector<size_t> binary_operations_numbers = {1, 10};
@@ -123,9 +121,9 @@ namespace forward {
 namespace one_input_transpose {
 
 std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
-                                          size_t num_binary_ops,
-                                          element::Type input_type,
-                                          size_t binary_transpose_input_idx) {
+                                      size_t num_binary_ops,
+                                      element::Type input_type,
+                                      size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
     const Shape const_shape{1, 55, 55, 96};
 
@@ -147,9 +145,9 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
-                                                   size_t num_binary_ops,
-                                                   element::Type input_type,
-                                                   size_t binary_transpose_input_idx) {
+                                               size_t num_binary_ops,
+                                               element::Type input_type,
+                                               size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
     const Shape const_shape{1, 55, 55, 96};
 
@@ -159,8 +157,7 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
     for (size_t i = 0; i < num_binary_ops; ++i) {
         auto in_constant = std::make_shared<Constant>(input_type, const_shape, Shape{1});
 
-        auto transpose_reversed_const =
-            std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+        auto transpose_reversed_const = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
         auto transpose_reversed = std::make_shared<Transpose>(in_constant, transpose_reversed_const);
 
         if (!binary_transpose_input_idx)
@@ -179,8 +176,8 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
 
 namespace double_transpose {
 std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
-                                          size_t num_binary_ops,
-                                          element::Type input_type) {
+                                      size_t num_binary_ops,
+                                      element::Type input_type) {
     const Shape input_shape{1, 96, 55, 55};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -201,8 +198,8 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
-                                                   size_t num_binary_ops,
-                                                   element::Type input_type) {
+                                               size_t num_binary_ops,
+                                               element::Type input_type) {
     const Shape input_shape{1, 96, 55, 55};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -214,8 +211,7 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
         auto ng_order1 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
         auto transpose1 = std::make_shared<Transpose>(in_constant, ng_order1);
 
-        auto transpose_reversed_const =
-            std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+        auto transpose_reversed_const = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
         auto transpose_reversed = std::make_shared<Transpose>(transpose1, transpose_reversed_const);
 
         in_op = binary_factory->create(in_op, transpose_reversed);
@@ -230,16 +226,17 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
 using CreateGraphBinaryTwoTransposeInputsF = std::function<
     std::shared_ptr<Model>(BinaryFactoryPtr binary_factory, size_t num_binary_ops, element::Type input_type)>;
 
-using TestBinaryTwoTransposeInputsParams = std::tuple<BinaryFactoryPtr,
-                                    PassFactoryPtr,
-                                    size_t,                                  /* num_binary_ops */
-                                    CreateGraphBinaryTwoTransposeInputsF,    /* model_factory */
-                                    CreateGraphBinaryTwoTransposeInputsF, /* reference_model_factory */
-                                    element::Type>;                      /* input type */
+using TestBinaryTwoTransposeInputsParams =
+    std::tuple<BinaryFactoryPtr,
+               PassFactoryPtr,
+               size_t,                               /* num_binary_ops */
+               CreateGraphBinaryTwoTransposeInputsF, /* model_factory */
+               CreateGraphBinaryTwoTransposeInputsF, /* reference_model_factory */
+               element::Type>;                       /* input type */
 
 class TransposeSinkingBinaryTwoTransposeInputsTestFixture
     : public ::testing::WithParamInterface<TestBinaryTwoTransposeInputsParams>,
-                                          public TransformationTestsF {
+      public TransformationTestsF {
 public:
     static std::string get_test_name(const testing::TestParamInfo<TestBinaryTwoTransposeInputsParams>& obj) {
         BinaryFactoryPtr binary_factory;
@@ -278,17 +275,15 @@ TEST_P(TransposeSinkingBinaryTwoTransposeInputsTestFixture, CompareFunctions) {
     pass_factory->registerPass(manager);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingBinaryTwoTransposeInputsForwardTestSuite,
-    TransposeSinkingBinaryTwoTransposeInputsTestFixture,
-    ::testing::Combine(::testing::ValuesIn(binary_factories),
-                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryForward)),
-                       ::testing::ValuesIn(binary_operations_numbers),
-                       ::testing::Values(CreateFunction),
-                       ::testing::Values(CreateReferenceFunction),
-                       ::testing::Values(element::f32)),
-                       TransposeSinkingBinaryTwoTransposeInputsTestFixture::get_test_name);
-
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingBinaryTwoTransposeInputsForwardTestSuite,
+                         TransposeSinkingBinaryTwoTransposeInputsTestFixture,
+                         ::testing::Combine(::testing::ValuesIn(binary_factories),
+                                            ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryForward)),
+                                            ::testing::ValuesIn(binary_operations_numbers),
+                                            ::testing::Values(CreateFunction),
+                                            ::testing::Values(CreateReferenceFunction),
+                                            ::testing::Values(element::f32)),
+                         TransposeSinkingBinaryTwoTransposeInputsTestFixture::get_test_name);
 
 }  // namespace double_transpose
 }  // namespace forward
@@ -296,9 +291,9 @@ INSTANTIATE_TEST_SUITE_P(
 namespace backward {
 namespace one_input_transpose {
 std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
-                                          size_t num_binary_ops,
-                                          element::Type input_type,
-                                          size_t binary_transpose_input_idx) {
+                                      size_t num_binary_ops,
+                                      element::Type input_type,
+                                      size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -319,9 +314,9 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
-                                                   size_t num_binary_ops,
-                                                   element::Type input_type,
-                                                   size_t binary_transpose_input_idx) {
+                                               size_t num_binary_ops,
+                                               element::Type input_type,
+                                               size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -348,16 +343,16 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
 }
 
 using CreateGraphBinaryF = std::function<std::shared_ptr<Model>(BinaryFactoryPtr binary_factory,
-                                                                    size_t num_binary_ops,
-                                                                    element::Type input_type,
-                                                                    size_t binary_transpose_input_idx)>;
+                                                                size_t num_binary_ops,
+                                                                element::Type input_type,
+                                                                size_t binary_transpose_input_idx)>;
 
 using TestBinaryParams = std::tuple<BinaryFactoryPtr,
                                     PassFactoryPtr,
                                     size_t,             /* num_binary_ops */
                                     CreateGraphBinaryF, /* model_factory */
                                     CreateGraphBinaryF, /* reference_model_factory */
-                                    element::Type,  /* input type */
+                                    element::Type,      /* input type */
                                     size_t>;            /* binary_transpose_input_idx */
 
 class TransposeSinkingBinaryTestFixture : public ::testing::WithParamInterface<TestBinaryParams>,
@@ -660,17 +655,17 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::ValuesIn(binary_transpose_input_indexes)),
     TransposeSinkingBinaryIncompatShapesTestFixture::get_test_name);
 
-} // namespace one_input_transpose
-} // namespace backward
-} // namespace single_consumer
+}  // namespace one_input_transpose
+}  // namespace backward
+}  // namespace single_consumer
 
 namespace mult_consumers {
 namespace forward {
 namespace input_transpose_consumers {
 
 std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
-                                          element::Type input_type,
-                                          size_t binary_transpose_input_idx) {
+                                      element::Type input_type,
+                                      size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
     const Shape const_shape{1, 55, 55, 96};
 
@@ -692,8 +687,8 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
-                                                   element::Type input_type,
-                                                   size_t binary_transpose_input_idx) {
+                                               element::Type input_type,
+                                               size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
     const Shape const_shape{1, 55, 55, 96};
 
@@ -707,8 +702,7 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
     NodePtr binary;
     auto in_constant = std::make_shared<Constant>(input_type, const_shape, Shape{1});
 
-    auto transpose_reversed_const =
-        std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+    auto transpose_reversed_const = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
     auto transpose_reversed = std::make_shared<Transpose>(in_constant, transpose_reversed_const);
 
     if (!binary_transpose_input_idx)
@@ -722,15 +716,15 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
     return std::make_shared<Model>(ov::OutputVector{transpose1, tanh}, ov::ParameterVector{X});
 }
 
-} // namespace input_transpose_consumers
+}  // namespace input_transpose_consumers
 
 namespace output_consumers {
 
 namespace one_binary {
 
 std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
-                                          element::Type input_type,
-                                          size_t binary_transpose_input_idx) {
+                                      element::Type input_type,
+                                      size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
     const Shape const_shape{1, 55, 55, 96};
 
@@ -753,8 +747,8 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
-                                                   element::Type input_type,
-                                                   size_t binary_transpose_input_idx) {
+                                               element::Type input_type,
+                                               size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
     const Shape const_shape{1, 55, 55, 96};
 
@@ -763,8 +757,7 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
     NodePtr binary;
     auto in_constant = std::make_shared<Constant>(input_type, const_shape, Shape{1});
 
-    auto transpose_reversed_const =
-        std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+    auto transpose_reversed_const = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
     auto transpose_reversed = std::make_shared<Transpose>(in_constant, transpose_reversed_const);
 
     if (!binary_transpose_input_idx)
@@ -788,8 +781,8 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
 namespace input_node_consumers {
 
 std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
-                                          element::Type input_type,
-                                          size_t binary_transpose_input_idx) {
+                                      element::Type input_type,
+                                      size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
     const Shape const_shape{1, 55, 55, 96};
 
@@ -811,23 +804,22 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
-                                                   element::Type input_type,
-                                                   size_t binary_transpose_input_idx) {
+                                               element::Type input_type,
+                                               size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
     const Shape const_shape{1, 55, 55, 96};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
-    
+
     auto tanh = std::make_shared<Tanh>(X);
-    
+
     auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
     NodePtr binary;
     auto in_constant = std::make_shared<Constant>(input_type, const_shape, Shape{1});
 
-    auto transpose_reversed_const =
-        std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+    auto transpose_reversed_const = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
     auto transpose_reversed = std::make_shared<Transpose>(in_constant, transpose_reversed_const);
 
     if (!binary_transpose_input_idx)
@@ -852,8 +844,8 @@ namespace output_consumers {
 namespace one_binary {
 
 std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
-                                          element::Type input_type,
-                                          size_t binary_transpose_input_idx) {
+                                      element::Type input_type,
+                                      size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -876,8 +868,8 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
-                                                   element::Type input_type,
-                                                   size_t binary_transpose_input_idx) {
+                                               element::Type input_type,
+                                               size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -910,13 +902,13 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
     return std::make_shared<Model>(ov::OutputVector{binary1, tanh1}, ov::ParameterVector{X});
 }
 
-} // namespace one_binary
+}  // namespace one_binary
 
 namespace multiple_binaries {
 
 std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
-                                          element::Type input_type,
-                                          size_t binary_transpose_input_idx) {
+                                      element::Type input_type,
+                                      size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
     const size_t n_binaries = 10;
 
@@ -942,8 +934,8 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
-                                                   element::Type input_type,
-                                                   size_t binary_transpose_input_idx) {
+                                               element::Type input_type,
+                                               size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
     const size_t n_binaries = 10;
 
@@ -965,7 +957,7 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
 
     // right branch
     auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<Transpose>(tanh0, ng_order0);    
+    auto transpose0 = std::make_shared<Transpose>(tanh0, ng_order0);
 
     in_op = transpose0;
     for (size_t i = 0; i < n_binaries; ++i) {
@@ -981,15 +973,15 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
     return std::make_shared<Model>(ov::OutputVector{in_op, tanh1}, ov::ParameterVector{X});
 }
 
-} // namespace multiple_binaries
+}  // namespace multiple_binaries
 
-} // namespace output_consumers
+}  // namespace output_consumers
 
 namespace input_node_consumers {
 
 std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
-                                          element::Type input_type,
-                                          size_t binary_transpose_input_idx) {
+                                      element::Type input_type,
+                                      size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -1012,8 +1004,8 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
-                                                   element::Type input_type,
-                                                   size_t binary_transpose_input_idx) {
+                                               element::Type input_type,
+                                               size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -1039,13 +1031,13 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
     return std::make_shared<Model>(ov::OutputVector{binary, tanh1}, ov::ParameterVector{X});
 }
 
-} // input_node_consumers
+}  // namespace input_node_consumers
 
 namespace output_transpose_mult_consumers {
 
 std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
-                                          element::Type input_type,
-                                          size_t binary_transpose_input_idx) {
+                                      element::Type input_type,
+                                      size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -1067,8 +1059,8 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
-                                                   element::Type input_type,
-                                                   size_t binary_transpose_input_idx) {
+                                               element::Type input_type,
+                                               size_t binary_transpose_input_idx) {
     const Shape input_shape{1, 96, 55, 55};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -1093,21 +1085,22 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
     return std::make_shared<Model>(ov::OutputVector{tanh0, tanh1}, ov::ParameterVector{X});
 }
 
-} // namespace output_transpose_mult_consumers
+}  // namespace output_transpose_mult_consumers
 
-} // namespace backward
+}  // namespace backward
 
-using CreateGraphF = std::function<
-    std::shared_ptr<Model>(BinaryFactoryPtr binary_factory, element::Type input_type, size_t binary_transpose_input_idx)>;
+using CreateGraphF = std::function<std::shared_ptr<Model>(BinaryFactoryPtr binary_factory,
+                                                          element::Type input_type,
+                                                          size_t binary_transpose_input_idx)>;
 
 struct CreateGraphFunctionDesc {
     CreateGraphFunctionDesc() = default;
     CreateGraphFunctionDesc(CreateGraphF a_model_factory,
                             CreateGraphF a_reference_model_factory,
-                            std::string a_subtest_name) :
-                            model_factory(a_model_factory),
-                            reference_model_factory(a_reference_model_factory),
-                            subtest_name(a_subtest_name) {}
+                            std::string a_subtest_name)
+        : model_factory(a_model_factory),
+          reference_model_factory(a_reference_model_factory),
+          subtest_name(a_subtest_name) {}
     CreateGraphF model_factory;
     CreateGraphF reference_model_factory;
     std::string subtest_name;
@@ -1119,9 +1112,8 @@ using TestBinaryParams = std::tuple<BinaryFactoryPtr,
                                     element::Type, /* input type */
                                     size_t>;       /*binary_transpose_input_idx*/
 
-class TransposeBinaryMultiSinkingFixture
-    : public ::testing::WithParamInterface<TestBinaryParams>,
-                                          public TransformationTestsF {
+class TransposeBinaryMultiSinkingFixture : public ::testing::WithParamInterface<TestBinaryParams>,
+                                           public TransformationTestsF {
 public:
     static std::string get_test_name(const testing::TestParamInfo<TestBinaryParams>& obj) {
         BinaryFactoryPtr binary_factory;
@@ -1130,8 +1122,7 @@ public:
         element::Type input_type;
         size_t binary_transpose_input_idx;
 
-        std::tie(binary_factory, pass_factory, function_desc, input_type, binary_transpose_input_idx) =
-            obj.param;
+        std::tie(binary_factory, pass_factory, function_desc, input_type, binary_transpose_input_idx) = obj.param;
 
         std::ostringstream test_name;
         test_name << "binary_factory=" << binary_factory->getTypeName() << "_";
@@ -1151,15 +1142,15 @@ TEST_P(TransposeBinaryMultiSinkingFixture, CompareFunctions) {
     element::Type input_type;
     size_t binary_transpose_input_idx;
 
-    std::tie(binary_factory, pass_factory, function_desc, input_type, binary_transpose_input_idx) =
-        this->GetParam();
+    std::tie(binary_factory, pass_factory, function_desc, input_type, binary_transpose_input_idx) = this->GetParam();
 
     model = function_desc.model_factory(binary_factory, input_type, binary_transpose_input_idx);
     model_ref = function_desc.reference_model_factory(binary_factory, input_type, binary_transpose_input_idx);
     pass_factory->registerPass(manager);
 }
 
-#define SUBTEST(nmspace, subtest_name) CreateGraphFunctionDesc(nmspace::CreateFunction, nmspace::CreateReferenceFunction, subtest_name)
+#define SUBTEST(nmspace, subtest_name) \
+    CreateGraphFunctionDesc(nmspace::CreateFunction, nmspace::CreateReferenceFunction, subtest_name)
 
 std::vector<CreateGraphFunctionDesc> forward_subtests = {
     SUBTEST(forward::input_transpose_consumers, "forward_input_transpose_consumers"),
@@ -1171,20 +1162,18 @@ std::vector<CreateGraphFunctionDesc> backward_subtests = {
     SUBTEST(backward::output_consumers::one_binary, "backward_output_consumers_one_binary"),
     SUBTEST(backward::output_consumers::multiple_binaries, "backward_output_consumers_multiple_binaries"),
     SUBTEST(backward::input_node_consumers, "backward_input_node_consumers"),
-    SUBTEST(backward::output_transpose_mult_consumers, "backward_output_transpose_mult_consumers")
-};
+    SUBTEST(backward::output_transpose_mult_consumers, "backward_output_transpose_mult_consumers")};
 
 #undef SUBTEST
 
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingBinaryForwardMultiConsumersTestSuite,
-    TransposeBinaryMultiSinkingFixture,
-    ::testing::Combine(::testing::ValuesIn(binary_factories),
-                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryForward)),
-                       ::testing::ValuesIn(forward_subtests),
-                       ::testing::Values(element::f32),
-                       ::testing::ValuesIn(binary_transpose_input_indexes)),
-                       TransposeBinaryMultiSinkingFixture::get_test_name);
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingBinaryForwardMultiConsumersTestSuite,
+                         TransposeBinaryMultiSinkingFixture,
+                         ::testing::Combine(::testing::ValuesIn(binary_factories),
+                                            ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryForward)),
+                                            ::testing::ValuesIn(forward_subtests),
+                                            ::testing::Values(element::f32),
+                                            ::testing::ValuesIn(binary_transpose_input_indexes)),
+                         TransposeBinaryMultiSinkingFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingBinaryBackwardMultiConsumersTestSuite,
@@ -1197,4 +1186,4 @@ INSTANTIATE_TEST_SUITE_P(
                        TransposeBinaryMultiSinkingFixture::get_test_name);
 } // namespace mult_consumers
 
-} // namespace transpose_sinking_binary_eltwise
+}  // namespace transpose_sinking_binary_eltwise

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -265,10 +265,10 @@ public:
             obj.param;
 
         std::ostringstream test_name;
-        test_name << "binary_factory=" << binary_factory->getTypeName() << "_";
-        test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
-        test_name << "num_binary_ops=" << num_binary_ops << "_";
-        test_name << "input_type=" << input_type;
+        test_name << "binaryFactory=" << binary_factory->getTypeName() << "/";
+        test_name << "passFactory=" << pass_factory->getTypeName() << "/";
+        test_name << "numBinaryOps=" << num_binary_ops << "/";
+        test_name << "inputType=" << input_type;
 
         return test_name.str();
     }
@@ -391,11 +391,11 @@ public:
                  binary_transpose_input_idx) = obj.param;
 
         std::ostringstream test_name;
-        test_name << "binary_factory=" << binary_factory->getTypeName() << "_";
-        test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
-        test_name << "num_binary_ops=" << num_binary_ops << "_";
-        test_name << "input_type=" << input_type << "_";
-        test_name << "binary_transpose_input_idx=" << binary_transpose_input_idx;
+        test_name << "binaryFactory=" << binary_factory->getTypeName() << "/";
+        test_name << "passFactory=" << pass_factory->getTypeName() << "/";
+        test_name << "numBinaryOps=" << num_binary_ops << "/";
+        test_name << "inputType=" << input_type << "/";
+        test_name << "binaryTransposeInputIdx=" << binary_transpose_input_idx;
 
         return test_name.str();
     }
@@ -486,12 +486,12 @@ public:
                  binary_transpose_input_idx) = obj.param;
 
         std::ostringstream test_name;
-        test_name << "binary_factory=" << binary_factory->getTypeName() << "_";
-        test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
-        test_name << "input_shape=" << to_string(input_shape) << "_";
-        test_name << "constant_shape=" << to_string(constant_shape) << "_";
-        test_name << "input_type=" << input_type << "_";
-        test_name << "binary_transpose_input_idx=" << binary_transpose_input_idx;
+        test_name << "binaryFactory=" << binary_factory->getTypeName() << "/";
+        test_name << "passFactory=" << pass_factory->getTypeName() << "/";
+        test_name << "inputShape=" << to_string(input_shape) << "/";
+        test_name << "constantShape=" << to_string(constant_shape) << "/";
+        test_name << "inputType=" << input_type << "/";
+        test_name << "binaryTransposeInputIdx=" << binary_transpose_input_idx;
 
         return test_name.str();
     }
@@ -906,6 +906,7 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
     return std::make_shared<Model>(ov::OutputVector{transpose0, tanh}, ov::ParameterVector{X});
 }
 
+#if 0
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
                                                element::Type input_type,
                                                size_t binary_transpose_input_idx) {
@@ -940,6 +941,7 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
 
     return std::make_shared<Model>(ov::OutputVector{binary1, tanh1}, ov::ParameterVector{X});
 }
+#endif
 
 }  // namespace one_binary
 
@@ -972,6 +974,7 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
     return std::make_shared<Model>(ov::OutputVector{transpose0, tanh}, ov::ParameterVector{X});
 }
 
+#if 0
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
                                                element::Type input_type,
                                                size_t binary_transpose_input_idx) {
@@ -1011,6 +1014,7 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
 
     return std::make_shared<Model>(ov::OutputVector{in_op, tanh1}, ov::ParameterVector{X});
 }
+#endif
 
 }  // namespace multiple_binaries
 
@@ -1164,11 +1168,11 @@ public:
         std::tie(binary_factory, pass_factory, function_desc, input_type, binary_transpose_input_idx) = obj.param;
 
         std::ostringstream test_name;
-        test_name << "binary_factory=" << binary_factory->getTypeName() << "_";
-        test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
-        test_name << function_desc.subtest_name << "_";
-        test_name << "input_type=" << input_type << "_";
-        test_name << "binary_transpose_input_idx=" << binary_transpose_input_idx;
+        test_name << "binaryFactory=" << binary_factory->getTypeName() << "/";
+        test_name << "passFactory=" << pass_factory->getTypeName() << "/";
+        test_name << function_desc.subtest_name << "/";
+        test_name << "inputType=" << input_type << "/";
+        test_name << "binaryTransposeInputIdx=" << binary_transpose_input_idx;
 
         return test_name.str();
     }
@@ -1192,17 +1196,16 @@ TEST_P(TransposeBinaryMultiSinkingFixture, CompareFunctions) {
     CreateGraphFunctionDesc(nmspace::CreateFunction, nmspace::CreateReferenceFunction, subtest_name)
 
 std::vector<CreateGraphFunctionDesc> forward_subtests = {
-    SUBTEST(forward::input_transpose_consumers, "forward_input_transpose_consumers"),
-    SUBTEST(forward::output_consumers::one_binary, "forward_output_consumers"),
-    SUBTEST(forward::input_node_consumers, "forward_input_node_consumers")};
+    SUBTEST(forward::input_transpose_consumers, "forwardInputTransposeConsumers"),
+    SUBTEST(forward::output_consumers::one_binary, "forwardOutputConsumers"),
+    SUBTEST(forward::input_node_consumers, "forwardInputNodeConsumers")};
 
 std::vector<CreateGraphFunctionDesc> backward_subtests = {
-    SUBTEST(backward::output_consumers::one_binary, "backward_output_consumers_one_binary"),
-    SUBTEST(backward::output_consumers::multiple_binaries, "backward_output_consumers_multiple_binaries"),
-    SUBTEST(backward::input_node_consumers, "backward_input_node_consumers"),
-    SUBTEST(backward::output_transpose_mult_consumers, "backward_output_transpose_mult_consumers")};
+    SUBTEST(backward::input_node_consumers, "backwardInputNodeConsumers"),
+    SUBTEST(backward::output_transpose_mult_consumers, "backwardOutputTransposeMultConsumers")};
 
 #undef SUBTEST
+
 
 INSTANTIATE_TEST_SUITE_P(TransposeSinkingBinaryForwardMultiConsumersTestSuite,
                          TransposeBinaryMultiSinkingFixture,
@@ -1221,6 +1224,84 @@ INSTANTIATE_TEST_SUITE_P(TransposeSinkingBinaryBackwardMultiConsumersTestSuite,
                                             ::testing::Values(element::f32),
                                             ::testing::ValuesIn(binary_transpose_input_indexes)),
                          TransposeBinaryMultiSinkingFixture::get_test_name);
+
+namespace no_sinking {
+
+struct CreateGraphFunctionDesc {
+    CreateGraphFunctionDesc() = default;
+    CreateGraphFunctionDesc(CreateGraphF a_model_factory,
+                            std::string a_subtest_name)
+        : model_factory(a_model_factory),
+          subtest_name(a_subtest_name) {}
+    CreateGraphF model_factory;
+    std::string subtest_name;
+};
+
+using TestBinaryParams = std::tuple<BinaryFactoryPtr,
+                                    PassFactoryPtr,
+                                    CreateGraphFunctionDesc,
+                                    element::Type, /* input type */
+                                    size_t>;       /*binary_transpose_input_idx*/
+
+class TransposeBinaryMultiSinkingBinaryMultiConsumersFixture : public ::testing::WithParamInterface<TestBinaryParams>,
+                                           public TransformationTestsF {
+public:
+    static std::string get_test_name(const testing::TestParamInfo<TestBinaryParams>& obj) {
+        BinaryFactoryPtr binary_factory;
+        PassFactoryPtr pass_factory;
+        CreateGraphFunctionDesc function_desc;
+        element::Type input_type;
+        size_t binary_transpose_input_idx;
+
+        std::tie(binary_factory, pass_factory, function_desc, input_type, binary_transpose_input_idx) = obj.param;
+
+        std::ostringstream test_name;
+        test_name << "binaryFactory=" << binary_factory->getTypeName() << "/";
+        test_name << "passFactory=" << pass_factory->getTypeName() << "/";
+        test_name << function_desc.subtest_name << "/";
+        test_name << "inputType=" << input_type << "/";
+        test_name << "binaryTransposeInputIdx=" << binary_transpose_input_idx;
+
+        return test_name.str();
+    }
+};
+
+TEST_P(TransposeBinaryMultiSinkingBinaryMultiConsumersFixture, CompareFunctions) {
+    BinaryFactoryPtr binary_factory;
+    PassFactoryPtr pass_factory;
+    CreateGraphFunctionDesc function_desc;
+    element::Type input_type;
+    size_t binary_transpose_input_idx;
+
+    std::tie(binary_factory, pass_factory, function_desc, input_type, binary_transpose_input_idx) = this->GetParam();
+
+    model = function_desc.model_factory(binary_factory, input_type, binary_transpose_input_idx);
+    model_ref = model->clone();
+    //model_ref = function_desc.model_factory(binary_factory, input_type, binary_transpose_input_idx);
+    pass_factory->registerPass(manager);
+}
+
+#define SUBTEST(nmspace, subtest_name) \
+    CreateGraphFunctionDesc(nmspace::CreateFunction, subtest_name)
+
+std::vector<CreateGraphFunctionDesc> backward_subtests_binary_consumers = {
+    SUBTEST(backward::output_consumers::one_binary, "backwardOutputConsumersOneBinary"),
+    SUBTEST(backward::output_consumers::multiple_binaries, "backwardOutputConsumersMultipleBinaries"),
+};
+#undef SUBTEST
+
+
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingBinaryBackwardBinaryMultiConsumersTestSuite,
+                         TransposeBinaryMultiSinkingBinaryMultiConsumersFixture,
+                         ::testing::Combine(::testing::ValuesIn(binary_factories),
+                                            ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryBackward)),
+                                            ::testing::ValuesIn(backward_subtests_binary_consumers),
+                                            ::testing::Values(element::f32),
+                                            ::testing::ValuesIn(binary_transpose_input_indexes)),
+                         TransposeBinaryMultiSinkingBinaryMultiConsumersFixture::get_test_name);
+
+} // namespace no_sinking
+
 }  // namespace mult_consumers
 
 }  // namespace transpose_sinking_binary_eltwise

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -105,14 +105,14 @@ public:
  * Unsqueeze insertion
  */
 std::vector<BinaryFactoryPtr> binary_elementwise_factories = {CREATE_BINARY_FACTORY(Add),
-                                                  CREATE_BINARY_FACTORY(Divide),
-                                                  CREATE_BINARY_FACTORY(Maximum),
-                                                  CREATE_BINARY_FACTORY(Minimum),
-                                                  CREATE_BINARY_FACTORY(Mod),
-                                                  CREATE_BINARY_FACTORY(Multiply),
-                                                  CREATE_BINARY_FACTORY(Power),
-                                                  CREATE_BINARY_FACTORY(SquaredDifference),
-                                                  CREATE_BINARY_FACTORY(Subtract)};
+                                                              CREATE_BINARY_FACTORY(Divide),
+                                                              CREATE_BINARY_FACTORY(Maximum),
+                                                              CREATE_BINARY_FACTORY(Minimum),
+                                                              CREATE_BINARY_FACTORY(Mod),
+                                                              CREATE_BINARY_FACTORY(Multiply),
+                                                              CREATE_BINARY_FACTORY(Power),
+                                                              CREATE_BINARY_FACTORY(SquaredDifference),
+                                                              CREATE_BINARY_FACTORY(Subtract)};
 
 std::vector<BinaryFactoryPtr> binary_factories = {CREATE_BINARY_FACTORY(Add),
                                                   CREATE_BINARY_FACTORY(Divide),
@@ -425,44 +425,42 @@ TEST_P(TransposeSinkingBinaryTestFixture, CompareFunctions) {
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingBinaryForwardTestSuite,
     TransposeSinkingBinaryTestFixture,
-    ::testing::Combine(
-        ::testing::ValuesIn(binary_factories),
-        ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryForward)),
-        ::testing::ValuesIn(binary_operations_numbers),
-        ::testing::Values(single_consumer::forward::one_input_transpose::CreateFunction),
-        ::testing::Values(single_consumer::forward::one_input_transpose::CreateReferenceFunction),
-        ::testing::Values(element::f32),
-        ::testing::ValuesIn(binary_transpose_input_indexes)),
+    ::testing::Combine(::testing::ValuesIn(binary_factories),
+                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryForward)),
+                       ::testing::ValuesIn(binary_operations_numbers),
+                       ::testing::Values(single_consumer::forward::one_input_transpose::CreateFunction),
+                       ::testing::Values(single_consumer::forward::one_input_transpose::CreateReferenceFunction),
+                       ::testing::Values(element::f32),
+                       ::testing::ValuesIn(binary_transpose_input_indexes)),
     TransposeSinkingBinaryTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingBinaryBackwardTestSuite,
     TransposeSinkingBinaryTestFixture,
-    ::testing::Combine(
-        ::testing::ValuesIn(binary_factories),
-        ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryBackward)),
-        ::testing::ValuesIn(binary_operations_numbers),
-        ::testing::Values(single_consumer::backward::one_input_transpose::CreateFunction),
-        ::testing::Values(single_consumer::backward::one_input_transpose::CreateReferenceFunction),
-        ::testing::Values(element::f32),
-        ::testing::ValuesIn(binary_transpose_input_indexes)),
+    ::testing::Combine(::testing::ValuesIn(binary_factories),
+                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryBackward)),
+                       ::testing::ValuesIn(binary_operations_numbers),
+                       ::testing::Values(single_consumer::backward::one_input_transpose::CreateFunction),
+                       ::testing::Values(single_consumer::backward::one_input_transpose::CreateReferenceFunction),
+                       ::testing::Values(element::f32),
+                       ::testing::ValuesIn(binary_transpose_input_indexes)),
     TransposeSinkingBinaryTestFixture::get_test_name);
 
 // --------------------------------------------------------------------------------------
 
 using CreateGraphBinaryIncompatShapesF = std::function<std::shared_ptr<Model>(BinaryFactoryPtr unary_factory,
-                                                                                  element::Type input_type,
-                                                                                  Shape input_shape,
-                                                                                  Shape constant_shape,
-                                                                                  size_t binary_transpose_input_idx)>;
+                                                                              element::Type input_type,
+                                                                              Shape input_shape,
+                                                                              Shape constant_shape,
+                                                                              size_t binary_transpose_input_idx)>;
 
 using TestBinaryIncompatShapesParams = std::tuple<BinaryFactoryPtr,
                                                   PassFactoryPtr,
-                                                  Shape,                        /* input shape */
-                                                  Shape,                        /* constant_shape */
+                                                  Shape,                            /* input shape */
+                                                  Shape,                            /* constant_shape */
                                                   CreateGraphBinaryIncompatShapesF, /* model_factory */
                                                   CreateGraphBinaryIncompatShapesF, /* reference_model_factory */
-                                                  element::Type,                /* input type */
+                                                  element::Type,                    /* input type */
                                                   size_t>;                          /* binary_transpose_input_idx */
 
 class TransposeSinkingBinaryIncompatShapesTestFixture
@@ -529,10 +527,10 @@ namespace backward {
 namespace incompat_shapes {
 
 std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
-                                          element::Type input_type,
-                                          Shape input_shape,
-                                          Shape constant_shape,
-                                          size_t binary_transpose_input_idx) {
+                                      element::Type input_type,
+                                      Shape input_shape,
+                                      Shape constant_shape,
+                                      size_t binary_transpose_input_idx) {
     auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     auto in_constant = std::make_shared<Constant>(input_type, constant_shape, Shape{1});
@@ -550,10 +548,10 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
-                                                   element::Type input_type,
-                                                   Shape input_shape,
-                                                   Shape constant_shape,
-                                                   size_t binary_transpose_input_idx) {
+                                               element::Type input_type,
+                                               Shape input_shape,
+                                               Shape constant_shape,
+                                               size_t binary_transpose_input_idx) {
     auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
@@ -587,10 +585,10 @@ namespace forward {
 namespace incompat_shapes {
 
 std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
-                                          element::Type input_type,
-                                          Shape input_shape,
-                                          Shape constant_shape,
-                                          size_t binary_transpose_input_idx) {
+                                      element::Type input_type,
+                                      Shape input_shape,
+                                      Shape constant_shape,
+                                      size_t binary_transpose_input_idx) {
     auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     auto in_constant = std::make_shared<Constant>(input_type, constant_shape, Shape{1});
@@ -608,10 +606,10 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
-                                                   element::Type input_type,
-                                                   Shape input_shape,
-                                                   Shape constant_shape,
-                                                   size_t binary_transpose_input_idx) {
+                                               element::Type input_type,
+                                               Shape input_shape,
+                                               Shape constant_shape,
+                                               size_t binary_transpose_input_idx) {
     auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     auto in_constant = std::make_shared<Constant>(input_type, constant_shape, Shape{1});
@@ -815,9 +813,9 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
     return std::make_shared<Model>(ov::OutputVector{tanh1, tanh2}, ov::ParameterVector{X});
 }
 
-} // namespace one_binary
+}  // namespace one_binary
 
-} // namespace output_consumers
+}  // namespace output_consumers
 
 namespace input_node_consumers {
 
@@ -874,9 +872,9 @@ std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
     return std::make_shared<Model>(ov::OutputVector{transpose1, tanh}, ov::ParameterVector{X});
 }
 
-} // namespace input_node_consumers
+}  // namespace input_node_consumers
 
-} // namespace forward
+}  // namespace forward
 
 namespace backward {
 
@@ -1196,8 +1194,7 @@ TEST_P(TransposeBinaryMultiSinkingFixture, CompareFunctions) {
 std::vector<CreateGraphFunctionDesc> forward_subtests = {
     SUBTEST(forward::input_transpose_consumers, "forward_input_transpose_consumers"),
     SUBTEST(forward::output_consumers::one_binary, "forward_output_consumers"),
-    SUBTEST(forward::input_node_consumers, "forward_input_node_consumers")
-};
+    SUBTEST(forward::input_node_consumers, "forward_input_node_consumers")};
 
 std::vector<CreateGraphFunctionDesc> backward_subtests = {
     SUBTEST(backward::output_consumers::one_binary, "backward_output_consumers_one_binary"),
@@ -1216,15 +1213,14 @@ INSTANTIATE_TEST_SUITE_P(TransposeSinkingBinaryForwardMultiConsumersTestSuite,
                                             ::testing::ValuesIn(binary_transpose_input_indexes)),
                          TransposeBinaryMultiSinkingFixture::get_test_name);
 
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingBinaryBackwardMultiConsumersTestSuite,
-    TransposeBinaryMultiSinkingFixture,
-    ::testing::Combine(::testing::ValuesIn(binary_factories),
-                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryBackward)),
-                       ::testing::ValuesIn(backward_subtests),
-                       ::testing::Values(element::f32),
-                       ::testing::ValuesIn(binary_transpose_input_indexes)),
-                       TransposeBinaryMultiSinkingFixture::get_test_name);
-} // namespace mult_consumers
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingBinaryBackwardMultiConsumersTestSuite,
+                         TransposeBinaryMultiSinkingFixture,
+                         ::testing::Combine(::testing::ValuesIn(binary_factories),
+                                            ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingBinaryBackward)),
+                                            ::testing::ValuesIn(backward_subtests),
+                                            ::testing::Values(element::f32),
+                                            ::testing::ValuesIn(binary_transpose_input_indexes)),
+                         TransposeBinaryMultiSinkingFixture::get_test_name);
+}  // namespace mult_consumers
 
 }  // namespace transpose_sinking_binary_eltwise

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -98,15 +98,18 @@ public:
 
 #undef CREATE_BINARY_FACTORY
 #define CREATE_BINARY_FACTORY(type_name) CreateBinaryFactory<ov::opset9::type_name>(#type_name)
-std::vector<BinaryFactoryPtr> binary_factories = {CREATE_BINARY_FACTORY(Add),
-                                                  CREATE_BINARY_FACTORY(Divide),
-                                                  CREATE_BINARY_FACTORY(Maximum),
-                                                  CREATE_BINARY_FACTORY(Minimum),
-                                                  CREATE_BINARY_FACTORY(Mod),
-                                                  CREATE_BINARY_FACTORY(Multiply),
-                                                  CREATE_BINARY_FACTORY(Power),
-                                                  CREATE_BINARY_FACTORY(SquaredDifference),
-                                                  CREATE_BINARY_FACTORY(Subtract)};
+std::vector<BinaryFactoryPtr> binary_factories = {
+    CREATE_BINARY_FACTORY(Add),
+    CREATE_BINARY_FACTORY(Divide),
+    CREATE_BINARY_FACTORY(Maximum),
+    CREATE_BINARY_FACTORY(Minimum),
+    CREATE_BINARY_FACTORY(Mod),
+    CREATE_BINARY_FACTORY(Multiply),
+    CREATE_BINARY_FACTORY(Power),
+    CREATE_BINARY_FACTORY(SquaredDifference),
+    CREATE_BINARY_FACTORY(Subtract),
+    CREATE_BINARY_FACTORY(PRelu)
+};
 #undef CREATE_BINARY_FACTORY
 
 std::vector<size_t> binary_operations_numbers = {1, 10};

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -18,7 +18,7 @@ using namespace ov::opset9;
 namespace {
 
 using NodePtr = std::shared_ptr<ov::Node>;
-using ModelPtr = std::shared_ptr<ov::Model>;
+using ModelPtr = std::shared_ptr<Model>;
 using Output = ov::Output<ov::Node>;
 
 namespace {
@@ -138,10 +138,10 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
             in_op = binary_factory->create(in_constant, in_op);
     }
 
-    return std::make_shared<ov::Model>(ov::OutputVector{in_op}, ov::ParameterVector{X});
+    return std::make_shared<Model>(ov::OutputVector{in_op}, ov::ParameterVector{X});
 }
 
-std::shared_ptr<ov::Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
+std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
                                                    size_t num_binary_ops,
                                                    element::Type input_type,
                                                    size_t binary_transpose_input_idx) {
@@ -167,13 +167,13 @@ std::shared_ptr<ov::Model> CreateReferenceFunction(BinaryFactoryPtr binary_facto
     auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
 
-    return std::make_shared<ov::Model>(ov::OutputVector{transpose0}, ov::ParameterVector{X});
+    return std::make_shared<Model>(ov::OutputVector{transpose0}, ov::ParameterVector{X});
 }
 
 }  // namespace one_input_transpose
 
 namespace double_transpose {
-std::shared_ptr<ov::Model> CreateFunction(BinaryFactoryPtr binary_factory,
+std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
                                           size_t num_binary_ops,
                                           element::Type input_type) {
     const Shape input_shape{1, 96, 55, 55};
@@ -192,10 +192,10 @@ std::shared_ptr<ov::Model> CreateFunction(BinaryFactoryPtr binary_factory,
         in_op = binary_factory->create(in_op, transpose1);
     }
 
-    return std::make_shared<ov::Model>(ov::OutputVector{in_op}, ov::ParameterVector{X});
+    return std::make_shared<Model>(ov::OutputVector{in_op}, ov::ParameterVector{X});
 }
 
-std::shared_ptr<ov::Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
+std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
                                                    size_t num_binary_ops,
                                                    element::Type input_type) {
     const Shape input_shape{1, 96, 55, 55};
@@ -219,11 +219,11 @@ std::shared_ptr<ov::Model> CreateReferenceFunction(BinaryFactoryPtr binary_facto
     auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
 
-    return std::make_shared<ov::Model>(ov::OutputVector{transpose0}, ov::ParameterVector{X});
+    return std::make_shared<Model>(ov::OutputVector{transpose0}, ov::ParameterVector{X});
 }
 
 using CreateGraphBinaryTwoTransposeInputsF = std::function<
-    std::shared_ptr<ov::Model>(BinaryFactoryPtr unary_factory, size_t num_binary_ops, element::Type input_type)>;
+    std::shared_ptr<Model>(BinaryFactoryPtr unary_factory, size_t num_binary_ops, element::Type input_type)>;
 
 using TestBinaryTwoTransposeInputsParams = std::tuple<BinaryFactoryPtr,
                                     PassFactoryPtr,
@@ -268,7 +268,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 namespace backward {
 namespace one_input_transpose {
-std::shared_ptr<ov::Model> CreateFunction(BinaryFactoryPtr binary_factory,
+std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
                                           size_t num_binary_ops,
                                           element::Type input_type,
                                           size_t binary_transpose_input_idx) {
@@ -288,10 +288,10 @@ std::shared_ptr<ov::Model> CreateFunction(BinaryFactoryPtr binary_factory,
     auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
 
-    return std::make_shared<ov::Model>(ov::OutputVector{transpose0}, ov::ParameterVector{X});
+    return std::make_shared<Model>(ov::OutputVector{transpose0}, ov::ParameterVector{X});
 }
 
-std::shared_ptr<ov::Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
+std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,
                                                    size_t num_binary_ops,
                                                    element::Type input_type,
                                                    size_t binary_transpose_input_idx) {
@@ -315,10 +315,10 @@ std::shared_ptr<ov::Model> CreateReferenceFunction(BinaryFactoryPtr binary_facto
             in_op = binary_factory->create(transpose, in_op);
     }
 
-    return std::make_shared<ov::Model>(ov::OutputVector{in_op}, ov::ParameterVector{X});
+    return std::make_shared<Model>(ov::OutputVector{in_op}, ov::ParameterVector{X});
 }
 
-using CreateGraphBinaryF = std::function<std::shared_ptr<ov::Model>(BinaryFactoryPtr unary_factory,
+using CreateGraphBinaryF = std::function<std::shared_ptr<Model>(BinaryFactoryPtr unary_factory,
                                                                     size_t num_binary_ops,
                                                                     element::Type input_type,
                                                                     size_t binary_transpose_input_idx)>;

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -1196,7 +1196,6 @@ TEST_P(TransposeBinaryMultiSinkingBinaryMultiConsumersFixture, CompareFunctions)
 
     model = function_desc.model_factory(binary_factory, input_type, binary_transpose_input_idx);
     model_ref = model->clone();
-    // model_ref = function_desc.model_factory(binary_factory, input_type, binary_transpose_input_idx);
     pass_factory->registerPass(manager);
 }
 

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_binary_test.cpp
@@ -796,7 +796,9 @@ std::shared_ptr<Model> CreateFunction(BinaryFactoryPtr binary_factory,
     else
         binary = binary_factory->create(in_constant, transpose0);
 
-    return std::make_shared<Model>(ov::OutputVector{binary}, ov::ParameterVector{X});
+    auto tanh = std::make_shared<Tanh>(X);
+
+    return std::make_shared<Model>(ov::OutputVector{binary, tanh}, ov::ParameterVector{X});
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(BinaryFactoryPtr binary_factory,

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_concat_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_concat_test.cpp
@@ -672,42 +672,7 @@ std::shared_ptr<Model> CreateFunction(size_t num_concat_ops,
 
     return std::make_shared<Model>(ov::OutputVector{transpose0, tanh}, ov::ParameterVector{X});
 }
-#if 0
-std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
-                                               element::Type input_type,
-                                               size_t concat_transpose_input_idx,
-                                               size_t num_concat_inputs) {
-    const Shape input_shape{1, 96, 55, 55};
 
-    auto X = std::make_shared<Parameter>(input_type, input_shape);
-
-    auto tanh0 = std::make_shared<Tanh>(X);
-
-    auto concat0 = CreateConcatChain(tanh0,
-                                     num_concat_ops,
-                                     input_type,
-                                     concat_transpose_input_idx,
-                                     num_concat_inputs,
-                                     input_shape,
-                                     /* axis */ 1);
-
-    auto tanh1 = std::make_shared<Tanh>(concat0);
-
-    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<Transpose>(tanh0, ng_order0);
-
-    auto concat1 = CreateConcatTransposedChain(transpose0,
-                                               num_concat_ops,
-                                               input_type,
-                                               concat_transpose_input_idx,
-                                               num_concat_inputs,
-                                               input_shape,
-                                               /* axis */ 3,
-                                               /* transpose order */ Shape{0, 2, 3, 1});
-
-    return std::make_shared<Model>(ov::OutputVector{concat1, tanh1}, ov::ParameterVector{X});
-}
-#endif
 }  // namespace one_binary
 
 namespace multiple_binaries {
@@ -737,43 +702,7 @@ std::shared_ptr<Model> CreateFunction(size_t num_concat_ops,
 
     return std::make_shared<Model>(ov::OutputVector{transpose0, tanh}, ov::ParameterVector{X});
 }
-#if 0
-std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
-                                               element::Type input_type,
-                                               size_t concat_transpose_input_idx,
-                                               size_t num_concat_inputs) {
-    const Shape input_shape{1, 96, 55, 55};
-    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto tanh0 = std::make_shared<Tanh>(X);
-
-    // left branch
-    auto concat = CreateConcatChain(tanh0,
-                                    num_concat_ops,
-                                    input_type,
-                                    concat_transpose_input_idx,
-                                    num_concat_inputs,
-                                    input_shape,
-                                    /* axis */ 1);
-
-    auto tanh1 = std::make_shared<Tanh>(concat);
-
-    // right branch
-    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<Transpose>(tanh0, ng_order0);
-
-    concat = CreateConcatTransposedChain(transpose0,
-                                         num_concat_ops,
-                                         input_type,
-                                         concat_transpose_input_idx,
-                                         num_concat_inputs,
-                                         input_shape,
-                                         /* axis */ 3,
-                                         /* transpose order */ Shape{0, 2, 3, 1});
-
-    return std::make_shared<Model>(ov::OutputVector{concat, tanh1}, ov::ParameterVector{X});
-}
-#endif
 }  // namespace multiple_binaries
 
 }  // namespace output_consumers

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_concat_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_concat_test.cpp
@@ -22,10 +22,13 @@ using ModelPtr = std::shared_ptr<Model>;
 
 class IPassFactory {
 public:
-    IPassFactory(const std::string & type_name) : type_name_(type_name) {}
+    IPassFactory(const std::string& type_name) : type_name_(type_name) {}
     virtual ~IPassFactory() = default;
     virtual void registerPass(ov::pass::Manager& pass_manager) const = 0;
-    const std::string & getTypeName() const { return type_name_; }
+    const std::string& getTypeName() const {
+        return type_name_;
+    }
+
 private:
     const std::string type_name_;
 };
@@ -35,7 +38,7 @@ using PassFactoryPtr = std::shared_ptr<IPassFactory>;
 template <typename PassT>
 class PassFactory : public IPassFactory {
 public:
-    PassFactory(const std::string & type_name) : IPassFactory(type_name) {}
+    PassFactory(const std::string& type_name) : IPassFactory(type_name) {}
     void registerPass(ov::pass::Manager& pass_manager) const override {
         pass_manager.register_pass<PassT>();
     }
@@ -43,7 +46,7 @@ public:
 
 #define CREATE_PASS_FACTORY(pass_name) std::make_shared<PassFactory<ov::pass::pass_name>>(#pass_name)
 
-} // namespace
+}  // namespace
 
 namespace {
 
@@ -92,8 +95,7 @@ NodePtr CreateConcatTransposedChain(NodePtr input_node,
 
                 auto transpose_const =
                     std::make_shared<Constant>(element::u64, Shape{transpose_order.size()}, transpose_order);
-                auto transpose =
-                    std::make_shared<Transpose>(in_constant, transpose_const);
+                auto transpose = std::make_shared<Transpose>(in_constant, transpose_const);
 
                 concat_inputs.push_back(transpose);
             }
@@ -139,7 +141,7 @@ NodePtr CreateConcatDoubleTransposedChain(NodePtr input_node,
     return in_op;
 }
 
-} // namespace
+}  // namespace
 
 namespace single_consumer {
 namespace forward {
@@ -169,9 +171,9 @@ std::shared_ptr<Model> CreateFunction(size_t num_concat_ops,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
-                                                   element::Type input_type,
-                                                   size_t concat_transpose_input_idx,
-                                                   size_t num_concat_inputs) {
+                                               element::Type input_type,
+                                               size_t concat_transpose_input_idx,
+                                               size_t num_concat_inputs) {
     const Shape input_shape{1, 96, 55, 55};
     const Shape const_shape{1, 55, 55, 96};
 
@@ -196,9 +198,7 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
 
 namespace double_transpose {
 
-std::shared_ptr<Model> CreateFunction(size_t num_concat_ops,
-                                          element::Type input_type,
-                                          size_t num_concat_inputs) {
+std::shared_ptr<Model> CreateFunction(size_t num_concat_ops, element::Type input_type, size_t num_concat_inputs) {
     const Shape input_shape{1, 96, 55, 55};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -219,8 +219,8 @@ std::shared_ptr<Model> CreateFunction(size_t num_concat_ops,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
-                                                   element::Type input_type,
-                                                   size_t num_concat_inputs) {
+                                               element::Type input_type,
+                                               size_t num_concat_inputs) {
     const Shape input_shape{1, 96, 55, 55};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -248,9 +248,9 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
 namespace backward {
 
 std::shared_ptr<Model> CreateFunction(size_t num_concat_ops,
-                                          element::Type input_type,
-                                          size_t concat_transpose_input_idx,
-                                          size_t num_concat_inputs) {
+                                      element::Type input_type,
+                                      size_t concat_transpose_input_idx,
+                                      size_t num_concat_inputs) {
     const Shape input_shape{1, 96, 55, 55};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -270,9 +270,9 @@ std::shared_ptr<Model> CreateFunction(size_t num_concat_ops,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
-                                                   element::Type input_type,
-                                                   size_t concat_transpose_input_idx,
-                                                   size_t num_concat_inputs) {
+                                               element::Type input_type,
+                                               size_t concat_transpose_input_idx,
+                                               size_t num_concat_inputs) {
     const Shape input_shape{1, 96, 55, 55};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -304,7 +304,7 @@ using TestConcatParams = std::tuple<PassFactoryPtr,
                                     size_t,             /* num_concat_ops */
                                     CreateGraphConcatF, /* model_factory */
                                     CreateGraphConcatF, /* reference_model_factory */
-                                    element::Type,  /* input type */
+                                    element::Type,      /* input type */
                                     size_t,             /* concat_transpose_input_idx */
                                     size_t>;            /* num_concat_inputs */
 
@@ -319,14 +319,14 @@ public:
         element::Type input_type;
         size_t concat_transpose_input_idx;
         size_t num_concat_inputs;
-    
+
         std::tie(pass_factory,
-             num_concat_ops,
-             model_factory,
-             reference_model_factory,
-             input_type,
-             concat_transpose_input_idx,
-             num_concat_inputs) = obj.param;
+                 num_concat_ops,
+                 model_factory,
+                 reference_model_factory,
+                 input_type,
+                 concat_transpose_input_idx,
+                 num_concat_inputs) = obj.param;
 
         std::ostringstream test_name;
         test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
@@ -370,31 +370,30 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(element::f32),
                        ::testing::ValuesIn(concat_transpose_input_indexes),
                        ::testing::Values(5)),
-                       TransposeSinkingConcatTestFixture::get_test_name);
+    TransposeSinkingConcatTestFixture::get_test_name);
 
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingConcatBackwardTestSuite,
-    TransposeSinkingConcatTestFixture,
-    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingConcatBackward)),
-                       ::testing::ValuesIn(concat_operations_numbers),
-                       ::testing::Values(single_consumer::backward::CreateFunction),
-                       ::testing::Values(single_consumer::backward::CreateReferenceFunction),
-                       ::testing::Values(element::f32),
-                       ::testing::ValuesIn(concat_transpose_input_indexes),
-                       ::testing::Values(5)),
-                       TransposeSinkingConcatTestFixture::get_test_name);
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingConcatBackwardTestSuite,
+                         TransposeSinkingConcatTestFixture,
+                         ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingConcatBackward)),
+                                            ::testing::ValuesIn(concat_operations_numbers),
+                                            ::testing::Values(single_consumer::backward::CreateFunction),
+                                            ::testing::Values(single_consumer::backward::CreateReferenceFunction),
+                                            ::testing::Values(element::f32),
+                                            ::testing::ValuesIn(concat_transpose_input_indexes),
+                                            ::testing::Values(5)),
+                         TransposeSinkingConcatTestFixture::get_test_name);
 
 // --------------------------------------------------------------------------------------
 
-using CreateGraphConcatAllTransposesInputF = std::function<
-    std::shared_ptr<Model>(size_t num_concat_ops, element::Type input_type, size_t num_concat_inputs)>;
+using CreateGraphConcatAllTransposesInputF =
+    std::function<std::shared_ptr<Model>(size_t num_concat_ops, element::Type input_type, size_t num_concat_inputs)>;
 
 using TestConcatAllTransposesInputParams =
     std::tuple<PassFactoryPtr,
                size_t,                               /* num_concat_ops */
                CreateGraphConcatAllTransposesInputF, /* model_factory */
                CreateGraphConcatAllTransposesInputF, /* reference_model_factory */
-               element::Type,                    /* input type */
+               element::Type,                        /* input type */
                size_t>;                              /* num_concat_inputs */
 
 class TransposeSinkingConcatAllTransposesInputTestFixture
@@ -408,13 +407,9 @@ public:
         CreateGraphConcatAllTransposesInputF reference_model_factory;
         element::Type input_type;
         size_t num_concat_inputs;
-    
-        std::tie(pass_factory,
-             num_concat_ops,
-             model_factory,
-             reference_model_factory,
-             input_type,
-             num_concat_inputs) = obj.param;
+
+        std::tie(pass_factory, num_concat_ops, model_factory, reference_model_factory, input_type, num_concat_inputs) =
+            obj.param;
 
         std::ostringstream test_name;
         test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
@@ -434,12 +429,8 @@ TEST_P(TransposeSinkingConcatAllTransposesInputTestFixture, CompareFunctions) {
     element::Type input_type;
     size_t num_concat_inputs;
 
-    std::tie(pass_factory,
-             num_concat_ops,
-             model_factory,
-             reference_model_factory,
-             input_type,
-             num_concat_inputs) = this->GetParam();
+    std::tie(pass_factory, num_concat_ops, model_factory, reference_model_factory, input_type, num_concat_inputs) =
+        this->GetParam();
 
     model = model_factory(num_concat_ops, input_type, num_concat_inputs);
     model_ref = reference_model_factory(num_concat_ops, input_type, num_concat_inputs);
@@ -455,7 +446,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(single_consumer::forward::double_transpose::CreateReferenceFunction),
                        ::testing::Values(element::f32),
                        ::testing::Values(5)),
-                       TransposeSinkingConcatAllTransposesInputTestFixture::get_test_name);
+    TransposeSinkingConcatAllTransposesInputTestFixture::get_test_name);
 
 // --------------------------------------------------------------------------------------
 
@@ -505,8 +496,7 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
     NodePtr binary;
     auto in_constant = std::make_shared<Constant>(input_type, const_shape, Shape{1});
 
-    auto transpose_reversed_const =
-        std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+    auto transpose_reversed_const = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
     auto transpose_reversed = std::make_shared<Transpose>(in_constant, transpose_reversed_const);
 
     auto concat = CreateConcatTransposedChain(X,
@@ -524,7 +514,7 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
     return std::make_shared<Model>(ov::OutputVector{transpose1, tanh}, ov::ParameterVector{X});
 }
 
-} // namespace input_transpose_consumers
+}  // namespace input_transpose_consumers
 
 namespace output_consumers {
 
@@ -566,8 +556,7 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
     NodePtr binary;
     auto in_constant = std::make_shared<Constant>(input_type, const_shape, Shape{1});
 
-    auto transpose_reversed_const =
-        std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+    auto transpose_reversed_const = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
     auto transpose_reversed = std::make_shared<Transpose>(in_constant, transpose_reversed_const);
 
     auto concat = CreateConcatTransposedChain(X,
@@ -588,7 +577,7 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
     return std::make_shared<Model>(ov::OutputVector{tanh1, tanh2}, ov::ParameterVector{X});
 }
 
-} // namespace output_consumers
+}  // namespace output_consumers
 
 namespace input_node_consumers {
 
@@ -625,9 +614,9 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
     const Shape const_shape{1, 55, 55, 96};
 
     auto X = std::make_shared<Parameter>(input_type, input_shape);
-    
+
     auto tanh = std::make_shared<Tanh>(X);
-    
+
     auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
@@ -649,10 +638,9 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
     return std::make_shared<Model>(ov::OutputVector{transpose1, tanh}, ov::ParameterVector{X});
 }
 
-} // namespace input_node_consumers
+}  // namespace input_node_consumers
 
-} // namespace forward
-
+}  // namespace forward
 
 namespace backward {
 
@@ -720,7 +708,7 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
     return std::make_shared<Model>(ov::OutputVector{concat1, tanh1}, ov::ParameterVector{X});
 }
 
-} // namespace one_binary
+}  // namespace one_binary
 
 namespace multiple_binaries {
 
@@ -772,7 +760,7 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
 
     // right branch
     auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<Transpose>(tanh0, ng_order0);    
+    auto transpose0 = std::make_shared<Transpose>(tanh0, ng_order0);
 
     concat = CreateConcatTransposedChain(transpose0,
                                          num_concat_ops,
@@ -786,9 +774,9 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
     return std::make_shared<Model>(ov::OutputVector{concat, tanh1}, ov::ParameterVector{X});
 }
 
-} // namespace multiple_binaries
+}  // namespace multiple_binaries
 
-} // namespace output_consumers
+}  // namespace output_consumers
 
 namespace input_node_consumers {
 
@@ -845,7 +833,7 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
     return std::make_shared<Model>(ov::OutputVector{concat, tanh1}, ov::ParameterVector{X});
 }
 
-} // input_node_consumers
+}  // namespace input_node_consumers
 
 namespace output_transpose_mult_consumers {
 
@@ -900,40 +888,37 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
     return std::make_shared<Model>(ov::OutputVector{tanh0, tanh1}, ov::ParameterVector{X});
 }
 
-} // namespace output_transpose_mult_consumers
+}  // namespace output_transpose_mult_consumers
 
-} // namespace backward
+}  // namespace backward
 
-
-using CreateGraphF = std::function<
-    std::shared_ptr<Model>(size_t num_concat_ops,
-                           element::Type input_type,
-                           size_t concat_transpose_input_idx,
-                           size_t num_concat_inputs)>;
+using CreateGraphF = std::function<std::shared_ptr<Model>(size_t num_concat_ops,
+                                                          element::Type input_type,
+                                                          size_t concat_transpose_input_idx,
+                                                          size_t num_concat_inputs)>;
 
 struct CreateGraphFunctionDesc {
     CreateGraphFunctionDesc() = default;
     CreateGraphFunctionDesc(CreateGraphF a_model_factory,
                             CreateGraphF a_reference_model_factory,
-                            std::string a_subtest_name) :
-                            model_factory(a_model_factory),
-                            reference_model_factory(a_reference_model_factory),
-                            subtest_name(a_subtest_name) {}
+                            std::string a_subtest_name)
+        : model_factory(a_model_factory),
+          reference_model_factory(a_reference_model_factory),
+          subtest_name(a_subtest_name) {}
     CreateGraphF model_factory;
     CreateGraphF reference_model_factory;
     std::string subtest_name;
 };
 
 using TestConcatParams = std::tuple<PassFactoryPtr,
-                                    size_t,             /* num_concat_ops */
+                                    size_t, /* num_concat_ops */
                                     CreateGraphFunctionDesc,
-                                    element::Type,  /* input type */
-                                    size_t,             /* concat_transpose_input_idx */
-                                    size_t>;            /* num_concat_inputs */
+                                    element::Type, /* input type */
+                                    size_t,        /* concat_transpose_input_idx */
+                                    size_t>;       /* num_concat_inputs */
 
-class TransposeConcatMultiSinkingFixture
-    : public ::testing::WithParamInterface<TestConcatParams>,
-                                          public TransformationTestsF {
+class TransposeConcatMultiSinkingFixture : public ::testing::WithParamInterface<TestConcatParams>,
+                                           public TransformationTestsF {
 public:
     static std::string get_test_name(const testing::TestParamInfo<TestConcatParams>& obj) {
         PassFactoryPtr pass_factory;
@@ -942,13 +927,13 @@ public:
         element::Type input_type;
         size_t concat_transpose_input_idx;
         size_t num_concat_inputs;
-    
+
         std::tie(pass_factory,
-             num_concat_ops,
-             function_desc,
-             input_type,
-             concat_transpose_input_idx,
-             num_concat_inputs) = obj.param;
+                 num_concat_ops,
+                 function_desc,
+                 input_type,
+                 concat_transpose_input_idx,
+                 num_concat_inputs) = obj.param;
 
         std::ostringstream test_name;
         test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
@@ -964,61 +949,57 @@ public:
 
 TEST_P(TransposeConcatMultiSinkingFixture, CompareFunctions) {
     PassFactoryPtr pass_factory;
-        size_t num_concat_ops;
-        CreateGraphFunctionDesc function_desc;
-        element::Type input_type;
-        size_t concat_transpose_input_idx;
-        size_t num_concat_inputs;
+    size_t num_concat_ops;
+    CreateGraphFunctionDesc function_desc;
+    element::Type input_type;
+    size_t concat_transpose_input_idx;
+    size_t num_concat_inputs;
 
-    std::tie(pass_factory,
-             num_concat_ops,
-             function_desc,
-             input_type,
-             concat_transpose_input_idx,
-             num_concat_inputs) = this->GetParam();
+    std::tie(pass_factory, num_concat_ops, function_desc, input_type, concat_transpose_input_idx, num_concat_inputs) =
+        this->GetParam();
 
     model = function_desc.model_factory(num_concat_ops, input_type, concat_transpose_input_idx, num_concat_inputs);
-    model_ref = function_desc.reference_model_factory(num_concat_ops, input_type, concat_transpose_input_idx, num_concat_inputs);
+    model_ref = function_desc.reference_model_factory(num_concat_ops,
+                                                      input_type,
+                                                      concat_transpose_input_idx,
+                                                      num_concat_inputs);
     pass_factory->registerPass(manager);
 }
 
-#define SUBTEST(nmspace, subtest_name) CreateGraphFunctionDesc(nmspace::CreateFunction, nmspace::CreateReferenceFunction, subtest_name)
+#define SUBTEST(nmspace, subtest_name) \
+    CreateGraphFunctionDesc(nmspace::CreateFunction, nmspace::CreateReferenceFunction, subtest_name)
 
 std::vector<CreateGraphFunctionDesc> forward_subtests = {
     SUBTEST(forward::input_transpose_consumers, "forward_input_transpose_consumers"),
     SUBTEST(forward::output_consumers, "forward_output_consumers"),
-    SUBTEST(forward::input_node_consumers, "forward_input_node_consumers")
-};
+    SUBTEST(forward::input_node_consumers, "forward_input_node_consumers")};
 
 std::vector<CreateGraphFunctionDesc> backward_subtests = {
     SUBTEST(backward::output_consumers::one_binary, "backward_output_consumers_one_binary"),
     SUBTEST(backward::output_consumers::multiple_binaries, "backward_output_consumers_multiple_binaries"),
     SUBTEST(backward::input_node_consumers, "backward_input_node_consumers"),
-    SUBTEST(backward::output_transpose_mult_consumers, "backward_output_transpose_mult_consumers")
-};
+    SUBTEST(backward::output_transpose_mult_consumers, "backward_output_transpose_mult_consumers")};
 
 #undef SUBTEST
 
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingConcatForwardMultiConsumersTestSuite,
-    TransposeConcatMultiSinkingFixture,
-    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingConcatForward)),
-                       ::testing::ValuesIn(concat_operations_numbers),
-                       ::testing::ValuesIn(forward_subtests),
-                       ::testing::Values(element::f32),
-                       ::testing::ValuesIn(concat_transpose_input_indexes),
-                       ::testing::Values(5)),
-                       TransposeConcatMultiSinkingFixture::get_test_name);
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingConcatForwardMultiConsumersTestSuite,
+                         TransposeConcatMultiSinkingFixture,
+                         ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingConcatForward)),
+                                            ::testing::ValuesIn(concat_operations_numbers),
+                                            ::testing::ValuesIn(forward_subtests),
+                                            ::testing::Values(element::f32),
+                                            ::testing::ValuesIn(concat_transpose_input_indexes),
+                                            ::testing::Values(5)),
+                         TransposeConcatMultiSinkingFixture::get_test_name);
 
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingConcatBackwardMultiConsumersTestSuite,
-    TransposeConcatMultiSinkingFixture,
-    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingConcatBackward)),
-                       ::testing::ValuesIn(concat_operations_numbers),
-                       ::testing::ValuesIn(backward_subtests),
-                       ::testing::Values(element::f32),
-                       ::testing::ValuesIn(concat_transpose_input_indexes),
-                       ::testing::Values(5)),
-                       TransposeConcatMultiSinkingFixture::get_test_name);
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingConcatBackwardMultiConsumersTestSuite,
+                         TransposeConcatMultiSinkingFixture,
+                         ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingConcatBackward)),
+                                            ::testing::ValuesIn(concat_operations_numbers),
+                                            ::testing::ValuesIn(backward_subtests),
+                                            ::testing::Values(element::f32),
+                                            ::testing::ValuesIn(concat_transpose_input_indexes),
+                                            ::testing::Values(5)),
+                         TransposeConcatMultiSinkingFixture::get_test_name);
 
-} // namespace mult_consumers
+}  // namespace mult_consumers

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_concat_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_concat_test.cpp
@@ -1011,7 +1011,7 @@ INSTANTIATE_TEST_SUITE_P(
                        TransposeConcatMultiSinkingFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingBinaryBackwardMultiConsumersTestSuite,
+    TransposeSinkingConcatBackwardMultiConsumersTestSuite,
     TransposeConcatMultiSinkingFixture,
     ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingConcatBackward)),
                        ::testing::ValuesIn(concat_operations_numbers),

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_concat_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_concat_test.cpp
@@ -828,9 +828,7 @@ using CreateGraphF = std::function<std::shared_ptr<Model>(size_t num_concat_ops,
 
 struct CreateGraphFunctionDesc {
     CreateGraphFunctionDesc() = default;
-    CreateGraphFunctionDesc(CreateGraphF a_model_factory,
-                            CreateGraphF a_ref_model_factory,
-                            std::string a_subtest_name)
+    CreateGraphFunctionDesc(CreateGraphF a_model_factory, CreateGraphF a_ref_model_factory, std::string a_subtest_name)
         : model_factory(a_model_factory),
           reference_model_factory(a_ref_model_factory),
           subtest_name(a_subtest_name) {}
@@ -933,8 +931,7 @@ namespace no_sinking {
 
 struct CreateGraphFunctionNoSinkingDesc {
     CreateGraphFunctionNoSinkingDesc() = default;
-    CreateGraphFunctionNoSinkingDesc(CreateGraphF a_model_factory,
-                            std::string a_subtest_name)
+    CreateGraphFunctionNoSinkingDesc(CreateGraphF a_model_factory, std::string a_subtest_name)
         : model_factory(a_model_factory),
           subtest_name(a_subtest_name) {}
     CreateGraphF model_factory;
@@ -949,7 +946,7 @@ using TestConcatParams = std::tuple<PassFactoryPtr,
                                     size_t>;       /* num_concat_inputs */
 
 class TransposeConcatMultiSinkingConcatConsumersFixture : public ::testing::WithParamInterface<TestConcatParams>,
-                                           public TransformationTestsF {
+                                                          public TransformationTestsF {
 public:
     static std::string get_test_name(const testing::TestParamInfo<TestConcatParams>& obj) {
         PassFactoryPtr pass_factory;
@@ -994,8 +991,7 @@ TEST_P(TransposeConcatMultiSinkingConcatConsumersFixture, CompareFunctions) {
     pass_factory->registerPass(manager);
 }
 
-#define SUBTEST(nmspace, subtest_name) \
-    CreateGraphFunctionNoSinkingDesc(nmspace::CreateFunction, subtest_name)
+#define SUBTEST(nmspace, subtest_name) CreateGraphFunctionNoSinkingDesc(nmspace::CreateFunction, subtest_name)
 
 std::vector<CreateGraphFunctionNoSinkingDesc> backward_subtests_no_sinking = {
     SUBTEST(backward::output_consumers::one_binary, "backwardOutputConsumersOneBinary"),
@@ -1013,6 +1009,6 @@ INSTANTIATE_TEST_SUITE_P(TransposeSinkingConcatBackwardMultiConsumersTestSuite,
                                             ::testing::Values(5)),
                          TransposeConcatMultiSinkingConcatConsumersFixture::get_test_name);
 
-} // no_sinking
+}  // namespace no_sinking
 
 }  // namespace mult_consumers

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_concat_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_concat_test.cpp
@@ -329,11 +329,11 @@ public:
                  num_concat_inputs) = obj.param;
 
         std::ostringstream test_name;
-        test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
-        test_name << "num_concat_ops=" << num_concat_ops << "_";
-        test_name << "concat_transpose_input_idx=" << concat_transpose_input_idx << "_";
-        test_name << "num_concat_inputs=" << num_concat_inputs << "_";
-        test_name << "input_type=" << input_type;
+        test_name << "passFactory=" << pass_factory->getTypeName() << "/";
+        test_name << "numConcatOps=" << num_concat_ops << "/";
+        test_name << "concatTransposeInputIdx=" << concat_transpose_input_idx << "/";
+        test_name << "numConcatInputs=" << num_concat_inputs << "/";
+        test_name << "inputType=" << input_type;
 
         return test_name.str();
     }
@@ -412,10 +412,10 @@ public:
             obj.param;
 
         std::ostringstream test_name;
-        test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
-        test_name << "num_concat_ops=" << num_concat_ops << "_";
-        test_name << "num_concat_inputs=" << num_concat_inputs << "_";
-        test_name << "input_type=" << input_type;
+        test_name << "passFactory=" << pass_factory->getTypeName() << "/";
+        test_name << "numConcatOps=" << num_concat_ops << "/";
+        test_name << "numConcatInputs=" << num_concat_inputs << "/";
+        test_name << "inputType=" << input_type;
 
         return test_name.str();
     }
@@ -672,7 +672,7 @@ std::shared_ptr<Model> CreateFunction(size_t num_concat_ops,
 
     return std::make_shared<Model>(ov::OutputVector{transpose0, tanh}, ov::ParameterVector{X});
 }
-
+#if 0
 std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
                                                element::Type input_type,
                                                size_t concat_transpose_input_idx,
@@ -707,7 +707,7 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
 
     return std::make_shared<Model>(ov::OutputVector{concat1, tanh1}, ov::ParameterVector{X});
 }
-
+#endif
 }  // namespace one_binary
 
 namespace multiple_binaries {
@@ -737,7 +737,7 @@ std::shared_ptr<Model> CreateFunction(size_t num_concat_ops,
 
     return std::make_shared<Model>(ov::OutputVector{transpose0, tanh}, ov::ParameterVector{X});
 }
-
+#if 0
 std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
                                                element::Type input_type,
                                                size_t concat_transpose_input_idx,
@@ -773,7 +773,7 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
 
     return std::make_shared<Model>(ov::OutputVector{concat, tanh1}, ov::ParameterVector{X});
 }
-
+#endif
 }  // namespace multiple_binaries
 
 }  // namespace output_consumers
@@ -900,10 +900,10 @@ using CreateGraphF = std::function<std::shared_ptr<Model>(size_t num_concat_ops,
 struct CreateGraphFunctionDesc {
     CreateGraphFunctionDesc() = default;
     CreateGraphFunctionDesc(CreateGraphF a_model_factory,
-                            CreateGraphF a_reference_model_factory,
+                            CreateGraphF a_ref_model_factory,
                             std::string a_subtest_name)
         : model_factory(a_model_factory),
-          reference_model_factory(a_reference_model_factory),
+          reference_model_factory(a_ref_model_factory),
           subtest_name(a_subtest_name) {}
     CreateGraphF model_factory;
     CreateGraphF reference_model_factory;
@@ -936,12 +936,12 @@ public:
                  num_concat_inputs) = obj.param;
 
         std::ostringstream test_name;
-        test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
-        test_name << "function_desc=" << function_desc.subtest_name << "_";
-        test_name << "num_concat_ops=" << num_concat_ops << "_";
-        test_name << "concat_transpose_input_idx=" << concat_transpose_input_idx << "_";
-        test_name << "num_concat_inputs=" << num_concat_inputs << "_";
-        test_name << "input_type=" << input_type;
+        test_name << "passFactory=" << pass_factory->getTypeName() << "/";
+        test_name << "functionDesc=" << function_desc.subtest_name << "/";
+        test_name << "numConcatOps=" << num_concat_ops << "/";
+        test_name << "concatTransposeInputIdx=" << concat_transpose_input_idx << "/";
+        test_name << "numConcatInputs=" << num_concat_inputs << "/";
+        test_name << "inputType=" << input_type;
 
         return test_name.str();
     }
@@ -970,15 +970,13 @@ TEST_P(TransposeConcatMultiSinkingFixture, CompareFunctions) {
     CreateGraphFunctionDesc(nmspace::CreateFunction, nmspace::CreateReferenceFunction, subtest_name)
 
 std::vector<CreateGraphFunctionDesc> forward_subtests = {
-    SUBTEST(forward::input_transpose_consumers, "forward_input_transpose_consumers"),
-    SUBTEST(forward::output_consumers, "forward_output_consumers"),
-    SUBTEST(forward::input_node_consumers, "forward_input_node_consumers")};
+    SUBTEST(forward::input_transpose_consumers, "forwardInputTransposeConsumers"),
+    SUBTEST(forward::output_consumers, "forwardOutputConsumers"),
+    SUBTEST(forward::input_node_consumers, "forwardInputNodeConsumers")};
 
 std::vector<CreateGraphFunctionDesc> backward_subtests = {
-    SUBTEST(backward::output_consumers::one_binary, "backward_output_consumers_one_binary"),
-    SUBTEST(backward::output_consumers::multiple_binaries, "backward_output_consumers_multiple_binaries"),
-    SUBTEST(backward::input_node_consumers, "backward_input_node_consumers"),
-    SUBTEST(backward::output_transpose_mult_consumers, "backward_output_transpose_mult_consumers")};
+    SUBTEST(backward::input_node_consumers, "backwardInputNodeConsumers"),
+    SUBTEST(backward::output_transpose_mult_consumers, "backwardOutputTransposeMultConsumers")};
 
 #undef SUBTEST
 
@@ -1001,5 +999,91 @@ INSTANTIATE_TEST_SUITE_P(TransposeSinkingConcatBackwardMultiConsumersTestSuite,
                                             ::testing::ValuesIn(concat_transpose_input_indexes),
                                             ::testing::Values(5)),
                          TransposeConcatMultiSinkingFixture::get_test_name);
+
+namespace no_sinking {
+
+struct CreateGraphFunctionNoSinkingDesc {
+    CreateGraphFunctionNoSinkingDesc() = default;
+    CreateGraphFunctionNoSinkingDesc(CreateGraphF a_model_factory,
+                            std::string a_subtest_name)
+        : model_factory(a_model_factory),
+          subtest_name(a_subtest_name) {}
+    CreateGraphF model_factory;
+    std::string subtest_name;
+};
+
+using TestConcatParams = std::tuple<PassFactoryPtr,
+                                    size_t, /* num_concat_ops */
+                                    CreateGraphFunctionNoSinkingDesc,
+                                    element::Type, /* input type */
+                                    size_t,        /* concat_transpose_input_idx */
+                                    size_t>;       /* num_concat_inputs */
+
+class TransposeConcatMultiSinkingConcatConsumersFixture : public ::testing::WithParamInterface<TestConcatParams>,
+                                           public TransformationTestsF {
+public:
+    static std::string get_test_name(const testing::TestParamInfo<TestConcatParams>& obj) {
+        PassFactoryPtr pass_factory;
+        size_t num_concat_ops;
+        CreateGraphFunctionNoSinkingDesc function_desc;
+        element::Type input_type;
+        size_t concat_transpose_input_idx;
+        size_t num_concat_inputs;
+
+        std::tie(pass_factory,
+                 num_concat_ops,
+                 function_desc,
+                 input_type,
+                 concat_transpose_input_idx,
+                 num_concat_inputs) = obj.param;
+
+        std::ostringstream test_name;
+        test_name << "passFactory=" << pass_factory->getTypeName() << "/";
+        test_name << "functionDesc=" << function_desc.subtest_name << "/";
+        test_name << "numConcatOps=" << num_concat_ops << "/";
+        test_name << "concatTransposeInputIdx=" << concat_transpose_input_idx << "/";
+        test_name << "numConcatInputs=" << num_concat_inputs << "/";
+        test_name << "inputType=" << input_type;
+
+        return test_name.str();
+    }
+};
+
+TEST_P(TransposeConcatMultiSinkingConcatConsumersFixture, CompareFunctions) {
+    PassFactoryPtr pass_factory;
+    size_t num_concat_ops;
+    CreateGraphFunctionNoSinkingDesc function_desc;
+    element::Type input_type;
+    size_t concat_transpose_input_idx;
+    size_t num_concat_inputs;
+
+    std::tie(pass_factory, num_concat_ops, function_desc, input_type, concat_transpose_input_idx, num_concat_inputs) =
+        this->GetParam();
+
+    model = function_desc.model_factory(num_concat_ops, input_type, concat_transpose_input_idx, num_concat_inputs);
+    model_ref = model->clone();
+    pass_factory->registerPass(manager);
+}
+
+#define SUBTEST(nmspace, subtest_name) \
+    CreateGraphFunctionNoSinkingDesc(nmspace::CreateFunction, subtest_name)
+
+std::vector<CreateGraphFunctionNoSinkingDesc> backward_subtests_no_sinking = {
+    SUBTEST(backward::output_consumers::one_binary, "backwardOutputConsumersOneBinary"),
+    SUBTEST(backward::output_consumers::multiple_binaries, "backwardOutputConsumersMultipleBinaries")};
+
+#undef SUBTEST
+
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingConcatBackwardMultiConsumersTestSuite,
+                         TransposeConcatMultiSinkingConcatConsumersFixture,
+                         ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingConcatBackward)),
+                                            ::testing::ValuesIn(concat_operations_numbers),
+                                            ::testing::ValuesIn(backward_subtests_no_sinking),
+                                            ::testing::Values(element::f32),
+                                            ::testing::ValuesIn(concat_transpose_input_indexes),
+                                            ::testing::Values(5)),
+                         TransposeConcatMultiSinkingConcatConsumersFixture::get_test_name);
+
+} // no_sinking
 
 }  // namespace mult_consumers

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_concat_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_concat_test.cpp
@@ -12,44 +12,22 @@
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "gtest/gtest.h"
 
+using namespace ov;
+using namespace ov::opset9;
+
 namespace {
 
 using NodePtr = std::shared_ptr<ov::Node>;
-using ModelPtr = std::shared_ptr<ov::Model>;
-using Output = ov::Output<ov::Node>;
-
-// ----------------------------------------------------------------------------
-
-class IBinaryFactory {
-public:
-    IBinaryFactory() = default;
-    virtual ~IBinaryFactory() = default;
-    virtual NodePtr create(NodePtr parent_left_node, NodePtr parent_right_node) const = 0;
-};
-
-using BinaryFactoryPtr = std::shared_ptr<IBinaryFactory>;
-
-template <typename BinaryT>
-class BinaryFactory : public IBinaryFactory {
-public:
-    BinaryFactory() = default;
-    NodePtr create(NodePtr parent_left_node, NodePtr parent_right_node) const override {
-        return std::make_shared<BinaryT>(parent_left_node, parent_right_node);
-    }
-};
-
-template <typename BinaryT>
-BinaryFactoryPtr CreateBinaryFactory() {
-    return std::make_shared<BinaryFactory<BinaryT>>();
-}
-
-// ----------------------------------------------------------------------------
+using ModelPtr = std::shared_ptr<Model>;
 
 class IPassFactory {
 public:
-    IPassFactory() = default;
+    IPassFactory(const std::string & type_name) : type_name_(type_name) {}
     virtual ~IPassFactory() = default;
     virtual void registerPass(ov::pass::Manager& pass_manager) const = 0;
+    const std::string & getTypeName() const { return type_name_; }
+private:
+    const std::string type_name_;
 };
 
 using PassFactoryPtr = std::shared_ptr<IPassFactory>;
@@ -57,34 +35,18 @@ using PassFactoryPtr = std::shared_ptr<IPassFactory>;
 template <typename PassT>
 class PassFactory : public IPassFactory {
 public:
+    PassFactory(const std::string & type_name) : IPassFactory(type_name) {}
     void registerPass(ov::pass::Manager& pass_manager) const override {
         pass_manager.register_pass<PassT>();
     }
 };
 
-template <typename PassT>
-PassFactoryPtr CreatePassFactory() {
-    return std::make_shared<PassFactory<PassT>>();
-}
-
-std::vector<BinaryFactoryPtr> binary_factories = {CreateBinaryFactory<ov::opset9::Add>(),
-                                                  CreateBinaryFactory<ov::opset9::Divide>(),
-                                                  CreateBinaryFactory<ov::opset9::Maximum>(),
-                                                  CreateBinaryFactory<ov::opset9::Minimum>(),
-                                                  CreateBinaryFactory<ov::opset9::Mod>(),
-                                                  CreateBinaryFactory<ov::opset9::Multiply>(),
-                                                  CreateBinaryFactory<ov::opset9::Power>(),
-                                                  CreateBinaryFactory<ov::opset9::SquaredDifference>(),
-                                                  CreateBinaryFactory<ov::opset9::Subtract>()};
-
-std::vector<size_t> binary_operations_numbers = {1, 10};
-
-std::vector<size_t> binary_transpose_input_indexes = {0, 1};
+#define CREATE_PASS_FACTORY(pass_name) std::make_shared<PassFactory<ov::pass::pass_name>>(#pass_name)
 
 }  // namespace
 
-using CreateGraphConcatF = std::function<std::shared_ptr<ov::Model>(size_t num_concat_ops,
-                                                                    ov::element::Type input_type,
+using CreateGraphConcatF = std::function<std::shared_ptr<Model>(size_t num_concat_ops,
+                                                                    element::Type input_type,
                                                                     size_t concat_transpose_input_idx,
                                                                     size_t num_concat_inputs)>;
 
@@ -92,7 +54,7 @@ using TestConcatParams = std::tuple<PassFactoryPtr,
                                     size_t,             /* num_concat_ops */
                                     CreateGraphConcatF, /* model_factory */
                                     CreateGraphConcatF, /* reference_model_factory */
-                                    ov::element::Type,  /* input type */
+                                    element::Type,  /* input type */
                                     size_t,             /* concat_transpose_input_idx */
                                     size_t>;            /* num_concat_inputs */
 
@@ -111,132 +73,132 @@ namespace single_consumer {
 namespace forward {
 namespace one_input_transpose {
 
-std::shared_ptr<ov::Model> CreateFunction(size_t num_concat_ops,
-                                          ov::element::Type input_type,
+std::shared_ptr<Model> CreateFunction(size_t num_concat_ops,
+                                          element::Type input_type,
                                           size_t concat_transpose_input_idx,
                                           size_t num_concat_inputs) {
-    const ov::Shape input_shape{1, 96, 55, 55};
-    const ov::Shape const_shape{1, 55, 55, 96};
+    const Shape input_shape{1, 96, 55, 55};
+    const Shape const_shape{1, 55, 55, 96};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(X, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
     NodePtr in_op = transpose0;
     for (size_t i = 0; i < num_concat_ops; ++i) {
-        ov::OutputVector concat_inputs;
+        OutputVector concat_inputs;
         for (size_t j = 0; j < num_concat_inputs; ++j) {
             if (j == concat_transpose_input_idx)
                 concat_inputs.push_back(in_op);
             else
-                concat_inputs.push_back(std::make_shared<ov::opset9::Constant>(input_type, const_shape, ov::Shape{1}));
+                concat_inputs.push_back(std::make_shared<Constant>(input_type, const_shape, Shape{1}));
         }
-        in_op = std::make_shared<ov::opset9::Concat>(concat_inputs, 1);
+        in_op = std::make_shared<Concat>(concat_inputs, 1);
     }
 
-    return std::make_shared<ov::Model>(ov::OutputVector{in_op}, ov::ParameterVector{X});
+    return std::make_shared<Model>(OutputVector{in_op}, ParameterVector{X});
 }
 
-std::shared_ptr<ov::Model> CreateReferenceFunction(size_t num_concat_ops,
-                                                   ov::element::Type input_type,
+std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
+                                                   element::Type input_type,
                                                    size_t concat_transpose_input_idx,
                                                    size_t num_concat_inputs) {
-    const ov::Shape input_shape{1, 96, 55, 55};
-    const ov::Shape const_shape{1, 55, 55, 96};
+    const Shape input_shape{1, 96, 55, 55};
+    const Shape const_shape{1, 55, 55, 96};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     NodePtr in_op = X;
     for (size_t i = 0; i < num_concat_ops; ++i) {
-        ov::OutputVector concat_inputs;
+        OutputVector concat_inputs;
         for (size_t j = 0; j < num_concat_inputs; ++j) {
             if (j == concat_transpose_input_idx) {
                 concat_inputs.push_back(in_op);
             } else {
-                auto in_constant = std::make_shared<ov::opset9::Constant>(input_type, const_shape, ov::Shape{1});
+                auto in_constant = std::make_shared<Constant>(input_type, const_shape, Shape{1});
 
                 auto transpose_reversed_const =
-                    std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
+                    std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
                 auto transpose_reversed =
-                    std::make_shared<ov::opset9::Transpose>(in_constant, transpose_reversed_const);
+                    std::make_shared<Transpose>(in_constant, transpose_reversed_const);
 
                 concat_inputs.push_back(transpose_reversed);
             }
         }
-        in_op = std::make_shared<ov::opset9::Concat>(concat_inputs, 2);
+        in_op = std::make_shared<Concat>(concat_inputs, 2);
     }
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(in_op, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
 
-    return std::make_shared<ov::Model>(ov::OutputVector{transpose0}, ov::ParameterVector{X});
+    return std::make_shared<Model>(OutputVector{transpose0}, ParameterVector{X});
 }
 
 }  // namespace one_input_transpose
 
 namespace double_transpose {
 
-std::shared_ptr<ov::Model> CreateFunction(size_t num_concat_ops,
-                                          ov::element::Type input_type,
+std::shared_ptr<Model> CreateFunction(size_t num_concat_ops,
+                                          element::Type input_type,
                                           size_t num_concat_inputs) {
-    const ov::Shape input_shape{1, 96, 55, 55};
+    const Shape input_shape{1, 96, 55, 55};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(X, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
     NodePtr in_op = transpose0;
     for (size_t i = 0; i < num_concat_ops; ++i) {
-        ov::OutputVector concat_inputs;
+        OutputVector concat_inputs;
         concat_inputs.push_back(in_op);
         for (size_t j = 1; j < num_concat_inputs; ++j) {
-            auto in_constant = std::make_shared<ov::opset9::Constant>(input_type, input_shape, ov::Shape{1});
+            auto in_constant = std::make_shared<Constant>(input_type, input_shape, Shape{1});
             auto ng_order1 =
-                std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-            auto transpose1 = std::make_shared<ov::opset9::Transpose>(in_constant, ng_order1);
+                std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+            auto transpose1 = std::make_shared<Transpose>(in_constant, ng_order1);
             concat_inputs.push_back(transpose1);
         }
-        in_op = std::make_shared<ov::opset9::Concat>(concat_inputs, 1);
+        in_op = std::make_shared<Concat>(concat_inputs, 1);
     }
 
-    return std::make_shared<ov::Model>(ov::OutputVector{in_op}, ov::ParameterVector{X});
+    return std::make_shared<Model>(OutputVector{in_op}, ParameterVector{X});
 }
 
-std::shared_ptr<ov::Model> CreateReferenceFunction(size_t num_concat_ops,
-                                                   ov::element::Type input_type,
+std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
+                                                   element::Type input_type,
                                                    size_t num_concat_inputs) {
-    const ov::Shape input_shape{1, 96, 55, 55};
+    const Shape input_shape{1, 96, 55, 55};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     NodePtr in_op = X;
     for (size_t i = 0; i < num_concat_ops; ++i) {
-        ov::OutputVector concat_inputs;
+        OutputVector concat_inputs;
 
         concat_inputs.push_back(in_op);
 
         for (size_t j = 1; j < num_concat_inputs; ++j) {
-            auto in_constant = std::make_shared<ov::opset9::Constant>(input_type, input_shape, ov::Shape{1});
+            auto in_constant = std::make_shared<Constant>(input_type, input_shape, Shape{1});
 
             auto ng_order1 =
-                std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-            auto transpose1 = std::make_shared<ov::opset9::Transpose>(in_constant, ng_order1);
+                std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+            auto transpose1 = std::make_shared<Transpose>(in_constant, ng_order1);
 
             auto transpose_reversed_const =
-                std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-            auto transpose_reversed = std::make_shared<ov::opset9::Transpose>(transpose1, transpose_reversed_const);
+                std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+            auto transpose_reversed = std::make_shared<Transpose>(transpose1, transpose_reversed_const);
 
             concat_inputs.push_back(transpose_reversed);
         }
-        in_op = std::make_shared<ov::opset9::Concat>(concat_inputs, 2);
+        in_op = std::make_shared<Concat>(concat_inputs, 2);
     }
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(in_op, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
 
-    return std::make_shared<ov::Model>(ov::OutputVector{transpose0}, ov::ParameterVector{X});
+    return std::make_shared<Model>(OutputVector{transpose0}, ParameterVector{X});
 }
 
 }  // namespace double_transpose
@@ -245,64 +207,64 @@ std::shared_ptr<ov::Model> CreateReferenceFunction(size_t num_concat_ops,
 
 namespace backward {
 
-std::shared_ptr<ov::Model> CreateFunction(size_t num_concat_ops,
-                                          ov::element::Type input_type,
+std::shared_ptr<Model> CreateFunction(size_t num_concat_ops,
+                                          element::Type input_type,
                                           size_t concat_transpose_input_idx,
                                           size_t num_concat_inputs) {
-    const ov::Shape input_shape{1, 96, 55, 55};
+    const Shape input_shape{1, 96, 55, 55};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     NodePtr in_op = X;
     for (size_t i = 0; i < num_concat_ops; ++i) {
-        ov::OutputVector concat_inputs;
+        OutputVector concat_inputs;
         for (size_t j = 0; j < num_concat_inputs; ++j) {
             if (j == concat_transpose_input_idx)
                 concat_inputs.push_back(in_op);
             else
-                concat_inputs.push_back(std::make_shared<ov::opset9::Constant>(input_type, input_shape, ov::Shape{1}));
+                concat_inputs.push_back(std::make_shared<Constant>(input_type, input_shape, Shape{1}));
         }
-        in_op = std::make_shared<ov::opset9::Concat>(concat_inputs, 1);
+        in_op = std::make_shared<Concat>(concat_inputs, 1);
     }
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(in_op, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
 
-    return std::make_shared<ov::Model>(ov::OutputVector{transpose0}, ov::ParameterVector{X});
+    return std::make_shared<Model>(OutputVector{transpose0}, ParameterVector{X});
 }
 
-std::shared_ptr<ov::Model> CreateReferenceFunction(size_t num_concat_ops,
-                                                   ov::element::Type input_type,
+std::shared_ptr<Model> CreateReferenceFunction(size_t num_concat_ops,
+                                                   element::Type input_type,
                                                    size_t concat_transpose_input_idx,
                                                    size_t num_concat_inputs) {
-    const ov::Shape input_shape{1, 96, 55, 55};
+    const Shape input_shape{1, 96, 55, 55};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(X, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
     NodePtr in_op = transpose0;
     for (size_t i = 0; i < num_concat_ops; ++i) {
-        ov::OutputVector concat_inputs;
+        OutputVector concat_inputs;
         for (size_t j = 0; j < num_concat_inputs; ++j) {
             if (j == concat_transpose_input_idx) {
                 concat_inputs.push_back(in_op);
             } else {
-                auto in_constant = std::make_shared<ov::opset9::Constant>(input_type, input_shape, ov::Shape{1});
+                auto in_constant = std::make_shared<Constant>(input_type, input_shape, Shape{1});
 
                 auto transpose_reversed_const =
-                    std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+                    std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
                 auto transpose_reversed =
-                    std::make_shared<ov::opset9::Transpose>(in_constant, transpose_reversed_const);
+                    std::make_shared<Transpose>(in_constant, transpose_reversed_const);
 
                 concat_inputs.push_back(transpose_reversed);
             }
         }
-        in_op = std::make_shared<ov::opset9::Concat>(concat_inputs, 3);
+        in_op = std::make_shared<Concat>(concat_inputs, 3);
     }
 
-    return std::make_shared<ov::Model>(ov::OutputVector{in_op}, ov::ParameterVector{X});
+    return std::make_shared<Model>(OutputVector{in_op}, ParameterVector{X});
 }
 
 }  // namespace backward
@@ -313,7 +275,7 @@ TEST_P(TransposeSinkingConcatTestFixture, CompareFunctions) {
     size_t num_concat_ops;
     CreateGraphConcatF model_factory;
     CreateGraphConcatF reference_model_factory;
-    ov::element::Type input_type;
+    element::Type input_type;
     size_t concat_transpose_input_idx;
     size_t num_concat_inputs;
     std::tie(pass_factory,
@@ -332,36 +294,36 @@ TEST_P(TransposeSinkingConcatTestFixture, CompareFunctions) {
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingConcatForwardTestSuite,
     TransposeSinkingConcatTestFixture,
-    ::testing::Combine(::testing::Values(CreatePassFactory<ov::pass::TransposeSinkingConcatForward>()),
+    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingConcatForward)),
                        ::testing::ValuesIn(concat_operations_numbers),
                        ::testing::Values(single_consumer::forward::one_input_transpose::CreateFunction),
                        ::testing::Values(single_consumer::forward::one_input_transpose::CreateReferenceFunction),
-                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(element::f32),
                        ::testing::ValuesIn(concat_transpose_input_indexes),
                        ::testing::Values(5)));
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingConcatBackwardTestSuite,
     TransposeSinkingConcatTestFixture,
-    ::testing::Combine(::testing::Values(CreatePassFactory<ov::pass::TransposeSinkingConcatBackward>()),
+    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingConcatBackward)),
                        ::testing::ValuesIn(concat_operations_numbers),
                        ::testing::Values(single_consumer::backward::CreateFunction),
                        ::testing::Values(single_consumer::backward::CreateReferenceFunction),
-                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(element::f32),
                        ::testing::ValuesIn(concat_transpose_input_indexes),
                        ::testing::Values(5)));
 
 // --------------------------------------------------------------------------------------
 
 using CreateGraphConcatAllTransposesInputF = std::function<
-    std::shared_ptr<ov::Model>(size_t num_concat_ops, ov::element::Type input_type, size_t num_concat_inputs)>;
+    std::shared_ptr<Model>(size_t num_concat_ops, element::Type input_type, size_t num_concat_inputs)>;
 
 using TestConcatAllTransposesInputParams =
     std::tuple<PassFactoryPtr,
                size_t,                               /* num_concat_ops */
                CreateGraphConcatAllTransposesInputF, /* model_factory */
                CreateGraphConcatAllTransposesInputF, /* reference_model_factory */
-               ov::element::Type,                    /* input type */
+               element::Type,                    /* input type */
                size_t>;                              /* num_concat_inputs */
 
 class TransposeSinkingConcatAllTransposesInputTestFixture
@@ -373,7 +335,7 @@ TEST_P(TransposeSinkingConcatAllTransposesInputTestFixture, CompareFunctions) {
     size_t num_concat_ops;
     CreateGraphConcatAllTransposesInputF model_factory;
     CreateGraphConcatAllTransposesInputF reference_model_factory;
-    ov::element::Type input_type;
+    element::Type input_type;
     size_t num_concat_inputs;
     std::tie(pass_factory, num_concat_ops, model_factory, reference_model_factory, input_type, num_concat_inputs) =
         this->GetParam();
@@ -386,9 +348,9 @@ TEST_P(TransposeSinkingConcatAllTransposesInputTestFixture, CompareFunctions) {
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingConcatForwardAllTransposesTestSuite,
     TransposeSinkingConcatAllTransposesInputTestFixture,
-    ::testing::Combine(::testing::Values(CreatePassFactory<ov::pass::TransposeSinkingConcatForward>()),
+    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingConcatForward)),
                        ::testing::ValuesIn(concat_operations_numbers),
                        ::testing::Values(single_consumer::forward::double_transpose::CreateFunction),
                        ::testing::Values(single_consumer::forward::double_transpose::CreateReferenceFunction),
-                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(element::f32),
                        ::testing::Values(5)));

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_split_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_split_test.cpp
@@ -56,9 +56,9 @@ namespace forward {
 namespace single_consumer {
 
 std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
-                                          size_t num_split_outputs,
-                                          element::Type input_type) {
-        const ov::Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
+                                      size_t num_split_outputs,
+                                      element::Type input_type) {
+        const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
         auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
 
@@ -68,10 +68,8 @@ std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
         ov::OutputVector outputs;
         ov::Output<ov::Node> in_op = transpose0->output(0);
         for (size_t i = 0; i < num_split_ops; ++i) {
-            auto split_axis_const = std::make_shared<ov::opset9::Constant>(ov::element::u64,
-                                                                           ov::Shape{},
-                                                                           2);
-            auto split = std::make_shared<ov::opset9::Split>(in_op, split_axis_const, num_split_outputs);
+            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 2);
+            auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
             for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
                 outputs.push_back(split->output(num_output));
             }
@@ -83,19 +81,17 @@ std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(size_t num_split_ops,
-                                                   size_t num_split_outputs,
-                                                   element::Type input_type) {
-        const ov::Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
+                                               size_t num_split_outputs,
+                                               element::Type input_type) {
+        const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
         auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
 
         ov::OutputVector outputs;
         ov::Output<ov::Node> in_op = X->output(0);
         for (size_t i = 0; i < num_split_ops; ++i) {
-            auto split_axis_const = std::make_shared<ov::opset9::Constant>(ov::element::u64,
-                                                                           ov::Shape{},
-                                                                           1);
-            auto split = std::make_shared<ov::opset9::Split>(in_op, split_axis_const, num_split_outputs);
+            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 1);
+            auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
             for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
                 auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
                 auto transpose0 = std::make_shared<ov::opset9::Transpose>(split->output(num_output), ng_order0);
@@ -118,8 +114,8 @@ namespace mult_consumers {
 namespace input_node_consumers {
 
 std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
-                                          size_t num_split_outputs,
-                                          element::Type input_type) {
+                                      size_t num_split_outputs,
+                                      element::Type input_type) {
         const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
         auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -132,9 +128,7 @@ std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
         ov::OutputVector outputs;
         auto in_op = transpose0->output(0);
         for (size_t i = 0; i < num_split_ops; ++i) {
-            auto split_axis_const = std::make_shared<Constant>(element::u64,
-                                                                           Shape{},
-                                                                           2);
+            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 2);
             auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
             for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
                 outputs.push_back(split->output(num_output));
@@ -150,8 +144,8 @@ std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(size_t num_split_ops,
-                                                   size_t num_split_outputs,
-                                                   element::Type input_type) {
+                                               size_t num_split_outputs,
+                                               element::Type input_type) {
         const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
         auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -161,9 +155,7 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_split_ops,
         ov::OutputVector outputs;
         auto in_op = tanh->output(0);
         for (size_t i = 0; i < num_split_ops; ++i) {
-            auto split_axis_const = std::make_shared<Constant>(element::u64,
-                                                                           Shape{},
-                                                                           1);
+            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 1);
             auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
             for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
                 auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
@@ -188,8 +180,8 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_split_ops,
 namespace input_transpose_consumers {
 
 std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
-                                          size_t num_split_outputs,
-                                          element::Type input_type) {
+                                      size_t num_split_outputs,
+                                      element::Type input_type) {
         const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
         auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -200,9 +192,7 @@ std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
         ov::OutputVector outputs;
         auto in_op = transpose0->output(0);
         for (size_t i = 0; i < num_split_ops; ++i) {
-            auto split_axis_const = std::make_shared<Constant>(element::u64,
-                                                                           Shape{},
-                                                                           2);
+            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 2);
             auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
             for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
                 outputs.push_back(split->output(num_output));
@@ -218,8 +208,8 @@ std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(size_t num_split_ops,
-                                                   size_t num_split_outputs,
-                                                   element::Type input_type) {
+                                               size_t num_split_outputs,
+                                               element::Type input_type) {
         const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
         auto X = std::make_shared<Parameter>(input_type, input_shape);
@@ -251,6 +241,72 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t num_split_ops,
 }
 
 } // namespace input_transpose_consumers
+
+namespace output_consumers {
+
+std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
+                                      size_t num_split_outputs,
+                                      element::Type input_type) {
+        const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
+
+        auto X = std::make_shared<Parameter>(input_type, input_shape);
+        
+        auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+        auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
+
+        ov::OutputVector outputs;
+        auto in_op = transpose0->output(0);
+        for (size_t i = 0; i < num_split_ops; ++i) {
+            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 2);
+            auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
+            for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
+                outputs.push_back(split->output(num_output));
+            }
+            in_op = split->output(num_split_outputs - 1);
+        }
+        outputs.push_back(in_op);
+
+        auto tanh = std::make_shared<Tanh>(in_op);
+        auto tanh1 = std::make_shared<Tanh>(in_op);
+        outputs.push_back(tanh);
+        outputs.push_back(tanh1);
+
+        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+}
+
+std::shared_ptr<Model> CreateReferenceFunction(size_t num_split_ops,
+                                               size_t num_split_outputs,
+                                               element::Type input_type) {
+        const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
+
+        auto X = std::make_shared<Parameter>(input_type, input_shape);
+
+        ov::OutputVector outputs;
+        auto in_op = X->output(0);
+        for (size_t i = 0; i < num_split_ops; ++i) {
+            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 1);
+            auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
+            for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
+                auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+                auto transpose0 = std::make_shared<Transpose>(split->output(num_output), ng_order0);
+                outputs.push_back(transpose0);
+            }
+            in_op = split->output(num_split_outputs - 1);
+        }
+
+        auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+        auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
+        outputs.push_back(transpose0);
+
+        auto tanh = std::make_shared<Tanh>(transpose0);
+        auto tanh1 = std::make_shared<Tanh>(transpose0);
+        outputs.push_back(tanh);
+        outputs.push_back(tanh1);
+
+        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+}
+
+} // namespace output_consumers
 
 } // namespace mult_consumers
 
@@ -434,6 +490,17 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::ValuesIn(split_outputs_numbers),
                        ::testing::Values(forward::mult_consumers::input_transpose_consumers::CreateFunction),
                        ::testing::Values(forward::mult_consumers::input_transpose_consumers::CreateReferenceFunction),
+                       ::testing::Values(element::f32)),
+                       TransposeSinkingSplitTestFixture::get_test_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    TransposeSinkingSplitForwardMultOutputConsumersTestSuite,
+    TransposeSinkingSplitTestFixture,
+    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitForward)),
+                       ::testing::ValuesIn(split_operations_numbers),
+                       ::testing::ValuesIn(split_outputs_numbers),
+                       ::testing::Values(forward::mult_consumers::output_consumers::CreateFunction),
+                       ::testing::Values(forward::mult_consumers::output_consumers::CreateReferenceFunction),
                        ::testing::Values(element::f32)),
                        TransposeSinkingSplitTestFixture::get_test_name);
 

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_split_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_split_test.cpp
@@ -478,6 +478,39 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t split_tree_depth,
 
 } // namespace mult_output_consumers
 
+namespace mult_split_consumers {
+
+std::shared_ptr<Model> CreateFunction(size_t split_tree_depth,
+                                      size_t num_split_outputs,
+                                      element::Type input_type) {
+        const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
+        const Shape input_shape{96, split_input_dim_value, 55, 55};
+
+        auto X = std::make_shared<Parameter>(input_type, input_shape);
+
+        ov::OutputVector split_tree_leaves;
+        {
+            SplitFactory split_factory(/* axis */ 1, num_split_outputs, /* elem_type */ element::u64);
+            CreateSplitTree(split_tree_depth, /* depth */ 0, X->output(0), split_factory, split_tree_leaves);
+        }
+
+        ov::OutputVector outputs;
+        for (auto& split_tree_leaf : split_tree_leaves) {
+            auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+            auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
+
+            auto tanh0 = std::make_shared<Tanh>(split_tree_leaf);
+            auto tanh1 = std::make_shared<Tanh>(split_tree_leaf);
+
+            outputs.push_back(tanh0);
+            outputs.push_back(tanh1);
+        }
+
+        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+}
+
+} // namespace mult_split_consumers
+
 } // namespace backward
 
 using CreateGraphSplitF = std::function< std::shared_ptr<Model> (size_t num_split_ops,
@@ -601,6 +634,17 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::ValuesIn(split_outputs_numbers),
                        ::testing::Values(backward::mult_output_consumers::CreateFunction),
                        ::testing::Values(backward::mult_output_consumers::CreateReferenceFunction),
+                       ::testing::Values(element::f32)),
+                       TransposeSinkingSplitTestFixture::get_test_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    TransposeSinkingSplitBackwardMultSplitConsumersTestSuite,
+    TransposeSinkingSplitTestFixture,
+    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitBackward)),
+                       ::testing::ValuesIn(split_tree_depth_nums),
+                       ::testing::ValuesIn(split_outputs_numbers),
+                       ::testing::Values(backward::mult_split_consumers::CreateFunction),
+                       ::testing::Values(backward::mult_split_consumers::CreateFunction),
                        ::testing::Values(element::f32)),
                        TransposeSinkingSplitTestFixture::get_test_name);
 

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_split_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_split_test.cpp
@@ -319,9 +319,7 @@ public:
     SplitFactory(size_t axis, size_t n_outputs, element::Type elem_type) :
         _axis(axis), _n_outputs(n_outputs), _elem_type(elem_type) {}
     NodePtr create(ov::Output<ov::Node> parent) const {
-        auto split_axis_const = std::make_shared<Constant>(_elem_type,
-                                                                       Shape{},
-                                                                       _axis);
+        auto split_axis_const = std::make_shared<Constant>(_elem_type, Shape{}, _axis);
         return std::make_shared<Split>(parent, split_axis_const, _n_outputs);
     }
 
@@ -331,7 +329,11 @@ private:
     const element::Type _elem_type;
 };
 
-void CreateSplitTree(size_t max_depth, size_t depth, ov::Output<ov::Node> parent, const SplitFactory & split_factory, ov::OutputVector & leaves) {
+void CreateSplitTree(size_t max_depth,
+                     size_t depth,
+                     ov::Output<ov::Node> parent,
+                     const SplitFactory& split_factory,
+                     ov::OutputVector& leaves) {
     if (depth == max_depth) {
         leaves.push_back(parent);
         return;
@@ -345,8 +347,8 @@ void CreateSplitTree(size_t max_depth, size_t depth, ov::Output<ov::Node> parent
 }
 
 std::shared_ptr<Model> CreateFunction(size_t split_tree_depth,
-                                          size_t num_split_outputs,
-                                          element::Type input_type) {
+                                      size_t num_split_outputs,
+                                      element::Type input_type) {
         const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
         const Shape input_shape{96, split_input_dim_value, 55, 55};
 
@@ -373,8 +375,8 @@ std::shared_ptr<Model> CreateFunction(size_t split_tree_depth,
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(size_t split_tree_depth,
-                                                   size_t num_split_outputs,
-                                                   element::Type input_type) {
+                                               size_t num_split_outputs,
+                                               element::Type input_type) {
         const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
         const Shape input_shape{96, split_input_dim_value, 55, 55};
 
@@ -403,8 +405,8 @@ std::shared_ptr<Model> CreateReferenceFunction(size_t split_tree_depth,
 } // namespace backward
 
 using CreateGraphSplitF = std::function< std::shared_ptr<Model> (size_t num_split_ops,
-                                                                            size_t num_split_outputs,
-                                                                            element::Type input_type)>;
+                                                                 size_t num_split_outputs,
+                                                                 element::Type input_type)>;
 
 using TestSplitParams = std::tuple<PassFactoryPtr,
                               size_t, /* num_split_ops */

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_split_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_split_test.cpp
@@ -24,10 +24,13 @@ using ModelPtr = std::shared_ptr<Model>;
 
 class IPassFactory {
 public:
-    IPassFactory(const std::string & type_name) : type_name_(type_name) {}
+    IPassFactory(const std::string& type_name) : type_name_(type_name) {}
     virtual ~IPassFactory() = default;
     virtual void registerPass(ov::pass::Manager& pass_manager) const = 0;
-    const std::string & getTypeName() const { return type_name_; }
+    const std::string& getTypeName() const {
+        return type_name_;
+    }
+
 private:
     const std::string type_name_;
 };
@@ -37,7 +40,7 @@ using PassFactoryPtr = std::shared_ptr<IPassFactory>;
 template <typename PassT>
 class PassFactory : public IPassFactory {
 public:
-    PassFactory(const std::string & type_name) : IPassFactory(type_name) {}
+    PassFactory(const std::string& type_name) : IPassFactory(type_name) {}
     void registerPass(ov::pass::Manager& pass_manager) const override {
         pass_manager.register_pass<PassT>();
     }
@@ -55,269 +58,263 @@ namespace forward {
 
 namespace single_consumer {
 
-std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
-                                      size_t num_split_outputs,
-                                      element::Type input_type) {
-        const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
+std::shared_ptr<Model> CreateFunction(size_t num_split_ops, size_t num_split_outputs, element::Type input_type) {
+    const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
-        auto X = std::make_shared<Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-        auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-        auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
+    auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
-        ov::OutputVector outputs;
-        ov::Output<ov::Node> in_op = transpose0->output(0);
-        for (size_t i = 0; i < num_split_ops; ++i) {
-            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 2);
-            auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
-            for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
-                outputs.push_back(split->output(num_output));
-            }
-            in_op = split->output(num_split_outputs - 1);
+    ov::OutputVector outputs;
+    ov::Output<ov::Node> in_op = transpose0->output(0);
+    for (size_t i = 0; i < num_split_ops; ++i) {
+        auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 2);
+        auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
+        for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
+            outputs.push_back(split->output(num_output));
         }
-        outputs.push_back(in_op);
+        in_op = split->output(num_split_outputs - 1);
+    }
+    outputs.push_back(in_op);
 
-        return std::make_shared<ov::Model>(outputs, ov::ParameterVector{X});
+    return std::make_shared<ov::Model>(outputs, ov::ParameterVector{X});
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(size_t num_split_ops,
                                                size_t num_split_outputs,
                                                element::Type input_type) {
-        const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
+    const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
-        auto X = std::make_shared<Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-        ov::OutputVector outputs;
-        ov::Output<ov::Node> in_op = X->output(0);
-        for (size_t i = 0; i < num_split_ops; ++i) {
-            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 1);
-            auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
-            for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
-                auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-                auto transpose0 = std::make_shared<Transpose>(split->output(num_output), ng_order0);
-                outputs.push_back(transpose0);
-            }
-            in_op = split->output(num_split_outputs - 1);
+    ov::OutputVector outputs;
+    ov::Output<ov::Node> in_op = X->output(0);
+    for (size_t i = 0; i < num_split_ops; ++i) {
+        auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 1);
+        auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
+        for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
+            auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
+            auto transpose0 = std::make_shared<Transpose>(split->output(num_output), ng_order0);
+            outputs.push_back(transpose0);
         }
+        in_op = split->output(num_split_outputs - 1);
+    }
 
-        auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-        auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
-        outputs.push_back(transpose0);
+    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
+    auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
+    outputs.push_back(transpose0);
 
-        return std::make_shared<ov::Model>(outputs, ov::ParameterVector{X});
+    return std::make_shared<ov::Model>(outputs, ov::ParameterVector{X});
 }
 
-} // namespace single_consumer
+}  // namespace single_consumer
 
 namespace mult_consumers {
 
 namespace input_node_consumers {
 
-std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
-                                      size_t num_split_outputs,
-                                      element::Type input_type) {
-        const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
+std::shared_ptr<Model> CreateFunction(size_t num_split_ops, size_t num_split_outputs, element::Type input_type) {
+    const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
-        auto X = std::make_shared<Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-        auto tanh = std::make_shared<Tanh>(X);
+    auto tanh = std::make_shared<Tanh>(X);
 
-        auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-        auto transpose0 = std::make_shared<Transpose>(tanh, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+    auto transpose0 = std::make_shared<Transpose>(tanh, ng_order0);
 
-        ov::OutputVector outputs;
-        auto in_op = transpose0->output(0);
-        for (size_t i = 0; i < num_split_ops; ++i) {
-            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 2);
-            auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
-            for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
-                outputs.push_back(split->output(num_output));
-            }
-            in_op = split->output(num_split_outputs - 1);
+    ov::OutputVector outputs;
+    auto in_op = transpose0->output(0);
+    for (size_t i = 0; i < num_split_ops; ++i) {
+        auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 2);
+        auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
+        for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
+            outputs.push_back(split->output(num_output));
         }
-        outputs.push_back(in_op);
+        in_op = split->output(num_split_outputs - 1);
+    }
+    outputs.push_back(in_op);
 
-        auto tanh1 = std::make_shared<Tanh>(tanh);
-        outputs.push_back(tanh1);
+    auto tanh1 = std::make_shared<Tanh>(tanh);
+    outputs.push_back(tanh1);
 
-        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+    return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(size_t num_split_ops,
                                                size_t num_split_outputs,
                                                element::Type input_type) {
-        const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
+    const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
-        auto X = std::make_shared<Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-        auto tanh = std::make_shared<Tanh>(X);
+    auto tanh = std::make_shared<Tanh>(X);
 
-        ov::OutputVector outputs;
-        auto in_op = tanh->output(0);
-        for (size_t i = 0; i < num_split_ops; ++i) {
-            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 1);
-            auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
-            for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
-                auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-                auto transpose0 = std::make_shared<Transpose>(split->output(num_output), ng_order0);
-                outputs.push_back(transpose0);
-            }
-            in_op = split->output(num_split_outputs - 1);
+    ov::OutputVector outputs;
+    auto in_op = tanh->output(0);
+    for (size_t i = 0; i < num_split_ops; ++i) {
+        auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 1);
+        auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
+        for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
+            auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+            auto transpose0 = std::make_shared<Transpose>(split->output(num_output), ng_order0);
+            outputs.push_back(transpose0);
         }
+        in_op = split->output(num_split_outputs - 1);
+    }
 
-        auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-        auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
-        outputs.push_back(transpose0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+    auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
+    outputs.push_back(transpose0);
 
-        auto tanh1 = std::make_shared<Tanh>(tanh);
-        outputs.push_back(tanh1);
+    auto tanh1 = std::make_shared<Tanh>(tanh);
+    outputs.push_back(tanh1);
 
-        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+    return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
-} // namespace input_node_consumers
+}  // namespace input_node_consumers
 
 namespace input_transpose_consumers {
 
-std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
-                                      size_t num_split_outputs,
-                                      element::Type input_type) {
-        const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
+std::shared_ptr<Model> CreateFunction(size_t num_split_ops, size_t num_split_outputs, element::Type input_type) {
+    const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
-        auto X = std::make_shared<Parameter>(input_type, input_shape);
-        
-        auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-        auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-        ov::OutputVector outputs;
-        auto in_op = transpose0->output(0);
-        for (size_t i = 0; i < num_split_ops; ++i) {
-            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 2);
-            auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
-            for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
-                outputs.push_back(split->output(num_output));
-            }
-            in_op = split->output(num_split_outputs - 1);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+    auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
+
+    ov::OutputVector outputs;
+    auto in_op = transpose0->output(0);
+    for (size_t i = 0; i < num_split_ops; ++i) {
+        auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 2);
+        auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
+        for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
+            outputs.push_back(split->output(num_output));
         }
-        outputs.push_back(in_op);
+        in_op = split->output(num_split_outputs - 1);
+    }
+    outputs.push_back(in_op);
 
-        auto tanh = std::make_shared<Tanh>(transpose0);
-        outputs.push_back(tanh);
+    auto tanh = std::make_shared<Tanh>(transpose0);
+    outputs.push_back(tanh);
 
-        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+    return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(size_t num_split_ops,
                                                size_t num_split_outputs,
                                                element::Type input_type) {
-        const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
+    const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
-        auto X = std::make_shared<Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-        ov::OutputVector outputs;
-        auto in_op = X->output(0);
-        for (size_t i = 0; i < num_split_ops; ++i) {
-            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 1);
-            auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
-            for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
-                auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-                auto transpose0 = std::make_shared<Transpose>(split->output(num_output), ng_order0);
-                outputs.push_back(transpose0);
-            }
-            in_op = split->output(num_split_outputs - 1);
+    ov::OutputVector outputs;
+    auto in_op = X->output(0);
+    for (size_t i = 0; i < num_split_ops; ++i) {
+        auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 1);
+        auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
+        for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
+            auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+            auto transpose0 = std::make_shared<Transpose>(split->output(num_output), ng_order0);
+            outputs.push_back(transpose0);
         }
+        in_op = split->output(num_split_outputs - 1);
+    }
 
-        auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-        auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
-        outputs.push_back(transpose0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+    auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
+    outputs.push_back(transpose0);
 
-        auto ng_order1 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-        auto transpose1 = std::make_shared<Transpose>(X, ng_order1);
+    auto ng_order1 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+    auto transpose1 = std::make_shared<Transpose>(X, ng_order1);
 
-        auto tanh = std::make_shared<Tanh>(transpose1);
-        outputs.push_back(tanh);
+    auto tanh = std::make_shared<Tanh>(transpose1);
+    outputs.push_back(tanh);
 
-        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+    return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
-} // namespace input_transpose_consumers
+}  // namespace input_transpose_consumers
 
 namespace output_consumers {
 
-std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
-                                      size_t num_split_outputs,
-                                      element::Type input_type) {
-        const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
+std::shared_ptr<Model> CreateFunction(size_t num_split_ops, size_t num_split_outputs, element::Type input_type) {
+    const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
-        auto X = std::make_shared<Parameter>(input_type, input_shape);
-        
-        auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-        auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-        ov::OutputVector outputs;
-        auto in_op = transpose0->output(0);
-        for (size_t i = 0; i < num_split_ops; ++i) {
-            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 2);
-            auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
-            for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
-                outputs.push_back(split->output(num_output));
-            }
-            in_op = split->output(num_split_outputs - 1);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+    auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
+
+    ov::OutputVector outputs;
+    auto in_op = transpose0->output(0);
+    for (size_t i = 0; i < num_split_ops; ++i) {
+        auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 2);
+        auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
+        for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
+            outputs.push_back(split->output(num_output));
         }
-        outputs.push_back(in_op);
+        in_op = split->output(num_split_outputs - 1);
+    }
+    outputs.push_back(in_op);
 
-        auto tanh = std::make_shared<Tanh>(in_op);
-        auto tanh1 = std::make_shared<Tanh>(in_op);
-        outputs.push_back(tanh);
-        outputs.push_back(tanh1);
+    auto tanh = std::make_shared<Tanh>(in_op);
+    auto tanh1 = std::make_shared<Tanh>(in_op);
+    outputs.push_back(tanh);
+    outputs.push_back(tanh1);
 
-        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+    return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(size_t num_split_ops,
                                                size_t num_split_outputs,
                                                element::Type input_type) {
-        const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
+    const Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
-        auto X = std::make_shared<Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-        ov::OutputVector outputs;
-        auto in_op = X->output(0);
-        for (size_t i = 0; i < num_split_ops; ++i) {
-            auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 1);
-            auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
-            for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
-                auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-                auto transpose0 = std::make_shared<Transpose>(split->output(num_output), ng_order0);
-                outputs.push_back(transpose0);
-            }
-            in_op = split->output(num_split_outputs - 1);
+    ov::OutputVector outputs;
+    auto in_op = X->output(0);
+    for (size_t i = 0; i < num_split_ops; ++i) {
+        auto split_axis_const = std::make_shared<Constant>(element::u64, Shape{}, 1);
+        auto split = std::make_shared<Split>(in_op, split_axis_const, num_split_outputs);
+        for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
+            auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+            auto transpose0 = std::make_shared<Transpose>(split->output(num_output), ng_order0);
+            outputs.push_back(transpose0);
         }
+        in_op = split->output(num_split_outputs - 1);
+    }
 
-        auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-        auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
-        outputs.push_back(transpose0);
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+    auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
+    outputs.push_back(transpose0);
 
-        auto tanh = std::make_shared<Tanh>(transpose0);
-        auto tanh1 = std::make_shared<Tanh>(transpose0);
-        outputs.push_back(tanh);
-        outputs.push_back(tanh1);
+    auto tanh = std::make_shared<Tanh>(transpose0);
+    auto tanh1 = std::make_shared<Tanh>(transpose0);
+    outputs.push_back(tanh);
+    outputs.push_back(tanh1);
 
-        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+    return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
-} // namespace output_consumers
+}  // namespace output_consumers
 
-} // namespace mult_consumers
+}  // namespace mult_consumers
 
-} // namespace forward
+}  // namespace forward
 
 namespace backward {
 
 class SplitFactory {
 public:
-    SplitFactory(size_t axis, size_t n_outputs, element::Type elem_type) :
-        _axis(axis), _n_outputs(n_outputs), _elem_type(elem_type) {}
+    SplitFactory(size_t axis, size_t n_outputs, element::Type elem_type)
+        : _axis(axis),
+          _n_outputs(n_outputs),
+          _elem_type(elem_type) {}
     NodePtr create(ov::Output<ov::Node> parent) const {
         auto split_axis_const = std::make_shared<Constant>(_elem_type, Shape{}, _axis);
         return std::make_shared<Split>(parent, split_axis_const, _n_outputs);
@@ -348,184 +345,181 @@ void CreateSplitTree(size_t max_depth,
 
 namespace single_consumer {
 
-std::shared_ptr<Model> CreateFunction(size_t split_tree_depth,
-                                      size_t num_split_outputs,
-                                      element::Type input_type) {
-        const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
-        const Shape input_shape{96, split_input_dim_value, 55, 55};
+std::shared_ptr<Model> CreateFunction(size_t split_tree_depth, size_t num_split_outputs, element::Type input_type) {
+    const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
+    const Shape input_shape{96, split_input_dim_value, 55, 55};
 
-        auto X = std::make_shared<Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-        auto tanh = std::make_shared<Tanh>(X);
+    auto tanh = std::make_shared<Tanh>(X);
 
-        ov::OutputVector split_tree_leaves;
-        {
-            SplitFactory split_factory(/* axis */ 1, num_split_outputs, /* elem_type */ element::u64);
-            CreateSplitTree(split_tree_depth, /* depth */ 0, tanh->output(0), split_factory, split_tree_leaves);
-        }
+    ov::OutputVector split_tree_leaves;
+    {
+        SplitFactory split_factory(/* axis */ 1, num_split_outputs, /* elem_type */ element::u64);
+        CreateSplitTree(split_tree_depth, /* depth */ 0, tanh->output(0), split_factory, split_tree_leaves);
+    }
 
-        ov::OutputVector outputs;
-        for (auto& split_tree_leaf : split_tree_leaves) {
-            auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-            auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
+    ov::OutputVector outputs;
+    for (auto& split_tree_leaf : split_tree_leaves) {
+        auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+        auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
 
-            const size_t split_dim_current_value = static_cast<size_t>(split_input_dim_value / std::pow(num_split_outputs, split_tree_depth));
-            auto reshape_const = std::make_shared<Constant>(element::u64, Shape{3}, Shape{96, 55, split_dim_current_value * 55});
-            auto reshape = std::make_shared<Reshape>(transpose, reshape_const, false);
-            outputs.push_back(reshape);
-        }
+        const size_t split_dim_current_value =
+            static_cast<size_t>(split_input_dim_value / std::pow(num_split_outputs, split_tree_depth));
+        auto reshape_const =
+            std::make_shared<Constant>(element::u64, Shape{3}, Shape{96, 55, split_dim_current_value * 55});
+        auto reshape = std::make_shared<Reshape>(transpose, reshape_const, false);
+        outputs.push_back(reshape);
+    }
 
-        auto tanh1 = std::make_shared<Tanh>(tanh);
-        outputs.push_back(tanh1);
+    auto tanh1 = std::make_shared<Tanh>(tanh);
+    outputs.push_back(tanh1);
 
-        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+    return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(size_t split_tree_depth,
                                                size_t num_split_outputs,
                                                element::Type input_type) {
-        const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
-        const Shape input_shape{96, split_input_dim_value, 55, 55};
+    const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
+    const Shape input_shape{96, split_input_dim_value, 55, 55};
 
-        auto X = std::make_shared<Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-        auto tanh = std::make_shared<Tanh>(X);
+    auto tanh = std::make_shared<Tanh>(X);
 
-        auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-        auto transpose = std::make_shared<Transpose>(tanh, ng_order);
+    auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+    auto transpose = std::make_shared<Transpose>(tanh, ng_order);
 
-        ov::OutputVector split_tree_leaves;
-        {
-            SplitFactory split_factory(/* axis */ 2, num_split_outputs, /* elem_type */ element::u64);
-            CreateSplitTree(split_tree_depth, /* depth */ 0, transpose->output(0), split_factory, split_tree_leaves);
-        }
+    ov::OutputVector split_tree_leaves;
+    {
+        SplitFactory split_factory(/* axis */ 2, num_split_outputs, /* elem_type */ element::u64);
+        CreateSplitTree(split_tree_depth, /* depth */ 0, transpose->output(0), split_factory, split_tree_leaves);
+    }
 
-        ov::OutputVector outputs;
-        for (auto& split_tree_leaf : split_tree_leaves) {
-            const size_t split_dim_current_value = static_cast<size_t>(split_input_dim_value / std::pow(num_split_outputs, split_tree_depth));
-            auto reshape_const = std::make_shared<Constant>(element::u64, Shape{3}, Shape{96, 55, split_dim_current_value * 55});
-            auto reshape = std::make_shared<Reshape>(split_tree_leaf, reshape_const, false);
-            outputs.push_back(reshape);
-        }
+    ov::OutputVector outputs;
+    for (auto& split_tree_leaf : split_tree_leaves) {
+        const size_t split_dim_current_value =
+            static_cast<size_t>(split_input_dim_value / std::pow(num_split_outputs, split_tree_depth));
+        auto reshape_const =
+            std::make_shared<Constant>(element::u64, Shape{3}, Shape{96, 55, split_dim_current_value * 55});
+        auto reshape = std::make_shared<Reshape>(split_tree_leaf, reshape_const, false);
+        outputs.push_back(reshape);
+    }
 
-        auto tanh1 = std::make_shared<Tanh>(tanh);
-        outputs.push_back(tanh1);
+    auto tanh1 = std::make_shared<Tanh>(tanh);
+    outputs.push_back(tanh1);
 
-        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+    return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
-} // namespace single_consumer
+}  // namespace single_consumer
 
 namespace mult_output_consumers {
 
-std::shared_ptr<Model> CreateFunction(size_t split_tree_depth,
-                                      size_t num_split_outputs,
-                                      element::Type input_type) {
-        const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
-        const Shape input_shape{96, split_input_dim_value, 55, 55};
+std::shared_ptr<Model> CreateFunction(size_t split_tree_depth, size_t num_split_outputs, element::Type input_type) {
+    const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
+    const Shape input_shape{96, split_input_dim_value, 55, 55};
 
-        auto X = std::make_shared<Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-        ov::OutputVector split_tree_leaves;
-        {
-            SplitFactory split_factory(/* axis */ 1, num_split_outputs, /* elem_type */ element::u64);
-            CreateSplitTree(split_tree_depth, /* depth */ 0, X->output(0), split_factory, split_tree_leaves);
-        }
+    ov::OutputVector split_tree_leaves;
+    {
+        SplitFactory split_factory(/* axis */ 1, num_split_outputs, /* elem_type */ element::u64);
+        CreateSplitTree(split_tree_depth, /* depth */ 0, X->output(0), split_factory, split_tree_leaves);
+    }
 
-        ov::OutputVector outputs;
-        for (auto& split_tree_leaf : split_tree_leaves) {
-            auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-            auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
+    ov::OutputVector outputs;
+    for (auto& split_tree_leaf : split_tree_leaves) {
+        auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+        auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
 
-            auto tanh0 = std::make_shared<Tanh>(transpose);
-            auto tanh1 = std::make_shared<Tanh>(transpose);
+        auto tanh0 = std::make_shared<Tanh>(transpose);
+        auto tanh1 = std::make_shared<Tanh>(transpose);
 
-            outputs.push_back(tanh0);
-            outputs.push_back(tanh1);
-        }
+        outputs.push_back(tanh0);
+        outputs.push_back(tanh1);
+    }
 
-        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+    return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
 std::shared_ptr<Model> CreateReferenceFunction(size_t split_tree_depth,
                                                size_t num_split_outputs,
                                                element::Type input_type) {
-        const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
-        const Shape input_shape{96, split_input_dim_value, 55, 55};
+    const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
+    const Shape input_shape{96, split_input_dim_value, 55, 55};
 
-        auto X = std::make_shared<Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-        auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-        auto transpose = std::make_shared<Transpose>(X, ng_order);
+    auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+    auto transpose = std::make_shared<Transpose>(X, ng_order);
 
-        ov::OutputVector split_tree_leaves;
-        {
-            SplitFactory split_factory(/* axis */ 2, num_split_outputs, /* elem_type */ element::u64);
-            CreateSplitTree(split_tree_depth, /* depth */ 0, transpose->output(0), split_factory, split_tree_leaves);
-        }
+    ov::OutputVector split_tree_leaves;
+    {
+        SplitFactory split_factory(/* axis */ 2, num_split_outputs, /* elem_type */ element::u64);
+        CreateSplitTree(split_tree_depth, /* depth */ 0, transpose->output(0), split_factory, split_tree_leaves);
+    }
 
-        ov::OutputVector outputs;
-        for (auto& split_tree_leaf : split_tree_leaves) {
-            auto tanh0 = std::make_shared<Tanh>(split_tree_leaf);
-            auto tanh1 = std::make_shared<Tanh>(split_tree_leaf);
+    ov::OutputVector outputs;
+    for (auto& split_tree_leaf : split_tree_leaves) {
+        auto tanh0 = std::make_shared<Tanh>(split_tree_leaf);
+        auto tanh1 = std::make_shared<Tanh>(split_tree_leaf);
 
-            outputs.push_back(tanh0);
-            outputs.push_back(tanh1);
-        }
+        outputs.push_back(tanh0);
+        outputs.push_back(tanh1);
+    }
 
-        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+    return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
-} // namespace mult_output_consumers
+}  // namespace mult_output_consumers
 
 namespace mult_split_consumers {
 
-std::shared_ptr<Model> CreateFunction(size_t split_tree_depth,
-                                      size_t num_split_outputs,
-                                      element::Type input_type) {
-        const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
-        const Shape input_shape{96, split_input_dim_value, 55, 55};
+std::shared_ptr<Model> CreateFunction(size_t split_tree_depth, size_t num_split_outputs, element::Type input_type) {
+    const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
+    const Shape input_shape{96, split_input_dim_value, 55, 55};
 
-        auto X = std::make_shared<Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-        ov::OutputVector split_tree_leaves;
-        {
-            SplitFactory split_factory(/* axis */ 1, num_split_outputs, /* elem_type */ element::u64);
-            CreateSplitTree(split_tree_depth, /* depth */ 0, X->output(0), split_factory, split_tree_leaves);
-        }
+    ov::OutputVector split_tree_leaves;
+    {
+        SplitFactory split_factory(/* axis */ 1, num_split_outputs, /* elem_type */ element::u64);
+        CreateSplitTree(split_tree_depth, /* depth */ 0, X->output(0), split_factory, split_tree_leaves);
+    }
 
-        ov::OutputVector outputs;
-        for (auto& split_tree_leaf : split_tree_leaves) {
-            auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
-            auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
+    ov::OutputVector outputs;
+    for (auto& split_tree_leaf : split_tree_leaves) {
+        auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+        auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
 
-            auto tanh0 = std::make_shared<Tanh>(split_tree_leaf);
-            auto tanh1 = std::make_shared<Tanh>(split_tree_leaf);
+        auto tanh0 = std::make_shared<Tanh>(split_tree_leaf);
+        auto tanh1 = std::make_shared<Tanh>(split_tree_leaf);
 
-            outputs.push_back(tanh0);
-            outputs.push_back(tanh1);
-        }
+        outputs.push_back(tanh0);
+        outputs.push_back(tanh1);
+    }
 
-        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+    return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
-} // namespace mult_split_consumers
+}  // namespace mult_split_consumers
 
-} // namespace backward
+}  // namespace backward
 
-using CreateGraphSplitF = std::function< std::shared_ptr<Model> (size_t num_split_ops,
-                                                                 size_t num_split_outputs,
-                                                                 element::Type input_type)>;
+using CreateGraphSplitF =
+    std::function<std::shared_ptr<Model>(size_t num_split_ops, size_t num_split_outputs, element::Type input_type)>;
 
 using TestSplitParams = std::tuple<PassFactoryPtr,
-                              size_t, /* num_split_ops */
-                              size_t, /* num_split_outputs */
-                              CreateGraphSplitF, /* model_factory */
-                              CreateGraphSplitF, /* reference_model_factory */
-                              element::Type> /* input type */;
+                                   size_t,            /* num_split_ops */
+                                   size_t,            /* num_split_outputs */
+                                   CreateGraphSplitF, /* model_factory */
+                                   CreateGraphSplitF, /* reference_model_factory */
+                                   element::Type> /* input type */;
 
-class TransposeSinkingSplitTestFixture: public ::testing::WithParamInterface<TestSplitParams>,
-                                        public TransformationTestsF {
+class TransposeSinkingSplitTestFixture : public ::testing::WithParamInterface<TestSplitParams>,
+                                         public TransformationTestsF {
 public:
     static std::string get_test_name(const testing::TestParamInfo<TestSplitParams>& obj) {
         PassFactoryPtr pass_factory;
@@ -535,12 +529,8 @@ public:
         CreateGraphSplitF reference_model_factory;
         element::Type input_type;
 
-        std::tie(pass_factory,
-             num_split_ops,
-             num_split_outputs,
-             model_factory,
-             reference_model_factory,
-             input_type) = obj.param;
+        std::tie(pass_factory, num_split_ops, num_split_outputs, model_factory, reference_model_factory, input_type) =
+            obj.param;
 
         std::ostringstream test_name;
         test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
@@ -559,28 +549,23 @@ TEST_P(TransposeSinkingSplitTestFixture, CompareFunctions) {
     CreateGraphSplitF model_factory;
     CreateGraphSplitF reference_model_factory;
     element::Type input_type;
-    std::tie(pass_factory,
-             num_split_ops,
-             num_split_outputs,
-             model_factory,
-             reference_model_factory,
-             input_type) = this->GetParam();
+    std::tie(pass_factory, num_split_ops, num_split_outputs, model_factory, reference_model_factory, input_type) =
+        this->GetParam();
 
     model = model_factory(num_split_ops, num_split_outputs, input_type);
     model_ref = reference_model_factory(num_split_ops, num_split_outputs, input_type);
     pass_factory->registerPass(manager);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingSplitForwardSingleConsumerTestSuite,
-    TransposeSinkingSplitTestFixture,
-    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitForward)),
-                       ::testing::ValuesIn(split_operations_numbers),
-                       ::testing::ValuesIn(split_outputs_numbers),
-                       ::testing::Values(forward::single_consumer::CreateFunction),
-                       ::testing::Values(forward::single_consumer::CreateReferenceFunction),
-                       ::testing::Values(element::f32)),
-                       TransposeSinkingSplitTestFixture::get_test_name);
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingSplitForwardSingleConsumerTestSuite,
+                         TransposeSinkingSplitTestFixture,
+                         ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitForward)),
+                                            ::testing::ValuesIn(split_operations_numbers),
+                                            ::testing::ValuesIn(split_outputs_numbers),
+                                            ::testing::Values(forward::single_consumer::CreateFunction),
+                                            ::testing::Values(forward::single_consumer::CreateReferenceFunction),
+                                            ::testing::Values(element::f32)),
+                         TransposeSinkingSplitTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingSplitForwardMultInputNodeConsumersTestSuite,
@@ -591,7 +576,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(forward::mult_consumers::input_node_consumers::CreateFunction),
                        ::testing::Values(forward::mult_consumers::input_node_consumers::CreateReferenceFunction),
                        ::testing::Values(element::f32)),
-                       TransposeSinkingSplitTestFixture::get_test_name);
+    TransposeSinkingSplitTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingSplitForwardMultInputTransposeConsumersTestSuite,
@@ -602,7 +587,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(forward::mult_consumers::input_transpose_consumers::CreateFunction),
                        ::testing::Values(forward::mult_consumers::input_transpose_consumers::CreateReferenceFunction),
                        ::testing::Values(element::f32)),
-                       TransposeSinkingSplitTestFixture::get_test_name);
+    TransposeSinkingSplitTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingSplitForwardMultOutputConsumersTestSuite,
@@ -613,70 +598,69 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(forward::mult_consumers::output_consumers::CreateFunction),
                        ::testing::Values(forward::mult_consumers::output_consumers::CreateReferenceFunction),
                        ::testing::Values(element::f32)),
-                       TransposeSinkingSplitTestFixture::get_test_name);
+    TransposeSinkingSplitTestFixture::get_test_name);
 
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingSplitBackwardTestSuite,
-    TransposeSinkingSplitTestFixture,
-    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitBackward)),
-                       ::testing::ValuesIn(split_tree_depth_nums),
-                       ::testing::ValuesIn(split_outputs_numbers),
-                       ::testing::Values(backward::single_consumer::CreateFunction),
-                       ::testing::Values(backward::single_consumer::CreateReferenceFunction),
-                       ::testing::Values(element::f32)),
-                       TransposeSinkingSplitTestFixture::get_test_name);
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingSplitBackwardTestSuite,
+                         TransposeSinkingSplitTestFixture,
+                         ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitBackward)),
+                                            ::testing::ValuesIn(split_tree_depth_nums),
+                                            ::testing::ValuesIn(split_outputs_numbers),
+                                            ::testing::Values(backward::single_consumer::CreateFunction),
+                                            ::testing::Values(backward::single_consumer::CreateReferenceFunction),
+                                            ::testing::Values(element::f32)),
+                         TransposeSinkingSplitTestFixture::get_test_name);
 
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingSplitBackwardMultOutputConsumersTestSuite,
-    TransposeSinkingSplitTestFixture,
-    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitBackward)),
-                       ::testing::ValuesIn(split_tree_depth_nums),
-                       ::testing::ValuesIn(split_outputs_numbers),
-                       ::testing::Values(backward::mult_output_consumers::CreateFunction),
-                       ::testing::Values(backward::mult_output_consumers::CreateReferenceFunction),
-                       ::testing::Values(element::f32)),
-                       TransposeSinkingSplitTestFixture::get_test_name);
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingSplitBackwardMultOutputConsumersTestSuite,
+                         TransposeSinkingSplitTestFixture,
+                         ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitBackward)),
+                                            ::testing::ValuesIn(split_tree_depth_nums),
+                                            ::testing::ValuesIn(split_outputs_numbers),
+                                            ::testing::Values(backward::mult_output_consumers::CreateFunction),
+                                            ::testing::Values(backward::mult_output_consumers::CreateReferenceFunction),
+                                            ::testing::Values(element::f32)),
+                         TransposeSinkingSplitTestFixture::get_test_name);
 
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingSplitBackwardMultSplitConsumersTestSuite,
-    TransposeSinkingSplitTestFixture,
-    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitBackward)),
-                       ::testing::ValuesIn(split_tree_depth_nums),
-                       ::testing::ValuesIn(split_outputs_numbers),
-                       ::testing::Values(backward::mult_split_consumers::CreateFunction),
-                       ::testing::Values(backward::mult_split_consumers::CreateFunction),
-                       ::testing::Values(element::f32)),
-                       TransposeSinkingSplitTestFixture::get_test_name);
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingSplitBackwardMultSplitConsumersTestSuite,
+                         TransposeSinkingSplitTestFixture,
+                         ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitBackward)),
+                                            ::testing::ValuesIn(split_tree_depth_nums),
+                                            ::testing::ValuesIn(split_outputs_numbers),
+                                            ::testing::Values(backward::mult_split_consumers::CreateFunction),
+                                            ::testing::Values(backward::mult_split_consumers::CreateFunction),
+                                            ::testing::Values(element::f32)),
+                         TransposeSinkingSplitTestFixture::get_test_name);
 
 namespace backward {
 namespace restrictions {
 
-using TransposeInsertF = std::function< ov::OutputVector (const ov::OutputVector& split_tree_leaves)>;
+using TransposeInsertF = std::function<ov::OutputVector(const ov::OutputVector& split_tree_leaves)>;
 
 std::shared_ptr<Model> CreateFunction(size_t split_tree_depth,
-                                          size_t num_split_outputs,
-                                          element::Type input_type,
-                                          TransposeInsertF transpose_insert_func) {
-        const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
-        const Shape input_shape{96, split_input_dim_value, 55, 55};
+                                      size_t num_split_outputs,
+                                      element::Type input_type,
+                                      TransposeInsertF transpose_insert_func) {
+    const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
+    const Shape input_shape{96, split_input_dim_value, 55, 55};
 
-        auto X = std::make_shared<Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-        ov::OutputVector split_tree_leaves;
-        {
-            SplitFactory split_factory(/* axis */ 1, num_split_outputs, /* elem_type */ element::u64);
-            CreateSplitTree(split_tree_depth, /* depth */ 0, X->output(0), split_factory, split_tree_leaves);
-        }
+    ov::OutputVector split_tree_leaves;
+    {
+        SplitFactory split_factory(/* axis */ 1, num_split_outputs, /* elem_type */ element::u64);
+        CreateSplitTree(split_tree_depth, /* depth */ 0, X->output(0), split_factory, split_tree_leaves);
+    }
 
-        ov::OutputVector outputs;
-        for (auto& split_tree_leaf : transpose_insert_func(split_tree_leaves)) {
-            const size_t split_dim_current_value = static_cast<size_t>(split_input_dim_value / std::pow(num_split_outputs, split_tree_depth));
-            auto reshape_const = std::make_shared<Constant>(element::u64, Shape{3}, Shape{96, 55, split_dim_current_value * 55});
-            auto reshape = std::make_shared<Reshape>(split_tree_leaf, reshape_const, false);
-            outputs.push_back(reshape);
-        }
+    ov::OutputVector outputs;
+    for (auto& split_tree_leaf : transpose_insert_func(split_tree_leaves)) {
+        const size_t split_dim_current_value =
+            static_cast<size_t>(split_input_dim_value / std::pow(num_split_outputs, split_tree_depth));
+        auto reshape_const =
+            std::make_shared<Constant>(element::u64, Shape{3}, Shape{96, 55, split_dim_current_value * 55});
+        auto reshape = std::make_shared<Reshape>(split_tree_leaf, reshape_const, false);
+        outputs.push_back(reshape);
+    }
 
-        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
+    return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
 ov::OutputVector OnlyFirstTranspose(const ov::OutputVector& split_tree_leaves) {
@@ -791,29 +775,28 @@ ov::OutputVector MiddleAnotherTranspose(const ov::OutputVector& split_tree_leave
 
 struct TransposeInsertFuncDesc {
     TransposeInsertFuncDesc() = default;
-    TransposeInsertFuncDesc(TransposeInsertF a_function,
-                            std::string a_name) :
-                            function(a_function),
-                            name(a_name) {}
+    TransposeInsertFuncDesc(TransposeInsertF a_function, std::string a_name) : function(a_function), name(a_name) {}
 
     TransposeInsertF function;
     std::string name;
 };
 
-using CreateGraphSplitBackwardRestrictF = std::function< std::shared_ptr<Model> (size_t split_tree_depth,
-                                                                                     size_t num_split_outputs,
-                                                                                     element::Type input_type,
-                                                                                     TransposeInsertF tranpose_insert_function)>;
+using CreateGraphSplitBackwardRestrictF =
+    std::function<std::shared_ptr<Model>(size_t split_tree_depth,
+                                         size_t num_split_outputs,
+                                         element::Type input_type,
+                                         TransposeInsertF tranpose_insert_function)>;
 
 using TestSplitBackwardRestrictParams = std::tuple<PassFactoryPtr,
-                              size_t, /* split_tree_depth */
-                              size_t, /* num_split_outputs */
-                              CreateGraphSplitBackwardRestrictF, /* model_factory */
-                              element::Type, /* input type */
-                              TransposeInsertFuncDesc>; /* insert transpose function */
+                                                   size_t,                            /* split_tree_depth */
+                                                   size_t,                            /* num_split_outputs */
+                                                   CreateGraphSplitBackwardRestrictF, /* model_factory */
+                                                   element::Type,                     /* input type */
+                                                   TransposeInsertFuncDesc>;          /* insert transpose function */
 
-class TransposeSinkingSplitBackwardRestrictTestFixture: public ::testing::WithParamInterface<TestSplitBackwardRestrictParams>,
-                                        public TransformationTestsF {
+class TransposeSinkingSplitBackwardRestrictTestFixture
+    : public ::testing::WithParamInterface<TestSplitBackwardRestrictParams>,
+      public TransformationTestsF {
 public:
     static std::string get_test_name(const testing::TestParamInfo<TestSplitBackwardRestrictParams>& obj) {
         PassFactoryPtr pass_factory;
@@ -824,11 +807,11 @@ public:
         TransposeInsertFuncDesc tranpose_insert_function;
 
         std::tie(pass_factory,
-             split_tree_depth,
-             num_split_outputs,
-             model_factory,
-             input_type,
-             tranpose_insert_function) = obj.param;
+                 split_tree_depth,
+                 num_split_outputs,
+                 model_factory,
+                 input_type,
+                 tranpose_insert_function) = obj.param;
 
         std::ostringstream test_name;
         test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
@@ -849,12 +832,8 @@ TEST_P(TransposeSinkingSplitBackwardRestrictTestFixture, CompareFunctions) {
     element::Type input_type;
     TransposeInsertFuncDesc tranpose_insert_function;
 
-    std::tie(pass_factory,
-             split_tree_depth,
-             num_split_outputs,
-             model_factory,
-             input_type,
-             tranpose_insert_function) = this->GetParam();
+    std::tie(pass_factory, split_tree_depth, num_split_outputs, model_factory, input_type, tranpose_insert_function) =
+        this->GetParam();
 
     model = model_factory(split_tree_depth, num_split_outputs, input_type, tranpose_insert_function.function);
     model_ref = model->clone();
@@ -863,31 +842,27 @@ TEST_P(TransposeSinkingSplitBackwardRestrictTestFixture, CompareFunctions) {
 
 #define FUNC(name) TransposeInsertFuncDesc(backward::restrictions::name, #name)
 
-std::vector<TransposeInsertFuncDesc> insertTransposeFactories = {
-    FUNC(OnlyFirstTranspose),
-    FUNC(OnlyLastTranspose),
-    FUNC(OnlyMiddleTranspose),
-    FUNC(FirstAnotherTranspose),
-    FUNC(LastAnotherTranspose),
-    FUNC(MiddleAnotherTranspose)
-};
+std::vector<TransposeInsertFuncDesc> insertTransposeFactories = {FUNC(OnlyFirstTranspose),
+                                                                 FUNC(OnlyLastTranspose),
+                                                                 FUNC(OnlyMiddleTranspose),
+                                                                 FUNC(FirstAnotherTranspose),
+                                                                 FUNC(LastAnotherTranspose),
+                                                                 FUNC(MiddleAnotherTranspose)};
 
 #undef FUNC
 
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingSplitBackwardRestrictTestSuite,
-    TransposeSinkingSplitBackwardRestrictTestFixture,
-    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitBackward)),
-                       ::testing::Values(1),
-                       ::testing::Values(5),
-                       ::testing::Values(backward::restrictions::CreateFunction),
-                       ::testing::Values(element::f32),
-                       ::testing::ValuesIn(insertTransposeFactories)),
-                       TransposeSinkingSplitBackwardRestrictTestFixture::get_test_name);
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingSplitBackwardRestrictTestSuite,
+                         TransposeSinkingSplitBackwardRestrictTestFixture,
+                         ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitBackward)),
+                                            ::testing::Values(1),
+                                            ::testing::Values(5),
+                                            ::testing::Values(backward::restrictions::CreateFunction),
+                                            ::testing::Values(element::f32),
+                                            ::testing::ValuesIn(insertTransposeFactories)),
+                         TransposeSinkingSplitBackwardRestrictTestFixture::get_test_name);
 
-} // namespace restrictions
+}  // namespace restrictions
 
+}  // namespace backward
 
-} // namespace backward
-
-} // namespace transpose_sinking_split
+}  // namespace transpose_sinking_split

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_split_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_split_test.cpp
@@ -12,44 +12,24 @@
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "gtest/gtest.h"
 
+using namespace ov;
+using namespace ov::opset9;
+
+namespace transpose_sinking_split {
+
 namespace {
 
 using NodePtr = std::shared_ptr<ov::Node>;
-using ModelPtr = std::shared_ptr<ov::Model>;
-using Output = ov::Output<ov::Node>;
-
-// ----------------------------------------------------------------------------
-
-class IBinaryFactory {
-public:
-    IBinaryFactory() = default;
-    virtual ~IBinaryFactory() = default;
-    virtual NodePtr create(NodePtr parent_left_node, NodePtr parent_right_node) const = 0;
-};
-
-using BinaryFactoryPtr = std::shared_ptr<IBinaryFactory>;
-
-template <typename BinaryT>
-class BinaryFactory : public IBinaryFactory {
-public:
-    BinaryFactory() = default;
-    NodePtr create(NodePtr parent_left_node, NodePtr parent_right_node) const override {
-        return std::make_shared<BinaryT>(parent_left_node, parent_right_node);
-    }
-};
-
-template <typename BinaryT>
-BinaryFactoryPtr CreateBinaryFactory() {
-    return std::make_shared<BinaryFactory<BinaryT>>();
-}
-
-// ----------------------------------------------------------------------------
+using ModelPtr = std::shared_ptr<Model>;
 
 class IPassFactory {
 public:
-    IPassFactory() = default;
+    IPassFactory(const std::string & type_name) : type_name_(type_name) {}
     virtual ~IPassFactory() = default;
     virtual void registerPass(ov::pass::Manager& pass_manager) const = 0;
+    const std::string & getTypeName() const { return type_name_; }
+private:
+    const std::string type_name_;
 };
 
 using PassFactoryPtr = std::shared_ptr<IPassFactory>;
@@ -57,184 +37,104 @@ using PassFactoryPtr = std::shared_ptr<IPassFactory>;
 template <typename PassT>
 class PassFactory : public IPassFactory {
 public:
+    PassFactory(const std::string & type_name) : IPassFactory(type_name) {}
     void registerPass(ov::pass::Manager& pass_manager) const override {
         pass_manager.register_pass<PassT>();
     }
 };
 
-template <typename PassT>
-PassFactoryPtr CreatePassFactory() {
-    return std::make_shared<PassFactory<PassT>>();
-}
-
-std::vector<BinaryFactoryPtr> binary_factories = {CreateBinaryFactory<ov::opset9::Add>(),
-                                                  CreateBinaryFactory<ov::opset9::Divide>(),
-                                                  CreateBinaryFactory<ov::opset9::Maximum>(),
-                                                  CreateBinaryFactory<ov::opset9::Minimum>(),
-                                                  CreateBinaryFactory<ov::opset9::Mod>(),
-                                                  CreateBinaryFactory<ov::opset9::Multiply>(),
-                                                  CreateBinaryFactory<ov::opset9::Power>(),
-                                                  CreateBinaryFactory<ov::opset9::SquaredDifference>(),
-                                                  CreateBinaryFactory<ov::opset9::Subtract>()};
-
-std::vector<size_t> binary_operations_numbers = {1, 10};
-
-std::vector<size_t> binary_transpose_input_indexes = {0, 1};
+#define CREATE_PASS_FACTORY(pass_name) std::make_shared<PassFactory<ov::pass::pass_name>>(#pass_name)
 
 }  // namespace
 
-// --------------------------------------------------------------------------------------
-
-using CreateGraphSplitForwardF = std::function<
-    std::shared_ptr<ov::Model>(size_t num_split_ops, size_t num_split_outputs, ov::element::Type input_type)>;
-
-using TestSplitForwardParams = std::tuple<PassFactoryPtr,
-                                          size_t,                   /* num_split_ops */
-                                          size_t,                   /* num_split_outputs */
-                                          CreateGraphSplitForwardF, /* model_factory */
-                                          CreateGraphSplitForwardF, /* reference_model_factory */
-                                          ov::element::Type> /* input type */;
-
-class TransposeSinkingSplitForwardTestFixture : public ::testing::WithParamInterface<TestSplitForwardParams>,
-                                                public TransformationTestsF {};
-
-namespace {
-
+std::vector<size_t> split_tree_depth_nums = {1, 3};
 std::vector<size_t> split_operations_numbers = {1, 10};
-
 std::vector<size_t> split_outputs_numbers = {2, 3};
-
-}  // namespace
 
 namespace split {
 namespace forward {
-std::shared_ptr<ov::Model> CreateFunction(size_t num_split_ops,
+
+std::shared_ptr<Model> CreateFunction(size_t num_split_ops,
                                           size_t num_split_outputs,
-                                          ov::element::Type input_type) {
-    const ov::Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
+                                          element::Type input_type) {
+        const ov::Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+        auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(X, ng_order0);
+        auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
+        auto transpose0 = std::make_shared<ov::opset9::Transpose>(X, ng_order0);
 
-    ov::OutputVector outputs;
-    Output in_op = transpose0->output(0);
-    for (size_t i = 0; i < num_split_ops; ++i) {
-        auto split_axis_const = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{}, 2);
-        auto split = std::make_shared<ov::opset9::Split>(in_op, split_axis_const, num_split_outputs);
-        for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
-            outputs.push_back(split->output(num_output));
+        ov::OutputVector outputs;
+        ov::Output<ov::Node> in_op = transpose0->output(0);
+        for (size_t i = 0; i < num_split_ops; ++i) {
+            auto split_axis_const = std::make_shared<ov::opset9::Constant>(ov::element::u64,
+                                                                           ov::Shape{},
+                                                                           2);
+            auto split = std::make_shared<ov::opset9::Split>(in_op, split_axis_const, num_split_outputs);
+            for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
+                outputs.push_back(split->output(num_output));
+            }
+            in_op = split->output(num_split_outputs - 1);
         }
-        in_op = split->output(num_split_outputs - 1);
-    }
-    outputs.push_back(in_op);
+        outputs.push_back(in_op);
 
-    return std::make_shared<ov::Model>(outputs, ov::ParameterVector{X});
+        return std::make_shared<ov::Model>(outputs, ov::ParameterVector{X});
 }
 
-std::shared_ptr<ov::Model> CreateReferenceFunction(size_t num_split_ops,
+std::shared_ptr<Model> CreateReferenceFunction(size_t num_split_ops,
                                                    size_t num_split_outputs,
-                                                   ov::element::Type input_type) {
-    const ov::Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
+                                                   element::Type input_type) {
+        const ov::Shape input_shape{96, static_cast<size_t>(std::pow(num_split_outputs, num_split_ops + 1)), 55, 55};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+        auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
 
-    ov::OutputVector outputs;
-    Output in_op = X->output(0);
-    for (size_t i = 0; i < num_split_ops; ++i) {
-        auto split_axis_const = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{}, 1);
-        auto split = std::make_shared<ov::opset9::Split>(in_op, split_axis_const, num_split_outputs);
-        for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
-            auto ng_order0 =
-                std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-            auto transpose0 = std::make_shared<ov::opset9::Transpose>(split->output(num_output), ng_order0);
-            outputs.push_back(transpose0);
+        ov::OutputVector outputs;
+        ov::Output<ov::Node> in_op = X->output(0);
+        for (size_t i = 0; i < num_split_ops; ++i) {
+            auto split_axis_const = std::make_shared<ov::opset9::Constant>(ov::element::u64,
+                                                                           ov::Shape{},
+                                                                           1);
+            auto split = std::make_shared<ov::opset9::Split>(in_op, split_axis_const, num_split_outputs);
+            for (size_t num_output = 0; num_output < num_split_outputs - 1; ++num_output) {
+                auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
+                auto transpose0 = std::make_shared<ov::opset9::Transpose>(split->output(num_output), ng_order0);
+                outputs.push_back(transpose0);
+            }
+            in_op = split->output(num_split_outputs - 1);
         }
-        in_op = split->output(num_split_outputs - 1);
-    }
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(in_op, ng_order0);
-    outputs.push_back(transpose0);
+        auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
+        auto transpose0 = std::make_shared<ov::opset9::Transpose>(in_op, ng_order0);
+        outputs.push_back(transpose0);
 
-    return std::make_shared<ov::Model>(outputs, ov::ParameterVector{X});
+        return std::make_shared<ov::Model>(outputs, ov::ParameterVector{X});
 }
 
-}  // namespace forward
-}  // namespace split
 
-TEST_P(TransposeSinkingSplitForwardTestFixture, CompareFunctions) {
-    PassFactoryPtr pass_factory;
-    size_t num_split_ops;
-    size_t num_split_outputs;
-    CreateGraphSplitForwardF model_factory;
-    CreateGraphSplitForwardF reference_model_factory;
-    ov::element::Type input_type;
-    std::tie(pass_factory, num_split_ops, num_split_outputs, model_factory, reference_model_factory, input_type) =
-        this->GetParam();
-
-    model = model_factory(num_split_ops, num_split_outputs, input_type);
-    model_ref = reference_model_factory(num_split_ops, num_split_outputs, input_type);
-    pass_factory->registerPass(manager);
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingSplitForwardTestSuite,
-    TransposeSinkingSplitForwardTestFixture,
-    ::testing::Combine(::testing::Values(CreatePassFactory<ov::pass::TransposeSinkingSplitForward>()),
-                       ::testing::ValuesIn(split_operations_numbers),
-                       ::testing::ValuesIn(split_outputs_numbers),
-                       ::testing::Values(split::forward::CreateFunction),
-                       ::testing::Values(split::forward::CreateReferenceFunction),
-                       ::testing::Values(ov::element::f32)));
-
-// --------------------------------------------------------------------------------------
-
-using CreateGraphSplitBackwardF = std::function<
-    std::shared_ptr<ov::Model>(size_t split_tree_depth, size_t num_split_outputs, ov::element::Type input_type)>;
-
-using TestSplitBackwardParams = std::tuple<PassFactoryPtr,
-                                           size_t,                    /* split_tree_depth */
-                                           size_t,                    /* num_split_outputs */
-                                           CreateGraphSplitBackwardF, /* model_factory */
-                                           CreateGraphSplitBackwardF, /* reference_model_factory */
-                                           ov::element::Type> /* input type */;
-
-class TransposeSinkingSplitBackwardTestFixture : public ::testing::WithParamInterface<TestSplitBackwardParams>,
-                                                 public TransformationTestsF {};
-
-namespace {
-std::vector<size_t> split_tree_depth_nums = {1, 3};
-}  // namespace
-
-// --------------------------------------------------------------------------------------
+} // namespace forward
+} // namespace split
 
 namespace split {
 namespace backward {
 
 class SplitFactory {
 public:
-    SplitFactory(size_t axis, size_t n_outputs, ov::element::Type elem_type)
-        : _axis(axis),
-          _n_outputs(n_outputs),
-          _elem_type(elem_type) {}
-    NodePtr create(Output parent) const {
-        auto split_axis_const = std::make_shared<ov::opset9::Constant>(_elem_type, ov::Shape{}, _axis);
-        return std::make_shared<ov::opset9::Split>(parent, split_axis_const, _n_outputs);
+    SplitFactory(size_t axis, size_t n_outputs, element::Type elem_type) :
+        _axis(axis), _n_outputs(n_outputs), _elem_type(elem_type) {}
+    NodePtr create(ov::Output<ov::Node> parent) const {
+        auto split_axis_const = std::make_shared<Constant>(_elem_type,
+                                                                       Shape{},
+                                                                       _axis);
+        return std::make_shared<Split>(parent, split_axis_const, _n_outputs);
     }
 
 private:
     const size_t _axis;
     const size_t _n_outputs;
-    const ov::element::Type _elem_type;
+    const element::Type _elem_type;
 };
 
-void CreateSplitTree(size_t max_depth,
-                     size_t depth,
-                     Output parent,
-                     const SplitFactory& split_factory,
-                     ov::OutputVector& leaves) {
+void CreateSplitTree(size_t max_depth, size_t depth, ov::Output<ov::Node> parent, const SplitFactory & split_factory, ov::OutputVector & leaves) {
     if (depth == max_depth) {
         leaves.push_back(parent);
         return;
@@ -247,168 +147,183 @@ void CreateSplitTree(size_t max_depth,
     }
 }
 
-std::shared_ptr<ov::Model> CreateFunction(size_t split_tree_depth,
+std::shared_ptr<Model> CreateFunction(size_t split_tree_depth,
                                           size_t num_split_outputs,
-                                          ov::element::Type input_type) {
-    const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
-    const ov::Shape input_shape{96, split_input_dim_value, 55, 55};
+                                          element::Type input_type) {
+        const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
+        const Shape input_shape{96, split_input_dim_value, 55, 55};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+        auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    ov::OutputVector split_tree_leaves;
-    {
-        SplitFactory split_factory(/* axis */ 1, num_split_outputs, /* elem_type */ ov::element::u64);
-        CreateSplitTree(split_tree_depth, /* depth */ 0, X->output(0), split_factory, split_tree_leaves);
-    }
+        ov::OutputVector split_tree_leaves;
+        {
+            SplitFactory split_factory(/* axis */ 1, num_split_outputs, /* elem_type */ element::u64);
+            CreateSplitTree(split_tree_depth, /* depth */ 0, X->output(0), split_factory, split_tree_leaves);
+        }
 
-    ov::OutputVector outputs;
-    for (auto& split_tree_leaf : split_tree_leaves) {
-        auto ng_order = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-        auto transpose = std::make_shared<ov::opset9::Transpose>(split_tree_leaf, ng_order);
+        ov::OutputVector outputs;
+        for (auto& split_tree_leaf : split_tree_leaves) {
+            auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+            auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
 
-        const size_t split_dim_current_value =
-            static_cast<size_t>(split_input_dim_value / std::pow(num_split_outputs, split_tree_depth));
-        auto reshape_const = std::make_shared<ov::opset9::Constant>(ov::element::u64,
-                                                                    ov::Shape{3},
-                                                                    ov::Shape{96, 55, split_dim_current_value * 55});
-        auto reshape = std::make_shared<ov::opset9::Reshape>(transpose, reshape_const, false);
-        outputs.push_back(reshape);
-    }
+            const size_t split_dim_current_value = static_cast<size_t>(split_input_dim_value / std::pow(num_split_outputs, split_tree_depth));
+            auto reshape_const = std::make_shared<Constant>(element::u64, Shape{3}, Shape{96, 55, split_dim_current_value * 55});
+            auto reshape = std::make_shared<Reshape>(transpose, reshape_const, false);
+            outputs.push_back(reshape);
+        }
 
-    return std::make_shared<ov::Model>(outputs, ov::ParameterVector{X});
+        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
-std::shared_ptr<ov::Model> CreateReferenceFunction(size_t split_tree_depth,
+std::shared_ptr<Model> CreateReferenceFunction(size_t split_tree_depth,
                                                    size_t num_split_outputs,
-                                                   ov::element::Type input_type) {
-    const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
-    const ov::Shape input_shape{96, split_input_dim_value, 55, 55};
+                                                   element::Type input_type) {
+        const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
+        const Shape input_shape{96, split_input_dim_value, 55, 55};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+        auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto ng_order = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-    auto transpose = std::make_shared<ov::opset9::Transpose>(X, ng_order);
+        auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+        auto transpose = std::make_shared<Transpose>(X, ng_order);
 
-    ov::OutputVector split_tree_leaves;
-    {
-        SplitFactory split_factory(/* axis */ 2, num_split_outputs, /* elem_type */ ov::element::u64);
-        CreateSplitTree(split_tree_depth, /* depth */ 0, transpose->output(0), split_factory, split_tree_leaves);
-    }
+        ov::OutputVector split_tree_leaves;
+        {
+            SplitFactory split_factory(/* axis */ 2, num_split_outputs, /* elem_type */ element::u64);
+            CreateSplitTree(split_tree_depth, /* depth */ 0, transpose->output(0), split_factory, split_tree_leaves);
+        }
 
-    ov::OutputVector outputs;
-    for (auto& split_tree_leaf : split_tree_leaves) {
-        const size_t split_dim_current_value =
-            static_cast<size_t>(split_input_dim_value / std::pow(num_split_outputs, split_tree_depth));
-        auto reshape_const = std::make_shared<ov::opset9::Constant>(ov::element::u64,
-                                                                    ov::Shape{3},
-                                                                    ov::Shape{96, 55, split_dim_current_value * 55});
-        auto reshape = std::make_shared<ov::opset9::Reshape>(split_tree_leaf, reshape_const, false);
-        outputs.push_back(reshape);
-    }
+        ov::OutputVector outputs;
+        for (auto& split_tree_leaf : split_tree_leaves) {
+            const size_t split_dim_current_value = static_cast<size_t>(split_input_dim_value / std::pow(num_split_outputs, split_tree_depth));
+            auto reshape_const = std::make_shared<Constant>(element::u64, Shape{3}, Shape{96, 55, split_dim_current_value * 55});
+            auto reshape = std::make_shared<Reshape>(split_tree_leaf, reshape_const, false);
+            outputs.push_back(reshape);
+        }
 
-    return std::make_shared<ov::Model>(outputs, ov::ParameterVector{X});
+        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
-}  // namespace backward
-}  // namespace split
+} // namespace backward
+} // namespace split
 
-TEST_P(TransposeSinkingSplitBackwardTestFixture, CompareFunctions) {
+using CreateGraphSplitF = std::function< std::shared_ptr<Model> (size_t num_split_ops,
+                                                                            size_t num_split_outputs,
+                                                                            element::Type input_type)>;
+
+using TestSplitParams = std::tuple<PassFactoryPtr,
+                              size_t, /* num_split_ops */
+                              size_t, /* num_split_outputs */
+                              CreateGraphSplitF, /* model_factory */
+                              CreateGraphSplitF, /* reference_model_factory */
+                              element::Type> /* input type */;
+
+class TransposeSinkingSplitTestFixture: public ::testing::WithParamInterface<TestSplitParams>,
+                                        public TransformationTestsF {
+public:
+    static std::string get_test_name(const testing::TestParamInfo<TestSplitParams>& obj) {
+        PassFactoryPtr pass_factory;
+        size_t num_split_ops;
+        size_t num_split_outputs;
+        CreateGraphSplitF model_factory;
+        CreateGraphSplitF reference_model_factory;
+        element::Type input_type;
+
+        std::tie(pass_factory,
+             num_split_ops,
+             num_split_outputs,
+             model_factory,
+             reference_model_factory,
+             input_type) = obj.param;
+
+        std::ostringstream test_name;
+        test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
+        test_name << "num_split_ops=" << num_split_ops << "_";
+        test_name << "num_split_outputs=" << num_split_outputs << "_";
+        test_name << "input_type=" << input_type;
+
+        return test_name.str();
+    }
+};
+
+TEST_P(TransposeSinkingSplitTestFixture, CompareFunctions) {
     PassFactoryPtr pass_factory;
-    size_t split_tree_depth;
+    size_t num_split_ops;
     size_t num_split_outputs;
-    CreateGraphSplitBackwardF model_factory;
-    CreateGraphSplitBackwardF reference_model_factory;
-    ov::element::Type input_type;
-    std::tie(pass_factory, split_tree_depth, num_split_outputs, model_factory, reference_model_factory, input_type) =
-        this->GetParam();
+    CreateGraphSplitF model_factory;
+    CreateGraphSplitF reference_model_factory;
+    element::Type input_type;
+    std::tie(pass_factory,
+             num_split_ops,
+             num_split_outputs,
+             model_factory,
+             reference_model_factory,
+             input_type) = this->GetParam();
 
-    model = model_factory(split_tree_depth, num_split_outputs, input_type);
-    model_ref = reference_model_factory(split_tree_depth, num_split_outputs, input_type);
+    model = model_factory(num_split_ops, num_split_outputs, input_type);
+    model_ref = reference_model_factory(num_split_ops, num_split_outputs, input_type);
     pass_factory->registerPass(manager);
 }
 
 INSTANTIATE_TEST_SUITE_P(
+    TransposeSinkingSplitForwardTestSuite,
+    TransposeSinkingSplitTestFixture,
+    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitForward)),
+                       ::testing::ValuesIn(split_operations_numbers),
+                       ::testing::ValuesIn(split_outputs_numbers),
+                       ::testing::Values(split::forward::CreateFunction),
+                       ::testing::Values(split::forward::CreateReferenceFunction),
+                       ::testing::Values(element::f32)),
+                       TransposeSinkingSplitTestFixture::get_test_name);
+
+INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingSplitBackwardTestSuite,
-    TransposeSinkingSplitBackwardTestFixture,
-    ::testing::Combine(::testing::Values(CreatePassFactory<ov::pass::TransposeSinkingSplitBackward>()),
+    TransposeSinkingSplitTestFixture,
+    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitBackward)),
                        ::testing::ValuesIn(split_tree_depth_nums),
                        ::testing::ValuesIn(split_outputs_numbers),
                        ::testing::Values(split::backward::CreateFunction),
                        ::testing::Values(split::backward::CreateReferenceFunction),
-                       ::testing::Values(ov::element::f32)));
+                       ::testing::Values(element::f32)),
+                       TransposeSinkingSplitTestFixture::get_test_name);
 
-using TransposeInsertF = std::function<ov::OutputVector(const ov::OutputVector& split_tree_leaves)>;
-
-using CreateGraphSplitBackwardRestrictF =
-    std::function<std::shared_ptr<ov::Model>(size_t split_tree_depth,
-                                             size_t num_split_outputs,
-                                             ov::element::Type input_type,
-                                             TransposeInsertF tranpose_insert_function)>;
-
-using TestSplitBackwardRestrictParams = std::tuple<PassFactoryPtr,
-                                                   size_t,                            /* split_tree_depth */
-                                                   size_t,                            /* num_split_outputs */
-                                                   CreateGraphSplitBackwardRestrictF, /* model_factory */
-                                                   ov::element::Type,                 /* input type */
-                                                   TransposeInsertF>;                 /* insert transpose function */
-
-class TransposeSinkingSplitBackwardRestrictTestFixture
-    : public ::testing::WithParamInterface<TestSplitBackwardRestrictParams>,
-      public TransformationTestsF {};
-
-TEST_P(TransposeSinkingSplitBackwardRestrictTestFixture, CompareFunctions) {
-    PassFactoryPtr pass_factory;
-    size_t split_tree_depth;
-    size_t num_split_outputs;
-    CreateGraphSplitBackwardRestrictF model_factory;
-    ov::element::Type input_type;
-    TransposeInsertF tranpose_insert_function;
-    std::tie(pass_factory, split_tree_depth, num_split_outputs, model_factory, input_type, tranpose_insert_function) =
-        this->GetParam();
-
-    model = model_factory(split_tree_depth, num_split_outputs, input_type, tranpose_insert_function);
-    model_ref = model->clone();
-    pass_factory->registerPass(manager);
-}
 namespace split {
 namespace backward {
 namespace restrictions {
 
-std::shared_ptr<ov::Model> CreateFunction(size_t split_tree_depth,
+using TransposeInsertF = std::function< ov::OutputVector (const ov::OutputVector& split_tree_leaves)>;
+
+std::shared_ptr<Model> CreateFunction(size_t split_tree_depth,
                                           size_t num_split_outputs,
-                                          ov::element::Type input_type,
+                                          element::Type input_type,
                                           TransposeInsertF transpose_insert_func) {
-    const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
-    const ov::Shape input_shape{96, split_input_dim_value, 55, 55};
+        const size_t split_input_dim_value = static_cast<size_t>(std::pow(num_split_outputs, split_tree_depth + 1));
+        const Shape input_shape{96, split_input_dim_value, 55, 55};
 
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+        auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    ov::OutputVector split_tree_leaves;
-    {
-        SplitFactory split_factory(/* axis */ 1, num_split_outputs, /* elem_type */ ov::element::u64);
-        CreateSplitTree(split_tree_depth, /* depth */ 0, X->output(0), split_factory, split_tree_leaves);
-    }
+        ov::OutputVector split_tree_leaves;
+        {
+            SplitFactory split_factory(/* axis */ 1, num_split_outputs, /* elem_type */ element::u64);
+            CreateSplitTree(split_tree_depth, /* depth */ 0, X->output(0), split_factory, split_tree_leaves);
+        }
 
-    ov::OutputVector outputs;
-    for (auto& split_tree_leaf : transpose_insert_func(split_tree_leaves)) {
-        const size_t split_dim_current_value =
-            static_cast<size_t>(split_input_dim_value / std::pow(num_split_outputs, split_tree_depth));
-        auto reshape_const = std::make_shared<ov::opset9::Constant>(ov::element::u64,
-                                                                    ov::Shape{3},
-                                                                    ov::Shape{96, 55, split_dim_current_value * 55});
-        auto reshape = std::make_shared<ov::opset9::Reshape>(split_tree_leaf, reshape_const, false);
-        outputs.push_back(reshape);
-    }
+        ov::OutputVector outputs;
+        for (auto& split_tree_leaf : transpose_insert_func(split_tree_leaves)) {
+            const size_t split_dim_current_value = static_cast<size_t>(split_input_dim_value / std::pow(num_split_outputs, split_tree_depth));
+            auto reshape_const = std::make_shared<Constant>(element::u64, Shape{3}, Shape{96, 55, split_dim_current_value * 55});
+            auto reshape = std::make_shared<Reshape>(split_tree_leaf, reshape_const, false);
+            outputs.push_back(reshape);
+        }
 
-    return std::make_shared<ov::Model>(outputs, ov::ParameterVector{X});
+        return std::make_shared<Model>(outputs, ov::ParameterVector{X});
 }
 
 ov::OutputVector OnlyFirstTranspose(const ov::OutputVector& split_tree_leaves) {
     ov::OutputVector outputs;
     {
         auto& split_tree_leaf = split_tree_leaves.front();
-        auto ng_order = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-        auto transpose = std::make_shared<ov::opset9::Transpose>(split_tree_leaf, ng_order);
+        auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+        auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
         outputs.push_back(transpose);
     }
 
@@ -423,8 +338,8 @@ ov::OutputVector OnlyLastTranspose(const ov::OutputVector& split_tree_leaves) {
     ov::OutputVector outputs;
     {
         auto& split_tree_leaf = split_tree_leaves.back();
-        auto ng_order = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-        auto transpose = std::make_shared<ov::opset9::Transpose>(split_tree_leaf, ng_order);
+        auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+        auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
         outputs.push_back(transpose);
     }
 
@@ -443,9 +358,8 @@ ov::OutputVector OnlyMiddleTranspose(const ov::OutputVector& split_tree_leaves) 
     for (size_t leaf_idx = 0; leaf_idx < split_tree_leaves.size() - 1; ++leaf_idx) {
         if (leaf_idx == middle_idx) {
             auto& split_tree_leaf = split_tree_leaves[leaf_idx];
-            auto ng_order =
-                std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-            auto transpose = std::make_shared<ov::opset9::Transpose>(split_tree_leaf, ng_order);
+            auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+            auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
             outputs.push_back(transpose);
         } else {
             outputs.push_back(split_tree_leaves[leaf_idx]);
@@ -459,15 +373,15 @@ ov::OutputVector FirstAnotherTranspose(const ov::OutputVector& split_tree_leaves
     ov::OutputVector outputs;
     {
         auto& split_tree_leaf = split_tree_leaves.front();
-        auto ng_order = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-        auto transpose = std::make_shared<ov::opset9::Transpose>(split_tree_leaf, ng_order);
+        auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+        auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
         outputs.push_back(transpose);
     }
 
     for (size_t leaf_idx = 1; leaf_idx < split_tree_leaves.size(); ++leaf_idx) {
         auto& split_tree_leaf = split_tree_leaves[leaf_idx];
-        auto ng_order = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-        auto transpose = std::make_shared<ov::opset9::Transpose>(split_tree_leaf, ng_order);
+        auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+        auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
         outputs.push_back(transpose);
     }
 
@@ -478,15 +392,15 @@ ov::OutputVector LastAnotherTranspose(const ov::OutputVector& split_tree_leaves)
     ov::OutputVector outputs;
     {
         auto& split_tree_leaf = split_tree_leaves.back();
-        auto ng_order = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-        auto transpose = std::make_shared<ov::opset9::Transpose>(split_tree_leaf, ng_order);
+        auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+        auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
         outputs.push_back(transpose);
     }
 
     for (size_t leaf_idx = 0; leaf_idx < split_tree_leaves.size() - 1; ++leaf_idx) {
         auto& split_tree_leaf = split_tree_leaves[leaf_idx];
-        auto ng_order = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-        auto transpose = std::make_shared<ov::opset9::Transpose>(split_tree_leaf, ng_order);
+        auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+        auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
         outputs.push_back(transpose);
     }
 
@@ -501,14 +415,12 @@ ov::OutputVector MiddleAnotherTranspose(const ov::OutputVector& split_tree_leave
     for (size_t leaf_idx = 0; leaf_idx < split_tree_leaves.size(); ++leaf_idx) {
         auto& split_tree_leaf = split_tree_leaves[leaf_idx];
         if (leaf_idx == middle_idx) {
-            auto ng_order =
-                std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-            auto transpose = std::make_shared<ov::opset9::Transpose>(split_tree_leaf, ng_order);
+            auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
+            auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
             outputs.push_back(transpose);
         } else {
-            auto ng_order =
-                std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 3, 1, 2});
-            auto transpose = std::make_shared<ov::opset9::Transpose>(split_tree_leaf, ng_order);
+            auto ng_order = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 3, 1, 2});
+            auto transpose = std::make_shared<Transpose>(split_tree_leaf, ng_order);
             outputs.push_back(transpose);
         }
     }
@@ -516,27 +428,104 @@ ov::OutputVector MiddleAnotherTranspose(const ov::OutputVector& split_tree_leave
     return outputs;
 }
 
-}  // namespace restrictions
-}  // namespace backward
-}  // namespace split
+struct TransposeInsertFuncDesc {
+    TransposeInsertFuncDesc() = default;
+    TransposeInsertFuncDesc(TransposeInsertF a_function,
+                            std::string a_name) :
+                            function(a_function),
+                            name(a_name) {}
 
-namespace {
+    TransposeInsertF function;
+    std::string name;
+};
 
-std::vector<TransposeInsertF> insertTransposeFactories = {split::backward::restrictions::OnlyFirstTranspose,
-                                                          split::backward::restrictions::OnlyLastTranspose,
-                                                          split::backward::restrictions::OnlyMiddleTranspose,
-                                                          split::backward::restrictions::FirstAnotherTranspose,
-                                                          split::backward::restrictions::LastAnotherTranspose,
-                                                          split::backward::restrictions::MiddleAnotherTranspose};
+using CreateGraphSplitBackwardRestrictF = std::function< std::shared_ptr<Model> (size_t split_tree_depth,
+                                                                                     size_t num_split_outputs,
+                                                                                     element::Type input_type,
+                                                                                     TransposeInsertF tranpose_insert_function)>;
 
-}  // namespace
+using TestSplitBackwardRestrictParams = std::tuple<PassFactoryPtr,
+                              size_t, /* split_tree_depth */
+                              size_t, /* num_split_outputs */
+                              CreateGraphSplitBackwardRestrictF, /* model_factory */
+                              element::Type, /* input type */
+                              TransposeInsertFuncDesc>; /* insert transpose function */
+
+class TransposeSinkingSplitBackwardRestrictTestFixture: public ::testing::WithParamInterface<TestSplitBackwardRestrictParams>,
+                                        public TransformationTestsF {
+public:
+    static std::string get_test_name(const testing::TestParamInfo<TestSplitBackwardRestrictParams>& obj) {
+        PassFactoryPtr pass_factory;
+        size_t split_tree_depth;
+        size_t num_split_outputs;
+        CreateGraphSplitBackwardRestrictF model_factory;
+        element::Type input_type;
+        TransposeInsertFuncDesc tranpose_insert_function;
+
+        std::tie(pass_factory,
+             split_tree_depth,
+             num_split_outputs,
+             model_factory,
+             input_type,
+             tranpose_insert_function) = obj.param;
+
+        std::ostringstream test_name;
+        test_name << "pass_factory=" << pass_factory->getTypeName() << "_";
+        test_name << "split_tree_depth=" << split_tree_depth << "_";
+        test_name << "num_split_outputs=" << num_split_outputs << "_";
+        test_name << "tranpose_insert_function=" << tranpose_insert_function.name << "_";
+        test_name << "input_type=" << input_type;
+
+        return test_name.str();
+    }
+};
+
+TEST_P(TransposeSinkingSplitBackwardRestrictTestFixture, CompareFunctions) {
+    PassFactoryPtr pass_factory;
+    size_t split_tree_depth;
+    size_t num_split_outputs;
+    CreateGraphSplitBackwardRestrictF model_factory;
+    element::Type input_type;
+    TransposeInsertFuncDesc tranpose_insert_function;
+
+    std::tie(pass_factory,
+             split_tree_depth,
+             num_split_outputs,
+             model_factory,
+             input_type,
+             tranpose_insert_function) = this->GetParam();
+
+    model = model_factory(split_tree_depth, num_split_outputs, input_type, tranpose_insert_function.function);
+    model_ref = model->clone();
+    pass_factory->registerPass(manager);
+}
+
+#define FUNC(name) TransposeInsertFuncDesc(split::backward::restrictions::name, #name)
+
+std::vector<TransposeInsertFuncDesc> insertTransposeFactories = {
+    FUNC(OnlyFirstTranspose),
+    FUNC(OnlyLastTranspose),
+    FUNC(OnlyMiddleTranspose),
+    FUNC(FirstAnotherTranspose),
+    FUNC(LastAnotherTranspose),
+    FUNC(MiddleAnotherTranspose)
+};
+
+#undef FUNC
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingSplitBackwardRestrictTestSuite,
     TransposeSinkingSplitBackwardRestrictTestFixture,
-    ::testing::Combine(::testing::Values(CreatePassFactory<ov::pass::TransposeSinkingSplitBackward>()),
+    ::testing::Combine(::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingSplitBackward)),
                        ::testing::Values(1),
                        ::testing::Values(5),
                        ::testing::Values(split::backward::restrictions::CreateFunction),
-                       ::testing::Values(ov::element::f32),
-                       ::testing::ValuesIn(insertTransposeFactories)));
+                       ::testing::Values(element::f32),
+                       ::testing::ValuesIn(insertTransposeFactories)),
+                       TransposeSinkingSplitBackwardRestrictTestFixture::get_test_name);
+
+} // namespace restrictions
+} // namespace backward
+} // namespace split
+
+} // namespace transpose_sinking_split

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_unary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_unary_test.cpp
@@ -12,13 +12,35 @@
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "gtest/gtest.h"
 
+using namespace ov::opset9;
+
+namespace {
+std::string to_string(const ov::Shape& shape) {
+    std::ostringstream result;
+    result << "{";
+    for (size_t idx = 0; idx < shape.size(); ++idx) {
+        if (idx)
+            result << ",";
+        result << shape[idx];
+    }
+    result << "}";
+    return result.str();
+}
+}  // namespace
+
 using NodePtr = std::shared_ptr<ov::Node>;
 
 class IUnaryFactory {
 public:
-    IUnaryFactory() = default;
+    IUnaryFactory(const std::string& type_name) : type_name_(type_name) {}
     virtual ~IUnaryFactory() = default;
     virtual NodePtr create(NodePtr parent_node) const = 0;
+
+    const std::string& getTypeName() const {
+        return type_name_;
+    }
+private:
+    const std::string type_name_;
 };
 
 using UnaryFactoryPtr = std::shared_ptr<IUnaryFactory>;
@@ -26,55 +48,63 @@ using UnaryFactoryPtr = std::shared_ptr<IUnaryFactory>;
 template <typename UnaryT>
 class UnaryFactory : public IUnaryFactory {
 public:
-    UnaryFactory() = default;
+    UnaryFactory(const std::string& type_name) : IUnaryFactory(type_name) {}
     NodePtr create(NodePtr parent_node) const override {
         return std::make_shared<UnaryT>(parent_node);
     }
 };
 
 template <>
-NodePtr UnaryFactory<ov::opset9::Elu>::create(NodePtr parent_node) const {
-    return std::make_shared<ov::opset9::Elu>(parent_node, 0.1);
+NodePtr UnaryFactory<Elu>::create(NodePtr parent_node) const {
+    return std::make_shared<Elu>(parent_node, 0.1);
 }
 
 template <>
-NodePtr UnaryFactory<ov::opset9::Clamp>::create(NodePtr parent_node) const {
-    return std::make_shared<ov::opset9::Clamp>(parent_node, 0.1, 0.2);
+NodePtr UnaryFactory<Clamp>::create(NodePtr parent_node) const {
+    return std::make_shared<Clamp>(parent_node, 0.1, 0.2);
 }
 
 template <>
-NodePtr UnaryFactory<ov::opset9::Convert>::create(NodePtr parent_node) const {
-    return std::make_shared<ov::opset9::Convert>(parent_node, ov::element::f64);
+NodePtr UnaryFactory<Convert>::create(NodePtr parent_node) const {
+    return std::make_shared<Convert>(parent_node, ov::element::f64);
 }
 
 template <typename UnaryT>
-UnaryFactoryPtr CreateUnaryFactory() {
-    return std::make_shared<UnaryFactory<UnaryT>>();
+UnaryFactoryPtr CreateUnaryFactory(const std::string& type_name) {
+    return std::make_shared<UnaryFactory<UnaryT>>(type_name);
 }
 
 // ----------------------------------------------------------------------------
 
 class IPassFactory {
 public:
-    IPassFactory() = default;
+    IPassFactory(const std::string& type_name) : type_name_(type_name) {}
     virtual ~IPassFactory() = default;
     virtual void registerPass(ov::pass::Manager& pass_manager) const = 0;
+    const std::string& getTypeName() const {
+        return type_name_;
+    }
+
+private:
+    const std::string type_name_;
 };
+
 
 using PassFactoryPtr = std::shared_ptr<IPassFactory>;
 
 template <typename PassT>
 class PassFactory : public IPassFactory {
 public:
+    PassFactory(const std::string& type_name) : IPassFactory(type_name) {}
     void registerPass(ov::pass::Manager& pass_manager) const override {
         pass_manager.register_pass<PassT>();
     }
 };
 
-template <typename PassT>
-PassFactoryPtr CreatePassFactory() {
-    return std::make_shared<PassFactory<PassT>>();
-}
+#define CREATE_PASS_FACTORY(pass_name) std::make_shared<PassFactory<ov::pass::pass_name>>(#pass_name)
+
+#undef CREATE_UNARY_FACTORY
+#define CREATE_UNARY_FACTORY(type_name) CreateUnaryFactory<type_name>(#type_name)
 
 // ----------------------------------------------------------------------------
 
@@ -94,7 +124,35 @@ using TestParams = std::tuple<UnaryFactoryPtr,
                               ov::element::Type>; /* input type */
 
 class TransposeSinkingUnaryTestFixture : public ::testing::WithParamInterface<TestParams>,
-                                         public TransformationTestsF {};
+                                         public TransformationTestsF {
+public:
+    static std::string get_test_name(const testing::TestParamInfo<TestParams>& obj) {
+        UnaryFactoryPtr unary_factory;
+        PassFactoryPtr pass_factory;
+        size_t num_unary_ops;
+        CreateGraphF model_factory;
+        CreateGraphF reference_model_factory;
+        ov::Shape input_shape;
+        ov::element::Type input_type;
+        std::tie(unary_factory,
+             pass_factory,
+             num_unary_ops,
+             model_factory,
+             reference_model_factory,
+             input_shape,
+             input_type) = obj.param;
+
+        std::ostringstream test_name;
+        test_name << "unaryFactory=" << unary_factory->getTypeName() << "/";
+        test_name << "numUnaryOps=" << num_unary_ops << "/";
+        test_name << "inputShape=" << to_string(input_shape) << "/";
+        test_name << "unaryFactory=" << unary_factory->getTypeName() << "/";
+        test_name << "passFactory=" << pass_factory->getTypeName() << "/";
+        test_name << "inputType=" << input_type;
+
+        return test_name.str();
+    }
+};
 
 namespace {
 
@@ -107,10 +165,10 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeBefore(UnaryFactoryPtr unary_f
                                                          size_t num_unary_ops,
                                                          const ov::Shape& input_shape,
                                                          ov::element::Type input_type) {
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(X, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
     NodePtr in_op = transpose0;
     for (size_t i = 0; i < num_unary_ops; ++i) {
@@ -124,23 +182,23 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeAfter(UnaryFactoryPtr unary_fa
                                                         size_t num_unary_ops,
                                                         const ov::Shape& input_shape,
                                                         ov::element::Type input_type) {
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     NodePtr in_op = X;
     for (size_t i = 0; i < num_unary_ops; ++i) {
         in_op = unary_factory->create(in_op);
     }
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(in_op, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
 
     return std::make_shared<ov::Model>(transpose0, ov::ParameterVector{X});
 }
 
 static NodePtr CreateReshape(NodePtr parent_node, const ov::Shape& input_shape) {
     const size_t mul = std::accumulate(input_shape.begin(), input_shape.end(), (size_t)1, std::multiplies<size_t>());
-    auto reshape_const = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{1}, ov::Shape{mul});
-    return std::make_shared<ov::opset9::Reshape>(parent_node, reshape_const, false);
+    auto reshape_const = std::make_shared<Constant>(ov::element::u64, ov::Shape{1}, ov::Shape{mul});
+    return std::make_shared<Reshape>(parent_node, reshape_const, false);
 }
 
 namespace mult_consumers_last_node {
@@ -150,15 +208,15 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeAfter(UnaryFactoryPtr unary_fa
                                                         size_t num_unary_ops,
                                                         const ov::Shape& input_shape,
                                                         ov::element::Type input_type) {
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     NodePtr in_op = X;
     for (size_t i = 0; i < num_unary_ops; ++i) {
         in_op = unary_factory->create(in_op);
     }
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(in_op, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
 
     auto reshape1 = CreateReshape(transpose0, input_shape);
     auto reshape2 = CreateReshape(transpose0, input_shape);
@@ -170,10 +228,10 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeBefore(UnaryFactoryPtr unary_f
                                                          size_t num_unary_ops,
                                                          const ov::Shape& input_shape,
                                                          ov::element::Type input_type) {
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(X, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
     NodePtr in_op = transpose0;
     for (size_t i = 0; i < num_unary_ops; ++i) {
@@ -193,22 +251,22 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeAfter(UnaryFactoryPtr unary_fa
                                                         size_t num_unary_ops,
                                                         const ov::Shape& input_shape,
                                                         ov::element::Type input_type) {
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     NodePtr in_op = X;
     for (size_t i = 0; i < num_unary_ops; ++i) {
         in_op = unary_factory->create(in_op);
     }
 
-    auto sinh = std::make_shared<ov::opset9::Sinh>(in_op);
+    auto sinh = std::make_shared<Sinh>(in_op);
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(sinh, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(sinh, ng_order0);
 
-    auto cosh = std::make_shared<ov::opset9::Cosh>(in_op);
+    auto cosh = std::make_shared<Cosh>(in_op);
 
-    auto ng_order1 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose1 = std::make_shared<ov::opset9::Transpose>(cosh, ng_order1);
+    auto ng_order1 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto transpose1 = std::make_shared<Transpose>(cosh, ng_order1);
 
     return std::make_shared<ov::Model>(ov::OutputVector{transpose0, transpose1}, ov::ParameterVector{X});
 }
@@ -217,18 +275,18 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeBefore(UnaryFactoryPtr unary_f
                                                          size_t num_unary_ops,
                                                          const ov::Shape& input_shape,
                                                          ov::element::Type input_type) {
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(X, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
     NodePtr in_op = transpose0;
     for (size_t i = 0; i < num_unary_ops; ++i) {
         in_op = unary_factory->create(in_op);
     }
 
-    auto sinh = std::make_shared<ov::opset9::Sinh>(in_op);
-    auto cosh = std::make_shared<ov::opset9::Cosh>(in_op);
+    auto sinh = std::make_shared<Sinh>(in_op);
+    auto cosh = std::make_shared<Cosh>(in_op);
 
     return std::make_shared<ov::Model>(ov::OutputVector{sinh, cosh}, ov::ParameterVector{X});
 }
@@ -243,46 +301,19 @@ std::shared_ptr<ov::Model> CreateFunction(UnaryFactoryPtr unary_factory,
                                           size_t num_unary_ops,
                                           const ov::Shape& input_shape,
                                           ov::element::Type input_type) {
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
     ov::OutputVector outputs;
 
     NodePtr in_op = X;
     for (size_t i = 0; i < num_unary_ops; ++i) {
         in_op = unary_factory->create(in_op);
-        auto cosh = std::make_shared<ov::opset9::Cosh>(in_op);
+        auto cosh = std::make_shared<Cosh>(in_op);
         outputs.push_back(cosh);
     }
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(in_op, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
     outputs.push_back(transpose0);
-
-    return std::make_shared<ov::Model>(outputs, ov::ParameterVector{X});
-}
-
-std::shared_ptr<ov::Model> CreateReferenceFunction(UnaryFactoryPtr unary_factory,
-                                                   size_t num_unary_ops,
-                                                   const ov::Shape& input_shape,
-                                                   ov::element::Type input_type) {
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
-    ov::OutputVector outputs;
-
-    NodePtr in_op = X;
-    for (size_t i = 0; i < num_unary_ops; ++i) {
-        in_op = unary_factory->create(in_op);
-        auto cosh = std::make_shared<ov::opset9::Cosh>(in_op);
-        outputs.push_back(cosh);
-    }
-
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(X, ng_order0);
-
-    in_op = transpose0;
-    for (size_t i = 0; i < num_unary_ops; ++i) {
-        in_op = unary_factory->create(in_op);
-    }
-
-    outputs.push_back(in_op);
 
     return std::make_shared<ov::Model>(outputs, ov::ParameterVector{X});
 }
@@ -295,12 +326,12 @@ std::shared_ptr<ov::Model> CreateFunction(UnaryFactoryPtr unary_factory,
                                           size_t num_unary_ops,
                                           const ov::Shape& input_shape,
                                           ov::element::Type input_type) {
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto sinh = std::make_shared<ov::opset9::Sinh>(X);
+    auto sinh = std::make_shared<Sinh>(X);
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(sinh, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(sinh, ng_order0);
 
     auto reshape = CreateReshape(transpose0, input_shape);
 
@@ -316,12 +347,12 @@ std::shared_ptr<ov::Model> CreateReferenceFunction(UnaryFactoryPtr unary_factory
                                                    size_t num_unary_ops,
                                                    const ov::Shape& input_shape,
                                                    ov::element::Type input_type) {
-    auto X = std::make_shared<ov::opset9::Parameter>(input_type, input_shape);
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto sinh = std::make_shared<ov::opset9::Sinh>(X);
+    auto sinh = std::make_shared<Sinh>(X);
 
-    auto ng_order0 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose0 = std::make_shared<ov::opset9::Transpose>(sinh, ng_order0);
+    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto transpose0 = std::make_shared<Transpose>(sinh, ng_order0);
     auto reshape = CreateReshape(transpose0, input_shape);
 
     NodePtr in_op = sinh;
@@ -329,8 +360,8 @@ std::shared_ptr<ov::Model> CreateReferenceFunction(UnaryFactoryPtr unary_factory
         in_op = unary_factory->create(in_op);
     }
 
-    auto ng_order1 = std::make_shared<ov::opset9::Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
-    auto transpose1 = std::make_shared<ov::opset9::Transpose>(in_op, ng_order1);
+    auto ng_order1 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto transpose1 = std::make_shared<Transpose>(in_op, ng_order1);
 
     return std::make_shared<ov::Model>(ov::OutputVector{transpose1, reshape}, ov::ParameterVector{X});
 }
@@ -339,21 +370,21 @@ std::shared_ptr<ov::Model> CreateReferenceFunction(UnaryFactoryPtr unary_factory
 }  // namespace mult_consumers_first_node
 
 std::vector<UnaryFactoryPtr> unary_factories = {
-    CreateUnaryFactory<ov::opset9::Clamp>(),    CreateUnaryFactory<ov::opset9::Elu>(),
-    CreateUnaryFactory<ov::opset9::SoftPlus>(), CreateUnaryFactory<ov::opset9::LogicalNot>(),
-    CreateUnaryFactory<ov::opset9::Convert>(),  CreateUnaryFactory<ov::opset9::Abs>(),
-    CreateUnaryFactory<ov::opset9::Acos>(),     CreateUnaryFactory<ov::opset9::Asin>(),
-    CreateUnaryFactory<ov::opset9::Asinh>(),    CreateUnaryFactory<ov::opset9::Atan>(),
-    CreateUnaryFactory<ov::opset9::Ceiling>(),  CreateUnaryFactory<ov::opset9::Cos>(),
-    CreateUnaryFactory<ov::opset9::Cosh>(),     CreateUnaryFactory<ov::opset9::Erf>(),
-    CreateUnaryFactory<ov::opset9::Exp>(),      CreateUnaryFactory<ov::opset9::Gelu>(),
-    CreateUnaryFactory<ov::opset9::HSigmoid>(), CreateUnaryFactory<ov::opset9::HSwish>(),
-    CreateUnaryFactory<ov::opset9::Log>(),      CreateUnaryFactory<ov::opset9::Negative>(),
-    CreateUnaryFactory<ov::opset9::Relu>(),     CreateUnaryFactory<ov::opset9::Sigmoid>(),
-    CreateUnaryFactory<ov::opset9::Sign>(),     CreateUnaryFactory<ov::opset9::Sin>(),
-    CreateUnaryFactory<ov::opset9::Sinh>(),     CreateUnaryFactory<ov::opset9::SoftSign>(),
-    CreateUnaryFactory<ov::opset9::Sqrt>(),     CreateUnaryFactory<ov::opset9::Tan>(),
-    CreateUnaryFactory<ov::opset9::Tanh>()};
+    CREATE_UNARY_FACTORY(Clamp),    CREATE_UNARY_FACTORY(Elu),
+    CREATE_UNARY_FACTORY(SoftPlus), CREATE_UNARY_FACTORY(LogicalNot),
+    CREATE_UNARY_FACTORY(Convert),  CREATE_UNARY_FACTORY(Abs),
+    CREATE_UNARY_FACTORY(Acos),     CREATE_UNARY_FACTORY(Asin),
+    CREATE_UNARY_FACTORY(Asinh),    CREATE_UNARY_FACTORY(Atan),
+    CREATE_UNARY_FACTORY(Ceiling),  CREATE_UNARY_FACTORY(Cos),
+    CREATE_UNARY_FACTORY(Cosh),     CREATE_UNARY_FACTORY(Erf),
+    CREATE_UNARY_FACTORY(Exp),      CREATE_UNARY_FACTORY(Gelu),
+    CREATE_UNARY_FACTORY(HSigmoid), CREATE_UNARY_FACTORY(HSwish),
+    CREATE_UNARY_FACTORY(Log),      CREATE_UNARY_FACTORY(Negative),
+    CREATE_UNARY_FACTORY(Relu),     CREATE_UNARY_FACTORY(Sigmoid),
+    CREATE_UNARY_FACTORY(Sign),     CREATE_UNARY_FACTORY(Sin),
+    CREATE_UNARY_FACTORY(Sinh),     CREATE_UNARY_FACTORY(SoftSign),
+    CREATE_UNARY_FACTORY(Sqrt),     CREATE_UNARY_FACTORY(Tan),
+    CREATE_UNARY_FACTORY(Tanh)};
 
 std::vector<size_t> unary_operations_numbers = {1, 10};
 
@@ -384,86 +415,83 @@ INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingUnaryForwardTestSuite,
     TransposeSinkingUnaryTestFixture,
     ::testing::Combine(::testing::ValuesIn(unary_factories),
-                       ::testing::Values(CreatePassFactory<ov::pass::TransposeSinkingUnaryForward>()),
+                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingUnaryForward)),
                        ::testing::ValuesIn(unary_operations_numbers),
                        ::testing::Values(CreateFunctionTransposeBefore),
                        ::testing::Values(CreateFunctionTransposeAfter),
                        ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)));
+                       ::testing::Values(ov::element::f32)),
+                       TransposeSinkingUnaryTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingUnaryBackwardTestSuite,
     TransposeSinkingUnaryTestFixture,
     ::testing::Combine(::testing::ValuesIn(unary_factories),
-                       ::testing::Values(CreatePassFactory<ov::pass::TransposeSinkingUnaryBackward>()),
+                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingUnaryBackward)),
                        ::testing::ValuesIn(unary_operations_numbers),
                        ::testing::Values(CreateFunctionTransposeAfter),
                        ::testing::Values(CreateFunctionTransposeBefore),
                        ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)));
+                       ::testing::Values(ov::element::f32)),
+                       TransposeSinkingUnaryTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingUnaryForwardMultConsumersTestSuiteLastNodeReshape,
     TransposeSinkingUnaryTestFixture,
     ::testing::Combine(::testing::ValuesIn(unary_factories),
-                       ::testing::Values(CreatePassFactory<ov::pass::TransposeSinkingUnaryForward>()),
+                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingUnaryForward)),
                        ::testing::ValuesIn(unary_operations_numbers),
                        ::testing::Values(mult_consumers_last_node::with_reshape::CreateFunctionTransposeBefore),
                        ::testing::Values(mult_consumers_last_node::with_reshape::CreateFunctionTransposeAfter),
                        ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)));
+                       ::testing::Values(ov::element::f32)),
+                       TransposeSinkingUnaryTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingUnaryBackwardMultConsumersTestSuiteLastNodeReshape,
     TransposeSinkingUnaryTestFixture,
     ::testing::Combine(::testing::ValuesIn(unary_factories),
-                       ::testing::Values(CreatePassFactory<ov::pass::TransposeSinkingUnaryBackward>()),
+                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingUnaryBackward)),
                        ::testing::ValuesIn(unary_operations_numbers),
                        ::testing::Values(mult_consumers_last_node::with_reshape::CreateFunctionTransposeAfter),
                        ::testing::Values(mult_consumers_last_node::with_reshape::CreateFunctionTransposeBefore),
                        ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)));
+                       ::testing::Values(ov::element::f32)),
+                       TransposeSinkingUnaryTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingUnaryForwardMultConsumersTestSuiteLastNodeEltwise,
     TransposeSinkingUnaryTestFixture,
     ::testing::Combine(::testing::ValuesIn(unary_factories),
-                       ::testing::Values(CreatePassFactory<ov::pass::TransposeSinkingUnaryForward>()),
+                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingUnaryForward)),
                        ::testing::ValuesIn(unary_operations_numbers),
                        ::testing::Values(mult_consumers_last_node::with_eltwise::CreateFunctionTransposeBefore),
                        ::testing::Values(mult_consumers_last_node::with_eltwise::CreateFunctionTransposeAfter),
                        ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)));
-
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingUnaryBackwardMultConsumersTestSuiteLastNodeEltwise,
-    TransposeSinkingUnaryTestFixture,
-    ::testing::Combine(::testing::ValuesIn(unary_factories),
-                       ::testing::Values(CreatePassFactory<ov::pass::TransposeSinkingUnaryBackward>()),
-                       ::testing::ValuesIn(unary_operations_numbers),
-                       ::testing::Values(mult_consumers_last_node::with_eltwise::CreateFunctionTransposeAfter),
-                       ::testing::Values(mult_consumers_last_node::with_eltwise::CreateFunctionTransposeBefore),
-                       ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)));
+                       ::testing::Values(ov::element::f32)),
+                       TransposeSinkingUnaryTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingUnaryForwardMultConsumersTestSuiteFirstNode,
     TransposeSinkingUnaryTestFixture,
     ::testing::Combine(::testing::ValuesIn(unary_factories),
-                       ::testing::Values(CreatePassFactory<ov::pass::TransposeSinkingUnaryForward>()),
+                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingUnaryForward)),
                        ::testing::ValuesIn(unary_operations_numbers),
                        ::testing::Values(mult_consumers_first_node::forward::CreateFunction),
                        ::testing::Values(mult_consumers_first_node::forward::CreateReferenceFunction),
                        ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)));
+                       ::testing::Values(ov::element::f32)),
+                       TransposeSinkingUnaryTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingUnaryBackwardMultConsumersTestSuiteFirstNode,
     TransposeSinkingUnaryTestFixture,
     ::testing::Combine(::testing::ValuesIn(unary_factories),
-                       ::testing::Values(CreatePassFactory<ov::pass::TransposeSinkingUnaryBackward>()),
+                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingUnaryBackward)),
                        ::testing::ValuesIn(unary_operations_numbers),
                        ::testing::Values(mult_consumers_first_node::backward::CreateFunction),
-                       ::testing::Values(mult_consumers_first_node::backward::CreateReferenceFunction),
+                       ::testing::Values(mult_consumers_first_node::backward::CreateFunction),
                        ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)));
+                       ::testing::Values(ov::element::f32)),
+                       TransposeSinkingUnaryTestFixture::get_test_name);
+

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_unary_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_unary_test.cpp
@@ -12,10 +12,11 @@
 #include "common_test_utils/ngraph_test_utils.hpp"
 #include "gtest/gtest.h"
 
+using namespace ov;
 using namespace ov::opset9;
 
 namespace {
-std::string to_string(const ov::Shape& shape) {
+std::string to_string(const Shape& shape) {
     std::ostringstream result;
     result << "{";
     for (size_t idx = 0; idx < shape.size(); ++idx) {
@@ -39,6 +40,7 @@ public:
     const std::string& getTypeName() const {
         return type_name_;
     }
+
 private:
     const std::string type_name_;
 };
@@ -66,7 +68,7 @@ NodePtr UnaryFactory<Clamp>::create(NodePtr parent_node) const {
 
 template <>
 NodePtr UnaryFactory<Convert>::create(NodePtr parent_node) const {
-    return std::make_shared<Convert>(parent_node, ov::element::f64);
+    return std::make_shared<Convert>(parent_node, element::f64);
 }
 
 template <typename UnaryT>
@@ -88,7 +90,6 @@ public:
 private:
     const std::string type_name_;
 };
-
 
 using PassFactoryPtr = std::shared_ptr<IPassFactory>;
 
@@ -112,19 +113,18 @@ using FloatPtr = std::unique_ptr<float[]>;
 
 using CreateGraphF = std::function<std::shared_ptr<ov::Model>(UnaryFactoryPtr unary_factory,
                                                               size_t num_unary_ops,
-                                                              const ov::Shape& input_shape,
-                                                              ov::element::Type input_type)>;
+                                                              const Shape& input_shape,
+                                                              element::Type input_type)>;
 
 using TestParams = std::tuple<UnaryFactoryPtr,
                               PassFactoryPtr,
-                              size_t,             /* num_unary_ops */
-                              CreateGraphF,       /* model_factory */
-                              CreateGraphF,       /* reference_model_factory */
-                              ov::Shape,          /* input shape */
-                              ov::element::Type>; /* input type */
+                              size_t,         /* num_unary_ops */
+                              CreateGraphF,   /* model_factory */
+                              CreateGraphF,   /* reference_model_factory */
+                              Shape,          /* input shape */
+                              element::Type>; /* input type */
 
-class TransposeSinkingUnaryTestFixture : public ::testing::WithParamInterface<TestParams>,
-                                         public TransformationTestsF {
+class TransposeSinkingUnaryTestFixture : public ::testing::WithParamInterface<TestParams>, public TransformationTestsF {
 public:
     static std::string get_test_name(const testing::TestParamInfo<TestParams>& obj) {
         UnaryFactoryPtr unary_factory;
@@ -132,15 +132,15 @@ public:
         size_t num_unary_ops;
         CreateGraphF model_factory;
         CreateGraphF reference_model_factory;
-        ov::Shape input_shape;
-        ov::element::Type input_type;
+        Shape input_shape;
+        element::Type input_type;
         std::tie(unary_factory,
-             pass_factory,
-             num_unary_ops,
-             model_factory,
-             reference_model_factory,
-             input_shape,
-             input_type) = obj.param;
+                 pass_factory,
+                 num_unary_ops,
+                 model_factory,
+                 reference_model_factory,
+                 input_shape,
+                 input_type) = obj.param;
 
         std::ostringstream test_name;
         test_name << "unaryFactory=" << unary_factory->getTypeName() << "/";
@@ -163,11 +163,11 @@ std::string GetFinalNodeName(std::shared_ptr<ov::Model> model, int index = 0) {
 
 std::shared_ptr<ov::Model> CreateFunctionTransposeBefore(UnaryFactoryPtr unary_factory,
                                                          size_t num_unary_ops,
-                                                         const ov::Shape& input_shape,
-                                                         ov::element::Type input_type) {
+                                                         const Shape& input_shape,
+                                                         element::Type input_type) {
     auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
     NodePtr in_op = transpose0;
@@ -180,8 +180,8 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeBefore(UnaryFactoryPtr unary_f
 
 std::shared_ptr<ov::Model> CreateFunctionTransposeAfter(UnaryFactoryPtr unary_factory,
                                                         size_t num_unary_ops,
-                                                        const ov::Shape& input_shape,
-                                                        ov::element::Type input_type) {
+                                                        const Shape& input_shape,
+                                                        element::Type input_type) {
     auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     NodePtr in_op = X;
@@ -189,15 +189,15 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeAfter(UnaryFactoryPtr unary_fa
         in_op = unary_factory->create(in_op);
     }
 
-    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
 
     return std::make_shared<ov::Model>(transpose0, ov::ParameterVector{X});
 }
 
-static NodePtr CreateReshape(NodePtr parent_node, const ov::Shape& input_shape) {
+static NodePtr CreateReshape(NodePtr parent_node, const Shape& input_shape) {
     const size_t mul = std::accumulate(input_shape.begin(), input_shape.end(), (size_t)1, std::multiplies<size_t>());
-    auto reshape_const = std::make_shared<Constant>(ov::element::u64, ov::Shape{1}, ov::Shape{mul});
+    auto reshape_const = std::make_shared<Constant>(element::u64, Shape{1}, Shape{mul});
     return std::make_shared<Reshape>(parent_node, reshape_const, false);
 }
 
@@ -206,8 +206,8 @@ namespace with_reshape {
 
 std::shared_ptr<ov::Model> CreateFunctionTransposeAfter(UnaryFactoryPtr unary_factory,
                                                         size_t num_unary_ops,
-                                                        const ov::Shape& input_shape,
-                                                        ov::element::Type input_type) {
+                                                        const Shape& input_shape,
+                                                        element::Type input_type) {
     auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     NodePtr in_op = X;
@@ -215,7 +215,7 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeAfter(UnaryFactoryPtr unary_fa
         in_op = unary_factory->create(in_op);
     }
 
-    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
 
     auto reshape1 = CreateReshape(transpose0, input_shape);
@@ -226,11 +226,11 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeAfter(UnaryFactoryPtr unary_fa
 
 std::shared_ptr<ov::Model> CreateFunctionTransposeBefore(UnaryFactoryPtr unary_factory,
                                                          size_t num_unary_ops,
-                                                         const ov::Shape& input_shape,
-                                                         ov::element::Type input_type) {
+                                                         const Shape& input_shape,
+                                                         element::Type input_type) {
     auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
     NodePtr in_op = transpose0;
@@ -249,8 +249,8 @@ namespace with_eltwise {
 
 std::shared_ptr<ov::Model> CreateFunctionTransposeAfter(UnaryFactoryPtr unary_factory,
                                                         size_t num_unary_ops,
-                                                        const ov::Shape& input_shape,
-                                                        ov::element::Type input_type) {
+                                                        const Shape& input_shape,
+                                                        element::Type input_type) {
     auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     NodePtr in_op = X;
@@ -260,12 +260,12 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeAfter(UnaryFactoryPtr unary_fa
 
     auto sinh = std::make_shared<Sinh>(in_op);
 
-    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose0 = std::make_shared<Transpose>(sinh, ng_order0);
 
     auto cosh = std::make_shared<Cosh>(in_op);
 
-    auto ng_order1 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto ng_order1 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose1 = std::make_shared<Transpose>(cosh, ng_order1);
 
     return std::make_shared<ov::Model>(ov::OutputVector{transpose0, transpose1}, ov::ParameterVector{X});
@@ -273,11 +273,11 @@ std::shared_ptr<ov::Model> CreateFunctionTransposeAfter(UnaryFactoryPtr unary_fa
 
 std::shared_ptr<ov::Model> CreateFunctionTransposeBefore(UnaryFactoryPtr unary_factory,
                                                          size_t num_unary_ops,
-                                                         const ov::Shape& input_shape,
-                                                         ov::element::Type input_type) {
+                                                         const Shape& input_shape,
+                                                         element::Type input_type) {
     auto X = std::make_shared<Parameter>(input_type, input_shape);
 
-    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose0 = std::make_shared<Transpose>(X, ng_order0);
 
     NodePtr in_op = transpose0;
@@ -299,8 +299,8 @@ namespace backward {
 
 std::shared_ptr<ov::Model> CreateFunction(UnaryFactoryPtr unary_factory,
                                           size_t num_unary_ops,
-                                          const ov::Shape& input_shape,
-                                          ov::element::Type input_type) {
+                                          const Shape& input_shape,
+                                          element::Type input_type) {
     auto X = std::make_shared<Parameter>(input_type, input_shape);
     ov::OutputVector outputs;
 
@@ -311,7 +311,7 @@ std::shared_ptr<ov::Model> CreateFunction(UnaryFactoryPtr unary_factory,
         outputs.push_back(cosh);
     }
 
-    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose0 = std::make_shared<Transpose>(in_op, ng_order0);
     outputs.push_back(transpose0);
 
@@ -324,13 +324,13 @@ namespace forward {
 
 std::shared_ptr<ov::Model> CreateFunction(UnaryFactoryPtr unary_factory,
                                           size_t num_unary_ops,
-                                          const ov::Shape& input_shape,
-                                          ov::element::Type input_type) {
+                                          const Shape& input_shape,
+                                          element::Type input_type) {
     auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     auto sinh = std::make_shared<Sinh>(X);
 
-    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose0 = std::make_shared<Transpose>(sinh, ng_order0);
 
     auto reshape = CreateReshape(transpose0, input_shape);
@@ -345,13 +345,13 @@ std::shared_ptr<ov::Model> CreateFunction(UnaryFactoryPtr unary_factory,
 
 std::shared_ptr<ov::Model> CreateReferenceFunction(UnaryFactoryPtr unary_factory,
                                                    size_t num_unary_ops,
-                                                   const ov::Shape& input_shape,
-                                                   ov::element::Type input_type) {
+                                                   const Shape& input_shape,
+                                                   element::Type input_type) {
     auto X = std::make_shared<Parameter>(input_type, input_shape);
 
     auto sinh = std::make_shared<Sinh>(X);
 
-    auto ng_order0 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto ng_order0 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose0 = std::make_shared<Transpose>(sinh, ng_order0);
     auto reshape = CreateReshape(transpose0, input_shape);
 
@@ -360,7 +360,7 @@ std::shared_ptr<ov::Model> CreateReferenceFunction(UnaryFactoryPtr unary_factory
         in_op = unary_factory->create(in_op);
     }
 
-    auto ng_order1 = std::make_shared<Constant>(ov::element::u64, ov::Shape{4}, ov::Shape{0, 2, 3, 1});
+    auto ng_order1 = std::make_shared<Constant>(element::u64, Shape{4}, Shape{0, 2, 3, 1});
     auto transpose1 = std::make_shared<Transpose>(in_op, ng_order1);
 
     return std::make_shared<ov::Model>(ov::OutputVector{transpose1, reshape}, ov::ParameterVector{X});
@@ -370,21 +370,16 @@ std::shared_ptr<ov::Model> CreateReferenceFunction(UnaryFactoryPtr unary_factory
 }  // namespace mult_consumers_first_node
 
 std::vector<UnaryFactoryPtr> unary_factories = {
-    CREATE_UNARY_FACTORY(Clamp),    CREATE_UNARY_FACTORY(Elu),
-    CREATE_UNARY_FACTORY(SoftPlus), CREATE_UNARY_FACTORY(LogicalNot),
-    CREATE_UNARY_FACTORY(Convert),  CREATE_UNARY_FACTORY(Abs),
-    CREATE_UNARY_FACTORY(Acos),     CREATE_UNARY_FACTORY(Asin),
-    CREATE_UNARY_FACTORY(Asinh),    CREATE_UNARY_FACTORY(Atan),
-    CREATE_UNARY_FACTORY(Ceiling),  CREATE_UNARY_FACTORY(Cos),
-    CREATE_UNARY_FACTORY(Cosh),     CREATE_UNARY_FACTORY(Erf),
-    CREATE_UNARY_FACTORY(Exp),      CREATE_UNARY_FACTORY(Gelu),
-    CREATE_UNARY_FACTORY(HSigmoid), CREATE_UNARY_FACTORY(HSwish),
-    CREATE_UNARY_FACTORY(Log),      CREATE_UNARY_FACTORY(Negative),
-    CREATE_UNARY_FACTORY(Relu),     CREATE_UNARY_FACTORY(Sigmoid),
-    CREATE_UNARY_FACTORY(Sign),     CREATE_UNARY_FACTORY(Sin),
-    CREATE_UNARY_FACTORY(Sinh),     CREATE_UNARY_FACTORY(SoftSign),
-    CREATE_UNARY_FACTORY(Sqrt),     CREATE_UNARY_FACTORY(Tan),
-    CREATE_UNARY_FACTORY(Tanh)};
+    CREATE_UNARY_FACTORY(Clamp),      CREATE_UNARY_FACTORY(Elu),      CREATE_UNARY_FACTORY(SoftPlus),
+    CREATE_UNARY_FACTORY(LogicalNot), CREATE_UNARY_FACTORY(Convert),  CREATE_UNARY_FACTORY(Abs),
+    CREATE_UNARY_FACTORY(Acos),       CREATE_UNARY_FACTORY(Asin),     CREATE_UNARY_FACTORY(Asinh),
+    CREATE_UNARY_FACTORY(Atan),       CREATE_UNARY_FACTORY(Ceiling),  CREATE_UNARY_FACTORY(Cos),
+    CREATE_UNARY_FACTORY(Cosh),       CREATE_UNARY_FACTORY(Erf),      CREATE_UNARY_FACTORY(Exp),
+    CREATE_UNARY_FACTORY(Gelu),       CREATE_UNARY_FACTORY(HSigmoid), CREATE_UNARY_FACTORY(HSwish),
+    CREATE_UNARY_FACTORY(Log),        CREATE_UNARY_FACTORY(Negative), CREATE_UNARY_FACTORY(Relu),
+    CREATE_UNARY_FACTORY(Sigmoid),    CREATE_UNARY_FACTORY(Sign),     CREATE_UNARY_FACTORY(Sin),
+    CREATE_UNARY_FACTORY(Sinh),       CREATE_UNARY_FACTORY(SoftSign), CREATE_UNARY_FACTORY(Sqrt),
+    CREATE_UNARY_FACTORY(Tan),        CREATE_UNARY_FACTORY(Tanh)};
 
 std::vector<size_t> unary_operations_numbers = {1, 10};
 
@@ -396,8 +391,8 @@ TEST_P(TransposeSinkingUnaryTestFixture, CompareFunctions) {
     size_t num_unary_ops;
     CreateGraphF model_factory;
     CreateGraphF reference_model_factory;
-    ov::Shape input_shape;
-    ov::element::Type input_type;
+    Shape input_shape;
+    element::Type input_type;
     std::tie(unary_factory,
              pass_factory,
              num_unary_ops,
@@ -411,29 +406,27 @@ TEST_P(TransposeSinkingUnaryTestFixture, CompareFunctions) {
     pass_factory->registerPass(manager);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingUnaryForwardTestSuite,
-    TransposeSinkingUnaryTestFixture,
-    ::testing::Combine(::testing::ValuesIn(unary_factories),
-                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingUnaryForward)),
-                       ::testing::ValuesIn(unary_operations_numbers),
-                       ::testing::Values(CreateFunctionTransposeBefore),
-                       ::testing::Values(CreateFunctionTransposeAfter),
-                       ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)),
-                       TransposeSinkingUnaryTestFixture::get_test_name);
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingUnaryForwardTestSuite,
+                         TransposeSinkingUnaryTestFixture,
+                         ::testing::Combine(::testing::ValuesIn(unary_factories),
+                                            ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingUnaryForward)),
+                                            ::testing::ValuesIn(unary_operations_numbers),
+                                            ::testing::Values(CreateFunctionTransposeBefore),
+                                            ::testing::Values(CreateFunctionTransposeAfter),
+                                            ::testing::Values(Shape{1, 96, 55, 55}),
+                                            ::testing::Values(element::f32)),
+                         TransposeSinkingUnaryTestFixture::get_test_name);
 
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingUnaryBackwardTestSuite,
-    TransposeSinkingUnaryTestFixture,
-    ::testing::Combine(::testing::ValuesIn(unary_factories),
-                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingUnaryBackward)),
-                       ::testing::ValuesIn(unary_operations_numbers),
-                       ::testing::Values(CreateFunctionTransposeAfter),
-                       ::testing::Values(CreateFunctionTransposeBefore),
-                       ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)),
-                       TransposeSinkingUnaryTestFixture::get_test_name);
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingUnaryBackwardTestSuite,
+                         TransposeSinkingUnaryTestFixture,
+                         ::testing::Combine(::testing::ValuesIn(unary_factories),
+                                            ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingUnaryBackward)),
+                                            ::testing::ValuesIn(unary_operations_numbers),
+                                            ::testing::Values(CreateFunctionTransposeAfter),
+                                            ::testing::Values(CreateFunctionTransposeBefore),
+                                            ::testing::Values(Shape{1, 96, 55, 55}),
+                                            ::testing::Values(element::f32)),
+                         TransposeSinkingUnaryTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingUnaryForwardMultConsumersTestSuiteLastNodeReshape,
@@ -443,9 +436,9 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::ValuesIn(unary_operations_numbers),
                        ::testing::Values(mult_consumers_last_node::with_reshape::CreateFunctionTransposeBefore),
                        ::testing::Values(mult_consumers_last_node::with_reshape::CreateFunctionTransposeAfter),
-                       ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)),
-                       TransposeSinkingUnaryTestFixture::get_test_name);
+                       ::testing::Values(Shape{1, 96, 55, 55}),
+                       ::testing::Values(element::f32)),
+    TransposeSinkingUnaryTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingUnaryBackwardMultConsumersTestSuiteLastNodeReshape,
@@ -455,9 +448,9 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::ValuesIn(unary_operations_numbers),
                        ::testing::Values(mult_consumers_last_node::with_reshape::CreateFunctionTransposeAfter),
                        ::testing::Values(mult_consumers_last_node::with_reshape::CreateFunctionTransposeBefore),
-                       ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)),
-                       TransposeSinkingUnaryTestFixture::get_test_name);
+                       ::testing::Values(Shape{1, 96, 55, 55}),
+                       ::testing::Values(element::f32)),
+    TransposeSinkingUnaryTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingUnaryForwardMultConsumersTestSuiteLastNodeEltwise,
@@ -467,9 +460,9 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::ValuesIn(unary_operations_numbers),
                        ::testing::Values(mult_consumers_last_node::with_eltwise::CreateFunctionTransposeBefore),
                        ::testing::Values(mult_consumers_last_node::with_eltwise::CreateFunctionTransposeAfter),
-                       ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)),
-                       TransposeSinkingUnaryTestFixture::get_test_name);
+                       ::testing::Values(Shape{1, 96, 55, 55}),
+                       ::testing::Values(element::f32)),
+    TransposeSinkingUnaryTestFixture::get_test_name);
 
 INSTANTIATE_TEST_SUITE_P(
     TransposeSinkingUnaryForwardMultConsumersTestSuiteFirstNode,
@@ -479,19 +472,17 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::ValuesIn(unary_operations_numbers),
                        ::testing::Values(mult_consumers_first_node::forward::CreateFunction),
                        ::testing::Values(mult_consumers_first_node::forward::CreateReferenceFunction),
-                       ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)),
-                       TransposeSinkingUnaryTestFixture::get_test_name);
+                       ::testing::Values(Shape{1, 96, 55, 55}),
+                       ::testing::Values(element::f32)),
+    TransposeSinkingUnaryTestFixture::get_test_name);
 
-INSTANTIATE_TEST_SUITE_P(
-    TransposeSinkingUnaryBackwardMultConsumersTestSuiteFirstNode,
-    TransposeSinkingUnaryTestFixture,
-    ::testing::Combine(::testing::ValuesIn(unary_factories),
-                       ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingUnaryBackward)),
-                       ::testing::ValuesIn(unary_operations_numbers),
-                       ::testing::Values(mult_consumers_first_node::backward::CreateFunction),
-                       ::testing::Values(mult_consumers_first_node::backward::CreateFunction),
-                       ::testing::Values(ov::Shape{1, 96, 55, 55}),
-                       ::testing::Values(ov::element::f32)),
-                       TransposeSinkingUnaryTestFixture::get_test_name);
-
+INSTANTIATE_TEST_SUITE_P(TransposeSinkingUnaryBackwardMultConsumersTestSuiteFirstNode,
+                         TransposeSinkingUnaryTestFixture,
+                         ::testing::Combine(::testing::ValuesIn(unary_factories),
+                                            ::testing::Values(CREATE_PASS_FACTORY(TransposeSinkingUnaryBackward)),
+                                            ::testing::ValuesIn(unary_operations_numbers),
+                                            ::testing::Values(mult_consumers_first_node::backward::CreateFunction),
+                                            ::testing::Values(mult_consumers_first_node::backward::CreateFunction),
+                                            ::testing::Values(Shape{1, 96, 55, 55}),
+                                            ::testing::Values(element::f32)),
+                         TransposeSinkingUnaryTestFixture::get_test_name);


### PR DESCRIPTION
### Details:
 -  TransposeSinking for binary elementwise, Concat, Split for multiple consumers case
 - wrote new unit tests for multi consumers cases
 - reorganize exited unit tests
 - TransposeSinking for PRelu

### Tickets:
 - 96628
 - 99240
 - 92223