### PR TITLE
Fixed compilation with gcc-7

### DIFF
--- a/src/core/reference/include/ngraph/runtime/reference/eye.hpp
+++ b/src/core/reference/include/ngraph/runtime/reference/eye.hpp
@@ -19,15 +19,8 @@ void eye(T* data, const Shape& out_shape, const int64_t diagonal_index) {
     const int64_t num_columns = out_shape[out_shape.size() - 1];
     const int64_t matrix_size = num_rows * num_columns;
 
-#if defined(__GNUC__) && !defined(__clang__)
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wclass-memaccess"  // to avoid warnings for memset of ov::float16, ov::bfloat16
-#endif
     // fill tensor by zero
     std::memset(data, 0, num_matrices * num_columns * num_rows * sizeof(T));
-#if defined(__GNUC__) && !defined(__clang__)
-#    pragma GCC diagnostic pop
-#endif
 
     // set ones on diagonal
     const int64_t shift_by_columns = std::max(diagonal_index, int64_t(0));

--- a/src/core/src/op/eye.cpp
+++ b/src/core/src/op/eye.cpp
@@ -24,8 +24,6 @@ bool evaluate_eye(const ov::HostTensorPtr& out, const int64_t diagonal_index) {
     switch (out->get_element_type()) {
         NGRAPH_TYPE_CASE(evaluate, i8, out, diagonal_index);
         NGRAPH_TYPE_CASE(evaluate, u8, out, diagonal_index);
-        NGRAPH_TYPE_CASE(evaluate, f16, out, diagonal_index);
-        NGRAPH_TYPE_CASE(evaluate, bf16, out, diagonal_index);
         NGRAPH_TYPE_CASE(evaluate, i32, out, diagonal_index);
         NGRAPH_TYPE_CASE(evaluate, f32, out, diagonal_index);
         NGRAPH_TYPE_CASE(evaluate, f64, out, diagonal_index);


### PR DESCRIPTION
### Details:
 - The operation was introduced here https://github.com/openvinotoolkit/openvino/pull/11538
 - @mitruska I suppose we don't need reference implementation for at least float16 and bfloat16 types?
 - If we remove f16 and bf16 from evaluate, warnings are eliminated