### PR TITLE
[GPU] Fix a bug of permute optimization

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1804,7 +1804,9 @@ void layout_optimizer::select_preferred_formats_for_onednn(program_node& node, d
                 // In this case, it can be handled by changing only the shape of permute without the kernel execution.
                 if (node.get_output_layout().get_rank() == 4 && node.get_dependency(0).is_type<permute>()) {
                     auto& pnode = node.get_dependency(0).as<permute>();
-                    can_optimize_permute = pnode.get_users().size() == 1 && pnode.get_dependencies().size() == 1
+                    can_optimize_permute = pnode.get_users().size() == 1
+                        && pnode.get_output_layout().data_type == node.get_output_layout().data_type
+                        && !pnode.has_fused_primitives()
                         && !pnode.is_output() && pnode.get_dependency(0).get_output_layout().is_static()
                         && pnode.is_reverse_rotating_except_batch();
                 }
@@ -1839,7 +1841,8 @@ void layout_optimizer::select_preferred_formats_for_onednn(program_node& node, d
             if (node.get_output_layout().get_rank() == 4
                 && node.get_users().size() == 1 && node.get_users().front()->is_type<permute>()) {
                 auto& pnode = node.get_users().front()->as<permute>();
-                auto can_optimize_permute = pnode.get_dependencies().size() == 1
+                auto can_optimize_permute = pnode.get_output_layout().data_type == node.get_output_layout().data_type
+                    && !pnode.has_fused_primitives()
                     && !pnode.is_output() && pnode.get_dependency(0).get_output_layout().is_static()
                     && pnode.is_rotating_except_batch();
                 if (can_optimize_permute) {

--- a/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
@@ -4171,7 +4171,7 @@ INSTANTIATE_TEST_SUITE_P(implicit_crop_concat_conv_fusings_gpu, implicit_crop_co
 
 class PermuteOptimizingTestOnednn : public BaseFusingTest<convolution_test_params> {
 public:
-    void execute(convolution_test_params& p, const std::string& expected_kernel = "undef") {
+    void execute(convolution_test_params& p, bool is_permute_optimized = true) {
         if (!engine.get_device_info().supports_immad)
             return;
 
@@ -4205,7 +4205,11 @@ public:
         });
 
         ASSERT_TRUE(permute_prim != pi_fused.end());
-        ASSERT_TRUE(permute_prim->kernel_id == expected_kernel);
+        if (is_permute_optimized) {
+            ASSERT_TRUE(permute_prim->kernel_id == "undef");
+        } else {
+            ASSERT_FALSE(permute_prim->kernel_id == "undef");
+        }
     }
 
     layout get_input_layout(convolution_test_params& p) {
@@ -4290,7 +4294,7 @@ TEST_P(conv_after_permute_not_optimizing, basic) {
     );
 
     tolerance = default_tolerance(p.default_type);
-    execute(p, "permute_ref__f16");
+    execute(p, false);
 }
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_after_permute_not_optimizing, ::testing::ValuesIn(std::vector<convolution_test_params>{

--- a/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
@@ -4171,7 +4171,7 @@ INSTANTIATE_TEST_SUITE_P(implicit_crop_concat_conv_fusings_gpu, implicit_crop_co
 
 class PermuteOptimizingTestOnednn : public BaseFusingTest<convolution_test_params> {
 public:
-    void execute(convolution_test_params& p) {
+    void execute(convolution_test_params& p, const std::string& expected_kernel = "undef") {
         if (!engine.get_device_info().supports_immad)
             return;
 
@@ -4205,7 +4205,7 @@ public:
         });
 
         ASSERT_TRUE(permute_prim != pi_fused.end());
-        ASSERT_TRUE(permute_prim->kernel_id == "undef");
+        ASSERT_TRUE(permute_prim->kernel_id == expected_kernel);
     }
 
     layout get_input_layout(convolution_test_params& p) {
@@ -4256,6 +4256,45 @@ TEST_P(conv_after_permute_optimizing, basic) {
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_after_permute_optimizing, ::testing::ValuesIn(std::vector<convolution_test_params>{
     convolution_test_params{ CASE_CONV_FP16_PERMUTE_1, 3, 2, 4 },
+}));
+
+#define CASE_CONV_INT8_PERMUTE_1 { 1, 4, 3, 5 }, { 1, 30, 2, 3 }, { 1, 1, 3, 3 }, { 1, 1 }, { 0, 0 }, { 1, 1 }, 1, data_types::f16, format::bfyx, data_types::i8, format::bfyx, data_types::f32, format::bfyx
+
+class conv_after_permute_not_optimizing : public PermuteOptimizingTestOnednn {};
+TEST_P(conv_after_permute_not_optimizing, basic) {
+    if (!engine.get_device_info().supports_immad)
+        return;
+
+    auto p = GetParam();
+
+    auto weights_layout = cldnn::layout { p.weights_type, p.weights_format,
+                                        cldnn::tensor(batch(p.out_shape.feature[0]), feature(p.in_shape.spatial[0]),
+                                        spatial(p.kernel.spatial[0], p.kernel.spatial[1], p.kernel.spatial[2])) };
+
+    auto bias_layout = cldnn::layout{ p.default_type, format::bfyx, tensor{1, p.out_shape.feature[0], 1, 1} };
+
+    create_topologies(
+        input_layout("input", get_input_layout(p)),
+        data("weights", get_mem(weights_layout)),
+        data("bias", get_mem(bias_layout)),
+        data("in_lo1", get_mem(get_single_element_layout(p), 0)),
+        data("in_hi1", get_mem(get_single_element_layout(p), 100)),
+        data("out_lo1", get_mem(get_single_element_layout(p), 0)),
+        data("out_hi1", get_mem(get_single_element_layout(p), 100)),
+        permute("permute", input_info("input"), {0, 3, 1, 2}),
+        quantize("quantize1", input_info("permute"), input_info("in_lo1"), input_info("in_hi1"),
+                 input_info("out_lo1"), input_info("out_hi1"), 256, data_types::i8),
+        convolution("conv_prim", input_info("quantize1"), { "weights" }, { "bias" }, p.groups, p.stride, p.pad, p.dilation),
+        activation("activation", input_info("conv_prim"), activation_func::abs),
+        reorder("reorder_bfyx", input_info("activation"), p.default_format, data_types::f32)
+    );
+
+    tolerance = default_tolerance(p.default_type);
+    execute(p, "permute_ref__f16");
+}
+
+INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_after_permute_not_optimizing, ::testing::ValuesIn(std::vector<convolution_test_params>{
+    convolution_test_params{ CASE_CONV_INT8_PERMUTE_1, 3, 3, 5 },
 }));
 
 class conv_before_permute_optimizing : public PermuteOptimizingTestOnednn {};


### PR DESCRIPTION
For int8 models, if there is FakeQuantize between permute and convolution, an operation like data type casting could be fused to permute. In this case, do not optimize permute.

### Tickets:
 - *103408*
 - *103386*
 - *103378*
