### PR TITLE
Increase cmake version for ENABLE_FASTER_BUILD up to 3.16.1

### DIFF
--- a/cmake/developer_package/features.cmake
+++ b/cmake/developer_package/features.cmake
@@ -54,7 +54,7 @@ ie_option (BUILD_SHARED_LIBS "Build as a shared library" ON)
 # see https://www.opengis.ch/2011/11/23/creating-non-versioned-shared-libraries-for-android/
 ie_dependent_option (ENABLE_LIBRARY_VERSIONING "Enable libraries versioning" ON "NOT WIN32;NOT ANDROID" OFF)
 
-ie_dependent_option (ENABLE_FASTER_BUILD "Enable build features (PCH, UNITY) to speed up build time" OFF "CMAKE_VERSION VERSION_GREATER_EQUAL 3.16" OFF)
+ie_dependent_option (ENABLE_FASTER_BUILD "Enable build features (PCH, UNITY) to speed up build time" OFF "CMAKE_VERSION VERSION_GREATER_EQUAL 3.16.1" OFF)
 
 if(UNIX AND NOT ANDROID)
     set(STYLE_CHECKS_DEFAULT ON)


### PR DESCRIPTION
### Details:
While testing possibility to build OV with `ENABLE_FASTER_BUILD` flag ON, it is discovered that OV cannot be built with this flag ON with CMake v3.16.0, only with v3.16.1

### Tickets:
 - Relates to: C#97761
