### PR TITLE
[GPU] Minor fixes for dynamic model

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -70,7 +70,7 @@ void prepare_primitive_fusing::remove_redundant_reshape(program &p) {
             for (auto prev : node.get_dependencies()) {
                 if (!prev.first->is_type<reshape>())
                     return;
-                if (prev.first->get_users().size() > 1)
+                if (prev.first->get_users().size() > 1 || prev.first->get_dependencies().size() > 1)
                     return;
                 if (prev.first->as<reshape>().input().get_output_layout() == node.get_output_layout()) {
                     p.add_optimized_primitive_info(prev.first->id());

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -153,6 +153,9 @@ void primitive_inst::update_shape() {
         auto idx = _deps[i].second;
         auto new_shape = _deps[i].first->_impl_params->get_output_layout(idx);
         if (_impl_params->get_input_layout(i) != new_shape) {
+            GPU_DEBUG_TRACE_DETAIL << id() << ": update shape dep: " << _deps[i].first->id()
+                                   << " was: " << _impl_params->get_input_layout(i).to_short_string()
+                                   << " now: " << new_shape.to_short_string() << std::endl;
             _impl_params->input_layouts[i] = new_shape;
             input_shape_changed = true;
         }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
@@ -297,7 +297,7 @@ KernelsData GatherKernelRef::GetKernelsData(const Params& params, const optional
                      2,
                      GetFusedPrimitiveInputsCount(params),
                      1,
-                     newParams.outputs[0].is_dynamic());
+                     newParams.has_dynamic_tensors());
 
     return {kd};
 }


### PR DESCRIPTION
### Details:
 - Fix removing redundant reshapes is skipped so that only the current reshape is not removed if only the input size of dependency reshape is not 1 among the sequence of reshapes in `prepare_primitive_fusing` opt pass
 - Fix to set kernel arguments correctly when only the input tensor of `gather` is dynamic

### Tickets:
 - 104936
