### PR TITLE
[PyOV] Add properties of GPU plugin to bindings

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
@@ -93,17 +93,18 @@ void regmodule_properties(py::module m) {
         "openvino.runtime.properties.intel_gpu.hint submodule that simulates ov::intel_gpu::hint");
 
     // `ThrottleLevel` enum is conflicting with `priorities.hint.Priority` in bindings.
-    // Thus below implementation will not be present. py::module_local() is forcing
-    // `Priorty` values to translate to `ThrottleLevel` on `ov.intel_gpu.hint` level
-    // where only `queue_throttle` is using it directly.
-    // py::enum_<ov::intel_gpu::hint::ThrottleLevel>(m_intel_gpu_hint,
-    //                                               "ThrottleLevel",
-    //                                               py::arithmetic(),
-    //                                               py::module_local())
-    //     .value("LOW", ov::intel_gpu::hint::ThrottleLevel::LOW)
-    //     .value("MEDIUM", ov::intel_gpu::hint::ThrottleLevel::MEDIUM)
-    //     .value("HIGH", ov::intel_gpu::hint::ThrottleLevel::HIGH)
-    //     .value("DEFAULT", ov::intel_gpu::hint::ThrottleLevel::DEFAULT);
+    // `ov::intel_gpu::hint::ThrottleLevel` workaround proxy class:
+    class ThrottleLevelProxy {};
+
+    py::class_<ThrottleLevelProxy, std::shared_ptr<ThrottleLevelProxy>> m_throttle_level(
+        m_intel_gpu_hint,
+        "ThrottleLevel",
+        "openvino.runtime.properties.intel_gpu.hint.ThrottleLevel that simulates ov::intel_gpu::hint::ThrottleLevel");
+
+    m_throttle_level.attr("LOW") = ov::intel_gpu::hint::ThrottleLevel::LOW;
+    m_throttle_level.attr("MEDIUM") = ov::intel_gpu::hint::ThrottleLevel::MEDIUM;
+    m_throttle_level.attr("HIGH") = ov::intel_gpu::hint::ThrottleLevel::HIGH;
+    m_throttle_level.attr("DEFAULT") = ov::intel_gpu::hint::ThrottleLevel::DEFAULT;
 
     wrap_property_RW(m_intel_gpu_hint, ov::intel_gpu::hint::queue_throttle, "queue_throttle");
     wrap_property_RW(m_intel_gpu_hint, ov::intel_gpu::hint::queue_priority, "queue_priority");

--- a/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
@@ -75,6 +75,41 @@ void regmodule_properties(py::module m) {
                      ov::intel_cpu::sparse_weights_decompression_rate,
                      "sparse_weights_decompression_rate");
 
+    // Submodule intel_gpu
+    py::module m_intel_gpu =
+        m_properties.def_submodule("intel_gpu",
+                                   "openvino.runtime.properties.intel_gpu submodule that simulates ov::intel_gpu");
+
+    wrap_property_RO(m_intel_gpu, ov::intel_gpu::device_total_mem_size, "device_total_mem_size");
+    wrap_property_RO(m_intel_gpu, ov::intel_gpu::uarch_version, "uarch_version");
+    wrap_property_RO(m_intel_gpu, ov::intel_gpu::execution_units_count, "execution_units_count");
+    wrap_property_RO(m_intel_gpu, ov::intel_gpu::memory_statistics, "memory_statistics");
+
+    wrap_property_RW(m_intel_gpu, ov::intel_gpu::enable_loop_unrolling, "enable_loop_unrolling");
+
+    // Submodule hint (intel_gpu)
+    py::module m_intel_gpu_hint = m_intel_gpu.def_submodule(
+        "hint",
+        "openvino.runtime.properties.intel_gpu.hint submodule that simulates ov::intel_gpu::hint");
+
+    // `ThrottleLevel` enum is conflicting with `priorities.hint.Priority` in bindings.
+    // Thus below implementation will not be present. py::module_local() is forcing
+    // `Priorty` values to translate to `ThrottleLevel` on `ov.intel_gpu.hint` level
+    // where only `queue_throttle` is using it directly.
+    // py::enum_<ov::intel_gpu::hint::ThrottleLevel>(m_intel_gpu_hint,
+    //                                               "ThrottleLevel",
+    //                                               py::arithmetic(),
+    //                                               py::module_local())
+    //     .value("LOW", ov::intel_gpu::hint::ThrottleLevel::LOW)
+    //     .value("MEDIUM", ov::intel_gpu::hint::ThrottleLevel::MEDIUM)
+    //     .value("HIGH", ov::intel_gpu::hint::ThrottleLevel::HIGH)
+    //     .value("DEFAULT", ov::intel_gpu::hint::ThrottleLevel::DEFAULT);
+
+    wrap_property_RW(m_intel_gpu_hint, ov::intel_gpu::hint::queue_throttle, "queue_throttle");
+    wrap_property_RW(m_intel_gpu_hint, ov::intel_gpu::hint::queue_priority, "queue_priority");
+    wrap_property_RW(m_intel_gpu_hint, ov::intel_gpu::hint::host_task_priority, "host_task_priority");
+    wrap_property_RW(m_intel_gpu_hint, ov::intel_gpu::hint::available_device_mem, "available_device_mem");
+
     // Submodule device
     py::module m_device =
         m_properties.def_submodule("device", "openvino.runtime.properties.device submodule that simulates ov::device");
