### PR TITLE
Fix dependency install issue for CentOS/RedHat

### DIFF
--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -105,8 +105,8 @@ elif [ -f /etc/redhat-release ] || grep -q "rhel" /etc/os-release ; then
         `# main openvino dependencies` \
         tbb-devel \
         pugixml-devel \
-        `# GPU plugin dependency`
-        libva-devel
+        `# GPU plugin dependency` \
+        libva-devel \
         `# python API` \
         python3-pip \
         python3-devel \

--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -60,7 +60,8 @@ if [ -f /etc/lsb-release ] || [ -f /etc/debian_version ] ; then
         python3-enchant \
         `# samples and tools` \
         libgflags-dev \
-        zlib1g-dev
+        zlib1g-dev \
+        wget
     # TF lite frontend
     if apt-cache search --names-only '^libflatbuffers-dev'| grep -q libflatbuffers-dev; then
         apt-get install -y --no-install-recommends libflatbuffers-dev
@@ -152,7 +153,6 @@ required_cmake_ver=3.20.0
 if [ ! "$(printf '%s\n' "$required_cmake_ver" "$current_cmake_ver" | sort -V | head -n1)" = "$required_cmake_ver" ]; then
     installed_cmake_ver=3.23.2
     arch=$(uname -m)
-    apt-get install -y --no-install-recommends wget
     wget "https://github.com/Kitware/CMake/releases/download/v${installed_cmake_ver}/cmake-${installed_cmake_ver}-linux-${arch}.sh"
     chmod +x "cmake-${installed_cmake_ver}-linux-${arch}.sh"
     "./cmake-${installed_cmake_ver}-linux-${arch}.sh" --skip-license --prefix=/usr/local


### PR DESCRIPTION
It failed in running 'install_build_dependencies.sh' for proper dependencies for CentOS/RedHat OS. 

Part of the error messages are:

```shell
Dependencies resolved.
Nothing to do.
Complete!
CMake Error: The source directory "/home/david/feMON/target/openvino/openvino/pugixml-devel" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.
./install_build_dependencies.sh: line 109: libva-devel: command not found
./install_build_dependencies.sh: line 111: python3-pip: command not found
./install_build_dependencies.sh: line 155: apt-get: command not found
```
Fix this.
