### PR TITLE
Added print ov::Tensor

### DIFF
--- a/src/core/include/openvino/runtime/tensor.hpp
+++ b/src/core/include/openvino/runtime/tensor.hpp
@@ -224,4 +224,5 @@ using ov::Tensor;
 using ov::TensorVector;
 }  // namespace runtime
 
+OPENVINO_API std::ostream& operator<<(std::ostream& out, const ov::Tensor& tensor);
 }  // namespace ov

--- a/src/core/src/runtime/ov_tensor.cpp
+++ b/src/core/src/runtime/ov_tensor.cpp
@@ -3,12 +3,105 @@
 //
 
 #include <numeric>
+#include <string>
 
 #include "blob_factory.hpp"     // IE private header
 #include "ie_ngraph_utils.hpp"  // IE private header
 #include "openvino/core/except.hpp"
+#include "openvino/core/type/element_type.hpp"
 #include "openvino/runtime/tensor.hpp"
 #include "runtime/blob_allocator.hpp"
+
+namespace {
+
+template <class T>
+std::string print_values(const T* data, size_t from, size_t size) {
+    std::string ret;
+    for (size_t i = from; i < size; i++) {
+        if (!ret.empty())
+            ret += ", ";
+        ret += std::to_string(data[i]);
+    }
+    return ret;
+}
+
+std::string serialize_values(const void* data, const ov::element::Type& element, size_t from, size_t size) {
+    switch (element) {
+    case ov::element::boolean:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::boolean>::value_type*>(data),
+                            from,
+                            size);
+    case ov::element::bf16:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::bf16>::value_type*>(data),
+                            from,
+                            size);
+    case ov::element::f16:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::f16>::value_type*>(data),
+                            from,
+                            size);
+    case ov::element::f32:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::f32>::value_type*>(data),
+                            from,
+                            size);
+    case ov::element::f64:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::f64>::value_type*>(data),
+                            from,
+                            size);
+    case ov::element::i4:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::i4>::value_type*>(data), from, size);
+    case ov::element::i8:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::i8>::value_type*>(data), from, size);
+    case ov::element::i16:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::i16>::value_type*>(data),
+                            from,
+                            size);
+    case ov::element::i32:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::i32>::value_type*>(data),
+                            from,
+                            size);
+    case ov::element::i64:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::i64>::value_type*>(data),
+                            from,
+                            size);
+    case ov::element::u1:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::u1>::value_type*>(data), from, size);
+    case ov::element::u4:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::u4>::value_type*>(data), from, size);
+    case ov::element::u8:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::u8>::value_type*>(data), from, size);
+    case ov::element::u16:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::u16>::value_type*>(data),
+                            from,
+                            size);
+    case ov::element::u32:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::u32>::value_type*>(data),
+                            from,
+                            size);
+    case ov::element::u64:
+        return print_values(static_cast<const ov::element_type_traits<ov::element::u64>::value_type*>(data),
+                            from,
+                            size);
+    default:
+        OPENVINO_UNREACHABLE("Unsupported tensor data type: ", element);
+    }
+}
+
+void print_values(std::ostream& out,
+                  const void* data,
+                  const ov::element::Type& element,
+                  size_t size,
+                  size_t max_elements) {
+    out << "    [";
+    size_t start_elem = size <= max_elements ? size : max_elements / 2;
+    size_t end_elem = size <= max_elements ? 0 : max_elements - start_elem;
+    out << serialize_values(data, element, 0, start_elem);
+    if (end_elem) {
+        out << ", ..., ";
+        out << serialize_values(data, element, size - end_elem, size);
+    }
+    out << "]" << std::endl;
+}
+}  // namespace
 
 namespace ov {
 
@@ -163,6 +256,21 @@ bool Tensor::operator!() const noexcept {
 
 Tensor::operator bool() const noexcept {
     return (!!_impl);
+}
+
+std::ostream& operator<<(std::ostream& out, const ov::Tensor& tensor) {
+    if (!tensor) {
+        out << "Tensor is not initialized!" << std::endl;
+        return out;
+    }
+    out << "Tensor " << tensor.get_element_type() << " " << tensor.get_shape() << " " << tensor.data() << std::endl;
+
+    auto precision = out.precision();
+    if (precision < 10)
+        precision = 10;
+    // Print some tensor elements
+    print_values(out, tensor.data(), tensor.get_element_type(), tensor.get_size(), precision);
+    return out;
 }
 
 }  // namespace ov

--- a/src/core/tests/ov_tensor_test.cpp
+++ b/src/core/tests/ov_tensor_test.cpp
@@ -10,6 +10,7 @@
 #include <openvino/core/shape.hpp>
 #include <openvino/core/strides.hpp>
 #include <openvino/core/type/element_type.hpp>
+#include <sstream>
 
 #include "ngraph/coordinate_transform.hpp"
 #include "openvino/core/except.hpp"
@@ -280,4 +281,60 @@ TEST_F(OVTensorTest, readRangeRoiBlob) {
             ASSERT_EQ(actual_addr, reinterpret_cast<const std::uint8_t*>(expected_addr));
         }
     }
