### PR TITLE
[Transformations] Enable missing runtime info check

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/strides_optimization.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/strides_optimization.cpp
@@ -14,7 +14,9 @@
 
 #include "itt.hpp"
 
+using namespace std;
 using namespace ov;
+using namespace ov::opset7;
 
 static bool can_propagate_conv_stride(const std::shared_ptr<ngraph::Node>& conv) {
     const auto& kernel_shape = conv->input_value(1).get_shape();
@@ -40,40 +42,36 @@ static std::tuple<ngraph::Strides, bool> check_next_ops(const std::vector<ngraph
     return std::make_tuple(strides[0], all_ops_are_valid);
 }
 
-static void insert_pooling(const ngraph::Output<ngraph::Node>& first,
-                           ngraph::Input<ngraph::Node>& second,
-                           const ngraph::Strides& strides) {
+static void insert_pooling(const Output<Node>& first, Input<Node>& second, const Strides& strides) {
+    pass::NodeRegistry rg;
     auto first_node = first.get_node_shared_ptr();
-    auto rank = first.get_partial_shape().rank();
-    bool do_reshape = rank.is_static() && static_cast<size_t>(rank.get_length()) < strides.size() + 2;
+    const auto rank = first.get_partial_shape().rank();
+    const bool do_reshape = rank.is_static() && static_cast<size_t>(rank.get_length()) < strides.size() + 2;
     if (do_reshape) {
-        size_t diff = strides.size() + 2 - static_cast<size_t>(rank.get_length());
-        auto ones = opset7::Constant::create(ngraph::element::i64, ngraph::Shape{diff}, std::vector<int64_t>(diff, 1));
-        auto current_shape = std::make_shared<opset7::ShapeOf>(first);
-        std::shared_ptr<ngraph::Node> new_shape =
-            std::make_shared<opset7::Concat>(ngraph::OutputVector{ones, current_shape}, 0);
-        std::shared_ptr<ngraph::Node> constant_new_shape = get_constant_from_source(new_shape);
-        if (constant_new_shape)
+        const size_t diff = strides.size() + 2 - static_cast<size_t>(rank.get_length());
+        const auto ones = rg.make<Constant>(element::i64, Shape{diff}, vector<int64_t>(diff, 1));
+        const auto current_shape = rg.make<ShapeOf>(first);
+        shared_ptr<Node> new_shape = rg.make<Concat>(OutputVector{ones, current_shape}, 0);
+        if (const auto constant_new_shape = get_constant_from_source(new_shape)) {
+            rg.add(constant_new_shape);
             new_shape = constant_new_shape;
-        first_node = std::make_shared<opset7::Reshape>(first_node, new_shape, false);
+        }
+        first_node = rg.make<Reshape>(first_node, new_shape, false);
     }
-    std::shared_ptr<ngraph::Node> new_node = std::make_shared<opset7::MaxPool>(first_node,
-                                                                               strides,
-                                                                               ngraph::Shape{},
-                                                                               ngraph::Shape{},
-                                                                               ngraph::Shape(strides.size(), 1));
+    shared_ptr<Node> new_node = rg.make<MaxPool>(first_node, strides, Shape{}, Shape{}, Shape(strides.size(), 1));
     if (do_reshape) {
         // squeeze dimensions back
-        size_t diff = strides.size() + 2 - static_cast<size_t>(rank.get_length());
-        std::vector<size_t> axes(diff);
-        std::iota(axes.begin(), axes.end(), 0);
-        new_node = std::make_shared<opset7::Squeeze>(
-            new_node,
-            opset7::Constant::create(ngraph::element::u64, ngraph::Shape{diff}, axes));
+        const size_t diff = strides.size() + 2 - static_cast<size_t>(rank.get_length());
+        vector<size_t> axes(diff);
+        iota(axes.begin(), axes.end(), 0);
+        new_node = rg.make<Squeeze>(new_node, rg.make<Constant>(element::u64, Shape{diff}, axes));
     }
-    std::shared_ptr<ngraph::Node> constant_new_node = get_constant_from_source(new_node);
-    if (constant_new_node)
+    if (const auto constant_new_node = get_constant_from_source(new_node)) {
+        rg.add(constant_new_node);
         new_node = constant_new_node;
+    }
+
+    copy_runtime_info(as_node_vector({second.get_source_output()}), rg.get());
     second.replace_source_output(new_node);
 }
 

--- a/src/common/transformations/tests/common_optimizations/strides_optimization.cpp
+++ b/src/common/transformations/tests/common_optimizations/strides_optimization.cpp
@@ -171,9 +171,6 @@ TEST_F(TransformationTestsF, StridesOptimization5) {
 
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_2}, ngraph::ParameterVector{data});
     }
-
-    // TODO: update transformation and remove this check XXX-68696
-    disable_rt_info_check();
 }
 
 // Pl->Conv(1x1,1x1)->Conv(1x1,2x2)->Conv(3x3,1x1)->Conv(1x1,2x2)
