### PR TITLE
PrePostProcessor - compilation warning fix

### DIFF
--- a/src/core/src/preprocess/pre_post_process.cpp
+++ b/src/core/src/preprocess/pre_post_process.cpp
@@ -285,7 +285,7 @@ PreProcessSteps& PreProcessSteps::convert_element_type(const element::Type& type
 }
 
 PreProcessSteps& PreProcessSteps::resize(ResizeAlgorithm alg, size_t dst_height, size_t dst_width) {
-    OPENVINO_ASSERT(dst_height <= std::numeric_limits<int>::max() && dst_width <= std::numeric_limits<int>::max(),
+    OPENVINO_ASSERT(dst_height <= std::numeric_limits<size_t>::max() && dst_width <= std::numeric_limits<size_t>::max(),
                     "Resize: Width/Height dimensions cannot be greater than ",
                     std::to_string(std::numeric_limits<int>::max()));
     m_impl->add_resize_impl(alg, static_cast<int>(dst_height), static_cast<int>(dst_width));

--- a/src/core/src/preprocess/pre_post_process.cpp
+++ b/src/core/src/preprocess/pre_post_process.cpp
@@ -285,7 +285,8 @@ PreProcessSteps& PreProcessSteps::convert_element_type(const element::Type& type
 }
 
 PreProcessSteps& PreProcessSteps::resize(ResizeAlgorithm alg, size_t dst_height, size_t dst_width) {
-    OPENVINO_ASSERT(dst_height <= std::numeric_limits<size_t>::max() && dst_width <= std::numeric_limits<size_t>::max(),
+    OPENVINO_ASSERT(dst_height <= static_cast<size_t>(std::numeric_limits<int>::max()) &&
+                        dst_width <= static_cast<size_t>(std::numeric_limits<int>::max()),
                     "Resize: Width/Height dimensions cannot be greater than ",
                     std::to_string(std::numeric_limits<int>::max()));
     m_impl->add_resize_impl(alg, static_cast<int>(dst_height), static_cast<int>(dst_width));


### PR DESCRIPTION
### Details:
 - Fixes a compilation warning produced by GCC-9

`openvino/src/core/src/preprocess/pre_post_process.cpp:288:32: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]`