### PR TITLE
[GPU] Fix remote blob creation to use original shape

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/infer_request.cpp
@@ -966,7 +966,7 @@ void InferRequest::prepare_input(const cldnn::primitive_id& inputName, Blob::Ptr
 
             auto input_layout = m_graph->GetInputLayouts().find(inputName);
             if (input_layout != m_graph->GetInputLayouts().end()) {
-                if (input_layout->second.format != inputMem->get_layout().format && input_layout->second.is_static()) {
+                if (input_layout->second != inputMem->get_layout() && input_layout->second.is_static()) {
                     inputMem = m_graph->GetNetwork()->get_engine().reinterpret_buffer(*inputMem, input_layout->second);
                 }
             }

--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -142,9 +142,9 @@ InferenceEngine::RemoteBlob::Ptr RemoteContextImpl::reuse_surface(InferenceEngin
     cldnn::shared_surface surf = extract_object<cldnn::shared_surface>(params, GPU_PARAM_KEY(DEV_OBJECT_HANDLE));
 #endif
 
-    cldnn::layout layout(ov::PartialShape(desc.getDims()),
-                         DataTypeFromPrecision(desc.getPrecision()),
-                         FormatFromLayout(desc.getLayout()));
+    cldnn::layout layout(DataTypeFromPrecision(desc.getPrecision()),
+                         ImageFormatFromLayout(desc.getLayout()),
+                         tensor_from_dims(desc.getDims()));
 
 #ifdef _WIN32
     auto blob = std::make_shared<RemoteD3DSurface>(public_context, stream,
@@ -164,9 +164,10 @@ InferenceEngine::RemoteBlob::Ptr RemoteContextImpl::reuse_memory(InferenceEngine
                                                                  cldnn::shared_handle mem,
                                                                  BlobType blob_type) {
     auto& stream = m_engine->get_service_stream();
-    cldnn::layout layout(ov::PartialShape(desc.getDims()),
-                         DataTypeFromPrecision(desc.getPrecision()),
-                         FormatFromLayout(desc.getLayout()));
+
+    cldnn::layout layout(DataTypeFromPrecision(desc.getPrecision()),
+                         FormatFromLayout(desc.getLayout()),
+                         tensor_from_dims(desc.getDims()));
 
     switch (blob_type) {
     case BlobType::BT_BUF_SHARED: {
@@ -193,10 +194,9 @@ InferenceEngine::RemoteBlob::Ptr RemoteContextImpl::reuse_memory(InferenceEngine
 
 InferenceEngine::RemoteBlob::Ptr RemoteContextImpl::create_buffer(InferenceEngine::gpu::ClContext::Ptr public_context,
                                                                   const InferenceEngine::TensorDesc& desc) {
-    cldnn::layout layout(ov::PartialShape(desc.getDims()),
-                         DataTypeFromPrecision(desc.getPrecision()),
-                         FormatFromLayout(desc.getLayout()));
-
+    cldnn::layout layout(DataTypeFromPrecision(desc.getPrecision()),
+                         FormatFromLayout(desc.getLayout()),
+                         tensor_from_dims(desc.getDims()));
     auto& stream = m_engine->get_service_stream();
     return std::make_shared<RemoteCLbuffer>(public_context,
                                             stream,
@@ -209,10 +209,9 @@ InferenceEngine::RemoteBlob::Ptr RemoteContextImpl::create_buffer(InferenceEngin
 InferenceEngine::RemoteBlob::Ptr RemoteContextImpl::create_usm(InferenceEngine::gpu::ClContext::Ptr public_context,
                                                                const InferenceEngine::TensorDesc& desc,
                                                                BlobType alloc_type) {
-    cldnn::layout layout(ov::PartialShape(desc.getDims()),
-                         DataTypeFromPrecision(desc.getPrecision()),
-                         FormatFromLayout(desc.getLayout()));
-
+    cldnn::layout layout(DataTypeFromPrecision(desc.getPrecision()),
+                         FormatFromLayout(desc.getLayout()),
+                         tensor_from_dims(desc.getDims()));
     auto& stream = m_engine->get_service_stream();
 
     return std::make_shared<RemoteUSMbuffer>(public_context,

--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -142,9 +142,9 @@ InferenceEngine::RemoteBlob::Ptr RemoteContextImpl::reuse_surface(InferenceEngin
     cldnn::shared_surface surf = extract_object<cldnn::shared_surface>(params, GPU_PARAM_KEY(DEV_OBJECT_HANDLE));
 #endif
 
-    cldnn::layout layout(DataTypeFromPrecision(desc.getPrecision()),
-                         ImageFormatFromLayout(desc.getLayout()),
-                         tensor_from_dims(desc.getDims()));
+    cldnn::layout layout(ov::PartialShape(desc.getDims()),
+                         DataTypeFromPrecision(desc.getPrecision()),
+                         FormatFromLayout(desc.getLayout()));
 
 #ifdef _WIN32
     auto blob = std::make_shared<RemoteD3DSurface>(public_context, stream,
@@ -164,10 +164,9 @@ InferenceEngine::RemoteBlob::Ptr RemoteContextImpl::reuse_memory(InferenceEngine
                                                                  cldnn::shared_handle mem,
                                                                  BlobType blob_type) {
     auto& stream = m_engine->get_service_stream();
-
-    cldnn::layout layout(DataTypeFromPrecision(desc.getPrecision()),
-                         FormatFromLayout(desc.getLayout()),
-                         tensor_from_dims(desc.getDims()));
+    cldnn::layout layout(ov::PartialShape(desc.getDims()),
+                         DataTypeFromPrecision(desc.getPrecision()),
+                         FormatFromLayout(desc.getLayout()));
 
     switch (blob_type) {
     case BlobType::BT_BUF_SHARED: {
@@ -194,9 +193,10 @@ InferenceEngine::RemoteBlob::Ptr RemoteContextImpl::reuse_memory(InferenceEngine
 
 InferenceEngine::RemoteBlob::Ptr RemoteContextImpl::create_buffer(InferenceEngine::gpu::ClContext::Ptr public_context,
                                                                   const InferenceEngine::TensorDesc& desc) {
-    cldnn::layout layout(DataTypeFromPrecision(desc.getPrecision()),
-                         FormatFromLayout(desc.getLayout()),
-                         tensor_from_dims(desc.getDims()));
+    cldnn::layout layout(ov::PartialShape(desc.getDims()),
+                         DataTypeFromPrecision(desc.getPrecision()),
+                         FormatFromLayout(desc.getLayout()));
+
     auto& stream = m_engine->get_service_stream();
     return std::make_shared<RemoteCLbuffer>(public_context,
                                             stream,
@@ -209,9 +209,10 @@ InferenceEngine::RemoteBlob::Ptr RemoteContextImpl::create_buffer(InferenceEngin
 InferenceEngine::RemoteBlob::Ptr RemoteContextImpl::create_usm(InferenceEngine::gpu::ClContext::Ptr public_context,
                                                                const InferenceEngine::TensorDesc& desc,
                                                                BlobType alloc_type) {
-    cldnn::layout layout(DataTypeFromPrecision(desc.getPrecision()),
-                         FormatFromLayout(desc.getLayout()),
-                         tensor_from_dims(desc.getDims()));
+    cldnn::layout layout(ov::PartialShape(desc.getDims()),
+                         DataTypeFromPrecision(desc.getPrecision()),
+                         FormatFromLayout(desc.getLayout()));
+
     auto& stream = m_engine->get_service_stream();
 
     return std::make_shared<RemoteUSMbuffer>(public_context,


### PR DESCRIPTION
### Details:
 - Fix remote blob memory checking failure due to the adjusted shape for cldnn::tensor 

### Tickets:
 
