### PR TITLE
[TF FE] Fix auto-pruning for QueueDequeue operation

### DIFF
--- a/src/frontends/tensorflow/src/op/queue_dequeue.cpp
+++ b/src/frontends/tensorflow/src/op/queue_dequeue.cpp
@@ -16,17 +16,68 @@ namespace ov {
 namespace frontend {
 namespace tensorflow {
 namespace op {
+OutputVector translate_queue_dequeue_base(const ov::frontend::tensorflow::NodeContext& node,
+                                          const Output<Node>& handle,
+                                          const Dimension& batch_dim) {
+    auto node_name = node.get_name();
+    // all data about output shapes and types are saved in FIFOQueue operation
+    auto fifo_queue = as_type_ptr<FIFOQueue>(handle.get_node_shared_ptr());
+    TENSORFLOW_OP_VALIDATION(
+        node,
+        fifo_queue,
+        "[TensorFlow Frontend] Internal error: only FIFOQueue is supported as a producer for QueueDequeue operation.");
+    auto output_types = fifo_queue->get_component_types();
+    size_t output_num = output_types.size();
+
+    // output shapes is optional for FIFOQueue
+    // by default this is empty list so we should rely on output types list
+    auto output_shapes = fifo_queue->get_component_shapes();
+    for (size_t ind = 0; ind < output_shapes.size(); ++ind) {
+        // update output shapes from FIFOQueue with batch dimension
+        auto& output_shape = output_shapes[ind];
+        output_shape.insert(output_shape.begin(), batch_dim);
+    }
+
+    // try to extract output shapes using _output_shapes attribute if exists
+    if (output_shapes.size() == 0) {
+        output_shapes = node.get_attribute<vector<PartialShape>>("_output_shapes", vector<PartialShape>{});
+    }
+
+    OutputVector queue_dequeue_outputs;
+    // perform auto-pruning: create Parameter nodes for each output of QueueDequeue
+    for (size_t output_ind = 0; output_ind < output_num; ++output_ind) {
+        auto output_shape = PartialShape::dynamic();
+        if (output_ind < output_shapes.size()) {
+            output_shape = output_shapes[output_ind];
+        }
+        auto output_type = output_types[output_ind];
+        auto parameter = make_shared<Parameter>(output_type, output_shape);
+        if (output_num == 1) {
+            set_node_name(node_name, parameter);
+        } else {
+            set_node_name(node_name + ":" + to_string(output_ind), parameter);
+        }
+        queue_dequeue_outputs.push_back(parameter);
+    }
+    return queue_dequeue_outputs;
+}
 
 OutputVector translate_queue_dequeue_op(const ov::frontend::tensorflow::NodeContext& node) {
     // QueueDequeue operation generates multiple outputs
     // which we prune and create Parameter node for
-    vector<string> supported_ops = {"QueueDequeue",
-                                    "QueueDequeueV2",
-                                    "QueueDequeueUpTo",
-                                    "QueueDequeueUpToV2",
-                                    "QueueDequeueMany"};
+    vector<string> supported_ops = {"QueueDequeue", "QueueDequeueV2"};
+
+    default_op_checks(node, 1, supported_ops);
+    auto handle = node.get_input(0);
+
+    return translate_queue_dequeue_base(node, handle, Dimension::dynamic());
+}
+
+OutputVector translate_queue_dequeue_many_op(const ov::frontend::tensorflow::NodeContext& node) {
+    // QueueDequeue operation generates multiple outputs
+    // which we prune and create Parameter node for
+    vector<string> supported_ops = {"QueueDequeueUpTo", "QueueDequeueUpToV2", "QueueDequeueMany"};
     default_op_checks(node, 2, supported_ops);
-    auto node_name = node.get_name();
     auto handle = node.get_input(0);
     auto n = node.get_input(1);
 
@@ -40,35 +91,7 @@ OutputVector translate_queue_dequeue_op(const ov::frontend::tensorflow::NodeCont
         }
     }
 
-    // all data about output shapes and types are saved in FIFOQueue operation
-    auto fifo_queue = as_type_ptr<FIFOQueue>(handle.get_node_shared_ptr());
-    TENSORFLOW_OP_VALIDATION(
-        node,
-        fifo_queue,
-        "[TensorFlow Frontend] Internal error: only FIFOQueue is supported as a producer for QueueDequeue operation.");
-    auto output_shapes = fifo_queue->get_component_shapes();
-    auto output_types = fifo_queue->get_component_types();
-    size_t output_num = output_shapes.size();
-    TENSORFLOW_OP_VALIDATION(
-        node,
-        output_num == output_types.size(),
-        "[TensorFlow Frontend] Incorrect input model: lenghts of output_types and output_shapes do not match.");
-
-    OutputVector queue_dequeue_outputs;
-    // perform auto-pruning: create Parameter nodes for each output of QueueDequeue
-    for (size_t output_ind = 0; output_ind < output_num; ++output_ind) {
-        auto output_shape = output_shapes[output_ind];
-        auto output_type = output_types[output_ind];
-        output_shape.insert(output_shape.begin(), batch_dim);
-        auto parameter = make_shared<Parameter>(output_type, output_shape);
-        if (output_num == 1) {
-            set_node_name(node_name, parameter);
-        } else {
-            set_node_name(node_name + ":" + to_string(output_ind), parameter);
-        }
-        queue_dequeue_outputs.push_back(parameter);
-    }
-    return queue_dequeue_outputs;
+    return translate_queue_dequeue_base(node, handle, batch_dim);
 }
 
 }  // namespace op

--- a/src/frontends/tensorflow/src/op_table.cpp
+++ b/src/frontends/tensorflow/src/op_table.cpp
@@ -29,6 +29,7 @@ TF_OP_CONVERTER(translate_iterator_op);
 TF_OP_CONVERTER(translate_lookup_table_insert_op);
 TF_OP_CONVERTER(translate_partitioned_call_op);
 TF_OP_CONVERTER(translate_queue_dequeue_op);
+TF_OP_CONVERTER(translate_queue_dequeue_many_op);
 TF_OP_CONVERTER(translate_sparse_fill_empty_rows_op);
 TF_OP_CONVERTER(translate_sparse_reshape_op);
 TF_OP_CONVERTER(translate_sparse_segment_sum_op);
@@ -186,9 +187,9 @@ const std::map<std::string, CreatorFunction> get_supported_ops() {
         {"PadV2", translate_padv2_op},
         {"QueueDequeue", translate_queue_dequeue_op},
         {"QueueDequeueV2", translate_queue_dequeue_op},
-        {"QueueDequeueUpTo", translate_queue_dequeue_op},
-        {"QueueDequeueUpToV2", translate_queue_dequeue_op},
-        {"QueueDequeueMany", translate_queue_dequeue_op},
+        {"QueueDequeueUpTo", translate_queue_dequeue_many_op},
+        {"QueueDequeueUpToV2", translate_queue_dequeue_many_op},
+        {"QueueDequeueMany", translate_queue_dequeue_many_op},
         {"DynamicStitch", translate_parallel_dynamic_stitch_op},
         {"ParallelDynamicStitch", translate_parallel_dynamic_stitch_op},
         {"PartitionedCall", translate_partitioned_call_op},

--- a/src/frontends/tensorflow/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow/tests/convert_tricky_models.cpp
@@ -310,6 +310,20 @@ TEST_F(TransformationTestsF, ModelWithQueueOperations) {
     }
 }
 
+TEST_F(TransformationTestsF, ModelWithQueueOperations2) {
+    { model = convert_model("model_with_queue_ops2/model_with_queue_ops2.pb"); }
+    {
+        // create a reference graph
+        auto x = make_shared<Parameter>(element::f32, PartialShape{1, Dimension::dynamic(), Dimension::dynamic(), 3});
+        auto y = make_shared<Constant>(element::f32,
+                                       Shape{1, 1, 1, 3},
+                                       vector<float>{123.68000030517578, 116.77899932861328, 103.93900299072266});
+        auto sub = make_shared<Subtract>(x, y);
+
+        model_ref = make_shared<Model>(OutputVector{sub}, ParameterVector{x});
+    }
+}
+
 TEST_F(TransformationTestsF, ModelWithLookupTableOperations) {
     { model = convert_model("model_with_lookup_table/model_with_lookup_table.pb"); }
     {

--- a/src/frontends/tensorflow/tests/test_models/models_pbtxt/model_with_queue_ops2.pbtxt
+++ b/src/frontends/tensorflow/tests/test_models/models_pbtxt/model_with_queue_ops2.pbtxt
@@ -1,0 +1,166 @@
+node {
+  name: "fifo_queue"
+  op: "FIFOQueueV2"
+  attr {
+    key: "_output_shapes"
+    value {
+      list {
+        shape {
+        }
+      }
+    }
+  }
+  attr {
+    key: "capacity"
+    value {
+      i: 20
+    }
+  }
+  attr {
+    key: "component_types"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_FLOAT
+        type: DT_FLOAT
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "shapes"
+    value {
+      list {
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "fifo_queue_Dequeue"
+  op: "QueueDequeueV2"
+  input: "fifo_queue"
+  attr {
+    key: "_output_shapes"
+    value {
+      list {
+        shape {
+          dim {
+            size: 1
+          }
+        }
+        shape {
+          dim {
+            size: 1
+          }
+          dim {
+            size: -1
+          }
+          dim {
+            size: -1
+          }
+          dim {
+            size: 3
+          }
+        }
+        shape {
+          dim {
+            size: 1
+          }
+        }
+      }
+    }
+  }
+  attr {
+    key: "component_types"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_FLOAT
+        type: DT_FLOAT
+      }
+    }
+  }
+  attr {
+    key: "timeout_ms"
+    value {
+      i: -1
+    }
+  }
+}
+node {
+  name: "img_mean"
+  op: "Const"
+  attr {
+    key: "_output_shapes"
+    value {
+      list {
+        shape {
+          dim {
+            size: 1
+          }
+          dim {
+            size: 1
+          }
+          dim {
+            size: 1
+          }
+          dim {
+            size: 3
+          }
+        }
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 1
+          }
+          dim {
+            size: 1
+          }
+          dim {
+            size: 1
+          }
+          dim {
+            size: 3
+          }
+        }
+        tensor_content: ")\\\367B\331\216\351B\305\340\317B"
+      }
+    }
+  }
+}
+node {
+  name: "sub"
+  op: "Sub"
+  input: "fifo_queue_Dequeue:1"
+  input: "img_mean"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}


### PR DESCRIPTION
**Details:** Fix auto-pruning for QueueDequeue operation. It allows OOB conversion for attrack-coco-multi model.

**Ticket:** 103793