+}
+
+TEST_F(OVTensorTest, serialize_tensor) {
+    ov::Tensor uninit_tensor;
+    {
+        std::stringstream str_stream;
+        str_stream << uninit_tensor;
+        std::cout << str_stream.str();
+        EXPECT_NE(str_stream.str().find("Tensor is not initialized!"), std::string::npos);
+    }
+    ov::Tensor empty_tensor(ov::element::i8, {0});
+    {
+        std::stringstream str_stream;
+        str_stream << empty_tensor;
+        std::cout << str_stream.str();
+        EXPECT_NE(str_stream.str().find("Tensor i8 [0]"), std::string::npos);
+        EXPECT_NE(str_stream.str().find("[]"), std::string::npos);
+    }
+    ov::Tensor small_tensor(ov::element::i32, {5});
+    {
+        const auto origPtr = small_tensor.data<int32_t>();
+        ASSERT_NE(nullptr, origPtr);
+        for (size_t i = 0; i < small_tensor.get_size(); ++i) {
+            origPtr[i] = static_cast<int32_t>(i);
+        }
+    }
+    {
+        std::stringstream str_stream;
+        str_stream << small_tensor;
+        std::cout << str_stream.str();
+        EXPECT_NE(str_stream.str().find("Tensor i32 [5]"), std::string::npos);
+        EXPECT_NE(str_stream.str().find("[0, 1, 2, 3, 4]"), std::string::npos);
+    }
+    ov::Tensor big_tensor{ov::element::i32, {1, 3, 4, 8}};
+    {
+        const auto origPtr = big_tensor.data<int32_t>();
+        ASSERT_NE(nullptr, origPtr);
+        for (size_t i = 0; i < big_tensor.get_size(); ++i) {
+            origPtr[i] = static_cast<int32_t>(i);
+        }
+    }
+    {
+        std::stringstream str_stream;
+        str_stream << big_tensor;
+        std::cout << str_stream.str();
+        EXPECT_NE(str_stream.str().find("Tensor i32 [1,3,4,8]"), std::string::npos);
+        EXPECT_NE(str_stream.str().find("[0, 1, 2, 3, 4, ..., 91, 92, 93, 94, 95]"), std::string::npos);
+    }
+    {
+        std::stringstream str_stream;
+        str_stream << std::setprecision(12) << big_tensor;
+        std::cout << str_stream.str();
+        EXPECT_NE(str_stream.str().find("Tensor i32 [1,3,4,8]"), std::string::npos);
+        EXPECT_NE(str_stream.str().find("[0, 1, 2, 3, 4, 5, ..., 90, 91, 92, 93, 94, 95]"), std::string::npos);
+    }
+    EXPECT_ANY_THROW(ov::Tensor unsupported_tensor(ov::element::dynamic, {5}));
 }


### PR DESCRIPTION
### Details:
 - Add `std::cout` for `ov::Tensor`
 - `std::setprecision` can be used to set minimal number of variables which will be printed (min: 10)

### Tickets:
 - *ticket-id*
