### PR TITLE
Install patchelf for aarch64 linux

### DIFF
--- a/src/bindings/python/wheel/requirements-dev.txt
+++ b/src/bindings/python/wheel/requirements-dev.txt
@@ -1,3 +1,3 @@
 setuptools>=53.0.0
 wheel>=0.38.1
-patchelf; sys_platform == 'linux' and platform_machine == 'x86_64'
+patchelf; sys_platform == 'linux' and platform_machine == 'x86_64' or sys_platform == 'linux' and platform_machine == 'aarch64'


### PR DESCRIPTION
### Details:
 - To enable platforms like openSUSE where patchelf is not available from system level package manager