### PR TITLE
[PyOV] Try to fix PosixPath error in CI

### DIFF
--- a/src/bindings/python/src/openvino/runtime/passes/__init__.py
+++ b/src/bindings/python/src/openvino/runtime/passes/__init__.py
@@ -14,6 +14,6 @@ from openvino._pyopenvino.passes import (
     type_matches,
     type_matches_any,
 )
-from openvino._pyopenvino.passes import Serialize, ConstantFolding, VisualizeTree, MakeStateful, LowLatency2, ConvertFP32ToFP16
+from openvino._pyopenvino.passes import Serialize, ConstantFolding, VisualizeTree, MakeStateful, LowLatency2, ConvertFP32ToFP16, Version
 from openvino.runtime.passes.manager import Manager
 from openvino.runtime.passes.graph_rewrite import GraphRewrite, BackwardGraphRewrite

--- a/src/bindings/python/src/pyopenvino/graph/passes/manager.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/passes/manager.cpp
@@ -19,17 +19,6 @@ namespace py = pybind11;
 using Version = ov::pass::Serialize::Version;
 using FilePaths = std::pair<const std::string, const std::string>;
 
-inline Version convert_to_version(const std::string& version) {
-    if (version == "UNSPECIFIED")
-        return Version::UNSPECIFIED;
-    if (version == "IR_V10")
-        return Version::IR_V10;
-    if (version == "IR_V11")
-        return Version::IR_V11;
-    throw ov::Exception("Invoked with wrong version argument: '" + version +
-                        "'! The supported versions are: 'UNSPECIFIED'(default), 'IR_V10', 'IR_V11'.");
-}
-
 void regclass_passes_Manager(py::module m) {
     py::class_<ov::pass::Manager> manager(m, "Manager");
     manager.doc() = "openvino.runtime.passes.Manager executes sequence of transformation on a given Model";
@@ -97,7 +86,7 @@ void regclass_passes_Manager(py::module m) {
             if (pass_name == "Serialize") {
                 self.register_pass<ov::pass::Serialize>(file_paths.first,
                                                         file_paths.second,
-                                                        convert_to_version(version));
+                                                        Common::utils::convert_to_version(version));
             }
         },
         py::arg("pass_name"),
@@ -140,7 +129,7 @@ void regclass_passes_Manager(py::module m) {
                                                "",
                                                "Please use register_pass(Serialize(xml, bin, version)) instead.");
             if (pass_name == "Serialize") {
-                self.register_pass<ov::pass::Serialize>(xml_path, bin_path, convert_to_version(version));
+                self.register_pass<ov::pass::Serialize>(xml_path, bin_path, Common::utils::convert_to_version(version));
             }
         },
         py::arg("pass_name"),

--- a/src/bindings/python/src/pyopenvino/graph/passes/transformations.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/passes/transformations.cpp
@@ -22,7 +22,6 @@
 namespace py = pybind11;
 using Version = ov::pass::Serialize::Version;
 
