### PR TITLE
[AUTO Plugin] AUTO/MULTI should not support the meta plugin appearing in candidate device list

### DIFF
--- a/src/plugins/auto/plugin.cpp
+++ b/src/plugins/auto/plugin.cpp
@@ -354,6 +354,9 @@ IExecutableNetworkInternal::Ptr MultiDeviceInferencePlugin::LoadNetworkImpl(cons
     std::unordered_map<std::string, InferenceEngine::Parameter> multiNetworkConfig;
     std::vector<DeviceInformation> metaDevices;
     auto priorities = fullConfig.find(MultiDeviceConfigParams::KEY_MULTI_DEVICE_PRIORITIES);
+    if (priorities->second.find("AUTO") != std::string::npos || priorities->second.find("MULTI") != std::string::npos) {
+        IE_THROW() << "The device candidate list should not include the meta plugin for " << GetName() << " device";
+    }
     // If the user sets the property, insert the property into the deviceConfig
     auto insertPropToConfig = [&](std::string property,
                                   std::string& deviceName,

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
@@ -307,4 +307,24 @@ INSTANTIATE_TEST_SUITE_P(smoke_MULTI_DoNotReturnDefaultHintTest,
                          OVClassLoadNetWorkDoNotReturnDefaultHintTest,
                          ::testing::Combine(::testing::Values("MULTI:CPU"),
                                             ::testing::ValuesIn(default_multi_properties)));
-} // namespace
+
+const std::vector<ov::AnyMap> configsWithEmpty = {{}};
+const std::vector<ov::AnyMap> configsWithMetaPlugin = {{ov::device::priorities("AUTO")},
+                                                       {ov::device::priorities("MULTI")},
+                                                       {ov::device::priorities("AUTO", "MULTI")},
+                                                       {ov::device::priorities("AUTO", "CPU")},
+                                                       {ov::device::priorities("MULTI", "CPU")}};
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_MULTI_AUTO_DoNotSupportMetaPluginLoadingItselfRepeatedlyWithEmptyConfigTest,
+    OVClassLoadNetworkWithCondidateDeviceListContainedMetaPluginTest,
+    ::testing::Combine(::testing::Values("MULTI:AUTO", "AUTO:MULTI", "MULTI:CPU,AUTO", "AUTO:CPU,MULTI"),
+                       ::testing::ValuesIn(configsWithEmpty)),
+    ::testing::PrintToStringParamName());
+
+INSTANTIATE_TEST_SUITE_P(smoke_MULTI_AUTO_DoNotSupportMetaPluginLoadingItselfRepeatedlyTest,
+                         OVClassLoadNetworkWithCondidateDeviceListContainedMetaPluginTest,
+                         ::testing::Combine(::testing::Values("MULTI", "AUTO"),
+                                            ::testing::ValuesIn(configsWithMetaPlugin)),
+                         ::testing::PrintToStringParamName());
+}  // namespace

--- a/src/tests/functional/plugin/shared/include/behavior/ov_plugin/core_integration.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_plugin/core_integration.hpp
@@ -124,6 +124,7 @@ using OVClassSetLogLevelConfigTest = OVClassBaseTestP;
 using OVClassSpecificDeviceTestSetConfig = OVClassBaseTestP;
 using OVClassSpecificDeviceTestGetConfig = OVClassBaseTestP;
 using OVClassLoadNetworkWithCorrectPropertiesTest = OVClassSetDevicePriorityConfigTest;
+using OVClassLoadNetworkWithCondidateDeviceListContainedMetaPluginTest = OVClassSetDevicePriorityConfigTest;
 using OVClassLoadNetWorkReturnDefaultHintTest = OVClassSetDevicePriorityConfigTest;
 using OVClassLoadNetWorkDoNotReturnDefaultHintTest = OVClassSetDevicePriorityConfigTest;
 using OVClassLoadNetworkAndCheckSecondaryPropertiesTest = OVClassSetDevicePriorityConfigTest;
@@ -1093,6 +1094,11 @@ TEST_P(OVClassLoadNetworkTest, LoadNetworkWithBigDeviceIDThrows) {
     } else {
         GTEST_FAIL() << "Device does not support DeviceID property" << std::endl;
     }
+}
+
+TEST_P(OVClassLoadNetworkWithCondidateDeviceListContainedMetaPluginTest, LoadNetworkRepeatedlyWithMetaPluginTestThrow) {
+    ov::Core ie = createCoreWithTemplate();
+    ASSERT_THROW(ie.compile_model(actualNetwork, target_device, configuration), ov::Exception);
 }
 
 TEST_P(OVClassLoadNetworkWithCorrectPropertiesTest, LoadNetworkWithCorrectPropertiesTest) {

--- a/src/tests/functional/plugin/shared/include/behavior/ov_plugin/core_integration.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_plugin/core_integration.hpp
@@ -1182,31 +1182,6 @@ TEST_P(OVClassLoadNetworkTest, LoadNetworkHETEROAndDeviceIDThrows) {
 }
 
 //
-// LoadNetwork with AUTO on MULTI combinations particular device
-//
-TEST_P(OVClassLoadNetworkTest, LoadNetworkMULTIwithAUTONoThrow) {
-    ov::Core ie = createCoreWithTemplate();
-    if (supportsDeviceID(ie, target_device) && supportsAvaliableDevices(ie, target_device)) {
-        std::string devices;
-        auto availableDevices = ie.get_property(target_device, ov::available_devices);
-        for (auto&& device : availableDevices) {
-            devices += target_device + '.' + device;
-            if (&device != &(availableDevices.back())) {
-                devices += ',';
-            }
-        }
-        OV_ASSERT_NO_THROW(
-            ie.compile_model(actualNetwork,
-                             CommonTestUtils::DEVICE_MULTI,
-                             ov::device::properties(CommonTestUtils::DEVICE_AUTO, ov::device::priorities(devices)),
-                             ov::device::properties(CommonTestUtils::DEVICE_MULTI,
-                                                    ov::device::priorities(CommonTestUtils::DEVICE_AUTO, target_device))));
-    } else {
-        GTEST_FAIL() << "Device does not support DeviceID property" << std::endl;
-    }
-}
-
-//
 // LoadNetwork with HETERO on MULTI combinations particular device
 //
 


### PR DESCRIPTION
### Details:
 - Disable AUTO/MULTI repeatedly loading network to meta plugin  itself

### Tickets:
 - 96209
