### PR TITLE
[CPU][Snippets]fix candidate merged node's subgraph inputs have common subgraph input

### DIFF
--- a/src/common/snippets/src/pass/collapse_subgraph.cpp
+++ b/src/common/snippets/src/pass/collapse_subgraph.cpp
@@ -389,8 +389,11 @@ TokenizeSnippets::TokenizeSnippets() {
                             size_t current_input_index = body_parameters.size();
                             for (size_t p_ind = 0; p_ind <  body_parameters.size(); p_ind++) {
                                 const auto & p = body_parameters[p_ind];
+                                // unite two body parameters from two input subgraphs only if:
+                                // 1. two input subgraphs are connected to the same parent node/subgraph,
+                                // 2. and connected to the same output port of this parent node/subgraph.
                                 if (p->get_friendly_name() == found->get_node_shared_ptr()->get_friendly_name() &&
-                                    external_inputs[p_ind] == *found) {  // or replace only when common parent subgraph have one output
+                                    external_inputs[p_ind] == *found) {
                                     current_input_index = p_ind;
                                     break;
                                 }

--- a/src/common/snippets/src/pass/collapse_subgraph.cpp
+++ b/src/common/snippets/src/pass/collapse_subgraph.cpp
@@ -389,7 +389,8 @@ TokenizeSnippets::TokenizeSnippets() {
                             size_t current_input_index = body_parameters.size();
                             for (size_t p_ind = 0; p_ind <  body_parameters.size(); p_ind++) {
                                 const auto & p = body_parameters[p_ind];
-                                if (p->get_friendly_name() == found->get_node_shared_ptr()->get_friendly_name()) {
+                                if (p->get_friendly_name() == found->get_node_shared_ptr()->get_friendly_name() &&
+                                    external_inputs[p_ind] == *found) {  // or replace only when common parent subgraph have one output
                                     current_input_index = p_ind;
                                     break;
                                 }

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/edge_replace.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/edge_replace.cpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/edge_replace.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+namespace {
+
+std::vector<InputShape> inShapes0{
+        {{}, {{1, 2}}}
+};
+std::vector<InputShape> inShapes1{
+        {{}, {{2}}}
+};
+std::vector<InputShape> inShapes2{
+        {{}, {{1, 2, 2, 3, 2}}}
+};
+std::vector<InputShape> inShapes3{
+        {{}, {{1, 2, 2, 3, 2}}}
+};
+std::vector<InputShape> inShapes4{
+        {{}, {{2, 2, 2, 3, 2}}}
+};
+std::vector<InputShape> inShapes5{
+        {{}, {{2, 2, 2, 3, 2}}}
+};
+std::vector<InputShape> inShapes6{
+        {{}, {{4, 2, 2, 3, 2}}}
+};
+std::vector<InputShape> inShapes7{
+        {{}, {{4, 2, 2, 3, 2}}}
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_edge_replace, EdgeReplace,
+                         ::testing::Combine(
+                                 ::testing::ValuesIn(inShapes0),
+                                 ::testing::ValuesIn(inShapes1),
+                                 ::testing::ValuesIn(inShapes2),
+                                 ::testing::ValuesIn(inShapes3),
+                                 ::testing::ValuesIn(inShapes4),
+                                 ::testing::ValuesIn(inShapes5),
+                                 ::testing::ValuesIn(inShapes6),
+                                 ::testing::ValuesIn(inShapes7),
+                                 ::testing::Values(ov::element::f32),
+                                 ::testing::Values(9),
+                                 ::testing::Values(5),
+                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                         EdgeReplace::getTestCaseName);
+
+} // namespace
+} // namespace snippets
+} // namespace test
+} // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/edge_replace.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/edge_replace.cpp
@@ -11,44 +11,14 @@ namespace snippets {
 
 namespace {
 
-std::vector<InputShape> inShapes0{
-        {{}, {{1, 2}}}
-};
-std::vector<InputShape> inShapes1{
-        {{}, {{2}}}
-};
-std::vector<InputShape> inShapes2{
-        {{}, {{1, 2, 2, 3, 2}}}
-};
-std::vector<InputShape> inShapes3{
-        {{}, {{1, 2, 2, 3, 2}}}
-};
-std::vector<InputShape> inShapes4{
-        {{}, {{2, 2, 2, 3, 2}}}
-};
-std::vector<InputShape> inShapes5{
-        {{}, {{2, 2, 2, 3, 2}}}
-};
-std::vector<InputShape> inShapes6{
-        {{}, {{4, 2, 2, 3, 2}}}
-};
-std::vector<InputShape> inShapes7{
-        {{}, {{4, 2, 2, 3, 2}}}
-};
+std::vector<ov::PartialShape> input_shapes{{4}};
 
 INSTANTIATE_TEST_SUITE_P(smoke_Snippets_edge_replace, EdgeReplace,
                          ::testing::Combine(
-                                 ::testing::ValuesIn(inShapes0),
-                                 ::testing::ValuesIn(inShapes1),
-                                 ::testing::ValuesIn(inShapes2),
-                                 ::testing::ValuesIn(inShapes3),
-                                 ::testing::ValuesIn(inShapes4),
-                                 ::testing::ValuesIn(inShapes5),
-                                 ::testing::ValuesIn(inShapes6),
-                                 ::testing::ValuesIn(inShapes7),
+                                 ::testing::ValuesIn(input_shapes),
                                  ::testing::Values(ov::element::f32),
-                                 ::testing::Values(9),
-                                 ::testing::Values(5),
+                                 ::testing::Values(3),
+                                 ::testing::Values(1),
                                  ::testing::Values(CommonTestUtils::DEVICE_CPU)),
                          EdgeReplace::getTestCaseName);
 

--- a/src/tests/functional/plugin/shared/include/snippets/edge_replace.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/edge_replace.hpp
@@ -11,14 +11,7 @@ namespace test {
 namespace snippets {
 
 typedef std::tuple<
-        InputShape,                  // Input 0 Shape
-        InputShape,                  // Input 1 Shape
-        InputShape,                  // Input 2 Shape
-        InputShape,                  // Input 3 Shape
-        InputShape,                  // Input 4 Shape
-        InputShape,                  // Input 5 Shape
-        InputShape,                  // Input 6 Shape
-        InputShape,                  // Input 7 Shape
+        ov::PartialShape,            // Input Shape
         ov::element::Type,           // Element type
         size_t,                      // Expected num nodes
         size_t,                      // Expected num subgraphs

--- a/src/tests/functional/plugin/shared/include/snippets/edge_replace.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/edge_replace.hpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/base/snippets_test_utils.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+typedef std::tuple<
+        InputShape,                  // Input 0 Shape
+        InputShape,                  // Input 1 Shape
+        InputShape,                  // Input 2 Shape
+        InputShape,                  // Input 3 Shape
+        InputShape,                  // Input 4 Shape
+        InputShape,                  // Input 5 Shape
+        InputShape,                  // Input 6 Shape
+        InputShape,                  // Input 7 Shape
+        ov::element::Type,           // Element type
+        size_t,                      // Expected num nodes
+        size_t,                      // Expected num subgraphs
+        std::string                  // Target Device
+> EdgeReplaceParams;
+
+class EdgeReplace : public testing::WithParamInterface<ov::test::snippets::EdgeReplaceParams>,
+                    virtual public ov::test::SnippetsTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<ov::test::snippets::EdgeReplaceParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+} // namespace snippets
+} // namespace test
+} // namespace ov

--- a/src/tests/functional/plugin/shared/src/snippets/edge_replace.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/edge_replace.cpp
@@ -13,54 +13,14 @@ namespace test {
 namespace snippets {
 
 std::string EdgeReplace::getTestCaseName(testing::TestParamInfo<ov::test::snippets::EdgeReplaceParams> obj) {
-    ov::test::InputShape inputShapes0, inputShapes1, inputShapes2, inputShapes3, inputShapes4, inputShapes5, inputShapes6, inputShapes7;
+    ov::PartialShape inputShape;
     ov::element::Type type;
     std::string targetDevice;
     size_t num_nodes, num_subgraphs;
-    std::tie(inputShapes0, inputShapes1, inputShapes2, inputShapes3, inputShapes4, inputShapes5, inputShapes6, inputShapes7,
-        type, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    std::tie(inputShape, type, num_nodes, num_subgraphs, targetDevice) = obj.param;
 
     std::ostringstream result;
-    result << "IS[0]=" << CommonTestUtils::partialShape2str({inputShapes0.first}) << "_";
-    result << "TS[0]=";
-    for (const auto& shape : inputShapes0.second) {
-        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
-    }
-    result << "IS[1]=" << CommonTestUtils::partialShape2str({inputShapes1.first}) << "_";
-    result << "TS[1]=";
-    for (const auto& shape : inputShapes1.second) {
-        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
-    }
-    result << "IS[2]=" << CommonTestUtils::partialShape2str({inputShapes2.first}) << "_";
-    result << "TS[2]=";
-    for (const auto& shape : inputShapes2.second) {
-        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
-    }
-    result << "IS[3]=" << CommonTestUtils::partialShape2str({inputShapes3.first}) << "_";
-    result << "TS[3]=";
-    for (const auto& shape : inputShapes3.second) {
-        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
-    }
-    result << "IS[4]=" << CommonTestUtils::partialShape2str({inputShapes4.first}) << "_";
-    result << "TS[4]=";
-    for (const auto& shape : inputShapes4.second) {
-        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
-    }
-    result << "IS[5]=" << CommonTestUtils::partialShape2str({inputShapes5.first}) << "_";
-    result << "TS[5]=";
-    for (const auto& shape : inputShapes5.second) {
-        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
-    }
-    result << "IS[6]=" << CommonTestUtils::partialShape2str({inputShapes6.first}) << "_";
-    result << "TS[6]=";
-    for (const auto& shape : inputShapes6.second) {
-        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
-    }
-    result << "IS[7]=" << CommonTestUtils::partialShape2str({inputShapes7.first}) << "_";
-    result << "TS[7]=";
-    for (const auto& shape : inputShapes7.second) {
-        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
-    }
+    result << "IS=" << CommonTestUtils::partialShape2str({inputShape}) << "_";
     result << "T=" << type << "_";
     result << "#N=" << num_nodes << "_";
     result << "#S=" << num_subgraphs << "_";
@@ -69,21 +29,12 @@ std::string EdgeReplace::getTestCaseName(testing::TestParamInfo<ov::test::snippe
 }
 
 void EdgeReplace::SetUp() {
-    ov::test::InputShape inputShape0, inputShape1, inputShape2, inputShape3, inputShape4, inputShape5, inputShape6, inputShape7;
+    ov::PartialShape inputShape;
     ov::element::Type type;
-    std::tie(inputShape0, inputShape1, inputShape2, inputShape3, inputShape4, inputShape5, inputShape6, inputShape7,
-        type, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
-    init_input_shapes({{inputShape0}, {inputShape1}, {inputShape2}, {inputShape3}, {inputShape4}, {inputShape5}, {inputShape6}, {inputShape7}});
+    std::tie(inputShape, type, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    init_input_shapes({{{inputShape}, {inputShape.get_shape()}}});
 
-    bool is_dynamic = inputShape0.first.is_dynamic();
-    auto f = ov::test::snippets::EdgeReplaceFunction({is_dynamic ? inputShape0.first : inputShape0.second[0],
-                                                      is_dynamic ? inputShape1.first : inputShape1.second[0],
-                                                      is_dynamic ? inputShape2.first : inputShape2.second[0],
-                                                      is_dynamic ? inputShape3.first : inputShape3.second[0],
-                                                      is_dynamic ? inputShape4.first : inputShape4.second[0],
-                                                      is_dynamic ? inputShape5.first : inputShape5.second[0],
-                                                      is_dynamic ? inputShape6.first : inputShape6.second[0],
-                                                      is_dynamic ? inputShape7.first : inputShape7.second[0]});
+    auto f = ov::test::snippets::EdgeReplaceFunction({inputShape});
     function = f.getOriginal();
     setInferenceType(type);
 }

--- a/src/tests/functional/plugin/shared/src/snippets/edge_replace.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/edge_replace.cpp
@@ -1,0 +1,98 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common_test_utils/common_utils.hpp"
+#include "snippets/edge_replace.hpp"
+#include "subgraph_simple.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+std::string EdgeReplace::getTestCaseName(testing::TestParamInfo<ov::test::snippets::EdgeReplaceParams> obj) {
+    ov::test::InputShape inputShapes0, inputShapes1, inputShapes2, inputShapes3, inputShapes4, inputShapes5, inputShapes6, inputShapes7;
+    ov::element::Type type;
+    std::string targetDevice;
+    size_t num_nodes, num_subgraphs;
+    std::tie(inputShapes0, inputShapes1, inputShapes2, inputShapes3, inputShapes4, inputShapes5, inputShapes6, inputShapes7,
+        type, num_nodes, num_subgraphs, targetDevice) = obj.param;
+
+    std::ostringstream result;
+    result << "IS[0]=" << CommonTestUtils::partialShape2str({inputShapes0.first}) << "_";
+    result << "TS[0]=";
+    for (const auto& shape : inputShapes0.second) {
+        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
+    }
+    result << "IS[1]=" << CommonTestUtils::partialShape2str({inputShapes1.first}) << "_";
+    result << "TS[1]=";
+    for (const auto& shape : inputShapes1.second) {
+        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
+    }
+    result << "IS[2]=" << CommonTestUtils::partialShape2str({inputShapes2.first}) << "_";
+    result << "TS[2]=";
+    for (const auto& shape : inputShapes2.second) {
+        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
+    }
+    result << "IS[3]=" << CommonTestUtils::partialShape2str({inputShapes3.first}) << "_";
+    result << "TS[3]=";
+    for (const auto& shape : inputShapes3.second) {
+        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
+    }
+    result << "IS[4]=" << CommonTestUtils::partialShape2str({inputShapes4.first}) << "_";
+    result << "TS[4]=";
+    for (const auto& shape : inputShapes4.second) {
+        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
+    }
+    result << "IS[5]=" << CommonTestUtils::partialShape2str({inputShapes5.first}) << "_";
+    result << "TS[5]=";
+    for (const auto& shape : inputShapes5.second) {
+        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
+    }
+    result << "IS[6]=" << CommonTestUtils::partialShape2str({inputShapes6.first}) << "_";
+    result << "TS[6]=";
+    for (const auto& shape : inputShapes6.second) {
+        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
+    }
+    result << "IS[7]=" << CommonTestUtils::partialShape2str({inputShapes7.first}) << "_";
+    result << "TS[7]=";
+    for (const auto& shape : inputShapes7.second) {
+        result << "(" << CommonTestUtils::vec2str(shape) << ")_";
+    }
+    result << "T=" << type << "_";
+    result << "#N=" << num_nodes << "_";
+    result << "#S=" << num_subgraphs << "_";
+    result << "targetDevice=" << targetDevice;
+    return result.str();
+}
+
+void EdgeReplace::SetUp() {
+    ov::test::InputShape inputShape0, inputShape1, inputShape2, inputShape3, inputShape4, inputShape5, inputShape6, inputShape7;
+    ov::element::Type type;
+    std::tie(inputShape0, inputShape1, inputShape2, inputShape3, inputShape4, inputShape5, inputShape6, inputShape7,
+        type, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    init_input_shapes({{inputShape0}, {inputShape1}, {inputShape2}, {inputShape3}, {inputShape4}, {inputShape5}, {inputShape6}, {inputShape7}});
+
+    bool is_dynamic = inputShape0.first.is_dynamic();
+    auto f = ov::test::snippets::EdgeReplaceFunction({is_dynamic ? inputShape0.first : inputShape0.second[0],
+                                                      is_dynamic ? inputShape1.first : inputShape1.second[0],
+                                                      is_dynamic ? inputShape2.first : inputShape2.second[0],
+                                                      is_dynamic ? inputShape3.first : inputShape3.second[0],
+                                                      is_dynamic ? inputShape4.first : inputShape4.second[0],
+                                                      is_dynamic ? inputShape5.first : inputShape5.second[0],
+                                                      is_dynamic ? inputShape6.first : inputShape6.second[0],
+                                                      is_dynamic ? inputShape7.first : inputShape7.second[0]});
+    function = f.getOriginal();
+    setInferenceType(type);
+}
+
+TEST_P(EdgeReplace, CompareWithRefImpl) {
+    run();
+    validateNumSubgraphs();
+}
+
+} // namespace snippets
+} // namespace test
+} // namespace ov

--- a/src/tests/ngraph_helpers/snippets_ngraph_functions/include/subgraph_simple.hpp
+++ b/src/tests/ngraph_helpers/snippets_ngraph_functions/include/subgraph_simple.hpp
@@ -244,8 +244,8 @@ protected:
     PartialShape m_target_shape;
 };
 
-/// yolo-v3 subgraph to cover edge replacement.
-//                subgraph
+/// graph use case to cover duplicated subgraphs edge elimination in such as in yolo-v3
+//              subgraph/node
 //                /     |
 //           subgraph  subgraph
 //                \     /
@@ -253,7 +253,7 @@ protected:
 class EdgeReplaceFunction : public SnippetsFunctionBase {
 public:
     explicit EdgeReplaceFunction(const std::vector<PartialShape>& inputShapes) : SnippetsFunctionBase(inputShapes) {
-        NGRAPH_CHECK(input_shapes.size() == 8, "Got invalid number of input shapes");
+        NGRAPH_CHECK(input_shapes.size() == 1, "Got invalid number of input shapes");
     }
 protected:
     std::shared_ptr<ov::Model> initOriginal() const override;

--- a/src/tests/ngraph_helpers/snippets_ngraph_functions/include/subgraph_simple.hpp
+++ b/src/tests/ngraph_helpers/snippets_ngraph_functions/include/subgraph_simple.hpp
@@ -243,6 +243,21 @@ protected:
 
     PartialShape m_target_shape;
 };
+
+/// yolo-v3 subgraph to cover edge replacement.
+//                subgraph
+//                /     \
+//         subgraph   subgraph
+//                \     /
+//              eltwise node
+class EdgeReplaceFunction : public SnippetsFunctionBase {
+public:
+    explicit EdgeReplaceFunction(const std::vector<PartialShape>& inputShapes) : SnippetsFunctionBase(inputShapes) {
+        NGRAPH_CHECK(input_shapes.size() == 8, "Got invalid number of input shapes");
+    }
+protected:
+    std::shared_ptr<ov::Model> initOriginal() const override;
+};
 }  // namespace snippets
 }  // namespace test
 }  // namespace ov

--- a/src/tests/ngraph_helpers/snippets_ngraph_functions/include/subgraph_simple.hpp
+++ b/src/tests/ngraph_helpers/snippets_ngraph_functions/include/subgraph_simple.hpp
@@ -246,8 +246,8 @@ protected:
 
 /// yolo-v3 subgraph to cover edge replacement.
 //                subgraph
-//                /     \
-//         subgraph   subgraph
+//                /     |
+//           subgraph  subgraph
 //                \     /
 //              eltwise node
 class EdgeReplaceFunction : public SnippetsFunctionBase {

--- a/src/tests/ngraph_helpers/snippets_ngraph_functions/src/subgraph_simple.cpp
+++ b/src/tests/ngraph_helpers/snippets_ngraph_functions/src/subgraph_simple.cpp
@@ -318,6 +318,96 @@ std::shared_ptr<ov::Model> BroadcastSelectFunction::initOriginal() const {
 
     return std::make_shared<Model>(NodeVector{select}, ParameterVector{data0, data1, data2});
 }
+
+std::shared_ptr<ov::Model> EdgeReplaceFunction::initOriginal() const {
+    auto img_shape = std::make_shared<op::v0::Parameter>(ov::element::f32, input_shapes[0]);
+    auto input = std::make_shared<op::v0::Parameter>(ov::element::i32, input_shapes[1]);
+    auto data0 = std::make_shared<op::v0::Parameter>(ov::element::f32, input_shapes[2]);
+    auto data1 = std::make_shared<op::v0::Parameter>(ov::element::f32, input_shapes[3]);
+    auto data2 = std::make_shared<op::v0::Parameter>(ov::element::f32, input_shapes[4]);
+    auto data3 = std::make_shared<op::v0::Parameter>(ov::element::f32, input_shapes[5]);
+    auto data4 = std::make_shared<op::v0::Parameter>(ov::element::f32, input_shapes[6]);
+    auto data5 = std::make_shared<op::v0::Parameter>(ov::element::f32, input_shapes[7]);
+    const auto shape_pattern = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::i32, ov::Shape({1}), std::vector<int>{2});
+    auto reshape = std::make_shared<ov::op::v1::Reshape>(img_shape, shape_pattern, true);
+    const auto power_input = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{1, 2});
+    auto power = std::make_shared<op::v1::Power>(reshape, power_input);
+
+    auto convert = std::make_shared<op::v0::Convert>(input, ov::element::Type_t::f32);
+
+    auto mul = std::make_shared<op::v1::Multiply>(power, convert);
+
+    std::vector<int> reduce_axes = {0};
+    auto reduceAxesNode = std::dynamic_pointer_cast<ngraph::Node>(
+                                 std::make_shared<op::v0::Constant>(ngraph::element::Type_t::i64, ngraph::Shape({1}), reduce_axes));
+    auto reduce = std::make_shared<op::v1::ReduceMean>(mul, reduceAxesNode, true);
+
+    auto mul_1 = std::make_shared<op::v1::Multiply>(reshape, reduce);
+    const auto const_f32 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{0.2, 0.01});
+    auto add = std::make_shared<op::v1::Add>(mul_1, const_f32);
+    auto ceil = std::make_shared<ov::op::v0::Ceiling>(add);
+
+    const auto power_input1 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{2, 2});
+    auto power_lhs = std::make_shared<op::v1::Power>(ceil, power_input1);
+    auto mul_lhs = std::make_shared<op::v1::Multiply>(power_lhs, convert);
+
+    auto mul_2 = std::make_shared<op::v1::Multiply>(ceil, const_f32);
+    auto add_1 = std::make_shared<op::v1::Add>(mul_2, convert);
+    auto mul_3 = std::make_shared<op::v1::Multiply>(add_1, const_f32);
+    const auto power_input2 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{1, 1});
+    auto power_rhs = std::make_shared<op::v1::Power>(convert, power_input2);
+    auto mul_rhs = std::make_shared<op::v1::Multiply>(mul_3, power_rhs);
+
+    // first block
+    const auto const_a4 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{0.2, 0.1});
+    auto mul_a4 = std::make_shared<op::v1::Multiply>(mul_rhs, const_a4);
+    auto add_a1 = std::make_shared<op::v1::Add>(mul_a4, data1);
+    auto mul_a5 = std::make_shared<op::v1::Multiply>(add_a1, mul_lhs);
+
+    auto mul_a1 = std::make_shared<op::v1::Multiply>(data0, mul_lhs);
+    const auto const_a2 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{0.2, 0.4});
+    auto mul_a2 = std::make_shared<op::v1::Multiply>(mul_a1, const_a2);
+    const auto const_a3 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{0.3, 0.1});
+    auto mul_a3 = std::make_shared<op::v1::Multiply>(mul_a2, const_a3);
+
+    auto add_a3 = std::make_shared<op::v1::Add>(mul_a5, mul_a3);
+    auto add_a2 = std::make_shared<op::v1::Add>(mul_a5, mul_a2);
+
+    // second block
+    const auto const_b4 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{0.66, 0.11});
+    auto mul_b4 = std::make_shared<op::v1::Multiply>(mul_rhs, const_a4);
+    auto add_b1 = std::make_shared<op::v1::Add>(mul_b4, data3);
+    auto mul_b5 = std::make_shared<op::v1::Multiply>(add_b1, mul_lhs);
+
+    auto mul_b1 = std::make_shared<op::v1::Multiply>(data2, mul_lhs);
+    const auto const_b2 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{0.1, 0.3});
+    auto mul_b2 = std::make_shared<op::v1::Multiply>(mul_b1, const_b2);
+    const auto const_b3 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{0.2, 0.4});
+    auto mul_b3 = std::make_shared<op::v1::Multiply>(mul_b2, const_b3);
+
+    auto add_b3 = std::make_shared<op::v1::Add>(mul_b5, mul_b3);
+    auto add_b2 = std::make_shared<op::v1::Add>(mul_b5, mul_b2);
+
+    // third block
+    const auto const_c4 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{0.1, 0.5});
+    auto mul_c4 = std::make_shared<op::v1::Multiply>(mul_rhs, const_c4);
+    auto add_c1 = std::make_shared<op::v1::Add>(mul_c4, data5);
+    auto mul_c5 = std::make_shared<op::v1::Multiply>(add_c1, mul_lhs);
+
+    auto mul_c1 = std::make_shared<op::v1::Multiply>(data4, mul_lhs);
+    const auto const_c2 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{2, 2});
+    auto mul_c2 = std::make_shared<op::v1::Multiply>(mul_c1, const_c2);
+    const auto const_c3 = std::make_shared<ov::opset8::Constant>(ov::element::Type_t::f32, ov::Shape({2}), std::vector<float>{3, 3});
+    auto mul_c3 = std::make_shared<op::v1::Multiply>(mul_c2, const_c3);
+
+    auto add_c3 = std::make_shared<op::v1::Add>(mul_c5, mul_c3);
+    auto add_c2 = std::make_shared<op::v1::Add>(mul_c5, mul_c2);
+
+    auto concat = std::make_shared<op::v0::Concat>(ngraph::OutputVector{add_a3, add_a2, add_b3, add_b2, add_c3, add_c2}, 0);
+
+    return std::make_shared<Model>(NodeVector{concat},
+        ParameterVector{img_shape, input, data0, data1, data2, data3, data4, data5});
+}
 }  // namespace snippets
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - *fix unite two body parameters from two input subgraphs when the two input subgraphs are connected to the same parent node/subgraph, but does not respect which output port the two edges link*

### Tickets:
 - *99399*