@@ -131,6 +166,27 @@ void regmodule_properties(py::module m) {
     m_capability.attr("BIN") = ov::device::capability::BIN;
     m_capability.attr("WINOGRAD") = ov::device::capability::WINOGRAD;
     m_capability.attr("EXPORT_IMPORT") = ov::device::capability::EXPORT_IMPORT;
+
+    // Submodule memory_type (intel_gpu)
+    class FakeMemoryType {};
+
+    py::class_<FakeMemoryType, std::shared_ptr<FakeMemoryType>> m_memory_type(
+        m_intel_gpu,
+        "MemoryType",
+        "openvino.runtime.properties.intel_gpu.MemoryType submodule that simulates ov::intel_gpu::memory_type");
+
+    m_memory_type.attr("surface") = ov::intel_gpu::memory_type::surface;
+    m_memory_type.attr("buffer") = ov::intel_gpu::memory_type::buffer;
+
+    // Submodule capability (intel_gpu)
+    class FakeCapabilityGPU {};
+
+    py::class_<FakeCapabilityGPU, std::shared_ptr<FakeCapabilityGPU>> m_capability_gpu(
+        m_intel_gpu,
+        "CapabilityGPU",
+        "openvino.runtime.properties.intel_gpu.CapabilityGPU submodule that simulates ov::intel_gpu::capability");
+
+    m_capability_gpu.attr("HW_MATMUL") = ov::intel_gpu::capability::HW_MATMUL;
 
     // Submodule log
     py::module m_log =

--- a/src/bindings/python/src/pyopenvino/core/properties/properties.hpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.hpp
@@ -9,6 +9,7 @@
 
 #include "openvino/runtime/properties.hpp"
 #include "openvino/runtime/intel_cpu/properties.hpp"
+#include "openvino/runtime/intel_gpu/properties.hpp"
 #include "pyopenvino/core/properties/properties.hpp"
 
 namespace py = pybind11;

--- a/src/bindings/python/src/pyopenvino/utils/utils.cpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.cpp
@@ -34,6 +34,8 @@ py::object from_ov_any(const ov::Any& any) {
     // Check for unsigned int
     else if (any.is<unsigned int>()) {
         return py::cast(any.as<unsigned int>());
+    } else if (any.is<uint64_t>()) {
+        return py::cast(any.as<uint64_t>());
     }
     // Check for float
     else if (any.is<float>()) {
@@ -84,6 +86,14 @@ py::object from_ov_any(const ov::Any& any) {
     // Check for std::map<std::string, int>
     else if (any.is<std::map<std::string, int>>()) {
         return py::cast(any.as<std::map<std::string, int>>());
+    }
+    // Check for std::map<std::string, uint64_t>
+    else if (any.is<std::map<std::string, uint64_t>>()) {
+        return py::cast(any.as<std::map<std::string, uint64_t>>());
+    }
+    // Check for std::map<element::Type, float>
+    else if (any.is<std::map<ov::element::Type, float>>()) {
+        return py::cast(any.as<std::map<ov::element::Type, float>>());
     }
     // Check for std::vector<ov::PropertyName>
     else if (any.is<std::vector<ov::PropertyName>>()) {

--- a/src/bindings/python/tests/test_runtime/test_properties.py
+++ b/src/bindings/python/tests/test_runtime/test_properties.py
@@ -109,7 +109,10 @@ def test_properties_enums(ov_enum, expected_values):
         (properties.device.type, "DEVICE_TYPE"),
         (properties.device.gops, "DEVICE_GOPS"),
         (properties.device.thermal, "DEVICE_THERMAL"),
-        (properties.device.capabilities, "OPTIMIZATION_CAPABILITIES"),
+        (properties.intel_gpu.device_total_mem_size, "GPU_DEVICE_TOTAL_MEM_SIZE"),
+        (properties.intel_gpu.uarch_version, "GPU_UARCH_VERSION"),
+        (properties.intel_gpu.execution_units_count, "GPU_EXECUTION_UNITS_COUNT"),
+        (properties.intel_gpu.memory_statistics, "GPU_MEMORY_STATISTICS"),
     ],
 )
 def test_properties_ro(ov_property_ro, expected_value):
@@ -207,6 +210,31 @@ def test_properties_ro(ov_property_ro, expected_value):
             "LOG_LEVEL",
             ((properties.log.Level.NO, properties.log.Level.NO),),
         ),
+        (
+            properties.intel_gpu.enable_loop_unrolling,
+            "GPU_ENABLE_LOOP_UNROLLING",
+            ((True, True),),
+        ),
+        (
+            properties.intel_gpu.hint.queue_throttle,
+            "GPU_QUEUE_THROTTLE",
+            ((properties.hint.Priority.LOW, properties.hint.Priority.LOW),),
+        ),
+        (
+            properties.intel_gpu.hint.queue_priority,
+            "GPU_QUEUE_PRIORITY",
+            ((properties.hint.Priority.LOW, properties.hint.Priority.LOW),),
+        ),
+        (
+            properties.intel_gpu.hint.host_task_priority,
+            "GPU_HOST_TASK_PRIORITY",
+            ((properties.hint.Priority.LOW, properties.hint.Priority.LOW),),
+        ),
+        (
+            properties.intel_gpu.hint.available_device_mem,
+            "AVAILABLE_DEVICE_MEM_SIZE",
+            ((128, 128),),
+        ),
     ],
 )
 def test_properties_rw(ov_property_rw, expected_value, test_values):
