### PR TITLE
Fix RTInfo for ReduceL2Decomposition

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/reduce_l2_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/reduce_l2_decomposition.cpp
@@ -32,7 +32,12 @@ ov::pass::ReduceL2Decomposition::ReduceL2Decomposition() {
                                                                    reduce_l2_node->get_keep_dims());
         auto sqrt = std::make_shared<ov::opset4::Sqrt>(reduce_sum);
         sqrt->set_friendly_name(m.get_match_root()->get_friendly_name());
-        ngraph::copy_runtime_info(reduce_l2_node, {sqrt, reduce_sum, square, const_2});
+        if (ov::op::util::is_constant(reduce_l2_node->input_value(1).get_node())) {
+            ngraph::copy_runtime_info({reduce_l2_node, reduce_l2_node->input_value(1).get_node()},
+                                      {sqrt, reduce_sum, square, const_2});
+        } else {
+            ngraph::copy_runtime_info(reduce_l2_node, {sqrt, reduce_sum, square, const_2});
+        }
         ngraph::replace_node(m.get_match_root(), sqrt);
         return true;
     };

--- a/src/common/transformations/src/transformations/op_conversions/reduce_l2_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/reduce_l2_decomposition.cpp
@@ -32,12 +32,11 @@ ov::pass::ReduceL2Decomposition::ReduceL2Decomposition() {
                                                                    reduce_l2_node->get_keep_dims());
         auto sqrt = std::make_shared<ov::opset4::Sqrt>(reduce_sum);
         sqrt->set_friendly_name(m.get_match_root()->get_friendly_name());
-        if (ov::op::util::is_constant(reduce_l2_node->input_value(1).get_node())) {
-            ngraph::copy_runtime_info({reduce_l2_node, reduce_l2_node->input_value(1).get_node()},
-                                      {sqrt, reduce_sum, square, const_2});
-        } else {
-            ngraph::copy_runtime_info(reduce_l2_node, {sqrt, reduce_sum, square, const_2});
-        }
+        ov::NodeVector rt_info_from_nodes{reduce_l2_node};
+        const auto reduce_l2_input_1 = reduce_l2_node->input_value(1).get_node();
+        if (ov::op::util::is_constant(reduce_l2_input_1))
+            rt_info_from_nodes.emplace_back(reduce_l2_input_1->shared_from_this());
+        ngraph::copy_runtime_info(rt_info_from_nodes, {sqrt, reduce_sum, square, const_2});
         ngraph::replace_node(m.get_match_root(), sqrt);
         return true;
     };


### PR DESCRIPTION
### Details:
 - *Constant name is missing in fused names of new operations in ReduceL2Decomposition which lead to problem after subsequent call of  ConvertReduceToPooling transformation. Model facenet is failed on HETERO:NVIDIA,GPU device due to cut Constant.*
 
```
Unsupported parameter nodes type in ReduceL2_361 (ReduceL2)
```

### Tickets:
 - *ticket-id*
