### PR TITLE
Check Node in Model creation

### DIFF
--- a/src/core/include/openvino/core/model.hpp
+++ b/src/core/include/openvino/core/model.hpp
@@ -536,9 +536,6 @@ private:
     /// model and registers them, otherwise checks all the Parameters are registered.
     void prerequirements(bool detect_variables, bool detect_parameters);
 
-    // Check that a Node argument for ctor isn't nullptr.
-    static const std::shared_ptr<Node>& verify_node(const std::shared_ptr<Node>& node);
-
     static std::atomic<size_t> m_next_instance_id;
     std::string m_name;
     const std::string m_unique_name;

--- a/src/core/include/openvino/core/model.hpp
+++ b/src/core/include/openvino/core/model.hpp
@@ -536,6 +536,9 @@ private:
     /// model and registers them, otherwise checks all the Parameters are registered.
     void prerequirements(bool detect_variables, bool detect_parameters);
 
+    // Check that a Node argument for ctor isn't nullptr.
+    static const std::shared_ptr<Node>& verify_node(const std::shared_ptr<Node>& node);
+
     static std::atomic<size_t> m_next_instance_id;
     std::string m_name;
     const std::string m_unique_name;

--- a/src/core/src/model.cpp
+++ b/src/core/src/model.cpp
@@ -118,7 +118,7 @@ ov::Model::Model(const NodeVector& results, const ngraph::ParameterVector& param
 ov::Model::Model(const std::shared_ptr<Node>& result,
                  const ngraph::ParameterVector& parameters,
                  const std::string& name)
-    : Model(result->outputs(), parameters, name) {}
+    : Model(verify_node(result)->outputs(), parameters, name) {}
 
 ov::Model::Model(const ngraph::ResultVector& results,
                  const ngraph::SinkVector& sinks,
@@ -1157,4 +1157,9 @@ void ov::set_batch(const std::shared_ptr<ov::Model>& f, ov::Dimension batch_size
         stream << "Original error message is: " << e.what();
         OPENVINO_ASSERT(false, stream.str());
     }
+}
+
+const std::shared_ptr<ov::Node>& ov::Model::verify_node(const std::shared_ptr<ov::Node>& node) {
+    OPENVINO_ASSERT(node != nullptr, "Model is incorrect! Some Node equals to nullptr.");
+    return node;
 }

--- a/src/core/src/model.cpp
+++ b/src/core/src/model.cpp
@@ -86,6 +86,12 @@ ngraph::ParameterVector auto_detect_parameters(const std::vector<std::shared_ptr
     return parameter_vector;
 }
 
+// Check that a Node argument for ctor isn't nullptr.
+const std::shared_ptr<ov::Node>& verify_node(const std::shared_ptr<ov::Node>& node) {
+    OPENVINO_ASSERT(node != nullptr, "Model is incorrect! Some Node equals to nullptr.");
+    return node;
+}
+
 }  // namespace
 
 ov::Model::Model(const ResultVector& results, const ngraph::ParameterVector& parameters, const std::string& name)
@@ -1157,9 +1163,4 @@ void ov::set_batch(const std::shared_ptr<ov::Model>& f, ov::Dimension batch_size
         stream << "Original error message is: " << e.what();
         OPENVINO_ASSERT(false, stream.str());
     }
-}
-
-const std::shared_ptr<ov::Node>& ov::Model::verify_node(const std::shared_ptr<ov::Node>& node) {
-    OPENVINO_ASSERT(node != nullptr, "Model is incorrect! Some Node equals to nullptr.");
-    return node;
 }

--- a/src/core/tests/model.cpp
+++ b/src/core/tests/model.cpp
@@ -2044,6 +2044,7 @@ TEST(model, set_complex_meta_information) {
 TEST(model, create_model) {
     EXPECT_NO_THROW(ov::Model({}, ""));
     EXPECT_THROW(ov::Model(ov::ResultVector{nullptr}, {}, ""), ov::Exception);
+    EXPECT_THROW(ov::Model(nullptr, {}, ""), ov::Exception);
     EXPECT_NO_THROW(ov::Model(ov::ResultVector{}, ov::ParameterVector{}, ""));
     EXPECT_THROW(ov::Model({nullptr}, {nullptr}, {nullptr}, {nullptr}, ""), ov::Exception);
     EXPECT_THROW(ov::Model({nullptr}, {}, {}, {}, ""), ov::Exception);


### PR DESCRIPTION
### Details:
 - Found that check for creating `Model` from `shared_ptr<Node> == nullptr` was missed (that called when a user tries to create it in python as `Model(None, [])` that caused segfault)
 - 
### Tickets:
 - 102965
