### PR TITLE
[GPU] Move some op parameters from node to primitive class

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/convolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/convolution.hpp
@@ -750,6 +750,9 @@ struct convolution : public primitive_base<convolution> {
     /// If bilinear_interpolation_pad is false and the sampling location is within one pixel outside of the feature map boundary,
     /// then the sampling location shifts to the inner boundary of the feature map.
     bool bilinear_interpolation_pad {false};
+
+    bool transposed {false};
+
     /// @param grouped_weights_shape Defines if weights tensor has explicit group dimension.
     bool grouped_weights_shape;
     /// @brief List of primitive ids containing weights data.
@@ -772,6 +775,7 @@ struct convolution : public primitive_base<convolution> {
         seed = hash_combine(seed, deformable_groups);
         seed = hash_combine(seed, deformable_mode);
         seed = hash_combine(seed, bilinear_interpolation_pad);
+        seed = hash_combine(seed, transposed);
         seed = hash_combine(seed, grouped_weights_shape);
         seed = hash_combine(seed, weights.size());
         seed = hash_combine(seed, bias.size());
@@ -797,6 +801,7 @@ struct convolution : public primitive_base<convolution> {
                cmp_fields(padding_below) &&
                cmp_fields(deformable_mode) &&
                cmp_fields(bilinear_interpolation_pad) &&
+               cmp_fields(transposed) &&
                cmp_fields(grouped_weights_shape) &&
                cmp_fields(weights.size()) &&
                cmp_fields(bias.size()) &&

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/quantize.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/quantize.hpp
@@ -36,6 +36,10 @@ struct quantize : public primitive_base<quantize> {
         : primitive_base(id, inputs, {output_padding}, {optional_data_type{output_data_type}})
         , levels(levels) {}
 
+    quantize() : primitive_base("", {}), levels(0) {}
+
+    DECLARE_OBJECT_TYPE_SERIALIZATION
+
     /// @brief levels The number of quantization levels.
     int levels;
 
@@ -118,6 +122,56 @@ struct quantize : public primitive_base<quantize> {
                out_hi == rhs_casted.out_hi &&
                out_scale == rhs_casted.out_scale &&
                out_shift == rhs_casted.out_shift;
+    }
+
+    void save(BinaryOutputBuffer& ob) const override {
+        ob << levels;
+        ob << scale_shift_opt;
+        ob << need_post_scale;
+        ob << need_post_shift;
+        ob << need_pre_shift;
+        ob << need_clamp;
+        ob << need_min_clamp;
+        ob << need_max_clamp;
+        ob << per_tensor_input_range;
+        ob << per_tensor_input_scale;
+        ob << per_tensor_input_shift;
+        ob << per_tensor_output_range;
+        ob << per_tensor_output_scale;
+        ob << per_tensor_output_shift;
+        ob << in_lo;
+        ob << in_hi;
+        ob << in_scale;
+        ob << in_shift;
+        ob << out_lo;
+        ob << out_hi;
+        ob << out_scale;
+        ob << out_shift;
+    }
+
+    void load(BinaryInputBuffer& ib) override {
+        ib >> levels;
+        ib >> scale_shift_opt;
+        ib >> need_post_scale;
+        ib >> need_post_shift;
+        ib >> need_pre_shift;
+        ib >> need_clamp;
+        ib >> need_min_clamp;
+        ib >> need_max_clamp;
+        ib >> per_tensor_input_range;
+        ib >> per_tensor_input_scale;
+        ib >> per_tensor_input_shift;
+        ib >> per_tensor_output_range;
+        ib >> per_tensor_output_scale;
+        ib >> per_tensor_output_shift;
+        ib >> in_lo;
+        ib >> in_hi;
+        ib >> in_scale;
+        ib >> in_shift;
+        ib >> out_lo;
+        ib >> out_hi;
+        ib >> out_scale;
+        ib >> out_shift;
     }
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/quantize.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/quantize.hpp
@@ -28,12 +28,65 @@ struct quantize : public primitive_base<quantize> {
         : primitive_base(id, {input, input_low, input_high, output_low, output_high}, {output_padding}, {optional_data_type{output_data_type}})
         , levels(levels) {}
 
+    quantize(const primitive_id& id,
+             const std::vector<input_info>& inputs,
+             const int levels,
+             const data_types output_data_type,
+             const padding& output_padding = padding())
+        : primitive_base(id, inputs, {output_padding}, {optional_data_type{output_data_type}})
+        , levels(levels) {}
+
     /// @brief levels The number of quantization levels.
     int levels;
+
+    bool scale_shift_opt = false;
+    bool need_post_scale = false;
+    bool need_post_shift = false;
+    bool need_pre_shift = false;
+    bool need_clamp = false;
+    bool need_min_clamp = false;
+    bool need_max_clamp = false;
+
+    bool per_tensor_input_range = false;
+    bool per_tensor_input_scale = false;
+    bool per_tensor_input_shift = false;
+    bool per_tensor_output_range = false;
+    bool per_tensor_output_scale = false;
+    bool per_tensor_output_shift = false;
+
+    float in_lo = 0.0f;
+    float in_hi = 0.0f;
+    float in_scale = 0.0f;
+    float in_shift = 0.0f;
+    float out_lo = 0.0f;
+    float out_hi = 0.0f;
+    float out_scale = 0.0f;
+    float out_shift = 0.0f;
 
     size_t hash() const override {
         size_t seed = primitive::hash();
         seed = cldnn::hash_combine(seed, levels);
+        seed = cldnn::hash_combine(seed, scale_shift_opt);
+        seed = cldnn::hash_combine(seed, need_post_scale);
+        seed = cldnn::hash_combine(seed, need_post_shift);
+        seed = cldnn::hash_combine(seed, need_pre_shift);
+        seed = cldnn::hash_combine(seed, need_clamp);
+        seed = cldnn::hash_combine(seed, need_min_clamp);
+        seed = cldnn::hash_combine(seed, need_max_clamp);
+        seed = cldnn::hash_combine(seed, per_tensor_input_range);
+        seed = cldnn::hash_combine(seed, per_tensor_input_scale);
+        seed = cldnn::hash_combine(seed, per_tensor_input_shift);
+        seed = cldnn::hash_combine(seed, per_tensor_output_range);
+        seed = cldnn::hash_combine(seed, per_tensor_output_scale);
+        seed = cldnn::hash_combine(seed, per_tensor_output_shift);
+        seed = cldnn::hash_combine(seed, in_lo);
+        seed = cldnn::hash_combine(seed, in_hi);
+        seed = cldnn::hash_combine(seed, in_scale);
+        seed = cldnn::hash_combine(seed, in_shift);
+        seed = cldnn::hash_combine(seed, out_lo);
+        seed = cldnn::hash_combine(seed, out_hi);
+        seed = cldnn::hash_combine(seed, out_scale);
+        seed = cldnn::hash_combine(seed, out_shift);
         return seed;
     }
 
@@ -43,7 +96,28 @@ struct quantize : public primitive_base<quantize> {
 
         auto rhs_casted = downcast<const quantize>(rhs);
 
-        return levels == rhs_casted.levels;
+        return levels == rhs_casted.levels &&
+               scale_shift_opt == rhs_casted.scale_shift_opt &&
+               need_post_scale == rhs_casted.need_post_scale &&
+               need_post_shift == rhs_casted.need_post_shift &&
+               need_pre_shift == rhs_casted.need_pre_shift &&
+               need_clamp == rhs_casted.need_clamp &&
+               need_min_clamp == rhs_casted.need_min_clamp &&
+               need_max_clamp == rhs_casted.need_max_clamp &&
+               per_tensor_input_range == rhs_casted.per_tensor_input_range &&
+               per_tensor_input_scale == rhs_casted.per_tensor_input_scale &&
+               per_tensor_input_shift == rhs_casted.per_tensor_input_shift &&
+               per_tensor_output_range == rhs_casted.per_tensor_output_range &&
+               per_tensor_output_scale == rhs_casted.per_tensor_output_scale &&
+               per_tensor_output_shift == rhs_casted.per_tensor_output_shift &&
+               in_lo == rhs_casted.in_lo &&
+               in_hi == rhs_casted.in_hi &&
+               in_scale == rhs_casted.in_scale &&
+               in_shift == rhs_casted.in_shift &&
+               out_lo == rhs_casted.out_lo &&
+               out_hi == rhs_casted.out_hi &&
+               out_scale == rhs_casted.out_scale &&
+               out_shift == rhs_casted.out_shift;
     }
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/pre_replace_deconv.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/pre_replace_deconv.cpp
@@ -146,10 +146,11 @@ void pre_replace_deconv::run(program& p) {
                                                                   output_padding);
                     }
                 }
+
+                conv_prim->transposed = true;
                 program_node& new_node = p.get_or_create(conv_prim);
 
                 auto& conv_node = new_node.as<convolution>();
-                conv_node.set_transposed(true);
 
                 // add connections input->convolution, weights->convolution and bias->convolution
                 p.add_connection(input_node, conv_node);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -404,9 +404,9 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
             conv_with_bias_prim->activations_zero_points = desc->activations_zero_points;
             conv_with_bias_prim->weights_zero_points = desc->weights_zero_points;
             conv_with_bias_prim->compensation = desc->compensation;
-            auto& new_conv_node = p.get_or_create(conv_with_bias_prim);
             // Copy transposed flag to new prim as convolution node might be produced by deconv -> conv replacement before this pass
-            new_conv_node.as<convolution>().set_transposed(conv.get_transposed());
+            conv_with_bias_prim->transposed = conv.get_transposed();
+            auto& new_conv_node = p.get_or_create(conv_with_bias_prim);
 
             fuse_bias_f(conv, new_conv_node, bias_node, eltw_node);
         } else if (replace_candidate.is_type<deconvolution>()) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
@@ -21,6 +21,8 @@
 
 using namespace cldnn;
 
+namespace {
+
 template<typename T>
 bool check_binarization(memory::ptr mem_input_low, memory::ptr mem_input_high, program& p) {
     bool is_binarization = true;
@@ -39,8 +41,14 @@ bool check_binarization(memory::ptr mem_input_low, memory::ptr mem_input_high, p
     return is_binarization;
 }
 
+inline float clamp(float val) {
+    return std::max(std::numeric_limits<float>::lowest(), std::min(std::numeric_limits<float>::max(), val));
+}
 
-void  prepare_quantization::prepare_scale_shift_opt(program &p, quantize_node& quantize_node) {
+}  // namespace
+
+
+void prepare_quantization::prepare_scale_shift_opt(program &p, quantize_node& quantize_node) {
     const auto& stream = p.get_stream();
 
     program_node &input_low_node = quantize_node.get_dependency(1);
@@ -153,7 +161,8 @@ void  prepare_quantization::prepare_scale_shift_opt(program &p, quantize_node& q
     bool has_negative_scales = false;
     bool need_post_scale = false;
     bool need_post_shift = false;
-    int levels = quantize_node.get_primitive()->levels;
+    auto primitive = quantize_node.get_primitive();
+    int levels = primitive->levels;
 
     for (int b = 0; b < scales_layout.batch(); b++) {
         for (int f = 0; f < scales_layout.feature(); f++) {
@@ -244,10 +253,47 @@ void  prepare_quantization::prepare_scale_shift_opt(program &p, quantize_node& q
     auto in_shift_prim = std::make_shared<data>(quantize_node.id() + "_in_shift", mem_input_shift);
     auto out_scale_prim = std::make_shared<data>(quantize_node.id() + "_output_scale", mem_output_scale);
     auto out_shift_prim = std::make_shared<data>(quantize_node.id() + "_output_shift", mem_output_shift);
+
+    std::vector<input_info> quantize_inputs = quantize_node.get_primitive()->input;
+    quantize_inputs.push_back(in_scale_prim->id);
+    quantize_inputs.push_back(in_shift_prim->id);
+    quantize_inputs.push_back(out_scale_prim->id);
+    quantize_inputs.push_back(out_shift_prim->id);
+
+    data_types out_dt = primitive->output_data_types.size() ? primitive->output_data_types[0].value_or(data_types::f32) : data_types::f32;
+    auto new_quantize_prim = std::make_shared<quantize>(quantize_node.id() + "_opt", quantize_inputs, primitive->levels, out_dt);
+    new_quantize_prim->origin_op_name = primitive->origin_op_name;
+    new_quantize_prim->origin_op_type_name = primitive->origin_op_type_name;
+
+    new_quantize_prim->scale_shift_opt = true;
+    new_quantize_prim->need_post_scale = need_post_scale;
+    new_quantize_prim->need_post_shift = need_post_shift;
+    new_quantize_prim->need_pre_shift = need_pre_shift;
+    new_quantize_prim->per_tensor_input_scale = per_tensor_in_scale;
+    new_quantize_prim->per_tensor_input_shift = per_tensor_in_shift && need_pre_shift;
+    new_quantize_prim->need_clamp = need_clamp;
+    new_quantize_prim->need_min_clamp = need_min_clamp;
+    new_quantize_prim->need_max_clamp = need_max_clamp;
+    new_quantize_prim->per_tensor_input_range = per_tensor_in_range;
+    new_quantize_prim->per_tensor_output_range = per_tensor_out_range;
+    new_quantize_prim->per_tensor_output_scale = per_tensor_out_scale;
+    new_quantize_prim->per_tensor_output_shift = per_tensor_out_shift;
+
+    // Clamp is needed to avoid inf and -inf which are converted to undefined "inf" constant in opencl
+    new_quantize_prim->in_scale  = clamp(in_scale_val);
+    new_quantize_prim->in_shift  = clamp(in_shift_val);
+    new_quantize_prim->in_lo     = clamp(in_lo_val);
+    new_quantize_prim->in_hi     = clamp(in_hi_val);
+    new_quantize_prim->out_lo    = clamp(out_lo_val);
+    new_quantize_prim->out_hi    = clamp(out_hi_val);
+    new_quantize_prim->out_scale = clamp(out_scale_val);
+    new_quantize_prim->out_shift = clamp(out_shift_val);
+
     auto& in_scale_node = p.get_or_create(in_scale_prim);
     auto& in_shift_node = p.get_or_create(in_shift_prim);
     auto& out_scale_node = p.get_or_create(out_scale_prim);
     auto& out_shift_node = p.get_or_create(out_shift_prim);
+    auto& new_quantize_node = p.get_or_create(new_quantize_prim);
 
     auto& inputs = p.get_inputs();
 
@@ -256,76 +302,20 @@ void  prepare_quantization::prepare_scale_shift_opt(program &p, quantize_node& q
     inputs.push_back(&out_scale_node);
     inputs.push_back(&out_shift_node);
 
-    p.add_connection(in_scale_node, quantize_node);
-    p.add_connection(in_shift_node, quantize_node);
-    p.add_connection(out_scale_node, quantize_node);
-    p.add_connection(out_shift_node, quantize_node);
-    quantize_node.add_memory_dependency(in_scale_node.id());
-    quantize_node.add_memory_dependency(in_shift_node.id());
-    quantize_node.add_memory_dependency(out_scale_node.id());
-    quantize_node.add_memory_dependency(out_shift_node.id());
-    p.get_processing_order().insert(&quantize_node, &in_shift_node);
-    p.get_processing_order().insert(&quantize_node, &in_scale_node);
-    p.get_processing_order().insert(&quantize_node, &out_shift_node);
-    p.get_processing_order().insert(&quantize_node, &out_scale_node);
+    p.replace(quantize_node, new_quantize_node);
 
-    quantize_node.set_scale_shift_opt();
-
-    if (need_post_scale) {
-        quantize_node.set_need_post_scale();
-    }
-
-    if (need_post_shift) {
-        quantize_node.set_need_post_shift();
-    }
-
-    if (need_pre_shift) {
-        quantize_node.set_need_pre_shift();
-    }
-
-    if (per_tensor_in_scale) {
-        quantize_node.set_per_tensor_input_scale();
-        quantize_node.set_input_scale_val(in_scale_val);
-    }
-
-    if (per_tensor_in_shift && need_pre_shift) {
-        quantize_node.set_per_tensor_input_shift();
-        quantize_node.set_input_shift_val(in_shift_val);
-    }
-
-    if (need_clamp) {
-        quantize_node.set_need_clamp();
-    }
-
-    if (need_min_clamp) {
-        quantize_node.set_need_min_clamp();
-    }
-
-    if (need_max_clamp) {
-        quantize_node.set_need_max_clamp();
-    }
-
-    if (per_tensor_in_range) {
-        quantize_node.set_per_tensor_input_range();
-        quantize_node.set_input_lo_val(in_lo_val);
-        quantize_node.set_input_hi_val(in_hi_val);
-    }
-
-    if (per_tensor_out_range) {
-        quantize_node.set_per_tensor_output_range();
-        quantize_node.set_output_lo_val(out_lo_val);
-        quantize_node.set_output_hi_val(out_hi_val);
-    }
-
-    if (per_tensor_out_scale) {
-        quantize_node.set_per_tensor_output_scale();
-        quantize_node.set_output_scale_val(out_scale_val);
-    }
-
-    if (per_tensor_out_shift) {
-        quantize_node.set_per_tensor_output_shift();
-        quantize_node.set_output_shift_val(out_shift_val);
-    }
+    p.add_connection(in_scale_node, new_quantize_node);
+    p.add_connection(in_shift_node, new_quantize_node);
+    p.add_connection(out_scale_node, new_quantize_node);
+    p.add_connection(out_shift_node, new_quantize_node);
+    new_quantize_node.add_memory_dependency(in_scale_node.id());
+    new_quantize_node.add_memory_dependency(in_shift_node.id());
+    new_quantize_node.add_memory_dependency(out_scale_node.id());
+    new_quantize_node.add_memory_dependency(out_shift_node.id());
+    p.get_processing_order().insert(&new_quantize_node, &in_shift_node);
+    p.get_processing_order().insert(&new_quantize_node, &in_scale_node);
+    p.get_processing_order().insert(&new_quantize_node, &out_shift_node);
+    p.get_processing_order().insert(&new_quantize_node, &out_scale_node);
 }
 
 void prepare_quantization::handle_quantize_node(program& p, quantize_node& quantize_node) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
@@ -30,7 +30,7 @@ protected:
         for (size_t i = 0; i < instance.inputs_memory_count(); i++) {
             args.inputs.push_back(instance.input_memory_ptr(i));
         }
-        if (instance.scale_shift_opt) {
+        if (instance.get_typed_desc<quantize>()->scale_shift_opt) {
             if (instance.dependencies().size() == 9) {
                 args.inputs.push_back(instance.dep_memory_ptr(5));
                 args.inputs.push_back(instance.dep_memory_ptr(6));
@@ -156,3 +156,4 @@ attach_quantize_impl::attach_quantize_impl() {
 }  // namespace cldnn
 
 BIND_BINARY_BUFFER_WITH_TYPE(cldnn::ocl::quantize_impl)
+BIND_BINARY_BUFFER_WITH_TYPE(cldnn::quantize)

--- a/src/plugins/intel_gpu/src/graph/include/convolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/convolution_inst.h
@@ -20,15 +20,13 @@ struct typed_program_node<convolution> : public typed_program_node_base<convolut
 public:
     typed_program_node(std::shared_ptr<primitive> prim, program& prog)
         : parent(prim, prog),
-          transposed(false),
           groups(this->get_primitive()->groups),
           deformable_groups(this->get_primitive()->deformable_groups),
           deformable_mode(this->get_primitive()->deformable_mode) {
         support_padding_all(true);
     }
 
-    void set_transposed(bool node_transposed) { transposed = node_transposed; }
-    bool get_transposed() const { return transposed; }
+    bool get_transposed() const { return get_primitive()->transposed; }
 
     uint32_t get_groups() const { return groups; }
 
@@ -110,13 +108,7 @@ public:
         return params;
     }
 
-    void calculate_hash() override {
-        parent::calculate_hash();
-        seed = hash_combine(seed, transposed);
-    }
-
 private:
-    bool transposed;
     uint32_t groups;
     uint32_t deformable_groups;
     bool deformable_mode;

--- a/src/plugins/intel_gpu/src/graph/include/deformable_convolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/deformable_convolution_inst.h
@@ -23,7 +23,6 @@ public:
         support_padding_all(true);
     }
 
-    void set_transposed(bool node_transposed) { transposed = node_transposed; }
     bool get_transposed() const { return transposed; }
 
     uint32_t get_groups() const { return groups; }
@@ -83,7 +82,6 @@ public:
         support_padding_all(true);
     }
 
-    void set_transposed(bool node_transposed) { transposed = node_transposed; }
     bool get_transposed() const { return transposed; }
 
     uint32_t get_groups() const { return groups; }

--- a/src/plugins/intel_gpu/src/graph/include/quantize_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/quantize_inst.h
@@ -205,12 +205,8 @@ public:
     static std::vector<layout> calc_output_layouts(quantize_node const& node, kernel_impl_params const& impl_param);
     static layout calc_output_layout(quantize_node const& node, kernel_impl_params const& impl_param);
     static std::string to_string(quantize_node const& node);
-    void save(BinaryOutputBuffer& ob) const override;
-    void load(BinaryInputBuffer& ib) override;
 
     typed_primitive_inst(network& network, quantize_node const& node);
-
-    bool scale_shift_opt;   // This is for serialization. Please do not remove it.
 };
 
 using quantize_inst = typed_primitive_inst<quantize>;

--- a/src/plugins/intel_gpu/src/graph/include/quantize_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/quantize_inst.h
@@ -144,133 +144,53 @@ public:
     size_t inputs_count() const { return get_dependencies().size(); }
     int get_levels() const { return get_primitive()->levels; }
     bool get_packed_binary_output() const { return get_output_layout().data_type == data_types::bin; }
-    bool get_scale_shift_opt() const { return scale_shift_opt; }
-    bool get_need_pre_shift() const { return need_pre_shift; }
-    bool get_need_post_scale() const { return need_post_scale; }
-    bool get_need_post_shift() const { return need_post_shift; }
-    bool get_need_clamp() const { return need_clamp; }
-    bool get_need_min_clamp() const { return need_min_clamp; }
-    bool get_need_max_clamp() const { return need_max_clamp; }
-    bool get_per_tensor_input_scale() const { return per_tensor_input_scale; }
-    bool get_per_tensor_input_shift() const { return per_tensor_input_shift; }
-    bool get_per_tensor_input_range() const { return per_tensor_input_range; }
-    bool get_per_tensor_output_scale() const { return per_tensor_output_scale; }
-    bool get_per_tensor_output_shift() const { return per_tensor_output_shift; }
-    bool get_per_tensor_output_range() const { return per_tensor_output_range; }
-    float get_input_scale_val() const { return in_scale; }
-    float get_input_shift_val() const { return in_shift; }
-    float get_input_lo_val() const { return in_lo; }
-    float get_input_hi_val() const { return in_hi; }
-    float get_output_scale_val() const { return out_scale; }
-    float get_output_shift_val() const { return out_shift; }
-    float get_output_lo_val() const { return out_lo; }
-    float get_output_hi_val() const { return out_hi; }
-
-    void set_scale_shift_opt() { scale_shift_opt = true; }
-    void set_need_post_scale() { need_post_scale = true; }
-    void set_need_post_shift() { need_post_shift = true; }
-    void set_need_pre_shift() { need_pre_shift = true; }
-    void set_need_clamp() { need_clamp = true; }
-    void set_need_min_clamp() { need_min_clamp = true; }
-    void set_need_max_clamp() { need_max_clamp = true; }
-    void set_per_tensor_input_scale() { per_tensor_input_scale = true; }
-    void set_per_tensor_input_shift() { per_tensor_input_shift = true; }
-    void set_per_tensor_input_range() { per_tensor_input_range = true; }
-    void set_per_tensor_output_scale() { per_tensor_output_scale = true; }
-    void set_per_tensor_output_shift() { per_tensor_output_shift = true; }
-    void set_per_tensor_output_range() { per_tensor_output_range = true; }
-    // Clamp is needed to avoid inf and -inf which are converted to undefined "inf" constant in opencl
-    void set_input_scale_val(float val) { in_scale = clamp(val); }
-    void set_input_shift_val(float val) { in_shift = clamp(val); }
-    void set_input_lo_val(float val) { in_lo = clamp(val); }
-    void set_input_hi_val(float val) { in_hi = clamp(val); }
-    void set_output_scale_val(float val) { out_scale = clamp(val); }
-    void set_output_shift_val(float val) { out_shift = clamp(val); }
-    void set_output_lo_val(float val) { out_lo = clamp(val); }
-    void set_output_hi_val(float val) { out_hi = clamp(val); }
+    bool get_scale_shift_opt() const { return get_primitive()->scale_shift_opt; }
+    bool get_need_pre_shift() const { return get_primitive()->need_pre_shift; }
+    bool get_need_post_scale() const { return get_primitive()->need_post_scale; }
+    bool get_need_post_shift() const { return get_primitive()->need_post_shift; }
+    bool get_need_clamp() const { return get_primitive()->need_clamp; }
+    bool get_need_min_clamp() const { return get_primitive()->need_min_clamp; }
+    bool get_need_max_clamp() const { return get_primitive()->need_max_clamp; }
+    bool get_per_tensor_input_scale() const { return get_primitive()->per_tensor_input_scale; }
+    bool get_per_tensor_input_shift() const { return get_primitive()->per_tensor_input_shift; }
+    bool get_per_tensor_input_range() const { return get_primitive()->per_tensor_input_range; }
+    bool get_per_tensor_output_scale() const { return get_primitive()->per_tensor_output_scale; }
+    bool get_per_tensor_output_shift() const { return get_primitive()->per_tensor_output_shift; }
+    bool get_per_tensor_output_range() const { return get_primitive()->per_tensor_output_range; }
+    float get_input_scale_val() const { return get_primitive()->in_scale; }
+    float get_input_shift_val() const { return get_primitive()->in_shift; }
+    float get_input_lo_val() const { return get_primitive()->in_lo; }
+    float get_input_hi_val() const { return get_primitive()->in_hi; }
+    float get_output_scale_val() const { return get_primitive()->out_scale; }
+    float get_output_shift_val() const { return get_primitive()->out_shift; }
+    float get_output_lo_val() const { return get_primitive()->out_lo; }
+    float get_output_hi_val() const { return get_primitive()->out_hi; }
 
     std::shared_ptr<NodeFuseParams> get_fuse_params() const override {
         return std::make_shared<QuantizeFuseParams>(get_output_layout(),
-                                                    scale_shift_opt,
-                                                    need_post_scale,
-                                                    need_post_shift,
-                                                    need_pre_shift,
-                                                    need_clamp,
-                                                    need_min_clamp,
-                                                    need_max_clamp,
-                                                    per_tensor_input_range,
-                                                    per_tensor_input_scale,
-                                                    per_tensor_input_shift,
-                                                    per_tensor_output_range,
-                                                    per_tensor_output_scale,
-                                                    per_tensor_output_shift,
-                                                    in_lo,
-                                                    in_hi,
-                                                    in_scale,
-                                                    in_shift,
-                                                    out_lo,
-                                                    out_hi,
-                                                    out_scale,
-                                                    out_shift);
+                                                    get_primitive()->scale_shift_opt,
+                                                    get_primitive()->need_post_scale,
+                                                    get_primitive()->need_post_shift,
+                                                    get_primitive()->need_pre_shift,
+                                                    get_primitive()->need_clamp,
+                                                    get_primitive()->need_min_clamp,
+                                                    get_primitive()->need_max_clamp,
+                                                    get_primitive()->per_tensor_input_range,
+                                                    get_primitive()->per_tensor_input_scale,
+                                                    get_primitive()->per_tensor_input_shift,
+                                                    get_primitive()->per_tensor_output_range,
+                                                    get_primitive()->per_tensor_output_scale,
+                                                    get_primitive()->per_tensor_output_shift,
+                                                    get_primitive()->in_lo,
+                                                    get_primitive()->in_hi,
+                                                    get_primitive()->in_scale,
+                                                    get_primitive()->in_shift,
+                                                    get_primitive()->out_lo,
+                                                    get_primitive()->out_hi,
+                                                    get_primitive()->out_scale,
+                                                    get_primitive()->out_shift);
     }
     std::vector<size_t> get_shape_infer_dependencies() const override { return {}; }
-
-    void calculate_hash() override {
-        parent::calculate_hash();
-
-        seed = hash_combine(seed, scale_shift_opt);
-        seed = hash_combine(seed, need_post_scale);
-        seed = hash_combine(seed, need_post_shift);
-        seed = hash_combine(seed, need_pre_shift);
-        seed = hash_combine(seed, need_clamp);
-        seed = hash_combine(seed, need_min_clamp);
-        seed = hash_combine(seed, need_max_clamp);
-
-        seed = hash_combine(seed, per_tensor_input_range);
-        seed = hash_combine(seed, per_tensor_input_scale);
-        seed = hash_combine(seed, per_tensor_input_shift);
-        seed = hash_combine(seed, per_tensor_output_range);
-        seed = hash_combine(seed, per_tensor_output_scale);
-        seed = hash_combine(seed, per_tensor_output_shift);
-
-        seed = hash_combine(seed, in_lo);
-        seed = hash_combine(seed, in_hi);
-        seed = hash_combine(seed, in_scale);
-        seed = hash_combine(seed, in_shift);
-        seed = hash_combine(seed, out_lo);
-        seed = hash_combine(seed, out_hi);
-        seed = hash_combine(seed, out_scale);
-        seed = hash_combine(seed, out_shift);
-    }
-
-private:
-    inline float clamp(float val) const {
-        return std::max(std::numeric_limits<float>::lowest(), std::min(std::numeric_limits<float>::max(), val));
-    }
-
-    bool scale_shift_opt = false;
-    bool need_post_scale = false;
-    bool need_post_shift = false;
-    bool need_pre_shift = false;
-    bool need_clamp = false;
-    bool need_min_clamp = false;
-    bool need_max_clamp = false;
-
-    bool per_tensor_input_range = false;
-    bool per_tensor_input_scale = false;
-    bool per_tensor_input_shift = false;
-    bool per_tensor_output_range = false;
-    bool per_tensor_output_scale = false;
-    bool per_tensor_output_shift = false;
-
-    float in_lo = 0.0f;
-    float in_hi = 0.0f;
-    float in_scale = 0.0f;
-    float in_shift = 0.0f;
-    float out_lo = 0.0f;
-    float out_hi = 0.0f;
-    float out_scale = 0.0f;
-    float out_shift = 0.0f;
 };
 
 using quantize_node = typed_program_node<quantize>;
@@ -288,7 +208,7 @@ public:
     void save(BinaryOutputBuffer& ob) const override;
     void load(BinaryInputBuffer& ib) override;
 
-    typed_primitive_inst(network& network, quantize_node const& desc);
+    typed_primitive_inst(network& network, quantize_node const& node);
 
     bool scale_shift_opt;   // This is for serialization. Please do not remove it.
 };

--- a/src/plugins/intel_gpu/src/graph/quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/quantize.cpp
@@ -73,17 +73,6 @@ std::string quantize_inst::to_string(quantize_node const& node) {
     return primitive_description.str();
 }
 
-quantize_inst::typed_primitive_inst(network& network, quantize_node const& node) : parent(network, node) {
-    scale_shift_opt = node.get_scale_shift_opt();
-}
+quantize_inst::typed_primitive_inst(network& network, quantize_node const& node) : parent(network, node) {}
 
-void quantize_inst::save(cldnn::BinaryOutputBuffer& ob) const {
-    parent::save(ob);
-    ob << scale_shift_opt;
-}
-
-void quantize_inst::load(BinaryInputBuffer& ib) {
-    parent::load(ib);
-    ib >> scale_shift_opt;
-}
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/tests/test_cases/hash_key_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/hash_key_gpu_test.cpp
@@ -286,7 +286,7 @@ TEST(check_hash_value, quantize_basic) {
     const auto prog_node_hash = prog_node.get_hash();
     const auto prim_inst_hash = prim_inst->get_impl_key();
 
-    ASSERT_EQ(primitive_hash, 1569171484239412698UL);
+    ASSERT_EQ(primitive_hash, 4135863035456568493UL);
     ASSERT_EQ(prog_node_hash, 4135863035456568493UL);
     ASSERT_EQ(prim_inst_hash, 13898649554943348250UL);
 }

--- a/src/plugins/intel_gpu/tests/test_cases/hash_key_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/hash_key_gpu_test.cpp
@@ -251,9 +251,9 @@ TEST(check_hash_value, conv_basic) {
     const auto prog_node_hash = prog_node.get_hash();
     const auto prim_inst_hash = prim_inst->get_impl_key();
 
-    ASSERT_EQ(primitive_hash, 12460716932918224126UL);
-    ASSERT_EQ(prog_node_hash, 14591386802538030726UL);
-    ASSERT_EQ(prim_inst_hash, 3099955169197623490UL);
+    ASSERT_EQ(primitive_hash, 14591385718963138714UL);
+    ASSERT_EQ(prog_node_hash, 14591385718963138714UL);
+    ASSERT_EQ(prim_inst_hash, 6876197578014654797UL);
 }
 
 TEST(check_hash_value, quantize_basic) {


### PR DESCRIPTION
### Details:
 - `transposed` flag was moved to `convolution` primitive
 - scale shift opt related parameters were moved from node to `quantize` primitive
 - now those primitives are created from scratch if we need to update such parameters instead of modifying program_node
 - this will allow to remove hashing for program_node and do it for kernel_impl_params only