### PR TITLE
Export nlohmann_json to openvino_common when ENABLE_TESTS is on for VPUx plugin

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -335,7 +335,7 @@ endif()
 # nlohmann json
 #
 
-if(ENABLE_SAMPLES)
+if(ENABLE_SAMPLES OR ENABLE_TESTS)
     add_subdirectory(json)
 
     # this is required only because of VPUX plugin reused this


### PR DESCRIPTION
Export nlohmann_json to openvino_common when ENABLE_TESTS is on for VPUx plugin.


### Details:
 - *This nlohmann_json is needed for VPUX plugin when ENABLE_TESTS is ON.*

### Tickets:
 - *ticket-id*
