### PR TITLE
remove tbb version check for using tbbbind static library

### DIFF
--- a/src/inference/src/threading/ie_parallel_custom_arena.cpp
+++ b/src/inference/src/threading/ie_parallel_custom_arena.cpp
@@ -12,7 +12,14 @@
 #        define TBBBIND_2_5_AVAILABLE 0
 #    endif
 
-#    define USE_TBBBIND_2_5          (TBBBIND_2_5_AVAILABLE && TBB_INTERFACE_VERSION < 12020)
+// On Ubuntu22.04, system tbb is 2021.5 oneTBB and tbbbind dynamic library doesn't exist.
+// In this case, tbbbind static library is needed.
+#    define USE_TBBBIND_2_5 TBBBIND_2_5_AVAILABLE
+#    if USE_TBBBIND_2_5
+#        pragma message("USE_TBBBIND_2_5 is enabled")
+#    else
+#        pragma message("USE_TBBBIND_2_5 is disabled")
+#    endif
 #    define TBB_NUMA_SUPPORT_PRESENT (TBB_INTERFACE_VERSION >= 11100)
 #    if defined(__APPLE__)
 // 2021.2 TBB doesn't export for macOS symbol:


### PR DESCRIPTION
### Details:
 - *On ubuntu22.04, system default tbb is oneTBB 2021.5 and tbbbind dynamic library does not exist, in this case the prebuilt tbbbind static library should be used.*

### Tickets:
 - *100340*
