### PR TITLE
ONNX functions expanding

### DIFF
--- a/src/frontends/onnx/frontend/src/core/transform.cpp
+++ b/src/frontends/onnx/frontend/src/core/transform.cpp
@@ -30,6 +30,22 @@ ONNX_NAMESPACE::TypeProto get_input_type(std::string const& name, ONNX_NAMESPACE
             return input.type();
         }
     }
+    for (auto& initializer : graph.initializer()) {
+        if (initializer.name() == name) {
+            ONNX_NAMESPACE::TypeProto ret;
+            auto* tensor_type = ret.mutable_tensor_type();
+            tensor_type->set_elem_type(initializer.data_type());
+            
+            auto* tensor_shape = tensor_type->mutable_shape();
+            tensor_shape->clear_dim();
+            const auto& initializer_dims = initializer.dims();
+            for (auto&& dim : initializer_dims) {
+                auto* new_dim = tensor_shape->add_dim();
+                new_dim->set_dim_value(dim);
+            }
+            return ret;
+        }
+    }
     for (auto& value_info : graph.value_info()) {
         if (value_info.name() == name) {
             return value_info.type();

--- a/src/frontends/onnx/frontend/src/core/transform.cpp
+++ b/src/frontends/onnx/frontend/src/core/transform.cpp
@@ -25,17 +25,17 @@ namespace onnx_import {
 namespace transform {
 namespace {
 ONNX_NAMESPACE::TypeProto get_input_type(std::string const& name, ONNX_NAMESPACE::GraphProto& graph) {
-    for (auto& input : graph.input()) {
+    for (const auto& input : graph.input()) {
         if (input.name() == name) {
             return input.type();
         }
     }
-    for (auto& initializer : graph.initializer()) {
+    for (const auto& initializer : graph.initializer()) {
         if (initializer.name() == name) {
             ONNX_NAMESPACE::TypeProto ret;
             auto* tensor_type = ret.mutable_tensor_type();
             tensor_type->set_elem_type(initializer.data_type());
-            
+
             auto* tensor_shape = tensor_type->mutable_shape();
             tensor_shape->clear_dim();
             const auto& initializer_dims = initializer.dims();
@@ -46,7 +46,7 @@ ONNX_NAMESPACE::TypeProto get_input_type(std::string const& name, ONNX_NAMESPACE
             return ret;
         }
     }
-    for (auto& value_info : graph.value_info()) {
+    for (const auto& value_info : graph.value_info()) {
         if (value_info.name() == name) {
             return value_info.type();
         }

--- a/src/frontends/onnx/tests/models/transformations/celu_with_initializers.prototxt
+++ b/src/frontends/onnx/tests/models/transformations/celu_with_initializers.prototxt
@@ -1,0 +1,39 @@
+ir_version: 8
+producer_name: "OV ONNX FE"
+graph {
+  node {
+    input: "X"
+    output: "Y"
+    op_type: "Celu"
+  }
+  name: "graph"
+  initializer {
+    dims: 2
+    dims: 2
+    data_type: 1
+    float_data: 0.5
+    float_data: 1.0
+    float_data: 1.5
+    float_data: 2.0
+    name: "X"
+  }
+  output {
+    name: "Y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 17
+}

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -509,6 +509,17 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_expand_context_dependent_function) {
     test_case.run();
 }
 
+NGRAPH_TEST(${BACKEND_NAME}, onnx_expand_function_with_initializers) {
+    const auto function =
+        onnx_import::import_onnx_model(file_util::path_join(CommonTestUtils::getExecutableDirectory(),
+                                                            SERIALIZED_ZOO,
+                                                            "onnx/transformations/celu_with_initializers.onnx"));
+
+    auto test_case = test::TestCase(function, s_device);
+    test_case.add_expected_output<float>({0.5, 1.0, 1.5, 2.0});
+    test_case.run();
+}
+
 // ############################################################################ OPERATOR TESTS
 NGRAPH_TEST(${BACKEND_NAME}, onnx_model_addmul_abc) {
     auto function = onnx_import::import_onnx_model(


### PR DESCRIPTION
### Details:
 - Fixes the TypeProto retrieval for ONNX context dependent functions
 - When the function Node is connected to an initializer it's possible to create a TypeProto on the fly using initializer's descriptor

### Tickets:
 - 103452
