### PR TITLE
[benchmark_app python] Fix crash in case of binary input and batch > 1

### DIFF
--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -105,7 +105,7 @@ def get_input_data(paths_to_input, app_input_info):
                                    f"provided data shapes. Only {binaries_to_be_used_map[info.name]} binaries will be processed for this input.")
                 elif binaries_to_be_used_map[info.name] < total_frames:
                     logger.warning(f"Some binaries will be dublicated: {total_frames} is required, "
-                                   f"but only {images_to_be_used_map[info.name]} were provided.")
+                                   f"but only {binaries_to_be_used_map[info.name]} were provided.")
             else:
                 if not (info.is_image_info and len(image_sizes) == 1):
                     logger.warning(f"No input files were given for input '{info.name}'!. This input will be filled with random values!")


### PR DESCRIPTION
### Details:
Python benchmark_app crashes with the `KeyError` exception in case of binary input file and batch_size > 1:
```
$ benchmark_app.py -m /tmp/models/public/robust-video-matting-mobilenetv3/FP32/robust-video-matting-mobilenetv3.xml -i src:image_0.png r1:r1.bin -b 4 
[Step 1/11] Parsing and validating input arguments
[ INFO ] Parsing input parameters
[Step 2/11] Loading OpenVINO Runtime
[ INFO ] OpenVINO:
[ INFO ] Build ................................. 2022.3.0-9052-9752fafe8eb-releases/2022/3
[ INFO ] 
[ INFO ] Device info:
[ INFO ] CPU
[ INFO ] Build ................................. 2022.3.0-9052-9752fafe8eb-releases/2022/3
[ INFO ] 
[ INFO ] 

<...>

[Step 9/11] Creating infer requests and preparing input tensors
[ WARNING ] Some images will be dublicated: 4 is required, but only 1 were provided.
[ ERROR ] 'r1'
Traceback (most recent call last):
  File "/mnt/c/repo/openvino/tools/benchmark_tool/openvino/tools/benchmark/main.py", line 486, in main
    data_queue = get_input_data(paths_to_input, app_inputs_info)
  File "/mnt/c/repo/openvino/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py", line 107, in get_input_data
    logger.warning(f"Some binaries will be dublicated: {total_frames} is required, "
KeyError: 'r1'
```