### PR TITLE
Smart github actions for shellcheck and clang-format

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -73,14 +73,6 @@ jobs:
           level: style
           reporter: github-pr-review
           check_all_files_with_shebangs: true
-          path: |
-            ./
-            ./scripts
-            ./samples/cpp
-            ./scripts/setupvars
-            ./scripts/install_dependencies
-            ./src/bindings/python/tests/test_onnx
-            ./src/bindings/python/tests_compatibility/test_onnx
           fail_on_error: true
 
   NamingConventionCheck:

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   clang-format:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -34,33 +36,19 @@ jobs:
 
       # Run cmake with -DENABLE_PROFILING_ITT=ON -DSELECTIVE_BUILD=COLLECT in order to enable codestyle check for ITT collector
       - name: CMake configure
-        run: |
-          cmake -DENABLE_PYTHON=ON -DENABLE_TESTS=ON -DENABLE_PROFILING_ITT=ON -DSELECTIVE_BUILD=COLLECT -B build
+        run: cmake -DENABLE_PYTHON=ON -DENABLE_TESTS=ON -DENABLE_PROFILING_ITT=ON -DSELECTIVE_BUILD=COLLECT -B build
 
-      - name: Check code style
-        run: cmake --build build --target clang_format_check_all -j8
+      - name: Fix code style
+        run: cmake --build build --target clang_format_fix_all -j8
 
-      - name: Create code style diff
-        if: failure()
-        run: |
-          cmake --build build --target clang_format_fix_all -j8
-          git diff > code_style_diff.diff
-
-      - name: suggester / clang-format
-        if: failure() && startsWith(github.event_name, 'pull_request')
-        uses: reviewdog/action-suggester@v1
+      - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          level: error
-          tool_name: clang-format
-
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: code_style_diff
-          path: code_style_diff.diff
+          commit_message: "[github actions] Apply clang-format code style fixes"
 
   ShellCheck:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -74,8 +62,26 @@ jobs:
       - name: CMake configure
         run: cmake -DENABLE_INTEL_MYRIAD_COMMON=OFF -B build
 
-      - name: ShellCheck
+      - name: Shellcheck cmake target
         run: cmake --build build --target ie_shellcheck -j8
+
+      # always provide suggestions even for skipped scripts in ie_shellcheck tagret
+      - name: ShellCheck action
+        if: always()
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          level: style
+          reporter: github-pr-review
+          check_all_files_with_shebangs: true
+          path: |
+            ./
+            ./scripts
+            ./samples/cpp
+            ./scripts/setupvars
+            ./scripts/install_dependencies
+            ./src/bindings/python/tests/test_onnx
+            ./src/bindings/python/tests_compatibility/test_onnx
+          fail_on_error: true
 
   NamingConventionCheck:
     runs-on: ubuntu-22.04

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -74,6 +74,9 @@ jobs:
           reporter: github-pr-review
           check_all_files_with_shebangs: true
           fail_on_error: true
+          exclude: |
+              "*/thirdparty/*"
+              "./temp/*"
 
   NamingConventionCheck:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### Details:
 - Added GitHub action to automatically apply code-style changes based on clang-format
 - Added GitHub action's step to review PRs for shell scripts mistakes