### PR TITLE
[Tools][MO] Clean up requirements for default installation

### DIFF
--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -162,7 +162,11 @@ jobs:
       # For running TensorFlow frontend unit tests
       python3 -m pip install -r $(REPO_DIR)/src/frontends/tensorflow/tests/requirements.txt
       # For MO unit tests
-      python3 -m pip install -r $(REPO_DIR)/tools/mo/requirements.txt
+      python3 -m pip install -r $(REPO_DIR)/tools/mo/requirements_mxnet.txt
+      python3 -m pip install -r $(REPO_DIR)/tools/mo/requirements_caffe.txt
+      python3 -m pip install -r $(REPO_DIR)/tools/mo/requirements_kaldi.txt
+      python3 -m pip install -r $(REPO_DIR)/tools/mo/requirements_onnx.txt
+      python3 -m pip install -r $(REPO_DIR)/tools/mo/requirements_tf2.txt
       python3 -m pip install -r $(REPO_DIR)/tools/mo/requirements_dev.txt
       # Speed up build
       wget https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip

--- a/.ci/azure/linux_debian.yml
+++ b/.ci/azure/linux_debian.yml
@@ -138,7 +138,11 @@ jobs:
       # For running TensorFlow frontend unit tests
       python3 -m pip install -r $(REPO_DIR)/src/frontends/tensorflow/tests/requirements.txt
       # For MO unit tests
-      python3 -m pip install -r $(REPO_DIR)/tools/mo/requirements.txt
+      python3 -m pip install -r $(REPO_DIR)/tools/mo/requirements_mxnet.txt
+      python3 -m pip install -r $(REPO_DIR)/tools/mo/requirements_caffe.txt
+      python3 -m pip install -r $(REPO_DIR)/tools/mo/requirements_kaldi.txt
+      python3 -m pip install -r $(REPO_DIR)/tools/mo/requirements_onnx.txt
+      python3 -m pip install -r $(REPO_DIR)/tools/mo/requirements_tf2.txt
       python3 -m pip install -r $(REPO_DIR)/tools/mo/requirements_dev.txt
       # Speed up build
       wget https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip

--- a/tools/mo/requirements.txt
+++ b/tools/mo/requirements.txt
@@ -1,13 +1,5 @@
 numpy>=1.16.6
-tensorflow>=1.15.5,<=2.11.0
-mxnet~=1.2.0; sys_platform == 'win32'
-mxnet>=1.7.0.post2,<=1.9.1; sys_platform != 'win32'
 networkx~=2.5; python_version <= "3.6"
 networkx<=2.8.8; python_version > "3.6"
-protobuf>=3.18.1,<4.0.0
-onnx>=1.8.1,<=1.12
 defusedxml>=0.7.1
-urllib3>=1.26.4
-requests>=2.25.1
-fastjsonschema~=2.15.1
 openvino-telemetry>=2022.1.0


### PR DESCRIPTION
**Details:** Clarify that `requirements.txt` file is used only for the default installation. Now it confuses the validation that it combines dependencies for all extras installation but it is not true. Moreover, we are going to remove duplicates in requirements files so that it will be more easier to update it by `dependant-bot`.

**Ticket:** TBD

Signed-off-by: Kazantsev, Roman <roman.kazantsev@intel.com>
