### PR TITLE
[GPU][DG2] Fix fusings_gpu/conv_int8_asymmetric_data.basic/0

### DIFF
--- a/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
+++ b/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
@@ -233,7 +233,11 @@ public:
     }
 
     layout get_activations_zp_layout(T& p) {
-        return layout{ p.data_type, p.default_format, tensor{1, p.in_shape.feature[0], 1, 1} };
+        auto shape = tensor{1, p.in_shape.feature[0], 1, 1};
+        //onednn doesn't support per-channel azp in convolution
+        if(engine.get_device_info().supports_immad)
+            shape.feature[0]=1;
+        return layout{ p.data_type, p.default_format, shape };
     }
 
     layout get_single_element_layout(T& p) {

--- a/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
+++ b/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
@@ -234,10 +234,10 @@ public:
 
     layout get_activations_zp_layout(T& p) {
         auto shape = tensor{1, p.in_shape.feature[0], 1, 1};
-        //onednn doesn't support per-channel azp in convolution
-        if(engine.get_device_info().supports_immad)
-            shape.feature[0]=1;
-        return layout{ p.data_type, p.default_format, shape };
+        // onednn doesn't support per-channel azp in convolution
+        if (engine.get_device_info().supports_immad)
+            shape.feature[0] = 1;
+        return layout{p.data_type, p.default_format, shape};
     }
 
     layout get_single_element_layout(T& p) {


### PR DESCRIPTION
### Symptom
Accuracy failed

### Root Cause
Onednn doesn't support per-channel azp in convolution. see https://oneapi-src.github.io/oneDNN/dev_guide_attributes_quantization.html#quantization-model

### per-channel azp benchdnn test
benchdnn --verbose=5 --mode=c --max-ms-per-prb=2e3 --conv --reset --allow-enum-tags-only=0 --engine=gpu:0 --dir=FWD_B --alg=direct --cfg=u8s8f32  --stag=acdb --wtag=AcdB8a4b --dtag=aBcd16b  --attr-zero-points=src0:per_dim_1:1* mb1_ic15oc30_ih5oh3kh3sh1dh0ph0_iw4ow2kw3sw1dw0pw0  
fail means per-channel azp in convolution not supported

### Tickets:
 - 67491