@@ -261,8 +258,6 @@ TEST_F(TransformationTestsF, StridesOptimization7) {
 
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_3, conv_4}, ngraph::ParameterVector{data});
     }
-    // TODO: update transformation and remove this check XXX-68696
-    disable_rt_info_check();
 }
 
 // Pl--->Conv(1x1,1x1)->ReLU--->Eltwise-->Conv(1x1,2x2)-->Eltwise-->Conv(1x1, 2x2)
@@ -318,8 +313,6 @@ TEST_F(TransformationTestsF, StridesOptimization8) {
 
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_3}, ngraph::ParameterVector{data, data_2});
     }
-    // TODO: update transformation and remove this check XXX-68696
-    disable_rt_info_check();
 }
 
 // Pl------->Conv(1x1,1x1)------>Eltwise------>Conv(1x1,2x2)---->Eltwise-->Conv(1x1, 2x2)
@@ -401,6 +394,4 @@ TEST_F(TransformationTestsF, StridesOptimization9) {
 
         function_ref = std::make_shared<ngraph::Function>(ngraph::NodeVector{conv_3}, ngraph::ParameterVector{data, data_2, data_3});
     }
-    // TODO: update transformation and remove this check XXX-68696
-    disable_rt_info_check();
 }

--- a/src/common/transformations/tests/offline_transformations/pruning_test.cpp
+++ b/src/common/transformations/tests/offline_transformations/pruning_test.cpp
@@ -267,7 +267,6 @@ TEST_F(TransformationTestsF, PropagateMasksBasic) {
     compare_masks(*getMask(conv2->output(0)),    Mask({{}, {}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -329,7 +328,6 @@ TEST_F(TransformationTestsF, PropagateMasksDynamicConvolution) {
     compare_masks(*getMask(conv2->output(0)),    Mask({{}, {}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -506,7 +504,6 @@ TEST_F(TransformationTestsF, PropagateMaskPassThrough) {
     compare_masks(*getMask(max_pool->output(0)),     Mask({{}, {1, 2, 3}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -655,7 +652,6 @@ TEST_F(TransformationTestsF, PropagateMasksHardDependencies) {
     //compare_masks(*getMask(conv2),    Mask({{}, {}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -770,7 +766,6 @@ TEST_F(TransformationTestsF, PropagateMasksQuantizedGroupConvolution) {
     compare_masks(*getMask(conv2->output(0)),  Mask({{}, {}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -905,7 +900,6 @@ TEST_F(TransformationTestsF, PropagateMasksQuantizedGroupConvolutionWithShapeOf)
     compare_masks(*getMask(weights_2->output(0)),  Mask({{}, {0, 1, 2, 3}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -1020,7 +1014,6 @@ TEST_F(TransformationTestsF, PropagateMasksFakeQuantizePerTensor) {
     compare_masks(*getMask(conv2->output(0)),  Mask({{}, {}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -1202,7 +1195,6 @@ TEST_F(TransformationTestsF, PropagateMasksFakeQuantizePerChannel) {
     compare_masks(*getMask(fq->input(4).get_source_output()),  Mask({{}, {0, 1, 2, 3, 4}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -1296,7 +1288,6 @@ TEST_F(TransformationTestsF, TestConcatMaskPropagation) {
     compare_masks(*getMask(weights_out_conv.get_node_shared_ptr()->output(0)),  Mask({{}, {0, 1, 2, 3, 15, 16, 17, 18, 28, 29, 30, 31}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -1400,7 +1391,6 @@ TEST_F(TransformationTestsF, TestConcatMaskPropagationUp) {
     compare_masks(*getMask(weights_out_conv.get_node_shared_ptr()->output(0)),  Mask({{}, {0, 1, 2, 3, 15, 16, 17, 18, 28, 29, 30, 31}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -1545,7 +1535,6 @@ TEST_F(TransformationTestsF, PruneConvIsClosingAndInGroup) {
     compare_masks(*getMask(end_conv->output(0)),  Mask({{}, {}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -1716,7 +1705,6 @@ TEST_F(TransformationTestsF, PruneReducelayerUp) {
     compare_masks(*getMask(conv_1->output(0)),  Mask({{}, {}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -1807,7 +1795,6 @@ TEST_F(TransformationTestsF, PruneReduceLayerDown) {
     compare_masks(*getMask(end_conv->output(0)),  Mask({{}, {}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -1965,7 +1952,6 @@ TEST_F(TransformationTestsF, MaskPropagationReshapeUp) {
     compare_masks(*getMask(conv_1->output(0)),  Mask({{}, {}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -2066,7 +2052,6 @@ TEST_P(TransformationTestsBoolParamF, MaskPropagationReshapeUpWithShapeOf) {
     compare_masks(*getMask(conv_1->output(0)),  Mask({{}, {}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -2254,7 +2239,6 @@ TEST_F(TransformationTestsF, MaskPropagationReshapeExtend) {
     compare_masks(*getMask(conv_1->output(0)),  Mask({{}, {}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -2351,7 +2335,6 @@ TEST_F(DISABLED_TransformationTestsF, MaskPropagationReshapeDownMul) {
     compare_masks(*getMask(last_conv->output(0)),  Mask({{}, {}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -2446,7 +2429,6 @@ TEST_F(TransformationTestsF, MaskPropagationReshapeDownAdd) {
     compare_masks(*getMask(last_conv->output(0)),  Mask({{}, {}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -2605,7 +2587,6 @@ TEST_F(TransformationTestsF, MaskPropagationReshapeUnsqueezeUp) {
     compare_masks(*getMask(mul_left->output(0)),  Mask({{}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -2670,7 +2651,6 @@ TEST_F(TransformationTestsF, MaskPropagationReshapeUnsqueezeDown) {
     compare_masks(*getMask(mul_left->output(0)),  Mask({{}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -2829,7 +2809,6 @@ TEST_F(TransformationTestsF, PruneSEBlock) {
     compare_masks(*getMask(end_conv->output(0)),  Mask({{}, {}, {}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -2918,7 +2897,6 @@ TEST_F(TransformationTestsF, PropagateMasksLinear) {
     compare_masks(*getMask(last_linear->output(0)), Mask{{}, {}});
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -3177,7 +3155,6 @@ TEST_F(TransformationTestsF, MaskPropagationLinearOuterDims) {
     compare_masks(*getMask(last_mul->output(0)),  Mask({{}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -3315,7 +3292,6 @@ TEST_F(TransformationTestsF, PruneMasksMatMulColsStopRowsUp) {
     compare_masks(*getMask(last_linear->output(0)), Mask{{}, {}, {}});
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -3393,7 +3369,6 @@ TEST_F(TransformationTestsF, PruneMasksMatMulRowsStopColsUp) {
     compare_masks(*getMask(last_linear->output(0)), Mask{{}, {}, {}});
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -3486,7 +3461,6 @@ TEST_F(TransformationTestsF, PropagateFlattenUp) {
     compare_masks(*getMask(linear->output(0)), Mask{{}, {}});
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -3556,7 +3530,6 @@ TEST_F(TransformationTestsF, PropagateFlattenDown) {
     compare_masks(*getMask(linear->output(0)), {{}, {}});
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -3607,7 +3580,6 @@ TEST_F(TransformationTestsF, PropagateMasksTranspose) {
     compare_masks(*getMask(last_mul->output(0)), Mask{{}, {}});
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -3680,7 +3652,6 @@ TEST_F(TransformationTestsF, PropagateMasksTransposeComplex) {
     compare_masks(*getMask(last_mul->output(0)), Mask{{}, {}, {}, {}, {}});
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -3879,7 +3850,6 @@ TEST_F(DISABLED_TransformationTestsF, PropagateMasksBroadcastedEltwiseWithInputs
     compare_masks(*getMask(last_mul->output(0)),  Mask({{}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -4054,7 +4024,6 @@ TEST_F(TransformationTestsF, PropagateMasksBroadcastedEltwise) {
     compare_masks(*getMask(last_mul->output(0)),  Mask({{}, {}}));
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -4240,7 +4209,6 @@ TEST_F(TransformationTestsF, MaskPropagationComplexReshape) {
         manager.register_pass<pass::ShrinkWeights>();
         manager.register_pass<ngraph::pass::VisualizeTree>(std::string(VISUALIZE_TREE_ROOT) + "MaskPropagationComplexReshapeWithMasks.svg", modifier);
     }
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -4431,7 +4399,6 @@ TEST_P(TransformationTestsBoolParamF, MaskPropagationReshapedPassThroughP) {
     auto postfix = (add_shape_of)? "True" : "False";
     manager.register_pass<ngraph::pass::VisualizeTree>(std::string(VISUALIZE_TREE_ROOT) +
     "MaskPropagationReverseFlattenWithMasks" + postfix + ".svg", modifier);
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -4496,9 +4463,7 @@ TEST_P(TransformationTestsBoolParamF, MaskPropagationBroadcastedSameRankEltwiseS
     compare_masks(*getMask(mult->output(0)), Mask{{1, 2, 3}, {}});
     compare_masks(*getMask(mul_last->output(0)), Mask{{}, {}, {}});
 
-
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
@@ -4658,7 +4623,6 @@ TEST_F(TransformationTestsF, MaskPropagationMatMulWithSeveralOutputs) {
     compare_masks(*getMask(right_matmul), Mask{{}, {}});
 
     manager.register_pass<pass::ShrinkWeights>();
-    disable_rt_info_check();
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 


### PR DESCRIPTION
### Details:
Backport of #15796
* Add rt info propagation to StridesOptimization
* Enable rt info check for pruning tests

### Tickets:
 - 68696
 - 103938

