### PR TITLE
[GPU] Fix reset_execution() method with wait option enabled for `in_order` queue type

### DIFF
--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -556,17 +556,22 @@ void network::set_arguments() {
 }
 
 void network::reset_execution(bool wait) {
-    if (wait && _events.size() > 0) {
-        std::vector<event::ptr> events;
-        for (auto& pair : _events) {
-            auto& ev = pair.second;
-            if (ev->is_set())
-                continue;
+    if (wait) {
+        auto queue_type = get_config().get_property(ov::intel_gpu::queue_type);
+        if (queue_type == QueueTypes::in_order) {
+            get_stream().finish();
+        } else if (queue_type == QueueTypes::out_of_order && _events.size() > 0) {
+            std::vector<event::ptr> events;
+            for (auto& pair : _events) {
+                auto& ev = pair.second;
+                if (ev->is_set())
+                    continue;
 
-            events.push_back(ev);
+                events.push_back(ev);
+            }
+
+            get_stream().wait_for_events(events);
         }
-
-        get_stream().wait_for_events(events);
     }
     _events.clear();
 }


### PR DESCRIPTION
### Details:
- This patch fixes synchronization issue caused by unproper `reset_execution(true)` in case of `in_order` queue type. The issue became visible in case of cross-networks memory usage during model loading stage (e.g. network1 produces output1 memory and network2 accepts output1 as input - and since network1's reset_execution(true) call does not wait for calculations to complete, network2 starts inference with invalid data).

Note: checked performance on several models in dGPU - didn't find any impact on performance.

### Tickets:
 - *102617*


