### PR TITLE
Fix warning: sequence point strict aliasing

### DIFF
--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -10,8 +10,6 @@ set(TARGET_NAME "openvino_intel_cpu_plugin")
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     ie_add_compiler_flags(-Wno-sign-compare)
-    ie_add_compiler_flags(-Wno-sequence-point)
-    ie_add_compiler_flags(-Wno-strict-aliasing)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # C4267, 4244 issues from mkl-dnn headers conversion from 'XXX' to 'YYY', possible loss of data
     ie_add_compiler_flags(/wd4267)

--- a/src/plugins/intel_cpu/src/nodes/unique.cpp
+++ b/src/plugins/intel_cpu/src/nodes/unique.cpp
@@ -429,8 +429,7 @@ void Unique::slicedTensorExec() {
                 }
                 for (int k = 0; k < uniqueLen; k++) {
                     if (mPos == moveTo[mPos]) {
-                        auto tmp = ++mPos;
-                        mPos = moveTo[tmp];
+                        mPos = moveTo[mPos + 1];
                         continue;
                     }
 

--- a/src/plugins/intel_cpu/src/nodes/unique.cpp
+++ b/src/plugins/intel_cpu/src/nodes/unique.cpp
@@ -405,7 +405,8 @@ void Unique::slicedTensorExec() {
                     auto dstIdx = moveTo[0];
                     for (int64_t b = 0; b < uniqueLen; b++) {
                         if (dstIdx == moveTo[dstIdx]) {
-                            dstIdx = moveTo[++dstIdx];
+                            auto tmp = ++dstIdx;
+                            dstIdx = moveTo[tmp];
                             continue;
                         }
                         T* dst = currDst + dstIdx * elPerPart;
@@ -429,7 +430,8 @@ void Unique::slicedTensorExec() {
                 }
                 for (int k = 0; k < uniqueLen; k++) {
                     if (mPos == moveTo[mPos]) {
-                        mPos = moveTo[++mPos];
+                        auto tmp = ++mPos;
+                        mPos = moveTo[tmp];
                         continue;
                     }
 

--- a/src/plugins/intel_cpu/src/nodes/unique.cpp
+++ b/src/plugins/intel_cpu/src/nodes/unique.cpp
@@ -405,8 +405,7 @@ void Unique::slicedTensorExec() {
                     auto dstIdx = moveTo[0];
                     for (int64_t b = 0; b < uniqueLen; b++) {
                         if (dstIdx == moveTo[dstIdx]) {
-                            auto tmp = ++dstIdx;
-                            dstIdx = moveTo[tmp];
+                            dstIdx = moveTo[dstIdx + 1];
                             continue;
                         }
                         T* dst = currDst + dstIdx * elPerPart;

--- a/src/plugins/intel_cpu/src/utils/blob_dump.cpp
+++ b/src/plugins/intel_cpu/src/utils/blob_dump.cpp
@@ -176,7 +176,9 @@ void BlobDumper::dumpAsTxt(std::ostream &stream) const {
             for (size_t i = 0; i < data_size; i++) {
                 int i16n = blob_ptr[desc.getElementOffset(i)];
                 i16n = i16n << 16;
-                float fn = *(reinterpret_cast<const float *>(&i16n));
+                float fn;
+                assert(sizeof(fn) == sizeof(i16n));
+                memcpy(&fn, &i16n, sizeof(fn));  // Avoid -Wstrict-aliasing
                 stream << fn << std::endl;
             }
             break;

--- a/src/plugins/intel_cpu/src/utils/blob_dump.cpp
+++ b/src/plugins/intel_cpu/src/utils/blob_dump.cpp
@@ -9,6 +9,7 @@
 #include <nodes/common/cpu_memcpy.h>
 
 #include "common/memory_desc_wrapper.hpp"
+#include "utils/bfloat16.hpp"
 
 #include <fstream>
 #include <memory_desc/cpu_memory_desc_utils.h>
@@ -172,13 +173,9 @@ void BlobDumper::dumpAsTxt(std::ostream &stream) const {
             break;
         }
         case Precision::BF16: {
-            auto *blob_ptr = reinterpret_cast<const int16_t*>(ptr);
+            auto *blob_ptr = reinterpret_cast<const bfloat16_t*>(ptr);
             for (size_t i = 0; i < data_size; i++) {
-                int i16n = blob_ptr[desc.getElementOffset(i)];
-                i16n = i16n << 16;
-                float fn;
-                assert(sizeof(fn) == sizeof(i16n));
-                memcpy(&fn, &i16n, sizeof(fn));  // Avoid -Wstrict-aliasing
+                float fn = (float)blob_ptr[desc.getElementOffset(i)];
                 stream << fn << std::endl;
             }
             break;

--- a/src/plugins/intel_cpu/src/utils/blob_dump.cpp
+++ b/src/plugins/intel_cpu/src/utils/blob_dump.cpp
@@ -175,7 +175,7 @@ void BlobDumper::dumpAsTxt(std::ostream &stream) const {
         case Precision::BF16: {
             auto *blob_ptr = reinterpret_cast<const bfloat16_t*>(ptr);
             for (size_t i = 0; i < data_size; i++) {
-                float fn = (float)blob_ptr[desc.getElementOffset(i)];
+                float fn = static_cast<float>(blob_ptr[desc.getElementOffset(i)]);
                 stream << fn << std::endl;
             }
             break;

--- a/src/plugins/intel_cpu/tests/functional/bfloat16/bfloat16_helpers.hpp
+++ b/src/plugins/intel_cpu/tests/functional/bfloat16/bfloat16_helpers.hpp
@@ -62,6 +62,7 @@ public:
         float f = in;
         int* i = reinterpret_cast<int*>(&f);
         int t2 = *i & 0xFFFF0000;
+        float ft1;
         memcpy(&ft1, &t2, sizeof(float));
         if ((*i & 0x8000) && (*i & 0x007F0000) != 0x007F0000) {
             t2 += 0x10000;

--- a/src/plugins/intel_cpu/tests/functional/bfloat16/bfloat16_helpers.hpp
+++ b/src/plugins/intel_cpu/tests/functional/bfloat16/bfloat16_helpers.hpp
@@ -62,17 +62,18 @@ public:
         float f = in;
         int* i = reinterpret_cast<int*>(&f);
         int t2 = *i & 0xFFFF0000;
-        float ft1 = *(reinterpret_cast<float*>(&t2));
+        memcpy(&ft1, &t2, sizeof(float));
         if ((*i & 0x8000) && (*i & 0x007F0000) != 0x007F0000) {
             t2 += 0x10000;
-            ft1 = *(reinterpret_cast<float*>(&t2));
+            memcpy(&ft1, &t2, sizeof(float));
         }
         return ft1;
     }
 
     static short reducePrecisionBitwiseS(const float in) {
         float f = reducePrecisionBitwise(in);
-        int intf = *reinterpret_cast<int*>(&f);
+        int intf;
+        memcpy(&intf, &f, sizeof(int));
         intf = intf >> 16;
         short s = intf;
         return s;

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/denormal_check.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/denormal_check.cpp
@@ -97,7 +97,9 @@ TEST_F(DenormalNullifyCheck, smoke_CPU_Denormal_Check) {
         for (size_t i = 0; i < elemsCount; ++i) {
             if (randomIndexSet.count(i)) {
                 auto denormal = random.Generate(denormalsRange) + 1;
-                pConstStorage->get_ptr()[i] = *(reinterpret_cast<float*>(&denormal));
+                float tmp;
+                memcpy(&tmp, &denormal, sizeof(float));
+                pConstStorage->get_ptr()[i] = tmp;
             } else {
                 pConstStorage->get_ptr()[i] = randomRange[i];
             }

--- a/src/tests/ie_test_utils/functional_test_utils/include/functional_test_utils/blob_utils.hpp
+++ b/src/tests/ie_test_utils/functional_test_utils/include/functional_test_utils/blob_utils.hpp
@@ -740,10 +740,11 @@ inline float reducePrecisionBitwise(const float in) {
     float f = in;
     int* i = reinterpret_cast<int*>(&f);
     int t2 = *i & 0xFFFF0000;
-    float ft1 = *(reinterpret_cast<float*>(&t2));
+    float ft1;
+    memcpy(&ft1, &t2, sizeof(flaot));
     if ((*i & 0x8000) && (*i & 0x007F0000) != 0x007F0000) {
         t2 += 0x10000;
-        ft1 = *(reinterpret_cast<float*>(&t2));
+        memcpy(&ft1, &t2, sizeof(flaot));
     }
     return ft1;
 }

--- a/src/tests/ie_test_utils/functional_test_utils/include/functional_test_utils/blob_utils.hpp
+++ b/src/tests/ie_test_utils/functional_test_utils/include/functional_test_utils/blob_utils.hpp
@@ -741,10 +741,10 @@ inline float reducePrecisionBitwise(const float in) {
     int* i = reinterpret_cast<int*>(&f);
     int t2 = *i & 0xFFFF0000;
     float ft1;
-    memcpy(&ft1, &t2, sizeof(flaot));
+    memcpy(&ft1, &t2, sizeof(float));
     if ((*i & 0x8000) && (*i & 0x007F0000) != 0x007F0000) {
         t2 += 0x10000;
-        memcpy(&ft1, &t2, sizeof(flaot));
+        memcpy(&ft1, &t2, sizeof(float));
     }
     return ft1;
 }


### PR DESCRIPTION
### Details:
 - *Remove: ie_add_compiler_flags(-Wno-sequence-point)*
 - *Remove: ie_add_compiler_flags(-Wno-strict-aliasing)*
 - *Fix corresponding warnings*

### Tickets:
 - *104795*
