### PR TITLE
[TF FE] Fix Transpose Sinking for dynamic shapes

### DIFF
--- a/src/frontends/tensorflow_common/include/pass/transpose_sinking.hpp
+++ b/src/frontends/tensorflow_common/include/pass/transpose_sinking.hpp
@@ -14,9 +14,7 @@ namespace pass {
 class TransposeSinking : public ov::pass::ModelPass {
 public:
     OPENVINO_RTTI("ov::frontend::tensorflow::pass::TransposeSinking");
-    TransposeSinking() {
-        set_property(ov::pass::PassProperty::REQUIRE_STATIC_SHAPE, true);
-    }
+    TransposeSinking() = default;
     bool run_on_model(const std::shared_ptr<ov::Model>& function) override;
 };
 


### PR DESCRIPTION
**Details:** The current Transpose Sinking actively uses `get_shape` method without checking if tensor is static.

**Ticket:** TBD
