### PR TITLE
[TESTS] make axis of VariadicSplit int in tests to support negative values

### DIFF
--- a/src/tests/functional/plugin/gpu/single_layer_tests/dynamic/split.cpp
+++ b/src/tests/functional/plugin/gpu/single_layer_tests/dynamic/split.cpp
@@ -16,7 +16,7 @@ namespace GPULayerTestsDefinitions {
 
 typedef std::tuple<
         size_t,                    // Num splits
-        size_t,                    // Axis
+        int64_t,                   // Axis
         ElementType,               // Net precision
         InputShape,                // Input shapes
         std::vector<size_t>        // Used outputs indices
@@ -52,7 +52,8 @@ public:
 protected:
     void SetUp() override {
         targetDevice = CommonTestUtils::DEVICE_GPU;
-        size_t axis, numSplits;
+        int64_t axis;
+        size_t numSplits;
         InputShape inputShape;
         std::vector<size_t> outIndices;
         ElementType netPrecision;
@@ -127,7 +128,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_SplitsCheck6D, SplitLayerGPUDynamicTest,
                         SplitLayerGPUDynamicTest::getTestCaseName);
 
 typedef std::tuple<
-        size_t,                    // Axis
+        int64_t,                   // Axis
         std::vector<int32_t>,      // SplitLength
         ElementType,               // Net precision
         InputShape                // Input shapes
@@ -138,7 +139,7 @@ class VariadicSplitLayerGPUDynamicTest : public testing::WithParamInterface<varS
 public:
     static std::string getTestCaseName(testing::TestParamInfo<varSplitDynamicGPUTestParams> obj) {
         std::ostringstream result;
-        size_t axis;
+        int64_t axis;
         std::vector<int32_t> splitLength;
         ElementType netPrecision;
         InputShape inputShape;
@@ -159,7 +160,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = CommonTestUtils::DEVICE_GPU;
-        size_t axis;
+        int64_t axis;
         InputShape inputShape;
         std::vector<int32_t> splitLength;
         ElementType netPrecision;

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/variadic_split.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/variadic_split.hpp
@@ -16,7 +16,7 @@ namespace LayerTestsDefinitions {
 
 typedef std::tuple<
         std::vector<size_t>,            // Num splits
-        size_t,                         // Axis
+        int64_t,                        // Axis
         InferenceEngine::Precision,     // Net precision
         InferenceEngine::Precision,     // Input precision
         InferenceEngine::Precision,     // Output precision

--- a/src/tests/functional/shared_test_classes/src/single_layer/variadic_split.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_layer/variadic_split.cpp
@@ -7,7 +7,7 @@
 namespace LayerTestsDefinitions {
 
     std::string VariadicSplitLayerTest::getTestCaseName(const testing::TestParamInfo<VariadicSplitParams>& obj) {
-        size_t axis;
+        int64_t axis;
         std::vector<size_t> numSplits;
         InferenceEngine::Precision netPrecision;
         InferenceEngine::Precision inPrc, outPrc;
@@ -30,7 +30,7 @@ namespace LayerTestsDefinitions {
     }
 
     void VariadicSplitLayerTest::SetUp() {
-        size_t axis;
+        int64_t axis;
         std::vector<size_t> inputShape, numSplits;
         InferenceEngine::Precision netPrecision;
         std::tie(numSplits, axis, netPrecision, inPrc, outPrc, inLayout, outLayout, inputShape, targetDevice) = this->GetParam();

--- a/src/tests/functional/shared_test_classes/src/subgraph/variadic_split_pad.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/variadic_split_pad.cpp
@@ -8,7 +8,7 @@ namespace SubgraphTestsDefinitions {
 
 std::string VariadicSplitPad::getTestCaseName(const testing::TestParamInfo<SplitPadTuple> &obj) {
     InferenceEngine::SizeVector inputShape;
-    size_t axis;
+    int64_t axis;
     std::vector<size_t> numSplits, connectIndexes;
     std::vector<int64_t> padsBegin, padsEnd;
     ngraph::helpers::PadMode padMode;
@@ -31,7 +31,7 @@ std::string VariadicSplitPad::getTestCaseName(const testing::TestParamInfo<Split
 
 void VariadicSplitPad::SetUp() {
     InferenceEngine::SizeVector inputs;
-    size_t axis;
+    int64_t axis;
     std::vector<size_t> numSplits, connectIndexes;
     std::vector<int64_t> padBegin, padEnd;
     ngraph::helpers::PadMode padMode;

--- a/src/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
+++ b/src/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
@@ -250,7 +250,7 @@ std::shared_ptr<ngraph::Node> makeSplit(const ngraph::Output<Node> &in,
 
 std::shared_ptr<ngraph::Node> makeVariadicSplit(const ngraph::Output<Node> &in,
                                                 const std::vector<size_t> numSplits,
-                                                size_t axis);
+                                                int64_t axis);
 
 std::shared_ptr<ngraph::Node> makeActivation(const ngraph::Output<Node> &in,
                                              const element::Type &type,

--- a/src/tests/ngraph_helpers/ngraph_functions/src/variadic_split.cpp
+++ b/src/tests/ngraph_helpers/ngraph_functions/src/variadic_split.cpp
@@ -11,9 +11,9 @@ namespace ngraph {
 namespace builder {
         std::shared_ptr<ngraph::Node> makeVariadicSplit(const ngraph::Output<Node> &in,
                                                         const std::vector<size_t> numSplits,
-                                                        size_t axis) {
-            auto splitAxisOp = std::make_shared<ngraph::opset3::Constant>(element::u64, ngraph::Shape{},
-                                                                          std::vector<size_t>{axis});
+                                                        int64_t axis) {
+            auto splitAxisOp = std::make_shared<ngraph::opset3::Constant>(element::i64, ngraph::Shape{},
+                                                                          std::vector<int64_t>{axis});
             auto numSplit = std::make_shared<ngraph::opset3::Constant>(element::u64, ngraph::Shape{numSplits.size()},
                                                                        numSplits);
             auto VariadicSplitNode = std::make_shared<ngraph::opset3::VariadicSplit>(in, splitAxisOp, numSplit);


### PR DESCRIPTION
### Details:
 - *Make axis of VariadicSplit int in tests to support negative values*
```
2: axis. Axis along data to split. A scalar or tensor with shape [1] of type T2 with value from range -rank(data) .. rank(data)-1. Negative values address dimensions from the end. Required.
```
[VariadicSplit](https://github.com/openvinotoolkit/openvino/blob/master/docs/ops/movement/VariadicSplit_1.md)

### Tickets:
 - *ticket-id*
