### PR TITLE
[CORE] Fixed VEX/NonVEX performance penalty inside Convert evaluate impl

### DIFF
--- a/src/core/reference/src/runtime/reference/convert.cpp
+++ b/src/core/reference/src/runtime/reference/convert.cpp
@@ -30,7 +30,7 @@ void jit_convert_vec<uint8_t, float16>(jit::Generator& gen, const Xbyak::RegExp&
     gen.vcvtdq2ps(fvec, i32vec);
     gen.vcvtps2ph(f16vec, fvec, 0);
     gen.vzeroupper();
-    gen.movdqu(gen.xword[dst], f16vec);
+    gen.vmovdqu(gen.xword[dst], f16vec);
 }
 
 template <>
@@ -38,7 +38,7 @@ void jit_convert_vec<float16, float>(jit::Generator& gen, const Xbyak::RegExp& s
     auto f16vec = gen.xmm3;
     auto f32vec = gen.ymm4;
 
-    gen.movdqu(f16vec, gen.xword[src]);
+    gen.vmovdqu(f16vec, gen.xword[src]);
     gen.vcvtph2ps(f32vec, f16vec);
     gen.vmovups(gen.yword[dst], f32vec);
 }


### PR DESCRIPTION
### Details:
 - Mixed Vex/NonVex encoded instruction inside Convert evaluate implementation (FP16->FP32, U8->FP16) led to significant performance penalties on ADL/RPL CPUs. PRs removes nonVEX istructions usage which allows to improve loadTime on several times for particular FP16 models.
