### PR TITLE
[CPU] Internal dynamism support for extensions

### DIFF
--- a/src/core/dev_api/shape_util.hpp
+++ b/src/core/dev_api/shape_util.hpp
@@ -16,7 +16,7 @@ namespace util {
  * @return 2-D shape with {0, SIZE_MAX}
  */
 OPENVINO_DEPRECATED("This function is deprecated and will be removed soon.")
-Shape make_dynamic_shape();
+OPENVINO_API Shape make_dynamic_shape();
 
 /**
  * @brief Check if Shape is marked as dynamic.
@@ -25,6 +25,6 @@ Shape make_dynamic_shape();
  * @return True if shape is dynamic otherwise false.
  */
 OPENVINO_DEPRECATED("This function is deprecated and will be removed soon.")
-bool is_dynamic_shape(const Shape& s);
+OPENVINO_API bool is_dynamic_shape(const Shape& s);
 }  // namespace util
 }  // namespace ov

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -540,7 +540,10 @@ void Node::execute(dnnl::stream strm) {
 void Node::updateShapes() {
     IE_ASSERT(isDynamicNode()) << "Node::updateShapes() is called to a static shape node of type: " << getTypeStr() << " with name: " << getName();
     if (needShapeInfer()) {
-        redefineOutputMemory(shapeInfer());
+        auto result = shapeInfer();
+        if (ShapeInferStatus::update == result.status) {
+            redefineOutputMemory(result.dims);
+        }
     }
 }
 
@@ -1503,14 +1506,19 @@ std::vector<VectorDims> Node::shapeInferGeneric(const std::vector<Shape>& shapes
             }
         }
 
-        return shapeInference->infer(input_shapes, input_values);
+        auto result = shapeInference->infer(input_shapes, input_values);
+        if (ShapeInferStatus::update != result.status) {
+            IE_THROW(Unexpected) << "Shape inference unexpectedly skipped";
+        }
+
+        return std::move(result.dims);
     }
     catch (const std::runtime_error& exp) {
         IE_THROW() << "Shape inference of " << getTypeStr()  << " node with name " << getName() << " failed: " << exp.what();
     }
 }
 
