### PR TITLE
[PyOV] Fix deprecation warning in tests

### DIFF
--- a/src/bindings/python/tests/test_graph/test_manager.py
+++ b/src/bindings/python/tests/test_graph/test_manager.py
@@ -8,7 +8,7 @@ import os
 import numpy as np
 import pytest
 
-import openvino.runtime.opset8 as ops
+import openvino.runtime.opset10 as ops
 from openvino.runtime import Core, Model
 from openvino.runtime.passes import Manager, Serialize, ConstantFolding, Version
 from tests.test_graph.util import count_ops_of_type

--- a/src/bindings/python/tests/test_graph/test_manager.py
+++ b/src/bindings/python/tests/test_graph/test_manager.py
@@ -8,17 +8,26 @@ import os
 import numpy as np
 import pytest
 
-import openvino.runtime.opset8 as ov
-from openvino.runtime import Model
+import openvino.runtime.opset8 as ops
+from openvino.runtime import Core, Model
 from openvino.runtime.passes import Manager, Serialize, ConstantFolding, Version
 from tests.test_graph.util import count_ops_of_type
-from openvino.runtime import Core
 
 from tests.test_utils.test_utils import create_filename_for_test
 
+def create_model():
+    shape = [100, 100, 2]
+    parameter_a = ops.parameter(shape, dtype=np.float32, name="A")
+    parameter_b = ops.parameter(shape, dtype=np.float32, name="B")
+    parameter_c = ops.parameter(shape, dtype=np.float32, name="C")
+    model = ops.floor(ops.minimum(ops.abs(parameter_a), ops.multiply(parameter_b, parameter_c)))
+    func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
+    return func
+
+
 def test_constant_folding():
-    node_constant = ov.constant(np.array([[0.0, 0.1, -0.1], [-2.5, 2.5, 3.0]], dtype=np.float32))
-    node_ceil = ov.ceiling(node_constant)
+    node_constant = ops.constant(np.array([[0.0, 0.1, -0.1], [-2.5, 2.5, 3.0]], dtype=np.float32))
+    node_ceil = ops.ceiling(node_constant)
     model = Model(node_ceil, [], "TestFunction")
 
     assert count_ops_of_type(model, node_ceil) == 1
@@ -43,9 +52,9 @@ def test_serialize_seperate_paths_kwargs(request, tmp_path):
     core = Core()
     xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     shape = [2, 2]
-    parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
-    parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
-    parameter_c = ov.parameter(shape, dtype=np.float32, name="C")
+    parameter_a = ops.parameter(shape, dtype=np.float32, name="A")
+    parameter_b = ops.parameter(shape, dtype=np.float32, name="B")
+    parameter_c = ops.parameter(shape, dtype=np.float32, name="C")
     model = (parameter_a + parameter_b) * parameter_c
     func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
 
@@ -67,10 +76,10 @@ def test_serialize_seperate_paths_args(request, tmp_path):
     core = Core()
     xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     shape = [2, 2]
-    parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
-    parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
-    parameter_c = ov.parameter(shape, dtype=np.float32, name="C")
-    parameter_d = ov.parameter(shape, dtype=np.float32, name="D")
+    parameter_a = ops.parameter(shape, dtype=np.float32, name="A")
+    parameter_b = ops.parameter(shape, dtype=np.float32, name="B")
+    parameter_c = ops.parameter(shape, dtype=np.float32, name="C")
+    parameter_d = ops.parameter(shape, dtype=np.float32, name="D")
     model = ((parameter_a + parameter_b) * parameter_c) / parameter_d
     func = Model(model, [parameter_a, parameter_b, parameter_c, parameter_d], "Model")
 
@@ -92,8 +101,8 @@ def test_serialize_pass_mixed_args_kwargs(request, tmp_path):
     core = Core()
     xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
     shape = [3, 2]
-    parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
-    parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
+    parameter_a = ops.parameter(shape, dtype=np.float32, name="A")
+    parameter_b = ops.parameter(shape, dtype=np.float32, name="B")
     model = parameter_a - parameter_b
     func = Model(model, [parameter_a, parameter_b], "Model")
 
@@ -114,20 +123,15 @@ def test_serialize_pass_mixed_args_kwargs(request, tmp_path):
 def test_serialize_pass_mixed_args_kwargs_v2(request, tmp_path):
     core = Core()
     xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
-    shape = [100, 100, 2]
-    parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
-    parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
-    parameter_c = ov.parameter(shape, dtype=np.float32, name="C")
-    model = ov.floor(ov.minimum(ov.abs(parameter_a), ov.multiply(parameter_b, parameter_c)))
-    func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
+    model = create_model()
     pass_manager = Manager()
     pass_manager.register_pass(Serialize(path_to_xml=xml_path, path_to_bin=bin_path))
