### PR TITLE
Make an exception for mold linker in ov_try_use_gold_linker cmake function

### DIFF
--- a/cmake/developer_package/compile_flags/os_flags.cmake
+++ b/cmake/developer_package/compile_flags/os_flags.cmake
@@ -499,6 +499,11 @@ endfunction()
 # Tries to use gold linker in current scope (directory, function)
 #
 function(ov_try_use_gold_linker)
+    # don't use the gold linker, if the mold linker is set
+    if(CMAKE_EXE_LINKER_FLAGS MATCHES "mold" OR CMAKE_MODULE_LINKER_FLAGS MATCHES "mold" OR CMAKE_SHARED_LINKER_FLAGS MATCHES "mold")
+        return()
+    endif()
+
     # gold linker on ubuntu20.04 may fail to link binaries build with sanitizer
     if(CMAKE_COMPILER_IS_GNUCXX AND NOT ENABLE_SANITIZER AND NOT CMAKE_CROSSCOMPILING)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=gold" PARENT_SCOPE)


### PR DESCRIPTION
### Details:
Using a custom linker leads to a compilation error, because `ov_try_use_gold_linker` overrides the linker used.
```
"cacheVariables": {
    "CMAKE_EXE_LINKER_FLAGS": "-B /usr/libexec/mold -Wl,--fork -Wl,--quick-exit -Wl,--thread-count=32",
    "CMAKE_MODULE_LINKER_FLAGS": "-B /usr/libexec/mold -Wl,--fork -Wl,--quick-exit -Wl,--thread-count=32",
    "CMAKE_SHARED_LINKER_FLAGS": "-B /usr/libexec/mold -Wl,--fork -Wl,--quick-exit -Wl,--thread-count=32"
}
```
Error message:
```
[build] /usr/bin/ld.gold: --fork: unknown option
[build] /usr/bin/ld.gold: use the --help option for usage information
[build] collect2: error: ld returned 1 exit status
```

### Tickets:
 - *ticket-id*
