### PR TITLE
[GPU][DG2] Fix fusings_gpu/gemm_2in_act_scale_eltwise.basic/4

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
@@ -167,6 +167,14 @@ public:
     }
 
     static std::unique_ptr<primitive_impl> create(const gemm_node& arg, const kernel_impl_params& impl_params) {
+        bool full_tensor_or_per_tensor = true;
+        for (auto prim : arg.get_fused_primitives()) {
+            full_tensor_or_per_tensor &=
+                prim.input_layout.count() == prim.output_layout.count() || prim.input_layout.count() == 1;
+        }
+        if (!full_tensor_or_per_tensor) {
+            IE_THROW() << "FIXME: Onednn gemm has an issue for post-op axis.";
+        }
         auto& engine = impl_params.prog->get_engine();
         auto& config = impl_params.prog->get_config();
         auto attr = arg.get_onednn_primitive_attributes();

--- a/src/plugins/intel_gpu/tests/fusions/gemm_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/gemm_fusion_test.cpp
@@ -74,6 +74,11 @@ public:
     }
 
     layout get_per_channel_layout(gemm_test_params& p) {
+        // WA: refer PR message
+        if (engine.get_device_info().supports_immad){
+            std::cout << "per_channel layout for onednn gemm not supported." << std::endl;
+            return layout{p.default_type, p.default_format, tensor{1, 1, 1, 1}};
+        }
         return layout{ p.default_type, p.default_format, tensor{ 1, p.in_shapes.at(0).feature[0], 1, 1 } };
     }
 


### PR DESCRIPTION
### Details:
 - Onednn only supports 2D/3D gemm but openvino GPU plugin policy enforces 4D~6D. This API mismatch causes problems in the post-op axis and requires massive code changes. Therefore we decided to insert throw code for now and fix this issue later if some models require non-(per tensor/full tensor) post-ops.

### Tickets:
 - 67491