-    pass_manager.run_passes(func)
+    pass_manager.run_passes(model)
 
     res_model = core.read_model(model=xml_path, weights=bin_path)
 
-    assert func.get_parameters() == res_model.get_parameters()
-    assert func.get_ordered_ops() == res_model.get_ordered_ops()
+    assert model.get_parameters() == res_model.get_parameters()
+    assert model.get_ordered_ops() == res_model.get_ordered_ops()
 
     os.remove(xml_path)
     os.remove(bin_path)
@@ -146,8 +150,8 @@ def test_serialize_pass_wrong_num_of_args(request, tmp_path):
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
 def test_serialize_results(request, tmp_path):
     core = Core()
-    node_constant = ov.constant(np.array([[0.0, 0.1, -0.1], [-2.5, 2.5, 3.0]], dtype=np.float32))
-    node_ceil = ov.ceiling(node_constant)
+    node_constant = ops.constant(np.array([[0.0, 0.1, -0.1], [-2.5, 2.5, 3.0]], dtype=np.float32))
+    node_ceil = ops.ceiling(node_constant)
     func = Model(node_ceil, [], "Model")
 
     xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
@@ -166,72 +170,18 @@ def test_serialize_results(request, tmp_path):
 
 
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_serialize_pass_tuple(request, tmp_path):
-    core = Core()
-    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
-    shape = [100, 100, 2]
-    parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
-    parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
-    parameter_c = ov.parameter(shape, dtype=np.float32, name="C")
-    parameter_d = ov.parameter(shape, dtype=np.float32, name="D")
-    model = ov.floor(ov.minimum(ov.abs(parameter_a), ov.multiply(parameter_b, parameter_c)))
-    func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
-    pass_manager = Manager()
-    pass_manager.register_pass("Serialize", output_files=(xml_path, bin_path))
-    pass_manager.run_passes(func)
-
-    res_model = core.read_model(model=xml_path, weights=bin_path)
-
-    assert func.get_parameters() == res_model.get_parameters()
-    assert func.get_ordered_ops() == res_model.get_ordered_ops()
-
-    os.remove(xml_path)
-    os.remove(bin_path)
-
-
-# request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
 def test_default_version(request, tmp_path):
     core = Core()
     xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
-    shape = [100, 100, 2]
-    parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
-    parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
-    parameter_c = ov.parameter(shape, dtype=np.float32, name="C")
-    parameter_d = ov.parameter(shape, dtype=np.float32, name="D")
-    model = ov.floor(ov.minimum(ov.abs(parameter_a), ov.multiply(parameter_b, parameter_c)))
-    func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
+    model = create_model()
     pass_manager = Manager()
-    pass_manager.register_pass("Serialize", output_files=(xml_path, bin_path))
-    pass_manager.run_passes(func)
+    pass_manager.register_pass(Serialize(xml_path, bin_path))
+    pass_manager.run_passes(model)
 
     res_model = core.read_model(model=xml_path, weights=bin_path)
 
-    assert func.get_parameters() == res_model.get_parameters()
-    assert func.get_ordered_ops() == res_model.get_ordered_ops()
-
-    os.remove(xml_path)
-    os.remove(bin_path)
-
-
-# request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
-def test_default_version_IR_V11_tuple(request, tmp_path):
-    core = Core()
-    xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
-    shape = [100, 100, 2]
-    parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
-    parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
-    parameter_c = ov.parameter(shape, dtype=np.float32, name="C")
-    parameter_d = ov.parameter(shape, dtype=np.float32, name="D")
-    model = ov.floor(ov.minimum(ov.abs(parameter_a), ov.multiply(parameter_b, parameter_c)))
-    func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
-    pass_manager = Manager()
-    pass_manager.register_pass("Serialize", output_files=(xml_path, bin_path), version="IR_V11")
-    pass_manager.run_passes(func)
-
-    res_model = core.read_model(model=xml_path, weights=bin_path)
-
-    assert func.get_parameters() == res_model.get_parameters()
-    assert func.get_ordered_ops() == res_model.get_ordered_ops()
+    assert model.get_parameters() == res_model.get_parameters()
+    assert model.get_ordered_ops() == res_model.get_ordered_ops()
 
     os.remove(xml_path)
     os.remove(bin_path)
