### PR TITLE
[GPU] Add real kernels' execution timings collection for DumpProfilingData debug option

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/profiling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/profiling.hpp
@@ -161,17 +161,24 @@ public:
 
     ~profiled_stage() {
         GPU_DEBUG_IF(profiling_enabled) {
+            using us = std::chrono::microseconds;
+
             _finish = std::chrono::high_resolution_clock::now();
-            auto total_duration = std::chrono::duration_cast<std::chrono::microseconds>(_finish - _start).count();
+            auto stage_duration = std::chrono::duration_cast<us>(_finish - _start).count();
+            auto custom_stage_duration = std::chrono::duration_cast<us>(custom_duration).count();
+            auto total_duration = custom_stage_duration == 0 ? stage_duration
+                                                             : custom_stage_duration;
             _obj.add_profiling_data(_stage, cache_hit, total_duration);
         }
     }
     void set_cache_hit(bool val = true) { cache_hit = val; }
+    void set_custom_stage_duration(std::chrono::nanoseconds duration) { custom_duration = duration; }
 
 private:
     bool profiling_enabled = false;
     std::chrono::high_resolution_clock::time_point _start = {};
     std::chrono::high_resolution_clock::time_point _finish = {};
+    std::chrono::nanoseconds custom_duration = {};
     ProfiledObjectType& _obj;
     instrumentation::pipeline_stage _stage;
     bool cache_hit = false;

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -523,6 +523,15 @@ event::ptr primitive_inst::execute(const std::vector<event::ptr>& events) {
 
         GPU_DEBUG_IF(!debug_config->dump_profiling_data.empty()) {
             get_network().get_stream().wait_for_events({ev});
+
+            if (ev != nullptr) {
+                auto profiling_info = ev->get_profiling_info();
+                for (const auto &interval : profiling_info) {
+                    if (interval.stage == cldnn::instrumentation::profiling_stage::executing) {
+                        GPU_DEBUG_CODE(stage_prof.set_custom_stage_duration(interval.value->value()));
+                    }
+                }
+            }
         }
 
         return ev;


### PR DESCRIPTION
### Details:
 - This patch allows to collect real kernels' execution time (ov::enable_profiling property should be enabled by -pc/-exec_graph_path benchmark_app's options or in any other way; otherwise wall-clock time will be collected)

### Tickets:
 - *ticket-id*
