### PR TITLE
Xuejun/remove apis in ov node

### DIFF
--- a/src/core/include/ngraph/graph_util.hpp
+++ b/src/core/include/ngraph/graph_util.hpp
@@ -190,12 +190,6 @@ NGRAPH_DEPRECATED("This method is deprecated and will be removed soon")
 NGRAPH_API
 size_t get_user_count(Node* node);
 
-// Return true if a node's user could potentially overwrite
-// the output of this node with in-place kernels
-NGRAPH_DEPRECATED("This method is deprecated and will be removed soon")
-NGRAPH_API
-bool possibly_overwritten(Node* node);
-
 NGRAPH_DEPRECATED("This method is deprecated and will be removed soon")
 NGRAPH_API
 bool is_strided(const Strides& strides);

--- a/src/core/include/openvino/core/node.hpp
+++ b/src/core/include/openvino/core/node.hpp
@@ -456,17 +456,6 @@ public:
     /// \throw std::out_of_range if the node does not have at least `output_index+1` outputs.
     Output<const Node> output(size_t output_index) const;
 
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    OPENVINO_DEPRECATED("This method is deprecated and will be removed soon.")
-    void set_op_annotations(std::shared_ptr<ngraph::op::util::OpAnnotations> op_annotations) {
-        m_op_annotations = op_annotations;
-    }
-    OPENVINO_DEPRECATED("This method is deprecated and will be removed soon.")
-    std::shared_ptr<ngraph::op::util::OpAnnotations> get_op_annotations() const {
-        return m_op_annotations;
-    }
-    OPENVINO_SUPPRESS_DEPRECATED_END
-
     virtual bool match_value(ov::pass::pattern::Matcher* matcher,
                              const Output<Node>& pattern_value,
                              const Output<Node>& graph_value);
@@ -490,9 +479,6 @@ private:
     static std::atomic<size_t> m_next_instance_id;
     std::deque<descriptor::Input> m_inputs;
     std::deque<descriptor::Output> m_outputs;
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    std::shared_ptr<ngraph::op::util::OpAnnotations> m_op_annotations;
-    OPENVINO_SUPPRESS_DEPRECATED_END
     RTMap m_rt_info;
 
     // The vector of SharedRTInfo attributes associated to Functions

--- a/src/core/include/openvino/core/node.hpp
+++ b/src/core/include/openvino/core/node.hpp
@@ -417,10 +417,6 @@ public:
         OPENVINO_SUPPRESS_DEPRECATED_END
     }
 
