### PR TITLE
[Snippets] Fixed potential constants getter for FQ

### DIFF
--- a/src/common/snippets/src/utils.cpp
+++ b/src/common/snippets/src/utils.cpp
@@ -11,21 +11,19 @@ namespace snippets {
 namespace utils {
 
 auto get_non_scalar_constant_count_for_fq(const std::shared_ptr<opset1::FakeQuantize>& fq) -> size_t {
-    std::vector<float> out_scales;
     std::vector<float> cl, ch, isc, ish, osc, osh;
     const bool status = ngraph::snippets::pass::FakeQuantizeDecomposition::getScalesAndShifts(fq, cl, ch, isc, ish, osc, osh);
+    bool is_optimized = false;  // The case when we can calculate only scales
     if (status) {
-        out_scales = ngraph::snippets::pass::FakeQuantizeDecomposition::calculateScales(fq->get_output_element_type(0), cl, ch, isc, ish, osc, osh);
-        if (out_scales.size() != 0) {
-            return out_scales.size() != 1;
-        }
+        const auto out_scales = ngraph::snippets::pass::FakeQuantizeDecomposition::calculateScales(fq->get_output_element_type(0), cl, ch, isc, ish, osc, osh);
+        is_optimized = out_scales.size() != 0;
     }
 
-    const bool only_quantized = status &&
-                                std::all_of(osc.cbegin(), osc.cend(),
-                                    [](float val) { return val == 1.f; }) &&
-                                std::all_of(osh.cbegin(), osh.cend(),
-                                    [](float val) { return val == 0.f; });
+    const bool only_quantized = is_optimized || (status &&
+                                                 std::all_of(osc.cbegin(), osc.cend(),
+                                                     [](float val) { return val == 1.f; }) &&
+                                                 std::all_of(osh.cbegin(), osh.cend(),
+                                                     [](float val) { return val == 0.f; }));
     const bool il = ngraph::shape_size(fq->input(1).get_shape()) != 1lu;
     const bool ih = ngraph::shape_size(fq->input(2).get_shape()) != 1lu;
     const bool ol = !only_quantized && ngraph::shape_size(fq->input(3).get_shape()) != 1lu;
@@ -40,23 +38,34 @@ auto get_non_scalar_constant_count_for_fq(const std::shared_ptr<opset1::FakeQuan
     //      - osh := ol
     // New formula:
     //      round(x * isc + ish) * osc + osh
-    // Thus, after FakeQuantize decompoisition we have 6 Constants instead of original 4:
-    //      ih, il (for Max/Min), isc, ish, osc, osh
+    // Thus, after FakeQuantize decompoisition we have:
+    //      - If it's non optimized FQ, 6 Constants instead of original 4:
+    //              ih, il (for Max/Min), isc, ish, osc, osh
+    //      - If it's optimized FQ, 3 Constants instead of original 4:
+    //              ih, il (for Max/Min), isc
     // Some of them can be scalar or non-scalar. It depends on which original 4 Constants are non-scalar
     // To sum it up, below conditions check all possible cases to calculate count of new generated non-scalars
-    if (ol && il && ih)
-        return 6;
-    else if ((ol && (il || ih)) || (il && ih && oh))
-        return 5;
-    else if ((il && oh) || (ih && oh) || (il && ih))
-        return 4;
-    else if (il || ih)
-        return 3;
-    else if (ol)
-        return 2;
-    else if (oh)
-        return 1;
-    return 0;
+    if (is_optimized) {
+        if (il && ih)
+            return 3;
+        else if (il || ih)
+            return 2;
+        return 0;
+    } else {
+        if (ol && il && ih)
+            return 6;
+        else if ((ol && (il || ih)) || (il && ih && oh))
+            return 5;
+        else if ((il && oh) || (ih && oh) || (il && ih))
+            return 4;
+        else if (il || ih)
+            return 3;
+        else if (ol)
+            return 2;
+        else if (oh)
+            return 1;
+        return 0;
+    }
 }
 std::vector<size_t> get_node_output_layout(const std::shared_ptr<Node>& node) {
     return get_node_output_layout(node.get());

--- a/src/common/snippets/tests/src/pass/collapse_subgraph.cpp
+++ b/src/common/snippets/tests/src/pass/collapse_subgraph.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <pass/collapse_subgraph.hpp>
 #include <subgraph_simple.hpp>
+#include <subgraph_fq.hpp>
 #include <subgraph_converts.hpp>
 #include "snippets/pass/tokenization.hpp"
 
@@ -87,6 +88,13 @@ TEST_F(CollapseSubgraphTests, smoke_Snippets_EltwiseTwoResultsFunction) {
     function = f.getOriginal();
     function_ref = f.getReference();
     comparator.enable(FunctionsComparator::CmpValues::NAMES);
+    run();
+}
+
+TEST_F(CollapseSubgraphTests, smoke_Snippets_ThreeFQFunction) {
+    const auto &f = ThreeFQFunction(std::vector<PartialShape>{});
+    function = f.getOriginal();
+    function_ref = f.getReference();
     run();
 }
 

--- a/src/tests/ngraph_helpers/snippets_ngraph_functions/CMakeLists.txt
+++ b/src/tests/ngraph_helpers/snippets_ngraph_functions/CMakeLists.txt
@@ -25,6 +25,7 @@ addIeTarget(
                 openvino::runtime::dev
                 commonTestUtils
                 inference_engine_snippets
+                lptNgraphFunctions
         ADD_CPPLINT
         DEVELOPER_PACKAGE
             tests

--- a/src/tests/ngraph_helpers/snippets_ngraph_functions/include/subgraph_fq.hpp
+++ b/src/tests/ngraph_helpers/snippets_ngraph_functions/include/subgraph_fq.hpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2022-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "ngraph/ngraph.hpp"
+#include "./snippets_helpers.hpp"
+
+/* This file contains definitions of relatively simple functions (models) that will be used
+ * to test snippets-specific behavior. All the functions are expected to be direct descendants of
+ * SnippetsFunctionBase, so their constructors take only one (inputShapes) argument.
+ */
+
+namespace ov {
+namespace test {
+namespace snippets {
+/// Non-supported potential count of Constants after FQ decomposition
+//    in1
+//    FQ - 3 Constants ---- Subgraph0 with 11 IO
+//    FQ - 6 Constants --/
+//    FQ - 3 Constants ---- Subgraph1 with 4 IO
+//   Result
+class ThreeFQFunction : public SnippetsFunctionBase {
+public:
+    explicit ThreeFQFunction(const std::vector<PartialShape>& inputShapes) : SnippetsFunctionBase({{1, 3, 20, 20}}) {}
+protected:
+    std::shared_ptr<ov::Model> initOriginal() const override;
+    std::shared_ptr<ov::Model> initReference() const override;
+};
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov

--- a/src/tests/ngraph_helpers/snippets_ngraph_functions/src/subgraph_fq.cpp
+++ b/src/tests/ngraph_helpers/snippets_ngraph_functions/src/subgraph_fq.cpp
@@ -1,0 +1,81 @@
+// Copyright (C) 2022-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "subgraph_fq.hpp"
+#include "common_test_utils/data_utils.hpp"
+#include "lpt_ngraph_functions/common/builders.hpp"
+#include <snippets/op/subgraph.hpp>
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+std::shared_ptr<ov::Model> ThreeFQFunction::initOriginal() const {
+    auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
+    auto fq0_data = ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
+                                                                              std::vector<ngraph::Shape>{{1, 3, 1, 1}, {1, 3, 1, 1}, {1}, {1}},
+                                                                              std::vector<float>{-397898.40625, -435929.78125, -476583.9375},
+                                                                              std::vector<float>{394789.84375, 432524.09375, 472860.625},
+                                                                              std::vector<float>{0},
+                                                                              std::vector<float>{255},
+                                                                              ov::element::u8);
+    auto fq0 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(data0, ov::element::f32, fq0_data);
+    auto fq1_data = ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
+                                                                              std::vector<ngraph::Shape>{{1, 3, 1, 1}, {1, 3, 1, 1}, {1}, {1}},
+                                                                              std::vector<float>{5.390228, 9.7712707, 9.333160},
+                                                                              std::vector<float>{250.524688, 254.905731, 254.467620},
+                                                                              std::vector<float>{-128},
+                                                                              std::vector<float>{127},
+                                                                              ov::element::i8);
+    auto fq1 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(fq0, ov::element::f32, fq1_data);
+    auto fq2_data = ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
+                                                                              std::vector<ngraph::Shape>{{1, 3, 1, 1}, {1, 3, 1, 1}, {1}, {1}},
+                                                                              std::vector<float>{-98.16883, -142.82466, -155.0642700},
+                                                                              std::vector<float>{97.334106, 141.599884, 153.8145446},
+                                                                              std::vector<float>{0},
+                                                                              std::vector<float>{255},
+                                                                              ov::element::u8);
+    auto fq2 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(fq1, ov::element::f32, fq2_data);
+    return std::make_shared<ov::Model>(NodeVector{fq2}, ParameterVector{data0});
+}
+std::shared_ptr<ov::Model> ThreeFQFunction::initReference() const {
+    auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
+
+    auto indata0 = std::make_shared<op::v0::Parameter>(precision, data0->get_shape());
+    auto fq0_data = ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
+                                                                              std::vector<ngraph::Shape>{{1, 3, 1, 1}, {1, 3, 1, 1}, {1}, {1}},
+                                                                              std::vector<float>{-397898.40625, -435929.78125, -476583.9375},
+                                                                              std::vector<float>{394789.84375, 432524.09375, 472860.625},
+                                                                              std::vector<float>{0},
+                                                                              std::vector<float>{255},
+                                                                              ov::element::u8);
+    auto fq0 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(indata0, ov::element::f32, fq0_data);
+    auto fq1_data = ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
+                                                                              std::vector<ngraph::Shape>{{1, 3, 1, 1}, {1, 3, 1, 1}, {1}, {1}},
+                                                                              std::vector<float>{5.390228, 9.7712707, 9.333160},
+                                                                              std::vector<float>{250.524688, 254.905731, 254.467620},
+                                                                              std::vector<float>{-128},
+                                                                              std::vector<float>{127},
+                                                                              ov::element::i8);
+    auto fq1 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(fq0, ov::element::f32, fq1_data);
+    auto subgraph0 = std::make_shared<ngraph::snippets::op::Subgraph>(NodeVector{data0},
+                                          std::make_shared<ov::Model>(NodeVector{fq1}, ParameterVector{indata0}));
+
+    auto indata1 = std::make_shared<op::v0::Parameter>(precision, subgraph0->get_shape());
+    auto fq2_data = ngraph::builder::subgraph::FakeQuantizeOnDataWithConstant(256,
+                                                                              std::vector<ngraph::Shape>{{1, 3, 1, 1}, {1, 3, 1, 1}, {1}, {1}},
+                                                                              std::vector<float>{-98.16883, -142.82466, -155.0642700},
+                                                                              std::vector<float>{97.334106, 141.599884, 153.8145446},
+                                                                              std::vector<float>{0},
+                                                                              std::vector<float>{255},
+                                                                              ov::element::u8);
+    auto fq2 = ngraph::builder::subgraph::makeFakeQuantizeTypeRelaxed(indata1, ov::element::f32, fq2_data);
+    auto subgraph1 = std::make_shared<ngraph::snippets::op::Subgraph>(NodeVector{subgraph0},
+                                      std::make_shared<ov::Model>(NodeVector{fq2}, ParameterVector{indata1}));
+
+    return std::make_shared<ov::Model>(NodeVector{subgraph1}, ParameterVector{data0});
+}
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - *Before `get_non_scalar_constant_count_for_fq` returned incorrect number of potential constants for optimized FQ*

### Tickets:
 - *103438*
 
 ### TODO:
- [x] *DLB validation on INT8 model cache - the results are attached to the ticket*
