### PR TITLE
[TF FE] Add Const to Result removing transformation

### DIFF
--- a/src/frontends/tensorflow/src/frontend.cpp
+++ b/src/frontends/tensorflow/src/frontend.cpp
@@ -6,9 +6,9 @@
 
 #include "graph_iterator_proto.hpp"
 #include "helper_transforms/block_lstm_replacer.hpp"
+#include "helper_transforms/const_to_result_remover.hpp"
 #include "helper_transforms/embedding_segments_feature_fusing.hpp"
 #include "helper_transforms/gru_block_cell_replacer.hpp"
-#include "helper_transforms/unsupported_const_to_result_remover.hpp"
 #include "input_model.hpp"
 #include "op_table.hpp"
 #include "openvino/frontend/tensorflow/extension/conversion.hpp"
@@ -252,7 +252,7 @@ void FrontEnd::normalize(const std::shared_ptr<ov::Model>& function) const {
     manager.register_pass<pass::EmbeddingSegmentSingleFeatureFusion>();
     manager.register_pass<pass::BlockLSTMReplacer>();
     manager.register_pass<pass::GRUBlockCellReplacer>();
-    manager.register_pass<pass::UnsupportedConstToResultRemover>();
+    manager.register_pass<pass::ConstToResultRemover>();
 
     manager.register_pass<ov::pass::TransposeSinkingGeneral>();
     manager.register_pass<ov::pass::ReverseShapeAndTypeInfer>();

--- a/src/frontends/tensorflow/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow/tests/convert_tricky_models.cpp
@@ -262,3 +262,26 @@ TEST_F(TransformationTestsF, ModelWithSaveV2) {
         model_ref = make_shared<Model>(OutputVector{add}, ParameterVector{x});
     }
 }
+
+TEST_F(TransformationTestsF, ModelWithConstResultSubgraphs) {
+    { model = convert_model("model_with_const_result/model_with_const_result.pb"); }
+    {
+        // create a reference graph
+        auto x = make_shared<Parameter>(element::f32, PartialShape{Dimension::dynamic(), 60, 60, 1});
+        auto perm_order = make_shared<Constant>(element::i64, Shape{4}, vector<int64_t>{0, 3, 1, 2});
+        auto transpose_to_nchw = make_shared<Transpose>(x, perm_order);
+        auto max_pool = make_shared<MaxPool>(transpose_to_nchw,
+                                             Strides{2, 2},
+                                             Strides{1, 1},
+                                             Shape{0, 0},
+                                             Shape{0, 0},
+                                             Shape{2, 2},
+                                             ov::op::RoundingType::FLOOR,
+                                             ov::op::PadType::VALID,
+                                             element::i64);
+        auto inverse_order = make_shared<Constant>(element::i64, Shape{4}, vector<int64_t>{0, 2, 3, 1});
+        auto transpose_to_nhwc = make_shared<Transpose>(max_pool, inverse_order);
+
+        model_ref = make_shared<Model>(OutputVector{transpose_to_nhwc}, ParameterVector{x});
+    }
+}

--- a/src/frontends/tensorflow/tests/test_models/models_pbtxt/model_with_const_result.pbtxt
+++ b/src/frontends/tensorflow/tests/test_models/models_pbtxt/model_with_const_result.pbtxt
@@ -1,0 +1,123 @@
+node {
+  name: "Adam/beta_1"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.8999999761581421
+      }
+    }
+  }
+}
+node {
+  name: "Adam/beta_2"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.9990000128746033
+      }
+    }
+  }
+}
+node {
+  name: "input_2"
+  op: "Placeholder"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: -1
+        }
+        dim {
+          size: 60
+        }
+        dim {
+          size: 60
+        }
+        dim {
+          size: 1
+        }
+      }
+    }
+  }
+}
+node {
+  name: "max_pooling2d_5/MaxPool"
+  op: "MaxPool"
+  input: "input_2"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+  attr {
+    key: "explicit_paddings"
+    value {
+      list {
+      }
+    }
+  }
+  attr {
+    key: "ksize"
+    value {
+      list {
+        i: 1
+        i: 2
+        i: 2
+        i: 1
+      }
+    }
+  }
+  attr {
+    key: "padding"
+    value {
+      s: "VALID"
+    }
+  }
+  attr {
+    key: "strides"
+    value {
+      list {
+        i: 1
+        i: 2
+        i: 2
+        i: 1
+      }
+    }
+  }
+}

