### PR TITLE
[AUTO] Failed to get the ov::model_name when loading network to target device is not ready

### DIFF
--- a/src/plugins/auto/auto_executable_network.cpp
+++ b/src/plugins/auto/auto_executable_network.cpp
@@ -172,6 +172,7 @@ IE::Parameter AutoExecutableNetwork::GetMetric(const std::string& name) const {
         }
         return decltype(ov::available_devices)::value_type {exeDevices};
     } else if (name == ov::model_name) {
+        std::lock_guard<std::mutex> lock(_autoSContext->_confMutex);
         if (_autoSchedule->_loadContext[CPU].isEnabled && _autoSchedule->_loadContext[CPU].isAlready)
             return _autoSchedule->_loadContext[CPU].executableNetwork->GetMetric(name);
         return _autoSchedule->_loadContext[ACTUALDEVICE].executableNetwork->GetMetric(name);

--- a/src/plugins/auto/auto_executable_network.cpp
+++ b/src/plugins/auto/auto_executable_network.cpp
@@ -172,6 +172,8 @@ IE::Parameter AutoExecutableNetwork::GetMetric(const std::string& name) const {
         }
         return decltype(ov::available_devices)::value_type {exeDevices};
     } else if (name == ov::model_name) {
+        if (_autoSchedule->_loadContext[CPU].isEnabled && _autoSchedule->_loadContext[CPU].isAlready)
+            return _autoSchedule->_loadContext[CPU].executableNetwork->GetMetric(name);
         return _autoSchedule->_loadContext[ACTUALDEVICE].executableNetwork->GetMetric(name);
     } else if (name == METRIC_KEY(SUPPORTED_METRICS)) {
         IE_SET_METRIC_RETURN(SUPPORTED_METRICS,


### PR DESCRIPTION
### Details:
 - Prioritize to get ov::model_name from CompiledModel(ExecutableNetwork) of acceleration device (CPU) since the target device CompiledModel(ExecutableNetwork) may not be ready.
 - Add the lock to guarantee the concurrency safe 

### Tickets:
 - 96206
