### PR TITLE
[GPU] fix bug on resample_opt

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_opt.cl
@@ -234,6 +234,11 @@ KERNEL (resample_opt)(__global INPUT0_TYPE* input,
     typedef ACC_VEC_TYPE acc_vec_t;
 
     const int in_size[5] = { INPUT0_BATCH_NUM, INPUT0_FEATURE_NUM, INPUT0_SIZE_Z, INPUT0_SIZE_Y, INPUT0_SIZE_X };
+    if (feature_num >= OUTPUT_FEATURE_NUM) {
+        return;
+    }
+
+    const int FEATURE_LIMIT = (int)(OUTPUT_FEATURE_NUM / FEATURE_SLICE_SIZE) * FEATURE_SLICE_SIZE;
 
 #ifdef SAMPLE_TYPE_NEAREST
     unroll_for (uint out_x = 0; out_x < OUTPUT_X_BLOCK_SIZE; out_x++) {
@@ -288,7 +293,10 @@ KERNEL (resample_opt)(__global INPUT0_TYPE* input,
 #if OUTPUT_DIMS == 5
         WRITE_FUNC(output, OUTPUT_GET_INDEX(b, feature_block, z, y, (x + out_x)), out);
 #else
-        WRITE_FUNC(output, OUTPUT_GET_INDEX(b, feature_block, y, (x + out_x)), out);
+        if (FEATURE_LIMIT > feature_num)
+            WRITE_FUNC(output, OUTPUT_GET_INDEX(b, feature_block, y, (x + out_x)), out);
+        else
+            output[OUTPUT_GET_INDEX(b, feature_num, y, (x + out_x))] = out[0];
 #endif
     }
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_opt.cl
@@ -227,18 +227,12 @@ KERNEL (resample_opt)(__global INPUT0_TYPE* input,
 #endif
     const int f_block = get_group_id(1);
     const int b = get_global_id(2);
-    const int feature_num = f_block * FEATURE_SLICE_SIZE + get_sub_group_local_id();
     const uint feature_block = f_block * FEATURE_SLICE_SIZE;
 
     typedef IN_VEC_TYPE in_vec_t;
     typedef ACC_VEC_TYPE acc_vec_t;
 
     const int in_size[5] = { INPUT0_BATCH_NUM, INPUT0_FEATURE_NUM, INPUT0_SIZE_Z, INPUT0_SIZE_Y, INPUT0_SIZE_X };
-    if (feature_num >= OUTPUT_FEATURE_NUM) {
-        return;
-    }
-
-    const int FEATURE_LIMIT = (int)(OUTPUT_FEATURE_NUM / FEATURE_SLICE_SIZE) * FEATURE_SLICE_SIZE;
 
 #ifdef SAMPLE_TYPE_NEAREST
     unroll_for (uint out_x = 0; out_x < OUTPUT_X_BLOCK_SIZE; out_x++) {
@@ -293,10 +287,7 @@ KERNEL (resample_opt)(__global INPUT0_TYPE* input,
 #if OUTPUT_DIMS == 5
         WRITE_FUNC(output, OUTPUT_GET_INDEX(b, feature_block, z, y, (x + out_x)), out);
 #else
-        if (FEATURE_LIMIT > feature_num)
-            WRITE_FUNC(output, OUTPUT_GET_INDEX(b, feature_block, y, (x + out_x)), out);
-        else
-            output[OUTPUT_GET_INDEX(b, feature_num, y, (x + out_x))] = TO_OUTPUT_TYPE(out);
+        WRITE_FUNC(output, OUTPUT_GET_INDEX(b, feature_block, y, (x + out_x)), out);
 #endif
     }
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_opt.cl
@@ -296,7 +296,7 @@ KERNEL (resample_opt)(__global INPUT0_TYPE* input,
         if (FEATURE_LIMIT > feature_num)
             WRITE_FUNC(output, OUTPUT_GET_INDEX(b, feature_block, y, (x + out_x)), out);
         else
-            output[OUTPUT_GET_INDEX(b, feature_num, y, (x + out_x))] = out[0];
+            output[OUTPUT_GET_INDEX(b, feature_num, y, (x + out_x))] = TO_OUTPUT_TYPE(out);
 #endif
     }
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_opt.cpp
@@ -90,11 +90,7 @@ static size_t get_vec_size(const resample_params &params) {
 }
 
 static int get_feature_slice_size(const resample_params &params) {
-    if (params.inputs[0].GetLayout() == DataLayout::fs_b_yx_fsv32) {
-        return 32;
-    } else {
-        return 16;
-    }
+    return 16 * get_vec_size(params);
 }
 
 ResampleKernelBase::DispatchData ResampleKernelOpt::SetDefault(const kernel_selector::resample_params &arg) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_opt.cpp
@@ -126,8 +126,7 @@ ResampleKernelBase::DispatchData ResampleKernelOpt::SetDefault(const kernel_sele
         } else {
             dispatchData.gws[0] = CeilDiv(out.X().v, opt_x_block_size) * out.Y().v;
         }
-        const size_t vec_size = get_vec_size(arg);
-        dispatchData.gws[1] = Align(vec_size == 1 ? out.Feature().v : (out.Feature().v + 1) / vec_size, sub_group_size);
+        dispatchData.gws[1] = Align(CeilDiv(out.Feature().v, get_vec_size(arg)), sub_group_size);
         dispatchData.gws[2] = arg.outputs[0].Batch().v;
 
         dispatchData.lws[0] = 1;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_opt.cpp
@@ -81,6 +81,22 @@ DeviceFeaturesKey ResampleKernelOpt::get_required_device_features_key(const Para
     return get_common_subgroups_device_features_key(params, options);
 }
 
+static size_t get_vec_size(const resample_params &params) {
+    if (params.inputs[0].GetLayout() == DataLayout::fs_b_yx_fsv32) {
+        return 2;
+    } else {
+        return 1;
+    }
+}
+
+static int get_feature_slice_size(const resample_params &params) {
+    if (params.inputs[0].GetLayout() == DataLayout::fs_b_yx_fsv32) {
+        return 32;
+    } else {
+        return 16;
+    }
+}
+
 ResampleKernelBase::DispatchData ResampleKernelOpt::SetDefault(const kernel_selector::resample_params &arg) const {
     DispatchData dispatchData;
     auto in_layout = arg.inputs[0].GetLayout();
@@ -110,7 +126,8 @@ ResampleKernelBase::DispatchData ResampleKernelOpt::SetDefault(const kernel_sele
         } else {
             dispatchData.gws[0] = CeilDiv(out.X().v, opt_x_block_size) * out.Y().v;
         }
-        dispatchData.gws[1] = Align(out.Feature().v, sub_group_size);
+        const size_t vec_size = get_vec_size(arg);
+        dispatchData.gws[1] = Align(vec_size == 1 ? out.Feature().v : (out.Feature().v + 1) / vec_size, sub_group_size);
         dispatchData.gws[2] = arg.outputs[0].Batch().v;
 
         dispatchData.lws[0] = 1;
@@ -165,14 +182,8 @@ JitConstants ResampleKernelOpt::GetJitConstants(const resample_params &params) c
     jit.AddConstant(MakeJitConstant("X_BLOCKS", CeilDiv(params.outputs[0].X().v, opt_x_block_size)));
     jit.AddConstant(MakeJitConstant("SUB_GROUP_SIZE", sub_group_size));
 
-    size_t vec_size = 0;
-    if (params.inputs[0].GetLayout() == DataLayout::fs_b_yx_fsv32) {
-        vec_size = 2;
-        jit.AddConstant(MakeJitConstant("FEATURE_SLICE_SIZE", 32));
-    } else {
-        vec_size = 1;
-        jit.AddConstant(MakeJitConstant("FEATURE_SLICE_SIZE", 16));
-    }
+    const size_t vec_size = get_vec_size(params);
+    jit.AddConstant(MakeJitConstant("FEATURE_SLICE_SIZE", get_feature_slice_size(params)));
     jit.AddConstant(MakeJitConstant("VEC_SIZE", vec_size));
 
     if (!params.fused_ops.empty()) {


### PR DESCRIPTION
- overwrite zero value to padding area of resample. This issue is occurred if implicit concat is next of resample.
- feature num includes padding.

### Tickets:
 - 101957
