### PR TITLE
Fixed PT FE compilation with clang on macOS

### DIFF
--- a/src/frontends/pytorch/src/place.cpp
+++ b/src/frontends/pytorch/src/place.cpp
@@ -19,7 +19,7 @@ Place::Place(const ov::frontend::InputModel& input_model, size_t tensor_index)
       m_is_input(false),
       m_is_output(false) {
     m_names.push_back(std::to_string(tensor_index));
-    const auto im = dynamic_cast<const ov::frontend::pytorch::InputModel*>(&input_model);
+    const auto im = dynamic_cast<const ov::frontend::pytorch::InputModel*>(&m_input_model);
     FRONT_END_GENERAL_CHECK(im, "PyTorch Place requires PyTorch InputModel class.");
     const auto& inputs = im->m_model_decoder->inputs();
     const auto& outputs = im->m_model_decoder->outputs();


### PR DESCRIPTION
### Details:
```
In file included from /openvino/src/frontends/pytorch/src/place.cpp:5:
/openvino/src/frontends/pytorch/src/place.hpp:37:37: error: private field 'm_input_model' is not used [-Werror,-Wunused-private-field]
    const ov::frontend::InputModel& m_input_model;
                                    ^
1 error generated.
```
On Android arm64 in post commit https://dev.azure.com/openvinoci/dldt/_build/results?buildId=510345&view=logs&j=92ba3447-fcaa-530d-6438-b829fe1e7d1d&t=b0a91e75-8666-5718-e63e-df215ecb48f9&l=2188