### PR TITLE
DOCS-Add-warnings-for-docs (#14776)

### DIFF
--- a/docs/suppress_warnings.txt
+++ b/docs/suppress_warnings.txt
@@ -101,3 +101,5 @@ explicit markup ends without a blank line
 \* modulenotfounderror
 unexpected unindent
 failed to import object
+autosummary: stub file not found
+failed to parse name


### PR DESCRIPTION
suppress additional build warnings:
autosummary: stub file not found
failed to parse name

port https://github.com/openvinotoolkit/openvino/pull/14776