### PR TITLE
[TF FE] Fix ResizeBilinear for uint8 type and test Resize operations

### DIFF
--- a/src/frontends/tensorflow/src/op/interpolate.cpp
+++ b/src/frontends/tensorflow/src/op/interpolate.cpp
@@ -70,15 +70,14 @@ OutputVector translate_interpolate_op(const NodeContext& node) {
     // we can avoid Transpose operation by specifying axes = {1, 2} for original NHWC layout
     auto axes = make_shared<Constant>(element::i32, Shape{2}, std::vector<int>({1, 2}));
 
-    auto interpolate = make_shared<Interpolate>(images, size, scales, axes, interpolate_attrs)->output(0);
-
     // according to the specification of ResizeBilinear,
-    // it always returns FP32 output type
+    // it always returns FP32 output type so we immediately align input type for it
     if (op_type == "ResizeBilinear") {
-        interpolate = make_shared<Convert>(interpolate, element::f32);
+        images = make_shared<Convert>(images, element::f32);
     }
 
-    set_node_name(node.get_name(), interpolate.get_node_shared_ptr());
+    auto interpolate = make_shared<Interpolate>(images, size, scales, axes, interpolate_attrs);
+    set_node_name(node.get_name(), interpolate);
     return {interpolate};
 }
 }  // namespace op

--- a/tests/layer_tests/tensorflow_tests/test_tf_Resize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Resize.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import tensorflow as tf
+from common.tf_layer_test_class import CommonTFLayerTest
+
+
+class TestResize(CommonTFLayerTest):
+    def _prepare_input(self, inputs_info):
+        assert 'images' in inputs_info, "Test error: inputs_info must contain `x`"
+        images_shape = inputs_info['images']
+        inputs_data = {}
+        inputs_data['images'] = np.random.randint(0, 10, images_shape)
+        return inputs_data
+
+    def create_resize_net(self, images_shape, images_type, size_value, align_corners, half_pixel_centers,
+                          resize_op):
+        tf.compat.v1.reset_default_graph()
+        # Create the graph and model
+        with tf.compat.v1.Session() as sess:
+            images = tf.compat.v1.placeholder(images_type, images_shape, 'images')
+            size = tf.constant(size_value, dtype=tf.int32)
+            resize_op(images=images, size=size, align_corners=align_corners,
+                      half_pixel_centers=half_pixel_centers)
+            tf.compat.v1.global_variables_initializer()
+
+            tf_net = sess.graph_def
+
+        return tf_net, None
+
+    test_data_basic = [
+        # ResizeBilinear testing
+        dict(images_shape=[1, 30, 30, 3], images_type=tf.float32, size_value=[40, 40], align_corners=False,
+             half_pixel_centers=False, resize_op=tf.raw_ops.ResizeBilinear),
+        dict(images_shape=[2, 100, 100, 3], images_type=tf.float32, size_value=[40, 40], align_corners=True,
+             half_pixel_centers=False, resize_op=tf.raw_ops.ResizeBilinear),
+        dict(images_shape=[2, 10, 10, 3], images_type=tf.float32, size_value=[40, 40], align_corners=False,
+             half_pixel_centers=True, resize_op=tf.raw_ops.ResizeBilinear),
+        dict(images_shape=[2, 40, 40, 3], images_type=tf.uint8, size_value=[10, 10], align_corners=False,
+             half_pixel_centers=False, resize_op=tf.raw_ops.ResizeBilinear),
+        pytest.param(dict(images_shape=[1, 40, 40, 3], images_type=tf.int32, size_value=[10, 10], align_corners=False,
+                          half_pixel_centers=True, resize_op=tf.raw_ops.ResizeBilinear),
+                     marks=pytest.mark.xfail(reason="100025")),
+        # ResizeNearestNeighbor testing
+        dict(images_shape=[1, 30, 30, 3], images_type=tf.float32, size_value=[40, 40], align_corners=False,
+             half_pixel_centers=False, resize_op=tf.raw_ops.ResizeNearestNeighbor),
+        dict(images_shape=[2, 100, 100, 3], images_type=tf.float32, size_value=[40, 40], align_corners=True,
+             half_pixel_centers=False, resize_op=tf.raw_ops.ResizeNearestNeighbor),
+        dict(images_shape=[2, 10, 10, 3], images_type=tf.float32, size_value=[40, 40], align_corners=False,
+             half_pixel_centers=True, resize_op=tf.raw_ops.ResizeNearestNeighbor),
+        dict(images_shape=[2, 40, 40, 3], images_type=tf.uint8, size_value=[10, 10], align_corners=False,
+             half_pixel_centers=False, resize_op=tf.raw_ops.ResizeNearestNeighbor),
+        dict(images_shape=[1, 40, 40, 3], images_type=tf.int32, size_value=[10, 10], align_corners=False,
+             half_pixel_centers=True, resize_op=tf.raw_ops.ResizeNearestNeighbor),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_basic)
+    @pytest.mark.precommit_tf_fe
+    def test_resize_basic(self, params, ie_device, precision, ir_version, temp_dir,
+                          use_new_frontend, use_old_api):
+        self._test(*self.create_resize_net(**params),
+                   ie_device, precision, ir_version, temp_dir=temp_dir,
+                   use_new_frontend=use_new_frontend, use_old_api=use_old_api)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Resize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Resize.py
@@ -40,9 +40,8 @@ class TestResize(CommonTFLayerTest):
              half_pixel_centers=True, resize_op=tf.raw_ops.ResizeBilinear),
         dict(images_shape=[2, 40, 40, 3], images_type=tf.uint8, size_value=[10, 10], align_corners=False,
              half_pixel_centers=False, resize_op=tf.raw_ops.ResizeBilinear),