@@ -259,6 +287,15 @@ def test_properties_capability():
     assert properties.device.Capability.BIN == "BIN"
     assert properties.device.Capability.WINOGRAD == "WINOGRAD"
     assert properties.device.Capability.EXPORT_IMPORT == "EXPORT_IMPORT"
+
+
+def test_properties_memory_type_gpu():
+    assert properties.intel_gpu.MemoryType.surface == "GPU_SURFACE"
+    assert properties.intel_gpu.MemoryType.buffer == "GPU_BUFFER"
+
+
+def test_properties_capability_gpu():
+    assert properties.intel_gpu.CapabilityGPU.HW_MATMUL == "GPU_HW_MATMUL"
 
 
 def test_properties_hint_model():

--- a/src/bindings/python/tests/test_runtime/test_properties.py
+++ b/src/bindings/python/tests/test_runtime/test_properties.py
@@ -90,6 +90,33 @@ def test_properties_enums(ov_enum, expected_values):
         assert int(property_obj) == property_int
 
 
+@pytest.mark.parametrize(
+    ("proxy_enums", "expected_values"),
+    [
+        (
+            (
+                properties.intel_gpu.hint.ThrottleLevel.LOW,
+                properties.intel_gpu.hint.ThrottleLevel.MEDIUM,
+                properties.intel_gpu.hint.ThrottleLevel.HIGH,
+                properties.intel_gpu.hint.ThrottleLevel.DEFAULT,
+            ),
+            (
+                ("Priority.LOW", 0),
+                ("Priority.MEDIUM", 1),
+                ("Priority.HIGH", 2),
+                ("Priority.MEDIUM", 1),
+            ),
+        ),
+    ]
+)
+def test_conflicting_enum(proxy_enums, expected_values):
+    assert len(proxy_enums) == len(expected_values)
+
+    for i in range(len(proxy_enums)):
+        assert str(proxy_enums[i]) == expected_values[i][0]
+        assert int(proxy_enums[i]) == expected_values[i][1]
+
+
 ###
 # Read-Only properties
 ###
@@ -109,6 +136,7 @@ def test_properties_enums(ov_enum, expected_values):
         (properties.device.type, "DEVICE_TYPE"),
         (properties.device.gops, "DEVICE_GOPS"),
         (properties.device.thermal, "DEVICE_THERMAL"),
+        (properties.device.capabilities, "OPTIMIZATION_CAPABILITIES"),
         (properties.intel_gpu.device_total_mem_size, "GPU_DEVICE_TOTAL_MEM_SIZE"),
         (properties.intel_gpu.uarch_version, "GPU_UARCH_VERSION"),
         (properties.intel_gpu.execution_units_count, "GPU_EXECUTION_UNITS_COUNT"),
@@ -218,7 +246,7 @@ def test_properties_ro(ov_property_ro, expected_value):
         (
             properties.intel_gpu.hint.queue_throttle,
             "GPU_QUEUE_THROTTLE",
-            ((properties.hint.Priority.LOW, properties.hint.Priority.LOW),),
+            ((properties.intel_gpu.hint.ThrottleLevel.LOW, properties.hint.Priority.LOW),),
         ),
         (
             properties.intel_gpu.hint.queue_priority,

--- a/src/bindings/python/tests/test_runtime/test_properties.py
+++ b/src/bindings/python/tests/test_runtime/test_properties.py
@@ -107,7 +107,7 @@ def test_properties_enums(ov_enum, expected_values):
                 ("Priority.MEDIUM", 1),
             ),
         ),
-    ]
+    ],
 )
 def test_conflicting_enum(proxy_enums, expected_values):
     assert len(proxy_enums) == len(expected_values)


### PR DESCRIPTION
### Details:
 - Added new submodules to properties: `intel_gpu`, `intel_gpu.hint`, `intel_gpu.MemoryType`, `intel_gpu.CapabilityGPU`
 - Added tests.
 - "in-line" explanation for conflicting `ov::intel_gpu::hint::ThrottleLevel`.
 
### Tickets:
 - *100915*
