### PR TITLE
[TF FE] Convert a model with Framework nodes

### DIFF
--- a/src/frontends/tensorflow/src/decoder_argdef.cpp
+++ b/src/frontends/tensorflow/src/decoder_argdef.cpp
@@ -77,8 +77,8 @@ ov::Any DecoderArgDef::get_attribute(const std::string& name) const {
     if (TYPE_MAP().count(m_arg_def->type())) {
         return TYPE_MAP().at(m_arg_def->type());
     } else {
-        // for all unsupported types return undefined type
-        return ov::element::undefined;
+        // for all unsupported types return dynamic type
+        return ov::element::dynamic;
     }
 }
 

--- a/src/frontends/tensorflow/src/decoder_proto.cpp
+++ b/src/frontends/tensorflow/src/decoder_proto.cpp
@@ -128,8 +128,8 @@ ov::Any DecoderProto::get_attribute(const std::string& name) const {
         if (TYPE_MAP().count(attrs[0].type())) {
             return TYPE_MAP().at(attrs[0].type());
         } else {
-            // for all unsupported types return undefined type
-            return ov::element::undefined;
+            // for all unsupported types return dynamic type
+            return ov::element::dynamic;
         }
     }
 

--- a/src/frontends/tensorflow/src/frontend.cpp
+++ b/src/frontends/tensorflow/src/frontend.cpp
@@ -37,7 +37,8 @@ std::vector<std::string> get_unconverted_types_from_model(const std::shared_ptr<
             unconverted_ops_types.push_back(op_type);
         }
         if (const auto& fw_node = ov::as_type_ptr<ov::op::util::MultiSubGraphOp>(node)) {
-            for (int i = 0; i < fw_node->get_internal_subgraphs_size(); i++) {
+            int subgraphs_size = static_cast<int>(fw_node->get_internal_subgraphs_size());
+            for (int i = 0; i < subgraphs_size; ++i) {
                 auto internal_types = get_unconverted_types_from_model(fw_node->get_function(i));
                 unconverted_ops_types.insert(unconverted_ops_types.begin(),
                                              internal_types.begin(),

--- a/src/frontends/tensorflow/src/input_model.cpp
+++ b/src/frontends/tensorflow/src/input_model.cpp
@@ -197,7 +197,7 @@ void InputModel::InputModelTFImpl::loadPlaces() {
     for (auto& output_name : op_names_without_consumers) {
         std::vector<std::string> output_names = {output_name};
         auto output_place =
-            std::make_shared<TensorPlace>(m_input_model, ov::PartialShape({}), ov::element::undefined, output_names);
+            std::make_shared<TensorPlace>(m_input_model, ov::PartialShape({}), ov::element::dynamic, output_names);
         m_tensor_places[output_name] = output_place;
         m_outputs.push_back(output_place);
     }
@@ -370,7 +370,7 @@ ov::frontend::Place::Ptr InputModel::InputModelTFImpl::getPlaceByTensorName(cons
         // new Tensor places must be constructed of dynamic rank and type
         std::vector<std::string> names = {tensorName};
         auto m_var_place =
-            std::make_shared<TensorPlace>(m_input_model, ov::PartialShape::dynamic(), ov::element::undefined, names);
+            std::make_shared<TensorPlace>(m_input_model, ov::PartialShape::dynamic(), ov::element::dynamic, names);
         m_tensor_places[tensorName] = m_var_place;
         return m_var_place;
     }

--- a/src/frontends/tensorflow/src/translate_session.cpp
+++ b/src/frontends/tensorflow/src/translate_session.cpp
@@ -106,7 +106,7 @@ void TranslateSession::translate_graph(const ov::frontend::InputModel::Ptr& inpu
         auto input_shape = input_tensor_place->get_partial_shape();
         auto input_type = input_tensor_place->get_element_type();
 
-        // in case of cutting graph, types of custom inputs can be undefined,
+        // in case of cutting graph, types of custom inputs can be dynamic,
         // according to MO help, fp32 is used by default in such cases
         if (input_type == element::undefined) {
             input_type = element::f32;

--- a/src/frontends/tensorflow/src/translate_session.cpp
+++ b/src/frontends/tensorflow/src/translate_session.cpp
@@ -200,13 +200,11 @@ void TranslateSession::translate_graph(const ov::frontend::InputModel::Ptr& inpu
 
         // generate OV node output vector for the current operation node
         ov::OutputVector ov_outputs;
-        bool is_converted = false;
         auto operation_type = operation_decoder->get_op_type();
         if (m_translator_map->count(operation_type)) {
             auto translator = m_translator_map->at(operation_decoder->get_op_type());
             NodeContext node_context(operation_decoder, ov_inputs, this);
             ov_outputs = translator(node_context);
-            is_converted = true;
         } else if (auto body_ov_model = get_body_ov_model(operation_type)) {
             inject_body_model(body_ov_model, operation_type, ov_inputs, ov_outputs);
 
@@ -214,7 +212,6 @@ void TranslateSession::translate_graph(const ov::frontend::InputModel::Ptr& inpu
             for (size_t idx = 0; idx < ov_outputs.size(); ++idx) {
                 ov_outputs[idx].get_tensor().set_names({operation_name + ":" + std::to_string(idx)});
             }
-            is_converted = true;
         } else {
             // continue translation by replacing with FrameworkNode
             // for example, it helps auto-pruning to be triggered on later nodes

--- a/src/frontends/tensorflow/src/translate_session.cpp
+++ b/src/frontends/tensorflow/src/translate_session.cpp
@@ -40,17 +40,12 @@ std::vector<T> reorder_ops_by_names(const std::vector<std::string>& names, const
 
 TranslateSession::TranslateSession(const ov::frontend::InputModel::Ptr& input_model,
                                    const std::shared_ptr<TranslatorDictionaryType>& translator_map,
-                                   const std::string& model_name,
-                                   bool fail_fast,
-                                   bool telemetry)
+                                   const std::string& model_name)
     : m_input_model(input_model),
-      m_fail_fast(fail_fast),
-      m_telemetry(telemetry),
       m_translator_map(translator_map),
       m_model_name(model_name),
-      m_cached_body_models(std::make_shared<CachedBodyModelsType>()),
-      m_telemetry_data(std::make_shared<TelemetryDataType>()),
-      m_ov_model(nullptr) {}
+      m_ov_model(nullptr),
+      m_cached_body_models(std::make_shared<CachedBodyModelsType>()) {}
 
 std::shared_ptr<ov::Model> TranslateSession::get_converted_model() {
     if (m_ov_model) {
@@ -58,10 +53,6 @@ std::shared_ptr<ov::Model> TranslateSession::get_converted_model() {
     }
     translate_graph(m_input_model, m_ov_model);
     return m_ov_model;
-}
-
-std::shared_ptr<TelemetryDataType> TranslateSession::get_telemetry_data() const {
-    return m_telemetry_data;
 }
 
 void TranslateSession::inject_body_model(std::shared_ptr<ov::Model> body_model,
@@ -187,6 +178,16 @@ void TranslateSession::translate_graph(const ov::frontend::InputModel::Ptr& inpu
                 ov_inputs.push_back(input_outputs_vector.at(0));
             } else if (ng_op_map.count(producer_name)) {
                 const auto& input_outputs_vector = ng_op_map.at(producer_name);
+                if (input_outputs_vector.size() <= producer_port_idx) {
+                    auto producer_node = input_outputs_vector[0].get_node_shared_ptr();
+                    if (std::dynamic_pointer_cast<FrameworkNode>(producer_node)) {
+                        // FrameworkNode node does not know in advance how many output ports will be used
+                        // so we can increase number of outputs by demand
+                        producer_node->set_output_type(producer_port_idx, element::dynamic, PartialShape::dynamic());
+                        // update output vector in node map
+                        ng_op_map[producer_name] = producer_node->outputs();
+                    }
+                }
                 FRONT_END_GENERAL_CHECK(input_outputs_vector.size() > producer_port_idx,
                                         "Input created with pruning must have one output");
                 ov_inputs.push_back(input_outputs_vector.at(producer_port_idx));
@@ -201,41 +202,27 @@ void TranslateSession::translate_graph(const ov::frontend::InputModel::Ptr& inpu
         ov::OutputVector ov_outputs;
         bool is_converted = false;
         auto operation_type = operation_decoder->get_op_type();
-        try {
-            if (m_translator_map->count(operation_type)) {
-                auto translator = m_translator_map->at(operation_decoder->get_op_type());
-                NodeContext node_context(operation_decoder, ov_inputs, this);
-                ov_outputs = translator(node_context);
-                is_converted = true;
-            } else if (auto body_ov_model = get_body_ov_model(operation_type)) {
-                inject_body_model(body_ov_model, operation_type, ov_inputs, ov_outputs);
+        if (m_translator_map->count(operation_type)) {
+            auto translator = m_translator_map->at(operation_decoder->get_op_type());
+            NodeContext node_context(operation_decoder, ov_inputs, this);
+            ov_outputs = translator(node_context);
+            is_converted = true;
+        } else if (auto body_ov_model = get_body_ov_model(operation_type)) {
+            inject_body_model(body_ov_model, operation_type, ov_inputs, ov_outputs);
 
-                // set output tensor names
-                for (size_t idx = 0; idx < ov_outputs.size(); ++idx) {
-                    ov_outputs[idx].get_tensor().set_names({operation_name + ":" + std::to_string(idx)});
-                }
-                is_converted = true;
+            // set output tensor names
+            for (size_t idx = 0; idx < ov_outputs.size(); ++idx) {
+                ov_outputs[idx].get_tensor().set_names({operation_name + ":" + std::to_string(idx)});
             }
-            FRONT_END_OP_CONVERSION_CHECK(
-                is_converted,
-                "[TensorFlow Frontend] Internal error: No translator found for " + operation_type + " node.");
-        } catch (...) {
-            if (m_fail_fast) {
-                // in case of decode, unsupported operation will be converted to FrameworkNode
-                if (m_telemetry && !is_converted) {
-                    // send event about which operation is not supported for conversion
-                    m_telemetry_data->push_back(
-                        std::make_pair<std::string, std::string>("error_cause", "tf_" + operation_type));
-                }
-                // re-throw any exception
-                throw;
-            } else {
-                auto ng_node = std::make_shared<FrameworkNode>(operation_decoder,
-                                                               ov_inputs,
-                                                               operation_place->get_output_ports().size());
-                set_node_name(operation_name, ng_node);
-                ov_outputs = ng_node->outputs();
-            }
+            is_converted = true;
+        } else {
+            // continue translation by replacing with FrameworkNode
+            // for example, it helps auto-pruning to be triggered on later nodes
+            auto fw_node = std::make_shared<FrameworkNode>(operation_decoder,
+                                                           ov_inputs,
+                                                           operation_place->get_output_ports().size());
+            set_node_name(operation_name, fw_node);
+            ov_outputs = fw_node->outputs();
         }
 
         // register OV node outputs in the map for new operation node

--- a/src/frontends/tensorflow/src/translate_session.cpp
+++ b/src/frontends/tensorflow/src/translate_session.cpp
@@ -108,7 +108,7 @@ void TranslateSession::translate_graph(const ov::frontend::InputModel::Ptr& inpu
 
         // in case of cutting graph, types of custom inputs can be dynamic,
         // according to MO help, fp32 is used by default in such cases
-        if (input_type == element::undefined) {
+        if (input_type == element::dynamic) {
             input_type = element::f32;
         }
 

--- a/src/frontends/tensorflow/src/translate_session.hpp
+++ b/src/frontends/tensorflow/src/translate_session.hpp
@@ -35,9 +35,8 @@ private:
     const ov::frontend::InputModel::Ptr m_input_model;
     const std::shared_ptr<TranslatorDictionaryType> m_translator_map;
     const std::string m_model_name;
-
-    std::shared_ptr<CachedBodyModelsType> m_cached_body_models;
     std::shared_ptr<ov::Model> m_ov_model;
+    std::shared_ptr<CachedBodyModelsType> m_cached_body_models;
 
     void update_cached_body_models(const std::string& operation_type,
                                    const std::shared_ptr<const ov::Model>& cached_body_model) {

--- a/src/frontends/tensorflow/src/translate_session.hpp
+++ b/src/frontends/tensorflow/src/translate_session.hpp
@@ -11,7 +11,6 @@ namespace ov {
 namespace frontend {
 namespace tensorflow {
 using CachedBodyModelsType = std::unordered_map<std::string, std::shared_ptr<const ov::Model>>;
-using TelemetryDataType = std::vector<std::pair<std::string, std::string>>;
 
 /// For one call of convert and decode method of Frontend, it creates one TranslateSession object to save data for the
 /// translation session: telemetry statistics, cache of convrted body graph models, operation translators (including
@@ -20,11 +19,8 @@ class TranslateSession {
 public:
     TranslateSession(const ov::frontend::InputModel::Ptr& input_model,
                      const std::shared_ptr<TranslatorDictionaryType>& translator_map,
-                     const std::string& model_name,
-                     bool fail_fast,
-                     bool telemetry);
+                     const std::string& model_name);
     std::shared_ptr<ov::Model> get_converted_model();
-    std::shared_ptr<TelemetryDataType> get_telemetry_data() const;
 
     void translate_graph(const ov::frontend::InputModel::Ptr& input_model, std::shared_ptr<ov::Model>& ov_model);
 
@@ -37,13 +33,10 @@ public:
 
 private:
     const ov::frontend::InputModel::Ptr m_input_model;
-    const bool m_fail_fast;
-    const bool m_telemetry;
     const std::shared_ptr<TranslatorDictionaryType> m_translator_map;
     const std::string m_model_name;
 
     std::shared_ptr<CachedBodyModelsType> m_cached_body_models;
-    std::shared_ptr<TelemetryDataType> m_telemetry_data;
     std::shared_ptr<ov::Model> m_ov_model;
 
     void update_cached_body_models(const std::string& operation_type,

--- a/src/frontends/tensorflow/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow/tests/convert_tricky_models.cpp
@@ -336,6 +336,17 @@ TEST_F(TransformationTestsF, ModelWithLookupTableOperations) {
     }
 }
 
+TEST_F(TransformationTestsF, ModelWithIteratorGetNextAndUnsupportedOp) {
+    { model = convert_model("unsupported_op_itergetnext/unsupported_op_itergetnext.pb"); }
+    {
+        // create then branch body graph
+        auto x = make_shared<Parameter>(f32, Shape{2, 3});
+        auto y = make_shared<Parameter>(f32, Shape{3});
+        auto add = make_shared<Add>(x, y);
+
+        model_ref = make_shared<Model>(OutputVector{add}, ParameterVector{x, y});
+    }
+}
 TEST_F(TransformationTestsF, ModelWithMultioutputBodyGraphNode) {
     { model = convert_model("partitioned_call2/partitioned_call2.pb"); }
     {

--- a/src/frontends/tensorflow/tests/convert_unsupported.cpp
+++ b/src/frontends/tensorflow/tests/convert_unsupported.cpp
@@ -58,7 +58,7 @@ TEST(FrontEndConvertModelTest, test_unsupported_tf1_while) {
                   "OpConversionFailure is expected.";
     } catch (const OpConversionFailure& error) {
         string error_message = error.what();
-        string ref_message = "No translator found for NextIteration node.";
+        string ref_message = "No translator found for Enter node.";
         ASSERT_TRUE(error_message.find(ref_message) != string::npos);
         ASSERT_EQ(function, nullptr);
     } catch (...) {

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_unsupported_op_itergetnext.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_unsupported_op_itergetnext.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2018-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import os
+import sys
+import tensorflow as tf
+
+
+def main():
+    tf.compat.v1.reset_default_graph()
+
+    with tf.compat.v1.Session() as sess:
+        iteratorv2 = tf.raw_ops.IteratorV2(shared_name="iterator", container="container",
+                                           output_types=[tf.float32, tf.float32], output_shapes=[[2, 3], [3]])
+        iterator_get_next = tf.raw_ops.IteratorGetNext(iterator=iteratorv2, output_types=[tf.float32, tf.float32],
+                                                       output_shapes=[[2, 3], [3]])
+
+        tf.raw_ops.AddV2(x=iterator_get_next[0], y=iterator_get_next[1])
+        tf.compat.v1.global_variables_initializer()
+        tf_net = sess.graph_def
+
+    tf.io.write_graph(tf_net, os.path.join(sys.argv[1], "unsupported_op_itergetnext"), "unsupported_op_itergetnext.pb",
+                      False)
+
+    with open(os.path.join(sys.argv[1], "unsupported_op_itergetnext", "unsupported_op_itergetnext.pb"),
+              mode='rb') as file:
+        modelContent = file.read()
+
+    modelContent = modelContent.replace(b"IteratorV2", b"IterVVVVVV")
+
+    with open(os.path.join(sys.argv[1], "unsupported_op_itergetnext", "unsupported_op_itergetnext.pb"),
+              mode='wb') as file:
+        file.write(modelContent)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/frontends/tensorflow_common/include/utils.hpp
+++ b/src/frontends/tensorflow_common/include/utils.hpp
@@ -6,6 +6,7 @@
 
 #include "openvino/core/validation_util.hpp"
 #include "openvino/frontend/node_context.hpp"
+#include "openvino/opsets/opset10.hpp"
 #include "openvino/opsets/opset8.hpp"
 #include "openvino/pass/graph_rewrite.hpp"
 
@@ -31,6 +32,17 @@ void set_out_name(const std::string& out_name, const Output<Node>& output);
 void set_node_name(const std::string& node_name, const std::shared_ptr<Node>& node);
 
 bool is_conditional_edge(const std::string& input_tensor_name);
+
+template <typename T>
+ov::Output<ov::Node> create_same_type_const_scalar(const ov::Output<ov::Node>& same_type_output, T value) {
+    if (same_type_output.get_element_type().is_static()) {
+        return make_shared<ov::opset10::Constant>(same_type_output.get_element_type(), ov::Shape{}, value);
+    } else {
+        Output<Node> const_res = make_shared<ov::opset10::Constant>(element::from<T>(), ov::Shape{}, value);
+        const_res = make_shared<ov::opset10::ConvertLike>(same_type_output, const_res);
+        return const_res;
+    }
+}
 
 template <typename T>
 void get_const_input(const NodeContext& node, int input_index, std::vector<T>* vector) {

--- a/src/frontends/tensorflow_common/include/utils.hpp
+++ b/src/frontends/tensorflow_common/include/utils.hpp
@@ -36,10 +36,10 @@ bool is_conditional_edge(const std::string& input_tensor_name);
 template <typename T>
 ov::Output<ov::Node> create_same_type_const_scalar(const ov::Output<ov::Node>& same_type_output, T value) {
     if (same_type_output.get_element_type().is_static()) {
-        return make_shared<ov::opset10::Constant>(same_type_output.get_element_type(), ov::Shape{}, value);
+        return std::make_shared<ov::opset10::Constant>(same_type_output.get_element_type(), ov::Shape{}, value);
     } else {
-        Output<Node> const_res = make_shared<ov::opset10::Constant>(element::from<T>(), ov::Shape{}, value);
-        const_res = make_shared<ov::opset10::ConvertLike>(same_type_output, const_res);
+        ov::Output<ov::Node> const_res = make_shared<ov::opset10::Constant>(ov::element::from<T>(), ov::Shape{}, value);
+        const_res = std::make_shared<ov::opset10::ConvertLike>(same_type_output, const_res);
         return const_res;
     }
 }

--- a/src/frontends/tensorflow_common/include/utils.hpp
+++ b/src/frontends/tensorflow_common/include/utils.hpp
@@ -38,7 +38,8 @@ ov::Output<ov::Node> create_same_type_const_scalar(const ov::Output<ov::Node>& s
     if (same_type_output.get_element_type().is_static()) {
         return std::make_shared<ov::opset10::Constant>(same_type_output.get_element_type(), ov::Shape{}, value);
     } else {
-        ov::Output<ov::Node> const_res = make_shared<ov::opset10::Constant>(ov::element::from<T>(), ov::Shape{}, value);
+        ov::Output<ov::Node> const_res =
+            std::make_shared<ov::opset10::Constant>(ov::element::from<T>(), ov::Shape{}, value);
         const_res = std::make_shared<ov::opset10::ConvertLike>(same_type_output, const_res);
         return const_res;
     }

--- a/src/frontends/tensorflow_common/src/op/const.cpp
+++ b/src/frontends/tensorflow_common/src/op/const.cpp
@@ -18,7 +18,7 @@ namespace op {
 OutputVector translate_const_op(const NodeContext& node) {
     auto ov_type = node.get_attribute<element::Type>("dtype");
     std::shared_ptr<Node> const_node;
-    if (ov_type == element::undefined) {
+    if (ov_type == element::dynamic) {
         const_node = std::make_shared<UnsupportedConstant>();
     } else {
         auto tensor = node.get_attribute<Tensor>("value");

--- a/tools/mo/openvino/tools/mo/moc_frontend/pipeline.py
+++ b/tools/mo/openvino/tools/mo/moc_frontend/pipeline.py
@@ -158,9 +158,9 @@ def moc_pipeline(argv: argparse.Namespace, moc_front_end: FrontEnd):
                 except NotImplementedFailure:
                     raise Error("Please specify type for value freezing {} node explicitly "
                                 "because the frontend does not support automatic type detection.".format(name))
-                # in case of cutting graph (or using custom inputs) and unspecified type,
+                # in case of cutting graph (or using custom inputs) and unspecified or dynamic type,
                 # the default type is fp32
-                if ov_type == Type.undefined:
+                if ov_type == Type.undefined or ov_type == Type.dynamic:
                     ov_type = Type.f32
                 dtype = get_numpy_ctype(ov_type)
 


### PR DESCRIPTION
**Details:** Now the conversion pipeline will convert all unsupported operations to Framework nodes, It is done with a hope that sub-graphs with Framework Nodes will be cut in later stages like auto-pruning and the conversion will not be failed immediately.

**Tickets:** TBD
