### PR TITLE
Fix clang warnings for transformation tests

### DIFF
--- a/src/common/transformations/tests/common_optimizations/eliminate_duplicate_ti_inputs.cpp
+++ b/src/common/transformations/tests/common_optimizations/eliminate_duplicate_ti_inputs.cpp
@@ -69,7 +69,7 @@ TEST(TransformationTests, EliminateDuplicateTIInputs) {
 
     shared_ptr<TensorIterator> ti_after_transformation;
     for (const auto& op : model->get_ordered_ops()) {
-        if (ti_after_transformation = dynamic_pointer_cast<TensorIterator>(op)) {
+        if ((ti_after_transformation = dynamic_pointer_cast<TensorIterator>(op))) {
             break;
         }
     }

--- a/src/common/transformations/tests/smart_reshape/broadcast_const_range_replacement.cpp
+++ b/src/common/transformations/tests/smart_reshape/broadcast_const_range_replacement.cpp
@@ -133,7 +133,6 @@ TEST_F(TransformationTestsF, BroadcastConstRangeReplacement_target_shapeof) {
     {
         constexpr auto elem_count = 236;
         constexpr auto data_elem_type = element::i32;
-        constexpr auto target_shape_elem_type = element::i64;
 
         std::vector<int32_t> sequence_pattern(elem_count);
         std::iota(sequence_pattern.begin(), sequence_pattern.end(), 0);
@@ -194,7 +193,6 @@ TEST_F(TransformationTestsF, BroadcastConstRangeReplacement_target_shapeof_mixed
     {
         constexpr auto elem_count = 236;
         constexpr auto data_elem_type = element::i32;
-        constexpr auto target_shape_elem_type = element::i64;
 
         std::vector<int32_t> sequence_pattern(elem_count);
         std::iota(sequence_pattern.begin(), sequence_pattern.end(), 0);
@@ -338,7 +336,6 @@ TEST(SmartReshapeTests, BroadcastConstRangeReplacement_reshape) {
     {
         constexpr auto elem_count = 236;
         constexpr auto data_elem_type = element::i32;
-        constexpr auto target_shape_elem_type = element::i64;
 
         std::vector<int32_t> sequence_pattern(elem_count);
         std::iota(sequence_pattern.begin(), sequence_pattern.end(), 0);


### PR DESCRIPTION
### Details:
 - Fix clang warnings for ov_transfomations_tests

### Tickets:
 - CVS-99423
