### PR TITLE
Fix samples build on armv7

### DIFF
--- a/cmake/developer_package/compile_flags/os_flags.cmake
+++ b/cmake/developer_package/compile_flags/os_flags.cmake
@@ -143,11 +143,11 @@ macro(ie_arm_neon_optimization_flags flags)
         if(ANDROID_ABI STREQUAL "arm64-v8a")
             set(${flags} -mfpu=neon -Wno-unused-command-line-argument)
         elseif(ANDROID_ABI STREQUAL "armeabi-v7a-hard with NEON")
-            set(${flags} -march=armv7-a -mfloat-abi=hard -mhard-float -D_NDK_MATH_NO_SOFTFP=1 -mfpu=neon -Wno-unused-command-line-argument)
+            set(${flags} -march=armv7-a+fp -mfloat-abi=hard -mhard-float -D_NDK_MATH_NO_SOFTFP=1 -mfpu=neon -Wno-unused-command-line-argument)
         elseif((ANDROID_ABI STREQUAL "armeabi-v7a with NEON") OR
                (ANDROID_ABI STREQUAL "armeabi-v7a" AND
                 DEFINED CMAKE_ANDROID_ARM_NEON AND CMAKE_ANDROID_ARM_NEON))
-                set(${flags} -march=armv7-a -mfloat-abi=softfp -mfpu=neon -Wno-unused-command-line-argument)
+                set(${flags} -march=armv7-a+fp -mfloat-abi=softfp -mfpu=neon -Wno-unused-command-line-argument)
         endif()
     else()
         if(AARCH64)

--- a/samples/cpp/CMakeLists.txt
+++ b/samples/cpp/CMakeLists.txt
@@ -79,7 +79,7 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)")
   set(ARM ON)
 endif()
 if(ARM AND NOT CMAKE_CROSSCOMPILING)
-    add_compile_options(-march=armv7-a)
+    add_compile_options(-march=armv7-a+fp)
 endif()
 
 set(CMAKE_POLICY_DEFAULT_CMP0063 NEW)


### PR DESCRIPTION
### Details:
On gcc-11 and higher armv7 architecture native build fails on samples compilation with the following error:
```
cc1plus: error: ‘-mfloat-abi=hard’: selected architecture lacks an FPU
```
This patch is intended to fix this issue.

Similar issue can be found here: https://bugs.launchpad.net/ubuntu/+source/gcc-defaults/+bug/1939379