### PR TITLE
Optimize reference node

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/reference.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reference.cpp
@@ -32,6 +32,25 @@ Reference::Reference(const std::shared_ptr<ngraph::Node>& op, const dnnl::engine
     if (ov::is_type<ngraph::op::v8::RandomUniform>(ngraphOp)) {
         constant = ConstantType::NoConst;
     }
+
+    // rt_info "inputsSupportBF16"/"outputsSupportBF16"
+    // indicates that the reference implementation support
+    // BF16 data type at runtime.
+    const auto & rtInfo = ngraphOp->get_rt_info();
+    auto it = rtInfo.find("inputsSupportBF16");
+    if (it != rtInfo.end()) {
+        inputsSupportBF16 = it->second.as<std::set<int>>();
+    }
+    it = rtInfo.find("outputsSupportBF16");
+    if (it != rtInfo.end()) {
+        outputsSupportBF16 = it->second.as<std::set<int>>();
+    }
+    it = rtInfo.find("internalDynamismShapeInfer");
+    if (it != rtInfo.end()) {
+        internalDynamismShapeInfer = it->second.as<bool>();
+    } else {
+        internalDynamismShapeInfer = true;
+    }
 }
 
 void Reference::getSupportedDescriptors() {}
@@ -40,36 +59,65 @@ void Reference::initSupportedPrimitiveDescriptors() {
     if (!supportedPrimitiveDescriptors.empty())
         return;
 
-    std::vector<PortConfigurator> inputConfigurators;
-    inputConfigurators.reserve(inputShapes.size());
-    for (size_t i = 0; i < inputShapes.size(); i++) {
-        inputConfigurators.emplace_back(LayoutType::ncsp, convertPrecision(ngraphOp->get_input_element_type(i)), inputShapes[i]);
-    }
+    auto addConfig = [&](bool useBF16) {
+        std::vector<PortConfigurator> inputConfigurators;
+        inputConfigurators.reserve(inputShapes.size());
+        for (size_t i = 0; i < inputShapes.size(); i++) {
+            auto prec = convertPrecision(ngraphOp->get_input_element_type(i));
+            if (useBF16 && inputsSupportBF16.count(i)) {
+                prec = Precision::BF16;
+            }
+            inputConfigurators.emplace_back(LayoutType::ncsp, prec, inputShapes[i]);
+        }
 
-    std::vector<PortConfigurator> outputConfigurators;
-    outputConfigurators.reserve(inputShapes.size());
-    for (size_t i = 0; i < outputShapes.size(); i++) {
-        outputConfigurators.emplace_back(LayoutType::ncsp, convertPrecision(ngraphOp->get_output_element_type(i)), outputShapes[i]);
-    }
+        std::vector<PortConfigurator> outputConfigurators;
+        outputConfigurators.reserve(inputShapes.size());
+        for (size_t i = 0; i < outputShapes.size(); i++) {
+            auto prec = convertPrecision(ngraphOp->get_output_element_type(i));
+            if (useBF16 && outputsSupportBF16.count(i)) {
+                prec = Precision::BF16;
+            }
+            outputConfigurators.emplace_back(LayoutType::ncsp, prec, outputShapes[i]);
+        }
 
-    addSupportedPrimDesc(inputConfigurators, outputConfigurators, impl_desc_type::ref);
+        addSupportedPrimDesc(inputConfigurators, outputConfigurators, impl_desc_type::ref);
+    };
+
+    addConfig(false);
+
+    if (!inputsSupportBF16.empty() || !outputsSupportBF16.empty()) {
+        addConfig(true);
+    }
 }
 
 void Reference::createPrimitive() {}
 
 void Reference::execute(dnnl::stream strm) {
+    auto getTensor = [this](TensorCache& tensorCache, int port, const Memory& mem) -> const ov::Tensor& {
+        auto prec = mem.getDesc().getPrecision();
+        auto dims = mem.getStaticDims();
+        void* ptr = mem.GetPtr();
+        auto it = tensorCache.find(port);
+        if (it != tensorCache.end()) {
+            TensorEntry& tentry = it->second;
+            // cache hit
+            if (std::get<0>(tentry) == prec && std::get<1>(tentry) == dims && std::get<2>(tentry) == ptr)
+                return std::get<3>(tentry);
+        }
+        tensorCache[port] = TensorEntry{prec, dims, ptr, ov::Tensor(convertPrecision(prec), dims, ptr)};
+        return std::get<3>(tensorCache[port]);
+    };
+
     ov::TensorVector inputs;
     for (size_t i = 0; i < inputShapes.size(); i++) {
-        void *srcDataPtr = getParentEdgesAtPort(i)[0]->getMemory().GetPtr();
-        inputs.push_back(ov::Tensor(ngraphOp->get_input_element_type(i),
-                                             getParentEdgesAtPort(i)[0]->getMemory().getStaticDims(), srcDataPtr));
+        const Memory& mem = getParentEdgesAtPort(i)[0]->getMemory();
+        inputs.push_back(getTensor(inputTensorCache, i, mem));
     }
 
     ov::TensorVector outputs;
     for (size_t i = 0; i < outputShapes.size(); i++) {
-        void *dstDataPtr = getChildEdgesAtPort(i)[0]->getMemory().GetPtr();
-        outputs.push_back(ov::Tensor(ngraphOp->get_output_element_type(i),
-                                              getChildEdgesAtPort(i)[0]->getMemory().getStaticDims(), dstDataPtr));
+        const Memory& mem = getChildEdgesAtPort(i)[0]->getMemory();
+        outputs.push_back(getTensor(outputTensorCache, i, mem));
     }
 
     if (!ngraphOp->evaluate(outputs, inputs)) {
@@ -86,7 +134,9 @@ bool Reference::created() const {
 }
 
 bool Reference::needShapeInfer() const {
-    return true;
+    if (internalDynamismShapeInfer)
+        return true;
+    return Node::needShapeInfer();
 }
 
 }   // namespace node

--- a/src/plugins/intel_cpu/src/nodes/reference.h
+++ b/src/plugins/intel_cpu/src/nodes/reference.h
@@ -27,6 +27,16 @@ public:
 private:
     const std::shared_ptr<ngraph::Node> ngraphOp;
     const std::string additionalErrorMessage;
+
+    bool internalDynamismShapeInfer;
+    std::set<int> inputsSupportBF16;
+    std::set<int> outputsSupportBF16;
+
+    using TensorEntry = std::tuple<InferenceEngine::Precision, VectorDims, void *, ov::Tensor>;
+    using TensorCache = std::map<int, TensorEntry>;
+
+    TensorCache inputTensorCache;
+    TensorCache outputTensorCache;
 };
 
 }   // namespace node


### PR DESCRIPTION
### Details:
 - Add support to rt info `inputsSupportBF16`/`outputsSupportBF16`, so performance of evaluate() method from customer extension can benefits from BF16 input/output tensor.
 - Add support to rt info `internalDynamismShapeInfer`, so overhead of shape-infer can be optimized if customer's extension is not  of internal-dynamism type;
 - Optimized overhead of wrapping CPU plugin memory into OpenVINO tensor for calling evaluate() by introducing a size-1 cache, when evaluate() is light-weighted, this overhead could be bottleneck.

### Tickets:
 - CVS-85825
