### PR TITLE
[DOCS] deployment_simplified image update for 22.3

### DIFF
--- a/docs/img/deployment_simplified.svg
+++ b/docs/img/deployment_simplified.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:774f53500c6ed360001ca0478c96452c1037fa2c42eb39459d13c836ebcaeee1
-size 22041
+oid sha256:68d5003431670cea03abc68eba89ffc9c566e08782ae6f5a80dd4a2a20766847
+size 21883


### PR DESCRIPTION
Update of deployment_simplified.svg image.

Port from https://github.com/openvinotoolkit/openvino/pull/15678