### PR TITLE
Use upper-bound version of numpy for Python binding testing

### DIFF
--- a/src/bindings/python/requirements_test.txt
+++ b/src/bindings/python/requirements_test.txt
@@ -37,3 +37,4 @@ tox
 types-pkg_resources
 wheel>=0.38.1
 protobuf~=3.18.1
+numpy>=1.16.6,<=1.23.4


### PR DESCRIPTION
**Details:** Fix upper-bound version of NumPy for testing Python bindings.
Tests use deprecated type

**Tickets:** TBD

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
