### PR TITLE
DOCS: Word wrapping in preformatted text

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -13,6 +13,10 @@ main  .searchForm {
     margin-bottom: 2rem;
     margin-top: 2rem;
 }
+pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
 
 /* navigation panels override */
 /* =================================================== */


### PR DESCRIPTION
This fix addresses word wrapping in &lt;pre&gt; tags in the output html files of documentation.

The result:
http://openvino-doc.iotg.sclab.intel.com/seba-test-p-1-1/notebooks/223-gpt2-text-prediction-with-output.html#run
