### PR TITLE
Snippets: linker issue fix in tests

### DIFF
--- a/src/tests/functional/plugin/shared/include/snippets/matmul.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/matmul.hpp
@@ -56,15 +56,6 @@ protected:
     void SetUp() override;
 };
 
-class TransposeMatMul : public testing::WithParamInterface<ov::test::snippets::TransposeMatMulParams>,
-                        virtual public ov::test::SnippetsTestsCommon {
-public:
-    static std::string getTestCaseName(testing::TestParamInfo<ov::test::snippets::TransposeMatMulParams> obj);
-
-protected:
-    void SetUp() override;
-};
-
 } // namespace snippets
 } // namespace test
 } // namespace ov

--- a/src/tests/functional/plugin/shared/src/snippets/matmul.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/matmul.cpp
@@ -98,41 +98,6 @@ void ExplicitTransposeMulMatMulBias::SetUp() {
     }
 }
 
-std::string TransposeMatMul::getTestCaseName(testing::TestParamInfo<ov::test::snippets::TransposeMatMulParams> obj) {
-    std::vector<ov::PartialShape> input_shapes;
-    size_t transpose_position;
-    ov::element::Type elem_type;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(input_shapes, transpose_position, elem_type, num_nodes, num_subgraphs, targetDevice) = obj.param;
-    if (input_shapes.size() != 2)
-        IE_THROW() << "Invalid input shapes vector size";
-    std::ostringstream result;
-    result << "IS[0]=" << CommonTestUtils::partialShape2str({input_shapes[0]}) << "_";
-    result << "IS[1]=" << CommonTestUtils::partialShape2str({input_shapes[1]}) << "_";
-    result << "Pos=" << transpose_position << "_";
-    result << "T=" << elem_type << "_";
-    result << "#N=" << num_nodes << "_";
-    result << "#S=" << num_subgraphs << "_";
-    result << "targetDevice=" << targetDevice;
-    return result.str();
-}
-
-void TransposeMatMul::SetUp() {
-    std::vector<ov::PartialShape> input_shapes;
-    size_t transpose_position;
-    ov::element::Type elem_type;
-    std::tie(input_shapes, transpose_position, elem_type, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
-    init_input_shapes(static_partial_shapes_to_test_representation(input_shapes));
-
-    auto f = ov::test::snippets::Transpose0213MatMulFunction(input_shapes, transpose_position);
-    function = f.getOriginal();
-    if (!configuration.count(InferenceEngine::PluginConfigInternalParams::KEY_SNIPPETS_MODE)) {
-        configuration.insert({InferenceEngine::PluginConfigInternalParams::KEY_SNIPPETS_MODE,
-                              InferenceEngine::PluginConfigInternalParams::IGNORE_CALLBACK});
-    }
-}
-
 TEST_P(MatMul, CompareWithRefImpl) {
     run();
     validateNumSubgraphs();
@@ -154,11 +119,6 @@ TEST_P(ExplicitTransposeMatMulBias, CompareWithRefImpl) {
 }
 
 TEST_P(ExplicitTransposeMulMatMulBias, CompareWithRefImpl) {
-    run();
-    validateNumSubgraphs();
-}
-
-TEST_P(TransposeMatMul, CompareWithRefImpl) {
     run();
     validateNumSubgraphs();
 }


### PR DESCRIPTION
### Details:
 - *Linker issue fix in snippets tests. There are two TransposeMatMul tests in the same namespace ov::test::snippets*