-    OPENVINO_DEPRECATED("This method is deprecated and will be removed soon.")
-    virtual std::shared_ptr<Node> get_default_value() const {
-        return nullptr;
-    }
     /// Use instance ids for comparison instead of memory addresses to improve determinism
     bool operator<(const Node& other) const {
         return m_instance_id < other.m_instance_id;

--- a/src/core/include/openvino/op/avg_pool.hpp
+++ b/src/core/include/openvino/op/avg_pool.hpp
@@ -69,10 +69,6 @@ public:
     void set_auto_pad(const PadType& auto_pad);
     op::RoundingType get_rounding_type() const;
     void set_rounding_type(op::RoundingType rounding_type);
-    /// \return The default value for AvgPool.
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    std::shared_ptr<Node> get_default_value() const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
 
 protected:
     Shape m_kernel;

--- a/src/core/include/openvino/op/convolution.hpp
+++ b/src/core/include/openvino/op/convolution.hpp
@@ -91,10 +91,6 @@ public:
     void set_auto_pad(const PadType& auto_pad) {
         m_auto_pad = auto_pad;
     }
-    /// \return The default value for Convolution.
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    std::shared_ptr<Node> get_default_value() const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
 
 protected:
     Strides m_strides;

--- a/src/core/include/openvino/op/cum_sum.hpp
+++ b/src/core/include/openvino/op/cum_sum.hpp
@@ -44,10 +44,6 @@ public:
     bool visit_attributes(AttributeVisitor& visitor) override;
     void validate_and_infer_types() override;
 
-    /// \return The default value for CumSum.
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    std::shared_ptr<Node> get_default_value() const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
     bool is_exclusive() const {
         return m_exclusive;
     }

--- a/src/core/include/openvino/op/group_conv.hpp
+++ b/src/core/include/openvino/op/group_conv.hpp
@@ -88,10 +88,6 @@ public:
     void set_auto_pad(const PadType& auto_pad) {
         m_auto_pad = auto_pad;
     }
-    /// \return The default value for Convolution.
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    std::shared_ptr<Node> get_default_value() const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
 
 protected:
     Strides m_strides;

--- a/src/core/include/openvino/op/max_pool.hpp
+++ b/src/core/include/openvino/op/max_pool.hpp
@@ -43,11 +43,6 @@ public:
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
-    /// \return The default value for MaxPool.
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    std::shared_ptr<Node> get_default_value() const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
-
     OPENVINO_SUPPRESS_DEPRECATED_START
     bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
     OPENVINO_SUPPRESS_DEPRECATED_END

--- a/src/core/include/openvino/op/reduce_l1.hpp
+++ b/src/core/include/openvino/op/reduce_l1.hpp
@@ -26,11 +26,6 @@ public:
     /// \param keep_dims If set to true it holds axes that are used for reduction.
     ReduceL1(const Output<Node>& arg, const Output<Node>& reduction_axes, bool keep_dims = false);
 
-    /// \return The default value for Reduce.
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    std::shared_ptr<Node> get_default_value() const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
-
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
     OPENVINO_SUPPRESS_DEPRECATED_START

--- a/src/core/include/openvino/op/reduce_l2.hpp
+++ b/src/core/include/openvino/op/reduce_l2.hpp
@@ -25,11 +25,6 @@ public:
     /// \param keep_dims If set to true it holds axes that are used for reduction.
     ReduceL2(const Output<Node>& arg, const Output<Node>& reduction_axes, bool keep_dims = false);
 
-    /// \return The default value for Reduce.
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    std::shared_ptr<Node> get_default_value() const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
-
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
     OPENVINO_SUPPRESS_DEPRECATED_START

--- a/src/core/include/openvino/op/reduce_prod.hpp
+++ b/src/core/include/openvino/op/reduce_prod.hpp
@@ -25,11 +25,6 @@ public:
     /// \param keep_dims If set to true it holds axes that are used for reduction.
     ReduceProd(const Output<Node>& arg, const Output<Node>& reduction_axes, bool keep_dims = false);
 
-    /// \return The default value for Product.
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    std::shared_ptr<Node> get_default_value() const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
-
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
     OPENVINO_SUPPRESS_DEPRECATED_START

--- a/src/core/include/openvino/op/reduce_sum.hpp
+++ b/src/core/include/openvino/op/reduce_sum.hpp
@@ -73,11 +73,6 @@ public:
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
-    /// \return The default value for Sum.
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    std::shared_ptr<Node> get_default_value() const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
-
     OPENVINO_SUPPRESS_DEPRECATED_START
     bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
     OPENVINO_SUPPRESS_DEPRECATED_END

--- a/src/core/src/graph_util.cpp
+++ b/src/core/src/graph_util.cpp
@@ -248,8 +248,6 @@ void clone_ov_nodes(const std::vector<std::shared_ptr<ov::Node>>& nodes,
                 cloned_node->input(input.get_index()).get_rt_info() = input.get_rt_info();
             }
 
-            cloned_node->set_op_annotations(node->get_op_annotations());
-
             node_map[node.get()] = cloned_node;
         }
     }
@@ -349,8 +347,6 @@ std::vector<std::shared_ptr<ngraph::Node>> ngraph::clone_nodes(const std::vector
                 new_input.get_rt_info() = output_rt_info;
             }
 
-            cloned_node->set_op_annotations(node->get_op_annotations());
-
             node_map[node.get()] = cloned_node;
         }
     }
