### PR TITLE
Undef DEBUG macro for log level property

### DIFF
--- a/src/inference/include/openvino/runtime/properties.hpp
+++ b/src/inference/include/openvino/runtime/properties.hpp
@@ -374,7 +374,7 @@ static constexpr Property<bool> enable_profiling{"PERF_COUNT"};
 namespace log {
 
 #ifdef DEBUG
-#    define WAS_DEBUG DEBUG
+#    define _OV_WAS_DEBUG DEBUG
 #    undef DEBUG
 #endif
 
@@ -439,9 +439,9 @@ inline std::istream& operator>>(std::istream& is, Level& level) {
  */
 static constexpr Property<Level> level{"LOG_LEVEL"};
 
-#ifdef WAS_DEBUG
-#    define DEBUG WAS_DEBUG
-#    undef WAS_DEBUG
+#ifdef _OV_WAS_DEBUG
+#    define DEBUG _OV_WAS_DEBUG
+#    undef _OV_WAS_DEBUG
 #endif
 }  // namespace log
 

--- a/src/inference/include/openvino/runtime/properties.hpp
+++ b/src/inference/include/openvino/runtime/properties.hpp
@@ -373,6 +373,11 @@ static constexpr Property<bool> enable_profiling{"PERF_COUNT"};
  */
 namespace log {
 
+#ifdef DEBUG
+#    define WAS_DEBUG DEBUG
+#    undef DEBUG
+#endif
+
 /**
  * @brief Enum to define possible log levels
  * @ingroup ov_runtime_cpp_prop_api
@@ -433,6 +438,11 @@ inline std::istream& operator>>(std::istream& is, Level& level) {
  * @ingroup ov_runtime_cpp_prop_api
  */
 static constexpr Property<Level> level{"LOG_LEVEL"};
+
+#ifdef WAS_DEBUG
+#    define DEBUG WAS_DEBUG
+#    undef WAS_DEBUG
+#endif
 }  // namespace log
 
 /**


### PR DESCRIPTION
### Details:
 - `error: expected unqualified-id` because component defines: `#define DEBUG 1`

### Tickets:
 - 100153
