### PR TITLE
[GPU] Adding copy functions for image2d memory

### DIFF
--- a/src/plugins/intel_gpu/src/graph/data.cpp
+++ b/src/plugins/intel_gpu/src/graph/data.cpp
@@ -68,8 +68,10 @@ void data_inst::save(cldnn::BinaryOutputBuffer& ob) const {
     if (_allocation_type == allocation_type::usm_host || _allocation_type == allocation_type::usm_shared) {
         ob << make_data(_outputs[0]->buffer_ptr(), data_size);
     } else {
-        mem_lock<char, mem_lock_type::read> lock{_outputs[0], get_node().get_program().get_stream()};
-        ob << make_data(lock.data(), data_size);
+        std::vector<uint8_t> _buf;
+        _buf.resize(data_size);
+        _outputs[0]->copy_to(get_network().get_stream(), _buf.data());
+        ob << make_data(_buf.data(), data_size);
     }
 }
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
@@ -178,6 +178,8 @@ gpu_image2d::gpu_image2d(ocl_engine* engine, const layout& layout)
 
     cl::ImageFormat imageFormat(order, type);
     _buffer = cl::Image2D(engine->get_cl_context(), CL_MEM_READ_WRITE, imageFormat, _width, _height, 0);
+    size_t elem_size = _buffer.getImageInfo<CL_IMAGE_ELEMENT_SIZE>();
+    _bytes_count = elem_size * _width * _height;
 }
 
 gpu_image2d::gpu_image2d(ocl_engine* engine,

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.hpp
@@ -67,11 +67,11 @@ struct gpu_image2d : public lockable_gpu_mem, public memory {
         return _buffer;
     }
 
-    event::ptr copy_from(stream& /* stream */, const memory& /* other */, bool /* blocking */) override;
-    event::ptr copy_from(stream& /* stream */, const void* /* other */, bool /* blocking */) override;
+    event::ptr copy_from(stream& stream, const memory& other, bool blocking) override;
+    event::ptr copy_from(stream& stream, const void* other, bool blocking) override;
 
-    event::ptr copy_to(stream& /* stream */, memory& /* other */, bool /* blocking */) override;
-    event::ptr copy_to(stream& /* stream */, void* /* other */, bool /* blocking */) override;
+    event::ptr copy_to(stream& stream, memory& other, bool blocking) override;
+    event::ptr copy_to(stream& stream, void* other, bool blocking) override;
 
 protected:
     cl::Image2D _buffer;


### PR DESCRIPTION
### Details:
 - This PR implements copy_to() and copy_from() functions for the `gpu_image2d` memory type.
 - These functions are required for GPU model caching.

### Tickets:
 - *ticket-id*
