### PR TITLE
Fixed samples build on Debian 10 with cmake 3.13

### DIFF
--- a/.ci/azure/linux_conditional_compilation.yml
+++ b/.ci/azure/linux_conditional_compilation.yml
@@ -30,6 +30,7 @@ resources:
     type: github
     endpoint: openvinotoolkit
     name: openvinotoolkit/testdata
+    ref: releases/2022/3
 
 jobs:
 - job: LinCC

--- a/.ci/azure/linux_cuda.yml
+++ b/.ci/azure/linux_cuda.yml
@@ -37,11 +37,13 @@ resources:
     type: github
     endpoint: openvinotoolkit
     name: openvinotoolkit/openvino_contrib
+    ref: releases/2022/3
 
   - repository: testdata
     type: github
     endpoint: openvinotoolkit
     name: openvinotoolkit/testdata
+    ref: releases/2022/3
 
 jobs:
 - job: CUDAPlugin_Lin

--- a/.ci/azure/windows_conditional_compilation.yml
+++ b/.ci/azure/windows_conditional_compilation.yml
@@ -30,6 +30,7 @@ resources:
     type: github
     endpoint: openvinotoolkit
     name: openvinotoolkit/testdata
+    ref: releases/2022/3
 
 jobs:
 - job: WinCC

--- a/samples/cpp/benchmark_app/CMakeLists.txt
+++ b/samples/cpp/benchmark_app/CMakeLists.txt
@@ -26,6 +26,7 @@ if(NOT TARGET nlohmann_json::nlohmann_json)
     if(TARGET nlohmann_json)
         # Ubuntu 18.04 case where target 'nlohmann_json' is here, but nlohmann_json_FOUND is OFF
         if(NOT TARGET nlohmann_json::nlohmann_json)
+            set_target_properties(nlohmann_json PROPERTIES IMPORTED_GLOBAL ON)
             add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json)
         endif()
         set(nlohmann_json_FOUND ON)

--- a/samples/cpp/speech_sample/CMakeLists.txt
+++ b/samples/cpp/speech_sample/CMakeLists.txt
@@ -15,8 +15,8 @@ endif()
 if(NOT TARGET zlib::zlib)
     if(PkgConfig_FOUND)
         pkg_search_module(zlib QUIET
-                        IMPORTED_TARGET GLOBAL
-                        zlib)
+                          IMPORTED_TARGET GLOBAL
+                          zlib)
         if(zlib_FOUND)
             add_library(zlib::zlib ALIAS PkgConfig::zlib)
         endif()

--- a/src/bindings/python/wheel/requirements-dev.txt
+++ b/src/bindings/python/wheel/requirements-dev.txt
@@ -1,3 +1,3 @@
-setuptools>=53.0.0
+setuptools>=53.0.0,<=65.7.0
 wheel>=0.38.1
 patchelf; sys_platform == 'linux' and platform_machine == 'x86_64'


### PR DESCRIPTION
```
CMake Error at benchmark_app/CMakeLists.txt:29 (add_library):
  add_library cannot create ALIAS target "nlohmann_json::nlohmann_json"
  because target "nlohmann_json" is imported but not globally visible.
```