### PR TITLE
fix core dump issue for ENABLE_DEBUG_CAPS

### DIFF
--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -256,6 +256,9 @@ void serializeToCout(const Graph &graph) {
 }
 
 void summary_perf(const Graph &graph) {
+    if (!graph.getGraphContext()) {
+        return;
+    }
     const std::string& summaryPerf = graph.getConfig().debugCaps.summaryPerf;
 
     if (summaryPerf.empty())


### PR DESCRIPTION
### Details:
 - *when openvino is compiled with option -DENABLE_DEBUG_CAPS=ON, run ./ov_cpu_func_tests  in a docker contain with a memory limit of 8G, then a crash error will appear for test case "smoke_MemoryTest/MemoryTest.CompareWithRefs/transformation=LOW_LATENCY_V2_iteration_count=3_IS=(3)_netPRC=FP32_trgDev=HETERO:CPU)"*

### Tickets:
