### PR TITLE
[GNA] Skip unconnected inputs when searching for the first input laye…

### DIFF
--- a/src/plugins/intel_gna/legacy/include/legacy/graph_tools.hpp
+++ b/src/plugins/intel_gna/legacy/include/legacy/graph_tools.hpp
@@ -608,10 +608,19 @@ inline CNNNetwork CNNNetCopy(const CNNNetwork& input, const Copier& cp) {
         },
         true);
 
-    // transfer input info
+    // !!!!! transfer input info
     InputsDataMap inputsInfo = input.getInputsInfo();
     std::set<DataPtr> insDatas;
     for (auto&& info : inputsInfo) {
+        auto secondLayer = getInputTo(info.second->getInputData());
+        if (secondLayer.size() == 0) {
+            // auto secondLayerNew = oldToNewLayers[secondLayer.second.get()];
+            InputInfo::Ptr infoNew = std::make_shared<InputInfo>();
+            infoNew->setInputData(info.second->getInputData());
+            net->setInputInfo(infoNew);
+            continue;
+        }
+
         for (auto secondLayer : getInputTo(info.second->getInputData())) {
             auto secondLayerNew = oldToNewLayers[secondLayer.second.get()];
             InputInfo::Ptr infoNew = std::make_shared<InputInfo>();

--- a/src/plugins/intel_gna/src/backend/gna_limitations.cpp
+++ b/src/plugins/intel_gna/src/backend/gna_limitations.cpp
@@ -862,12 +862,22 @@ bool AreLayersSupported(InferenceEngine::CNNNetwork& network, std::string& errMe
             InferenceEngine::details::convertPrecision(inputs.begin()->second->getPrecision()),
             true);
 
-        auto& secondLayers = getInputTo(inputs.begin()->second->getInputData());
-        if (secondLayers.empty()) {
+        // Find the first input connected to any layer in the graph
+        bool emptyGraph = true;
+        for (auto input : inputs) {
+            auto& secondLayers = getInputTo(input.second->getInputData());
+
+            if (!secondLayers.empty()) {
+                startLayer = secondLayers.begin()->second;
+                emptyGraph = false;
+                break;
+            }
+        }
+
+        if (emptyGraph) {
             errMessage = "Network consists of input layer only (GNA)\n";
             return false;
         }
-        startLayer = secondLayers.begin()->second;
     }
     auto batch_size = network.getBatchSize();
     bool check_result = true;

--- a/src/plugins/intel_gna/src/frontend/model_quantizer.hpp
+++ b/src/plugins/intel_gna/src/frontend/model_quantizer.hpp
@@ -56,8 +56,10 @@ public:
         for (auto&& inputData : dm) {
             auto input_layer = getCreatorLayer(inputData.second->getInputData()).lock();
             auto quant_data = InferenceEngine::getInjectedData<frontend::QuantizedLayerParams>(input_layer);
-            IE_ASSERT(quant_data != nullptr);
-            quant_data->_src_quant.SetScale(inputs.at(input_layer->name).scale_factor);
+            //            IE_ASSERT(quant_data != nullptr);
+            if (quant_data) {
+                quant_data->_src_quant.SetScale(inputs.at(input_layer->name).scale_factor);
+            }
         }
 
         // Propagate scale factor and quantize layers

--- a/src/plugins/intel_gna/src/frontend/scale_factor_calc.cpp
+++ b/src/plugins/intel_gna/src/frontend/scale_factor_calc.cpp
@@ -763,7 +763,9 @@ bool ScaleFactorCalculator::ScaleFactorPerLayerCNN(InferenceEngine::CNNLayer* cn
     }
 
     if (!CNNNetHasPrevLayer(cnnLayer)) {
-        quant->_dst_quant = quant->_src_quant;
+        if (quant) {
+            quant->_dst_quant = quant->_src_quant;
+        }
         return true;
     }
 


### PR DESCRIPTION
…r in the graph.

### Details:
 - Skip unconnected inputs when validating supported layers and only report exceptions if all inputs are unconnected during the search for the first input layer in the graph.

### Tickets:
 - 102360
