### PR TITLE
Fix coverity uninialized variable

### DIFF
--- a/src/inference/src/dev/converter_utils.cpp
+++ b/src/inference/src/dev/converter_utils.cpp
@@ -471,9 +471,11 @@ public:
     std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> GetPerformanceCounts() const override {
         auto res = m_request->get_profiling_info();
         std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> ret;
-        for (const auto& info : res) {
+        for (size_t i = 0; i < res.size(); i++) {
+            const auto& info = res[i];
             InferenceEngine::InferenceEngineProfileInfo old_info;
             old_info.cpu_uSec = info.cpu_time.count();
+            old_info.execution_index = static_cast<unsigned>(i);
             old_info.realTime_uSec = info.real_time.count();
             strncpy(old_info.exec_type, info.exec_type.c_str(), sizeof(old_info.exec_type));
             old_info.exec_type[sizeof(old_info.exec_type) - 1] = 0;


### PR DESCRIPTION
### Details:
 - `old_info.execution_index` wasn't initalized

### Tickets:
 - 104206