### PR TITLE
[GPU] Fix oneDNN gemm binary post-op bug

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -971,7 +971,7 @@ void program_node::init_onednn_primitive_attributes() {
                     update_onednn_post_op_list(op_type, dep_idx);
                 } else if (is_type<gemm>()) {
                     size_t rank = cldnn::format::dimension(in.format);
-                    dnnl::memory::dims dims = onednn::convert_gemm_tensor(in.get_tensor(), rank, in.batch() > 1);
+                    dnnl::memory::dims dims = onednn::convert_gemm_tensor(in.get_tensor(), rank, in.batch() == 1);
                     dnnl::memory::data_type dt = onednn::convert_data_type(in.data_type);
                     dnnl::memory::format_tag fmt = onednn::convert_gemm_data_format(dims);
                     post_ops.append_binary(alg, dnnl::memory::desc(dims, dt, fmt));


### PR DESCRIPTION
convert_gemm_tensor func's last parameter is bool variable for batched_dims_can_be_removed. 'True' condition should be batch 1 NOT multi batchs, but it was being used incorrectly.

* bert-small-uncased-whole-word-masking-squad-int8-0002
F1: 91.50%
EM: 84.68%
* bert-small-uncased-whole-word-masking-squad-0002
F1: 91.94% 
EM: 85.44%

### Tickets:
 - *ticket-id*
