### PR TITLE
Clearing of CustomReplacementRegistry.registry in convert_model()

### DIFF
--- a/tests/layer_tests/mo_python_api_tests/test_legacy_exts/test_config_transform/front/custom_transform.py
+++ b/tests/layer_tests/mo_python_api_tests/test_legacy_exts/test_config_transform/front/custom_transform.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2018-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from openvino.tools.mo.front.tf.replacement import FrontReplacementFromConfigFileGeneral
+from openvino.tools.mo.graph.graph import Graph
+from openvino.tools.mo.utils.error import Error
+
+
+class ConfigBasedTestReplacement(FrontReplacementFromConfigFileGeneral):
+    replacement_id = 'ConfigBasedTestReplacement'
+    run_not_recursively = True
+
+    def transform_graph(self, graph: Graph, replacement_descriptions):
+        sigmoid_nodes = graph.get_op_nodes(op='Sigmoid')
+        assert len(sigmoid_nodes) > 0, "Error while applying ConfigBasedTestReplacement."

--- a/tests/layer_tests/mo_python_api_tests/test_transform_config/test_config.json
+++ b/tests/layer_tests/mo_python_api_tests/test_transform_config/test_config.json
@@ -1,0 +1,9 @@
+[
+    {
+       "custom_attributes": {
+            "masks_node_prefix_name": "node_name"
+        },
+        "id": "ConfigBasedTestReplacement",
+        "match_kind": "general"
+    }
+]

--- a/tools/mo/openvino/tools/mo/utils/class_registration.py
+++ b/tools/mo/openvino/tools/mo/utils/class_registration.py
@@ -7,6 +7,7 @@ from enum import Enum
 
 import networkx as nx
 
+from openvino.tools.mo.front.common.custom_replacement_registry import CustomReplacementRegistry
 from openvino.tools.mo.graph.graph import Graph
 from openvino.tools.mo.middle.passes.eliminate import shape_inference
 from openvino.tools.mo.middle.pattern_match import for_graph_and_each_sub_graph_recursively
@@ -337,4 +338,5 @@ def apply_replacements(graph: Graph, replacements_type: list):
 
 
 def clear_registered_classes_dict():
+    CustomReplacementRegistry.registry = {}
     _registered_classes_dict.clear()


### PR DESCRIPTION
Root cause analysis: 
Custom replacement are registered in global class field CustomReplacementRegistry.registry.
If convert_model() runs multiple times this field keeps previously registered custom replacements which break MO pipeline.

Solution: Clear CustomReplacementRegistry.registry at start of convert_model().

Ticket: 104326, 104379


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR - N/A
* [x]  Transformation preserves original framework node names - N/A
* [x]  Transformation preserves tensor names - N/A


Validation:
* [x]  Unit tests 
* [x]  Framework operation tests - N/A
* [x]  Transformation tests - N/A
* [x]  Model Optimizer IR Reader check - N/A
* [x]  This case is covered in convert_model() e2e, ticket 99815
* [x]  Validation was performed on custom job with e2e run

Documentation:
* [x]  Supported frameworks operations list - N/A
* [x]  Guide on how to convert the **public** model - N/A
* [x]  User guide update - N/A