### PR TITLE
[GPU] Fix shape infer for 0d broadcast

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/broadcast.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/broadcast.hpp
@@ -107,7 +107,7 @@ struct broadcast : public primitive_base<broadcast> {
           target_shape(target_shape),
           axes_mapping(axes_mapping),
           broadcast_mode(broadcast_spec),
-          broadcast_sizes({}),
+          broadcast_sizes(target_shape.empty() ? tensor(1) : tensor(0)),
           broadcast_axes({}) {}
 
     /// @brief Constructs broadcast primitive / layer with dynamic target_shape.

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/broadcast.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/broadcast.cpp
@@ -26,6 +26,22 @@ const std::vector<InferenceEngine::Precision> inputTPrecisions = {
 };
 
 // NUMPY MODE //////////////////////////////////////////
+// 0D
+std::vector<std::vector<size_t>> targetShapesNumpy0D = {
+        {},
+};
+
+INSTANTIATE_TEST_CASE_P(smoke_TestNumpyBroadcast0D,
+                        BroadcastLayerTest,
+                        ::testing::Combine(::testing::ValuesIn(targetShapesNumpy0D),
+                                           ::testing::Values(ngraph::AxisSet{}),  // not used in numpy mode
+                                           ::testing::Values(ngraph::op::BroadcastType::NUMPY),
+                                           ::testing::Values(std::vector<size_t>{}),
+                                           ::testing::ValuesIn(inputPrecisions),
+                                           ::testing::Values(CommonTestUtils::DEVICE_GPU)),
+                        BroadcastLayerTest::getTestCaseName);
+
+// NUMPY MODE //////////////////////////////////////////
 // 1D
 std::vector<std::vector<size_t>> targetShapesNumpy1D = {
         {1},


### PR DESCRIPTION
### Details:
 - Broadcast op shape infer impl for scalar input and scalar target shape could return tensor with 0 shape which can't be processed correctly in some cases. This patch initialize `broadcast_sizes` with tensor(1) for the cases when target shape is empty to convert scalar to 1d tensor.

### Tickets:
 - *99651*
