### PR TITLE
Ignore empty tensor for hash calculation

### DIFF
--- a/src/inference/src/compilation_context.cpp
+++ b/src/inference/src/compilation_context.cpp
@@ -150,17 +150,19 @@ std::string NetworkCompilationContext::computeHash(const std::string& modelStr,
     seed = hash_combine(seed, modelStr);
 
     // tensor data
-    seed = hash_combine(seed, tensor.get_size());
+    if (tensor) {
+        seed = hash_combine(seed, tensor.get_size());
 
-    auto ptr = static_cast<size_t*>(tensor.data());
-    size_t size = tensor.get_size() / sizeof(size_t);
-    for (size_t i = 0; i < size; i++)
-        seed = hash_combine(seed, ptr[i]);
-    auto size_done = size * sizeof(size_t);
-    auto ptr_left = static_cast<uint8_t*>(tensor.data()) + size_done;
-    size_t size_left = tensor.get_size() - size_done;
-    for (size_t i = 0; i < size_left; i++)
-        seed = hash_combine(seed, ptr_left[i]);
+        auto ptr = static_cast<size_t*>(tensor.data());
+        size_t size = tensor.get_size() / sizeof(size_t);
+        for (size_t i = 0; i < size; i++)
+            seed = hash_combine(seed, ptr[i]);
+        auto size_done = size * sizeof(size_t);
+        auto ptr_left = static_cast<uint8_t*>(tensor.data()) + size_done;
+        size_t size_left = tensor.get_size() - size_done;
+        for (size_t i = 0; i < size_left; i++)
+            seed = hash_combine(seed, ptr_left[i]);
+    }
 
     // compile options
     for (const auto& kvp : compileOptions) {

--- a/src/tests/functional/plugin/shared/include/behavior/ov_plugin/caching_tests.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_plugin/caching_tests.hpp
@@ -89,11 +89,14 @@ class CompileModelLoadFromMemoryTestBase : public testing::WithParamInterface<co
                                            virtual public SubgraphBaseTest,
                                            virtual public OVPluginTestBase {
     std::string m_cacheFolderName;
+    std::vector<std::uint8_t> weights_vector;
+
+protected:
     std::string m_modelName;
     std::string m_weightsName;
     std::string m_model;
     ov::Tensor m_weights;
-    std::vector<std::uint8_t> weights_vector;
+
 
 public:
     static std::string getTestCaseName(testing::TestParamInfo<compileModelLoadFromMemoryParams> obj);

--- a/src/tests/functional/plugin/shared/src/behavior/ov_plugin/caching_tests.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_plugin/caching_tests.cpp
@@ -15,6 +15,8 @@
 #include "ngraph_functions/builders.hpp"
 #include "ngraph_functions/subgraph_builders.hpp"
 #include "cpp_interfaces/interface/ie_internal_plugin_config.hpp"
+#include "openvino/core/node_vector.hpp"
+#include "openvino/op/parameter.hpp"
 
 #define GTEST_COUT std::cout << "[          ] [ INFO ] "
 
@@ -449,6 +451,33 @@ void CompileModelLoadFromMemoryTestBase::run() {
 }
 
 TEST_P(CompileModelLoadFromMemoryTestBase, CanLoadFromMemoryWithoutExecption) {
+    run();
+}
+
+TEST_P(CompileModelLoadFromMemoryTestBase, CanLoadFromMemoryWithoutWeightsANdExecption) {
+    ngraph::pass::Manager manager;
+    std::shared_ptr<ov::Model> model;
+    {
+        auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3, 1, 2});
+
+        auto mul = std::make_shared<ov::op::v1::Multiply>(data, data);
+
+        auto res = std::make_shared<ov::op::v0::Result>(mul);
+        model = std::make_shared<ov::Model>(ov::ResultVector{res}, ov::ParameterVector{data});
+    }
+
+    manager.register_pass<ov::pass::Serialize>(m_modelName, m_weightsName);
+    manager.run_passes(model);
+
+    try {
+        std::ifstream model_file(m_modelName, std::ios::binary);
+        std::stringstream ss;
+        ss << model_file.rdbuf();
+        m_model = ss.str();
+    } catch (const Exception& ex) {
+        GTEST_FAIL() << "Can't read xml file from: " << m_modelName << "\nException [" << ex.what() << "]" << std::endl;
+    }
+    m_weights = ov::Tensor();
     run();
 }
 


### PR DESCRIPTION
### Details:
 - Compute hash doesn't work with empty tensor

### Tickets:
 - *ticket-id*
