### PR TITLE
Fix unet3d mlperf dump

### DIFF
--- a/src/plugins/intel_gpu/src/graph/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/deconvolution.cpp
@@ -230,8 +230,10 @@ std::string deconvolution_inst::to_string(deconvolution_node const& node) {
 
     ss_weights << node.weights().id();
     ss_weights << ", count: " << node.weights().get_output_layout().count();
-    ss_biases << node.bias().id();
-    ss_biases << ", count: " << node.bias().get_output_layout().count();
+    if (node.get_dependencies().size() == 3) {  // W.A: convolutionbackpropdata:conv3d_transpose in unet3d_mlperf doesn't have bias(). Test code, need to check.
+        ss_biases << node.bias().id();
+        ss_biases << ", count: " << node.bias().get_output_layout().count();
+    }
 
     json_composite deconv_info;
     deconv_info.add("stride", cldnn::to_string(strd));

--- a/src/plugins/intel_gpu/src/graph/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/deconvolution.cpp
@@ -230,7 +230,7 @@ std::string deconvolution_inst::to_string(deconvolution_node const& node) {
 
     ss_weights << node.weights().id();
     ss_weights << ", count: " << node.weights().get_output_layout().count();
-    if (node.get_dependencies().size() == 3) {  // W.A: convolutionbackpropdata:conv3d_transpose in unet3d_mlperf doesn't have bias(). Test code, need to check.
+    if (node.get_dependencies().size() == 3) {
         ss_biases << node.bias().id();
         ss_biases << ", count: " << node.bias().get_output_layout().count();
     }

--- a/src/plugins/intel_gpu/src/graph/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/deconvolution.cpp
@@ -226,14 +226,6 @@ std::string deconvolution_inst::to_string(deconvolution_node const& node) {
     auto node_info = node.desc_to_json();
 
     std::stringstream primitive_description;
-    std::stringstream ss_weights, ss_biases;
-
-    ss_weights << node.weights().id();
-    ss_weights << ", count: " << node.weights().get_output_layout().count();
-    if (node.get_dependencies().size() == 3) {
-        ss_biases << node.bias().id();
-        ss_biases << ", count: " << node.bias().get_output_layout().count();
-    }
 
     json_composite deconv_info;
     deconv_info.add("stride", cldnn::to_string(strd));
@@ -244,6 +236,17 @@ std::string deconvolution_inst::to_string(deconvolution_node const& node) {
         ud_out_size_info.add("size", desc->output_size.to_string());
         deconv_info.add("with_user_defined_output_size", ud_out_size_info);
     }
+    std::stringstream ss_weights;
+    ss_weights << node.weights().id();
+    ss_weights << ", count: " << node.weights().get_output_layout().count();
+    deconv_info.add("weights", ss_weights.str());
+    if (node.bias_term()) {
+        std::stringstream ss_biases;
+        ss_biases << node.bias().id();
+        ss_biases << ", count: " << node.bias().get_output_layout().count();
+        deconv_info.add("bias", ss_biases.str());
+    }
+
     node_info->add("deconvolution info", deconv_info);
     node_info->dump(primitive_description);
     return primitive_description.str();


### PR DESCRIPTION
convolutionbackpropdata:conv3d_transpose in unet3d_mlperf doesn't have bias(),

### Tickets:
 - *106024*
