### PR TITLE
[GPU] fix stridedslice begin index bound check

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
@@ -148,7 +148,7 @@ public:
                 if (params.striding_params[1][dim] < 0)
                     params.striding_params[1][dim] = std::max(out_shape[dim] + params.striding_params[1][dim], (int32_t)0);
 
-                params.striding_params[0][dim] = std::min(params.striding_params[0][dim], out_shape[dim]);
+                params.striding_params[0][dim] = std::min(params.striding_params[0][dim], std::max((int32_t)0, out_shape[dim] - 1));
                 params.striding_params[1][dim] = std::min(params.striding_params[1][dim], out_shape[dim]);
 
                 auto& begin = params.striding_params[0][dim];

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/strided_slice_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/strided_slice_ref.cl
@@ -159,7 +159,7 @@ inline int FUNC(check_begin_bound)(BEGIN_TYPE begin_num,
     } else {
         num = begin_num;
     }
-    num = min(num, (int)out_num);
+    num = min(num, (int)max(TO_BEGIN_TYPE(out_num) - TO_BEGIN_TYPE(1), TO_BEGIN_TYPE(0)));
     return num;
 }
 


### PR DESCRIPTION
There's special cases when some dim of begin is larger than the corresponding value of output dim, it needs to set the begin value to output dim value - 1, because begin is indexed from 0.

### Details:
 - *Example of the special case:*
   - Input:
     - Shape: 1x2x3x3
     - Data: 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 16.0f, 17.0f 
   - Begin: [0, 1000000000]
   - End: [1000000000, -1000000000]
   - Stride: [1, -1]
   - Output:
     - Shape: 1x2x3x3
     - Expected: 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f
     - Answer w/o patch: 0,0,0,0,0,0,0,0,0,9,10,11,12,13,14,15,16,17

### Tickets:
 - *100666*
