### PR TITLE
[GPU][DG2] Fix gemm unit tests

### DIFF
--- a/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
@@ -3825,6 +3825,8 @@ public:
 class onednn_binary_add_full_tensor : public EltwiseSumFusingTestOneDNN {};
 TEST_P(onednn_binary_add_full_tensor, basic) {
     auto p = GetParam();
+    if (engine.get_device_info().supports_immad)
+        p.expected_fused_primitives = p.expected_fused_primitives_onednn;
 
     create_topologies(
         input_layout("input", get_input_layout(p)),
@@ -3853,15 +3855,17 @@ TEST_P(onednn_binary_add_full_tensor, basic) {
 #define CASE_CONV_ELTW_SUM_SUM_DIFF_DTYPE_1 { 1, 32, 4, 4 }, { 1, 16, 4, 4 }, { 1, 1, 3, 3 }, { 1, 1 }, { 1, 1 }, { 1, 1 }, 1, data_types::u8, format::b_fs_yx_fsv32, data_types::i8, format::bfyx, data_types::i8, format::b_fs_yx_fsv32, data_types::u8, format::b_fs_yx_fsv32, data_types::f32, format::bfyx
 
 INSTANTIATE_TEST_SUITE_P(eltwise_sum_fusings_gpu, onednn_binary_add_full_tensor, ::testing::ValuesIn(std::vector<convolution_eltw_sum_test_params>{
-    convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_BINARY_ADD_1, 2, 3, 5 },
-    convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_SUM_1, 2, 3, 5 },
-    convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_SUM_DIFF_DTYPE_1, 2, 3, 5 },
+    convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_BINARY_ADD_1, 2, 4, 5 },
+    convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_SUM_1, 2, 4, 5 },
+    convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_SUM_DIFF_DTYPE_1, 2, 4, 5 },
 }));
 
 
 class onednn_multiple_binary_add_full_tensor : public EltwiseSumFusingTestOneDNN {};
 TEST_P(onednn_multiple_binary_add_full_tensor, basic) {
     auto p = GetParam();
+    if (engine.get_device_info().supports_immad)
+        p.expected_fused_primitives = p.expected_fused_primitives_onednn;
 
     create_topologies(
         input_layout("input", get_input_layout(p)),
@@ -3889,8 +3893,8 @@ TEST_P(onednn_multiple_binary_add_full_tensor, basic) {
 }
 
 INSTANTIATE_TEST_SUITE_P(multiple_eltwise_sum_fusings_gpu, onednn_multiple_binary_add_full_tensor, ::testing::ValuesIn(std::vector<convolution_eltw_sum_test_params>{
-    convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_BINARY_ADD_1, 2, 3, 7 },
-    convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_SUM_1, 2, 3, 7 },
+    convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_BINARY_ADD_1, 2, 4, 7 },
+    convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_SUM_1, 2, 4, 7 },
 }));
 
 struct implicit_crop_concat_convolution_test_params {

--- a/src/plugins/intel_gpu/tests/fusions/gemm_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/gemm_fusion_test.cpp
@@ -355,11 +355,8 @@ TEST_P(gemm_2in_act_scale_eltwise, basic) {
         reorder("reorder_bfyx", input_info("sum"), p.default_format, data_types::f32)
     );
     // Activation won't be fused because onednn doesn't support negative activation
-    if (engine.get_device_info().supports_immad) {
+    if (engine.get_device_info().supports_immad && !p.kernel_name.empty())
         p.expected_fused_primitives += 2;
-        if (!p.kernel_name.empty())
-            p.expected_not_fused_primitives += 2;
-    }
 
     tolerance = default_tolerance(p.default_type);
     execute(p);
@@ -379,11 +376,8 @@ TEST_P(gemm_2in_act_scale_eltwise, broadcast_eltwise) {
         reorder("reorder_bfyx", input_info("sum"), p.default_format, data_types::f32)
     );
     // Activation won't be fused because onednn doesn't support negative activation
-    if (engine.get_device_info().supports_immad) {
+    if (engine.get_device_info().supports_immad && !p.kernel_name.empty())
         p.expected_fused_primitives += 2;
-        if (!p.kernel_name.empty())
-            p.expected_not_fused_primitives += 2;
-    }
 
     tolerance = default_tolerance(p.default_type);
     execute(p);

--- a/src/plugins/intel_gpu/tests/fusions/gemm_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/gemm_fusion_test.cpp
@@ -303,7 +303,7 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, gemm_2in_act_scale_quantize_i8, ::testing:
     gemm_test_params{ CASE_GEMM_2IN_FP16_1, 3, 6 },
     gemm_test_params{ CASE_GEMM_2IN_FP16_2, 3, 6 },
     gemm_test_params{ CASE_GEMM_2IN_FP16_3, 3, 6 },
-    gemm_test_params{ CASE_GEMM_2IN_FP16_4, 3, 6 },//
+    gemm_test_params{ CASE_GEMM_2IN_FP16_4, 3, 6 },
     gemm_test_params{ CASE_GEMM_2IN_U8S8_1, 3, 6 },
     gemm_test_params{ CASE_GEMM_2IN_S8U8_1, 3, 6 },
 }));


### PR DESCRIPTION
### Related Test Cases:
 - fusings_gpu/gemm_2in_scale.basic/7
 - fusings_gpu/gemm_2in_scale.fp16_scale_out/7
   - Set default tolerance
 - fusings_gpu/gemm_2in_act_scale_eltwise.basic/0
 - fusings_gpu/gemm_2in_act_scale_eltwise.broadcast_eltwise/0
   - Fix incorrect condition of expected_fused_count adjustment
 - eltwise_sum_fusings_gpu/onednn_binary_add_full_tensor.basic/0
 - multiple_eltwise_sum_fusings_gpu/onednn_multiple_binary_add_full_tensor.basic/0
   - Onednn does not support 'negative' activation function.

### Tickets:
 - 67491
