### PR TITLE
[ARM] Added neon_mathfun license

### DIFF
--- a/cmake/packaging/copyrights/arm_cpu
+++ b/cmake/packaging/copyrights/arm_cpu
@@ -23,3 +23,25 @@ License: MIT
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
+
+Files: *
+Comment: neon_mathfun.h
+Copyright: (C) 2011  Julien Pommier
+License: zlib
+
+ This software is provided 'as-is', without any express or implied
+ warranty.  In no event will the authors be held liable for any damages
+ arising from the use of this software.
+
+ Permission is granted to anyone to use this software for any purpose,
+ including commercial applications, and to alter it and redistribute it
+ freely, subject to the following restrictions:
+
+ 1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software
+    in a product, an acknowledgment in the product documentation would be
+    appreciated but is not required.
+ 2. Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+ 3. This notice may not be removed or altered from any source distribution.
+ 


### PR DESCRIPTION
Should be merged after https://github.com/openvinotoolkit/openvino_contrib/pull/489