### PR TITLE
[DOCS] Supported Layers update - for 22.3

### DIFF
--- a/docs/OV_Runtime_UG/supported_plugins/Supported_Devices.md
+++ b/docs/OV_Runtime_UG/supported_plugins/Supported_Devices.md
@@ -165,7 +165,7 @@ The following layers are supported by the plugins:
 | Eltwise-Greater                | Supported     |Supported\*\*\*| Supported     | Not Supported | Supported       |
 | Eltwise-GreaterEqual           | Supported     |Supported\*\*\*| Supported     | Not Supported | Supported       |
 | Eltwise-Less                   | Supported     |Supported\*\*\*| Supported     | Not Supported | Supported\*     |
-| Eltwise-LessEqual              | Supported     |Supported\*\*\*| Supported     | Not Supported | Supported\*     |
+| Eltwise-LessEqual              | Supported     |Supported\*\*\*| Not Supported | Not Supported | Supported\*     |
 | Eltwise-LogicalAnd             | Supported     |Supported\*\*\*| Supported     | Not Supported | Supported       |
 | Eltwise-LogicalOr              | Supported     |Supported\*\*\*| Supported     | Not Supported | Supported       |
 | Eltwise-LogicalXor             | Supported     |Supported\*\*\*| Supported     | Not Supported | Supported       |

--- a/docs/OV_Runtime_UG/supported_plugins/Supported_Devices.md
+++ b/docs/OV_Runtime_UG/supported_plugins/Supported_Devices.md
@@ -183,7 +183,7 @@ The following layers are supported by the plugins:
 | FakeQuantize                   | Not Supported | Supported     | Not Supported | Not Supported | Supported\*     |
 | Fill                           | Not Supported | Supported\*\* | Not Supported | Not Supported | Not Supported   |
 | Flatten                        | Supported     | Supported     | Supported     | Not Supported | Not Supported   |
-| Floor                          | Supported     | Supported\*\* | Supported     | Not Supported | Supported       |
+| Floor                          | Supported     | Supported\*\* | Supported\*   | Not Supported | Supported       |
 | FullyConnected (Inner Product) | Supported     |Supported\*\*\*| Supported     | Supported     | Supported       |
 | Gather                         | Supported     | Supported\*\* | Supported     | Not Supported | Supported\*     |
 | GatherTree                     | Not Supported | Supported\*\* | Not Supported | Not Supported |Supported\*\*\*\*|
@@ -242,7 +242,7 @@ The following layers are supported by the plugins:
 | Select                         | Supported     | Supported     | Supported     | Not Supported | Supported       |
 | Selu                           | Supported     | Supported\*\* | Not Supported | Not Supported |Supported\*\*\*\*|
 | ShuffleChannels                | Supported     | Supported\*\* | Not Supported | Not Supported | Supported       |
-| Sign                           | Supported     | Supported\*\* | Supported     | Not Supported | Supported       |
+| Sign                           | Supported     | Supported\*\* | Not Supported | Not Supported | Supported       |
 | Sin                            | Supported     | Supported\*\* | Not Supported | Not Supported | Supported       |
 | Sinh                           | Supported     | Supported\*\* | Not Supported | Not Supported |Supported\*\*\*\*|
 | SimplerNMS                     | Supported     | Supported\*\* | Not Supported | Not Supported | Not Supported   |

--- a/docs/OV_Runtime_UG/supported_plugins/VPU.md
+++ b/docs/OV_Runtime_UG/supported_plugins/VPU.md
@@ -149,6 +149,9 @@ For a list of VPU-supported layers, see the **Supported Layers** section of the 
 * `MVN` layer uses fixed value for `eps` parameters (1e-9).
 * `Normalize` layer uses fixed value for `eps` parameters (1e-9) and is supported for zero value of `across_spatial` only.
 * `Pad` layer works only with 4D tensors.
+* `Floor` layer works only with FP16 type.
+* `ConvTranspose` layer is not supported.
+* `GatherElements` layer is not supported for negative axis.
 
 ## See Also
 


### PR DESCRIPTION
Porting: https://github.com/openvinotoolkit/openvino/pull/13580
Changing Eltwise-LessEqual layer to Not Supported.
---
Porting: https://github.com/openvinotoolkit/openvino/pull/13997
Update support "Sign" layer to not supported.
Update support "Floor" layer to limited support.
Tickets: 88871, 88693
--
Porting: https://github.com/openvinotoolkit/openvino/pull/13995
Add "Floor" in Known Layers Limitations section.
Add "ConvTranspose" in Known Layers Limitations section.
Add "GatherElements" in Known Layers Limitations section.
Tickets: 88871, 75208, 88690