@@ -395,7 +391,6 @@ std::list<std::shared_ptr<ngraph::Node>> ngraph::clone_nodes(const std::vector<s
                 cloned_node->set_friendly_name(node->get_friendly_name());
                 auto rt_info = node->get_rt_info();
                 cloned_node->get_rt_info() = rt_info;
-                cloned_node->set_op_annotations(node->get_op_annotations());
                 for (const auto& cloned_value : cloned_node->outputs()) {
                     auto original_value = node_outputs.at(cloned_value.get_index());
                     if (output_map.count(original_value) == 0) {
@@ -629,24 +624,6 @@ size_t ngraph::get_user_count(Node* node) {
         count += is_used(node_user.get());
     }
     return count;
-}
-
-bool ngraph::possibly_overwritten(Node* node) {
-    for (auto& output : node->outputs()) {
-        for (auto& input : output.get_target_inputs()) {
-            if (op::is_op(input.get_node())) {
-                auto op = static_cast<ngraph::op::Op*>(input.get_node());
-                if (auto op_annotations = op->get_op_annotations()) {
-                    for (auto oi_pair : op_annotations->get_in_place_oi_pairs()) {
-                        if (input.get_index() == oi_pair.input && oi_pair.destructive) {
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-    }
-    return false;
 }
 
 bool ngraph::is_strided(const Strides& strides) {

--- a/src/core/src/node.cpp
+++ b/src/core/src/node.cpp
@@ -38,7 +38,6 @@ ov::Node::Node(const Node& node)
       m_inputs(node.m_inputs)  // will be modified in the body
       // skip m_outputs -- should be initialized outside
       ,
-      m_op_annotations(node.m_op_annotations),
       m_rt_info(node.m_rt_info) {
     // cannot do it without copying node.m_inputs first due to too limiting const qualifiers
     for (auto& input : m_inputs) {
@@ -53,7 +52,6 @@ ov::Node& ov::Node::operator=(const Node& node) {
     this->m_instance_id = m_next_instance_id.fetch_add(1);
     this->m_friendly_name = node.m_friendly_name;
     this->m_inputs = node.m_inputs;
-    this->m_op_annotations = node.m_op_annotations;
     this->m_rt_info = node.m_rt_info;
     // cannot do it without copying node.m_inputs first due to too limiting const qualifiers
     for (auto& input : m_inputs) {

--- a/src/core/src/op/avg_pool.cpp
+++ b/src/core/src/op/avg_pool.cpp
@@ -200,7 +200,3 @@ shared_ptr<ov::Node> ov::op::v1::AvgPool::clone_with_new_inputs(const OutputVect
                                     m_rounding_type,
                                     m_auto_pad);
 }
-
-shared_ptr<ov::Node> ov::op::v1::AvgPool::get_default_value() const {
-    return op::v0::Constant::create(get_element_type(), get_shape(), {0});
-}

--- a/src/core/src/op/convolution.cpp
+++ b/src/core/src/op/convolution.cpp
@@ -91,12 +91,6 @@ shared_ptr<Node> op::v1::Convolution::clone_with_new_inputs(const OutputVector& 
                                         m_auto_pad);
 }
 
-NGRAPH_SUPPRESS_DEPRECATED_START
-shared_ptr<Node> op::v1::Convolution::get_default_value() const {
-    return ngraph::make_constant_from_string("0", get_element_type(), get_shape());
-}
-NGRAPH_SUPPRESS_DEPRECATED_END
-
 // *** ConvolutionBackpropData OP SET 1 ***
 op::v1::ConvolutionBackpropData::ConvolutionBackpropData(const Output<Node>& data,
                                                          const Output<Node>& filters,

--- a/src/core/src/op/cum_sum.cpp
+++ b/src/core/src/op/cum_sum.cpp
@@ -57,12 +57,6 @@ shared_ptr<Node> op::v0::CumSum::clone_with_new_inputs(const OutputVector& new_a
     }
 }
 
-OPENVINO_SUPPRESS_DEPRECATED_START
-shared_ptr<Node> op::v0::CumSum::get_default_value() const {
-    return ngraph::make_constant_from_string("0", get_element_type(), get_shape());
-}
-OPENVINO_SUPPRESS_DEPRECATED_END
-
 namespace {
 template <element::Type_t DATA_ET, element::Type_t AXIS_ET>
 bool evaluate_cum_sum(TensorVector& outputs, const TensorVector& inputs, const bool exclusive, const bool reverse) {

--- a/src/core/src/op/group_conv.cpp
+++ b/src/core/src/op/group_conv.cpp
@@ -18,10 +18,6 @@ using namespace ngraph;
 //                        v1::GroupConvolution
 //------------------------------------------------------------------------------
 
-shared_ptr<Node> op::v1::GroupConvolution::get_default_value() const {
-    return op::v0::Constant::create(get_element_type(), get_shape(), {0});
-}
-
 op::v1::GroupConvolution::GroupConvolution(const Output<Node>& data_batch,
                                            const Output<Node>& filters,
                                            const Strides& strides,

--- a/src/core/src/op/max_pool.cpp
+++ b/src/core/src/op/max_pool.cpp
@@ -59,10 +59,6 @@ shared_ptr<Node> op::v1::MaxPool::clone_with_new_inputs(const OutputVector& new_
                                     m_auto_pad);
 }
 
-shared_ptr<Node> op::v1::MaxPool::get_default_value() const {
-    return op::v0::Constant::create(get_element_type(), get_shape(), {0});
-}
-
 namespace maxpool {
 namespace {
 template <element::Type_t ET>

--- a/src/core/src/op/reduce_l1.cpp
+++ b/src/core/src/op/reduce_l1.cpp
@@ -21,12 +21,6 @@ op::v4::ReduceL1::ReduceL1(const Output<Node>& arg, const Output<Node>& reductio
     constructor_validate_and_infer_types();
 }
 
-NGRAPH_SUPPRESS_DEPRECATED_START
-shared_ptr<Node> op::v4::ReduceL1::get_default_value() const {
-    return ngraph::make_constant_from_string("0", get_element_type(), get_shape());
-}
-NGRAPH_SUPPRESS_DEPRECATED_END
-
 shared_ptr<Node> op::v4::ReduceL1::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v4_ReduceL1_clone_with_new_inputs);
     check_new_args_count(this, new_args);

--- a/src/core/src/op/reduce_l2.cpp
+++ b/src/core/src/op/reduce_l2.cpp
@@ -21,12 +21,6 @@ op::v4::ReduceL2::ReduceL2(const Output<Node>& arg, const Output<Node>& reductio
     constructor_validate_and_infer_types();
 }
 
-NGRAPH_SUPPRESS_DEPRECATED_START
-shared_ptr<Node> op::v4::ReduceL2::get_default_value() const {
-    return ngraph::make_constant_from_string("0", get_element_type(), get_shape());
-}
-NGRAPH_SUPPRESS_DEPRECATED_END
-
 shared_ptr<Node> op::v4::ReduceL2::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v4_ReduceL2_clone_with_new_inputs);
     check_new_args_count(this, new_args);

--- a/src/core/src/op/reduce_prod.cpp
+++ b/src/core/src/op/reduce_prod.cpp
@@ -20,12 +20,6 @@ op::v1::ReduceProd::ReduceProd(const Output<Node>& arg, const Output<Node>& redu
     constructor_validate_and_infer_types();
 }
 
-NGRAPH_SUPPRESS_DEPRECATED_START
-shared_ptr<Node> op::v1::ReduceProd::get_default_value() const {
-    return ngraph::make_constant_from_string("1", get_element_type(), get_shape());
-}
-NGRAPH_SUPPRESS_DEPRECATED_END
-
 shared_ptr<Node> op::v1::ReduceProd::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v1_ReduceProd_clone_with_new_inputs);
     check_new_args_count(this, new_args);

--- a/src/core/src/op/reduce_sum.cpp
+++ b/src/core/src/op/reduce_sum.cpp
@@ -23,12 +23,6 @@ op::v1::ReduceSum::ReduceSum(const Output<Node>& arg, const Output<Node>& reduct
     constructor_validate_and_infer_types();
 }
 
-NGRAPH_SUPPRESS_DEPRECATED_START
-shared_ptr<Node> op::v1::ReduceSum::get_default_value() const {
-    return ngraph::make_constant_from_string("0", get_element_type(), get_shape());
-}
-NGRAPH_SUPPRESS_DEPRECATED_END
-
 shared_ptr<Node> op::v1::ReduceSum::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v1_ReduceSum_clone_with_new_inputs);
     check_new_args_count(this, new_args);


### PR DESCRIPTION
### Details:
 - remove deprecated api `get_default_value()`
 - remove deprecated api `set_op_annotations()`
 - remove deprecated api `get_op_annotations()`

### Tickets:
 - 100091
