### PR TITLE
Remove `setupTestEnv()` from  `frontend_shared_test_classes`

### DIFF
--- a/src/frontends/tests/frontend/shared/src/basic_api.cpp
+++ b/src/frontends/tests/frontend/shared/src/basic_api.cpp
@@ -16,7 +16,6 @@ std::string FrontEndBasicTest::getTestCaseName(const testing::TestParamInfo<Basi
 }
 
 void FrontEndBasicTest::SetUp() {
-    FrontEndTestUtils::setupTestEnv();
     m_fem = FrontEndManager();  // re-initialize after setting up environment
     initParamTest();
 }

--- a/src/frontends/tests/frontend/shared/src/conversion.cpp
+++ b/src/frontends/tests/frontend/shared/src/conversion.cpp
@@ -20,7 +20,6 @@ std::string FrontEndConversionExtensionTest::getTestCaseName(
 }
 
 void FrontEndConversionExtensionTest::SetUp() {
-    FrontEndTestUtils::setupTestEnv();
     initParamTest();
 }
 

--- a/src/frontends/tests/frontend/shared/src/convert_model.cpp
+++ b/src/frontends/tests/frontend/shared/src/convert_model.cpp
@@ -18,7 +18,6 @@ std::string FrontEndConvertModelTest::getTestCaseName(const testing::TestParamIn
 }
 
 void FrontEndConvertModelTest::SetUp() {
-    FrontEndTestUtils::setupTestEnv();
     m_fem = FrontEndManager();  // re-initialize after setting up environment
     initParamTest();
 }

--- a/src/frontends/tests/frontend/shared/src/cut_specific_model.cpp
+++ b/src/frontends/tests/frontend/shared/src/cut_specific_model.cpp
@@ -24,7 +24,6 @@ std::string FrontEndCutModelTest::getTestCaseName(const testing::TestParamInfo<C
 }
 
 void FrontEndCutModelTest::SetUp() {
-    FrontEndTestUtils::setupTestEnv();
     m_fem = FrontEndManager();  // re-initialize after setting up environment
     initParamTest();
 }

--- a/src/frontends/tests/frontend/shared/src/library_extension.cpp
+++ b/src/frontends/tests/frontend/shared/src/library_extension.cpp
@@ -19,7 +19,6 @@ std::string FrontendLibraryExtensionTest::getTestCaseName(
 }
 
 void FrontendLibraryExtensionTest::SetUp() {
-    FrontEndTestUtils::setupTestEnv();
     m_fem = FrontEndManager();  // re-initialize after setting up environment
     initParamTest();
 }

--- a/src/frontends/tests/frontend/shared/src/load_from.cpp
+++ b/src/frontends/tests/frontend/shared/src/load_from.cpp
@@ -18,7 +18,6 @@ std::string FrontEndLoadFromTest::getTestCaseName(const testing::TestParamInfo<L
 }
 
 void FrontEndLoadFromTest::SetUp() {
-    FrontEndTestUtils::setupTestEnv();
     m_fem = FrontEndManager();  // re-initialize after setting up environment
     m_param = GetParam();
 }

--- a/src/frontends/tests/frontend/shared/src/op_extension.cpp
+++ b/src/frontends/tests/frontend/shared/src/op_extension.cpp
@@ -20,7 +20,6 @@ std::string FrontEndOpExtensionTest::getTestCaseName(const testing::TestParamInf
 }
 
 void FrontEndOpExtensionTest::SetUp() {
-    FrontEndTestUtils::setupTestEnv();
     initParamTest();
 }
 

--- a/src/frontends/tests/frontend/shared/src/op_fuzzy.cpp
+++ b/src/frontends/tests/frontend/shared/src/op_fuzzy.cpp
@@ -24,7 +24,6 @@ std::string FrontEndFuzzyOpTest::getTestCaseName(const testing::TestParamInfo<Fu
 }
 
 void FrontEndFuzzyOpTest::SetUp() {
-    FrontEndTestUtils::setupTestEnv();
     m_fem = FrontEndManager();  // re-initialize after setting up environment
     initParamTest();
 }

--- a/src/frontends/tests/frontend/shared/src/partial_shape.cpp
+++ b/src/frontends/tests/frontend/shared/src/partial_shape.cpp
@@ -21,7 +21,6 @@ std::string FrontEndPartialShapeTest::getTestCaseName(const testing::TestParamIn
 }
 
 void FrontEndPartialShapeTest::SetUp() {
-    FrontEndTestUtils::setupTestEnv();
     m_fem = FrontEndManager();  // re-initialize after setting up environment
     initParamTest();
 }

--- a/src/frontends/tests/frontend/shared/src/set_element_type.cpp
+++ b/src/frontends/tests/frontend/shared/src/set_element_type.cpp
@@ -15,7 +15,6 @@ std::string FrontEndElementTypeTest::getTestCaseName(const testing::TestParamInf
 }
 
 void FrontEndElementTypeTest::SetUp() {
-    FrontEndTestUtils::setupTestEnv();
     m_fem = FrontEndManager();  // re-initialize after setting up environment
     initParamTest();
 }

--- a/src/frontends/tests/frontend/shared/src/telemetry.cpp
+++ b/src/frontends/tests/frontend/shared/src/telemetry.cpp
@@ -15,7 +15,6 @@ std::string FrontEndTelemetryTest::getTestCaseName(const testing::TestParamInfo<
 }
 
 void FrontEndTelemetryTest::SetUp() {
-    FrontEndTestUtils::setupTestEnv();
     m_fem = FrontEndManager();  // re-initialize after setting up environment
     initParamTest();
 }


### PR DESCRIPTION
### Details:
 - Remove extra dependency - OV_FRONTEND_PATH points to the same place from what FrontEndManager loads frontends by default

### Tickets:
 - 101687
