### PR TITLE
Revert "Fixed linker warnings in docs snippets on Windows (#15119)"

### DIFF
--- a/docs/snippets/src/main.c
+++ b/docs/snippets/src/main.c
@@ -6,7 +6,7 @@
 #include <openvino/c/openvino.h>
 //! [include]
 
-int main_c() {
+int main() {
 //! [part1]
 ov_core_t* core = NULL;
 ov_core_create(&core);

--- a/docs/snippets/src/main.cpp
+++ b/docs/snippets/src/main.cpp
@@ -6,7 +6,7 @@
 #include <openvino/openvino.hpp>
 //! [include]
 
-int main_cpp() {
+int main() {
 //! [part1]
 ov::Core core;
 //! [part1]


### PR DESCRIPTION
This reverts commit 372699ec49e72edc08b87c0767527401f0614adf.
This PR breaks linux build

```
FAILED: /agent/_work/1/openvino/bin/aarch64/Release/ov_integration_snippet_c 
: && ccache /usr/bin/aarch64-linux-gnu-gcc -fsigned-char -ffunction-sections -fdata-sections -fdiagnostics-show-option -Wundef -Wreturn-type -Wunused-variable -Wuninitialized -Winit-self -Wmaybe-uninitialized -Wall -Wno-unused-variable -Wno-unused-variable -Wno-unused-but-set-variable -O3 -DNDEBUG  -Wformat -Wformat-security -D_FORTIFY_SOURCE=2 -fno-strict-overflow -fno-delete-null-pointer-checks -fwrapv -fstack-protector-strong -s -Wl,--exclude-libs,ALL -Wl,--gc-sections  -pie  -z noexecstack -z relro -z now docs/snippets/CMakeFiles/ov_integration_snippet_c.dir/src/main.c.o -o /agent/_work/1/openvino/bin/aarch64/Release/ov_integration_snippet_c  -Wl,-rpath,/agent/_work/1/openvino/bin/aarch64/Release:/agent/_work/1/_w/build/extras/oneTBB/lib  /agent/_work/1/openvino/bin/aarch64/Release/libopenvino_c.so.2023.0.0  -Wl,-rpath-link,/agent/_work/1/openvino/bin/aarch64/Release:/agent/_work/1/_w/build/extras/oneTBB/lib && :
/usr/lib/gcc-cross/aarch64-linux-gnu/9/../../../../aarch64-linux-gnu/bin/ld: /usr/lib/gcc-cross/aarch64-linux-gnu/9/../../../../aarch64-linux-gnu/lib/../lib/Scrt1.o: in function `_start':
(.text+0x18): undefined reference to `main'
/usr/lib/gcc-cross/aarch64-linux-gnu/9/../../../../aarch64-linux-gnu/bin/ld: (.text+0x1c): undefined reference to `main'
collect2: error: ld returned 1 exit status

```
### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
