### PR TITLE
[GNA] Skip GNA config structure initialization when compiling in GNA_…

### DIFF
--- a/src/plugins/intel_gna/src/gna_plugin.cpp
+++ b/src/plugins/intel_gna/src/gna_plugin.cpp
@@ -1121,7 +1121,8 @@ std::string GNAPlugin::effectiveGnaCompileTarget() const {
 }
 
 std::shared_ptr<request::Worker> GNAPlugin::createWorkerForLoadNetwork(bool trivial, bool fp32Mode) {
-    return createWorker(createModelWrapperForLoadNetwork(trivial), trivial, fp32Mode);
+    // Do not initialize gna model for fp32 mode (create trivial model wraper)
+    return createWorker(createModelWrapperForLoadNetwork(trivial || fp32Mode), trivial, fp32Mode);
 }
 
 std::shared_ptr<request::Worker> GNAPlugin::createWorker(std::shared_ptr<request::ModelWrapper> modelWrapper,


### PR DESCRIPTION
…SW_FP32 mode

### Details:
 - The assert is triggered during the initialization of the GNA configuration structure when compiling model in GNA_SW_FP32 mode. The solution to the problem is to skip the initialization of mentioned structure.

### Tickets:
 - 100705
