### PR TITLE
[CPU] Execute shape_of path in FP32 for BF16 case

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1565,6 +1565,74 @@ void Graph::EnforceBF16() {
             }
         }
     }
+
+    // in case of dynamism we need execute all shape_of path in FP32 to avoid possible accuracy loss
+    std::unordered_set<NodePtr> visitedNodes;
+    std::function<void(const NodePtr&)> markPathAsFloat = [&](const NodePtr& node) -> void {
+        if (node->getType() == Type::ShapeOf || visitedNodes.count(node)) {
+            return;
+        }
+
+        for (size_t i = 0; i < node->getOriginalInputsNumber(); i++) {
+            if (node->getOriginalInputPrecisionAtPort(i) == Precision::BF16)
+                node->setOriginalInputPrecisionAtPort(i, Precision::FP32);
+        }
+        for (size_t i = 0; i < node->getOriginalOutputsNumber(); i++) {
+            if (node->getOriginalOutputPrecisionAtPort(i) == Precision::BF16)
+                node->setOriginalOutputPrecisionAtPort(i, Precision::FP32);
+        }
+        visitedNodes.insert(node);
+
+        for (size_t i = 0; i < node->getParentEdges().size(); i++) {
+            markPathAsFloat(node->getParentEdgesAtPort(i)[0]->getParent());
+        }
+    };
+
+    for (const auto& node : graphNodes) {
+        if (!one_of(node->getType(),
+                   Type::AdaptivePooling,
+                   Type::Broadcast,
+                   Type::Deconvolution,
+                   Type::Interpolate,
+                   Type::OneHot,
+                   Type::Reshape)) {
+            continue;
+        }
+
+        switch (node->getType()) {
+            case Type::AdaptivePooling: {
+                markPathAsFloat(node->getParentEdgesAtPort(1)[0]->getParent());
+                break;
+            }
+            case Type::Broadcast: {
+                markPathAsFloat(node->getParentEdgesAtPort(1)[0]->getParent());
+                break;
+            }
+            case Type::Deconvolution: {
+                if (node->getParentEdges().size() > 2) {
+                    markPathAsFloat(node->getParentEdgesAtPort(2)[0]->getParent());
+                }
+                break;
+            }
+            case Type::Interpolate: {
+                markPathAsFloat(node->getParentEdgesAtPort(1)[0]->getParent());
+                markPathAsFloat(node->getParentEdgesAtPort(2)[0]->getParent());
+                break;
+            }
+            case Type::OneHot: {
+                markPathAsFloat(node->getParentEdgesAtPort(1)[0]->getParent());
+                break;
+            }
+            case Type::Reshape: {
+                markPathAsFloat(node->getParentEdgesAtPort(1)[0]->getParent());
+                break;
+            }
+            default: {
+                IE_THROW() << "Can't mark shape_of path for node with type: " << NameFromType(node->getType()) << " and name: " << node->getName()
+                           << " as FP32";
+            }
+        }
+    }
 }
 
 std::shared_ptr<ngraph::Function> Graph::dump() const {

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/bf16_shapeof_path.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/bf16_shapeof_path.cpp
@@ -1,0 +1,75 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <shared_test_classes/base/ov_subgraph.hpp>
+#include <ngraph_functions/builders.hpp>
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
+#include "test_utils/cpu_test_utils.hpp"
+
+using namespace ov::test;
+using namespace CPUTestUtils;
+
+namespace SubgraphTestsDefinitions {
+
+class BF16ShapeOfPath : virtual public SubgraphBaseTest, public CPUTestsBase {
+    void SetUp() override {
+        targetDevice = CommonTestUtils::DEVICE_CPU;
+
+        if (InferenceEngine::with_cpu_x86_avx512f()) {
+            configuration[InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16] = InferenceEngine::PluginConfigParams::YES;
+        }
+
+        std::vector <InputShape> inputShapes{
+            {{-1, -1, -1, -1}, {{{1, 11, 4, 4}, {2, 7, 6, 5}}}},
+            {{-1, -1}, {{1, 2}, {2, 2}}}
+        };
+
+        init_input_shapes({inputShapes});
+
+        auto ngPrc = ngraph::element::f32;
+        auto inputParams = ngraph::builder::makeDynamicParams(ngPrc, inputDynamicShapes);
+
+        // shape_of subgraph
+        auto shapeof = std::make_shared<ngraph::opset3::ShapeOf>(inputParams[1], ngraph::element::i32);
+        auto convert = std::make_shared<ngraph::opset3::Convert>(shapeof, ngraph::element::f32);
+
+        auto sndInAdd = std::make_shared<ngraph::opset3::Constant>(ngraph::element::Type_t::f32, ov::Shape{1}, std::vector<float>{1});
+        auto add = std::make_shared<ngraph::opset3::Add>(convert, sndInAdd);
+
+        auto sndInMult = std::make_shared<ngraph::opset3::Constant>(ngraph::element::Type_t::f32, ov::Shape{1}, std::vector<float>{2});
+        auto mult = std::make_shared<ngraph::opset3::Multiply>(add, sndInMult);
+
+        // interpolate node
+        using InterpOp = ngraph::op::v4::Interpolate;
+        InterpOp::InterpolateAttrs interpAttr{InterpOp::InterpolateMode::NEAREST,
+                                              InterpOp::ShapeCalcMode::SCALES,
+                                              std::vector<size_t>{0, 0, 0, 0},
+                                              std::vector<size_t>{0, 0, 0, 0},
+                                              InterpOp::CoordinateTransformMode::ASYMMETRIC,
+                                              InterpOp::NearestMode::SIMPLE,
+                                              false,
+                                              -0.75f};
+        std::vector<int32_t> sizes{20, 20};
+        auto sizesInput = std::make_shared<ngraph::opset3::Constant>(ngraph::element::Type_t::i32, ov::Shape{sizes.size()}, sizes);
+        auto axesInput = std::make_shared<ngraph::opset3::Constant>(ngraph::element::Type_t::i32, ov::Shape{2}, std::vector<int32_t>{2, 3});
+
+        auto interpolate = std::make_shared<InterpOp>(inputParams[0],
+                                                      sizesInput,
+                                                      mult,
+                                                      axesInput,
+                                                      interpAttr);
+
+        function = makeNgraphFunction(ngPrc, inputParams, interpolate, "InterpolateShapeOfPath");
+    }
+};
+
+TEST_F(BF16ShapeOfPath, smoke) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    run();
+    CheckNodeRuntimePrecision(compiledModel, "Eltwise", InferenceEngine::Precision::FP32);
+}
+
+} // namespace SubgraphTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/bf16_shapeof_path.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/bf16_shapeof_path.cpp
@@ -69,7 +69,7 @@ TEST_F(BF16ShapeOfPath, smoke) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
     run();