-
 inline Version convert_to_version(const std::string& version) {
     if (version == "UNSPECIFIED")
         return Version::UNSPECIFIED;
@@ -35,35 +34,34 @@ inline Version convert_to_version(const std::string& version) {
 }
 
 void regclass_transformations(py::module m) {
+    py::enum_<Version>(m, "Version", py::arithmetic())
+        .value("UNSPECIFIED", Version::UNSPECIFIED)
+        .value("IR_V10", Version::IR_V10)
+        .value("IR_V11", Version::IR_V11);
+
     py::class_<ov::pass::Serialize, std::shared_ptr<ov::pass::Serialize>, ov::pass::ModelPass, ov::pass::PassBase>
         serialize(m, "Serialize");
     serialize.doc() = "openvino.runtime.passes.Serialize transformation";
-    serialize.def(py::init([](const py::object& path_to_xml, const py::object& path_to_bin) {
-                      return std::make_shared<ov::pass::Serialize>(Common::utils::convert_path_to_string(path_to_xml),
-                                                                   Common::utils::convert_path_to_string(path_to_bin));
-                  }),
-                  py::arg("path_to_xml"),
-                  py::arg("path_to_bin"),
-                  R"(
-                  Create Serialize pass which is used for Model to IR serialization.
-
-                  :param path_to_xml: Path where *.xml file will be saved.
-                  :type path_to_xml: Union[str, bytes, pathlib.Path]
-
-                  :param path_to_xml: Path where *.bin file will be saved.
-                  :type path_to_xml: Union[str, bytes, pathlib.Path]
-    )");
 
     serialize.def(
         py::init(
-            [](const py::object& path_to_xml, const py::object& path_to_bin, const std::string& version) {
-                return std::make_shared<ov::pass::Serialize>(Common::utils::convert_path_to_string(path_to_xml),
-                                                             Common::utils::convert_path_to_string(path_to_bin),
-                                                             convert_to_version(version));
+            [](const py::object& path_to_xml, const py::object& path_to_bin, const py::object& version) {
+                if (py::isinstance<py::str>(version)) {
+                    return std::make_shared<ov::pass::Serialize>(Common::utils::convert_path_to_string(path_to_xml),
+                                                                 Common::utils::convert_path_to_string(path_to_bin),
+                                                                 convert_to_version(version.cast<std::string>()));
+                } else if (py::isinstance<ov::pass::Serialize::Version>(version)) {
+                    return std::make_shared<ov::pass::Serialize>(Common::utils::convert_path_to_string(path_to_xml),
+                                                                 Common::utils::convert_path_to_string(path_to_bin),
+                                                                 version.cast<ov::pass::Serialize::Version>());
+                } else {
+                    return std::make_shared<ov::pass::Serialize>(Common::utils::convert_path_to_string(path_to_xml),
+                                                                 Common::utils::convert_path_to_string(path_to_bin));
+                }
             }),
         py::arg("path_to_xml"),
         py::arg("path_to_bin"),
-        py::arg("version"),
+        py::arg("version") = py::none(),
         R"(
         Create Serialize pass which is used for Model to IR serialization.
 
@@ -73,8 +71,8 @@ void regclass_transformations(py::module m) {
         :param path_to_xml: Path where *.bin file will be saved.
         :type path_to_xml: Union[str, bytes, pathlib.Path]
 
-        :param version: serialized IR version.
-        :type version: int
+        :param version: Optional serialized IR version.
+        :type version: Union[str, openvino.runtime.passes.Version]
     )");
 
     py::class_<ov::pass::ConstantFolding,

--- a/src/bindings/python/src/pyopenvino/graph/passes/transformations.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/passes/transformations.cpp
@@ -20,6 +20,19 @@
 #include "pyopenvino/utils/utils.hpp"
 
 namespace py = pybind11;
+using Version = ov::pass::Serialize::Version;
+
+
+inline Version convert_to_version(const std::string& version) {
+    if (version == "UNSPECIFIED")
+        return Version::UNSPECIFIED;
+    if (version == "IR_V10")
+        return Version::IR_V10;
+    if (version == "IR_V11")
+        return Version::IR_V11;
+    throw ov::Exception("Invoked with wrong version argument: '" + version +
+                        "'! The supported versions are: 'UNSPECIFIED'(default), 'IR_V10', 'IR_V11'.");
+}
 
 void regclass_transformations(py::module m) {
     py::class_<ov::pass::Serialize, std::shared_ptr<ov::pass::Serialize>, ov::pass::ModelPass, ov::pass::PassBase>
@@ -43,10 +56,10 @@ void regclass_transformations(py::module m) {
 
     serialize.def(
         py::init(
-            [](const py::object& path_to_xml, const py::object& path_to_bin, ov::pass::Serialize::Version version) {
+            [](const py::object& path_to_xml, const py::object& path_to_bin, const std::string& version) {
                 return std::make_shared<ov::pass::Serialize>(Common::utils::convert_path_to_string(path_to_xml),
                                                              Common::utils::convert_path_to_string(path_to_bin),
-                                                             version);
+                                                             convert_to_version(version));
             }),
         py::arg("path_to_xml"),
         py::arg("path_to_bin"),

--- a/src/bindings/python/src/pyopenvino/graph/passes/transformations.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/passes/transformations.cpp
@@ -22,17 +22,6 @@
 namespace py = pybind11;
 using Version = ov::pass::Serialize::Version;
 
-inline Version convert_to_version(const std::string& version) {
-    if (version == "UNSPECIFIED")
-        return Version::UNSPECIFIED;
-    if (version == "IR_V10")
-        return Version::IR_V10;
-    if (version == "IR_V11")
-        return Version::IR_V11;
-    throw ov::Exception("Invoked with wrong version argument: '" + version +
-                        "'! The supported versions are: 'UNSPECIFIED'(default), 'IR_V10', 'IR_V11'.");
-}
-
 void regclass_transformations(py::module m) {
     py::enum_<Version>(m, "Version", py::arithmetic())
         .value("UNSPECIFIED", Version::UNSPECIFIED)
@@ -44,21 +33,21 @@ void regclass_transformations(py::module m) {
     serialize.doc() = "openvino.runtime.passes.Serialize transformation";
 
     serialize.def(
-        py::init(
-            [](const py::object& path_to_xml, const py::object& path_to_bin, const py::object& version) {
-                if (py::isinstance<py::str>(version)) {
-                    return std::make_shared<ov::pass::Serialize>(Common::utils::convert_path_to_string(path_to_xml),
-                                                                 Common::utils::convert_path_to_string(path_to_bin),
-                                                                 convert_to_version(version.cast<std::string>()));
-                } else if (py::isinstance<ov::pass::Serialize::Version>(version)) {
-                    return std::make_shared<ov::pass::Serialize>(Common::utils::convert_path_to_string(path_to_xml),
-                                                                 Common::utils::convert_path_to_string(path_to_bin),
-                                                                 version.cast<ov::pass::Serialize::Version>());
-                } else {
-                    return std::make_shared<ov::pass::Serialize>(Common::utils::convert_path_to_string(path_to_xml),
-                                                                 Common::utils::convert_path_to_string(path_to_bin));
-                }
-            }),
+        py::init([](const py::object& path_to_xml, const py::object& path_to_bin, const py::object& version) {
+            if (py::isinstance<py::str>(version)) {
+                return std::make_shared<ov::pass::Serialize>(
+                    Common::utils::convert_path_to_string(path_to_xml),
+                    Common::utils::convert_path_to_string(path_to_bin),
+                    Common::utils::convert_to_version(version.cast<std::string>()));
+            } else if (py::isinstance<Version>(version)) {
+                return std::make_shared<ov::pass::Serialize>(Common::utils::convert_path_to_string(path_to_xml),
+                                                             Common::utils::convert_path_to_string(path_to_bin),
+                                                             version.cast<Version>());
+            } else {
+                return std::make_shared<ov::pass::Serialize>(Common::utils::convert_path_to_string(path_to_xml),
+                                                             Common::utils::convert_path_to_string(path_to_bin));
+            }
+        }),
         py::arg("path_to_xml"),
         py::arg("path_to_bin"),
         py::arg("version") = py::none(),

--- a/src/bindings/python/src/pyopenvino/utils/utils.cpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.cpp
@@ -14,6 +14,8 @@
 #include "Python.h"
 #include "openvino/frontend/decoder.hpp"
 
+using Version = ov::pass::Serialize::Version;
+
 namespace Common {
 namespace utils {
 
@@ -163,6 +165,17 @@ std::string convert_path_to_string(const py::object& path) {
         << " does not exist. Please provide valid model's path either as a string, bytes or pathlib.Path. "
            "Examples:\n(1) '/home/user/models/model.onnx'\n(2) Path('/home/user/models/model/model.onnx')";
     throw ov::Exception(str.str());
+}
+
+Version convert_to_version(const std::string& version) {
+    if (version == "UNSPECIFIED")
+        return Version::UNSPECIFIED;
+    if (version == "IR_V10")
+        return Version::IR_V10;
+    if (version == "IR_V11")
+        return Version::IR_V11;
+    throw ov::Exception("Invoked with wrong version argument: '" + version +
+                        "'! The supported versions are: 'UNSPECIFIED'(default), 'IR_V10', 'IR_V11'.");
 }
 
 void deprecation_warning(const std::string& function_name, const std::string& version, const std::string& message) {

--- a/src/bindings/python/src/pyopenvino/utils/utils.hpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.hpp
@@ -9,6 +9,7 @@
 #include "openvino/core/any.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/runtime/properties.hpp"
+#include "openvino/pass/serialize.hpp"
 
 namespace py = pybind11;
 
@@ -23,6 +24,8 @@ namespace utils {
     void deprecation_warning(const std::string& function_name, const std::string& version = std::string(), const std::string& message = std::string());
 
     ov::Any py_object_to_any(const py::object& py_obj);
+
+    ov::pass::Serialize::Version convert_to_version(const std::string& version);
 
 }; // namespace utils
 }; // namespace Common

--- a/src/bindings/python/tests/test_graph/test_manager.py
+++ b/src/bindings/python/tests/test_graph/test_manager.py
@@ -10,7 +10,7 @@ import pytest
 
 import openvino.runtime.opset8 as ov
 from openvino.runtime import Model
-from openvino.runtime.passes import Manager, Serialize, ConstantFolding
+from openvino.runtime.passes import Manager, Serialize, ConstantFolding, Version
 from tests.test_graph.util import count_ops_of_type
 from openvino.runtime import Core
 
@@ -118,7 +118,6 @@ def test_serialize_pass_mixed_args_kwargs_v2(request, tmp_path):
     parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
     parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
     parameter_c = ov.parameter(shape, dtype=np.float32, name="C")
-    parameter_d = ov.parameter(shape, dtype=np.float32, name="D")
     model = ov.floor(ov.minimum(ov.abs(parameter_a), ov.multiply(parameter_b, parameter_c)))
     func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
     pass_manager = Manager()
@@ -250,7 +249,7 @@ def test_default_version_IR_V11_seperate_paths(request, tmp_path):
     model = ov.floor(ov.minimum(ov.abs(parameter_a), ov.multiply(parameter_b, parameter_c)))
     func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
     pass_manager = Manager()
-    pass_manager.register_pass(Serialize(path_to_xml=xml_path, path_to_bin=bin_path, version="IR_V11"))
+    pass_manager.register_pass(Serialize(path_to_xml=xml_path, path_to_bin=bin_path, version=Version.IR_V11))
     pass_manager.run_passes(func)
 
     res_model = core.read_model(model=xml_path, weights=bin_path)

--- a/src/bindings/python/tests/test_graph/test_manager.py
+++ b/src/bindings/python/tests/test_graph/test_manager.py
@@ -10,7 +10,7 @@ import pytest
 
 import openvino.runtime.opset8 as ov
 from openvino.runtime import Model
-from openvino.runtime.passes import Manager
+from openvino.runtime.passes import Manager, Serialize, ConstantFolding
 from tests.test_graph.util import count_ops_of_type
 from openvino.runtime import Core
 
@@ -25,7 +25,7 @@ def test_constant_folding():
     assert count_ops_of_type(model, node_constant) == 1
 
     pass_manager = Manager()
-    pass_manager.register_pass("ConstantFolding")
+    pass_manager.register_pass(ConstantFolding())
     pass_manager.run_passes(model)
 
     assert count_ops_of_type(model, node_ceil) == 0
@@ -50,7 +50,7 @@ def test_serialize_seperate_paths_kwargs(request, tmp_path):
     func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
 
     pass_manager = Manager()
-    pass_manager.register_pass(pass_name="Serialize", xml_path=xml_path, bin_path=bin_path)
+    pass_manager.register_pass(Serialize(path_to_xml=xml_path, path_to_bin=bin_path))
     pass_manager.run_passes(func)
 
     res_model = core.read_model(model=xml_path, weights=bin_path)
@@ -75,7 +75,7 @@ def test_serialize_seperate_paths_args(request, tmp_path):
     func = Model(model, [parameter_a, parameter_b, parameter_c, parameter_d], "Model")
 
     pass_manager = Manager()
-    pass_manager.register_pass("Serialize", xml_path, bin_path)
+    pass_manager.register_pass(Serialize(xml_path, bin_path))
     pass_manager.run_passes(func)
 
     res_model = core.read_model(model=xml_path, weights=bin_path)
@@ -98,7 +98,7 @@ def test_serialize_pass_mixed_args_kwargs(request, tmp_path):
     func = Model(model, [parameter_a, parameter_b], "Model")
 
     pass_manager = Manager()
-    pass_manager.register_pass("Serialize", xml_path, bin_path=bin_path)
+    pass_manager.register_pass(Serialize(xml_path, path_to_bin=bin_path))
     pass_manager.run_passes(func)
 
     res_model = core.read_model(model=xml_path, weights=bin_path)
@@ -122,7 +122,7 @@ def test_serialize_pass_mixed_args_kwargs_v2(request, tmp_path):
     model = ov.floor(ov.minimum(ov.abs(parameter_a), ov.multiply(parameter_b, parameter_c)))
     func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
     pass_manager = Manager()
-    pass_manager.register_pass("Serialize", xml_path=xml_path, bin_path=bin_path)
+    pass_manager.register_pass(Serialize(path_to_xml=xml_path, path_to_bin=bin_path))
     pass_manager.run_passes(func)
 
     res_model = core.read_model(model=xml_path, weights=bin_path)
@@ -140,7 +140,7 @@ def test_serialize_pass_wrong_num_of_args(request, tmp_path):
 
     pass_manager = Manager()
     with pytest.raises(TypeError) as e:
-        pass_manager.register_pass(pass_name="Serialize", xml_path=xml_path, bin_path=bin_path, model=5)
+        pass_manager.register_pass(Serialize(path_to_xml=xml_path, path_to_bin=bin_path, model=5))
     assert "Invoked with:" in str(e.value)
 
 
@@ -153,7 +153,7 @@ def test_serialize_results(request, tmp_path):
 
     xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     pass_manager = Manager()
-    pass_manager.register_pass("Serialize", xml_path=xml_path, bin_path=bin_path)
+    pass_manager.register_pass(Serialize(path_to_xml=xml_path, path_to_bin=bin_path))
     pass_manager.run_passes(func)
 
     res_model = core.read_model(model=xml_path, weights=bin_path)
@@ -178,7 +178,7 @@ def test_serialize_pass_tuple(request, tmp_path):
     model = ov.floor(ov.minimum(ov.abs(parameter_a), ov.multiply(parameter_b, parameter_c)))
     func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
     pass_manager = Manager()
-    pass_manager.register_pass("Serialize", output_files=(xml_path, bin_path))
+    pass_manager.register_pass("Serialize", output_files=(str(xml_path), str(bin_path)))
     pass_manager.run_passes(func)
 
     res_model = core.read_model(model=xml_path, weights=bin_path)
@@ -202,7 +202,7 @@ def test_default_version(request, tmp_path):
     model = ov.floor(ov.minimum(ov.abs(parameter_a), ov.multiply(parameter_b, parameter_c)))
     func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
     pass_manager = Manager()
-    pass_manager.register_pass("Serialize", output_files=(xml_path, bin_path))
+    pass_manager.register_pass("Serialize", output_files=(str(xml_path), str(bin_path)))
     pass_manager.run_passes(func)
 
     res_model = core.read_model(model=xml_path, weights=bin_path)
@@ -226,7 +226,7 @@ def test_default_version_IR_V11_tuple(request, tmp_path):
     model = ov.floor(ov.minimum(ov.abs(parameter_a), ov.multiply(parameter_b, parameter_c)))
     func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
     pass_manager = Manager()
-    pass_manager.register_pass("Serialize", output_files=(xml_path, bin_path), version="IR_V11")
+    pass_manager.register_pass("Serialize", output_files=(str(xml_path), str(bin_path)), version="IR_V11")
     pass_manager.run_passes(func)
 
     res_model = core.read_model(model=xml_path, weights=bin_path)
@@ -250,7 +250,7 @@ def test_default_version_IR_V11_seperate_paths(request, tmp_path):
     model = ov.floor(ov.minimum(ov.abs(parameter_a), ov.multiply(parameter_b, parameter_c)))
     func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
     pass_manager = Manager()
-    pass_manager.register_pass("Serialize", xml_path=xml_path, bin_path=bin_path, version="IR_V11")
+    pass_manager.register_pass(Serialize(path_to_xml=xml_path, path_to_bin=bin_path, version="IR_V11"))
     pass_manager.run_passes(func)
 
     res_model = core.read_model(model=xml_path, weights=bin_path)

--- a/src/bindings/python/tests/test_graph/test_manager.py
+++ b/src/bindings/python/tests/test_graph/test_manager.py
@@ -39,9 +39,9 @@ def test_constant_folding():
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_serialize_seperate_paths_kwargs(request):
+def test_serialize_seperate_paths_kwargs(request, tmp_path):
     core = Core()
-    xml_path, bin_path = create_filename_for_test(request.node.name)
+    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     shape = [2, 2]
     parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
     parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
@@ -63,9 +63,9 @@ def test_serialize_seperate_paths_kwargs(request):
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_serialize_seperate_paths_args(request):
+def test_serialize_seperate_paths_args(request, tmp_path):
     core = Core()
-    xml_path, bin_path = create_filename_for_test(request.node.name)
+    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     shape = [2, 2]
     parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
     parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
@@ -88,9 +88,9 @@ def test_serialize_seperate_paths_args(request):
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_serialize_pass_mixed_args_kwargs(request):
+def test_serialize_pass_mixed_args_kwargs(request, tmp_path):
     core = Core()
-    xml_path, bin_path = create_filename_for_test(request.node.name)
+    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     shape = [3, 2]
     parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
     parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
@@ -111,9 +111,9 @@ def test_serialize_pass_mixed_args_kwargs(request):
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_serialize_pass_mixed_args_kwargs_v2(request):
+def test_serialize_pass_mixed_args_kwargs_v2(request, tmp_path):
     core = Core()
-    xml_path, bin_path = create_filename_for_test(request.node.name)
+    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     shape = [100, 100, 2]
     parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
     parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
@@ -135,8 +135,8 @@ def test_serialize_pass_mixed_args_kwargs_v2(request):
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_serialize_pass_wrong_num_of_args(request):
-    xml_path, bin_path = create_filename_for_test(request.node.name)
+def test_serialize_pass_wrong_num_of_args(request, tmp_path):
+    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
 
     pass_manager = Manager()
     with pytest.raises(TypeError) as e:
@@ -145,13 +145,13 @@ def test_serialize_pass_wrong_num_of_args(request):
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_serialize_results(request):
+def test_serialize_results(request, tmp_path):
     core = Core()
     node_constant = ov.constant(np.array([[0.0, 0.1, -0.1], [-2.5, 2.5, 3.0]], dtype=np.float32))
     node_ceil = ov.ceiling(node_constant)
     func = Model(node_ceil, [], "Model")
 
-    xml_path, bin_path = create_filename_for_test(request.node.name)
+    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     pass_manager = Manager()
     pass_manager.register_pass("Serialize", xml_path=xml_path, bin_path=bin_path)
     pass_manager.run_passes(func)
@@ -167,9 +167,9 @@ def test_serialize_results(request):
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_serialize_pass_tuple(request):
+def test_serialize_pass_tuple(request, tmp_path):
     core = Core()
-    xml_path, bin_path = create_filename_for_test(request.node.name)
+    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     shape = [100, 100, 2]
     parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
     parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
@@ -191,9 +191,9 @@ def test_serialize_pass_tuple(request):
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_default_version(request):
+def test_default_version(request, tmp_path):
     core = Core()
-    xml_path, bin_path = create_filename_for_test(request.node.name)
+    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     shape = [100, 100, 2]
     parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
     parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
@@ -215,9 +215,9 @@ def test_default_version(request):
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_default_version_IR_V11_tuple(request):
+def test_default_version_IR_V11_tuple(request, tmp_path):
     core = Core()
-    xml_path, bin_path = create_filename_for_test(request.node.name)
+    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     shape = [100, 100, 2]
     parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
     parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
@@ -239,9 +239,9 @@ def test_default_version_IR_V11_tuple(request):
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_default_version_IR_V11_seperate_paths(request):
+def test_default_version_IR_V11_seperate_paths(request, tmp_path):
     core = Core()
-    xml_path, bin_path = create_filename_for_test(request.node.name)
+    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     shape = [100, 100, 2]
     parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
     parameter_b = ov.parameter(shape, dtype=np.float32, name="B")

--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -453,7 +453,7 @@ def test_reshape_with_python_types(device):
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_serialize_rt_info(request):
+def test_serialize_rt_info(request, tmp_path):
     version = "TestVersion"
     config = "TestConfig"
     framework_batch = "1"
@@ -474,7 +474,7 @@ def test_serialize_rt_info(request):
             assert model.get_rt_info(["optimization", "test"])
 
     core = Core()
-    xml_path, bin_path = create_filename_for_test(request.node.name)
+    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     input_shape = PartialShape([1])
     param = ops.parameter(input_shape, dtype=np.float32, name="data")
     relu1 = ops.relu(param, name="relu1")
@@ -518,7 +518,7 @@ def test_serialize_rt_info(request):
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_serialize_complex_rt_info(request):
+def test_serialize_complex_rt_info(request, tmp_path):
     def check_rt_info(model, serialized):
         if serialized:
             threshold = "13.23"
@@ -561,7 +561,7 @@ def test_serialize_complex_rt_info(request):
         assert model.get_rt_info(["config", "model_parameters", "mean_values"]) == mean
 
     core = Core()
-    xml_path, bin_path = create_filename_for_test(request.node.name)
+    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     input_shape = PartialShape([1])
     param = ops.parameter(input_shape, dtype=np.float32, name="data")
     relu1 = ops.relu(param, name="relu1")

--- a/src/bindings/python/tests/test_transformations/test_offline_api.py
+++ b/src/bindings/python/tests/test_transformations/test_offline_api.py
@@ -174,9 +174,10 @@ def test_fused_names_cleanup():
     (False, False),
 ],
 )
-def test_serialize_pass_v2(request, is_path_xml, is_path_bin):
+def test_serialize_pass_v2(request, tmp_path, is_path_xml, is_path_bin):
     core = Core()
     xml_path, bin_path = create_filename_for_test(request.node.name,
+                                                  tmp_path,
                                                   is_path_xml,
                                                   is_path_bin)
     shape = [100, 100, 2]
@@ -219,9 +220,10 @@ def test_compress_model_transformation():
     (False, False),
 ],
 )
-def test_version_default(request, is_path_xml, is_path_bin):
+def test_version_default(request, tmp_path, is_path_xml, is_path_bin):
     core = Core()
     xml_path, bin_path = create_filename_for_test(request.node.name,
+                                                  tmp_path,
                                                   is_path_xml,
                                                   is_path_bin)
     shape = [100, 100, 2]
@@ -248,8 +250,9 @@ def test_version_default(request, is_path_xml, is_path_bin):
     (False, False),
 ],
 )
-def test_serialize_default_bin(request, is_path_xml, is_path_bin):
+def test_serialize_default_bin(request, tmp_path, is_path_xml, is_path_bin):
     xml_path, bin_path = create_filename_for_test(request.node.name,
+                                                  tmp_path,
                                                   is_path_xml,
                                                   is_path_bin)
     model = get_relu_model()
@@ -260,9 +263,9 @@ def test_serialize_default_bin(request, is_path_xml, is_path_bin):
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_version_ir_v10(request):
+def test_version_ir_v10(request, tmp_path):
     core = Core()
-    xml_path, bin_path = create_filename_for_test(request.node.name)
+    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     shape = [100, 100, 2]
     parameter_a = ov.opset8.parameter(shape, dtype=np.float32, name="A")
     parameter_b = ov.opset8.parameter(shape, dtype=np.float32, name="B")
@@ -280,9 +283,9 @@ def test_version_ir_v10(request):
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_version_ir_v11(request):
+def test_version_ir_v11(request, tmp_path):
     core = Core()
-    xml_path, bin_path = create_filename_for_test(request.node.name)
+    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     shape = [100, 100, 2]
     parameter_a = ov.opset8.parameter(shape, dtype=np.float32, name="A")
     parameter_b = ov.opset8.parameter(shape, dtype=np.float32, name="B")

--- a/src/bindings/python/tests/test_transformations/test_public_transformations.py
+++ b/src/bindings/python/tests/test_transformations/test_public_transformations.py
@@ -111,9 +111,10 @@ def test_low_latency2():
     (False, False),
 ],
 )
-def test_serialize_pass(request, is_path_xml, is_path_bin):
+def test_serialize_pass(request, tmp_path, is_path_xml, is_path_bin):
     core = Core()
     xml_path, bin_path = create_filename_for_test(request.node.name,
+                                                  tmp_path,
                                                   is_path_xml,
                                                   is_path_bin)
 

--- a/src/bindings/python/tests/test_utils/test_utils.py
+++ b/src/bindings/python/tests/test_utils/test_utils.py
@@ -107,7 +107,7 @@ def test_deprecation_decorator():
         deprecated_function4()
 
 
-def create_filename_for_test(test_name, is_xml_path=False, is_bin_path=False):
+def create_filename_for_test(test_name, tmp_path, is_xml_path=False, is_bin_path=False):
     """Return a tuple with automatically generated paths for xml and bin files.
 
     :param test_name: Name used in generating.
@@ -116,8 +116,8 @@ def create_filename_for_test(test_name, is_xml_path=False, is_bin_path=False):
     :return: Tuple with two objects representing xml and bin files.
     """
     python_version = str(sys.version_info.major) + "_" + str(sys.version_info.minor)
-    filename = "./" + test_name.replace("test_", "").replace("[", "_").replace("]", "_")
+    filename = test_name.replace("test_", "").replace("[", "_").replace("]", "_")
     filename = filename + "_" + python_version
-    _xml = Path(filename + ".xml") if is_xml_path else filename + ".xml"
-    _bin = Path(filename + ".bin") if is_bin_path else filename + ".bin"
+    _xml = tmp_path / Path(filename + ".xml") if is_xml_path else tmp_path / Path(filename + ".xml")
+    _bin = tmp_path / Path(filename + ".bin") if is_bin_path else tmp_path / Path(filename + ".bin")
     return (_xml, _bin)


### PR DESCRIPTION
### Details:
 - Added `tmp_path` [fixture](https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html#the-tmp-path-fixture) for working with temporary files in tests.
 - Update `test_manager.py` -- reduce amount of `DeprecationWarning` (use Serialize transformation directly wherever it's possible).
 - Update `Serialize` python ctor -- support of `IR Vesrion` enum in python + add `string`-type for `IR Version` to be aligned with `manager.register_path` for Serialize transformation.
 - Move `convert_to_version` under `Common::utils` namespace.

### Tickets:
 - 98936
