### PR TITLE
[apiConformancForce] creating plugin before setting properties

### DIFF
--- a/src/tests/functional/plugin/shared/src/behavior/ov_plugin/properties_tests.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_plugin/properties_tests.cpp
@@ -80,6 +80,7 @@ TEST_P(OVEmptyPropertiesTests, SetEmptyProperties) {
 
 // Setting correct properties doesn't throw
 TEST_P(OVPropertiesTests, SetCorrectProperties) {
+    core->get_versions(target_device);
     OV_ASSERT_NO_THROW(core->set_property(target_device, properties));
 }
 
@@ -94,6 +95,7 @@ TEST_P(OVPropertiesTests, canSetPropertyAndCheckGetProperty) {
 }
 
 TEST_P(OVPropertiesIncorrectTests, SetPropertiesWithIncorrectKey) {
+    core->get_versions(target_device);
     ASSERT_THROW(core->set_property(target_device, properties), ov::Exception);
 }
 


### PR DESCRIPTION
### Details:
 - *When we just call set_properties and no initialize plugin before it or indirectly(in compile_model for example), the properties will set just in PluginRegistry to structure with type of values Any and no validations will be made. So, let's add get_version to force initialization of plugin.*
 - *Please note, that commit fixes test SetPropertiesWithIncorrectKey , but after adding the function call tests SetCorrectProperties for CPU plugin will be fails, because of unsupported DeviceID, but looks like it more correct.*

### Tickets:
 - *CVS-98405*
