### PR TITLE
Update calculateFileInfo for the null string case

### DIFF
--- a/src/inference/src/compilation_context.cpp
+++ b/src/inference/src/compilation_context.cpp
@@ -49,7 +49,7 @@ std::string NetworkCompilationContext::calculateFileInfo(const std::string& file
     if (filePath.size() > 0) {
         try {
             absPath = FileUtils::absoluteFilePath(filePath);
-        } catch (...) {
+        } catch (std::runtime_error &) {
             // can't get absolute path, will use filePath for hash
         }
     }

--- a/src/inference/src/compilation_context.cpp
+++ b/src/inference/src/compilation_context.cpp
@@ -46,10 +46,12 @@ static int32_t as_int32_t(T v) {
 std::string NetworkCompilationContext::calculateFileInfo(const std::string& filePath) {
     uint64_t seed = 0;
     auto absPath = filePath;
-    try {
-        absPath = FileUtils::absoluteFilePath(filePath);
-    } catch (...) {
-        // can't get absolute path, will use filePath for hash
+    if (filePath.size() > 0) {
+        try {
+            absPath = FileUtils::absoluteFilePath(filePath);
+        } catch (...) {
+            // can't get absolute path, will use filePath for hash
+        }
     }
 
     seed = hash_combine(seed, absPath);

--- a/src/inference/src/compilation_context.cpp
+++ b/src/inference/src/compilation_context.cpp
@@ -49,7 +49,7 @@ std::string NetworkCompilationContext::calculateFileInfo(const std::string& file
     if (filePath.size() > 0) {
         try {
             absPath = FileUtils::absoluteFilePath(filePath);
-        } catch (std::runtime_error &) {
+        } catch (std::runtime_error&) {
             // can't get absolute path, will use filePath for hash
         }
     }


### PR DESCRIPTION
### Details:
 - `modelPath` of `CacheContent` can be a null string.
 - In this case, `InferenceEngine::NetworkCompilationContext::calculateFileInfo` returns non-consistent results on some environments
        https://github.com/openvinotoolkit/openvino/blob/9c7beee5e55808730418dfd6bb5fb22e7bb28dc8/src/inference/src/compilation_context.cpp#L46-L64

    1. Let's assume that `filePath` = "" @ L46
    2.  `FileUtils::absoluteFilePath(filePath)` returns the present working DIRECTORY of current app @ L50
    3.  `stat(absPath.c_str(), &result)` succeeds @ L59
    4.  `result.st_mtime` is the last modification time of the present working DIRECTORY @ L60
    5.  if some changes occur in the DIRECTORY, different FileInfo is generated.
    6.  FileInfo mismatch in `ov::CoreImpl::LoadNetworkFromCache`
        https://github.com/openvinotoolkit/openvino/blob/9c7beee5e55808730418dfd6bb5fb22e7bb28dc8/src/inference/src/ie_core.cpp#L463-L467
    7.  current cache blob is removed, and a new one is regenerated.
        https://github.com/openvinotoolkit/openvino/blob/9c7beee5e55808730418dfd6bb5fb22e7bb28dc8/src/inference/src/ie_core.cpp#L477-L480
 - This PR prevents this situation by not fining absolute path for a null `filePath`.

### Tickets:
 - 100835
