### PR TITLE
[CPU] I64 support for Add, Sub, Mul and Equal emitters.

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/jit_eltwise_emitters.cpp
@@ -18,9 +18,9 @@ namespace intel_cpu {
 
 /// ADD ///
 jit_add_emitter::jit_add_emitter(x64::jit_generator *host, x64::cpu_isa_t host_isa, const std::shared_ptr<ov::Node>& node, Precision exec_prc)
-: jit_emitter(host, host_isa, node, exec_prc) {}
+    : jit_emitter(host, host_isa, node, exec_prc) {}
 jit_add_emitter::jit_add_emitter(x64::jit_generator *host, x64::cpu_isa_t host_isa, Precision exec_prc)
-: jit_emitter(host, host_isa, exec_prc) {}
+    : jit_emitter(host, host_isa, exec_prc) {}
 
 size_t jit_add_emitter::get_inputs_num() const { return 2; }
 
@@ -45,31 +45,23 @@ void jit_add_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, const std
     Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
     Vmm vmm_dst = Vmm(out_vec_idxs[0]);
 
-    auto uni_vadd = [this](Vmm vmm_dst, Vmm vmm_src0, Vmm vmm_src1) {
-        switch (exec_prc_) {
-            case Precision::FP32: h->uni_vaddps(vmm_dst, vmm_src0, vmm_src1); break;
-            case Precision::I32:  h->uni_vpaddd(vmm_dst, vmm_src0, vmm_src1); break;
-            default: assert(!"unsupported precision");
-        }
-    };
-
-    if (isa == x64::sse41) {
-        h->uni_vmovups(vmm_dst, vmm_src0);
-        uni_vadd(vmm_dst, vmm_dst, vmm_src1);
-    } else {
-        uni_vadd(vmm_dst, vmm_src0, vmm_src1);
+    switch (exec_prc_) {
+        case Precision::FP32: h->uni_vaddps(vmm_dst, vmm_src0, vmm_src1); break;
+        case Precision::I32:  h->uni_vpaddd(vmm_dst, vmm_src0, vmm_src1); break;
+        case Precision::I64:  h->uni_vpaddq(vmm_dst, vmm_src0, vmm_src1); break;
+        default: IE_THROW() << "jit_add_emitter doesn't support precision '" << exec_prc_ << "'";
     }
 }
 
 std::set<Precision> jit_add_emitter::get_supported_precisions() {
-    return {Precision::FP32, Precision::I32};
+    return { Precision::FP32, Precision::I32, Precision::I64 };
 }
 
 /// MUL_ADD ///
 jit_mul_add_emitter::jit_mul_add_emitter(x64::jit_generator *host, x64::cpu_isa_t host_isa, const std::shared_ptr<ov::Node>& node, Precision exec_prc)
-: jit_emitter(host, host_isa, node, exec_prc) {}
+    : jit_emitter(host, host_isa, node, exec_prc) {}
 jit_mul_add_emitter::jit_mul_add_emitter(x64::jit_generator *host, x64::cpu_isa_t host_isa, Precision exec_prc)
-: jit_emitter(host, host_isa, exec_prc) {}
+    : jit_emitter(host, host_isa, exec_prc) {}
 
 size_t jit_mul_add_emitter::get_inputs_num() const { return 3; }
 
@@ -160,9 +152,9 @@ std::set<Precision> jit_mul_add_emitter::get_supported_precisions() {
 
 /// SUB ///
 jit_subtract_emitter::jit_subtract_emitter(x64::jit_generator *host, x64::cpu_isa_t host_isa, const std::shared_ptr<ov::Node>& node, Precision exec_prc)
-: jit_emitter(host, host_isa, node, exec_prc) {}
+    : jit_emitter(host, host_isa, node, exec_prc) {}
 jit_subtract_emitter::jit_subtract_emitter(x64::jit_generator *host, x64::cpu_isa_t host_isa, Precision exec_prc)
-: jit_emitter(host, host_isa, exec_prc) {}
+    : jit_emitter(host, host_isa, exec_prc) {}
 
 size_t jit_subtract_emitter::get_inputs_num() const { return 2; }
 
@@ -187,31 +179,23 @@ void jit_subtract_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, cons
     Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
     Vmm vmm_dst = Vmm(out_vec_idxs[0]);
 
-    auto uni_vsub = [this](Vmm vmm_dst, Vmm vmm_src0, Vmm vmm_src1) {
-        switch (exec_prc_) {
-            case Precision::FP32: h->uni_vsubps(vmm_dst, vmm_src0, vmm_src1); break;
-            case Precision::I32:  h->uni_vpsubd(vmm_dst, vmm_src0, vmm_src1); break;
-            default: assert(!"unsupported precision");
-        }
-    };
-
-    if (isa == x64::sse41) {
-        h->uni_vmovups(vmm_dst, vmm_src0);
-        uni_vsub(vmm_dst, vmm_dst, vmm_src1);
-    } else {
-        uni_vsub(vmm_dst, vmm_src0, vmm_src1);
+    switch (exec_prc_) {
+        case Precision::FP32: h->uni_vsubps(vmm_dst, vmm_src0, vmm_src1); break;
+        case Precision::I32:  h->uni_vpsubd(vmm_dst, vmm_src0, vmm_src1); break;
+        case Precision::I64:  h->uni_vpsubq(vmm_dst, vmm_src0, vmm_src1); break;
+        default: IE_THROW() << "jit_subtract_emitter doesn't support precision '" << exec_prc_ << "'";
     }
 }
 
 std::set<Precision> jit_subtract_emitter::get_supported_precisions() {
-    return {Precision::FP32, Precision::I32};
+    return { Precision::FP32, Precision::I32, Precision::I64 };
 }
 
 /// MULTIPLY ///
 jit_multiply_emitter::jit_multiply_emitter(x64::jit_generator *host, x64::cpu_isa_t host_isa, const std::shared_ptr<ov::Node>& node, Precision exec_prc)
-: jit_emitter(host, host_isa, node, exec_prc) {}
+    : jit_emitter(host, host_isa, node, exec_prc) {}
 jit_multiply_emitter::jit_multiply_emitter(x64::jit_generator *host, x64::cpu_isa_t host_isa, Precision exec_prc)
-: jit_emitter(host, host_isa, exec_prc) {}
+    : jit_emitter(host, host_isa, exec_prc) {}
 
 size_t jit_multiply_emitter::get_inputs_num() const { return 2; }
 
@@ -236,24 +220,20 @@ void jit_multiply_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, cons
     Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
     Vmm vmm_dst = Vmm(out_vec_idxs[0]);
 
-    auto uni_vmul = [this](Vmm vmm_dst, Vmm vmm_src0, Vmm vmm_src1) {
-        switch (exec_prc_) {
-            case Precision::FP32: h->uni_vmulps(vmm_dst, vmm_src0, vmm_src1); break;
-            case Precision::I32:  h->uni_vpmulld(vmm_dst, vmm_src0, vmm_src1); break;
-            default: assert(!"unsupported precision");
-        }
-    };
-
-    if (isa == x64::sse41) {
-        h->uni_vmovups(vmm_dst, vmm_src0);
-        uni_vmul(vmm_dst, vmm_dst, vmm_src1);
-    } else {
-        uni_vmul(vmm_dst, vmm_src0, vmm_src1);
+    switch (exec_prc_) {
+        case Precision::FP32: h->uni_vmulps(vmm_dst, vmm_src0, vmm_src1); break;
+        case Precision::I32:  h->uni_vpmulld(vmm_dst, vmm_src0, vmm_src1); break;
+        case Precision::I64:  h->vpmullq(vmm_dst, vmm_src0, vmm_src1); break;
+        default: IE_THROW() << "jit_multiply_emitter doesn't support precision '" << exec_prc_ << "'";
     }
 }
 
 std::set<Precision> jit_multiply_emitter::get_supported_precisions() {
-    return {Precision::FP32, Precision::I32};
+    if (x64::mayiuse(x64::avx512_core)) {
+        return { Precision::FP32, Precision::I32, Precision::I64 };
+    } else {
+        return { Precision::FP32, Precision::I32 };
+    }
 }
 
 /// DIVIDE ///
@@ -757,11 +737,11 @@ void jit_power_dynamic_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs,
 
 /// EQUAL ///
 jit_equal_emitter::jit_equal_emitter(x64::jit_generator *host, x64::cpu_isa_t host_isa, const std::shared_ptr<ov::Node>& node, Precision exec_prc)
-: jit_emitter(host, host_isa, node, exec_prc) {
+        : jit_emitter(host, host_isa, node, exec_prc) {
     prepare_table();
 }
 jit_equal_emitter::jit_equal_emitter(x64::jit_generator *host, x64::cpu_isa_t host_isa, Precision exec_prc)
-: jit_emitter(host, host_isa, exec_prc) {
+        : jit_emitter(host, host_isa, exec_prc) {
     prepare_table();
 }
 
@@ -787,33 +767,59 @@ void jit_equal_emitter::emit_isa(const std::vector<size_t> &in_vec_idxs, const s
     Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
     Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
     Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
-    Vmm vmm_aux1 = Vmm(aux_vec_idxs[1]);
 
-    if (isa == x64::sse41) {
-        h->movups(vmm_aux0, vmm_src0);
-        h->cmpps(vmm_aux0, vmm_src1, _cmp_eq_oq);
-        h->movups(vmm_aux1, table_val("one"));
-        h->pxor(vmm_dst, vmm_dst);
-        h->blendvps(vmm_dst, vmm_aux1);
-    } else if (isa == x64::avx2) {
-        h->vcmpeqps(vmm_aux0, vmm_src0, vmm_src1);
-        h->uni_vmovups(vmm_dst, table_val("zero"));
-        h->uni_vblendvps(vmm_dst, vmm_dst, table_val("one"), vmm_aux0);
+    // TODO: Actually the Result is bool in U8 representation. 0x01 or 0xFF - is there a difference for real models?
+    // Remove all vpsrld instructions if there is no difference.
+    if (isa == x64::sse41 || isa == x64::avx2) {
+        Vmm vmm_src0_t = vmm_src0;
+        if (isa == x64::sse41 && vmm_dst.getIdx() != vmm_src0.getIdx()) {
+            h->uni_vmovups(vmm_dst, vmm_src0);
+            vmm_src0_t = vmm_dst;
+        }
+        switch (exec_prc_) {
+            case Precision::FP32:
+                h->uni_vcmpps(vmm_dst, vmm_src0_t, vmm_src1, _cmp_eq_oq);
+                h->uni_vandps(vmm_dst, vmm_dst, table_val("oneF"));
+                break;
+            case Precision::I32:
+                h->uni_vpcmpeqd(vmm_dst, vmm_src0_t, vmm_src1);
+                h->uni_vpsrld(vmm_dst, vmm_dst, 31);
+                break;
+            case Precision::I64:
+                h->uni_vpcmpeqq(vmm_dst, vmm_src0_t, vmm_src1);
+                h->uni_vpsrlq(vmm_dst, vmm_dst, 63);
+                break;
+            default: IE_THROW() << "jit_equal_emitter doesn't support precision '" << exec_prc_ << "'";
+        }
     } else {
-        h->vcmpps(k_mask, vmm_src0, vmm_src1, _cmp_eq_oq);
-        h->uni_vmovups(vmm_dst, table_val("zero"));
-        h->vblendmps(vmm_dst | k_mask, vmm_dst, table_val("one"));
+        switch (exec_prc_) {
+            case Precision::FP32:
+                h->vcmpps(k_mask, vmm_src0, vmm_src1, _cmp_eq_oq);
+                h->uni_vmovups(vmm_dst | k_mask | h->T_z, table_val("oneF"));
+                break;
+            case Precision::I32:
+                h->vpcmpeqd(k_mask, vmm_src0, vmm_src1);
+                h->vpmovm2d(vmm_dst, k_mask);
+                h->uni_vpsrld(vmm_dst, vmm_dst, 31);
+                break;
+            case Precision::I64:
+                h->vpcmpeqq(k_mask, vmm_src0, vmm_src1);
+                h->vpmovm2q(vmm_dst, k_mask);
+                h->vpsrlq(vmm_dst, vmm_dst, 63);
+                break;
+            default: IE_THROW() << "jit_equal_emitter doesn't support precision '" << exec_prc_ << "'";
+        }
     }
 }
 
 void jit_equal_emitter::register_table_entries() {
-    push_arg_entry_of("zero", 0x00000000, true);
-    push_arg_entry_of("one", CONST_1_F, true);
+    if (exec_prc_ == Precision::FP32) {
+        push_arg_entry_of("oneF", CONST_1_F, true);
+    }
 }
 
-size_t jit_equal_emitter::aux_vecs_count() const {
-    return 2;
+std::set<Precision> jit_equal_emitter::get_supported_precisions() {
+    return { Precision::FP32, Precision::I32, Precision::I64 };
 }
 
 /// NOT_EQUAL ///

--- a/src/plugins/intel_cpu/src/emitters/jit_eltwise_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/jit_eltwise_emitters.hpp
@@ -274,6 +274,7 @@ public:
                       InferenceEngine::Precision exec_prc = InferenceEngine::Precision::FP32);
 
     size_t get_inputs_num() const override;
+    static std::set<InferenceEngine::Precision> get_supported_precisions();
 
 private:
     void emit_impl(const std::vector<size_t> &in_vec_idxs, const std::vector<size_t> &out_vec_idxs,
@@ -284,7 +285,6 @@ private:
     void emit_isa(const std::vector<size_t> &in_vec_idxs, const std::vector<size_t> &out_vec_idxs) const;
 
     void register_table_entries() override;
-    size_t aux_vecs_count() const override;
 };
 
 

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -145,11 +145,11 @@ void Graph::Replicate(const std::shared_ptr<const ov::Model> &subgraph) {
 
         graphNodes.push_back(node);
 
-        if (op->get_type_info() == ngraph::op::v0::Parameter::get_type_info_static()) {
+        if (op->get_type_info() == ov::op::v0::Parameter::get_type_info_static()) {
             inputNodesMap[node->getName()] = node;
         }
 
-        if (op->get_type_info() == ngraph::op::v0::Result::get_type_info_static()) {
+        if (op->get_type_info() == ov::op::v0::Result::get_type_info_static()) {
             const auto prev = op->input_value(0);
             const std::string inputID = ov::op::util::get_ie_output_name(prev);
 
@@ -168,9 +168,9 @@ void Graph::Replicate(const std::shared_ptr<const ov::Model> &subgraph) {
         }
 
         if (!one_of(op->get_type_info(),
-                ngraph::op::v0::Result::get_type_info_static(),
-                ngraph::op::v3::Assign::get_type_info_static(),
-                ngraph::op::v6::Assign::get_type_info_static())) {
+                ov::op::v0::Result::get_type_info_static(),
+                ov::op::v3::Assign::get_type_info_static(),
+                ov::op::v6::Assign::get_type_info_static())) {
             for (int oi = 0; oi < op->get_output_size(); oi++) {
                 if (op->get_output_target_inputs(oi).empty()) {
                     unusedOutputs.push_back(op->output(oi));
@@ -253,7 +253,7 @@ void Graph::Replicate(const CNNNetwork &network) {
 
         graphNodes.push_back(node);
 
-        if (op->get_type_info() == ngraph::op::v0::Parameter::get_type_info_static()) {
+        if (op->get_type_info() == ov::op::v0::Parameter::get_type_info_static()) {
             const auto inInfo = inputsInfo.find(node->getName());
             if (inInfo != inputsInfo.end()) {
                 inputNodesMap[node->getName()] = node;
@@ -263,7 +263,7 @@ void Graph::Replicate(const CNNNetwork &network) {
             }
         }
 
-        if (op->get_type_info() == ngraph::op::v0::Result::get_type_info_static()) {
+        if (op->get_type_info() == ov::op::v0::Result::get_type_info_static()) {
             const auto &input = op->input_value(0);
             const auto name = ov::op::util::get_ie_output_name(input);
 
@@ -284,9 +284,9 @@ void Graph::Replicate(const CNNNetwork &network) {
         }
 
         if (!one_of(op->get_type_info(),
-                ngraph::op::v0::Result::get_type_info_static(),
-                ngraph::op::v3::Assign::get_type_info_static(),
-                ngraph::op::v6::Assign::get_type_info_static())) {
+                ov::op::v0::Result::get_type_info_static(),
+                ov::op::v3::Assign::get_type_info_static(),
+                ov::op::v6::Assign::get_type_info_static())) {
             for (int oi = 0; oi < op->get_output_size(); oi++) {
                 if (op->get_output_target_inputs(oi).empty()) {
                     unusedOutputs.push_back(op->output(oi));

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -105,7 +105,7 @@ Node::Node(const std::shared_ptr<ngraph::Node>& op,
         originalInputPrecisions.emplace_back(details::convertPrecision(op->get_input_element_type(i)));
     }
 
-    if (typeStr != "Result" && typeStr != "Assign") {
+    if (type != Type::Output && type != Type::MemoryOutput) {
         if (op->get_output_size() == 0) {
             IE_THROW() << "Node with type '" << typeStr << "' and name '" << name << "' does not have any outputs.";
         }

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -26,7 +26,7 @@
 using namespace dnnl;
 using namespace InferenceEngine;
 using namespace details;
-using namespace ngraph::op;
+using namespace ov::op;
 using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
 
@@ -230,7 +230,7 @@ jit_has_subnormals_base::fn_t jit_has_subnormals_function() {
 
 }   // namespace
 
-Input::Input(const std::shared_ptr<ngraph::Node>& op, const GraphContext::CPtr context)
+Input::Input(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
         : Node(op, context, PassThroughShapeInferFactory()) {
     if (!one_of(op->get_type_info(),
             v0::Parameter::get_type_info_static(),
@@ -242,7 +242,7 @@ Input::Input(const std::shared_ptr<ngraph::Node>& op, const GraphContext::CPtr c
 
     constant = ConstantType::NoConst;
 
-    constOp = ngraph::as_type_ptr<ngraph::op::Constant>(op);
+    constOp = ov::as_type_ptr<v0::Constant>(op);
     if (constOp) {
         constant = ConstantType::Const;
         cloneBlobIfRequired();
@@ -250,7 +250,7 @@ Input::Input(const std::shared_ptr<ngraph::Node>& op, const GraphContext::CPtr c
 }
 
 void Input::cloneBlobIfRequired() {
-    Shape shape(constOp->get_shape().empty() ? ngraph::Shape(1, 1) : constOp->get_shape());
+    Shape shape(constOp->get_shape().empty() ? ov::Shape(1, 1) : constOp->get_shape());
     const auto prec = convertPrecision(constOp->get_element_type());
     const size_t size = shape.getElementsCount();
     DnnlBlockedMemoryDesc memDesc(prec, shape);

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/comparison.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/comparison.cpp
@@ -8,6 +8,7 @@
 
 using namespace LayerTestsDefinitions;
 using namespace LayerTestsDefinitions::ComparisonParams;
+using namespace InferenceEngine;
 
 namespace {
 
@@ -18,13 +19,6 @@ std::map<std::vector<size_t>, std::vector<std::vector<size_t>>> inputShapes = {
         {{1, 3, 20}, {{20}, {2, 1, 1}}},
         {{2, 17, 3, 4}, {{4}, {1, 3, 4}, {2, 1, 3, 4}}},
         {{2, 1, 1, 3, 1}, {{1}, {1, 3, 4}, {2, 1, 3, 4}, {1, 1, 1, 1, 1}}},
-};
-
-std::vector<InferenceEngine::Precision> inputsPrecisions = {
-        InferenceEngine::Precision::FP32,
-        InferenceEngine::Precision::FP16,
-        InferenceEngine::Precision::I32,
-        InferenceEngine::Precision::BOOL,
 };
 
 std::vector<ngraph::helpers::ComparisonTypes> comparisonOpTypes = {
@@ -43,17 +37,29 @@ std::vector<ngraph::helpers::InputLayerType> secondInputTypes = {
 
 std::map<std::string, std::string> additional_config = {};
 
-const auto ComparisonTestParams = ::testing::Combine(
-        ::testing::ValuesIn(CommonTestUtils::combineParams(inputShapes)),
-        ::testing::ValuesIn(inputsPrecisions),
-        ::testing::ValuesIn(comparisonOpTypes),
-        ::testing::ValuesIn(secondInputTypes),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(CommonTestUtils::DEVICE_CPU),
-        ::testing::Values(additional_config));
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs, ComparisonLayerTest, 
+        ::testing::Combine(
+                ::testing::ValuesIn(CommonTestUtils::combineParams(inputShapes)),
+                ::testing::ValuesIn(std::vector<Precision>{Precision::FP32, Precision::I32, Precision::I64}),
+                ::testing::ValuesIn(comparisonOpTypes),
+                ::testing::ValuesIn(secondInputTypes),
+                ::testing::Values(Precision::UNSPECIFIED),
+                ::testing::Values(Precision::UNSPECIFIED),
+                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                ::testing::Values(additional_config)),
+        ComparisonLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs, ComparisonLayerTest, ComparisonTestParams, ComparisonLayerTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(nightly_CompareWithRefs, ComparisonLayerTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(CommonTestUtils::combineParams(inputShapes)),
+                ::testing::ValuesIn(std::vector<Precision>{Precision::FP16, Precision::BOOL}),
+                ::testing::ValuesIn(comparisonOpTypes),
+                ::testing::ValuesIn(secondInputTypes),
+                ::testing::Values(Precision::UNSPECIFIED),
+                ::testing::Values(Precision::UNSPECIFIED),
+                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                ::testing::Values(additional_config)),
+        ComparisonLayerTest::getTestCaseName);
 
 
 std::vector<InputShapesTuple> inputShapesIsOps = {
@@ -80,11 +86,11 @@ std::vector<ngraph::helpers::ComparisonTypes> comparisonOpTypesIs = {
 
 const auto ComparisonTestParamsIs = ::testing::Combine(
         ::testing::ValuesIn(inputShapesIsOps),
-        ::testing::Values(InferenceEngine::Precision::FP32),
+        ::testing::Values(Precision::FP32),
         ::testing::ValuesIn(comparisonOpTypesIs),
         ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-        ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+        ::testing::Values(Precision::UNSPECIFIED),
+        ::testing::Values(Precision::UNSPECIFIED),
         ::testing::Values(CommonTestUtils::DEVICE_CPU),
         ::testing::Values(additional_config));
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -41,10 +41,15 @@ std::vector<std::vector<ov::test::InputShape>> inShapesDynamic = {
          {{ngraph::Dimension(1, 10), 200}, {{2, 200}, {5, 200}}}},
 };
 
-std::vector<ov::test::ElementType> netPrecisions = {
+std::vector<ov::test::ElementType> smokeNetPrecisions = {
         ov::element::f32,
+        ov::element::i32
+};
+
+std::vector<ov::test::ElementType> nightlyNetPrecisions = {
         ov::element::f16,
-        ov::element::i32,
+        ov::element::bf16,
+        ov::element::i64
 };
 
 std::vector<ngraph::helpers::InputLayerType> secondaryInputTypes = {
@@ -89,7 +94,7 @@ const auto multiply_params = ::testing::Combine(
         ::testing::ValuesIn(eltwiseOpTypes),
         ::testing::ValuesIn(secondaryInputTypes),
         ::testing::ValuesIn(opTypes),
-        ::testing::ValuesIn(netPrecisions),
+        ::testing::ValuesIn(smokeNetPrecisions),
         ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::element::undefined),
         ::testing::Values(CommonTestUtils::DEVICE_CPU),
@@ -100,7 +105,7 @@ const auto collapsing_params = ::testing::Combine(
         ::testing::ValuesIn(eltwiseOpTypes),
         ::testing::ValuesIn(secondaryInputTypes),
         ::testing::Values(opTypes[1]),
-        ::testing::ValuesIn(netPrecisions),
+        ::testing::ValuesIn(smokeNetPrecisions),
         ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::element::undefined),
         ::testing::Values(CommonTestUtils::DEVICE_CPU),
@@ -111,7 +116,7 @@ const auto multiply_params_dynamic = ::testing::Combine(
         ::testing::ValuesIn(eltwiseOpTypesDynamic),
         ::testing::ValuesIn(secondaryInputTypesDynamic),
         ::testing::ValuesIn(opTypesDynamic),
-        ::testing::ValuesIn(netPrecisions),
+        ::testing::ValuesIn(smokeNetPrecisions),
         ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::element::undefined),
         ::testing::Values(CommonTestUtils::DEVICE_CPU),
@@ -120,6 +125,45 @@ const auto multiply_params_dynamic = ::testing::Combine(
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_static, EltwiseLayerTest, multiply_params, EltwiseLayerTest::getTestCaseName);
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_static_check_collapsing, EltwiseLayerTest, collapsing_params, EltwiseLayerTest::getTestCaseName);
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_dynamic, EltwiseLayerTest, multiply_params_dynamic, EltwiseLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(nightly_CompareWithRefs_static, EltwiseLayerTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inShapesStatic)),
+                ::testing::ValuesIn(eltwiseOpTypes),
+                ::testing::ValuesIn(secondaryInputTypes),
+                ::testing::ValuesIn(opTypes),
+                ::testing::ValuesIn(nightlyNetPrecisions),
+                ::testing::Values(ov::element::undefined),
+                ::testing::Values(ov::element::undefined),
+                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                ::testing::Values(additional_config)),
+        EltwiseLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(nightly_CompareWithRefs_static_check_collapsing, EltwiseLayerTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inShapesStaticCheckCollapse)),
+                ::testing::ValuesIn(eltwiseOpTypes),
+                ::testing::ValuesIn(secondaryInputTypes),
+                ::testing::Values(opTypes[1]),
+                ::testing::ValuesIn(nightlyNetPrecisions),
+                ::testing::Values(ov::element::undefined),
+                ::testing::Values(ov::element::undefined),
+                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                ::testing::Values(additional_config)),
+        EltwiseLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(nightly_CompareWithRefs_dynamic, EltwiseLayerTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(inShapesDynamic),
+                ::testing::ValuesIn(eltwiseOpTypesDynamic),
+                ::testing::ValuesIn(secondaryInputTypesDynamic),
+                ::testing::ValuesIn(opTypesDynamic),
+                ::testing::ValuesIn(nightlyNetPrecisions),
+                ::testing::Values(ov::element::undefined),
+                ::testing::Values(ov::element::undefined),
+                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                ::testing::Values(additional_config)),
+        EltwiseLayerTest::getTestCaseName);
 
 
 std::vector<std::vector<ov::Shape>> inShapesSingleThread = {
@@ -142,13 +186,26 @@ const auto single_thread_params = ::testing::Combine(
         ::testing::ValuesIn(eltwiseOpTypesSingleThread),
         ::testing::ValuesIn(secondaryInputTypes),
         ::testing::ValuesIn(opTypes),
-        ::testing::ValuesIn(netPrecisions),
+        ::testing::ValuesIn(smokeNetPrecisions),
         ::testing::Values(ov::element::undefined),
         ::testing::Values(ov::element::undefined),
         ::testing::Values(CommonTestUtils::DEVICE_CPU),
         ::testing::Values(additional_config_single_thread));
 
 INSTANTIATE_TEST_SUITE_P(smoke_SingleThread, EltwiseLayerTest, single_thread_params, EltwiseLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(nightly_SingleThread, EltwiseLayerTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inShapesSingleThread)),
+                ::testing::ValuesIn(eltwiseOpTypesSingleThread),
+                ::testing::ValuesIn(secondaryInputTypes),
+                ::testing::ValuesIn(opTypes),
+                ::testing::ValuesIn(nightlyNetPrecisions),
+                ::testing::Values(ov::element::undefined),
+                ::testing::Values(ov::element::undefined),
+                ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                ::testing::Values(additional_config_single_thread)),
+        EltwiseLayerTest::getTestCaseName);
 
 
 } // namespace


### PR DESCRIPTION
### Details:
 - *I64 support for Add, Sub, Mul and Equal emitters.*
 - *Required I64 changes in the OneDNN.*

### Tickets:
 - *100339*
