### PR TITLE
[CPU] Use static post ops in the FC node

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -266,9 +266,9 @@ void FullyConnected::getSupportedDescriptors() {
 }
 
 void FullyConnected::createPrimitive() {
-    Node::createPrimitive();
     setPostOps(attr, outDims);
     attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    Node::createPrimitive();
     appendPostOpArgs(attr, primArgs, postOpsArgs);
 }
 
@@ -505,7 +505,7 @@ bool FullyConnected::canFuse(const NodePtr& node) const {
     return canFuseSimpleOperation(node);
 }
 
-void FullyConnected::setPostOps(dnnl::primitive_attr& attr, const VectorDims& dims_ext, bool initWeights) {
+void FullyConnected::setPostOps(dnnl::primitive_attr& attr, const VectorDims& dims_ext) {
     dnnl::post_ops ops;
 
     // accoridng to https://oneapi-src.github.io/oneDNN/dev_guide_inner_product.html
@@ -596,14 +596,6 @@ const std::vector<impl_desc_type>& FullyConnected::getPrimitivesPriority() {
             implPriorities.push_back(impl);
     }
     return implPriorities;
-}
-
-Node::AttrPtr FullyConnected::initPrimitiveAttr() {
-    auto attr = std::make_shared<dnnl::primitive_attr>(dnnl::primitive_attr());
-
-    setPostOps(*attr, outDims);
-
-    return attr;
 }
 
 // WA: creation DnnlMemoryDesc with format == any is prohibited

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.h
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.h
@@ -52,8 +52,6 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ngraph::Node>& op, std::string& errorMessage) noexcept;
 
-    std::shared_ptr<dnnl::primitive_attr> initPrimitiveAttr() override;
-
     void prepareParams() override;
     void executeDynamicImpl(dnnl::stream strm) override;
 
@@ -69,7 +67,7 @@ private:
     VectorDims inDims;
     VectorDims outDims;
 
-    void setPostOps(dnnl::primitive_attr &attr, const VectorDims &dims, bool initWeights = false);
+    void setPostOps(dnnl::primitive_attr &attr, const VectorDims &dims);
 
     bool withBiases = false;
 

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.h
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.h
@@ -42,7 +42,7 @@ public:
 
     void initSupportedPrimitiveDescriptors() override;
     void initOptimalPrimitiveDescriptor() override;
-    // void createPrimitive() override;
+    void createPrimitive() override;
     std::shared_ptr<MemoryDesc> getSrcMemDesc(dnnl::primitive_desc_iterator &primitive_desc_it, size_t idx) override;
     std::shared_ptr<MemoryDesc> getDstMemDesc(dnnl::primitive_desc_iterator &primitive_desc_it, size_t idx) override;
 
@@ -89,6 +89,7 @@ private:
     // When weightCache is enabled, it holds weight ptr reference since weightCache does not hold the
     // reference
     std::unordered_map<std::string, MemoryPtr> privateWeightCache;
+    dnnl::primitive_attr attr;
 
     class ExecutorInnerProduct : public DnnlExecutor {
         public:


### PR DESCRIPTION
### Details:
Since the FC node always has a constant tenzor on its second input the OC size is always static, and we can exploit this fact and initialize the `dnnl::primitive_attr` object only once on the `createPrimitive` stage. This modification helps to save a lot of `prepareParams` time in the case of dynamic shapes.

