### PR TITLE
Fix C1083 issue in CI

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(cpuSpecificRtInfo STATIC $<TARGET_PROPERTY:openvino_intel_cpu_plugin
                                      $<TARGET_PROPERTY:openvino_intel_cpu_plugin,SOURCE_DIR>/src/utils/rt_info/memory_formats_attribute.cpp)
 target_link_libraries(cpuSpecificRtInfo PRIVATE openvino::runtime)
 
+set(CMAKE_OBJECT_PATH_MAX 512)
 set(INCLUDES ${CMAKE_CURRENT_SOURCE_DIR} $<TARGET_PROPERTY:openvino_intel_cpu_plugin,SOURCE_DIR>/src)
 set(DEPENDENCIES openvino_intel_cpu_plugin)
 set(LINK_LIBRARIES funcSharedTests cpuSpecificRtInfo inference_engine_snippets)


### PR DESCRIPTION
### Details:
 - CI build failure: output_layers_handling_in_transformations_for_concat_multi_channel.cpp fatal error C1083: Cannot open compiler generated file: '': Invalid argument

### Tickets:
 - 97736
