### PR TITLE
[GPU] Minor fixes : are_data_types_suitable_for_onednn not to invalidate output layout

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1172,8 +1172,8 @@ layout layout_optimizer::get_expected_layout(layout const& current_layout,
 }
 
 bool layout_optimizer::are_data_types_suitable_for_onednn(program_node& node) {
-    auto in_dt = node.get_dependency(0).get_output_layout().data_type;
-    auto out_dt = node.get_output_layout().data_type;
+    auto in_dt = node.get_dependency(0).get_output_layout(false).data_type;
+    auto out_dt = node.get_output_layout(false).data_type;
 
     if (in_dt == data_types::f32 && (!node.is_type<fully_connected>() && !node.is_type<convolution>()))
         return false;

--- a/src/plugins/intel_gpu/src/graph/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/resample.cpp
@@ -138,7 +138,8 @@ std::string resample_inst::to_string(resample_node const& node) {
             axesAndScalesDump += delim;
             delim = ", ";
             axesAndScalesDump += std::to_string(desc->axes[i]) + ": ";
-            axesAndScalesDump += std::to_string(desc->scales[i]);
+            if (desc->scales.size() > i)
+                axesAndScalesDump += std::to_string(desc->scales[i]);
         }
         resample_info.add("scales:", axesAndScalesDump);
     }


### PR DESCRIPTION
### Details:
- Fix are_data_types_suitable_for_onednn not to invalidate output layout
- Fix seg fault of printing resample node info
