### PR TITLE
Xuejun/remove api serialize

### DIFF
--- a/src/core/include/openvino/pass/serialize.hpp
+++ b/src/core/include/openvino/pass/serialize.hpp
@@ -34,18 +34,8 @@ public:
     };
     bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 
-    OPENVINO_DEPRECATED("This constructor is deprecated. Please use new extension API")
-    Serialize(std::ostream& xmlFile,
-              std::ostream& binFile,
-              std::map<std::string, ngraph::OpSet> custom_opsets,
-              Version version = Version::UNSPECIFIED);
     Serialize(std::ostream& xmlFile, std::ostream& binFile, Version version = Version::UNSPECIFIED);
 
-    OPENVINO_DEPRECATED("This constructor is deprecated. Please use new extension API")
-    Serialize(const std::string& xmlPath,
-              const std::string& binPath,
-              std::map<std::string, ngraph::OpSet> custom_opsets,
-              Version version = Version::UNSPECIFIED);
     Serialize(const std::string& xmlPath, const std::string& binPath, Version version = Version::UNSPECIFIED);
 
 private:

--- a/src/core/include/openvino/pass/serialize.hpp
+++ b/src/core/include/openvino/pass/serialize.hpp
@@ -68,11 +68,6 @@ public:
 
     bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 
-    OPENVINO_DEPRECATED("This constructor is deprecated. Please use new extension API")
-    StreamSerialize(std::ostream& stream,
-                    std::map<std::string, ngraph::OpSet>&& custom_opsets = {},
-                    const std::function<void(std::ostream&)>& custom_data_serializer = {},
-                    Serialize::Version version = Serialize::Version::UNSPECIFIED);
     StreamSerialize(std::ostream& stream,
                     const std::function<void(std::ostream&)>& custom_data_serializer = {},
                     Serialize::Version version = Serialize::Version::UNSPECIFIED);

