### PR TITLE
Downgrade doxygen version due to the sourceforge issues

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -7,7 +7,7 @@ on:
       - 'releases/**'
 
 env:
-  DOXY_VER: '1.9.2'
+  DOXY_VER: '1.9.1'
   DOXYREST_VER: '2.1.3'
 
 concurrency:


### PR DESCRIPTION
The link to 1.9.2 is not working anymore. Looks like all later versions are not available on sourceforge anymore (temporary issues?)