### PR TITLE
Fix OpenVINO 2022.3.0 Chrome OS compilation

### DIFF
--- a/src/core/include/openvino/op/constant.hpp
+++ b/src/core/include/openvino/op/constant.hpp
@@ -521,13 +521,13 @@ private:
         if (!std::is_same<T, StorageDataType>::value) {
             OPENVINO_ASSERT(!std::numeric_limits<T>::is_signed ||
                             std::numeric_limits<StorageDataType>::lowest() <= value);
-            OPENVINO_ASSERT(value <= std::numeric_limits<StorageDataType>::max());
+            OPENVINO_ASSERT(std::numeric_limits<StorageDataType>::max() >= value);
         }
 #if defined(_MSC_VER)
 #    pragma warning(pop)
 #endif
 #ifdef __clang__
-#    pragma GangC diagnostic pop
+#    pragma clang diagnostic pop
 #endif
 #ifdef __GNUC__
 #    pragma GCC diagnostic pop


### PR DESCRIPTION
This patch fixes two issues:
 * Typo in clang pragma directive
 * Reverse the order of the arguments in OPENVINO_ASSERT() in constant.hpp so this assert compiles successfully for ov::bfloat16 and ov::float16 argument types which have implemented binary comparison operators as the member functions