@@ -241,21 +191,15 @@ def test_default_version_IR_V11_tuple(request, tmp_path):
 def test_default_version_IR_V11_seperate_paths(request, tmp_path):
     core = Core()
     xml_path, bin_path = create_filename_for_test(request.node.name, tmp_path)
-    shape = [100, 100, 2]
-    parameter_a = ov.parameter(shape, dtype=np.float32, name="A")
-    parameter_b = ov.parameter(shape, dtype=np.float32, name="B")
-    parameter_c = ov.parameter(shape, dtype=np.float32, name="C")
-    parameter_d = ov.parameter(shape, dtype=np.float32, name="D")
-    model = ov.floor(ov.minimum(ov.abs(parameter_a), ov.multiply(parameter_b, parameter_c)))
-    func = Model(model, [parameter_a, parameter_b, parameter_c], "Model")
+    model = create_model()
     pass_manager = Manager()
     pass_manager.register_pass(Serialize(path_to_xml=xml_path, path_to_bin=bin_path, version=Version.IR_V11))
-    pass_manager.run_passes(func)
+    pass_manager.run_passes(model)
 
     res_model = core.read_model(model=xml_path, weights=bin_path)
 
-    assert func.get_parameters() == res_model.get_parameters()
-    assert func.get_ordered_ops() == res_model.get_ordered_ops()
+    assert model.get_parameters() == res_model.get_parameters()
+    assert model.get_ordered_ops() == res_model.get_ordered_ops()
 
     os.remove(xml_path)
     os.remove(bin_path)

--- a/src/bindings/python/tests/test_transformations/test_manager.py
+++ b/src/bindings/python/tests/test_transformations/test_manager.py
@@ -32,14 +32,10 @@ def test_registration_and_pass_name():
     GraphRewrite().set_name("Anchor")
     BackwardGraphRewrite().set_name("BackAnchor")
 
-    # Preserve legacy behaviour when registered pass doesn't exist
-    # and in this case we shouldn't throw an exception.
-    manager.register_pass("NotExistingPass")
-
 
 def test_negative_pass_registration():
     manager = Manager()
     expect_exception(lambda: manager.register_pass(PatternReplacement))
     expect_exception(lambda: manager.register_pass("PatternReplacement", PatternReplacement()))
     expect_exception(lambda: manager.register_pass("Serialize", Serialize("out.xml", "out.bin")))
-    expect_exception(lambda: manager.register_pass("Serialize", "out.xml", "out.bin", "out.wrong"))
+    expect_exception(lambda: manager.register_pass(Serialize("out.xml", "out.bin", "out.wrong")))

--- a/src/bindings/python/tests/test_transformations/test_offline_api.py
+++ b/src/bindings/python/tests/test_transformations/test_offline_api.py
@@ -6,7 +6,7 @@ import os
 import pytest
 import numpy as np
 from openvino.runtime import serialize
-from openvino.offline_transformations import (
+from openvino._offline_transformations import (
     apply_moc_transformations,
     apply_pot_transformations,
     apply_low_latency_transformation,

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_einsum.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_einsum.py
@@ -27,7 +27,7 @@ def einsum_op_exec(input_shapes: list, equation: str, data_type: np.dtype,
     ng_inputs = []
     np_inputs = []
     for i in range(num_inputs):
-        input_i = np.random.random_integers(10, size=input_shapes[i]).astype(data_type)
+        input_i = np.random.randint(1, 10 + 1, size=input_shapes[i]).astype(data_type)
         np_inputs.append(input_i)
         ng_inputs.append(ng.parameter(input_i.shape, dtype=data_type))
 

--- a/src/bindings/python/tests_compatibility/test_ngraph/test_ops_fused.py
+++ b/src/bindings/python/tests_compatibility/test_ngraph/test_ops_fused.py
@@ -33,7 +33,7 @@ def test_elu_operator_with_scalar():
 
 
 def test_fake_quantize():
-    levels = np.float32(4)
+    levels = np.int32(4)
 
     data_shape = [1, 2, 3, 4]
     bound_shape = []
@@ -60,7 +60,7 @@ def test_fake_quantize():
 def test_depth_to_space():
     data_shape = [1, 4, 2, 3]
     mode = "blocks_first"
-    block_size = np.float32(2)
+    block_size = np.int32(2)
 
     parameter_data = ng.parameter(data_shape, name="Data", dtype=np.float32)
 


### PR DESCRIPTION
### Details:
 - Some overloadings of `register_pass` are deprecated and should be removed in this release, so I updated tests
 -  17 warnings -> 0 warnings for `tests` folder.
 -  24 warnings -> 0 warnings for `tests_compatibility` folder.

### Tickets:
 - 104388
