### PR TITLE
Script: avoid file name renaming by wget if broken cmake install file exists

### DIFF
--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -153,8 +153,10 @@ required_cmake_ver=3.20.0
 if [ ! "$(printf '%s\n' "$required_cmake_ver" "$current_cmake_ver" | sort -V | head -n1)" = "$required_cmake_ver" ]; then
     installed_cmake_ver=3.23.2
     arch=$(uname -m)
-    wget "https://github.com/Kitware/CMake/releases/download/v${installed_cmake_ver}/cmake-${installed_cmake_ver}-linux-${arch}.sh"
-    chmod +x "cmake-${installed_cmake_ver}-linux-${arch}.sh"
-    "./cmake-${installed_cmake_ver}-linux-${arch}.sh" --skip-license --prefix=/usr/local
-    rm -rf "cmake-${installed_cmake_ver}-linux-${arch}.sh"
+    cmake_install_bin="cmake-${installed_cmake_ver}-linux-${arch}.sh"
+    github_cmake_release="https://github.com/Kitware/CMake/releases/download/v${installed_cmake_ver}/${cmake_install_bin}"
+    wget "${github_cmake_release}" -O "${cmake_install_bin}"
+    chmod +x "${cmake_install_bin}"
+    "./${cmake_install_bin}" --skip-license --prefix=/usr/local
+    rm -rf "${cmake_install_bin}"
 fi

--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -86,7 +86,7 @@ elif [ -f /etc/redhat-release ] || grep -q "rhel" /etc/os-release ; then
     yum install -y centos-release-scl epel-release
     yum install -y \
         file \
-        `# build tools`
+        `# build tools` \
         cmake3 \
         ccache \
         gcc \


### PR DESCRIPTION
'wget' will rename the cmake intall binary file name, 'cmake-${installed_cmake_ver}-linux-${arch}.sh' here, with the suffix '.1', '.2' or '.N' if the target cmake install binary file already existed. But the script only executes the install binary with no suffix. This will prevent the installation of cmake tool if a broken 'cmake-${installed_cmake_ver}-linux-${arch}.sh' exists.

This PR prevents the 'wget' renaming by adding a '-O' parameter. 

This PR also fixes script error by adding a tailing backslash for [line 89](https://github.com/openvinotoolkit/openvino/blob/c79f4cbb23b3bc06bbfe55bb57a15d9ed9ef7f95/install_build_dependencies.sh#L89).
