### PR TITLE
[PyOV] Add ExecutionMode enum and property

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
@@ -57,10 +57,16 @@ void regmodule_properties(py::module m) {
         .value("THROUGHPUT", ov::hint::PerformanceMode::THROUGHPUT)
         .value("CUMULATIVE_THROUGHPUT", ov::hint::PerformanceMode::CUMULATIVE_THROUGHPUT);
 
+    py::enum_<ov::hint::ExecutionMode>(m_hint, "ExecutionMode", py::arithmetic())
+        .value("UNDEFINED", ov::hint::ExecutionMode::UNDEFINED)
+        .value("PERFORMANCE", ov::hint::ExecutionMode::PERFORMANCE)
+        .value("ACCURACY", ov::hint::ExecutionMode::ACCURACY);
+
     // Submodule hint - properties
     wrap_property_RW(m_hint, ov::hint::inference_precision, "inference_precision");
     wrap_property_RW(m_hint, ov::hint::model_priority, "model_priority");
     wrap_property_RW(m_hint, ov::hint::performance_mode, "performance_mode");
+    wrap_property_RW(m_hint, ov::hint::execution_mode, "execution_mode");
     wrap_property_RW(m_hint, ov::hint::num_requests, "num_requests");
     wrap_property_RW(m_hint, ov::hint::model, "model");
     wrap_property_RW(m_hint, ov::hint::allow_auto_batching, "allow_auto_batching");

--- a/src/bindings/python/src/pyopenvino/utils/utils.cpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.cpp
@@ -114,6 +114,8 @@ py::object from_ov_any(const ov::Any& any) {
         return py::cast(any.as<ov::hint::Priority>());
     } else if (any.is<ov::hint::PerformanceMode>()) {
         return py::cast(any.as<ov::hint::PerformanceMode>());
+    } else if (any.is<ov::hint::ExecutionMode>()) {
+        return py::cast(any.as<ov::hint::ExecutionMode>());
     } else if (any.is<ov::log::Level>()) {
         return py::cast(any.as<ov::log::Level>());
     } else if (any.is<ov::device::Type>()) {

--- a/src/bindings/python/tests/test_runtime/test_properties.py
+++ b/src/bindings/python/tests/test_runtime/test_properties.py
@@ -61,6 +61,14 @@ def test_properties_rw_base():
             ),
         ),
         (
+            properties.hint.ExecutionMode,
+            (
+                (properties.hint.ExecutionMode.UNDEFINED, "ExecutionMode.UNDEFINED", -1),
+                (properties.hint.ExecutionMode.PERFORMANCE, "ExecutionMode.PERFORMANCE", 1),
+                (properties.hint.ExecutionMode.ACCURACY, "ExecutionMode.ACCURACY", 2),
+            ),
+        ),
+        (
             properties.device.Type,
             (
                 (properties.device.Type.INTEGRATED, "Type.INTEGRATED", 0),
@@ -210,6 +218,11 @@ def test_properties_ro(ov_property_ro, expected_value):
             properties.hint.performance_mode,
             "PERFORMANCE_HINT",
             ((properties.hint.PerformanceMode.UNDEFINED, properties.hint.PerformanceMode.UNDEFINED),),
+        ),
+        (
+            properties.hint.execution_mode,
+            "EXECUTION_MODE_HINT",
+            ((properties.hint.ExecutionMode.UNDEFINED, properties.hint.ExecutionMode.UNDEFINED),),
         ),
         (
             properties.hint.num_requests,


### PR DESCRIPTION
### Details:
- Added the `ExecutionMode` enum and  `execution_mode` property to Python API.
- New translator in dispatching of related ov::Any directly to a value.
- Added test.

### Tickets:
- 102675
- 102435