### PR TITLE
[CONFORMANCE] Enable ref cache if it exists

### DIFF
--- a/src/tests/functional/plugin/conformance/test_runner/conformance_infra/include/conformance.hpp
+++ b/src/tests/functional/plugin/conformance/test_runner/conformance_infra/include/conformance.hpp
@@ -17,6 +17,7 @@ namespace test {
 namespace conformance {
 extern const char* targetDevice;
 extern const char *targetPluginName;
+extern const char* refCachePath;
 
 extern std::vector<std::string> IRFolderPaths;
 extern std::vector<std::string> disabledTests;
@@ -103,8 +104,19 @@ static std::set<std::string> get_element_type_names() {
 static auto unique_ops = get_unique_ops();
 static auto element_type_names = get_element_type_names();
 
-inline std::vector<std::string> getModelPaths(const std::vector<std::string>& conformance_ir_paths,
-                                              const std::string& opName = "Other") {
+inline std::string get_ref_path(const std::string& model_path) {
+    std::string path_to_cache = "";
+    if (CommonTestUtils::directoryExists(refCachePath)) {
+        std::string ref_name = model_path.substr(model_path.rfind(CommonTestUtils::FileSeparator) + 1);
+        ref_name = CommonTestUtils::replaceExt(ref_name, ".bin");
+        path_to_cache += refCachePath + std::string(CommonTestUtils::FileSeparator) + ref_name;
+    }
+    return path_to_cache;
+}
+
+// vector<ir_path, ref_path>
+inline std::vector<std::pair<std::string, std::string>> getModelPaths(const std::vector<std::string>& conformance_ir_paths,
+                                                                      const std::string& opName = "Other") {
     // This is required to prevent re-scan folders each call in case there is nothing found
     static bool listPrepared = false;
     if (!listPrepared) {
@@ -125,7 +137,7 @@ inline std::vector<std::string> getModelPaths(const std::vector<std::string>& co
         listPrepared = true;
     }
 
-    std::vector<std::string> result;
+    std::vector<std::pair<std::string, std::string>> result;
     if (!opName.empty() && opName != "Other") {
         for (const auto& op_version : unique_ops[opName]) {
             std::string final_op_name = op_version == "" ? opName : opName + "-" + op_version;
@@ -133,7 +145,7 @@ inline std::vector<std::string> getModelPaths(const std::vector<std::string>& co
             auto it = dirList.begin();
             while (it != dirList.end()) {
                 if (it->find(strToFind) != std::string::npos) {
-                    result.push_back(*it);
+                    result.push_back({*it, get_ref_path(*it)});
                     it = dirList.erase(it);
                 } else {
                     ++it;
@@ -142,7 +154,10 @@ inline std::vector<std::string> getModelPaths(const std::vector<std::string>& co
         }
     } else if (opName == "Other") {
         // For "Undefined" operation name - run all applicable files in "Undefined" handler
-        result.insert(result.end(), dirList.begin(), dirList.end());
+        // result.insert(result.end(), dirList.begin(), dirList.end());
+        for (const auto& file : dirList) {
+            result.push_back({file, get_ref_path(file)});
+        }
     }
     return result;
 }

--- a/src/tests/functional/plugin/conformance/test_runner/conformance_infra/include/conformance.hpp
+++ b/src/tests/functional/plugin/conformance/test_runner/conformance_infra/include/conformance.hpp
@@ -105,12 +105,16 @@ static auto unique_ops = get_unique_ops();
 static auto element_type_names = get_element_type_names();
 
 inline std::string get_ref_path(const std::string& model_path) {
-    std::string path_to_cache = "";
-    if (CommonTestUtils::directoryExists(refCachePath)) {
-        std::string ref_name = model_path.substr(model_path.rfind(CommonTestUtils::FileSeparator) + 1);
-        ref_name = CommonTestUtils::replaceExt(ref_name, ".bin");
-        path_to_cache += refCachePath + std::string(CommonTestUtils::FileSeparator) + ref_name;
+    if (std::string(refCachePath) == "") {
+        return "";
     }
+    if (!CommonTestUtils::directoryExists(refCachePath)) {
+        CommonTestUtils::createDirectoryRecursive(refCachePath);
+    }
+    std::string path_to_cache = refCachePath + std::string(CommonTestUtils::FileSeparator);
+    std::string ref_name = model_path.substr(model_path.rfind(CommonTestUtils::FileSeparator) + 1);
+    ref_name = CommonTestUtils::replaceExt(ref_name, "bin");
+    path_to_cache +=  ref_name;
     return path_to_cache;
 }
 

--- a/src/tests/functional/plugin/conformance/test_runner/conformance_infra/include/gflag_config.hpp
+++ b/src/tests/functional/plugin/conformance/test_runner/conformance_infra/include/gflag_config.hpp
@@ -46,6 +46,7 @@ static const char extract_body_message[] = "Optional. Allows to count extracted 
 static const char shape_mode_message[] = "Optional. Allows to run `static`, `dynamic` or both scenarios. Default value is empty string allows to run both"
                                          " scenarios. Possible values are `static`, `dynamic`, ``";
 static const char test_timeout_message[] = "Optional. Setup timeout for each test in seconds, default timeout 900seconds (15 minutes).";
+static const char reference_cache_dir_message[] = "Optional. Set the directory with reference cache";
 
 
 DEFINE_bool(h, false, help_message);
@@ -62,6 +63,7 @@ DEFINE_bool(report_unique_name, false, report_unique_name_message);
 DEFINE_bool(extract_body, false, extract_body_message);
 DEFINE_string(shape_mode, "", shape_mode_message);
 DEFINE_uint32(test_timeout, UINT_MAX, test_timeout_message);
+DEFINE_string(ref_dir, "", reference_cache_dir_message);
 
 /**
 * @brief This function shows a help message
@@ -85,6 +87,7 @@ static void showUsage() {
     std::cout << "    --plugin_lib_name                " << output_folder_message << std::endl;
     std::cout << "    --shape_mode  \"<value>\"          " << shape_mode_message << std::endl;
     std::cout << "    --test_timeout  \"<value>\"        " << test_timeout_message << std::endl;
+    std::cout << "    --ref_dir  \"<paths>\"             " << reference_cache_dir_message << std::endl;
 }
 
 }  // namespace conformance

--- a/src/tests/functional/plugin/conformance/test_runner/conformance_infra/include/read_ir_test/read_ir.hpp
+++ b/src/tests/functional/plugin/conformance/test_runner/conformance_infra/include/read_ir_test/read_ir.hpp
@@ -19,7 +19,7 @@ enum ShapeMode {
 extern ShapeMode shapeMode;
 
 using ReadIRParams = std::tuple<
-        std::string,                         // IR path
+        std::pair<std::string, std::string>, // pair<ir_path, cache_path>
         std::string,                         // Target Device
         ov::AnyMap>;                         // Plugin Config
 
@@ -28,14 +28,14 @@ class ReadIRTest : public testing::WithParamInterface<ReadIRParams>,
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ReadIRParams> &obj);
     void query_model() override;
+    std::vector<ov::Tensor> calculate_refs() override;
 
 protected:
     void SetUp() override;
 
 private:
-    std::string pathToModel;
-    std::string sourceModel;
-    std::vector<std::pair<std::string, size_t>> ocuranceInModels;
+    std::string path_to_model, path_to_cache, source_model;
+    std::vector<std::pair<std::string, size_t>> ocurance_in_models;
 };
 } // namespace subgraph
 } // namespace test

--- a/src/tests/functional/plugin/conformance/test_runner/conformance_infra/src/main.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/conformance_infra/src/main.cpp
@@ -67,6 +67,7 @@ int main(int argc, char* argv[]) {
     // ---------------------------Initialization of Gtest env -----------------------------------------------
     ov::test::conformance::targetDevice = FLAGS_device.c_str();
     ov::test::conformance::IRFolderPaths = CommonTestUtils::splitStringByDelimiter(FLAGS_input_folders);
+    ov::test::conformance::refCachePath = FLAGS_ref_dir.c_str();
     if (!FLAGS_plugin_lib_name.empty()) {
         ov::test::conformance::targetPluginName = FLAGS_plugin_lib_name.c_str();
     }

--- a/src/tests/functional/plugin/conformance/test_runner/conformance_infra/src/read_ir_test/read_ir.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/conformance_infra/src/read_ir_test/read_ir.cpp
@@ -296,7 +296,7 @@ std::vector<ov::Tensor> ReadIRTest::calculate_refs() {
         for (const auto& output : functionRefs->outputs()) {
             buf_size += (sizeof output.get_element_type() * ov::shape_size(output.get_partial_shape().get_shape()));
         }
-        char* ref_buffer;
+        char* ref_buffer = nullptr;
         ref_data_ifstream.read(ref_buffer, buf_size);
 
         size_t pos = 0;

--- a/src/tests/functional/plugin/conformance/test_runner/conformance_infra/src/read_ir_test/read_ir.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/conformance_infra/src/read_ir_test/read_ir.cpp
@@ -292,13 +292,16 @@ std::vector<ov::Tensor> ReadIRTest::calculate_refs() {
         if (!ref_data_ifstream.is_open())
             IE_THROW() << "Weights file " << path_to_cache << " cannot be opened!";
 
-
-        std::vector<unsigned char> ref_buffer(std::istreambuf_iterator<char>(ref_data_ifstream), {});
-        auto ref_data = ref_buffer.data();
+        size_t buf_size = 0;
+        for (const auto& output : functionRefs->outputs()) {
+            buf_size += (sizeof output.get_element_type() * ov::shape_size(output.get_partial_shape().get_shape()));
+        }
+        char* ref_buffer;
+        ref_data_ifstream.read(ref_buffer, buf_size);
 
         size_t pos = 0;
         for (const auto& output : functionRefs->outputs()) {
-            auto out_tensor = ov::runtime::Tensor(output.get_element_type(), output.get_shape(), &ref_data[pos]);
+            auto out_tensor = ov::runtime::Tensor(output.get_element_type(), output.get_shape(), &ref_buffer[pos]);
             pos += out_tensor.get_byte_size();
         }
     }
@@ -313,4 +316,5 @@ std::vector<ov::Tensor> ReadIRTest::calculate_refs() {
 } // namespace subgraph
 } // namespace test
 } // namespace ov
+
 

--- a/src/tests/functional/plugin/conformance/test_runner/conformance_infra/src/skip_tests_config.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/conformance_infra/src/skip_tests_config.cpp
@@ -15,6 +15,7 @@ namespace conformance {
 
 const char *targetDevice = "";
 const char *targetPluginName = "";
+const char *refCachePath = "";
 
 std::vector<std::string> IRFolderPaths = {};
 std::vector<std::string> disabledTests = {};

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -279,11 +279,6 @@ void SubgraphBaseTest::infer() {
 }
 
 std::vector<ov::Tensor> SubgraphBaseTest::calculate_refs() {
-    if (is_report_stages) {
-        std::cout << "[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is started"<< std::endl;
-    }
-    auto start_time = std::chrono::system_clock::now();
-
     using InputsMap = std::map<std::shared_ptr<ov::Node>, ov::Tensor>;
 
     auto functionToProcess = functionRefs->clone();
@@ -341,11 +336,6 @@ std::vector<ov::Tensor> SubgraphBaseTest::calculate_refs() {
     functionToProcess = p.build();
 
     auto results = ngraph::helpers::interpretFunction(functionToProcess, inputs);
-    if (is_report_stages) {
-        auto end_time = std::chrono::system_clock::now();
-        std::chrono::duration<double> duration = end_time - start_time;
-        std::cout << "[ REFERENCE   ] `SubgraphBaseTest::calculate_refs()` is finished successfully. Duration is " << duration.count() << "s" << std::endl;
-    }
     return results;
 }
 


### PR DESCRIPTION
### Details:
 - *Add new command-line argument for conformance to enable using pre-generated reference*
 - *If `ref_dir=""` then use default scenario*

### Tickets:
 - *102268*
