### PR TITLE
DEB: use alternative package names for nlohmann json

### DIFF
--- a/cmake/packaging/debian.cmake
+++ b/cmake/packaging/debian.cmake
@@ -336,12 +336,11 @@ macro(ov_cpack_settings)
     set(samples_build_deps "cmake, g++, gcc, libc6-dev, make, pkg-config")
     set(samples_build_deps_suggest "libopencv-core-dev, libopencv-imgproc-dev, libopencv-imgcodecs-dev")
     set(samples_opencl_suggest "ocl-icd-opencl-dev, opencl-headers")
-    if(OV_GLIBC_VERSION VERSION_LESS_EQUAL 2.27)
-        # Ubuntu 18.04, Debian 9 cases
-        set(json_library "nlohmann-json-dev")
-    else()
-        set(json_library "nlohmann-json3-dev")
-    endif()
+    # Ubuntu 18.04, Debian 9 cases have nlohmann-json-dev
+    # newer systems have nlohmann-json3-dev
+    # according to https://www.debian.org/doc/debian-policy/ch-relationships.html#syntax-of-relationship-fields
+    # we can use | (pipe) to provide alternative package names
+    set(json_library "nlohmann-json3-dev | nlohmann-json-dev")
 
     # c_samples / cpp_samples
     set(CPACK_COMPONENT_SAMPLES_DESCRIPTION "Intel(R) Distribution of OpenVINO(TM) Toolkit C / C++ Samples")

--- a/samples/cpp/benchmark_app/CMakeLists.txt
+++ b/samples/cpp/benchmark_app/CMakeLists.txt
@@ -46,7 +46,7 @@ if(NOT TARGET nlohmann_json::nlohmann_json)
         # for example, on debian 9 there is no cmake / pkgconfig files
         find_file(nlohmann_include_file
                   NAMES "json.hpp"
-                  "Path to json.hpp (nlohmann-json-dev )")
+                  "Path to json.hpp (nlohmann-json-dev)")
         if(nlohmann_include_file)
             add_library(nlohmann_json::nlohmann_json INTERFACE IMPORTED)
             get_filename_component(nlohmann_include_dir "${nlohmann_include_file}" PATH)


### PR DESCRIPTION
### Details:
 - To avoid distribute-dependent package names in dependencies. Now, the list is unified and dependency name is resolved automatically. 