### PR TITLE
DOCS: Hiding Transition to API 2.0 banner - for 22.2

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -140,15 +140,32 @@ div.highlight {
     border: none;
     border-radius: 0;
     font-weight: bold;
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
 }
 
 .transition-banner > p {
     margin-bottom: 0;
 }
 
-.transition-banner .close {
+.transition-banner .close-banner {
+    position:absolute;
+    top:0;
+    right:0;
     padding: 0 1.25rem;
     color: #000;
+    background-color: transparent;
+    border: 0;
+    float: right;
+    font-size: 1.5rem;
+    font-weight: 700;
+    line-height: 1;
+    text-shadow: 0 1px 0 #fff;
+    opacity: .5;
+}
+.hidden-banner {
+    display: none!important;
 }
 
 

--- a/docs/_static/js/hide_banner.js
+++ b/docs/_static/js/hide_banner.js
@@ -2,7 +2,7 @@ function closeTransitionBanner() {
    var cookieContent = 'TransitionBannerIsHiddenX=true;';
    var expiry ='expires=';
    var date = new Date();
-   var expirationDate = date.getTime() + (30 * 24 * 60 * 60 * 1000);
+   var expirationDate = date.getTime() + (365 * 24 * 60 * 60 * 1000);
    date.setTime(expirationDate);
    expiry += date.toUTCString();
    document.cookie = cookieContent + expiry;

--- a/docs/_static/js/hide_banner.js
+++ b/docs/_static/js/hide_banner.js
@@ -1,0 +1,15 @@
+function closeTransitionBanner() {
+   var cookieContent = 'TransitionBannerIsHiddenX=true;';
+   var expiry ='expires=';
+   var date = new Date();
+   var expirationDate = date.getTime() + (30 * 24 * 60 * 60 * 1000);
+   date.setTime(expirationDate);
+   expiry += date.toUTCString();
+   document.cookie = cookieContent + expiry;
+   var transitionBanner = document.getElementById("info-banner");
+   transitionBanner.classList.add("hidden-banner");
+   }
+ if (document.cookie.split(';').filter(function (find_cookie_name) {return find_cookie_name.trim().indexOf('TransitionBannerIsHiddenX=') === 0; }).length) {
+     var transitionBanner = document.getElementById("info-banner");
+     transitionBanner.classList.add("hidden-banner");
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -17,10 +17,11 @@
 
 {% block docs_navbar %}
 {{ super() }}
-<div class="transition-banner container-fluid alert alert-info alert-dismissible fade show" role="alert">
+<div id="info-banner" class="transition-banner">
     <p>OpenVINO 2022.1 introduces a new version of OpenVINO API (API 2.0). For more information on the changes and transition steps, see the <a href="https://docs.openvino.ai/latest/openvino_2_0_transition_guide.html">transition guide</a></p>
-    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <button type="button" class="close-banner" onclick="closeTransitionBanner()">
       <span aria-hidden="true">&times;</span>
     </button>
 </div>
+<script src="{{ pathto('_static/js/hide_banner.js', 1) }}"></script>
 {% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -18,7 +18,7 @@
 {% block docs_navbar %}
 {{ super() }}
 <div id="info-banner" class="transition-banner">
-    <p>OpenVINO 2022.1 introduces a new version of OpenVINO API (API 2.0). For more information on the changes and transition steps, see the <a href="https://docs.openvino.ai/latest/openvino_2_0_transition_guide.html">transition guide</a></p>
+    <p>OpenVINO 2022.1 introduces a new version of OpenVINO API (API 2.0). For more information on the changes and transition steps, see the <a href="https://docs.openvino.ai/2022.2/openvino_2_0_transition_guide.html">transition guide</a></p>
     <button type="button" class="close-banner" onclick="closeTransitionBanner()">
       <span aria-hidden="true">&times;</span>
     </button>


### PR DESCRIPTION
Porting: https://github.com/openvinotoolkit/openvino/pull/14949
This enables keeping the banner hidden after closing it.