### PR TITLE
[PT FE]: update masked_fill support for multiple precisions

### DIFF
--- a/src/frontends/pytorch/src/op/masked_fill.cpp
+++ b/src/frontends/pytorch/src/op/masked_fill.cpp
@@ -6,6 +6,7 @@
 #include "openvino/op/broadcast.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
+#include "openvino/op/convert_like.hpp"
 #include "openvino/op/select.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "utils.hpp"
@@ -21,10 +22,10 @@ OutputVector translate_masked_fill(NodeContext& context) {
     num_inputs_check(context, 3, 3);
     auto data = context.get_input(0);
     auto mask = context.get_input(1);
-    auto value = context.const_input<float>(2);
+    auto value = context.get_input(2);
     auto data_shape = context.mark_node(std::make_shared<v3::ShapeOf>(data));
-    auto value_const = context.mark_node(v0::Constant::create(element::f32, Shape({}), {value}));
-    auto broadcasted_value = context.mark_node(std::make_shared<v3::Broadcast>(value_const, data_shape));
+    value = context.mark_node(std::make_shared<v1::ConvertLike>(value, data));
+    auto broadcasted_value = context.mark_node(std::make_shared<v3::Broadcast>(value, data_shape));
     auto bool_mask = context.mark_node(std::make_shared<v0::Convert>(mask, element::boolean));
     return {context.mark_node(std::make_shared<v1::Select>(bool_mask, broadcasted_value, data))};
 };


### PR DESCRIPTION
### Details:
 - *fixed aten:masked_fill translator for non float32 cases and non constant values*
 - *exteneded tests*
 
tested on bart and led models families from hf
