### PR TITLE
Support exporting network in AUTO and AUTO BATCH plugins 

### DIFF
--- a/src/plugins/auto/auto_executable_network.cpp
+++ b/src/plugins/auto/auto_executable_network.cpp
@@ -184,4 +184,19 @@ IE::Parameter AutoExecutableNetwork::GetMetric(const std::string& name) const {
     }
     IE_THROW() << "Unsupported metric key: " << name;
 }
+
+void AutoExecutableNetwork::Export(std::ostream& model) {
+    if (_autoSchedule->_loadContext[ACTUALDEVICE].isAlready) {
+        return _autoSchedule->_loadContext[ACTUALDEVICE].executableNetwork->Export(model);
+    }
+    return _autoSchedule->_loadContext[CPU].executableNetwork->Export(model);
+}
+
+void AutoExecutableNetwork::Export(const std::string& modelFileName) {
+    if (_autoSchedule->_loadContext[ACTUALDEVICE].isAlready) {
+        return _autoSchedule->_loadContext[ACTUALDEVICE].executableNetwork->Export(modelFileName);
+    }
+    return _autoSchedule->_loadContext[CPU].executableNetwork->Export(modelFileName);
+}
+
 }  // namespace MultiDevicePlugin

--- a/src/plugins/auto/auto_executable_network.hpp
+++ b/src/plugins/auto/auto_executable_network.hpp
@@ -30,6 +30,8 @@ public:
     IE::Parameter GetConfig(const std::string& name) const override;
     IE::Parameter GetMetric(const std::string& name) const override;
     std::shared_ptr<IE::RemoteContext> GetContext() const override;
+    void Export(std::ostream& model) override;
+    void Export(const std::string& modelFileName) override;
     virtual ~AutoExecutableNetwork() = default;
 
 private:

--- a/src/plugins/auto_batch/auto_batch.cpp
+++ b/src/plugins/auto_batch/auto_batch.cpp
@@ -624,6 +624,14 @@ InferenceEngine::Parameter AutoBatchExecutableNetwork::GetConfig(const std::stri
     }
 }
 
+void AutoBatchExecutableNetwork::Export(std::ostream& model) {
+    _networkWithoutBatch->Export(model);
+}
+
+void AutoBatchExecutableNetwork::Export(const std::string& modelFileName) {
+    _networkWithoutBatch->Export(modelFileName);
+}
+
 InferenceEngine::Parameter AutoBatchExecutableNetwork::GetMetric(const std::string& name) const {
     if (name == METRIC_KEY(OPTIMAL_NUMBER_OF_INFER_REQUESTS)) {
         auto reqs = 0;

--- a/src/plugins/auto_batch/auto_batch.hpp
+++ b/src/plugins/auto_batch/auto_batch.hpp
@@ -65,6 +65,8 @@ public:
         const std::vector<std::shared_ptr<const ov::Node>>& outputs) override;
     std::shared_ptr<InferenceEngine::RemoteContext> GetContext() const override;
     std::shared_ptr<ngraph::Function> GetExecGraphInfo() override;
+    void Export(std::ostream& model) override;
+    void Export(const std::string& modelFileName) override;
     virtual ~AutoBatchExecutableNetwork();
 
 protected:


### PR DESCRIPTION
Plugins would call `Export()` method for underlying executable networks