-        pytest.param(dict(images_shape=[1, 40, 40, 3], images_type=tf.int32, size_value=[10, 10], align_corners=False,
-                          half_pixel_centers=True, resize_op=tf.raw_ops.ResizeBilinear),
-                     marks=pytest.mark.xfail(reason="100025")),
+        dict(images_shape=[1, 40, 40, 3], images_type=tf.int32, size_value=[10, 10], align_corners=False,
+             half_pixel_centers=True, resize_op=tf.raw_ops.ResizeBilinear),
         # ResizeNearestNeighbor testing
         dict(images_shape=[1, 30, 30, 3], images_type=tf.float32, size_value=[40, 40], align_corners=False,
              half_pixel_centers=False, resize_op=tf.raw_ops.ResizeNearestNeighbor),

--- a/tests/layer_tests/tensorflow_tests/test_tf_Resize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Resize.py
@@ -34,6 +34,8 @@ class TestResize(CommonTFLayerTest):
         # ResizeBilinear testing
         dict(images_shape=[1, 30, 30, 3], images_type=tf.float32, size_value=[40, 40], align_corners=False,
              half_pixel_centers=False, resize_op=tf.raw_ops.ResizeBilinear),
+        dict(images_shape=[1, 30, 30, 3], images_type=tf.float64, size_value=[40, 40], align_corners=False,
+             half_pixel_centers=False, resize_op=tf.raw_ops.ResizeBilinear),
         dict(images_shape=[2, 100, 100, 3], images_type=tf.float32, size_value=[40, 40], align_corners=True,
              half_pixel_centers=False, resize_op=tf.raw_ops.ResizeBilinear),
         dict(images_shape=[2, 10, 10, 3], images_type=tf.float32, size_value=[40, 40], align_corners=False,


### PR DESCRIPTION
**Details:** Fix ResizeBilinear operation for uint8 input type and add layer tests for ResizeBilinear and ResizeNearestNeighbor operations.

**Tickets:** 92858, 92859, 95182

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
