### PR TITLE
[GPU] Use ocl for i32 dtype concat / enable_profiling for dump_profiling

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
@@ -42,25 +42,33 @@ struct typed_primitive_onednn_impl : public typed_primitive_impl<PType> {
     bool _enable_profiling = false;
 
     typed_primitive_onednn_impl(const engine& engine,
-                                const ExecutionConfig& config,
-                                std::shared_ptr<dnnl::primitive_attr> attrs,
-                                const PrimDescType& pd,
-                                kernel_selector::WeightsReorderParams weights_reorder = {})
+            const ExecutionConfig& config,
+            std::shared_ptr<dnnl::primitive_attr> attrs,
+            const PrimDescType& pd,
+            kernel_selector::WeightsReorderParams weights_reorder = {})
         : typed_primitive_impl<PType>(weights_reorder, pd.impl_info_str()),
-          _engine(&engine),
-          _attrs(attrs),
-          _pd(pd),
-          _enable_profiling(config.get_property(ov::enable_profiling)) {
+        _engine(&engine),
+        _attrs(attrs),
+        _pd(pd) {
+            _enable_profiling = config.get_property(ov::enable_profiling);
+            GPU_DEBUG_GET_INSTANCE(debug_config);
+            GPU_DEBUG_IF(!debug_config->dump_profiling_data.empty()) {
+                _enable_profiling = true;
+            }
             build_primitive(config);
         }
 
     typed_primitive_onednn_impl(const engine& engine, const ExecutionConfig& config = {})
         : typed_primitive_impl<PType>({}, "undef"),
-          _engine(&engine),
-          _pd(),
-          _prim(),
-          _enable_profiling(config.get_property(ov::enable_profiling)) {
-    }
+        _engine(&engine),
+        _pd(),
+        _prim() {
+            _enable_profiling = config.get_property(ov::enable_profiling);
+            GPU_DEBUG_GET_INSTANCE(debug_config);
+            GPU_DEBUG_IF(!debug_config->dump_profiling_data.empty()) {
+                _enable_profiling = true;
+            }
+        }
 
     typed_primitive_onednn_impl()
         : typed_primitive_impl<PType>({}, "undef"),

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1564,6 +1564,9 @@ impl_types layout_optimizer::get_preferred_impl_type(program_node& node, format 
         if (!_optimization_attributes.use_onednn_impls)
             return impl_types::ocl;
 
+        if (node.get_output_layout().data_type == data_types::i32)
+            return impl_types::ocl;
+
         for (auto& dep : node.get_dependencies()) {
             if (dep.first->is_in_data_flow() && dep.first->get_preferred_impl_type() == impl_types::onednn) {
                 return impl_types::onednn;


### PR DESCRIPTION
### Details:
 - onednn concat impl does not support i32
- enable onednn enable_profiling for dump_profiling
