### PR TITLE
[CPU] [DEBUG CAPS] Extend performance info for dynamic shapes

### DIFF
--- a/src/plugins/intel_cpu/docs/debug_capabilities/perf_measurements.md
+++ b/src/plugins/intel_cpu/docs/debug_capabilities/perf_measurements.md
@@ -1,0 +1,31 @@
+# Performance measurements
+
+Performance counters are controlled by plugin config option **PERF_COUNT** and forcibly enabled in [Verbose mode](verbose.md). If it is enabled *total* performance counters are aggregated by default and could be retrieved via API (for example, *-pc* option in *benchmark_app*).
+
+## Aggregate performance counters
+
+If performance counters are enabled, aggregation of additional performance counters is controlled by environment variable **OV_CPU_PERF_TABLES_PATH**:
+```sh
+    OV_CPU_PERF_TABLES_PATH=<path/prefix> binary ...
+```
+
+\<prefix\> is optional, so slash have to be stated at the end of path if no prefix:
+```sh
+    OV_CPU_PERF_TABLES_PATH="/path/to/dumpDir/" binary ...
+    OV_CPU_PERF_TABLES_PATH="/path/to/dumpDir/table_prefix_" binary ...
+```
+
+CSV tables with aggregate performance counters are dumped upon *ExecNetwork* destruction:
+* \<prefix\>perf_modelInputs.csv\
+Map of model input shapes to indexes.
+* \<prefix\>perf_raw_nodes.csv\
+Aggregate performance counters without processing.
+* \<prefix\>perf_0_\<0_model_input_shape\>\_nodes.csv ... \<prefix\>perf_N_\<N_model_input_shape\>\_nodes.csv\
+Aggregate performance counters per node for corresponding model inputs.
+* \<prefix\>perf_0_\<0_model_input_shape\>\_nodeTypes.csv ... \<prefix\>perf_N_\<N_model_input_shape\>\_nodeTypes.csv\
+Aggregate performance counters per node type for corresponding model inputs.
+* \<prefix\>perf_all_nodeTypes.csv\
+Aggregate performance counters per node type for all model inputs.\
+This table is absent in case of single model input (static case) since it is the same as \<prefix\>perf_0_\<0_model_input_shape\>_nodeTypes.csv
+
+\<model_input_shape\> in table name is limited by 100 characters, so complete shape is additionally stated at the end of corresponding table and in \<prefix\>perf_modelInputs.csv.

--- a/src/plugins/intel_cpu/docs/debug_capabilities/verbose.md
+++ b/src/plugins/intel_cpu/docs/debug_capabilities/verbose.md
@@ -1,6 +1,7 @@
 # Verbose mode
 
 It is possible to enable tracing execution of plugin nodes to cout and collect statistics, such as:
+  - inference request number
   - node implementer:
     * cpu (CPU plugin)
     * dnnl (oneDNN library)
@@ -10,18 +11,23 @@ It is possible to enable tracing execution of plugin nodes to cout and collect s
   - node algorithm
   - node primitive info
   - input / output ports info
-  - fused nodes
-  - execution time
+  - fused nodes (omitted if no)
+  - time measurements:
+    * for static case - total
+    * for dynamic case - total, shapeInfer, prepareParams, exec
+  - cache hit info (omitted if no):
+    * execCacheHit (if primitives cache hit occurred)
   - etc
 
 Format:
 ```sh
-    ov_cpu_verbose,exec,<node_implemeter>,\
-    <node_name>:<node_type>:<node_alg>,<impl_type>,\
-    src:<port_id>:<precision>::<type>:<format>:f0:<shape> ...,\
-    dst:<port_id>:<precision>::<type>:<format>:f0:<shape> ...,\
-    post_ops:'<node_name>:<node_type>:<node_alg>;...;',\
-    <execution_time>
+    ov_cpu_verbose,<inference_request_number>,exec,<node_implemeter>,
+    <node_name>:<node_type>:<node_alg>,<impl_type>,
+    src:<port_id>:<precision>::<type>:<format>:f0:<shape> ...
+    dst:<port_id>:<precision>::<type>:<format>:f0:<shape> ...,
+    post_ops:'<node_name>:<node_type>:<node_alg>;...;',
+    time:<time_measurement>:<number>ms ...,
+    cacheHit:<cache_hit_info> ...
 ```
 
 To turn on verbose mode the following environment variable should be used:

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -67,8 +67,11 @@ Config::Config() {
  */
 void Config::applyDebugCapsProperties() {
     // always enable perf counters for verbose mode and performance summary
-    if (!debugCaps.verbose.empty() || !debugCaps.summaryPerf.empty())
+    if (!debugCaps.verbose.empty() ||
+        !debugCaps.summaryPerf.empty() ||
+        !debugCaps.perfTablesPath.empty()) {
         collectPerfCounters = true;
+    }
 }
 #endif
 

--- a/src/plugins/intel_cpu/src/cpu_shape.h
+++ b/src/plugins/intel_cpu/src/cpu_shape.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "perf_count.h"
 #include <vector>
 #include <utility>
 #include <ie_common.h>

--- a/src/plugins/intel_cpu/src/exec_network.cpp
+++ b/src/plugins/intel_cpu/src/exec_network.cpp
@@ -189,6 +189,7 @@ ExecNetwork::GraphGuard::Lock ExecNetwork::GetGraph() const {
                     ctx = std::make_shared<GraphContext>(_cfg, extensionManager, weightsCache, isQuantizedFlag);
                 }
                 graphLock._graph.CreateGraph(_network, ctx);
+                CPU_DEBUG_CAP_ENABLE(graphLock._graph.setNestingLevel(1));
             } catch (...) {
                 exception = std::current_exception();
             }

--- a/src/plugins/intel_cpu/src/exec_network.h
+++ b/src/plugins/intel_cpu/src/exec_network.h
@@ -47,6 +47,11 @@ public:
 
     void Export(std::ostream& modelStream) override;
 
