### PR TITLE
fix warnings of overloaded virtual function

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/jit_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/jit_emitter.hpp
@@ -147,8 +147,7 @@ private:
         const auto scale = te.bcast ? get_vec_length() : sizeof(table_entry_val_t);
         return te.off + key_off_val_shift * scale;
     }
-    virtual void validate_arguments(const std::vector<size_t>&, const std::vector<size_t>&,
-                                    const std::vector<size_t>&, const std::vector<size_t> &) const {}
+    virtual void validate_arguments(const std::vector<size_t>&, const std::vector<size_t>&) const {}
 };
 
 }   // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/emitters/jit_snippets_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/jit_snippets_emitters.hpp
@@ -83,8 +83,9 @@ public:
                    const std::vector<size_t> &out) const;
 
 private:
+    using jit_emitter::emit_code;
     void validate_arguments(const std::vector<size_t> &in,
-                            const std::vector<size_t> &out) const;
+                            const std::vector<size_t> &out) const override;
     void emit_impl(const std::vector<size_t>& in,
                    const std::vector<size_t>& out) const override;
     void init_data_pointers(size_t, size_t, bool, const Reg64&, const Reg64&, const std::vector<Reg64>&) const;
@@ -117,8 +118,9 @@ public:
     size_t get_inputs_num() const override {return 0;}
 
 private:
+    using jit_emitter::emit_code;
     void validate_arguments(const std::vector<size_t> &in,
-                            const std::vector<size_t> &out) const;
+                            const std::vector<size_t> &out) const override;
     void emit_impl(const std::vector<size_t>& in,
                    const std::vector<size_t>& out) const override;
 
@@ -137,8 +139,9 @@ public:
     size_t get_inputs_num() const override {return 0;}
 
 private:
+    using jit_emitter::emit_code;
     void validate_arguments(const std::vector<size_t> &in,
-                            const std::vector<size_t> &out) const;
+                            const std::vector<size_t> &out) const override;
 
     void emit_impl(const std::vector<size_t>& in,
                    const std::vector<size_t>& out) const override;


### PR DESCRIPTION
### Details:
 - *fix warnings by telling compiler explicitly that function is overloaded or override*
