### PR TITLE
Fix inference pipeline C++ doc: refer to the correct input blob for 22.3

### DIFF
--- a/docs/snippets/ie_common.cpp
+++ b/docs/snippets/ie_common.cpp
@@ -38,7 +38,7 @@ int main() {
     }
 
     InferenceEngine::Blob::Ptr input_blob2 = infer_request.GetBlob("data2");
-    // fill first blob
+    // fill second blob
     InferenceEngine::MemoryBlob::Ptr minput2 = InferenceEngine::as<InferenceEngine::MemoryBlob>(input_blob2);
     if (minput2) {
         // locked memory holder should be alive all time while access to its


### PR DESCRIPTION
Minor documentation fix:

In the ["Fill Input Tensors with Data" section](https://docs.openvino.ai/latest/openvino_2_0_inference_pipeline.html#doxid-openvino-2-0-inference-pipeline-1fill-tensor) of the [Inference Engine documentation](https://docs.openvino.ai/latest/openvino_2_0_inference_pipeline.html), in the example using the Inference Engine API, the comment should refer to the first blob, then to the second blob. This PR fixes that.

Port from https://github.com/openvinotoolkit/openvino/pull/14709