### PR TITLE
[PT FE] Add skip for prim::device

### DIFF
--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -301,6 +301,8 @@ const std::map<std::string, CreatorFunction> get_supported_ops() {
         {"aten::zeros", op::translate_zeros},
         {"aten::zeros_like", op::translate_zeros_like},
         {"prim::Constant", op::translate_constant},
+        {"prim::device", op::skip_node},  // In openvino how tensors are stored in memory is internal plugin detail,
+                                          //   we don't differentiate used devices in model graph.
         {"prim::GetAttr", op::translate_get_attr},
         {"prim::If", op::translate_if},
         {"prim::is_cuda", op::return_false_scalar},

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -302,7 +302,7 @@ const std::map<std::string, CreatorFunction> get_supported_ops() {
         {"aten::zeros_like", op::translate_zeros_like},
         {"prim::Constant", op::translate_constant},
         {"prim::device", op::skip_node},  // In openvino how tensors are stored in memory is internal plugin detail,
-                                          //   we don't differentiate used devices in model graph.
+                                          // we don't differentiate used devices in model graph.
         {"prim::GetAttr", op::translate_get_attr},
         {"prim::If", op::translate_if},
         {"prim::is_cuda", op::return_false_scalar},


### PR DESCRIPTION
### Details:
 - *Skip prim::device operation*
Operator `prim::device` in PyTorch is used to indicate on with device Tensors will be allocated. Skipping it, since in OV we don't have operations that support such actions

### Tickets:
 - *99232*
