### PR TITLE
[GPU] Fix segmentation fault for dynamic model

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
@@ -42,14 +42,18 @@ void prepare_primitive_fusing_through::run(program& p) {
                 node->get_output_layout().data_type != node->get_dependency(0).get_output_layout().data_type)
                 return false;
 
-            // Not to fuse reshape after Reduce changing the order of un-reduced axes. It is expected to be optimized out.
-            if (node->is_type<reshape>() && node->get_dependencies().front().first->is_type<reduce>())
-                return false;
+            if (node->is_type<reshape>()) {
+                // Not to fuse reshape after Reduce changing the order of un-reduced axes. It is expected to be optimized out.
+                if (node->get_dependencies().front().first->is_type<reduce>())
+                    return false;
 
-            // Not to raise up target node through reshape where the size of dimension is changed (e.g. Unsqueeze)
-            if (node->is_type<reshape>() &&
-                node->get_output_layout().get_partial_shape().size() != node->get_dependency(0).get_output_layout().get_partial_shape().size())
-                return false;
+                // Not to raise up target node through reshape where the size of dimension is changed (e.g. Squeeze, Unsqueeze)
+                // except for squeezing ND tensor to 0D tensor
+                auto input_pshape = node->get_dependency(0).get_output_layout().get_partial_shape();
+                auto output_pshape = node->get_output_layout().get_partial_shape();
+                if (output_pshape.size() != 0 && input_pshape.size() != output_pshape.size())
+                    return false;
+            }
 
             return true;
         };

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -193,7 +193,7 @@ void primitive_inst::update_shape() {
         // Events may be not created for in-order queue, so take them for OOO queue only
         if (_network.has_event(dep.id()) && queue_type == QueueTypes::out_of_order) {
             dependencies_events.push_back(_network.get_primitive_event(dep_id));
-            GPU_DEBUG_TRACE_DETAIL << id() << ": shape infer waits for " << i << " dependency\n";
+            GPU_DEBUG_TRACE_DETAIL << id() << ": shape infer waits for " << i << " dependency: " << dep_id << std::endl;
         }
         auto dep_mem = _network.get_output_memory(dep_id);
         memory_deps.insert({i, dep_mem});


### PR DESCRIPTION
### Details:
 - Follow up segmentation fault issue from https://github.com/openvinotoolkit/openvino/pull/16158
 - Allow eltwise to raise up through dependency squeeze(ND->0D) in `prepare_primitive_fusing_through` opt pass

### Tickets:
 - *ticket-id*
