### PR TITLE
[GPU] Added missing supports_image initialization in EngineInfo

### DIFF
--- a/src/plugins/intel_gpu/src/graph/kernel_selector_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/kernel_selector_helper.cpp
@@ -1021,6 +1021,7 @@ void set_params(const kernel_impl_params& param_info, kernel_selector::params& p
     params.engineInfo.supports_intel_subgroups_short = device_info.supports_intel_subgroups_short;
     params.engineInfo.supports_intel_subgroups_char = device_info.supports_intel_subgroups_char;
     params.engineInfo.supports_intel_required_subgroup_size = device_info.supports_intel_required_subgroup_size;
+    params.engineInfo.supports_image = device_info.supports_image;
 
     params.engineInfo.supports_imad = device_info.supports_imad;
     params.engineInfo.supports_immad = device_info.supports_immad;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_1x1_hgemm_buf_16x1.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_1x1_hgemm_buf_16x1.cl
@@ -55,14 +55,14 @@ KERNEL(convolution_gpu_bfyx_1x1_hgemm_buf_16x1)(
 
         // 512 MADs
 
-        half8 B0 = as_half8(_sub_group_block_read_us8(weights, coordB));
+        half8 B0 = as_half8(intel_sub_group_block_read_us8(weights, coordB));
         coordB.y += 8;
-        half8 B8 = as_half8(_sub_group_block_read_us8(weights, coordB));
+        half8 B8 = as_half8(intel_sub_group_block_read_us8(weights, coordB));
         coordB.y += 8;
 
-        half8 B16 = as_half8(_sub_group_block_read_us8(weights, coordB));
+        half8 B16 = as_half8(intel_sub_group_block_read_us8(weights, coordB));
         coordB.y += 8;
-        half8 B24 = as_half8(_sub_group_block_read_us8(weights, coordB));
+        half8 B24 = as_half8(intel_sub_group_block_read_us8(weights, coordB));
         coordB.y += 8;
 
         half8 A0 = A_load[K8*0 + k8];

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_winograd_6x3_s1_fused.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_winograd_6x3_s1_fused.cl
@@ -297,7 +297,7 @@ KERNEL(convolution_gpu_winograd_6x3_s1_fused)
 
 							// Fetch 8 channels of Winograd components from f(k,s)
 #if FILTER_LAYOUT_IMAGE_2D_WEIGHTS_WINOGRAD_6x3_S1_FBXYB || FILTER_LAYOUT_IMAGE_2D_WEIGHTS_WINOGRAD_6x3_S1_XFBYB
-							const UNIT_TYPE_8 f00 = as_half8(_sub_group_block_read_us8(U, (int2)(coordU0.x, coordU0.y)));
+							const UNIT_TYPE_8 f00 = as_half8(intel_sub_group_block_read_us8(U, (int2)(coordU0.x, coordU0.y)));
 #else
 							const UNIT_TYPE_8 f00 = (UNIT_TYPE_8)(
 								as_half(_sub_group_block_read_us((__global unsigned short *)&U[flatA + 0 * WEIGHTWIDTH])),
@@ -467,7 +467,7 @@ KERNEL(convolution_gpu_winograd_6x3_s1_fused)
 							DOT8i_7(M6.s1, f00, V8, 10 + c8);
 
 #if FILTER_LAYOUT_IMAGE_2D_WEIGHTS_WINOGRAD_6x3_S1_FBXYB || FILTER_LAYOUT_IMAGE_2D_WEIGHTS_WINOGRAD_6x3_S1_XFBYB
-							const UNIT_TYPE_8 f01 = as_half8(_sub_group_block_read_us8(U, (int2)(coordU0.x + 16 * sizeof(UNIT_TYPE), coordU0.y)));
+							const UNIT_TYPE_8 f01 = as_half8(intel_sub_group_block_read_us8(U, (int2)(coordU0.x + 16 * sizeof(UNIT_TYPE), coordU0.y)));
 #else
 							const UNIT_TYPE_8 f01 = (UNIT_TYPE_8)(
 								as_half(_sub_group_block_read_us((__global unsigned short *)&U[flatA + 16 + 0 * WEIGHTWIDTH])),
@@ -637,7 +637,7 @@ KERNEL(convolution_gpu_winograd_6x3_s1_fused)
 							DOT8i_7(M6.s1, f01, V8, 12 + c8);
 
 #if FILTER_LAYOUT_IMAGE_2D_WEIGHTS_WINOGRAD_6x3_S1_FBXYB || FILTER_LAYOUT_IMAGE_2D_WEIGHTS_WINOGRAD_6x3_S1_XFBYB
-							const UNIT_TYPE_8 f02 = as_half8(_sub_group_block_read_us8(U, (int2)(coordU0.x + 32 * sizeof(UNIT_TYPE), coordU0.y)));
+							const UNIT_TYPE_8 f02 = as_half8(intel_sub_group_block_read_us8(U, (int2)(coordU0.x + 32 * sizeof(UNIT_TYPE), coordU0.y)));
 #else
 							const UNIT_TYPE_8 f02 = (UNIT_TYPE_8)(
 								as_half(_sub_group_block_read_us((__global unsigned short *)&U[flatA + 32 + 0 * WEIGHTWIDTH])),

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gen9_common_conv_fwd_data_f32.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gen9_common_conv_fwd_data_f32.cl
@@ -180,9 +180,9 @@ const float sum_scale = 1;
 
 #if USE_IMAGE == 1
                         float8 blockB00 = as_float8(
-                                _sub_group_block_read8(wei, coordB0));
+                                intel_sub_group_block_read8(wei, coordB0));
                         float8 blockB01 = as_float8(
-                                _sub_group_block_read8(wei, coordB1));
+                                intel_sub_group_block_read8(wei, coordB1));
 #else
         float8 blockB00 = as_float8(
                 _sub_group_block_read8((const __global uint *)wei1));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_1x1_gemm_buf.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_1x1_gemm_buf.cpp
@@ -70,6 +70,9 @@ bool ConvolutionKernel_bfyx_1x1_gemm_buf::Validate(const Params& p, const option
         return false;
     }
 
+    if (!params.engineInfo.supports_image)
+        return false;
+
     return true;
 }
 


### PR DESCRIPTION
### Details:
 - Fixed perf regression on several models. Use intel_sub_group_block_read_us8 instead of wrapper _sub_group_block_read_us8 for image cases

### Tickets:
 - *100290*
