### PR TITLE
Added missed licenses to openvino-dev

### DIFF
--- a/tools/openvino_dev/CMakeLists.txt
+++ b/tools/openvino_dev/CMakeLists.txt
@@ -67,6 +67,10 @@ set(openvino_wheels_output_dir "${CMAKE_BINARY_DIR}/wheels")
 set(openvino_wheel_path "${openvino_wheels_output_dir}/${openvino_wheel_name}")
 
 add_custom_command(OUTPUT ${openvino_wheel_path}
+    COMMAND ${CMAKE_COMMAND} -E copy "${OpenVINO_SOURCE_DIR}/thirdparty/open_model_zoo/licensing/omz-third-party-programs.txt" "${CMAKE_CURRENT_BINARY_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy "${OpenVINO_SOURCE_DIR}/licensing/dev-third-party-programs.txt" "${CMAKE_CURRENT_BINARY_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy "${OpenVINO_SOURCE_DIR}/LICENSE" "${CMAKE_CURRENT_BINARY_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/readme.txt" "${CMAKE_CURRENT_BINARY_DIR}"
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/setup.cfg" "${CMAKE_CURRENT_BINARY_DIR}"
     COMMAND ${CMAKE_COMMAND} -E env OPENVINO_VERSION=${WHEEL_VERSION}
         ${PYTHON_EXECUTABLE} ${SETUP_PY} bdist_wheel

--- a/tools/openvino_dev/setup.cfg
+++ b/tools/openvino_dev/setup.cfg
@@ -18,5 +18,3 @@ license_files =
     *LICENSE*
     *license*
     *third-party-programs*
-    ../../licensing/dev-third-party-programs.txt
-    ../../LICENSE

--- a/tools/openvino_dev/setup.py
+++ b/tools/openvino_dev/setup.py
@@ -152,7 +152,7 @@ class CustomBuild(build):
             unique_req = list(set(map(lambda x: x.lower(), req)))
             self.distribution.extras_require[extra] = unique_req
 
-        # add dependecy on runtime package
+        # add dependency on runtime package
         runtime_req = [f'openvino=={self.distribution.get_version()}']
         self.distribution.install_requires.extend(runtime_req)
 


### PR DESCRIPTION
### Details:
 - Since 2022.3 `openvino-dev` is built using open-source scripts, which missed license files