-std::vector<VectorDims> Node::shapeInfer() const {
+IShapeInfer::ShapeInferResult Node::shapeInfer() const {
     try {
         std::vector<std::reference_wrapper<const VectorDims>> input_shapes;
         auto input_value_port_mask = shapeInference->get_port_mask();

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -541,7 +541,7 @@ void Node::updateShapes() {
     IE_ASSERT(isDynamicNode()) << "Node::updateShapes() is called to a static shape node of type: " << getTypeStr() << " with name: " << getName();
     if (needShapeInfer()) {
         auto result = shapeInfer();
-        if (ShapeInferStatus::update == result.status) {
+        if (ShapeInferStatus::success == result.status) {
             redefineOutputMemory(result.dims);
         }
     }
@@ -1507,7 +1507,7 @@ std::vector<VectorDims> Node::shapeInferGeneric(const std::vector<Shape>& shapes
         }
 
         auto result = shapeInference->infer(input_shapes, input_values);
-        if (ShapeInferStatus::update != result.status) {
+        if (ShapeInferStatus::success != result.status) {
             IE_THROW(Unexpected) << "Shape inference unexpectedly skipped";
         }
 
@@ -1518,7 +1518,7 @@ std::vector<VectorDims> Node::shapeInferGeneric(const std::vector<Shape>& shapes
     }
 }
 
-IShapeInfer::ShapeInferResult Node::shapeInfer() const {
+IShapeInfer::Result Node::shapeInfer() const {
     try {
         std::vector<std::reference_wrapper<const VectorDims>> input_shapes;
         auto input_value_port_mask = shapeInference->get_port_mask();

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -636,7 +636,7 @@ protected:
     bool inputShapesModified() const;
     virtual bool needShapeInfer() const;
     std::vector<VectorDims> shapeInferGeneric(const std::vector<Shape>& inputDims) const;
-    IShapeInfer::ShapeInferResult shapeInfer() const;
+    IShapeInfer::Result shapeInfer() const;
     // TODO [DS] : make pure after all nodes will be support dynamic shapes
     virtual void executeDynamicImpl(dnnl::stream strm) {
         IE_THROW(NotImplemented) << "[DS] executeDynamicImpl not implemented for node with type: " << getTypeStr();

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -636,7 +636,7 @@ protected:
     bool inputShapesModified() const;
     virtual bool needShapeInfer() const;
     std::vector<VectorDims> shapeInferGeneric(const std::vector<Shape>& inputDims) const;
-    virtual std::vector<VectorDims> shapeInfer() const;
+    IShapeInfer::ShapeInferResult shapeInfer() const;
     // TODO [DS] : make pure after all nodes will be support dynamic shapes
     virtual void executeDynamicImpl(dnnl::stream strm) {
         IE_THROW(NotImplemented) << "[DS] executeDynamicImpl not implemented for node with type: " << getTypeStr();

--- a/src/plugins/intel_cpu/src/nodes/adaptive_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/adaptive_pooling.cpp
@@ -32,7 +32,7 @@ namespace {
 class AdaptivePoolingShapeInfer : public ShapeInferEmptyPads {
 public:
     explicit AdaptivePoolingShapeInfer(size_t outputs_count) : m_outputs_count(outputs_count) {}
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const auto& inputDims = input_shapes[0].get();
@@ -49,7 +49,7 @@ public:
         }
 
         std::vector<VectorDims> result(m_outputs_count, outputDims);
-        return {std::move(result), ShapeInferStatus::update};
+        return {std::move(result), ShapeInferStatus::success};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/adaptive_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/adaptive_pooling.cpp
@@ -32,7 +32,7 @@ namespace {
 class AdaptivePoolingShapeInfer : public ShapeInferEmptyPads {
 public:
     explicit AdaptivePoolingShapeInfer(size_t outputs_count) : m_outputs_count(outputs_count) {}
-    std::vector<VectorDims> infer(
+    ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const auto& inputDims = input_shapes[0].get();
@@ -49,7 +49,7 @@ public:
         }
 
         std::vector<VectorDims> result(m_outputs_count, outputDims);
-        return result;
+        return {std::move(result), ShapeInferStatus::update};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/color_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/color_convert.cpp
@@ -974,14 +974,15 @@ public:
 class ColorConvertShapeInfer : public ShapeInferEmptyPads {
 public:
     ColorConvertShapeInfer(bool singlePlain) : m_singlePlain(singlePlain) {}
-    std::vector<VectorDims> infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
-                                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
+    ShapeInferResult infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
+                           const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const auto& dims = input_shapes.front().get();
         if (dims.size() != 4)
             IE_THROW() <<"NV12Converter node has incorrect input dimensions";
-        return m_singlePlain
+        return { m_singlePlain
                     ? std::vector<VectorDims>{ { dims[Converter::N_DIM], dims[Converter::H_DIM] * 2 / 3, dims[Converter::W_DIM], 3 } }
-                    : std::vector<VectorDims>{ { dims[Converter::N_DIM], dims[Converter::H_DIM], dims[Converter::W_DIM], 3 } };
+                    : std::vector<VectorDims>{ { dims[Converter::N_DIM], dims[Converter::H_DIM], dims[Converter::W_DIM], 3 } },
+                    ShapeInferStatus::update };
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/color_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/color_convert.cpp
@@ -974,7 +974,7 @@ public:
 class ColorConvertShapeInfer : public ShapeInferEmptyPads {
 public:
     ColorConvertShapeInfer(bool singlePlain) : m_singlePlain(singlePlain) {}
-    ShapeInferResult infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
+    Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                            const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const auto& dims = input_shapes.front().get();
         if (dims.size() != 4)
@@ -982,7 +982,7 @@ public:
         return { m_singlePlain
                     ? std::vector<VectorDims>{ { dims[Converter::N_DIM], dims[Converter::H_DIM] * 2 / 3, dims[Converter::W_DIM], 3 } }
                     : std::vector<VectorDims>{ { dims[Converter::N_DIM], dims[Converter::H_DIM], dims[Converter::W_DIM], 3 } },
-                    ShapeInferStatus::update };
+                    ShapeInferStatus::success };
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -578,7 +578,7 @@ VectorDims Deconvolution::shapeInferInternal(const VectorDims &inDims, std::vect
     }
 
     auto result = shapeInference->infer(inputShapesRefs, inputValues);
-    if (ShapeInferStatus::update != result.status) {
+    if (ShapeInferStatus::success != result.status) {
         IE_THROW(Unexpected) << "Unexpected shape inference result status in node of type " << getTypeStr() << " with name " << getName();
     }
     return std::move(result.dims.back());

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -577,8 +577,11 @@ VectorDims Deconvolution::shapeInferInternal(const VectorDims &inDims, std::vect
         }
     }
 
-    auto outputShapes = shapeInference->infer(inputShapesRefs, inputValues);
-    return outputShapes.back();
+    auto result = shapeInference->infer(inputShapesRefs, inputValues);
+    if (ShapeInferStatus::update != result.status) {
+        IE_THROW(Unexpected) << "Unexpected shape inference result status in node of type " << getTypeStr() << " with name " << getName();
+    }
+    return std::move(result.dims.back());
 }
 
 void Deconvolution::setDynamicBatchLim(int lim) {

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -108,7 +108,7 @@ struct EltwiseEmitter<jit_is_inf_emitter> {
  */
 class EltwiseShapeInfer : public ShapeInferEmptyPads {
 public:
-    std::vector<VectorDims> infer(
+    ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         size_t max_rank = 0;
@@ -141,7 +141,7 @@ public:
                 }
             }
         }
-        return { output_shape };
+        return { { std::move(output_shape) }, ShapeInferStatus::update };
     }
     port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -108,7 +108,7 @@ struct EltwiseEmitter<jit_is_inf_emitter> {
  */
 class EltwiseShapeInfer : public ShapeInferEmptyPads {
 public:
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         size_t max_rank = 0;
@@ -141,7 +141,7 @@ public:
                 }
             }
         }
-        return { { std::move(output_shape) }, ShapeInferStatus::update };
+        return { { std::move(output_shape) }, ShapeInferStatus::success };
     }
     port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -86,7 +86,7 @@ bool FCKey::operator==(const FCKey &rhs) const {
 class FCShapeInfer : public ShapeInferEmptyPads {
 public:
     FCShapeInfer(size_t outPut_rank) : out_rank(outPut_rank) {}
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const VectorDims& activationShape = input_shapes[0].get();
@@ -108,7 +108,7 @@ public:
             outputShape[i + startIdx] = activationShape[i];
         }
 
-        return {{std::move(outputShape)}, ShapeInferStatus::update};
+        return {{std::move(outputShape)}, ShapeInferStatus::success};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -86,7 +86,7 @@ bool FCKey::operator==(const FCKey &rhs) const {
 class FCShapeInfer : public ShapeInferEmptyPads {
 public:
     FCShapeInfer(size_t outPut_rank) : out_rank(outPut_rank) {}
-    std::vector<VectorDims> infer(
+    ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const VectorDims& activationShape = input_shapes[0].get();
@@ -108,7 +108,7 @@ public:
             outputShape[i + startIdx] = activationShape[i];
         }
 
-        return {outputShape};
+        return {{std::move(outputShape)}, ShapeInferStatus::update};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/generic.cpp
+++ b/src/plugins/intel_cpu/src/nodes/generic.cpp
@@ -25,11 +25,11 @@ namespace {
 class GenericShapeInfer : public ShapeInferEmptyPads {
 public:
     GenericShapeInfer() = default;
-    std::vector<VectorDims> infer(
+    ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         IE_THROW(Unexpected) << "Generic operations doesn't support shape inference.";
-        return {};
+        return {{}, ShapeInferStatus::skip};
     }
 
     port_mask_t get_port_mask() const override { return EMPTY_PORT_MASK; }

--- a/src/plugins/intel_cpu/src/nodes/generic.cpp
+++ b/src/plugins/intel_cpu/src/nodes/generic.cpp
@@ -25,7 +25,7 @@ namespace {
 class GenericShapeInfer : public ShapeInferEmptyPads {
 public:
     GenericShapeInfer() = default;
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         IE_THROW(Unexpected) << "Generic operations doesn't support shape inference.";

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -116,7 +116,7 @@ public:
         m_out_rank(out_rank), m_transpose_a(transpose_a), m_transpose_b(transpose_b) {
         m_shapeY = VectorDims(m_out_rank, 1); // for output and cache
     }
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const VectorDims& shapeA = input_shapes[0].get();
@@ -132,7 +132,7 @@ public:
         // 5. Just support the same rank of matmul
         // 6. simplify the broadcast check
         if (rankA == 1 && rankB == 1 && shapeA[0] == shapeB[0]) {
-            return {{m_shapeY}, ShapeInferStatus::update};
+            return {{m_shapeY}, ShapeInferStatus::success};
         }
 
         m_shapeY[m_out_rank-2] = m_transpose_a ? shapeA[rankA-1] : shapeA[rankA-2];
@@ -151,7 +151,7 @@ public:
             m_shapeY[i] = shapeB[i];
         }
 
-        return {{m_shapeY}, ShapeInferStatus::update};
+        return {{m_shapeY}, ShapeInferStatus::success};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -116,7 +116,7 @@ public:
         m_out_rank(out_rank), m_transpose_a(transpose_a), m_transpose_b(transpose_b) {
         m_shapeY = VectorDims(m_out_rank, 1); // for output and cache
     }
-    std::vector<VectorDims> infer(
+    ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const VectorDims& shapeA = input_shapes[0].get();
@@ -132,7 +132,7 @@ public:
         // 5. Just support the same rank of matmul
         // 6. simplify the broadcast check
         if (rankA == 1 && rankB == 1 && shapeA[0] == shapeB[0]) {
-            return {m_shapeY};
+            return {{m_shapeY}, ShapeInferStatus::update};
         }
 
         m_shapeY[m_out_rank-2] = m_transpose_a ? shapeA[rankA-1] : shapeA[rankA-2];
@@ -151,7 +151,7 @@ public:
             m_shapeY[i] = shapeB[i];
         }
 
-        return {m_shapeY};
+        return {{m_shapeY}, ShapeInferStatus::update};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/one_hot.cpp
+++ b/src/plugins/intel_cpu/src/nodes/one_hot.cpp
@@ -30,7 +30,7 @@ namespace {
 class OneHotShapeInfer : public ShapeInferEmptyPads {
 public:
     explicit OneHotShapeInfer(int64_t axis) : m_axis(axis) {}
-    std::vector<VectorDims> infer(
+    ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         auto depth = reinterpret_cast<int32_t *>(data_dependency.at(1)->GetPtr())[0];
@@ -38,7 +38,7 @@ public:
         auto result = input_shapes.front().get();
         result.insert(result.begin() + m_axis, depth);
 
-        return { result };
+        return {{std::move(result)}, ShapeInferStatus::update};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/one_hot.cpp
+++ b/src/plugins/intel_cpu/src/nodes/one_hot.cpp
@@ -30,7 +30,7 @@ namespace {
 class OneHotShapeInfer : public ShapeInferEmptyPads {
 public:
     explicit OneHotShapeInfer(int64_t axis) : m_axis(axis) {}
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         auto depth = reinterpret_cast<int32_t *>(data_dependency.at(1)->GetPtr())[0];
@@ -38,7 +38,7 @@ public:
         auto result = input_shapes.front().get();
         result.insert(result.begin() + m_axis, depth);
 
-        return {{std::move(result)}, ShapeInferStatus::update};
+        return {{std::move(result)}, ShapeInferStatus::success};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/priorbox.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox.cpp
@@ -30,14 +30,14 @@ class PriorBoxShapeInfer : public ShapeInferEmptyPads {
  */
 public:
     explicit PriorBoxShapeInfer(int64_t number_of_priors) : m_number_of_priors(number_of_priors) {}
-    std::vector<VectorDims> infer(
+    ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const int* in_data = reinterpret_cast<const int*>(data_dependency.at(0)->GetPtr());
         const int H = in_data[0];
         const int W = in_data[1];
         const auto output = static_cast<size_t>(4 * H * W * m_number_of_priors);
-        return {{2, output}};
+        return {{{2, output}}, ShapeInferStatus::update};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/priorbox.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox.cpp
@@ -30,14 +30,14 @@ class PriorBoxShapeInfer : public ShapeInferEmptyPads {
  */
 public:
     explicit PriorBoxShapeInfer(int64_t number_of_priors) : m_number_of_priors(number_of_priors) {}
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const int* in_data = reinterpret_cast<const int*>(data_dependency.at(0)->GetPtr());
         const int H = in_data[0];
         const int W = in_data[1];
         const auto output = static_cast<size_t>(4 * H * W * m_number_of_priors);
-        return {{{2, output}}, ShapeInferStatus::update};
+        return {{{2, output}}, ShapeInferStatus::success};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
@@ -29,14 +29,14 @@ namespace {
 class PriorBoxClusteredShapeInfer : public ShapeInferEmptyPads {
 public:
     explicit PriorBoxClusteredShapeInfer(size_t number_of_priors) : m_number_of_priors(number_of_priors) {}
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const int* in_data = reinterpret_cast<const int*>(data_dependency.at(0)->GetPtr());
         const int H = in_data[0];
         const int W = in_data[1];
         const auto output = static_cast<size_t>(4 * H * W * m_number_of_priors);
-        return {{{2, output}}, ShapeInferStatus::update};
+        return {{{2, output}}, ShapeInferStatus::success};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
@@ -29,14 +29,14 @@ namespace {
 class PriorBoxClusteredShapeInfer : public ShapeInferEmptyPads {
 public:
     explicit PriorBoxClusteredShapeInfer(size_t number_of_priors) : m_number_of_priors(number_of_priors) {}
-    std::vector<VectorDims> infer(
+    ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const int* in_data = reinterpret_cast<const int*>(data_dependency.at(0)->GetPtr());
         const int H = in_data[0];
         const int W = in_data[1];
         const auto output = static_cast<size_t>(4 * H * W * m_number_of_priors);
-        return {{2, output}};
+        return {{{2, output}}, ShapeInferStatus::update};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/reference.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reference.cpp
@@ -4,6 +4,7 @@
 
 #include "reference.h"
 #include <ie_ngraph_utils.hpp>
+#include <shape_util.hpp>
 #include <dnnl_extension_utils.h>
 #include "openvino/runtime/tensor.hpp"
 #include "common/blocked_desc_creator.h"
@@ -80,7 +81,7 @@ void Reference::executeDynamicImpl(dnnl::stream strm) {
             if (mem_desc->isDefined()) {
                 outputs.emplace_back(ngraphOp->get_output_element_type(i), mem_desc->getShape().getStaticDims());
             } else {
-                outputs.emplace_back(ngraphOp->get_output_element_type(i), ov::Shape(mem_desc->getShape().getRank()));
+                outputs.emplace_back(ngraphOp->get_output_element_type(i), ov::util::make_dynamic_shape());
             }
         }
     } else {

--- a/src/plugins/intel_cpu/src/nodes/reference.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reference.cpp
@@ -72,7 +72,7 @@ void Reference::executeDynamicImpl(dnnl::stream strm) {
     auto result = Node::shapeInfer();
     if (ShapeInferStatus::update == result.status) {
         Node::redefineOutputMemory(result.dims);
-        auto outputs = prepareOutputs();
+        outputs = prepareOutputs();
     } else if (ShapeInferStatus::skip == result.status) {
         outputs.reserve(outputShapes.size());
         for (size_t i = 0; i < outputShapes.size(); ++i) {
@@ -102,7 +102,7 @@ void Reference::executeDynamicImpl(dnnl::stream strm) {
             auto memory = getChildEdgesAtPort(i)[0]->getMemoryPtr();
             auto& tensor = outputs[i];
             if (memory->GetSize() != tensor.get_byte_size()) {
-                IE_THROW(Unexpected) << "Output tensor data size mismatch happened during the inference of a node with type " <<
+                IE_THROW(Unexpected) << "Output tensor data size mismatch occurred during the inference of a node with type " <<
                 getTypeStr() << " and name " << getName() << " on output port number " << i;
             }
             cpu_memcpy(memory->GetData(), tensor.data(), tensor.get_byte_size());

--- a/src/plugins/intel_cpu/src/nodes/reference.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reference.cpp
@@ -70,7 +70,7 @@ void Reference::executeDynamicImpl(dnnl::stream strm) {
     auto inputs = prepareInputs();
     ov::TensorVector outputs;
     auto result = Node::shapeInfer();
-    if (ShapeInferStatus::update == result.status) {
+    if (ShapeInferStatus::success == result.status) {
         Node::redefineOutputMemory(result.dims);
         outputs = prepareOutputs();
     } else if (ShapeInferStatus::skip == result.status) {

--- a/src/plugins/intel_cpu/src/nodes/reference.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reference.cpp
@@ -8,6 +8,7 @@
 #include "openvino/runtime/tensor.hpp"
 #include "common/blocked_desc_creator.h"
 #include <ngraph/opsets/opset1.hpp>
+#include "common/cpu_memcpy.h"
 
 using namespace dnnl;
 using namespace InferenceEngine;
@@ -58,27 +59,55 @@ void Reference::initSupportedPrimitiveDescriptors() {
 void Reference::createPrimitive() {}
 
 void Reference::execute(dnnl::stream strm) {
-    ov::TensorVector inputs;
-    for (size_t i = 0; i < inputShapes.size(); i++) {
-        void *srcDataPtr = getParentEdgesAtPort(i)[0]->getMemory().GetPtr();
-        inputs.push_back(ov::Tensor(ngraphOp->get_input_element_type(i),
-                                             getParentEdgesAtPort(i)[0]->getMemory().getStaticDims(), srcDataPtr));
-    }
-
-    ov::TensorVector outputs;
-    for (size_t i = 0; i < outputShapes.size(); i++) {
-        void *dstDataPtr = getChildEdgesAtPort(i)[0]->getMemory().GetPtr();
-        outputs.push_back(ov::Tensor(ngraphOp->get_output_element_type(i),
-                                              getChildEdgesAtPort(i)[0]->getMemory().getStaticDims(), dstDataPtr));
-    }
-
+    auto inputs = prepareInputs();
+    auto outputs = prepareOutputs();
     if (!ngraphOp->evaluate(outputs, inputs)) {
         IE_THROW() << "Evaluation failed on node of type: " << std::string(ngraphOp->get_type_name()) << " name: " << getName();
     }
 }
 
 void Reference::executeDynamicImpl(dnnl::stream strm) {
-    execute(strm);
+    auto inputs = prepareInputs();
+    ov::TensorVector outputs;
+    auto result = Node::shapeInfer();
+    if (ShapeInferStatus::update == result.status) {
+        Node::redefineOutputMemory(result.dims);
+        auto outputs = prepareOutputs();
+    } else if (ShapeInferStatus::skip == result.status) {
+        outputs.reserve(outputShapes.size());
+        for (size_t i = 0; i < outputShapes.size(); ++i) {
+            auto mem_desc = getBaseMemDescAtOutputPort(i);
+            if (mem_desc->isDefined()) {
+                outputs.emplace_back(ngraphOp->get_output_element_type(i), mem_desc->getShape().getStaticDims());
+            } else {
+                outputs.emplace_back(ngraphOp->get_output_element_type(i), ov::Shape(mem_desc->getShape().getRank()));
+            }
+        }
+    } else {
+         IE_THROW(Unexpected) <<
+            "Unexpected shape infer result status during the inference of a node with type " <<
+            getTypeStr() << " and name " << getName();
+    }
+    if (!ngraphOp->evaluate(outputs, inputs)) {
+        IE_THROW() << "Evaluation failed on node of type: " << std::string(ngraphOp->get_type_name()) << " name: " << getName();
+    }
+    if (ShapeInferStatus::skip == result.status) {
+        std::vector<VectorDims> newOutputDims;
+        newOutputDims.reserve(outputs.size());
+        for (auto& tensor : outputs) {
+            newOutputDims.emplace_back(tensor.get_shape());
+        }
+        Node::redefineOutputMemory(newOutputDims);
+        for (size_t i = 0; i < outputShapes.size(); ++i) {
+            auto memory = getChildEdgesAtPort(i)[0]->getMemoryPtr();
+            auto& tensor = outputs[i];
+            if (memory->GetSize() != tensor.get_byte_size()) {
+                IE_THROW(Unexpected) << "Output tensor data size mismatch happened during the inference of a node with type " <<
+                getTypeStr() << " and name " << getName() << " on output port number " << i;
+            }
+            cpu_memcpy(memory->GetData(), tensor.data(), tensor.get_byte_size());
+        }
+    }
 }
 
 bool Reference::created() const {
@@ -86,7 +115,27 @@ bool Reference::created() const {
 }
 
 bool Reference::needShapeInfer() const {
-    return true;
+    return false;
+}
+
+ov::TensorVector Reference::prepareInputs() const {
+    ov::TensorVector inputs;
+    for (size_t i = 0; i < inputShapes.size(); i++) {
+        void *srcDataPtr = getParentEdgesAtPort(i)[0]->getMemory().GetPtr();
+        inputs.push_back(ov::Tensor(ngraphOp->get_input_element_type(i),
+                                             getParentEdgesAtPort(i)[0]->getMemory().getStaticDims(), srcDataPtr));
+    }
+    return inputs;
+}
+
+ov::TensorVector Reference::prepareOutputs() const {
+    ov::TensorVector outputs;
+    for (size_t i = 0; i < outputShapes.size(); i++) {
+        void *dstDataPtr = getChildEdgesAtPort(i)[0]->getMemory().GetPtr();
+        outputs.push_back(ov::Tensor(ngraphOp->get_output_element_type(i),
+                                              getChildEdgesAtPort(i)[0]->getMemory().getStaticDims(), dstDataPtr));
+    }
+    return outputs;
 }
 
 }   // namespace node

--- a/src/plugins/intel_cpu/src/nodes/reference.h
+++ b/src/plugins/intel_cpu/src/nodes/reference.h
@@ -25,6 +25,10 @@ public:
     void executeDynamicImpl(dnnl::stream strm) override;
 
 private:
+    ov::TensorVector prepareInputs() const;
+    ov::TensorVector prepareOutputs() const;
+
+private:
     const std::shared_ptr<ngraph::Node> ngraphOp;
     const std::string additionalErrorMessage;
 };

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -314,16 +314,21 @@ public:
             native_order = RNN::testNativeOrder(op);
         }
 
-    std::vector<VectorDims> infer(
+    ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
-        auto originOutputShapes = NgraphShapeInfer::infer(input_shapes, data_dependency);
+        auto result = NgraphShapeInfer::infer(input_shapes, data_dependency);
+        if (ShapeInferStatus::update != result.status) {
+            IE_THROW(Unexpected) << "Unexpected shape inference result status";
+        }
+
+        auto& originOutputShapes = result.dims;
 
         // Graph optimizer makes the same optimization. So this is required to make shapes compatible.
         if (is_sequence && !native_order && originOutputShapes[0].size() == 4lu && originOutputShapes[0][1] == 1lu) {
             originOutputShapes[0].erase(originOutputShapes[0].begin() + 1);
         }
-        return originOutputShapes;
+        return {std::move(originOutputShapes), result.status};
     }
 
 private:

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -314,11 +314,11 @@ public:
             native_order = RNN::testNativeOrder(op);
         }
 
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         auto result = NgraphShapeInfer::infer(input_shapes, data_dependency);
-        if (ShapeInferStatus::update != result.status) {
+        if (ShapeInferStatus::success != result.status) {
             IE_THROW(Unexpected) << "Unexpected shape inference result status";
         }
 

--- a/src/plugins/intel_cpu/src/nodes/shapeof.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.cpp
@@ -21,11 +21,11 @@ namespace {
 class ShapeOfShapeInfer : public ShapeInferEmptyPads {
 public:
     ShapeOfShapeInfer() = default;
-    std::vector<VectorDims> infer(
+    ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         IE_ASSERT(!input_shapes.empty());
-        return {VectorDims{input_shapes.front().get().size()}};
+        return {{VectorDims{input_shapes.front().get().size()}}, ShapeInferStatus::update};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/shapeof.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.cpp
@@ -21,11 +21,11 @@ namespace {
 class ShapeOfShapeInfer : public ShapeInferEmptyPads {
 public:
     ShapeOfShapeInfer() = default;
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         IE_ASSERT(!input_shapes.empty());
-        return {{VectorDims{input_shapes.front().get().size()}}, ShapeInferStatus::update};
+        return {{VectorDims{input_shapes.front().get().size()}}, ShapeInferStatus::success};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -37,9 +37,38 @@ namespace ov {
 namespace intel_cpu {
 namespace node {
 
+/* This class implementation is a temporal WA
+   TODO: revise the implementation to remove the node reference*/    
+class SnippetShapeInfer : public ShapeInferEmptyPads {
+public:
+    SnippetShapeInfer(Snippet* node) : m_node(node) {}
+    ShapeInferResult infer(
+        const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
+        const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
+        return {m_node->shapeInfer(), ShapeInferStatus::update};
+    }
+
+    port_mask_t get_port_mask() const override {
+        return EMPTY_PORT_MASK;
+    }
+
+private:
+    Snippet* m_node;
+};
+
+class SnippetShapeInferFactory : public ShapeInferFactory {
+public:
+    SnippetShapeInferFactory(Snippet* node) : m_node(node) {}
+    ShapeInferPtr makeShapeInfer() const override {
+        return std::make_shared<SnippetShapeInfer>(m_node);
+    }
+
+private:
+    Snippet* m_node;
+};
 
 Snippet::Snippet(const std::shared_ptr<ngraph::Node>& op, const GraphContext::CPtr context)
-        : Node(op, context, NgraphShapeInferFactory(op, EMPTY_PORT_MASK)) {
+        : Node(op, context, SnippetShapeInferFactory(this)) {
     host_isa = dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core) ?
         dnnl::impl::cpu::x64::avx512_core : dnnl::impl::cpu::x64::avx2;
     original_snippet = ov::as_type_ptr<ngraph::snippets::op::Subgraph>(op);
@@ -349,65 +378,65 @@ void Snippet::createPrimitive() {
     buffer_scratchpad.resize(buffer_scratchpad_size * parallel_get_max_threads(), 0);
 }
 
-// std::vector<VectorDims> Snippet::shapeInfer() const {
-//     // todo: it's very strange that we don't have broadcast_merge_into for cpu shapes
-//     auto broadcast_merge = [](VectorDims& dst, const VectorDims& src){
-//         // Ranks are both static.
-//         auto dst_rank = dst.size();
-//         auto src_rank = src.size();
-//         const auto new_rank = std::max(dst_rank, src_rank);
-//         dst.insert(dst.begin(), new_rank - dst_rank, 1);
-//         std::vector<Dimension> dims(new_rank);
-//         bool success = true;
-//         for (int64_t i = 0; i < new_rank; i++) {
-//             auto dsti = i < (new_rank - dst_rank) ? 1 : dst[i - (new_rank - dst_rank)];
-//             auto srci = i < (new_rank - src_rank) ? 1 : src[i - (new_rank - src_rank)];
-//             if (dsti != srci && srci != Shape::UNDEFINED_DIM) {
-//                 if (dsti == 1 || dsti == Shape::UNDEFINED_DIM) {
-//                     dsti = srci;
-//                 } else {
-//                     success = false;
-//                 }
-//             }
-//         }
-//         return success;
-//     };
-//     for (size_t i = 0; i < getParentEdges().size(); i++) {
-//         VectorDims inDims {getParentEdgesAtPort(i)[0]->getMemory().GetShape().getDims()};
-//         if (masterShapeIsBlocked && !inputShapeIsBlocked[i])
-//             inDims.insert(inDims.end(), 1);
-//         // todo: this is a simple master_shape inference for shape-agnostic operations,
-//         //  we'll need to account for body operations semantics in the future
-//         if (i == 0)
-//             masterShape = inDims;
-//         else
-//             broadcast_merge(masterShape, inDims);
-//         normInputShapes[i] = std::move(inDims);
-//     }
-//     if (std::any_of(masterShape.begin(), masterShape.end(), [](const Dim& d){ return d == Shape::UNDEFINED_DIM;})) {
-//         std::ostringstream errorMessage;
-//         errorMessage << "Can't compute static master shape for Snippet node with name: " << getName();
-//         errorMessage << ". Input shapes = ( ";
-//         for (size_t i = 0; i < getParentEdges().size(); i++) {
-//             errorMessage << i << " port = " << getParentEdgesAtPort(i)[0]->getMemory().GetShape().toString() << ", ";
-//         }
-//         errorMessage << "). Master shape = ( " << Shape(masterShape).toString() << " )";
-//         IE_THROW() << errorMessage.str();
-//     }
+std::vector<VectorDims> Snippet::shapeInfer() {
+    // todo: it's very strange that we don't have broadcast_merge_into for cpu shapes
+    auto broadcast_merge = [](VectorDims& dst, const VectorDims& src){
+        // Ranks are both static.
+        auto dst_rank = dst.size();
+        auto src_rank = src.size();
+        const auto new_rank = std::max(dst_rank, src_rank);
+        dst.insert(dst.begin(), new_rank - dst_rank, 1);
+        std::vector<Dimension> dims(new_rank);
+        bool success = true;
+        for (int64_t i = 0; i < new_rank; i++) {
+            auto dsti = i < (new_rank - dst_rank) ? 1 : dst[i - (new_rank - dst_rank)];
+            auto srci = i < (new_rank - src_rank) ? 1 : src[i - (new_rank - src_rank)];
+            if (dsti != srci && srci != Shape::UNDEFINED_DIM) {
+                if (dsti == 1 || dsti == Shape::UNDEFINED_DIM) {
+                    dsti = srci;
+                } else {
+                    success = false;
+                }
+            }
+        }
+        return success;
+    };
+    for (size_t i = 0; i < getParentEdges().size(); i++) {
+        VectorDims inDims {getParentEdgesAtPort(i)[0]->getMemory().GetShape().getDims()};
+        if (masterShapeIsBlocked && !inputShapeIsBlocked[i])
+            inDims.insert(inDims.end(), 1);
+        // todo: this is a simple master_shape inference for shape-agnostic operations,
+        //  we'll need to account for body operations semantics in the future
+        if (i == 0)
+            masterShape = inDims;
+        else
+            broadcast_merge(masterShape, inDims);
+        normInputShapes[i] = std::move(inDims);
+    }
+    if (std::any_of(masterShape.begin(), masterShape.end(), [](const Dim& d){ return d == Shape::UNDEFINED_DIM;})) {
+        std::ostringstream errorMessage;
+        errorMessage << "Can't compute static master shape for Snippet node with name: " << getName();
+        errorMessage << ". Input shapes = ( ";
+        for (size_t i = 0; i < getParentEdges().size(); i++) {
+            errorMessage << i << " port = " << getParentEdgesAtPort(i)[0]->getMemory().GetShape().toString() << ", ";
+        }
+        errorMessage << "). Master shape = ( " << Shape(masterShape).toString() << " )";
+        IE_THROW() << errorMessage.str();
+    }
 
-//     if (normOutputShapes.size() == 1) {
-//         normOutputShapes[0] = masterShape;
-//         return {masterShape};
-//     }
-//     std::vector<VectorDims> outputDims;
-//     std::vector<ov::Shape> new_shapes;
-//     for (const auto& s : normInputShapes)
-//         new_shapes.emplace_back(s);
-//     const auto& outputShapes = snippet->reshape_body(new_shapes);
-//     for (size_t i = 0; i < outputShapes.size(); i++)
-//             normOutputShapes[i] = outputShapes[i];
-//     return normOutputShapes;
-// }
+    if (normOutputShapes.size() == 1) {
+        normOutputShapes[0] = masterShape;
+        return {masterShape};
+    }
+    std::vector<VectorDims> outputDims;
+    std::vector<ov::Shape> new_shapes;
+    for (const auto& s : normInputShapes)
+        new_shapes.emplace_back(s);
+    const auto& outputShapes = snippet->reshape_body(new_shapes);
+    for (size_t i = 0; i < outputShapes.size(); i++)
+            normOutputShapes[i] = outputShapes[i];
+    return normOutputShapes;
+}
 
 void Snippet::prepareParams() {
     masterShape = getNormalizedDimsBySize(masterShape, tensorRank);

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -42,10 +42,10 @@ namespace node {
 class SnippetShapeInfer : public ShapeInferEmptyPads {
 public:
     SnippetShapeInfer(Snippet* node) : m_node(node) {}
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
-        return {m_node->shapeInfer(), ShapeInferStatus::update};
+        return {m_node->shapeInfer(), ShapeInferStatus::success};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/subgraph.h
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.h
@@ -39,7 +39,7 @@ public:
     // Here we convert to canonical for & jit everything
     void createPrimitive() override;
     void prepareParams() override;
-    std::vector<VectorDims> shapeInfer() const override;
+    //std::vector<VectorDims> shapeInfer() const override;
     bool needPrepareParams() const override;
 
     bool canBeInPlace() const override;

--- a/src/plugins/intel_cpu/src/nodes/subgraph.h
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.h
@@ -39,7 +39,7 @@ public:
     // Here we convert to canonical for & jit everything
     void createPrimitive() override;
     void prepareParams() override;
-    //std::vector<VectorDims> shapeInfer() const override;
+    std::vector<VectorDims> shapeInfer();
     bool needPrepareParams() const override;
 
     bool canBeInPlace() const override;
@@ -100,10 +100,9 @@ private:
     std::vector<bool> outputShapeIsBlocked = {}; // we need this info to shape-infer mixed layouts
     bool masterShapeIsBlocked = false;
 
-    // master shape is mutable since we need to modify it inside const shapeInfer method
-    mutable VectorDims masterShape = {};
-    mutable std::vector<VectorDims> normInputShapes = {};
-    mutable std::vector<VectorDims> normOutputShapes = {};
+    VectorDims masterShape = {};
+    std::vector<VectorDims> normInputShapes = {};
+    std::vector<VectorDims> normOutputShapes = {};
 
     std::vector<ptrdiff_t> start_offset_in = {};
     std::vector<ptrdiff_t> start_offset_out = {};

--- a/src/plugins/intel_cpu/src/nodes/transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/transpose.cpp
@@ -40,7 +40,7 @@ bool Transpose::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, 
 class TransposeDynShapeInfer : public ShapeInferEmptyPads {
 public:
     TransposeDynShapeInfer() = default;
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         IE_THROW(NotImplemented) << "TODO: Support parameterized Order input for dynamic shapes.";
@@ -56,7 +56,7 @@ public:
     TransposeShapeInfer(const size_t& out_rank, const std::vector<size_t>& axes_vec)
     : m_out_rank(out_rank), m_axes_vec(axes_vec), m_outputShape(out_rank, 1), m_needReverse(axes_vec.empty()) {}
 
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const VectorDims& shapeIn = input_shapes[0].get();
@@ -69,7 +69,7 @@ public:
                 m_outputShape[i] = shapeIn[m_axes_vec[i]];
             }
         }
-        return {{m_outputShape}, ShapeInferStatus::update};
+        return {{m_outputShape}, ShapeInferStatus::success};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/nodes/transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/transpose.cpp
@@ -40,7 +40,7 @@ bool Transpose::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, 
 class TransposeDynShapeInfer : public ShapeInferEmptyPads {
 public:
     TransposeDynShapeInfer() = default;
-    std::vector<VectorDims> infer(
+    ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         IE_THROW(NotImplemented) << "TODO: Support parameterized Order input for dynamic shapes.";
@@ -56,7 +56,7 @@ public:
     TransposeShapeInfer(const size_t& out_rank, const std::vector<size_t>& axes_vec)
     : m_out_rank(out_rank), m_axes_vec(axes_vec), m_outputShape(out_rank, 1), m_needReverse(axes_vec.empty()) {}
 
-    std::vector<VectorDims> infer(
+    ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const VectorDims& shapeIn = input_shapes[0].get();
@@ -69,7 +69,7 @@ public:
                 m_outputShape[i] = shapeIn[m_axes_vec[i]];
             }
         }
-        return {m_outputShape};
+        return {{m_outputShape}, ShapeInferStatus::update};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.cpp
@@ -116,12 +116,12 @@ class entryIO : public entryBase {
 public:
     using entryBase::entryBase;
 
-    IShapeInferCommon::ShapeInferResult
+    IShapeInferCommon::Result
     infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         auto op = static_cast<OP*>(node.get());
         std::vector<StaticShape> output_shapes(op->get_output_size());
         shape_infer(op, input_shapes, output_shapes);
-        return {std::move(output_shapes), ShapeInferStatus::update};
+        return {std::move(output_shapes), ShapeInferStatus::success};
     }
 };
 
@@ -130,12 +130,12 @@ class entryIOC : public entryBase {
 public:
     using entryBase::entryBase;
 
-    IShapeInferCommon::ShapeInferResult
+    IShapeInferCommon::Result
     infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         auto op = static_cast<OP*>(node.get());
         std::vector<StaticShape> output_shapes(op->get_output_size());
         shape_infer(op, input_shapes, output_shapes, constant_data);
-        return {std::move(output_shapes), ShapeInferStatus::update};
+        return {std::move(output_shapes), ShapeInferStatus::success};
     }
 };
 
@@ -143,12 +143,12 @@ class entryCopy : public entryBase {
 public:
     using entryBase::entryBase;
 
-    IShapeInferCommon::ShapeInferResult
+    IShapeInferCommon::Result
     infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         auto op = node.get();
         std::vector<StaticShape> output_shapes(op->get_output_size());
         copy_shape_infer(op, input_shapes, output_shapes);
-        return {std::move(output_shapes), ShapeInferStatus::update};
+        return {std::move(output_shapes), ShapeInferStatus::success};
     }
 };
 
@@ -156,12 +156,12 @@ class entryFirstPassthrough : public entryBase {
 public:
     using entryBase::entryBase;
 
-    IShapeInferCommon::ShapeInferResult
+    IShapeInferCommon::Result
     infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         auto op = node.get();
         std::vector<StaticShape> output_shapes(op->get_output_size());
         first_input_passthrough_infer(op, input_shapes, output_shapes);
-        return {std::move(output_shapes), ShapeInferStatus::update};
+        return {std::move(output_shapes), ShapeInferStatus::success};
     }
 };
 
@@ -169,12 +169,12 @@ class entryEltwise : public entryBase {
 public:
     using entryBase::entryBase;
 
-    IShapeInferCommon::ShapeInferResult
+    IShapeInferCommon::Result
     infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         auto op = node.get();
         std::vector<StaticShape> output_shapes(op->get_output_size());
         eltwise_shape_infer(op, input_shapes, output_shapes);
-        return {std::move(output_shapes), ShapeInferStatus::update};
+        return {std::move(output_shapes), ShapeInferStatus::success};
     }
 };
 
@@ -199,7 +199,7 @@ public:
 
     virtual void post_validate_and_infer_types(const std::shared_ptr<ov::Node>& local_op) {}
 
-    IShapeInferCommon::ShapeInferResult
+    IShapeInferCommon::Result
     infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         auto op = node.get();
         std::vector<StaticShape> output_shapes;
@@ -244,7 +244,7 @@ public:
 
         post_validate_and_infer_types(local_op);
 
-        return {std::move(output_shapes), ShapeInferStatus::update};
+        return {std::move(output_shapes), ShapeInferStatus::success};
     }
 };
 
@@ -287,14 +287,14 @@ class entryInterpolate : public entryBase {
 public:
     using entryBase::entryBase;
 
-    IShapeInferCommon::ShapeInferResult
+    IShapeInferCommon::Result
     infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         std::vector<size_t> pads_begin, pads_end;
         auto op = static_cast<OP*>(node.get());
         std::vector<StaticShape> output_shapes(op->get_output_size());
         correct_pads_attr(op, pads_begin, pads_end, input_shapes);
         shape_infer(op, pads_begin, pads_end, input_shapes, output_shapes, constant_data);
-        return {std::move(output_shapes), ShapeInferStatus::update};
+        return {std::move(output_shapes), ShapeInferStatus::success};
     }
 };
 
@@ -308,7 +308,7 @@ public:
     const ov::CoordinateDiff& get_pads_end() override {
         return pads_end;
     }
-    IShapeInferCommon::ShapeInferResult
+    IShapeInferCommon::Result
     infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         auto op = static_cast<OP*>(node.get());
         std::vector<StaticShape> output_shapes(op->get_output_size());
@@ -316,7 +316,7 @@ public:
         OPENVINO_ASSERT(status,
                         "Convolution shape inference doesn't have enough information to calculate static shapes");
         shape_infer(op, pads_begin, pads_end, input_shapes, output_shapes);
-        return {std::move(output_shapes), ShapeInferStatus::update};
+        return {std::move(output_shapes), ShapeInferStatus::success};
     }
 
 protected:
@@ -334,7 +334,7 @@ public:
     const ov::CoordinateDiff& get_pads_end() override {
         return pads_end;
     }
-    IShapeInferCommon::ShapeInferResult
+    IShapeInferCommon::Result
     infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         StaticShape output_shape_input;
         auto op = static_cast<OP*>(node.get());
@@ -352,7 +352,7 @@ public:
             status,
             "ConvolutionBackpropData shape inference doesn't have enough information to calculate static shapes");
         shape_infer(op, pads_begin, pads_end, output_shape_input, input_shapes, output_shapes);
-        return {std::move(output_shapes), ShapeInferStatus::update};
+        return {std::move(output_shapes), ShapeInferStatus::success};
     }
 
 protected:
@@ -374,7 +374,7 @@ public:
         }
     }
 
-    IShapeInferCommon::ShapeInferResult
+    IShapeInferCommon::Result
     infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         // For backward compatibility, create ov tensors and run shape inference.
         TensorVector tensors;
@@ -388,10 +388,10 @@ public:
         return infer(input_shapes, const_tensor_map);
     }
 
-    IShapeInferCommon::ShapeInferResult
+    IShapeInferCommon::Result
     infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, std::reference_wrapper<const Tensor>>& constant_data) override {
         auto result = shape_infer(static_cast<TOp*>(m_node.get()), input_shapes, constant_data);
-        return {std::move(result), ShapeInferStatus::update};
+        return {std::move(result), ShapeInferStatus::success};
     }
 
     const ov::CoordinateDiff& get_pads_begin() override {

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.cpp
@@ -116,12 +116,12 @@ class entryIO : public entryBase {
 public:
     using entryBase::entryBase;
 
-    std::vector<StaticShape> infer(const std::vector<StaticShape>& input_shapes,
-                                   const std::map<size_t, HostTensorPtr>& constant_data) override {
+    IShapeInferCommon::ShapeInferResult
+    infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         auto op = static_cast<OP*>(node.get());
         std::vector<StaticShape> output_shapes(op->get_output_size());
         shape_infer(op, input_shapes, output_shapes);
-        return output_shapes;
+        return {std::move(output_shapes), ShapeInferStatus::update};
     }
 };
 
@@ -130,12 +130,12 @@ class entryIOC : public entryBase {
 public:
     using entryBase::entryBase;
 
-    std::vector<StaticShape> infer(const std::vector<StaticShape>& input_shapes,
-                                   const std::map<size_t, HostTensorPtr>& constant_data) override {
+    IShapeInferCommon::ShapeInferResult
+    infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         auto op = static_cast<OP*>(node.get());
         std::vector<StaticShape> output_shapes(op->get_output_size());
         shape_infer(op, input_shapes, output_shapes, constant_data);
-        return output_shapes;
+        return {std::move(output_shapes), ShapeInferStatus::update};
     }
 };
 
@@ -143,12 +143,12 @@ class entryCopy : public entryBase {
 public:
     using entryBase::entryBase;
 
-    std::vector<StaticShape> infer(const std::vector<StaticShape>& input_shapes,
-                                   const std::map<size_t, HostTensorPtr>& constant_data) override {
+    IShapeInferCommon::ShapeInferResult
+    infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         auto op = node.get();
         std::vector<StaticShape> output_shapes(op->get_output_size());
         copy_shape_infer(op, input_shapes, output_shapes);
-        return output_shapes;
+        return {std::move(output_shapes), ShapeInferStatus::update};
     }
 };
 
@@ -156,12 +156,12 @@ class entryFirstPassthrough : public entryBase {
 public:
     using entryBase::entryBase;
 
-    std::vector<StaticShape> infer(const std::vector<StaticShape>& input_shapes,
-                                   const std::map<size_t, HostTensorPtr>& constant_data) override {
+    IShapeInferCommon::ShapeInferResult
+    infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         auto op = node.get();
         std::vector<StaticShape> output_shapes(op->get_output_size());
         first_input_passthrough_infer(op, input_shapes, output_shapes);
-        return output_shapes;
+        return {std::move(output_shapes), ShapeInferStatus::update};
     }
 };
 
@@ -169,12 +169,12 @@ class entryEltwise : public entryBase {
 public:
     using entryBase::entryBase;
 
-    std::vector<StaticShape> infer(const std::vector<StaticShape>& input_shapes,
-                                   const std::map<size_t, HostTensorPtr>& constant_data) override {
+    IShapeInferCommon::ShapeInferResult
+    infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         auto op = node.get();
         std::vector<StaticShape> output_shapes(op->get_output_size());
         eltwise_shape_infer(op, input_shapes, output_shapes);
-        return output_shapes;
+        return {std::move(output_shapes), ShapeInferStatus::update};
     }
 };
 
@@ -199,8 +199,8 @@ public:
 
     virtual void post_validate_and_infer_types(const std::shared_ptr<ov::Node>& local_op) {}
 
-    std::vector<StaticShape> infer(const std::vector<StaticShape>& input_shapes,
-                                   const std::map<size_t, HostTensorPtr>& constant_data) override {
+    IShapeInferCommon::ShapeInferResult
+    infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         auto op = node.get();
         std::vector<StaticShape> output_shapes;
 
@@ -236,19 +236,7 @@ public:
             const auto& partial_shape = local_op->get_output_partial_shape(i);
 
             if (partial_shape.is_dynamic()) {
-                std::ostringstream errorMessage;
-                errorMessage << "Can't compute static output shape on " << i << " port for " << op->get_type_name()
-                             << " node with name: " << op->get_name();
-                errorMessage << ". Input shapes = ( ";
-                for (size_t in = 0; in < op->get_input_size(); in++) {
-                    errorMessage << in << " port = " << op->get_input_partial_shape(in) << ", ";
-                }
-                errorMessage << "). Output shapes = ( ";
-                for (size_t out = 0; out < op->get_output_size(); out++) {
-                    errorMessage << out << " port = " << op->get_output_partial_shape(out) << ", ";
-                }
-                errorMessage << ")";
-                OPENVINO_ASSERT(false, errorMessage.str());
+                return {{}, ShapeInferStatus::skip};
             }
 
             output_shapes[i] = StaticShape(partial_shape.to_shape());
@@ -256,7 +244,7 @@ public:
 
         post_validate_and_infer_types(local_op);
 
-        return output_shapes;
+        return {std::move(output_shapes), ShapeInferStatus::update};
     }
 };
 
@@ -299,15 +287,14 @@ class entryInterpolate : public entryBase {
 public:
     using entryBase::entryBase;
 
-    std::vector<StaticShape> infer(
-        const std::vector<StaticShape>& input_shapes,
-        const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data) override {
+    IShapeInferCommon::ShapeInferResult
+    infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         std::vector<size_t> pads_begin, pads_end;
         auto op = static_cast<OP*>(node.get());
         std::vector<StaticShape> output_shapes(op->get_output_size());
         correct_pads_attr(op, pads_begin, pads_end, input_shapes);
         shape_infer(op, pads_begin, pads_end, input_shapes, output_shapes, constant_data);
-        return output_shapes;
+        return {std::move(output_shapes), ShapeInferStatus::update};
     }
 };
 
@@ -321,16 +308,15 @@ public:
     const ov::CoordinateDiff& get_pads_end() override {
         return pads_end;
     }
-    std::vector<StaticShape> infer(
-        const std::vector<StaticShape>& input_shapes,
-        const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data) override {
+    IShapeInferCommon::ShapeInferResult
+    infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         auto op = static_cast<OP*>(node.get());
         std::vector<StaticShape> output_shapes(op->get_output_size());
         bool status = resolve_auto_pad_for_shape(op, pads_begin, pads_end, input_shapes, 2, is_grouped ? 3 : 2);
         OPENVINO_ASSERT(status,
                         "Convolution shape inference doesn't have enough information to calculate static shapes");
         shape_infer(op, pads_begin, pads_end, input_shapes, output_shapes);
-        return output_shapes;
+        return {std::move(output_shapes), ShapeInferStatus::update};
     }
 
 protected:
@@ -348,9 +334,8 @@ public:
     const ov::CoordinateDiff& get_pads_end() override {
         return pads_end;
     }
-    std::vector<StaticShape> infer(
-        const std::vector<StaticShape>& input_shapes,
-        const std::map<size_t, std::shared_ptr<ngraph::runtime::HostTensor>>& constant_data) override {
+    IShapeInferCommon::ShapeInferResult
+    infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         StaticShape output_shape_input;
         auto op = static_cast<OP*>(node.get());
         std::vector<StaticShape> output_shapes(op->get_output_size());
@@ -367,7 +352,7 @@ public:
             status,
             "ConvolutionBackpropData shape inference doesn't have enough information to calculate static shapes");
         shape_infer(op, pads_begin, pads_end, output_shape_input, input_shapes, output_shapes);
-        return output_shapes;
+        return {std::move(output_shapes), ShapeInferStatus::update};
     }
 
 protected:
@@ -389,8 +374,8 @@ public:
         }
     }
 
-    std::vector<StaticShape> infer(const std::vector<StaticShape>& input_shapes,
-                                   const std::map<size_t, HostTensorPtr>& constant_data) override {
+    IShapeInferCommon::ShapeInferResult
+    infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, HostTensorPtr>& constant_data) override {
         // For backward compatibility, create ov tensors and run shape inference.
         TensorVector tensors;
         tensors.reserve(constant_data.size());
@@ -403,10 +388,10 @@ public:
         return infer(input_shapes, const_tensor_map);
     }
 
-    std::vector<StaticShape> infer(
-        const std::vector<StaticShape>& input_shapes,
-        const std::map<size_t, std::reference_wrapper<const Tensor>>& constant_data) override {
-        return shape_infer(static_cast<TOp*>(m_node.get()), input_shapes, constant_data);
+    IShapeInferCommon::ShapeInferResult
+    infer(const std::vector<StaticShape>& input_shapes, const std::map<size_t, std::reference_wrapper<const Tensor>>& constant_data) override {
+        auto result = shape_infer(static_cast<TOp*>(m_node.get()), input_shapes, constant_data);
+        return {std::move(result), ShapeInferStatus::update};
     }
 
     const ov::CoordinateDiff& get_pads_begin() override {
@@ -672,6 +657,5 @@ std::shared_ptr<IStaticShapeInfer> make_shape_inference<IStaticShapeInfer>(std::
         return {};
     }
 }
-
 }  // namespace intel_cpu
 }  // namespace ov

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.hpp
@@ -9,14 +9,21 @@
 #include <openvino/core/node.hpp>
 
 #include "static_shape.hpp"
+#include "shape_inference_status.hpp"
 
 namespace ov {
 namespace intel_cpu {
 
 class IShapeInferCommon {
 public:
-    virtual std::vector<StaticShape> infer(const std::vector<StaticShape>& input_shapes,
-                                           const std::map<size_t, HostTensorPtr>& constant_data) = 0;
+    struct ShapeInferResult {
+        std::vector<StaticShape> shapes;
+        ShapeInferStatus status;
+    };
+
+public:
+    virtual ShapeInferResult infer(const std::vector<StaticShape>& input_shapes,
+                                   const std::map<size_t, HostTensorPtr>& constant_data) = 0;
 
     // infer may generate padding as by-product, these APIs is designed to retrieve them back
     virtual const ov::CoordinateDiff& get_pads_begin() = 0;
@@ -29,7 +36,7 @@ class IStaticShapeInfer : public IShapeInferCommon {
 public:
     using IShapeInferCommon::infer;
 
-    virtual std::vector<StaticShape> infer(
+    virtual ShapeInferResult infer(
         const std::vector<StaticShape>& input_shapes,
         const std::map<size_t, std::reference_wrapper<const Tensor>>& constant_data) = 0;
 };

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.hpp
@@ -16,13 +16,13 @@ namespace intel_cpu {
 
 class IShapeInferCommon {
 public:
-    struct ShapeInferResult {
+    struct Result {
         std::vector<StaticShape> shapes;
         ShapeInferStatus status;
     };
 
 public:
-    virtual ShapeInferResult infer(const std::vector<StaticShape>& input_shapes,
+    virtual Result infer(const std::vector<StaticShape>& input_shapes,
                                    const std::map<size_t, HostTensorPtr>& constant_data) = 0;
 
     // infer may generate padding as by-product, these APIs is designed to retrieve them back
@@ -36,7 +36,7 @@ class IStaticShapeInfer : public IShapeInferCommon {
 public:
     using IShapeInferCommon::infer;
 
-    virtual ShapeInferResult infer(
+    virtual Result infer(
         const std::vector<StaticShape>& input_shapes,
         const std::map<size_t, std::reference_wrapper<const Tensor>>& constant_data) = 0;
 };

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_cpu.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_cpu.hpp
@@ -8,6 +8,8 @@
 #include <cpu_memory.h>
 #include <openvino/core/node.hpp>
 
+#include "shape_inference_status.hpp"
+
 namespace ov {
 namespace intel_cpu {
 /**
@@ -18,6 +20,11 @@ class IShapeInfer {
 public:
     using port_mask_t = uint32_t;
 
+    struct ShapeInferResult {
+        std::vector<VectorDims> dims;
+        ShapeInferStatus status;
+    };
+
 public:
     ~IShapeInfer() = default;
 
@@ -27,9 +34,9 @@ public:
      * @param input_shapes are the input tensors shapes
      * @param data_dependency are the input tensors data, which are required by the shape inference algorithm. To define
      * which inputs data are actually required, get_port_mask() is used
-     * @return std::vector<VectorDims> resulting array of calculated shapes (per each output port)
+     * @return ShapeInferResult which contains resulting array of calculated shapes (per each output port) plus status of the shape infer call
      */
-    virtual std::vector<VectorDims> infer(
+    virtual ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) = 0;
 

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_cpu.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_cpu.hpp
@@ -20,7 +20,7 @@ class IShapeInfer {
 public:
     using port_mask_t = uint32_t;
 
-    struct ShapeInferResult {
+    struct Result {
         std::vector<VectorDims> dims;
         ShapeInferStatus status;
     };
@@ -36,7 +36,7 @@ public:
      * which inputs data are actually required, get_port_mask() is used
      * @return ShapeInferResult which contains resulting array of calculated shapes (per each output port) plus status of the shape infer call
      */
-    virtual ShapeInferResult infer(
+    virtual Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) = 0;
 

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_internal_dyn.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_internal_dyn.hpp
@@ -17,11 +17,10 @@ namespace intel_cpu {
 class InternalDynShapeInfer final : public ShapeInferEmptyPads {
 public:
     InternalDynShapeInfer() = default;
-    std::vector<VectorDims> infer(
-        const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
-        const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
-        IE_THROW(Unexpected) << "InternalDynShapeInfer infer method unexpected call";
-        return {};
+    ShapeInferResult
+    infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
+          const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
+        return {{}, ShapeInferStatus::skip};
     }
 
     port_mask_t get_port_mask() const override {

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_internal_dyn.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_internal_dyn.hpp
@@ -17,7 +17,7 @@ namespace intel_cpu {
 class InternalDynShapeInfer final : public ShapeInferEmptyPads {
 public:
     InternalDynShapeInfer() = default;
-    ShapeInferResult
+    Result
     infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
           const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         return {{}, ShapeInferStatus::skip};

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_ngraph.cpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_ngraph.cpp
@@ -6,7 +6,8 @@
 
 using namespace ov::intel_cpu;
 
-std::vector<VectorDims> NgraphShapeInfer::infer(
+IShapeInfer::ShapeInferResult
+NgraphShapeInfer::infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) {
     const auto& iranks = m_shape_infer->get_input_ranks();
@@ -39,13 +40,13 @@ std::vector<VectorDims> NgraphShapeInfer::infer(
         }
     }
     // call shape inference API
-    std::vector<StaticShape> output_shapes = m_shape_infer->infer(input_static_shapes, input_values);
+    auto shape_infer_result = m_shape_infer->infer(input_static_shapes, input_values);
 
     std::vector<VectorDims> result;
-    result.reserve(output_shapes.size());
-    for (const auto& shape : output_shapes) {
+    result.reserve(shape_infer_result.shapes.size());
+    for (const auto& shape : shape_infer_result.shapes) {
         result.emplace_back(shape.to_shape());
     }
 
-    return result;
+    return {std::move(result), shape_infer_result.status};
 }

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_ngraph.cpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_ngraph.cpp
@@ -6,7 +6,7 @@
 
 using namespace ov::intel_cpu;
 
-IShapeInfer::ShapeInferResult
+IShapeInfer::Result
 NgraphShapeInfer::infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) {

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_ngraph.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_ngraph.hpp
@@ -20,7 +20,7 @@ public:
     NgraphShapeInfer(std::shared_ptr<IShapeInferCommon> shape_infer, IShapeInfer::port_mask_t port_mask) :
         m_shape_infer(shape_infer), m_port_mask(port_mask) {}
 
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
 

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_ngraph.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_ngraph.hpp
@@ -20,7 +20,7 @@ public:
     NgraphShapeInfer(std::shared_ptr<IShapeInferCommon> shape_infer, IShapeInfer::port_mask_t port_mask) :
         m_shape_infer(shape_infer), m_port_mask(port_mask) {}
 
-    std::vector<VectorDims> infer(
+    ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
 

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_pass_through.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_pass_through.hpp
@@ -17,11 +17,11 @@ namespace intel_cpu {
 class ShapeInferPassThrough final : public ShapeInferEmptyPads {
 public:
     ShapeInferPassThrough() = default;
-    ShapeInferResult infer(
+    Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         IE_ASSERT(!input_shapes.empty());
-        return {{input_shapes.front()}, ShapeInferStatus::update};
+        return {{input_shapes.front()}, ShapeInferStatus::success};
     }
     port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_pass_through.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_pass_through.hpp
@@ -17,11 +17,11 @@ namespace intel_cpu {
 class ShapeInferPassThrough final : public ShapeInferEmptyPads {
 public:
     ShapeInferPassThrough() = default;
-    std::vector<VectorDims> infer(
+    ShapeInferResult infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         IE_ASSERT(!input_shapes.empty());
-        return {input_shapes.front()};
+        return {{input_shapes.front()}, ShapeInferStatus::update};
     }
     port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_status.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_status.hpp
@@ -8,8 +8,10 @@ namespace ov {
 namespace intel_cpu {
 
 enum class ShapeInferStatus {
-    success, // shapes were successfully calculated
-    skip // shape infer was skipped
+    success, ///< shapes were successfully calculated
+    skip ///< shape inference was skipped.
+    ///< This status is used when the implementation was expectedly not able to compute defined output shape
+    ///< e.g. in the case of internal dynamism.
 };
 
 }  // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_status.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_status.hpp
@@ -1,0 +1,16 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+namespace ov {
+namespace intel_cpu {
+
+enum class ShapeInferStatus {
+    update, // shapes were successfully calculated
+    skip // shape infer was skipped
+};
+
+}  // namespace intel_cpu
+}  // namespace ov

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_status.hpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_status.hpp
@@ -8,7 +8,7 @@ namespace ov {
 namespace intel_cpu {
 
 enum class ShapeInferStatus {
-    update, // shapes were successfully calculated
+    success, // shapes were successfully calculated
     skip // shape infer was skipped
 };
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/custom_op_internal_dyn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/custom_op_internal_dyn.cpp
@@ -1,0 +1,137 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <openvino/op/op.hpp>
+#include <shared_test_classes/base/ov_subgraph.hpp>
+#include <ngraph_functions/builders.hpp>
+#include <common_test_utils/ov_tensor_utils.hpp>
+
+using namespace ov::test;
+
+namespace CPULayerTestsDefinitions {
+
+/* This is a synthetic op that mimics the general behaviour of operations with internal dynamics, i.e. nodes where the
+   the output shapes may only be defined after the actual computations. */
+
+class CustomOp : public ov::op::Op {
+public:
+    OPENVINO_OP("CustomOp");
+
+    CustomOp() = default;
+    CustomOp(const ov::OutputVector& args) : Op(args) {
+        constructor_validate_and_infer_types();
+    }
+
+    void validate_and_infer_types() override {
+        const auto& inputs_count = input_values().size();
+        OPENVINO_ASSERT(inputs_count == 1,
+                        "Input count must be 1, Got: ",
+                        inputs_count);
+        set_output_size(2);
+
+        auto shape0 = get_input_partial_shape(0);
+        auto rank0  = shape0.rank();
+
+        OPENVINO_ASSERT(rank0.compatible(3),
+                        "The input must be 3D.");
+
+        //here we set undefined shapes since they can only be determined after the actual calculations
+        set_output_type(0, get_input_element_type(0), ov::PartialShape({ov::Dimension()}));
+        set_output_type(1, get_input_element_type(0), ov::PartialShape({ov::Dimension(), ov::Dimension(), ov::Dimension()}));
+    }
+
+    std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override {
+        OPENVINO_ASSERT(new_args.size() == 1, "Incorrect number of new arguments");
+
+        return std::make_shared<CustomOp>(new_args);
+    }
+
+    bool visit_attributes(ov::AttributeVisitor& visitor) override {
+        return true;
+    }
+
+    bool evaluate(ov::TensorVector& outputs, const ov::TensorVector& inputs) const override {
+        auto in = inputs[0];
+        auto out0 = outputs[0];
+        auto out1 = outputs[1];
+        std::vector<float> out0_data(100, 1.5);
+        auto out0_shape = ov::Shape({100});
+        out0.set_shape(out0_shape);
+        memcpy(out0.data(), out0_data.data(), sizeof(out0_data[0]) * out0_data.size());
+
+        out1.set_shape(in.get_shape());
+        memcpy(out1.data(), in.data(), in.get_byte_size());
+        return true;
+    }
+
+    OPENVINO_SUPPRESS_DEPRECATED_START
+    // old fashion evaluate method, just to make the whole test subsystem work
+    bool evaluate(const ov::HostTensorVector& outputs, const ov::HostTensorVector& inputs) const override {
+        ov::TensorVector tmp_inputs;
+        for (auto& input : inputs) {
+            tmp_inputs.emplace_back(input->get_element_type(), input->get_shape(), input->get_data_ptr());
+        }
+        ov::TensorVector tmp_outputs;
+        for (auto& output : outputs) {
+            tmp_outputs.emplace_back(output->get_element_type(), ov::Shape(output->get_partial_shape().rank().get_length()));
+        }
+        evaluate(tmp_outputs, tmp_inputs);
+        OPENVINO_ASSERT(tmp_outputs.size() == outputs.size());
+        for (size_t i = 0; i < tmp_outputs.size(); ++i) {
+            outputs[i]->set_shape(tmp_outputs[i].get_shape());
+            outputs[i]->write(tmp_outputs[i].data(), tmp_outputs[i].get_byte_size());
+        }
+        return true;
+    }
+    OPENVINO_SUPPRESS_DEPRECATED_END
+
+    bool has_evaluate() const override {
+        return true;
+    }
+};
+
+class CustomOpCPUTest : public SubgraphBaseTest {
+protected:
+    void SetUp() override {
+        targetDevice = CommonTestUtils::DEVICE_CPU;
+
+        InputShape inputShapes{{-1, -1, -1}, {{10, 5, 3}, {16, 24, 16}, {4, 8, 12}}};
+
+        init_input_shapes({inputShapes});
+        auto ngPrc = ngraph::element::f32;
+        auto inputParams = ngraph::builder::makeDynamicParams(ngPrc, inputDynamicShapes);
+        auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(inputParams));
+        auto customOp = std::make_shared<CustomOp>(paramOuts);
+
+        ngraph::ResultVector results{std::make_shared<ngraph::opset3::Result>(customOp)};
+        function = std::make_shared<ngraph::Function>(results, inputParams, "customOpTest");
+    }
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        inputs.clear();
+        const auto& funcInputs = function->inputs();
+        for (int i = 0; i < funcInputs.size(); ++i) {
+            const auto& funcInput = funcInputs[i];
+            auto tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i]);
+            inputs.insert({funcInput.get_node_shared_ptr(), tensor});
+        }
+    }
+
+    void compare(const std::vector<ov::Tensor>& expected, const std::vector<ov::Tensor>& actual) override {
+        ASSERT_EQ(expected.size(), actual.size());
+        ASSERT_EQ(expected.size(), function->get_results().size());
+        const auto& results = function->get_results();
+        for (size_t j = 0; j < results.size(); j++) {
+            const auto result = results[j];
+            for (size_t i = 0; i < result->get_input_size(); ++i) {
+                ov::test::utils::compare(expected[j], actual[j], abs_threshold, rel_threshold);
+            }
+        }
+    }
+};
+
+TEST_F(CustomOpCPUTest, smoke_CustomOpInternalDynamismCPUTest) {
+    run();
+}
+} // namespace CPULayerTestsDefinitions

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/utils.hpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/utils.hpp
@@ -21,7 +21,9 @@ void shape_inference(ov::Node* op,
                      std::vector<StaticShape>& output_shapes,
                      const std::map<size_t, TTensorPtr>& constant_data = {}) {
     const auto shape_infer = make_shape_inference<TIface>(op->shared_from_this());
-    output_shapes = shape_infer->infer(input_shapes, constant_data);
+    auto result = shape_infer->infer(input_shapes, constant_data);
+    OPENVINO_ASSERT(ShapeInferStatus::success == result.status, "shape inference result has unexpected status");
+    output_shapes = std::move(result.shapes);
 }
 }  // namespace intel_cpu
 }  // namespace ov


### PR DESCRIPTION
### Details:
This PR introduce support for extension operations with so called internal dynamism, i.e. when the output shapes can only be defined after performing the computations, for example NMS operation.

### Tickets:
 - 99106
 - 81379