--- a/src/frontends/tensorflow_common/include/helper_transforms/const_to_result_remover.hpp
+++ b/src/frontends/tensorflow_common/include/helper_transforms/const_to_result_remover.hpp
@@ -11,11 +11,14 @@ namespace frontend {
 namespace tensorflow {
 namespace pass {
 
-// This transformation removes isolated subgraph Unsupported constant going to the Result node
-class UnsupportedConstToResultRemover : public ov::pass::ModelPass {
+// This transformation removes isolated subgraph Constant going to the Result node
+// It can be case that TensorFlow can remain training artifacts in the form
+// of multiple Constant nodes storing training parameter values
+// We need to remove them because separate sub-graphs can solidly affect performance
+class ConstToResultRemover : public ov::pass::ModelPass {
 public:
     OPENVINO_RTTI("ov::frontend::tensorflow::pass::UnsupportedConstToResultRemover");
-    UnsupportedConstToResultRemover() {}
+    ConstToResultRemover() {}
 
     bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 };

--- a/src/frontends/tensorflow_common/src/helper_transforms/const_to_result_remover.cpp
+++ b/src/frontends/tensorflow_common/src/helper_transforms/const_to_result_remover.cpp
@@ -21,12 +21,8 @@ bool ConstToResultRemover::run_on_model(const std::shared_ptr<ov::Model>& m) {
     // also, find isolated Constant->Result sub-graphs to remove
     for (const auto& result : m->get_results()) {
         auto unsupported_const = as_type_ptr<UnsupportedConstant>(result->get_input_node_shared_ptr(0));
-        if (unsupported_const && unsupported_const->output(0).get_target_inputs().size() == 1) {
-            results_to_remove.push_back(result);
-            continue;
-        }
         auto const_node = as_type_ptr<Constant>(result->get_input_node_shared_ptr(0));
-        if (const_node && const_node->output(0).get_target_inputs().size() == 1) {
+        if (unsupported_const || const_node) {
             results_to_remove.push_back(result);
         }
     }

--- a/src/frontends/tensorflow_common/src/helper_transforms/const_to_result_remover.cpp
+++ b/src/frontends/tensorflow_common/src/helper_transforms/const_to_result_remover.cpp
@@ -2,23 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "helper_transforms/unsupported_const_to_result_remover.hpp"
+#include "helper_transforms/const_to_result_remover.hpp"
 
 #include "helper_ops/unsupported_constant.hpp"
+#include "openvino/opsets/opset10.hpp"
 
 using namespace std;
+using namespace ov::opset10;
 
 namespace ov {
 namespace frontend {
 namespace tensorflow {
 namespace pass {
 
-bool UnsupportedConstToResultRemover::run_on_model(const std::shared_ptr<ov::Model>& m) {
+bool ConstToResultRemover::run_on_model(const std::shared_ptr<ov::Model>& m) {
     ResultVector results_to_remove;
     // look for isolated UnsupportedConst->Result sub-graphs to remove
+    // also, find isolated Constant->Result sub-graphs to remove
     for (const auto& result : m->get_results()) {
         auto unsupported_const = as_type_ptr<UnsupportedConstant>(result->get_input_node_shared_ptr(0));
         if (unsupported_const && unsupported_const->output(0).get_target_inputs().size() == 1) {
+            results_to_remove.push_back(result);
+            continue;
+        }
+        auto const_node = as_type_ptr<Constant>(result->get_input_node_shared_ptr(0));
+        if (const_node && const_node->output(0).get_target_inputs().size() == 1) {
             results_to_remove.push_back(result);
         }
     }


### PR DESCRIPTION
**Details:** Add Const to Result removing transformation. TensorFlow can remain training artifacts in models. It can be multiple isolated Constant nodes storing training artifacts. In IR they are expressed in a form of Const to Result sub-graphs. Multiple sub-graphs in the model can significantly affect performance.

**Ticket:** 103927

