### PR TITLE
Fixed samples build on Debian 10 with cmake 3.13

### DIFF
--- a/samples/cpp/benchmark_app/CMakeLists.txt
+++ b/samples/cpp/benchmark_app/CMakeLists.txt
@@ -26,6 +26,7 @@ if(NOT TARGET nlohmann_json::nlohmann_json)
     if(TARGET nlohmann_json)
         # Ubuntu 18.04 case where target 'nlohmann_json' is here, but nlohmann_json_FOUND is OFF
         if(NOT TARGET nlohmann_json::nlohmann_json)
+            set_target_properties(nlohmann_json PROPERTIES IMPORTED_GLOBAL ON)
             add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json)
         endif()
         set(nlohmann_json_FOUND ON)

--- a/samples/cpp/speech_sample/CMakeLists.txt
+++ b/samples/cpp/speech_sample/CMakeLists.txt
@@ -15,8 +15,8 @@ endif()
 if(NOT TARGET zlib::zlib)
     if(PkgConfig_FOUND)
         pkg_search_module(zlib QUIET
-                        IMPORTED_TARGET GLOBAL
-                        zlib)
+                          IMPORTED_TARGET GLOBAL
+                          zlib)
         if(zlib_FOUND)
             add_library(zlib::zlib ALIAS PkgConfig::zlib)
         endif()


### PR DESCRIPTION
```
CMake Error at benchmark_app/CMakeLists.txt:29 (add_library):
  add_library cannot create ALIAS target "nlohmann_json::nlohmann_json"
  because target "nlohmann_json" is imported but not globally visible.
```