### PR TITLE
Remove `openvino_intel_cpu_plugin_obj` library

### DIFF
--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -88,36 +88,5 @@ cross_compiled_file(${TARGET_NAME}
 
 ie_add_api_validator_post_build_step(TARGET ${TARGET_NAME})
 
-#  add test object library
-
-if(BUILD_SHARED_LIBS)
-    add_library(${TARGET_NAME}_obj OBJECT ${SOURCES} ${HEADERS})
-    link_system_libraries(${TARGET_NAME}_obj PUBLIC dnnl openvino::pugixml)
-
-    target_include_directories(${TARGET_NAME}_obj
-        PRIVATE
-            $<TARGET_PROPERTY:openvino::runtime::dev,INTERFACE_INCLUDE_DIRECTORIES>
-            $<TARGET_PROPERTY:openvino::itt,INTERFACE_INCLUDE_DIRECTORIES>
-            $<TARGET_PROPERTY:ov_shape_inference,INTERFACE_INCLUDE_DIRECTORIES>
-            $<TARGET_PROPERTY:inference_engine_snippets,INTERFACE_INCLUDE_DIRECTORIES>
-        PUBLIC
-            ${CMAKE_CURRENT_SOURCE_DIR}/src
-            $<TARGET_PROPERTY:openvino::conditional_compilation,INTERFACE_INCLUDE_DIRECTORIES>)
-
-    target_include_directories(${TARGET_NAME}_obj SYSTEM PUBLIC $<TARGET_PROPERTY:dnnl,INCLUDE_DIRECTORIES>)
-
-    set_ie_threading_interface_for(${TARGET_NAME}_obj)
-
-    target_compile_definitions(${TARGET_NAME}_obj PRIVATE
-        USE_STATIC_IE IMPLEMENT_INFERENCE_ENGINE_PLUGIN IMPLEMENT_INFERENCE_EXTENSION_API
-        $<TARGET_PROPERTY:ngraph,INTERFACE_COMPILE_DEFINITIONS>
-        $<TARGET_PROPERTY:inference_engine_plugin_api,INTERFACE_COMPILE_DEFINITIONS>)
-
-    set_target_properties(${TARGET_NAME}_obj PROPERTIES EXCLUDE_FROM_ALL ON)
-
-    # LTO
-    set_target_properties(${TARGET_NAME}_obj PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})
-endif()
-
 # LTO
 set_target_properties(${TARGET_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ${ENABLE_LTO})

--- a/src/plugins/intel_cpu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_cpu/tests/unit/CMakeLists.txt
@@ -5,7 +5,7 @@
 set(TARGET_NAME ov_cpu_unit_tests)
 
 if(BUILD_SHARED_LIBS)
-    set (OBJ_LIB $<TARGET_OBJECTS:openvino_intel_cpu_plugin_obj>)
+    set (OBJ_LIB $<TARGET_OBJECTS:openvino_intel_cpu_plugin>)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")


### PR DESCRIPTION
### Details:
 - Remove `openvino_cpu_intel_plugin_obj` object library and use objects of `openvino_cpu_intel_plugin` instead for `ov_cpu_unit_tests`.

All sources of the CPU plugin are currently compiled twice - once for `openvino_intel_cpu_plugin` and once for `openvino_intel_cpu_plugin_obj` targets. The `openvino_intel_cpu_plugin_obj` object library is compiled with `USE_STATIC_IE` flag that [specifies](https://github.com/openvinotoolkit/openvino/blob/271681a07ff30cde8b80694851052a83a0e7bae4/src/inference/include/ie/ie_api.h#L12) visibility attributes of some symbols. These attributes are intended for shared libraries linking and linkers do not seem to impose them on executables.  So, plugin objects for `ov_cpu_unit_tests` can be compiled w/o the flag - like in openvino_cpu_intel_plugin target.

VPUX Plugin build is configured similarly ([vpux_plugin/CMakeLists.txt](https://github.com/openvinotoolkit/vpux-plugin/blob/develop/src/vpux_plugin/CMakeLists.txt)) - the same object files are used both for the plugin itself and a tests executable.


