### PR TITLE
Print unknown argument itself instead of pointer address

### DIFF
--- a/tools/compile_tool/main.cpp
+++ b/tools/compile_tool/main.cpp
@@ -576,7 +576,7 @@ static bool parseCommandLine(int* argc, char*** argv) {
         std::stringstream message;
         message << "Unknown arguments: ";
         for (auto arg = 1; arg < *argc; arg++) {
-            message << argv[arg];
+            message << (*argv)[arg];
             if (arg < *argc) {
                 message << " ";
             }


### PR DESCRIPTION
### Details:
Fixes issue in compile_tool whereby unknown argument error prints address instead of string.

### Tickets:
 - 102048
