### PR TITLE
[PyOV] Remove `setuptools` upperbound

### DIFF
--- a/src/bindings/python/wheel/requirements-dev.txt
+++ b/src/bindings/python/wheel/requirements-dev.txt
@@ -1,3 +1,3 @@
-setuptools>=65.6.1,<=65.7.0
+setuptools>=65.6.1
 wheel>=0.38.1
 patchelf; sys_platform == 'linux' and platform_machine == 'x86_64'


### PR DESCRIPTION
### Details:
 - Now that https://github.com/openvinotoolkit/openvino/pull/16021 has been merged and POT version has been made PEP440 compliant we can remove `setuptools` upper bound.
 - Please wait for my confirmation that `openvino-dev` wheel is being generated correctly in CIs before merging

### Tickets:
 - 101371
