### PR TITLE
Detect loops in topological_sort

### DIFF
--- a/src/core/tests/model.cpp
+++ b/src/core/tests/model.cpp
@@ -1334,6 +1334,63 @@ bool all_ops_have_same_info(const std::shared_ptr<ov::Model>& f) {
 }
 }  // namespace
 
+TEST(model, topological_sort_throws_if_loop_with_one_node) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto result = std::make_shared<ov::opset8::Result>(relu1);
+
+    // Loop relu2->relu2
+    auto relu2 = std::make_shared<ov::opset8::Relu>(relu1->output(0));
+    ov::replace_node(relu1, relu2);
+    ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
+                 ov::Exception);
+}
+
+TEST(model, topological_sort_throws_if_loop_with_several_nodes) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto result = std::make_shared<ov::opset8::Result>(relu1);
+
+    // Loop relu2->relu3->relu2
+    auto relu2 = std::make_shared<ov::opset8::Relu>(relu1->output(0));
+    auto relu3 = std::make_shared<ov::opset8::Relu>(relu2);
+    ov::replace_node(relu1, relu3);
+
+    ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
+                 ov::Exception);
+}
+
+TEST(model, topological_sort_throws_if_loop_with_control_dependency) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto relu2 = std::make_shared<ov::opset8::Relu>(relu1);
+    auto result = std::make_shared<ov::opset8::Result>(relu2);
+
+    // Loop relu1->relu2->relu1
+    relu1->add_control_dependency(relu2);
+
+    ASSERT_THROW(std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{arg0}),
+                 ov::Exception);
+}
+
+TEST(model, topological_sort_throws_if_loop_with_control_dependency_only) {
+    auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu0 = std::make_shared<ov::opset8::Relu>(arg0);
+    auto result0 = std::make_shared<ov::opset8::Result>(relu0);
+
+    auto arg1 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
+    auto relu1 = std::make_shared<ov::opset8::Relu>(arg1);
+    auto result1 = std::make_shared<ov::opset8::Result>(relu1);
+
+    // Loop relu0->relu1->relu0
+    relu0->add_control_dependency(relu1);
+    relu1->add_control_dependency(relu0);
+
+    ASSERT_THROW(
+        std::ignore = std::make_shared<ov::Model>(ov::ResultVector{result0, result1}, ov::ParameterVector{arg0, arg1}),
+        ov::Exception);
+}
+
 TEST(model, topological_sort_caching_basic) {
     auto arg0 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1});
     auto relu1 = std::make_shared<ov::opset8::Relu>(arg0);


### PR DESCRIPTION
### Details:
 - For the moment any loop (generated with `replace_node` or `add_control_dependency`) leads to infinite execution. In this case added a detector which checks that there is no nodes visited more than twice. If loop detected, throw exception

### Tickets:
 - 102982
