### PR TITLE
DOCS: Word wrapping in preformatted text - port to 22.2

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -14,6 +14,10 @@ footer div.container div.footer-item p:nth-child(2) {
 .switcher-set {
     margin-bottom:1rem;
 }
+pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
 
 main img {
     cursor: pointer;


### PR DESCRIPTION
Porting: 
https://github.com/openvinotoolkit/openvino/pull/14889

This fix addresses word wrapping in &lt;pre&gt; tags in the output html files of documentation.

The result:
http://openvino-doc.iotg.sclab.intel.com/seba-test-p-1-1/notebooks/223-gpt2-text-prediction-with-output.html#run

