### PR TITLE
DOCS: Word wrapping in preformatted text - port to 22.1

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -9,6 +9,12 @@ main img {
 .doxyrest-title-code-block {
     margin-bottom: 0;
 }
+
+pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
 /* doc version dropdown formatting override*/
 
 [aria-labelledby="version-selector"]  {


### PR DESCRIPTION
Porting:
https://github.com/openvinotoolkit/openvino/pull/14889

This fix addresses word wrapping in &lt;pre&gt; tags in the output html files of documentation.

The result:
http://openvino-doc.iotg.sclab.intel.com/seba-test-p-1-1/notebooks/223-gpt2-text-prediction-with-output.html#run
