### PR TITLE
[CPU] Prevent out of bounds executableGraphNodes read

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1077,11 +1077,12 @@ void Graph::InferDynamic(InferRequestBase* request) {
     std::function<void(size_t, size_t)> updateDynParams;
 
     updateShapes = [&](size_t node_indx, size_t stop_indx) {
-        const auto& node = executableGraphNodes[node_indx];
         prepareCounter.store(node_indx);
         if (node_indx >= stop_indx) {
             return;
         }
+
+        const auto& node = executableGraphNodes[node_indx];
         if (node->isDynamicNode()) {
             node->updateShapes();
         }
@@ -1092,11 +1093,12 @@ void Graph::InferDynamic(InferRequestBase* request) {
     };
 
     updateDynParams = [&](size_t node_indx, size_t stop_indx) {
-        const auto& node = executableGraphNodes[node_indx];
         if (node_indx >= stop_indx) {
             prepareCounter.store(node_indx);
             return;
         }
+
+        const auto& node = executableGraphNodes[node_indx];
         if (node->isDynamicNode()) {
             node->updateDynamicParams();
         }


### PR DESCRIPTION
### Details:
Change the call sequences to prevent possible read out of bounds the executableGraphNodes  vector.

### Tickets:
 - 105041
