### PR TITLE
Add debug feature: DisableMemoryPool

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/debug_configuration.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/debug_configuration.hpp
@@ -52,6 +52,7 @@ public:
     int serialize_compile;                  // Serialize creating primitives and compiling kernels
     std::string forced_impl_type;           // Force implementation type either ocl or onednn
     int max_kernels_per_batch;              // Maximum number of kernels in a batch during compiling kernels
+    bool disable_memory_pool;               // Disable memory pool. If false, memory could not be re-used.
     static const debug_configuration *get_instance();
     bool is_dumped_layer(const std::string& layerName, bool is_output = false) const;
 };

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/engine_configuration.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/engine_configuration.hpp
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <thread>
 #include <threading/ie_cpu_streams_executor.hpp>
+#include "intel_gpu/runtime/debug_configuration.hpp"
 
 namespace cldnn {
 
@@ -103,7 +104,12 @@ struct engine_configuration {
         , use_unified_shared_memory(use_unified_shared_memory)
         , kernels_cache_path(kernels_cache_path)
         , throughput_streams(throughput_streams)
-        , tuning_cache_path(tuning_cache_path) { }
+        , tuning_cache_path(tuning_cache_path) {
+            GPU_DEBUG_GET_INSTANCE(debug_config);
+            GPU_DEBUG_IF(debug_config->disable_memory_pool) {
+                this->use_memory_pool = false;
+            }
+        }
 };
 
 /// @}

--- a/src/plugins/intel_gpu/src/runtime/debug_configuration.cpp
+++ b/src/plugins/intel_gpu/src/runtime/debug_configuration.cpp
@@ -124,6 +124,7 @@ static void print_help_messages() {
                               " For primitives, fc:onednn, fc:ocl, do:cpu, do:ocl, reduce:onednn, reduce:ocl, concat:onednn,"
                               " and concat:ocl are supported");
     message_list.emplace_back("OV_GPU_MaxKernelsPerBatch", "Maximum number of kernels in a batch during compiling kernels");
+    message_list.emplace_back("OV_GPU_DisableMemoryPool", "Disable memory pool. If false, memory could not be re-used");
 
     auto max_name_length_item = std::max_element(message_list.begin(), message_list.end(),
         [](std::pair<std::string, std::string>& a, std::pair<std::string, std::string>& b){
@@ -181,6 +182,7 @@ debug_configuration::debug_configuration()
     get_gpu_debug_env_var("SerialCompile", serialize_compile);
     get_gpu_debug_env_var("ForceImplType", forced_impl_type);
     get_gpu_debug_env_var("MaxKernelsPerBatch", max_kernels_per_batch);
+    get_gpu_debug_env_var("DisableMemoryPool", disable_memory_pool);
 
     if (help > 0) {
         print_help_messages();


### PR DESCRIPTION
add debug feature to on/off memory pool.
If off, it can not use memory re-use.