--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -1117,13 +1117,10 @@ pass::Serialize::Serialize(const std::string& xmlPath,
       m_binPath{provide_bin_path(xmlPath, binPath)},
       m_version{version} {}
 
-OPENVINO_SUPPRESS_DEPRECATED_START
 pass::StreamSerialize::StreamSerialize(std::ostream& stream,
-                                       std::map<std::string, ngraph::OpSet>&& custom_opsets,
                                        const std::function<void(std::ostream&)>& custom_data_serializer,
                                        Serialize::Version version)
     : m_stream(stream),
-      m_custom_opsets(std::move(custom_opsets)),
       m_custom_data_serializer(custom_data_serializer),
       m_version(version) {
     if (version != Serialize::Version::UNSPECIFIED && version != Serialize::Version::IR_V10 &&
@@ -1131,12 +1128,6 @@ pass::StreamSerialize::StreamSerialize(std::ostream& stream,
         throw ngraph_error("Unsupported version");
     }
 }
-
-pass::StreamSerialize::StreamSerialize(std::ostream& stream,
-                                       const std::function<void(std::ostream&)>& custom_data_serializer,
-                                       Serialize::Version version)
-    : StreamSerialize(stream, {}, custom_data_serializer, version) {}
-OPENVINO_SUPPRESS_DEPRECATED_END
 
 bool pass::StreamSerialize::run_on_model(const std::shared_ptr<ngraph::Function>& f) {
     RUN_ON_MODEL_SCOPE(StreamSerialize);

--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -1099,35 +1099,23 @@ bool pass::Serialize::run_on_model(const std::shared_ptr<ngraph::Function>& f_or
     return false;
 }
 
-OPENVINO_SUPPRESS_DEPRECATED_START
 pass::Serialize::Serialize(std::ostream& xmlFile,
                            std::ostream& binFile,
-                           std::map<std::string, ngraph::OpSet> custom_opsets,
                            pass::Serialize::Version version)
     : m_xmlFile{&xmlFile},
       m_binFile{&binFile},
       m_xmlPath{},
       m_binPath{},
-      m_version{version},
-      m_custom_opsets{custom_opsets} {}
-
-pass::Serialize::Serialize(std::ostream& xmlFile, std::ostream& binFile, pass::Serialize::Version version)
-    : pass::Serialize::Serialize(xmlFile, binFile, std::map<std::string, ngraph::OpSet>{}, version) {}
+      m_version{version} {}
 
 pass::Serialize::Serialize(const std::string& xmlPath,
                            const std::string& binPath,
-                           std::map<std::string, ngraph::OpSet> custom_opsets,
                            pass::Serialize::Version version)
     : m_xmlFile{nullptr},
       m_binFile{nullptr},
       m_xmlPath{valid_xml_path(xmlPath)},
       m_binPath{provide_bin_path(xmlPath, binPath)},
-      m_version{version},
-      m_custom_opsets{custom_opsets} {}
-
-pass::Serialize::Serialize(const std::string& xmlPath, const std::string& binPath, pass::Serialize::Version version)
-    : pass::Serialize::Serialize(xmlPath, binPath, std::map<std::string, ngraph::OpSet>{}, version) {}
-OPENVINO_SUPPRESS_DEPRECATED_END
+      m_version{version} {}
 
 OPENVINO_SUPPRESS_DEPRECATED_START
 pass::StreamSerialize::StreamSerialize(std::ostream& stream,

--- a/src/core/tests/pass/serialization/custom_ops.cpp
+++ b/src/core/tests/pass/serialization/custom_ops.cpp
@@ -109,7 +109,6 @@ TEST_F(CustomOpsSerializationTest, CustomOpNoExtensions) {
     ov::pass::Manager manager;
     manager.register_pass<ov::pass::Serialize>(m_out_xml_path,
                                                m_out_bin_path,
-                                               extension->getOpSets(),
                                                ov::pass::Serialize::Version::IR_V10);
     manager.run_passes(expected);
     auto result = core.read_model(m_out_xml_path, m_out_bin_path);

--- a/src/inference/src/cnn_network_ngraph_impl.cpp
+++ b/src/inference/src/cnn_network_ngraph_impl.cpp
@@ -567,14 +567,9 @@ StatusCode CNNNetworkNGraphImpl::serialize(const std::string& xmlPath,
                                            const std::string& binPath,
                                            ResponseDesc* resp) const noexcept {
     try {
-        std::map<std::string, ngraph::OpSet> custom_opsets;
-        for (const auto& extension : _ie_extensions) {
-            auto opset = extension->getOpSets();
-            custom_opsets.insert(begin(opset), end(opset));
-        }
         ngraph::pass::Manager manager;
         using namespace ov::pass;
-        REGISTER_PASS(manager, Serialize, xmlPath, binPath, custom_opsets, ov::pass::Serialize::Version::IR_V10)
+        REGISTER_PASS(manager, Serialize, xmlPath, binPath, ov::pass::Serialize::Version::IR_V10)
         manager.run_passes(_ngraph_function);
     } catch (const Exception& e) {
         return DescriptionBuffer(GENERAL_ERROR, resp) << e.what();
@@ -589,14 +584,9 @@ StatusCode CNNNetworkNGraphImpl::serialize(const std::string& xmlPath,
 StatusCode CNNNetworkNGraphImpl::serialize(std::ostream& xmlBuf, std::ostream& binBuf, ResponseDesc* resp) const
     noexcept {
     try {
-        std::map<std::string, ngraph::OpSet> custom_opsets;
-        for (const auto& extension : _ie_extensions) {
-            auto opset = extension->getOpSets();
-            custom_opsets.insert(begin(opset), end(opset));
-        }
         ngraph::pass::Manager manager;
         using namespace ov::pass;
-        REGISTER_PASS(manager, Serialize, xmlBuf, binBuf, custom_opsets, ov::pass::Serialize::Version::IR_V10)
+        REGISTER_PASS(manager, Serialize, xmlBuf, binBuf, ov::pass::Serialize::Version::IR_V10)
         manager.run_passes(_ngraph_function);
     } catch (const Exception& e) {
         return DescriptionBuffer(GENERAL_ERROR, resp) << e.what();
@@ -611,16 +601,10 @@ StatusCode CNNNetworkNGraphImpl::serialize(std::ostream& xmlBuf, std::ostream& b
 StatusCode CNNNetworkNGraphImpl::serialize(std::ostream& xmlBuf, Blob::Ptr& binBlob, ResponseDesc* resp) const
     noexcept {
     try {
-        std::map<std::string, ngraph::OpSet> custom_opsets;
-        for (const auto& extension : _ie_extensions) {
-            auto opset = extension->getOpSets();
-            custom_opsets.insert(begin(opset), end(opset));
-        }
-
         std::stringstream binBuf;
         ngraph::pass::Manager manager;
         using namespace ov::pass;
-        REGISTER_PASS(manager, Serialize, xmlBuf, binBuf, custom_opsets, ov::pass::Serialize::Version::IR_V10)
+        REGISTER_PASS(manager, Serialize, xmlBuf, binBuf, ov::pass::Serialize::Version::IR_V10)
         manager.run_passes(_ngraph_function);
 
         std::streambuf* pbuf = binBuf.rdbuf();

--- a/src/plugins/intel_cpu/src/serialize.cpp
+++ b/src/plugins/intel_cpu/src/serialize.cpp
@@ -113,9 +113,7 @@ void CNNNetworkSerializer::operator << (const CNNNetwork & network) {
     };
 
     // Serialize to old representation in case of old API
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    ov::pass::StreamSerialize serializer(_ostream, getCustomOpSets(), serializeInputsAndOutputs);
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    ov::pass::StreamSerialize serializer(_ostream, serializeInputsAndOutputs);
     serializer.run_on_model(std::const_pointer_cast<ngraph::Function>(network.getFunction()));
 }
 


### PR DESCRIPTION
### Details:
 - remove deprecated api Serialize(std::ostream& xmlFile, ...
 - remove deprecated api Serialize(const std::string& xmlPath,...
 - remove deprecated api StreamSerialize(std::ostream& stream....

### Tickets:
 - 100091
