### PR TITLE
[MO]: fix mo.convert_model for pytorch

### DIFF
--- a/tools/mo/openvino/tools/mo/convert_impl.py
+++ b/tools/mo/openvino/tools/mo/convert_impl.py
@@ -965,13 +965,14 @@ def _convert(cli_parser: argparse.ArgumentParser, framework, args):
                 args['onnx_opset_version'] = None
 
                 try:
-                    ov_model = _convert(cli_parser, framework, args)
+                    ov_model, argv = _convert(cli_parser, framework, args)
                 except Exception as e:
                     remove_tmp_onnx_model(out_dir)
                     raise e
 
                 remove_tmp_onnx_model(out_dir)
-                return ov_model, None
+
+                return ov_model, argv
 
         argv = pack_params_to_args_namespace(args, cli_parser)
 

--- a/tools/mo/openvino/tools/mo/convert_impl.py
+++ b/tools/mo/openvino/tools/mo/convert_impl.py
@@ -930,7 +930,7 @@ def remove_tmp_onnx_model(out_dir):
 def _convert(cli_parser: argparse.ArgumentParser, framework, args):
     if 'help' in args and args['help']:
         show_mo_convert_help()
-        return None
+        return None, None
 
     telemetry = tm.Telemetry(tid=get_tid(), app_name='Model Optimizer', app_version=get_simplified_mo_version())
     telemetry.start_session('mo')
@@ -971,7 +971,7 @@ def _convert(cli_parser: argparse.ArgumentParser, framework, args):
                     raise e
 
                 remove_tmp_onnx_model(out_dir)
-                return ov_model
+                return ov_model, None
 
         argv = pack_params_to_args_namespace(args, cli_parser)
 


### PR DESCRIPTION
### Details:
Fix for issue:
```python
model = torchvision.models.resnet50(pretrained=True)
mo.convert_model(model, example_input=torch.zeros(1, 3, 224, 224))
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "openvino/tools/mo/openvino/tools/mo/convert.py", line 55, in convert_model
    ov_model, _ = _convert(cli_parser, framework, args)
TypeError: cannot unpack non-iterable openvino._pyopenvino.Model object*
