### PR TITLE
【PaddlePaddle Hackathon 4】add silu op mapping in Paddle frontend

### DIFF
--- a/src/frontends/paddle/src/op/silu.cpp
+++ b/src/frontends/paddle/src/op/silu.cpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "default_opset.hpp"
+#include "openvino/frontend/paddle/node_context.hpp"
+
+namespace ov {
+namespace frontend {
+namespace paddle {
+namespace op {
+NamedOutputs silu(const NodeContext& node) {
+    const auto x = node.get_input("X");
+    const float beta = node.get_attribute<float>("beta", 1.0f);
+    const auto beta_node = default_opset::Constant::create(element::f32, Shape{}, {beta});
+
+    return node.default_single_output_mapping({std::make_shared<default_opset::Swish>(x, beta_node)}, {"Out"});
+}
+
+}  // namespace op
+}  // namespace paddle
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/paddle/src/op_table.cpp
+++ b/src/frontends/paddle/src/op_table.cpp
@@ -92,6 +92,7 @@ OP_CONVERTER(slice);
 OP_CONVERTER(softmax);
 OP_CONVERTER(softplus);
 OP_CONVERTER(sigmoid);
+OP_CONVERTER(silu);
 OP_CONVERTER(split);
 OP_CONVERTER(sqrt);
 OP_CONVERTER(squeeze);
@@ -206,6 +207,7 @@ std::map<std::string, CreatorFunction> get_supported_ops() {
             {"softmax", op::softmax},
             {"softplus", op::softplus},
             {"sigmoid", op::sigmoid},
+            {"silu", op::silu},
             {"split", op::split},
             {"sqrt", op::sqrt},
             {"squeeze2", op::squeeze},

--- a/src/frontends/paddle/tests/op_fuzzy.cpp
+++ b/src/frontends/paddle/tests/op_fuzzy.cpp
@@ -447,6 +447,7 @@ static const std::vector<std::string> models{
     std::string("scale_tensor_bias_before"),
     std::string("shape"),
     std::string("sigmoid"),
+    std::string("silu"),
     std::string("slice"),
     std::string("slice_1d"),
     std::string("slice_decrease_axis/slice_decrease_axis.pdmodel"),

--- a/src/frontends/paddle/tests/test_models/gen_scripts/generate_silu.py
+++ b/src/frontends/paddle/tests/test_models/gen_scripts/generate_silu.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2018-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# silu paddle model generator
+#
+import numpy as np
+from save_model import saveModel
+import paddle
+import sys
+
+
+def silu(name: str, x):
+    import paddle
+    paddle.enable_static()
+
+    with paddle.static.program_guard(paddle.static.Program(), paddle.static.Program()):
+        node_x = paddle.static.data(name='x', shape=x.shape, dtype='float32')
+        out = paddle.nn.functional.silu(node_x)
+
+        cpu = paddle.static.cpu_places(1)
+        exe = paddle.static.Executor(cpu[0])
+        # startup program will call initializer to initialize the parameters.
+        exe.run(paddle.static.default_startup_program())
+
+        outs = exe.run(
+            feed={'x': x},
+            fetch_list=[out])
+
+        saveModel(name, exe, feedkeys=['x'], fetchlist=[out],
+                  inputs=[x], outputs=[outs[0]], target_dir=sys.argv[1])
+
+    return outs[0]
+
+
+def main():
+    data = np.array([1., 2., 3., 4.]).astype('float32')
+
+    silu("silu", data)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Details:
- add silu operation in Paddle front end
- map silu to swish because of similar equivalent formula

### Tickets:

### Reference:
https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/Silu_cn.html#silu

### UT:
![image](https://user-images.githubusercontent.com/13817444/220702797-b64b858b-1031-4e9f-b890-9a227ac80b1b.png)
