### PR TITLE
[VPUX] - benchmark app issue fix - PERFORMANCE_HINT: UNDEFINED

### DIFF
--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -851,7 +851,7 @@ int main(int argc, char* argv[]) {
             if (!modelStream.is_open()) {
                 throw std::runtime_error("Cannot open model file " + FLAGS_m);
             }
-            compiledModel = core.import_model(modelStream, device_name, {});
+            compiledModel = core.import_model(modelStream, device_name, device_config);
             modelStream.close();
 
             auto duration_ms = get_duration_ms_till_now(startTime);

--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -442,7 +442,7 @@ def main():
             next_step()
 
             start_time = datetime.utcnow()
-            compiled_model = benchmark.core.import_model(args.path_to_model)
+            compiled_model = benchmark.core.import_model(args.path_to_model, benchmark.device, device_config)
             duration_ms = f"{(datetime.utcnow() - start_time).total_seconds() * 1000:.2f}"
             logger.info(f"Import model took {duration_ms} ms")
             if statistics:


### PR DESCRIPTION
Ticket: E-71637

With the latest OV master benchmark_app output looks like this:

<img width="200" alt="image" src="https://user-images.githubusercontent.com/52502732/222490426-9d92208d-28ea-46e9-bd0d-b721761b6d22.png">

It should be like this:
<img width="240" alt="image" src="https://user-images.githubusercontent.com/52502732/222490623-ca6e6f22-93ca-41af-9e29-4b4b2ad10e9e.png">

The `performance_hint` parameter is ignored.

These changes seem to cause this behavior:
- https://github.com/openvinotoolkit/openvino/commit/a088d1ab7dd92d471f392003df05d3daa8c903cd#diff-e7a536b4318b2270a4ee67f723b8ff57e9a5aed0928c11fa46e5a0b02db6300fL609-L613
- https://github.com/openvinotoolkit/openvino/commit/a088d1ab7dd92d471f392003df05d3daa8c903cd#diff-f311f9345d31892350d1e310ba8f0119806af62f514f7936f632df7fa6a32995L325

I tested the changes from this PR in our Net-Validation CI job. But feel free to point out any other OV check to confirm the fix.