### PR TITLE
[GPU] Use onednn fc/gemm in dGPU.

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/debug_configuration.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/debug_configuration.hpp
@@ -78,26 +78,26 @@ private:
 
 public:
     static const char *prefix;
-    int help;                               // Print help messages
-    int verbose;                            // Verbose execution
-    int print_multi_kernel_perf;            // Print execution time of each kernel in multi-kernel primitimive
-    int disable_usm;                        // Disable usm usage
-    int disable_onednn;                     // Disable onednn for discrete GPU (no effect for integrated GPU)
-    int disable_onednn_opt_post_ops;        // Disable onednn optimize post operators
-    std::string dump_profiling_data;        // Enables dump of extended performance profiling to specified dir
-    std::string dump_graphs;                // Dump optimized graph
-    std::string dump_sources;               // Dump opencl sources
-    std::string dump_layers_path;           // Enable dumping intermediate buffers and set the dest path
-    std::vector<std::string> dump_layers;   // Dump intermediate buffers of specified layers only
-    std::string dry_run_path;               // Dry run and serialize execution graph into the specified path
-    int dump_layers_dst_only;               // Dump only output of layers
-    int dump_layers_result;                 // Dump result layers
-    int dump_layers_limit_batch;            // Limit the size of batch to dump
-    int base_batch_for_memory_estimation;   // Base batch size to be used in memory estimation
-    std::vector<std::string> after_proc;    // Start inference after the listed processes
-    int serialize_compile;                  // Serialize creating primitives and compiling kernels
-    std::string forced_impl_type;           // Force implementation type either ocl or onednn
-    int max_kernels_per_batch;              // Maximum number of kernels in a batch during compiling kernels
+    int help;                                   // Print help messages
+    int verbose;                                // Verbose execution
+    int print_multi_kernel_perf;                // Print execution time of each kernel in multi-kernel primitimive
+    int disable_usm;                            // Disable usm usage
+    int disable_onednn;                         // Disable onednn for discrete GPU (no effect for integrated GPU)
+    int disable_onednn_opt_post_ops;            // Disable onednn optimize post operators
+    std::string dump_profiling_data;            // Enables dump of extended performance profiling to specified dir
+    std::string dump_graphs;                    // Dump optimized graph
+    std::string dump_sources;                   // Dump opencl sources
+    std::string dump_layers_path;               // Enable dumping intermediate buffers and set the dest path
+    std::vector<std::string> dump_layers;       // Dump intermediate buffers of specified layers only
+    std::string dry_run_path;                   // Dry run and serialize execution graph into the specified path
+    int dump_layers_dst_only;                   // Dump only output of layers
+    int dump_layers_result;                     // Dump result layers
+    int dump_layers_limit_batch;                // Limit the size of batch to dump
+    int base_batch_for_memory_estimation;       // Base batch size to be used in memory estimation
+    std::vector<std::string> after_proc;        // Start inference after the listed processes
+    int serialize_compile;                      // Serialize creating primitives and compiling kernels
+    std::vector<std::string> forced_impl_types; // Force implementation type either ocl or onednn
+    int max_kernels_per_batch;                  // Maximum number of kernels in a batch during compiling kernels
     static const debug_configuration *get_instance();
     bool is_dumped_layer(const std::string& layerName, bool is_output = false) const;
 };

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/add_onednn_optimization_attributes.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/add_onednn_optimization_attributes.cpp
@@ -16,22 +16,6 @@ void add_onednn_optimization_attributes::run(program& p) {
 #ifdef ENABLE_ONEDNN_FOR_GPU
     for (auto& node : p.get_processing_order()) {
         if (node->get_preferred_impl_type() == impl_types::onednn) {
-            if (node->is_type<fully_connected>()) {
-                auto fc_prim = node->as<fully_connected>().get_primitive();
-
-                // Reshape fused ops tensors for OneDNN FC if needed
-                if (fc_prim->input_size == 3) {
-                    for (auto& fused_prim : node->get_fused_primitives()) {
-                        if (fused_prim.is_type<eltwise>()) {
-                            auto& dependency = node->get_dependency(fused_prim.dep_start_idx);
-                            auto original_layout = dependency.get_output_layout();
-                            onednn::combine_bf_with_first_spatial_dim(original_layout);
-                            dependency.set_output_layout(original_layout, false);
-                        }
-                    }
-                }
-            }
-
             node->init_onednn_primitive_attributes();
         }
     }

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -57,9 +57,8 @@ protected:
 
         auto input_pshape = input_layout.get_partial_shape();
         auto weights_pshape = weights_layout.get_partial_shape();
-        size_t input_size = (cldnn_prim->input_size > input_pshape.size()) ? input_pshape.size() : cldnn_prim->input_size;
-        int64_t feature = input_pshape[std::min(input_size, static_cast<size_t>(4)) - 1].get_length();
-        if (input_size == 3) {
+        int64_t feature = input_pshape[std::min(cldnn_prim->input_size, static_cast<size_t>(4)) - 1].get_length();
+        if (cldnn_prim->input_size == 3) {
             feature = std::max({input_layout.spatial(0), input_layout.spatial(1), input_layout.spatial(2)});
         }
         if (weights_pshape.size() != 2) {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -57,8 +57,9 @@ protected:
 
         auto input_pshape = input_layout.get_partial_shape();
         auto weights_pshape = weights_layout.get_partial_shape();
-        int64_t feature = input_pshape[std::min(cldnn_prim->input_size, static_cast<size_t>(4)) - 1].get_length();
-        if (cldnn_prim->input_size == 3) {
+        size_t input_size = (cldnn_prim->input_size > input_pshape.size()) ? input_pshape.size() : cldnn_prim->input_size;
+        int64_t feature = input_pshape[std::min(input_size, static_cast<size_t>(4)) - 1].get_length();
+        if (input_size == 3) {
             feature = std::max({input_layout.spatial(0), input_layout.spatial(1), input_layout.spatial(2)});
         }
         if (weights_pshape.size() != 2) {
@@ -96,7 +97,7 @@ protected:
     }
 
     static std::shared_ptr<dnnl::inner_product_forward::primitive_desc> get_fully_connected_primitive_descriptor(const kernel_impl_params& impl_params,
-                                                                                                cldnn::engine& engine, size_t input_size, bool has_bias,
+                                                                                                cldnn::engine& engine, size_t prim_input_size, bool has_bias,
                                                                                                 const dnnl::primitive_attr& attr = dnnl::primitive_attr()) {
         auto input_layout = impl_params.get_input_layout(0);
         auto weights_layout = impl_params.get_input_layout(1);
@@ -105,6 +106,7 @@ protected:
         auto input_pshape = input_layout.get_partial_shape();
         auto weights_pshape = weights_layout.get_partial_shape();
 
+        size_t input_size = (prim_input_size > input_pshape.size()) ? input_pshape.size() : prim_input_size;
         int64_t feature = input_pshape[std::min(input_size, static_cast<size_t>(4)) - 1].get_length();
         if (input_size == 3) {
             feature = std::max({input_layout.spatial(0), input_layout.spatial(1), input_layout.spatial(2)});

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -865,11 +865,11 @@ static bool is_node_for_onednn(deconvolution_node const& node) {
 
 
 static bool is_node_for_onednn(fully_connected_node const& node) {
-    bool is_suitable_for_onednn = true;
     auto fc_prim = node.get_primitive();
     auto ps = node.get_output_layout().get_partial_shape();
-    int rank = ps.size();
     int non_spatial_count = 2 + (fc_prim->input_size == 3 ? 1 : 0);
+    int rank = ps.size();
+
     // OneDnn doesn't support spatial dimensions for output
     for (int i = non_spatial_count; i < rank; i++) {
         if (ps[i].is_dynamic() || ps[i] != 1) {
@@ -877,7 +877,7 @@ static bool is_node_for_onednn(fully_connected_node const& node) {
         }
     }
 
-    return is_suitable_for_onednn;
+    return true;
 }
 
 // This function is needed to avoid performance regressions for the convolutions with byxf layout
@@ -1573,7 +1573,6 @@ impl_types layout_optimizer::get_preferred_impl_type(program_node& node, format 
             if (!is_node_for_onednn(node.as<fully_connected>()))
                 impl_candidate = impl_types::ocl;
         } else {
-            auto gemm_prim = node.as<gemm>().get_primitive();
             if (node.is_dynamic()) {
                 impl_candidate = impl_types::ocl;
             }

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -954,10 +954,7 @@ void program_node::init_onednn_primitive_attributes() {
             auto get_fc_input_desc = [&](cldnn::layout in) {
                 const kernel_impl_params& impl_params = *get_kernel_impl_params();
                 auto prim = impl_params.typed_desc<fully_connected>();
-                auto input_layout = impl_params.get_input_layout(0);
-                auto input_pshape = input_layout.get_partial_shape();
-                size_t input_size = (prim->input_size > input_pshape.size()) ? input_pshape.size() : prim->input_size;
-                if (input_size == 3) {
+                if (prim->input_size == 3) {
                     cldnn::onednn::combine_bf_with_first_spatial_dim(in);
                 }
                 return onednn::layout_to_memory_desc(in, dnnl::memory::format_tag::ab);

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -9,6 +9,7 @@
 #include "intel_gpu/runtime/debug_configuration.hpp"
 #ifdef ENABLE_ONEDNN_FOR_GPU
 #include "convolution_inst.h"
+#include "gemm_inst.h"
 #include "fully_connected_inst.h"
 #include "deconvolution_inst.h"
 #include "quantize_inst.h"
@@ -951,13 +952,26 @@ void program_node::init_onednn_primitive_attributes() {
             auto dep_idx = desc.dep_start_idx;
             auto in = get_dependency(dep_idx).get_output_layout();
 
-            auto get_fc_input_desc = [&](cldnn::layout in) {
-                const kernel_impl_params& impl_params = *get_kernel_impl_params();
-                auto prim = impl_params.typed_desc<fully_connected>();
-                if (prim->input_size == 3) {
-                    cldnn::onednn::combine_bf_with_first_spatial_dim(in);
+            auto set_binary_op = [&](dnnl::algorithm alg, onednn_post_op_type op_type) {
+                if (is_type<fully_connected>()) {
+                    const kernel_impl_params& impl_params = *get_kernel_impl_params();
+                    auto prim = impl_params.typed_desc<fully_connected>();
+                    if (prim->input_size == 3) {
+                        cldnn::onednn::combine_bf_with_first_spatial_dim(in);
+                    }
+                    post_ops.append_binary(alg, onednn::layout_to_memory_desc(in, dnnl::memory::format_tag::ab));
+                    update_onednn_post_op_list(op_type, dep_idx);
+                } else if (is_type<gemm>()) {
+                    size_t rank = cldnn::format::dimension(in.format);
+                    dnnl::memory::dims dims = onednn::convert_gemm_tensor(in.get_tensor(), rank, in.batch() > 1);
+                    dnnl::memory::data_type dt = onednn::convert_data_type(in.data_type);
+                    dnnl::memory::format_tag fmt = onednn::convert_gemm_data_format(dims);
+                    post_ops.append_binary(alg, dnnl::memory::desc(dims, dt, fmt));
+                    update_onednn_post_op_list(op_type, dep_idx);
+                } else {
+                    post_ops.append_binary(alg, onednn::layout_to_memory_desc(in));
+                    update_onednn_post_op_list(op_type, dep_idx);
                 }
-                return onednn::layout_to_memory_desc(in, dnnl::memory::format_tag::ab);
             };
 
             if (desc.typed_desc<eltwise>()->mode == eltwise_mode::sum) {
@@ -971,18 +985,12 @@ void program_node::init_onednn_primitive_attributes() {
                     update_onednn_post_op_list(onednn_post_op_type::sum, dep_idx);
                     num_sum_post_ops++;
                 } else {
-                    dnnl::memory::desc in_desc = is_type<fully_connected>() ? get_fc_input_desc(in) : onednn::layout_to_memory_desc(in);
-                    post_ops.append_binary(dnnl::algorithm::binary_add, in_desc);
-                    update_onednn_post_op_list(onednn_post_op_type::binary_add, dep_idx);
+                    set_binary_op(dnnl::algorithm::binary_add, onednn_post_op_type::binary_add);
                 }
             } else if (desc.typed_desc<eltwise>()->mode == eltwise_mode::sub) {
-                dnnl::memory::desc in_desc = is_type<fully_connected>() ? get_fc_input_desc(in) : onednn::layout_to_memory_desc(in);
-                post_ops.append_binary(dnnl::algorithm::binary_sub, in_desc);
-                update_onednn_post_op_list(onednn_post_op_type::binary_sub, dep_idx);
+                set_binary_op(dnnl::algorithm::binary_sub, onednn_post_op_type::binary_sub);
             } else if (desc.typed_desc<eltwise>()->mode == eltwise_mode::prod) {
-                dnnl::memory::desc in_desc = is_type<fully_connected>() ? get_fc_input_desc(in) : onednn::layout_to_memory_desc(in);
-                post_ops.append_binary(dnnl::algorithm::binary_mul, in_desc);
-                update_onednn_post_op_list(onednn_post_op_type::binary_mul, dep_idx, dnnl::memory::format_tag::ab, true);
+                set_binary_op(dnnl::algorithm::binary_mul, onednn_post_op_type::binary_mul);
             } else {
                 std::stringstream error_msg;
                 error_msg << "Unsupported eltwise mode: " << static_cast<int>(desc.typed_desc<eltwise>()->mode) << ". ";

--- a/src/plugins/intel_gpu/src/runtime/debug_configuration.cpp
+++ b/src/plugins/intel_gpu/src/runtime/debug_configuration.cpp
@@ -122,9 +122,9 @@ static void print_help_messages() {
     message_list.emplace_back("OV_GPU_AfterProc", "Run inference after the specified process PIDs are finished, separated by space."
                               " Supported on only on linux.");
     message_list.emplace_back("OV_GPU_SerialCompile", "Serialize creating primitives and compiling kernels");
-    message_list.emplace_back("OV_GPU_ForceImplType", "Force implementation type of a target primitive or layer. [primitive or layout_name]:[impl_type]"
-                              " For primitives, fc:onednn, fc:ocl, do:cpu, do:ocl, reduce:onednn, reduce:ocl, concat:onednn,"
-                              " and concat:ocl are supported");
+    message_list.emplace_back("OV_GPU_ForceImplTypes", "Force implementation type of a target primitive or layer. [primitive or layout_name]:[impl_type]"
+                              " For example fc:onednn gemm:onednn reduce:ocl do:cpu"
+                              " For primitives fc, gemm, do, reduce, concat are supported. Separated by space.");
     message_list.emplace_back("OV_GPU_MaxKernelsPerBatch", "Maximum number of kernels in a batch during compiling kernels");
 
     auto max_name_length_item = std::max_element(message_list.begin(), message_list.end(),
@@ -158,7 +158,6 @@ debug_configuration::debug_configuration()
         , dump_layers_limit_batch(std::numeric_limits<int>::max())
         , base_batch_for_memory_estimation(-1)
         , serialize_compile(0)
-        , forced_impl_type(std::string())
         , max_kernels_per_batch(0) {
 #ifdef GPU_DEBUG_CONFIG
     get_gpu_debug_env_var("Help", help);
@@ -181,7 +180,8 @@ debug_configuration::debug_configuration()
     std::string after_proc_str;
     get_gpu_debug_env_var("AfterProc", after_proc_str);
     get_gpu_debug_env_var("SerialCompile", serialize_compile);
-    get_gpu_debug_env_var("ForceImplType", forced_impl_type);
+    std::string forced_impl_types_str;
+    get_gpu_debug_env_var("ForceImplTypes", forced_impl_types_str);
     get_gpu_debug_env_var("MaxKernelsPerBatch", max_kernels_per_batch);
 
     if (help > 0) {
@@ -195,6 +195,15 @@ debug_configuration::debug_configuration()
         std::string layer;
         while (ss >> layer) {
             dump_layers.push_back(layer);
+        }
+    }
+
+    if (forced_impl_types_str.length() > 0) {
+        forced_impl_types_str = " " + forced_impl_types_str + " "; // Insert delimiter for easier parsing when used
+        std::stringstream ss(forced_impl_types_str);
+        std::string type;
+        while (ss >> type) {
+            forced_impl_types.push_back(type);
         }
     }
 


### PR DESCRIPTION
Huge performance improvement FC and gemm in oneDNN3.0
Update to use onednn FC and gemm in OV and remove W.A code force using cldnn in FC, gemm
Fix the issues used from onednn fc, gemm(eltwise post op)
 - FC b16 ACC issue: cldnn updates yxfb format in b16 for opt kernel, but FC onednn should bfyx
 - FC ACC issue: 3 input dims with eltwise post-po.
 - gemm ACC issue: multiple batch with eltwise post-po.

Signed-off-by: hyunback <hyunback.kim@intel.com>


### Tickets:
 - *101284*
