### PR TITLE
[Snippets] Added matcher_name in ConvertConstantsToScalars pass

### DIFF
--- a/src/common/snippets/src/pass/convert_constants.cpp
+++ b/src/common/snippets/src/pass/convert_constants.cpp
@@ -32,5 +32,5 @@ ngraph::snippets::pass::ConvertConstantsToScalars::ConvertConstantsToScalars() {
         ngraph::replace_node(constant, scalar);
         return true;
     };
-    register_matcher(std::make_shared<ov::pass::pattern::Matcher>(constants), callback);
+    register_matcher(std::make_shared<ov::pass::pattern::Matcher>(constants, matcher_name), callback);
 }

--- a/src/common/snippets/src/pass/convert_power_to_powerstatic.cpp
+++ b/src/common/snippets/src/pass/convert_power_to_powerstatic.cpp
@@ -16,7 +16,7 @@ ngraph::snippets::pass::ConvertPowerToPowerStatic::ConvertPowerToPowerStatic() {
                                                                is_type<snippets::op::Scalar>(n->get_input_node_shared_ptr(1));
                                                     });
     ngraph::graph_rewrite_callback callback = [](ngraph::pattern::Matcher &m) {
-        OV_ITT_SCOPED_TASK(ngraph::pass::itt::domains::SnippetsTransform, "Snippets::op::ConvertConstantsToScalars")
+        OV_ITT_SCOPED_TASK(ngraph::pass::itt::domains::SnippetsTransform, "Snippets::op::ConvertPowerToPowerStatic")
         auto power = ov::as_type_ptr<ov::op::v1::Power>(m.get_match_root());
         auto scalar = ov::as_type_ptr<snippets::op::Scalar>(power->get_input_node_shared_ptr(1));
         auto value = scalar->cast_vector<float>()[0];


### PR DESCRIPTION
### Details:
 - *Fixed CC for Snippets - there was missed name for matcher pass `ConvertConstantsToScalars`*
 - *Fixed ITT task name for `ConvertPowerToPowerStatic` pass*

### Tickets:
 - *104501*