-    CheckNodeRuntimePrecision(compiledModel, "Eltwise", InferenceEngine::Precision::FP32);
+    CheckNodeRuntimePrecision(compiledModel, "Subgraph", InferenceEngine::Precision::FP32);
 }
 
 } // namespace SubgraphTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/test_utils/cpu_test_utils.cpp
+++ b/src/plugins/intel_cpu/tests/functional/test_utils/cpu_test_utils.cpp
@@ -392,6 +392,26 @@ void CheckNumberOfNodesWithType(InferenceEngine::ExecutableNetwork &execNet, std
     CheckNumberOfNodesWithTypeImpl(function, nodeType, expectedCount);
 }
 
+void CheckNodeRuntimePrecision(ov::CompiledModel &execNet, std::string nodeType, InferenceEngine::Precision prec) {
+    std::shared_ptr<const ov::Model> function = execNet.get_runtime_model();
+    ASSERT_NE(nullptr, function);
+    size_t foundNodesNum = 0;
+    for (const auto &node : function->get_ops()) {
+        const auto & rtInfo = node->get_rt_info();
+        auto getExecValue = [&rtInfo](const std::string & paramName) -> std::string {
+            auto it = rtInfo.find(paramName);
+            IE_ASSERT(rtInfo.end() != it);
+            return it->second.as<std::string>();
+        };
+        if (getExecValue(ExecGraphInfoSerialization::LAYER_TYPE) == nodeType) {
+            foundNodesNum++;
+            ASSERT_EQ(std::string(InferenceEngine::Precision(prec).name()),
+                      getExecValue(ExecGraphInfoSerialization::RUNTIME_PRECISION));
+        }
+    }
+    ASSERT_NE(0, foundNodesNum);
+}
+
 std::vector<CPUSpecificParams> filterCPUInfoForDevice(std::vector<CPUSpecificParams> CPUParams) {
     std::vector<CPUSpecificParams> resCPUParams;
     const int selectedTypeIndex = 3;

--- a/src/plugins/intel_cpu/tests/functional/test_utils/cpu_test_utils.hpp
+++ b/src/plugins/intel_cpu/tests/functional/test_utils/cpu_test_utils.hpp
@@ -180,4 +180,5 @@ std::vector<CPUSpecificParams> filterCPUSpecificParams(std::vector<CPUSpecificPa
 std::vector<CPUSpecificParams> filterCPUInfoForDevice(std::vector<CPUSpecificParams> CPUParams);
 void CheckNumberOfNodesWithType(ov::CompiledModel &compiledModel, std::string nodeType, size_t expectedCount);
 void CheckNumberOfNodesWithType(InferenceEngine::ExecutableNetwork &execNet, std::string nodeType, size_t expectedCount);
+void CheckNodeRuntimePrecision(ov::CompiledModel &execNet, std::string nodeType, InferenceEngine::Precision prec);
 } // namespace CPUTestUtils


### PR DESCRIPTION
### Details:
Original PR https://github.com/openvinotoolkit/openvino/pull/10210
This PR attempts to address a problem with insufficient numerical resolution of bf16 numbers to process the results of the ShapeOf operation, especially when a floating point type cast was inserted in the original model.

### Tickets:
 - CVS-78144