+ #ifdef CPU_DEBUG_CAPS
+    friend void perfDump(const ExecNetwork& execNet);
+    ~ExecNetwork() { perfDump(*this); }
+ #endif
+
 protected:
     friend class InferRequestBase;
     ExtensionManager::Ptr extensionManager;

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -554,6 +554,7 @@ std::vector<memory::format_tag> Node::getAvailableFormatsForDims(const Shape &di
 void Node::updateShapes() {
     IE_ASSERT(isDynamicNode()) << "Node::updateShapes() is called to a static shape node of type: " << getTypeStr() << " with name: " << getName();
     if (needShapeInfer()) {
+        PERF_SHAPE_INFER(this);
         auto result = shapeInfer();
         if (ShapeInferStatus::success == result.status) {
             redefineOutputMemory(result.dims);
@@ -565,6 +566,7 @@ void Node::updateDynamicParams() {
     IE_ASSERT(isDynamicNode()) << "Node::updateDynamicParams() is called to a static shape node of type: " << getTypeStr() << " with name: " << getName();
     if (isExecutable()) {
         if (needPrepareParams()) {
+            PERF_PREPARE_PARAMS(this);
             IE_ASSERT(inputShapesDefined()) << "Can't prepare params for " << getTypeStr() << " node with name: " << getName() <<
                 " since the input shapes are not defined.";
             DEBUG_LOG(" prepareParams() on #", getExecIndex(), " ", getTypeStr(), " ", algToString(getAlgorithm()),

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -31,6 +31,8 @@
 #include "config.h"
 #include "nodes/node_config.h"
 #include "cache/multi_cache.h"
+#include "perf_count.h"
+#include "utils/verbose_node_helper.h"
 
 #include <utils/shape_inference/shape_inference_cpu.hpp>
 #include "utils/debug_capabilities.h"
@@ -726,6 +728,9 @@ private:
 
 #ifdef CPU_DEBUG_CAPS
     friend class Verbose;
+
+protected:
+    VerboseNodeStorage _verboseStorage;
 #endif
 };
 

--- a/src/plugins/intel_cpu/src/nodes/common/reorder_prim.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/reorder_prim.cpp
@@ -42,10 +42,10 @@ bool ReorderKey::operator==(const ReorderKey& rhs) const {
     return retVal;
 }
 
-dnnl::reorder getReorderPrim(MultiCachePtr cache,
-                             const dnnl::engine& engine,
-                             const dnnl::memory::desc& src,
-                             const dnnl::memory::desc& dest) {
+std::pair<dnnl::reorder, CacheEntryBase::LookUpStatus> getReorderPrim(MultiCachePtr cache,
+                                                                      const dnnl::engine& engine,
+                                                                      const dnnl::memory::desc& src,
+                                                                      const dnnl::memory::desc& dest) {
     auto builder = [&engine](const ReorderKey& key) {
         dnnl::primitive_attr attr;
         DEBUG_LOG(key.src, "->", key.dest);
@@ -58,10 +58,10 @@ dnnl::reorder getReorderPrim(MultiCachePtr cache,
 
     ReorderKey key = {src, dest};
     if (cache) {
-        auto result = cache->getOrCreate(key, builder);
-        return result.first;
+        return cache->getOrCreate(key, builder);
     }
-    return builder(key);
+
+    return {builder(key), CacheEntryBase::LookUpStatus::Miss};
 }
 
 }  // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/common/reorder_prim.h
+++ b/src/plugins/intel_cpu/src/nodes/common/reorder_prim.h
@@ -12,7 +12,7 @@
 namespace ov {
 namespace intel_cpu {
 
-dnnl::reorder getReorderPrim(MultiCachePtr cache,
+std::pair<dnnl::reorder, CacheEntryBase::LookUpStatus> getReorderPrim(MultiCachePtr cache,
                              const dnnl::engine& engine,
                              const dnnl::memory::desc& src,
                              const dnnl::memory::desc& dest);

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -201,7 +201,7 @@ public:
     }
 
     void infer() {
-        _graph->ResetInferCount();
+        CPU_DEBUG_CAP_ENABLE(_graph->ResetInferCount());
         _graph->Infer();
     }
 
@@ -1447,7 +1447,7 @@ void Convolution::prepareParams() {
     execPtr = nullptr;
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(key, builder);
-
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
     execPtr = result.first;
 
     if (!execPtr)

--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
@@ -192,6 +192,7 @@ void DepthToSpace::prepareParams() {
 
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(attrs, builder);
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
     if (!result.first) {
         IE_THROW() << "DepthToSpaceExecutor was not found for node " << getName() << ".";
     }

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -2273,6 +2273,7 @@ void Eltwise::prepareParams() {
 
         auto cache = context->getParamsCache();
         auto result = cache->getOrCreate(key, buildExecutor);
+        VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
         execPtr = result.first;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
+++ b/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
@@ -401,6 +401,7 @@ void ExtractImagePatches::prepareParams() {
     };
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(key, buildExecutor);
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
     execPtr = result.first;
 }
 

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -1481,6 +1481,7 @@ void FakeQuantize::createPrimitive() {
             return std::make_shared<FakeQuantizeJitExecutor>(key.jqp);
         };
         auto result = cache->getOrCreate(key, buildExecutor);
+        VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
         execPtr = result.first;
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -370,6 +370,7 @@ void FullyConnected::prepareParams() {
 
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(key, builder);
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
 
     if (!result.first) {
         IE_THROW() << "Primitive descriptor was not found for node " << getName() << ".";

--- a/src/plugins/intel_cpu/src/nodes/if.cpp
+++ b/src/plugins/intel_cpu/src/nodes/if.cpp
@@ -225,7 +225,7 @@ void If::execute(dnnl::stream strm) {
 
     for (auto &mapper : beforeMappers)
         mapper->execute(strm);
-    subGraph.ResetInferCount();
+    CPU_DEBUG_CAP_ENABLE(subGraph.ResetInferCount());
     subGraph.Infer();
     for (auto &mapper : afterMappers)
         mapper->execute(strm);

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -2347,6 +2347,7 @@ void Interpolate::prepareParams() {
 
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(key, buildExecutor);
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
     execPtr = result.first;
 
     lastOutputDims = dstDimsOrign;

--- a/src/plugins/intel_cpu/src/nodes/lrn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/lrn.cpp
@@ -206,6 +206,8 @@ void Lrn::prepareParams() {
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(key, builder);
     execPtr = result.first;
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
+
     if (!execPtr) {
         IE_THROW() << "Primitive descriptor was not found for node " << getName() << ".";
     }

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -643,6 +643,7 @@ void MatMul::prepareParams() {
 
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(key, builder);
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
 
     execPtr = result.first;
     if (!execPtr) {

--- a/src/plugins/intel_cpu/src/nodes/mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mvn.cpp
@@ -1397,6 +1397,7 @@ void MVN::prepareParams() {
 
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(key, builder);
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
     execPtr = result.first;
 }
 

--- a/src/plugins/intel_cpu/src/nodes/normalize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/normalize.cpp
@@ -921,6 +921,7 @@ void NormalizeL2::prepareParams() {
 
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(key, builder);
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
 
     if (!result.first) {
         IE_THROW() << "Primitive descriptor was not found for node " << getName() << ".";

--- a/src/plugins/intel_cpu/src/nodes/pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pooling.cpp
@@ -461,6 +461,7 @@ void Pooling::prepareParams() {
         auto result = cache->getOrCreate(key, builder);
 
         dnnlExecPtr = result.first;
+        VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
 
         if (!dnnlExecPtr) {
             IE_THROW() << "Primitive descriptor was not found for node " << getName() << ".";

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -1975,6 +1975,7 @@ void Reduce::prepareParams() {
         ReduceKey key = {jcp, attr.get_post_ops()};
         auto cache = context->getParamsCache();
         auto result = cache->getOrCreate(key, builder);
+        VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
         if (!result.first) {
             IE_THROW() << errorPrefix << " has not found jit_uni_reduce_post_kernel_f32.";
         }

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -1078,6 +1078,7 @@ void RNN::prepareParams() {
     auto result = cache->getOrCreate(key, builder);
     auto prevExecPtr = execPtr;
     execPtr = result.first;
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
 
     if (!execPtr) {
         IE_THROW() << "Primitive descriptor was not found for node " << getName() << ".";

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
@@ -527,6 +527,7 @@ void ROIPooling::prepareParams() {
     };
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(key, builder);
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
     execPtr = result.first;
 }
 

--- a/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
@@ -158,6 +158,7 @@ void ShuffleChannels::prepareParams() {
 
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(attrs, builder);
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
     if (!result.first) {
         IE_THROW() << "ShuffleChannelsExecutor was not found for node " << getName() << ".";
     }

--- a/src/plugins/intel_cpu/src/nodes/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/softmax.cpp
@@ -205,6 +205,7 @@ void SoftMax::prepareParams() {
 
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(key, builder);
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
 
     execPtr = result.first;
     if (!execPtr) {

--- a/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
@@ -199,6 +199,7 @@ void SpaceToDepth::prepareParams() {
 
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(attrs, builder);
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
     if (!result.first) {
         IE_THROW() << "SpaceToDepthExecutor was not found for node " << getName() << ".";
     }

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -122,7 +122,8 @@ public:
             mem_holder_src = from->GetPrimitive();
             mem_holder_dst = chunk_mem;
         }
-        reorder = getReorderPrim(cache, mem_holder_dst.get_engine(), mem_holder_src.get_desc(), mem_holder_dst.get_desc());
+        const auto result = getReorderPrim(cache, mem_holder_dst.get_engine(), mem_holder_src.get_desc(), mem_holder_dst.get_desc());
+        reorder = result.first;
     }
 
     void execute(dnnl::stream strm, int iter) override {
@@ -150,7 +151,8 @@ public:
     BackEdgePortHelper(MultiCachePtr cache, const MemoryPtr &from, const MemoryPtr &to, const dnnl::engine& eng) {
         mem_holder_src = from->GetPrimitive();
         mem_holder_dst = to->GetPrimitive();
-        reorder = getReorderPrim(cache, mem_holder_dst.get_engine(), mem_holder_src.get_desc(), mem_holder_dst.get_desc());
+        const auto result = getReorderPrim(cache, mem_holder_dst.get_engine(), mem_holder_src.get_desc(), mem_holder_dst.get_desc());
+        reorder = result.first;
     }
 
     void execute(dnnl::stream strm, int iter = -1) override {
@@ -568,7 +570,7 @@ void TensorIterator::prepareParams() {
 }
 
 void TensorIterator::execute(dnnl::stream strm) {
-    sub_graph.ResetInferCount();
+    CPU_DEBUG_CAP_ENABLE(sub_graph.ResetInferCount());
 
     bool continue_cond = initial_cond_check->getStatus();
     int max_num_iter = trip_count_check->getStatus();
@@ -598,7 +600,7 @@ void TensorIterator::execute(dnnl::stream strm) {
 
 void TensorIterator::executeDynamicImpl(dnnl::stream strm) {
     const auto &eng = getEngine();
-    sub_graph.ResetInferCount();
+    CPU_DEBUG_CAP_ENABLE(sub_graph.ResetInferCount());
 
     bool continue_cond = initial_cond_check->getStatus();
     int max_num_iter = trip_count_check->getStatus();

--- a/src/plugins/intel_cpu/src/nodes/transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/transpose.cpp
@@ -191,11 +191,12 @@ void Transpose::prepareParams() {
         auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
         auto dstDesc = dstMemPtr->GetDescWithType<DnnlMemoryDesc>()->getDnnlDesc();
         auto srcDesc = dnnl::memory::desc(dstDesc.get_dims(), dstDesc.get_data_type(), memory::format_tag::acdb);
-        auto result = getReorderPrim(context->getParamsCache(), getEngine(), srcDesc, dstDesc);
-        if (!result) {
+        const auto result = getReorderPrim(context->getParamsCache(), getEngine(), srcDesc, dstDesc);
+        prim = result.first;
+        if (!prim) {
             IE_THROW() << "Reorder primitive descriptor was not found for Transpose node " << getName() << ".";
         }
-        prim = result;
+        VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
 
         getSelectedPrimitiveDescriptor()->setImplementationType(
             parse_impl_name(DnnlExtensionUtils::query_impl_info_str(prim.get_primitive_desc())));
@@ -228,6 +229,7 @@ void Transpose::prepareParams() {
 
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(params, builder);
+    VERBOSE_HELPER_NODE_PREPARE_PARAMS(result.second);
 
     if (!result.first) {
         IE_THROW() << "Primitive descriptor was not found for node " << getName() << ".";

--- a/src/plugins/intel_cpu/src/perf_count.h
+++ b/src/plugins/intel_cpu/src/perf_count.h
@@ -6,6 +6,9 @@
 
 #include <chrono>
 #include <ratio>
+#include "utils/perf_count_debug_caps.h"
+
+#ifndef CPU_DEBUG_CAPS
 
 namespace ov {
 namespace intel_cpu {
@@ -19,10 +22,6 @@ class PerfCount {
 
 public:
     PerfCount(): total_duration(0), num(0) {}
-
-    std::chrono::duration<double, std::milli> duration() const {
-        return __finish - __start;
-    }
 
     uint64_t avg() const { return (num == 0) ? 0 : total_duration / num; }
     uint32_t count() const { return num; }
@@ -53,5 +52,10 @@ public:
 }   // namespace intel_cpu
 }   // namespace ov
 
-#define GET_PERF(_node) std::unique_ptr<PerfHelper>(new PerfHelper(_node->PerfCounter()))
-#define PERF(_node, _need) auto pc = _need ? GET_PERF(_node) : nullptr;
+#  define PERF(_node, _need, _itrKey) PERF_COUNTER(_need, PerfHelper, _node->PerfCounter())
+#  define PERF_SHAPE_INFER(_node)
+#  define PERF_PREPARE_PARAMS(_node)
+#endif // ifndef CPU_DEBUG_CAPS
+
+#define GET_PERF(_helper, ...) std::unique_ptr<_helper>(new _helper(__VA_ARGS__))
+#define PERF_COUNTER(_need, _helper, ...) auto pc = _need ? GET_PERF(_helper, __VA_ARGS__) : nullptr;

--- a/src/plugins/intel_cpu/src/utils/debug_caps_config.cpp
+++ b/src/plugins/intel_cpu/src/utils/debug_caps_config.cpp
@@ -63,6 +63,9 @@ void DebugCapsConfig::readProperties() {
 
     if ((envVarValue = readEnv("OV_CPU_DUMP_IR")))
         dumpIR.parseAndSet(envVarValue);
+
+    if ((envVarValue = readEnv("OV_CPU_PERF_TABLES_PATH")))
+        perfTablesPath = envVarValue;
 }
 
 }   // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/utils/debug_caps_config.h
+++ b/src/plugins/intel_cpu/src/utils/debug_caps_config.h
@@ -42,6 +42,7 @@ public:
     // std::hash<int> is necessary for Ubuntu-16.04 (gcc-5.4 and defect in C++11 standart)
     std::unordered_map<FILTER, std::string, std::hash<int>> blobDumpFilters;
     std::string summaryPerf = "";
+    std::string perfTablesPath;
 
     struct TransformationFilter {
         enum Type : uint8_t {

--- a/src/plugins/intel_cpu/src/utils/node_dumper.h
+++ b/src/plugins/intel_cpu/src/utils/node_dumper.h
@@ -19,8 +19,8 @@ class DumpHelper {
     const DebugCapsConfig& config;
 
 public:
-    explicit DumpHelper(const NodePtr& _node, const DebugCapsConfig& _config, int _count = -1):
-        node(_node), count(_count), config(_config) {
+    explicit DumpHelper(const NodePtr& _node, const DebugCapsConfig& _config, const uint8_t nestingLevel, int _count = -1):
+        node(_node), count(nestingLevel > 1 ? _count : -1), config(_config) {
         dumpInputBlobs(node, config, count);
     }
 

--- a/src/plugins/intel_cpu/src/utils/perf_count_debug_caps.cpp
+++ b/src/plugins/intel_cpu/src/utils/perf_count_debug_caps.cpp
@@ -1,0 +1,469 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifdef CPU_DEBUG_CAPS
+
+#include "perf_count_debug_caps.h"
+#include "exec_network.h"
+#include <fstream>
+#include <iomanip>
+
+namespace ov {
+namespace intel_cpu {
+
+static double perfAvg(const uint64_t sum, const uint64_t num);
+static double perfAvg(const double sum, const uint64_t num);
+static double perfPercent(const uint64_t val, const uint64_t total);
+static double perfDeviationPercent(const std::vector<double>& values, const double sum);
+static void perfShapeToStr(const VectorDims& shape, std::string& str);
+static void perfDumpNodes(const std::string& path, const std::vector<NodePtr>& nodes, const std::vector<std::string>& modelInputShapes);
+
+void PerfCount::finish_itr(const PerfKey itrKey, const std::shared_ptr<Node>& node) {
+    finish_itr();
+
+    assert(itrKey <= _perfData.size());
+    if (itrKey == _perfData.size())
+        _perfData.emplace_back();
+
+    auto& perfData = _perfData[itrKey];
+    for (uint8_t i = 0; i < NumberOfCounters; i++) {
+        if (_itrDuration[i] != std::chrono::high_resolution_clock::duration::zero()) {
+            perfData.counters[i].duration += std::chrono::duration_cast<std::chrono::microseconds>(_itrDuration[i]).count();
+            perfData.counters[i].num++;
+        }
+    }
+
+    std::vector<VectorDims> in, out;
+    in.reserve(node->getParentEdges().size());
+    for (auto i = 0; i < node->getParentEdges().size(); i++) {
+        in.push_back(node->getParentEdgeAt(i)->getMemory().getStaticDims());
+    }
+    out.reserve(node->getChildEdges().size());
+    for (auto i = 0; i < node->getChildEdges().size(); i++) {
+        out.push_back(node->getChildEdgeAt(i)->getMemory().getStaticDims());
+    }
+    perfData.nodeShapesSet.insert(std::make_pair(std::move(in), std::move(out)));
+}
+
+PerfHelper::PerfHelper(const std::shared_ptr<Node>& node, const PerfKey itrKey) :
+        _node(node), _itrKey(itrKey) {
+    _node->PerfCounter().start_itr();
+}
+
+PerfHelper::~PerfHelper() {
+    if (_itrKey != std::numeric_limits<PerfKey>::max()) {
+        _node->PerfCounter().finish_itr(_itrKey, _node);
+    } else {
+        _node->PerfCounter().finish_itr();
+    }
+}
+
+PerfKey perfGetKey(Graph& graph) {
+    if (graph.getConfig().debugCaps.perfTablesPath.empty() || !graph.getConfig().collectPerfCounters)
+        return std::numeric_limits<PerfKey>::max();
+
+    std::vector<VectorDims> modelInputDims;
+    modelInputDims.reserve(graph.inputNodesMap.size());
+    for (const auto& input : graph.inputNodesMap) {
+        modelInputDims.push_back(input.second->getChildEdgeAt(0)->getMemory().getStaticDims());
+    }
+    return graph.perfKeysMap.emplace(std::move(modelInputDims), graph.perfKeysMap.size()).first->second;
+}
+
+void perfDump(const ExecNetwork& execNet) {
+    auto& graphs = execNet._graphs;
+    const auto graphsNum = graphs.size();
+    auto& graph = graphs[0];
+
+    if (graphsNum == 0 ||
+        graph.getConfig().debugCaps.perfTablesPath.empty() || graph.perfKeysMap.size() == 0)
+        return;
+
+    // use 1st graph to accamulate perf data (save memory and time)
+    for (auto graphIdx = 1; graphIdx < graphsNum; graphIdx++) {
+        if (graphs[graphIdx].perfKeysMap.size() == 0)
+            continue;
+
+        PerfKey keyToKey[graphs[graphIdx].perfKeysMap.size()];
+        for (const auto& pair : graphs[graphIdx].perfKeysMap) {
+            keyToKey[pair.second] =
+                graph.perfKeysMap.emplace(pair.first, graph.perfKeysMap.size()).first->second;;
+        }
+        assert(graph.executableGraphNodes.size() == graphs[graphIdx].executableGraphNodes.size());
+        for (auto nodeIdx = 0; nodeIdx < graph.executableGraphNodes.size(); nodeIdx++) {
+            auto& aggPerfData = graph.executableGraphNodes[nodeIdx]->PerfCounter()._perfData;
+            const auto& perfData = graphs[graphIdx].executableGraphNodes[nodeIdx]->PerfCounter()._perfData;
+            aggPerfData.resize(graph.perfKeysMap.size());
+            for (auto key = 0; key < perfData.size(); key++) {
+                aggPerfData[keyToKey[key]] += perfData[key];
+            }
+        }
+    }
+
+    std::vector<std::string> inputNames;
+    inputNames.reserve(graph.inputNodesMap.size());
+    for (const auto& input : graph.inputNodesMap) {
+        inputNames.emplace_back(inputNames.size() ? ',' + input.first : input.first);
+    }
+    std::vector<std::string> modelInputs(graph.perfKeysMap.size());
+    for (auto perf : graph.perfKeysMap) {
+        assert(perf.second < modelInputs.size());
+        auto& modelInput = modelInputs[perf.second];
+        assert(modelInput.empty());
+        assert(perf.first.size() == inputNames.size());
+        for (auto idx = 0; idx < inputNames.size(); idx++) {
+            modelInput.append(inputNames[idx]);
+            perfShapeToStr(perf.first[idx], modelInput);
+        }
+    }
+
+    perfDumpNodes(graph.getConfig().debugCaps.perfTablesPath, graph.executableGraphNodes, modelInputs);
+}
+
+static double perfAvg(const uint64_t sum, const uint64_t num) {
+    return num ? sum / static_cast<double>(num) : 0;
+}
+static double perfAvg(const double sum, const uint64_t num) {
+    return num ? sum / num : 0;
+}
+
+static double perfPercent(const uint64_t val, const uint64_t total) {
+    return val ? static_cast<double>(val) / total * 100 : 0;
+}
+
+static double perfDeviationPercent(const std::vector<double>& values, const double sum) {
+    if (values.size() == 0 || sum == 0)
+        return 0;
+
+    const double n = static_cast<double>(values.size());
+    const double avg = sum / n;
+    double variance = 0;
+
+    for (double val : values) {
+        val -= avg;
+        variance += val * val;
+    }
+    variance /= n;
+
+    return std::sqrt(variance) / avg * 100;
+}
+
+static void perfShapeToStr(const VectorDims& shape, std::string& str) {
+    str.push_back('{');
+    for (auto i = 0; i < shape.size(); i++) {
+        if (i)
+            str.push_back(',');
+        str.append(std::to_string(shape[i]));
+    }
+    str.push_back('}');
+}
+
+static void perfDumpNodes(const std::string& path, const std::vector<NodePtr>& nodes,
+                   const std::vector<std::string>& modelInputShapes) {
+    assert(modelInputShapes.size());
+    const std::string pathPrefix(path + "/perf_");
+    std::ofstream csv;
+    auto openCsv = [&] (std::ofstream& csv, const std::string& name) {
+        std::string fullPath(pathPrefix + name);
+        csv.open(fullPath);
+        if (!csv.is_open())
+            IE_THROW() << "Dumping perf counters. Cannot open file " << fullPath;
+
+        csv << std::fixed << std::setprecision(2);
+    };
+
+    openCsv(csv, "modelInputs.csv");
+    const auto modelInputsNum = modelInputShapes.size();
+    csv << "Model input index,Model input shape\n";
+    for (auto i = 0; i < modelInputsNum; i++) {
+        csv << i << ",\"" << modelInputShapes[i] << "\"\n";
+    }
+    csv.close();
+
+    enum CounterIdx : uint8_t {
+        Total = 0,
+        Exec,
+        ShapeInfer,
+        PrepareParams,
+        NumberOfCounters
+    };
+
+    struct NodeTypePerfCounter {
+        std::vector<double> avgValues = {};
+        double avgSum = 0;
+        uint64_t durationSum = 0;
+    };
+
+    struct NodeTypePerfData {
+        void cleanup() {
+            for (uint8_t idx = 0; idx < NumberOfCounters; idx++) {
+                auto& cntr = counters[idx];
+                cntr.avgValues.clear();
+                cntr.avgSum = cntr.durationSum = 0;
+            }
+            uniqShapesSet.clear();
+            nodeNum = 0;
+        }
+        void validate(const size_t avgNum) const {
+            assert(nodeNum >= 1);
+            assert(uniqShapesSet.size() >= 1);
+            assert(counters[Total].durationSum ==
+                   counters[ShapeInfer].durationSum + counters[PrepareParams].durationSum + counters[Exec].durationSum);
+            assert(counters[ShapeInfer].durationSum != 0 ||
+                   counters[PrepareParams].durationSum != 0 ||
+                   counters[Total].durationSum == counters[Exec].durationSum);
+            for (uint8_t idx = Total; idx < NumberOfCounters; idx++) {
+                assert(avgNum >= 1);
+                assert(counters[idx].avgValues.size() == avgNum);
+                assert(counters[idx].avgSum ==
+                          std::accumulate(counters[idx].avgValues.begin(),
+                                          counters[idx].avgValues.end(), 0.0));
+            }
+        }
+
+        NodeTypePerfCounter counters[NumberOfCounters];
+        std::set<PerfCount::PerfData::PerfNodeShape> uniqShapesSet;
+        uint32_t nodeNum = 0;
+    };
+
+    auto nodeShapeToStr = [] (const PerfCount::PerfData::PerfNodeShape& shape) {
+        auto shapesToStr = [] (const std::vector<VectorDims>& shape, std::string& str) {
+            for (auto i = 0; i < shape.size(); i++) {
+                if (i)
+                    str.push_back(',');
+                perfShapeToStr(shape[i], str);
+            }
+        };
+        std::string str;
+        shapesToStr(shape.first, str);
+        str.append("->");
+        shapesToStr(shape.second, str);
+        return str;
+    };
+
+    auto modelInputToFileName = [&modelInputShapes] (const size_t idx) {
+        return std::to_string(idx) + '_' + modelInputShapes[idx].substr(0, 100);
+    };
+    auto closeWithModelInput = [&modelInputShapes] (std::ofstream& csv, const size_t idx) {
+        csv << "Model Input Shape:,\"" << modelInputShapes[idx] << "\"\n";
+        csv.close();
+    };
+
+    std::vector<std::map<Type, NodeTypePerfData>> modelInputs(modelInputsNum);
+
+    openCsv(csv, "raw_nodes.csv");
+    csv << "Node name,Node type,Model input index,Model input shape,Node in->out shapes,"
+           "\"Total time (avg, us)\",\"Total time (sum, us)\",Total (n),"
+           "\"Exec time (avg, us)\",\"Exec time (sum, us)\",Exec (n),"
+           "\"ShapeInfer time (avg, us)\",\"ShapeInfer time (sum, us)\",ShapeInfer (n),"
+           "\"PrepareParams time (avg, us)\",\"PrepareParams time (sum, us)\",PrepareParams (n),"
+           "Comments\n";
+    std::vector<std::ofstream> nodeCsvs(modelInputsNum);
+    for (const auto& node : nodes) {
+        const std::string nodePrefixStr('"' + node->getName() + "\",\"" +
+                                        NameFromType(node->getType()) + "\",");
+        for (auto idx = 0; idx < node->PerfCounter()._perfData.size(); idx++) {
+            const auto& nodePerfData = node->PerfCounter()._perfData[idx];
+            auto& modelInputNodeTypesMap = modelInputs[idx];
+            auto& modelInputCsv = nodeCsvs[idx];
+
+
+            csv << nodePrefixStr << idx << ",\"" << modelInputShapes[idx] << "\",\"";
+            if (!modelInputCsv.is_open()) {
+                openCsv(modelInputCsv, modelInputToFileName(idx) + "_nodes.csv");
+                modelInputCsv << "Node name,Node type,Node in->out shapes,"
+                                 "\"Total time (avg, us)\",\"Exec time (avg, us)\","
+                                 "\"ShapeInfer time (avg, us)\",\"PrepareParams time (avg, us)\","
+                                 "Comments\n";
+            }
+            modelInputCsv << nodePrefixStr << '"';
+
+            auto& nodeTypePerfData = modelInputNodeTypesMap[node->getType()];
+            nodeTypePerfData.nodeNum++;
+
+            for (const auto& shape : nodePerfData.nodeShapesSet) {
+                std::string shapeStr(nodeShapeToStr(shape));
+                csv << shapeStr;
+                modelInputCsv << shapeStr;
+                nodeTypePerfData.uniqShapesSet.insert(shape);
+            }
+            csv << "\",";
+            modelInputCsv << "\",";
+
+            for (uint8_t nodeTypeCntrIdx = Total; nodeTypeCntrIdx < NumberOfCounters; nodeTypeCntrIdx++) {
+                auto& nodeTypeCntr = nodeTypePerfData.counters[nodeTypeCntrIdx];
+                const PerfCount::CounterIdx nodeCntrIdxMap[NumberOfCounters] =
+                    {PerfCount::Total, PerfCount::NumberOfCounters, PerfCount::ShapeInfer, PerfCount::PrepareParams};
+                const auto nodeCntrIdx = nodeCntrIdxMap[nodeTypeCntrIdx];
+
+                uint64_t nodeCntrDuration;
+                uint32_t nodeCntrNum;
+                if (nodeCntrIdx != PerfCount::NumberOfCounters) {
+                    const auto& nodeCntr = nodePerfData.counters[nodeCntrIdx];
+                    nodeCntrDuration = nodeCntr.duration;
+                    nodeCntrNum = nodeCntr.num;
+                } else {
+                    assert(nodeTypeCntrIdx == Exec);
+                    nodeCntrDuration = nodePerfData.calcExecDuration();
+                    nodeCntrNum = nodePerfData.counters[PerfCount::Total].num;
+                }
+
+                nodeTypeCntr.durationSum += nodeCntrDuration;
+                const auto avg = perfAvg(nodeCntrDuration, nodeCntrNum);
+                nodeTypeCntr.avgValues.push_back(avg);
+                nodeTypeCntr.avgSum += avg;
+
+                csv << avg  << ',' << nodeCntrDuration << ',' << nodeCntrNum << ',';
+                modelInputCsv << avg << ',';
+            }
+
+            const std::string ending(nodePerfData.nodeShapesSet.size() > 1 ? "internal dynamism\n" : ",\n");
+            csv << ending;
+            modelInputCsv << ending;
+        }
+    }
+    csv.close();
+    for (size_t i = 0; i < nodeCsvs.size(); i++) {
+        closeWithModelInput(nodeCsvs[i], i);
+    } // raw_nodes.csv and *_nodes.csv
+    assert(modelInputs.size() == modelInputsNum);
+
+    const std::string nodeTypeHeader(
+        "Node type,Node number,Uniq shape number,"
+        "\"Total time (avg, us)\",\"Total time (dev, %)\",\"Total time (sum, us)\",Total time (%),"
+        "\"Exec time (avg, us)\",\"Exec time (dev, %)\",\"Exec time (sum, us)\",Exec time (%),"
+        "\"ShapeInfer time (avg, us)\",\"ShapeInfer time (dev, %)\",\"ShapeInfer time (sum, us)\",ShapeInfer time (%),"
+        "\"PrepareParams time (avg, us)\",\"PrepareParams time (dev, %)\",\"PrepareParams time (sum, us)\",PrepareParams time (%)\n");
+    auto printNodeTypeCntr = [] (std::ofstream& csv, const NodeTypePerfCounter& cntr,
+                                 const double avg, const uint64_t totalDuration) {
+        csv << ','
+            << avg << ','
+            << perfDeviationPercent(cntr.avgValues, cntr.avgSum) << ','
+            << cntr.durationSum << ','
+            << perfPercent(cntr.durationSum, totalDuration);
+    };
+    auto finalizeNodeTypeCsv = [&printNodeTypeCntr] (std::ofstream& csv,
+                                   const NodeTypePerfData& aggregateData, const size_t num) {
+        aggregateData.validate(num);
+        csv << "Total,"
+            << aggregateData.nodeNum << ','
+            << aggregateData.uniqShapesSet.size();
+        for (uint8_t idx = Total; idx < NumberOfCounters; idx++) {
+            const auto& cntr = aggregateData.counters[idx];
+            printNodeTypeCntr(csv, aggregateData.counters[idx],
+                              perfAvg(cntr.avgSum, num), aggregateData.counters[Total].durationSum);
+        }
+        csv << std::endl;
+    };
+
+    const bool isDynamicModelInput = (modelInputsNum > 1);
+    std::map<Type, NodeTypePerfData> aggregateNodeTypesMap;
+
+    NodeTypePerfData modelInputTotal, total;
+    const auto nodeTypesNum = modelInputs[0].size();
+    for (uint8_t idx = Total; idx < NumberOfCounters; idx++) {
+        modelInputTotal.counters[idx].avgValues.reserve(nodeTypesNum);
+        if (isDynamicModelInput)
+            total.counters[idx].avgValues.reserve(nodeTypesNum);
+    }
+    for (auto& nodeType : modelInputs[0]) {
+        total.nodeNum += nodeType.second.nodeNum;
+        if (isDynamicModelInput) {
+            auto& aggregateNodeType = aggregateNodeTypesMap[nodeType.first];
+            aggregateNodeType.nodeNum = nodeType.second.nodeNum;
+            for (uint8_t idx = Total; idx < NumberOfCounters; idx++) {
+                aggregateNodeType.counters[idx].avgValues.reserve(modelInputsNum);
+            }
+        }
+    }
+
+    for (auto i = 0; i < modelInputsNum; i++) {
+        const auto& nodeTypesMap = modelInputs[i];
+
+        openCsv(csv, modelInputToFileName(i) + "_nodeTypes.csv");
+        csv << nodeTypeHeader;
+
+        modelInputTotal.nodeNum = total.nodeNum;
+        for (auto& nodeType : nodeTypesMap) {
+            for (uint8_t idx = Total; idx < NumberOfCounters; idx++) {
+                modelInputTotal.counters[idx].durationSum += nodeType.second.counters[idx].durationSum;
+            }
+        }
+        if (isDynamicModelInput) {
+            for (uint8_t idx = Total; idx < NumberOfCounters; idx++) {
+                total.counters[idx].durationSum += modelInputTotal.counters[idx].durationSum;
+            }
+        }
+
+        for (auto& nodeType : nodeTypesMap) {
+            auto& nodeTypePerfData = nodeType.second;
+            nodeTypePerfData.validate(nodeTypePerfData.nodeNum);
+
+            csv << '"' << NameFromType(nodeType.first) << "\","
+                << nodeTypePerfData.nodeNum << ',' << nodeTypePerfData.uniqShapesSet.size();
+
+            modelInputTotal.uniqShapesSet.insert(nodeTypePerfData.uniqShapesSet.begin(),
+                                                 nodeTypePerfData.uniqShapesSet.end());
+            if (isDynamicModelInput) {
+                auto& aggregateNodeType = aggregateNodeTypesMap[nodeType.first];
+                assert(aggregateNodeType.nodeNum == nodeTypePerfData.nodeNum);
+                aggregateNodeType.uniqShapesSet.insert(nodeTypePerfData.uniqShapesSet.begin(),
+                                                       nodeTypePerfData.uniqShapesSet.end());
+            }
+
+            for (uint8_t idx = Total; idx < NumberOfCounters; idx++) {
+                auto& cntr = nodeTypePerfData.counters[idx];
+                auto& modelInputAggregateCntr = modelInputTotal.counters[idx];
+                const auto avg = perfAvg(cntr.avgSum, nodeTypePerfData.nodeNum);
+
+                printNodeTypeCntr(csv, cntr, avg, modelInputAggregateCntr.durationSum);
+
+                modelInputAggregateCntr.avgValues.push_back(avg);
+                modelInputAggregateCntr.avgSum += avg;
+                if (isDynamicModelInput) {
+                    auto& nodeTypeAggregateCntr = aggregateNodeTypesMap[nodeType.first].counters[idx];
+                    nodeTypeAggregateCntr.durationSum += cntr.durationSum;
+                    nodeTypeAggregateCntr.avgValues.push_back(avg);
+                    nodeTypeAggregateCntr.avgSum += avg;
+                }
+            }
+            csv << std::endl;
+        }
+        finalizeNodeTypeCsv(csv, modelInputTotal, nodeTypesMap.size());
+        closeWithModelInput(csv, i);
+        modelInputTotal.cleanup();
+    } // *_nodeTypes.csv
+
+    if (isDynamicModelInput) {
+        openCsv(csv, "all_nodeTypes.csv");
+        csv << nodeTypeHeader;
+        for (auto& nodeType : aggregateNodeTypesMap) {
+            auto& nodeTypePerfData = nodeType.second;
+            nodeTypePerfData.validate(modelInputsNum);
+
+            csv << '"' << NameFromType(nodeType.first) << "\","
+                << nodeTypePerfData.nodeNum << ',' << nodeTypePerfData.uniqShapesSet.size();
+            total.uniqShapesSet.insert(nodeTypePerfData.uniqShapesSet.begin(),
+                                       nodeTypePerfData.uniqShapesSet.end());
+
+            for (uint8_t idx = Total; idx < NumberOfCounters; idx++) {
+                const auto& cntr = nodeTypePerfData.counters[idx];
+                auto& totalCntr = total.counters[idx];
+                const auto avg = perfAvg(cntr.avgSum, cntr.avgValues.size());
+
+                printNodeTypeCntr(csv, cntr, avg, totalCntr.durationSum);
+
+                totalCntr.avgValues.push_back(avg);
+                totalCntr.avgSum += avg;
+            }
+            csv << std::endl;
+        }
+        finalizeNodeTypeCsv(csv, total, aggregateNodeTypesMap.size());
+        csv.close();
+    }
+}
+
+}   // namespace intel_cpu
+}   // namespace ov
+#endif // CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/utils/perf_count_debug_caps.h
+++ b/src/plugins/intel_cpu/src/utils/perf_count_debug_caps.h
@@ -1,0 +1,142 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#ifdef CPU_DEBUG_CAPS
+
+#include "perf_count.h"
+#include "cpu_types.h"
+
+#include <string>
+#include <vector>
+#include <set>
+#include <memory>
+#include <cassert>
+
+namespace ov {
+namespace intel_cpu {
+
+class Node;
+typedef size_t PerfKey;
+
+class PerfCount {
+public:
+    enum CounterIdx : uint8_t {
+        Total = 0,
+        ShapeInfer,
+        PrepareParams,
+        NumberOfCounters
+    };
+    struct CounterSum {
+        uint64_t duration = 0;
+        uint32_t num = 0;
+    };
+    struct PerfData {
+        uint64_t calcExecDuration() const {
+            return counters[Total].duration - counters[ShapeInfer].duration - counters[PrepareParams].duration;
+        }
+
+        PerfData& operator+=(const PerfData& rhs) {
+            for (uint8_t i = 0; i < NumberOfCounters; i++) {
+                counters[i].duration += rhs.counters[i].duration;
+                counters[i].num += rhs.counters[i].num;
+            }
+            nodeShapesSet.insert(rhs.nodeShapesSet.begin(),
+                                 rhs.nodeShapesSet.end());
+            return *this;
+        }
+
+        CounterSum counters[NumberOfCounters];
+        typedef std::pair<std::vector<VectorDims>, std::vector<VectorDims>> PerfNodeShape;
+        std::set<PerfNodeShape> nodeShapesSet;
+    };
+
+    std::vector<PerfData> _perfData;
+
+    std::vector<std::pair<std::string, double>> getItrDurationReport() const {
+        const auto& total = _itrDuration[Total];
+        const auto& shapeInfer = _itrDuration[ShapeInfer];
+        const auto& prepareParams = _itrDuration[PrepareParams];
+
+        std::vector<std::pair<std::string, double>> report{{"total", total.count()}};
+        if (shapeInfer != std::chrono::high_resolution_clock::duration::zero() ||
+            prepareParams != std::chrono::high_resolution_clock::duration::zero()) {
+            report.emplace_back(std::make_pair("shapeInfer", shapeInfer.count()));
+            report.emplace_back(std::make_pair("prepareParams", prepareParams.count()));
+            report.emplace_back(std::make_pair("exec", (total - shapeInfer - prepareParams).count()));
+        }
+        return report;
+    }
+
+    uint64_t avg() const { return _total.num ? _total.duration / _total.num : 0; }
+    uint32_t count() const { return _total.num; }
+
+    bool isItrStarted() const { return _isItrStarted; }
+
+private:
+    bool _isItrStarted = false;
+    std::chrono::high_resolution_clock::time_point _itrStart[NumberOfCounters] = {};
+    std::chrono::duration<double, std::milli> _itrDuration[NumberOfCounters] = {};
+    CounterSum _total;
+
+    void start_itr() {
+        _isItrStarted = true;
+        _itrDuration[ShapeInfer] = _itrDuration[PrepareParams] =
+            std::chrono::high_resolution_clock::duration::zero();
+        _itrStart[Total] = std::chrono::high_resolution_clock::now();
+    }
+
+    void start_stage(const CounterIdx cntrIdx) {
+        assert(cntrIdx == ShapeInfer || cntrIdx == PrepareParams);
+        _itrStart[cntrIdx] = std::chrono::high_resolution_clock::now();
+    }
+    void finish_stage(const CounterIdx cntrIdx) {
+        assert(cntrIdx == ShapeInfer || cntrIdx == PrepareParams);
+        _itrDuration[cntrIdx] = std::chrono::high_resolution_clock::now() - _itrStart[cntrIdx];
+    }
+
+    void finish_itr() {
+        _itrDuration[Total] = std::chrono::high_resolution_clock::now() - _itrStart[Total];
+        _total.duration += std::chrono::duration_cast<std::chrono::microseconds>(_itrDuration[Total]).count();
+        _total.num++;
+        _isItrStarted = false;
+    }
+    void finish_itr(const PerfKey itrKey, const std::shared_ptr<Node>& node);
+
+    friend class PerfHelper;
+    friend class PerfHelperStage;
+};
+
+class PerfHelper {
+    const std::shared_ptr<Node>& _node;
+    const PerfKey _itrKey;
+
+public:
+    explicit PerfHelper(const std::shared_ptr<Node>& node, const PerfKey itrKey);
+    ~PerfHelper();
+};
+
+class PerfHelperStage {
+    PerfCount& _count;
+    const PerfCount::CounterIdx _cntrIdx;
+
+public:
+    explicit PerfHelperStage(PerfCount& count, const PerfCount::CounterIdx cntrIdx) :
+        _count(count), _cntrIdx(cntrIdx) { _count.start_stage(_cntrIdx); }
+    ~PerfHelperStage() { _count.finish_stage(_cntrIdx); }
+};
+
+class Graph;
+PerfKey perfGetKey(Graph& graph);
+class ExecNetwork;
+void perfDump(const ExecNetwork& execNet);
+
+}   // namespace intel_cpu
+}   // namespace ov
+
+#  define PERF(_node, _need, _itrKey) PERF_COUNTER(_need, PerfHelper, _node, _itrKey)
+#  define PERF_SHAPE_INFER(_node) PERF_COUNTER(_node->PerfCounter().isItrStarted(), PerfHelperStage, _node->PerfCounter(), PerfCount::ShapeInfer)
+#  define PERF_PREPARE_PARAMS(_node) PERF_COUNTER(_node->PerfCounter().isItrStarted(), PerfHelperStage, _node->PerfCounter(), PerfCount::PrepareParams)
+#endif // CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/utils/verbose.cpp
+++ b/src/plugins/intel_cpu/src/utils/verbose.cpp
@@ -29,59 +29,50 @@ bool Verbose::shouldBePrinted() const {
         return false;
     return true;
 }
+std::string Verbose::colorize(const Color color, const std::string& str) const {
+    /* 1,  2,  3,  etc -> no color
+     * 11, 22, 33, etc -> colorize */
+    bool colorUp = lvl / 10 > 0 ? true : false;
+
+    if (!colorUp)
+        return str;
+
+    const std::string     red("\033[1;31m");
+    const std::string   green("\033[1;32m");
+    const std::string  yellow("\033[1;33m");
+    const std::string    blue("\033[1;34m");
+    const std::string  purple("\033[1;35m");
+    const std::string    cyan("\033[1;36m");
+    const std::string   reset("\033[0m");
+    std::string colorCode;
+
+    switch (color) {
+    case RED:    colorCode = red;
+        break;
+    case GREEN:  colorCode = green;
+        break;
+    case YELLOW: colorCode = yellow;
+        break;
+    case BLUE:   colorCode = blue;
+        break;
+    case PURPLE: colorCode = purple;
+        break;
+    case CYAN:   colorCode = cyan;
+        break;
+    default:     colorCode = reset;
+        break;
+    }
+
+    return colorCode + str + reset;
+}
+
 /**
  * Print node verbose execution information to cout.
  * Similiar to DNNL_VERBOSE output
  * Formating written in C using oneDNN format functions.
  * Can be rewritten in pure C++ if necessary
  */
-void Verbose::printInfo() {
-    /* 1,  2,  3,  etc -> no color
-     * 11, 22, 33, etc -> colorize */
-    bool colorUp = lvl / 10 > 0 ? true : false;
-
-    enum Color {
-        RED,
-        GREEN,
-        YELLOW,
-        BLUE,
-        PURPLE,
-        CYAN
-    };
-
-    auto colorize = [&](const Color color, const std::string& str) {
-        if (!colorUp)
-            return str;
-
-        const std::string     red("\033[1;31m");
-        const std::string   green("\033[1;32m");
-        const std::string  yellow("\033[1;33m");
-        const std::string    blue("\033[1;34m");
-        const std::string  purple("\033[1;35m");
-        const std::string    cyan("\033[1;36m");
-        const std::string   reset("\033[0m");
-        std::string colorCode;
-
-        switch (color) {
-        case RED:    colorCode = red;
-            break;
-        case GREEN:  colorCode = green;
-            break;
-        case YELLOW: colorCode = yellow;
-            break;
-        case BLUE:   colorCode = blue;
-            break;
-        case PURPLE: colorCode = purple;
-            break;
-        case CYAN:   colorCode = cyan;
-            break;
-        default:     colorCode = reset;
-            break;
-        }
-
-        return colorCode + str + reset;
-    };
-
+void Verbose::printInfo(const int inferCount) {
     // can be increased if necessary
     const int CPU_VERBOSE_DAT_LEN = 512;
     char portsInfo[CPU_VERBOSE_DAT_LEN] = {'\0'};
@@ -151,6 +142,7 @@ void Verbose::printInfo() {
     const std::string& nodePrimImplType =  impl_type_to_string(node->getSelectedPrimitiveDescriptor()->getImplementationType());
 
     stream << "ov_cpu_verbose" << ','
+           << colorize(YELLOW, std::to_string(inferCount)) << ','
            << "exec" << ','
            << nodeImplementer << ','
            << nodeName << ":" << nodeType << ":" << nodeAlg << ','
@@ -159,9 +151,16 @@ void Verbose::printInfo() {
            << post_ops << ',';
 }
 
-void Verbose::printDuration() {
-    const auto& duration = node->PerfCounter().duration().count();
-    stream << duration << "ms";
+void Verbose::printLastInfo() {
+    const auto& timeReport = node->PerfCounter().getItrDurationReport();
+    for (auto it = timeReport.begin(); it < timeReport.end(); it++) {
+        if (it != timeReport.begin())
+            stream << ' ';
+        stream << colorize(PURPLE, "time:" + it->first + ':') << it->second << "ms";
+    }
+    if (node->_verboseStorage.isPrepareParamsCacheHit()) {
+        stream << ",cacheHit:execCacheHit";
+    }
 }
 
 void Verbose::flush() const {

--- a/src/plugins/intel_cpu/src/utils/verbose.h
+++ b/src/plugins/intel_cpu/src/utils/verbose.h
@@ -6,6 +6,7 @@
 #ifdef CPU_DEBUG_CAPS
 
 #include <node.h>
+#include "utils/verbose_node_helper.h"
 
 #include <string>
 #include <cstdlib>
@@ -16,18 +17,19 @@ namespace intel_cpu {
 
 class Verbose {
 public:
-    Verbose(const NodePtr& _node, const std::string& _lvl)
+    Verbose(const NodePtr& _node, const std::string& _lvl, const int inferCount)
         : node(_node), lvl(atoi(_lvl.c_str())) {
         if (!shouldBePrinted())
             return;
-        printInfo();
+        node->_verboseStorage.cleanup();
+        printInfo(inferCount);
     }
 
     ~Verbose() {
         if (!shouldBePrinted())
             return;
 
-        printDuration();
+        printLastInfo();
         flush();
     }
 
@@ -37,9 +39,19 @@ private:
     std::stringstream stream;
 
     bool shouldBePrinted() const;
-    void printInfo();
-    void printDuration();
+    void printInfo(const int inferCount);
+    void printLastInfo();
     void flush() const;
+
+    enum Color {
+        RED,
+        GREEN,
+        YELLOW,
+        BLUE,
+        PURPLE,
+        CYAN
+    };
+    std::string colorize(const Color color, const std::string& str) const;
 };
 
 // use heap allocation instead of stack to align with PERF macro (to have proper destruction order)

--- a/src/plugins/intel_cpu/src/utils/verbose_node_helper.h
+++ b/src/plugins/intel_cpu/src/utils/verbose_node_helper.h
@@ -1,0 +1,31 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#ifdef CPU_DEBUG_CAPS
+
+#include "cache/cache_entry.h"
+
+namespace ov {
+namespace intel_cpu {
+
+struct VerboseNodeStorage {
+    void cleanup() {
+        prepareParamsCacheLookUpStatus = CacheEntryBase::LookUpStatus::Miss;
+    }
+
+    bool isPrepareParamsCacheHit() const {
+        return prepareParamsCacheLookUpStatus == CacheEntryBase::LookUpStatus::Hit;
+    }
+
+    CacheEntryBase::LookUpStatus prepareParamsCacheLookUpStatus;
+};
+
+#define VERBOSE_HELPER_NODE_PREPARE_PARAMS(lookUpStatus) \
+    _verboseStorage.prepareParamsCacheLookUpStatus = lookUpStatus
+}   // namespace intel_cpu
+}   // namespace ov
+#else
+#define VERBOSE_HELPER_NODE_PREPARE_PARAMS(lookUpStatus)
+#endif // CPU_DEBUG_CAPS


### PR DESCRIPTION
### Details:
 - Measurements for node shapeInfer and prepareParams stages were added
including support of aggregate tables in csv format.
 - Verbose output was appended by corresponding durations
and prepareParams cache hit info.

### Tickets:
 - 73282