### PR TITLE
[GPU] Fix onednn concat, activation fusing functional regression.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -697,6 +697,8 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                 return;
 
             if (_lo.get_optimization_attributes().use_onednn_impls) {
+                if (input.is_type<reshape>() || input.is_type<concatenation>())
+                    return;
                 #ifdef ENABLE_ONEDNN_FOR_GPU
                 // Activation should not fused if it isn't supported in onednn
                 try {


### PR DESCRIPTION
onednn doesn't support activation fusing. Add missed check-logic.
faceboxes, icv-reid-embeddin, modnet_webcam_portrait_matting fail to run.

Signed-off-by: hyunback <hyunback.kim@intel.com>

### Tickets:
 - *102215*
