### PR TITLE
Fix unit test on dGPU

### DIFF
--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -322,7 +322,6 @@ network::network(program::ptr program, const ExecutionConfig& config, stream::pt
     GPU_DEBUG_IF(debug_config->after_proc.size() != 0) {
         wait_for_the_turn();
     }
-    _config.apply_user_properties(_engine.get_device_info());
 
     allocate_primitives();
     configure_primitives_second_output();

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -322,6 +322,7 @@ network::network(program::ptr program, const ExecutionConfig& config, stream::pt
     GPU_DEBUG_IF(debug_config->after_proc.size() != 0) {
         wait_for_the_turn();
     }
+    _config.apply_user_properties(_engine.get_device_info());
 
     allocate_primitives();
     configure_primitives_second_output();

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1190,10 +1190,6 @@ void program::dump_program(const char* stage,
                            bool with_full_info,
                            std::function<bool(program_node const&)> const& filter) const {
     std::string path = get_dir_path(_config);
-    GPU_DEBUG_GET_INSTANCE(debug_inst);
-    GPU_DEBUG_IF(debug_inst->dump_graphs.size()) {
-        path = debug_inst->dump_graphs;
-    }
     if (path.empty() || !with_full_info) {
         return;
     }

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -150,7 +150,7 @@ program::program(engine& engine)
       processing_order() {
     init_primitives();
     _config.apply_user_properties(_engine.get_device_info());
-}
+      }
 
 program::~program() {
 }
@@ -1190,6 +1190,10 @@ void program::dump_program(const char* stage,
                            bool with_full_info,
                            std::function<bool(program_node const&)> const& filter) const {
     std::string path = get_dir_path(_config);
+    GPU_DEBUG_GET_INSTANCE(debug_inst);
+    GPU_DEBUG_IF(debug_inst->dump_graphs.size()) {
+        path = debug_inst->dump_graphs;
+    }
     if (path.empty() || !with_full_info) {
         return;
     }

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -150,7 +150,7 @@ program::program(engine& engine)
       processing_order() {
     init_primitives();
     _config.apply_user_properties(_engine.get_device_info());
-      }
+}
 
 program::~program() {
 }

--- a/src/plugins/intel_gpu/tests/dynamic_execution/memory_realloc_test.cpp
+++ b/src/plugins/intel_gpu/tests/dynamic_execution/memory_realloc_test.cpp
@@ -42,7 +42,7 @@ TEST(softmax_gpu_dynamic_f32_test_upper_bound, input_same_values) {
         layout(ov::PartialShape{ov::Dimension{1, 10}, ov::Dimension{1, 10}, ov::Dimension{1, 10}, ov::Dimension{1, 10}},
                data_types::f32,
                format::bfyx);
-    network network(engine, topology(input_layout("input", in_layout), softmax("softmax", input_info("input"), 3)));
+    network network(engine, topology(input_layout("input", in_layout), softmax("softmax", input_info("input"), 3)), get_test_default_config(engine));
 
     // First run
     float out_buffer_1[out_size_1];

--- a/src/plugins/intel_gpu/tests/fusions/activation_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/activation_fusion_test.cpp
@@ -32,7 +32,7 @@ public:
     void execute(activation_test_params& p) {
         auto input_prim = get_mem(get_input_layout(p));
 
-        ExecutionConfig cfg;
+        ExecutionConfig cfg = get_test_default_config(engine);
         ov::intel_gpu::ImplementationDesc activation_impl = { p.input_format, p.kernel_name };
         cfg.set_property(ov::intel_gpu::optimize_data(true));
         cfg.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "act", activation_impl } }));

--- a/src/plugins/intel_gpu/tests/fusions/concatenate_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/concatenate_fusion_test.cpp
@@ -42,12 +42,14 @@ public:
         ov::intel_gpu::ImplementationDesc cldnn_impl = { p.input_format, "", impl_types::ocl };
 
         // for onednn fusing test, topology_non_fused means cldnn, topology_fused is onednn
-        ExecutionConfig cldnn_cfg{ov::intel_gpu::queue_type(QueueTypes::in_order),
+        ExecutionConfig cldnn_cfg = get_test_default_config(engine,
+                                  {ov::intel_gpu::queue_type(QueueTypes::in_order),
                                   ov::intel_gpu::optimize_data(true),
-                                  ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "concat", cldnn_impl } })};
-        ExecutionConfig onednn_cfg{ov::intel_gpu::queue_type(QueueTypes::in_order),
+                                  ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "concat", cldnn_impl } })});
+        ExecutionConfig onednn_cfg = get_test_default_config(engine,
+                                   {ov::intel_gpu::queue_type(QueueTypes::in_order),
                                    ov::intel_gpu::optimize_data(true),
-                                   ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "concat", onednn_impl } })};
+                                   ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "concat", onednn_impl } })});
         network network_fused_cldnn(this->engine, this->topology_non_fused, cldnn_cfg);
         network network_fused_onednn(this->engine, this->topology_fused, onednn_cfg);
 

--- a/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
@@ -4178,8 +4178,6 @@ public:
         p.expected_fused_primitives = p.expected_fused_primitives_onednn;
 
         cldnn::memory::ptr input_prim = get_mem(get_input_layout(p));
-        cfg_fused.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
-        cfg_not_fused.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
 
         network network_not_fused(this->engine, this->topology_non_fused, cfg_not_fused);
         network network_fused(this->engine, this->topology_fused, cfg_fused);

--- a/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/convolution_fusion_test.cpp
@@ -208,7 +208,7 @@ class ConvFusingForceKernelTest : public BaseFusingTest<bc_force_kernel_params> 
     public:
     void execute(bc_force_kernel_params& p) {
         auto input_prim = get_mem(get_input_layout(p));
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
         ov::intel_gpu::ImplementationDesc conv_impl = { p.input_format, p.kernel_name };
         config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_prim", conv_impl } }));

--- a/src/plugins/intel_gpu/tests/fusions/fully_connected_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/fully_connected_fusion_test.cpp
@@ -278,9 +278,6 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, fc_int8_eltwise, ::testing::ValuesIn(std::
     fully_connected_test_params{ CASE_FC_U8S8_1, 2, 3 },
     fully_connected_test_params{ CASE_FC_U8S8_2, 2, 3 },
     fully_connected_test_params{ CASE_FC_U8S8_3, 2, 3 },
-    fully_connected_test_params{ CASE_FC_U8S8_3D_1, 2, 3 },
-    fully_connected_test_params{ CASE_FC_U8S8_3D_2, 2, 3 },
-    fully_connected_test_params{ CASE_FC_U8S8_3D_3, 2, 3 },
 }));
 
 class fc_int8_quantize_u8 : public FullyConnectedFusingTest {};

--- a/src/plugins/intel_gpu/tests/fusions/fully_connected_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/fully_connected_fusion_test.cpp
@@ -278,6 +278,9 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, fc_int8_eltwise, ::testing::ValuesIn(std::
     fully_connected_test_params{ CASE_FC_U8S8_1, 2, 3 },
     fully_connected_test_params{ CASE_FC_U8S8_2, 2, 3 },
     fully_connected_test_params{ CASE_FC_U8S8_3, 2, 3 },
+    fully_connected_test_params{ CASE_FC_U8S8_3D_1, 2, 3 },
+    fully_connected_test_params{ CASE_FC_U8S8_3D_2, 2, 3 },
+    fully_connected_test_params{ CASE_FC_U8S8_3D_3, 2, 3 },
 }));
 
 class fc_int8_quantize_u8 : public FullyConnectedFusingTest {};

--- a/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
+++ b/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
@@ -31,13 +31,12 @@ public:
     static const int max_random = 200;
 
     void SetUp() override {
+        cfg_fused = get_test_default_config(engine);
+        cfg_not_fused = get_test_default_config(engine);
+
         cfg_fused.set_property(ov::intel_gpu::optimize_data(true));
         cfg_not_fused.set_property(ov::intel_gpu::optimize_data(false));
         cfg_not_fused.set_property(ov::intel_gpu::allow_static_input_reorder(true));
-        if (engine.get_device_info().supports_immad) {
-            cfg_fused.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
-            cfg_not_fused.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
-        }
     }
 
     void compare(network& not_fused, network& fused, T& p, bool count_reorder = false) {

--- a/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
+++ b/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
@@ -38,7 +38,7 @@ public:
             cfg_fused.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
             cfg_not_fused.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
 #ifdef ENABLE_ONEDNN_FOR_GPU
-            engine.create_onednn_engine({});
+            engine.create_onednn_engine(cfg_fused);
 #endif
         }
     }

--- a/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
+++ b/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
@@ -38,7 +38,7 @@ public:
             cfg_fused.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
             cfg_not_fused.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
 #ifdef ENABLE_ONEDNN_FOR_GPU
-            engine.create_onednn_engine(cfg_fused);
+            engine.create_onednn_engine({});
 #endif
         }
     }

--- a/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
+++ b/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
@@ -37,9 +37,6 @@ public:
         if (engine.get_device_info().supports_immad) {
             cfg_fused.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
             cfg_not_fused.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
-#ifdef ENABLE_ONEDNN_FOR_GPU
-            engine.create_onednn_engine({});
-#endif
         }
     }
 

--- a/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
+++ b/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
@@ -37,6 +37,9 @@ public:
         if (engine.get_device_info().supports_immad) {
             cfg_fused.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
             cfg_not_fused.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
+#ifdef ENABLE_ONEDNN_FOR_GPU
+            engine.create_onednn_engine({});
+#endif
         }
     }
 

--- a/src/plugins/intel_gpu/tests/fusions/gemm_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/gemm_fusion_test.cpp
@@ -288,7 +288,6 @@ TEST_P(gemm_2in_add, eltwise_postop) {
     if (engine.get_device_info().supports_immad) {
         ov::intel_gpu::ImplementationDesc gemmv_impl = { cldnn::format::type::any, "", impl_types::onednn };
         cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "gemm_prim", gemmv_impl } }));
-        cfg_fused.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     }
 
     auto add_data_layout = get_output_layout(p);

--- a/src/plugins/intel_gpu/tests/fusions/lrn_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/lrn_fusion_test.cpp
@@ -35,7 +35,7 @@ public:
     void execute(lrn_test_params& p) {
         auto input_prim = get_mem(get_input_layout(p));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         ov::intel_gpu::ImplementationDesc lrn_impl = { p.input_format, p.kernel_name };
         config.set_property(ov::intel_gpu::optimize_data(true));
         config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "lrn_norm", lrn_impl } }));

--- a/src/plugins/intel_gpu/tests/fusions/pooling_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/pooling_fusion_test.cpp
@@ -35,8 +35,9 @@ public:
     void execute(pooling_test_params& p) {
         if (engine.get_device_info().supports_immad)
             p.expected_fused_primitives = p.expected_fused_primitives_onednn;
+
         auto input_prim = get_mem(get_input_layout(p));
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
         if (!p.kernel_name.empty()) {
             ov::intel_gpu::ImplementationDesc impl = { p.input_format, p.kernel_name };

--- a/src/plugins/intel_gpu/tests/fusions/pooling_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/pooling_fusion_test.cpp
@@ -541,12 +541,14 @@ public:
         ov::intel_gpu::ImplementationDesc onednn_impl = { p.input_format, "", impl_types::onednn };
         ov::intel_gpu::ImplementationDesc cldnn_impl = { p.input_format, "", impl_types::ocl };
 
-        ExecutionConfig cldnn_cfg{ov::intel_gpu::queue_type(QueueTypes::in_order),
+        ExecutionConfig cldnn_cfg = get_test_default_config(engine,
+                                  {ov::intel_gpu::queue_type(QueueTypes::in_order),
                                   ov::intel_gpu::optimize_data(true),
-                                  ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "pooling", cldnn_impl } })};
-        ExecutionConfig onednn_cfg{ov::intel_gpu::queue_type(QueueTypes::in_order),
+                                  ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "pooling", cldnn_impl } })});
+        ExecutionConfig onednn_cfg = get_test_default_config(engine,
+                                   {ov::intel_gpu::queue_type(QueueTypes::in_order),
                                    ov::intel_gpu::optimize_data(true),
-                                   ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "pooling", onednn_impl } })};
+                                   ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "pooling", onednn_impl } })});
 
         // for onednn fusing test, topology_non_fused means cldnn, topology_fused is onednn
         network network_fused_cldnn(this->engine, this->topology_non_fused, cldnn_cfg);

--- a/src/plugins/intel_gpu/tests/fusions/resample_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/resample_fusion_test.cpp
@@ -217,6 +217,7 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_quantize_concat, ::testing::Value
     resample_test_params{ CASE_RESAMPLE_FP16_11, RESAMPLE_QUANTIZE_CONCAT_CNT },
     resample_test_params{ CASE_RESAMPLE_FP16_12, RESAMPLE_QUANTIZE_CONCAT_CNT },
     resample_test_params{ CASE_RESAMPLE_FP16_13, RESAMPLE_QUANTIZE_CONCAT_CNT },
+    resample_test_params{ CASE_RESAMPLE_FP16_14, RESAMPLE_QUANTIZE_CONCAT_CNT },
 }));
 
 class resample_eltwise_concat : public ResamplePrimitiveFusingTest {};
@@ -261,6 +262,7 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_eltwise_concat, ::testing::Values
     resample_test_params{ CASE_RESAMPLE_FP16_11, RESAMPLE_ELTWISE_CONCAT_CNT },
     resample_test_params{ CASE_RESAMPLE_FP16_12, RESAMPLE_ELTWISE_CONCAT_CNT },
     resample_test_params{ CASE_RESAMPLE_FP16_13, RESAMPLE_ELTWISE_CONCAT_CNT },
+    resample_test_params{ CASE_RESAMPLE_FP16_14, RESAMPLE_ELTWISE_CONCAT_CNT },
 
     resample_test_params{ CASE_RESAMPLE_I8_1, RESAMPLE_ELTWISE_CONCAT_CNT },
     resample_test_params{ CASE_RESAMPLE_I8_2, RESAMPLE_ELTWISE_CONCAT_CNT },

--- a/src/plugins/intel_gpu/tests/fusions/resample_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/resample_fusion_test.cpp
@@ -217,7 +217,6 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_quantize_concat, ::testing::Value
     resample_test_params{ CASE_RESAMPLE_FP16_11, RESAMPLE_QUANTIZE_CONCAT_CNT },
     resample_test_params{ CASE_RESAMPLE_FP16_12, RESAMPLE_QUANTIZE_CONCAT_CNT },
     resample_test_params{ CASE_RESAMPLE_FP16_13, RESAMPLE_QUANTIZE_CONCAT_CNT },
-    resample_test_params{ CASE_RESAMPLE_FP16_14, RESAMPLE_QUANTIZE_CONCAT_CNT },
 }));
 
 class resample_eltwise_concat : public ResamplePrimitiveFusingTest {};
@@ -262,7 +261,6 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_eltwise_concat, ::testing::Values
     resample_test_params{ CASE_RESAMPLE_FP16_11, RESAMPLE_ELTWISE_CONCAT_CNT },
     resample_test_params{ CASE_RESAMPLE_FP16_12, RESAMPLE_ELTWISE_CONCAT_CNT },
     resample_test_params{ CASE_RESAMPLE_FP16_13, RESAMPLE_ELTWISE_CONCAT_CNT },
-    resample_test_params{ CASE_RESAMPLE_FP16_14, RESAMPLE_ELTWISE_CONCAT_CNT },
 
     resample_test_params{ CASE_RESAMPLE_I8_1, RESAMPLE_ELTWISE_CONCAT_CNT },
     resample_test_params{ CASE_RESAMPLE_I8_2, RESAMPLE_ELTWISE_CONCAT_CNT },

--- a/src/plugins/intel_gpu/tests/module_tests/graph_manipulation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/module_tests/graph_manipulation_gpu_test.cpp
@@ -28,7 +28,7 @@ using namespace ::tests;
    in similar way as it is done in tests utilizing clDNN API */
 TEST(basic, test1) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     auto input = engine.allocate_memory({ data_types::f16, format::yxfb,{ 1, 1, 2, 2 } });
@@ -67,9 +67,9 @@ TEST(basic, test1) {
 // Thus, a single method from program like add_intermediate might be tested separately.
 TEST(add_intermediate_gpu, test1)
 {
-    ExecutionConfig config;
     topology topology;
     auto& engine = get_test_engine();
+    ExecutionConfig config = get_test_default_config(engine);
 
     auto input = engine.allocate_memory({ data_types::f32, format::bfyx, {2, 2, 2, 2} });
     auto weights = engine.allocate_memory({ data_types::f32, format::bfyx, {2, 2, 2, 2} });
@@ -124,9 +124,9 @@ TEST(add_intermediate_gpu, test1)
 // Disabled for now as it produces wrong results
 TEST(add_intermediate_gpu, test2)
 {
-    ExecutionConfig config;
     topology topology;
     auto& engine = get_test_engine();
+    ExecutionConfig config = get_test_default_config(engine);
 
     auto input = engine.allocate_memory({ data_types::f32, format::bfyx,{ 2, 2, 2, 2 } });
     auto weights = engine.allocate_memory({ data_types::f32, format::bfyx,{ 2, 2, 2, 2 } });

--- a/src/plugins/intel_gpu/tests/passes/handle_reshape.cpp
+++ b/src/plugins/intel_gpu/tests/passes/handle_reshape.cpp
@@ -35,7 +35,7 @@ TEST(handle_reshape, dont_remove_reshape_that_changes_rank) {
     topology.add(reshape("reshape", input_info("e1"), false, {1}, {1}));
     topology.add(eltwise("e2", input_info("reshape"), input_info("data1"), eltwise_mode::sum));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     config.set_property(ov::intel_gpu::optimize_data(true));
     auto prog = program::build_program(engine, topology, config, false, true);

--- a/src/plugins/intel_gpu/tests/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/passes/prepare_buffer_fusing_test.cpp
@@ -34,7 +34,7 @@ TEST(prepare_buffer_fusing, optimize_reshape) {
     topology.add(permute("permute2", input_info("reshape"), {0, 3, 2, 1}));
     topology.add(reorder("reorder", input_info("permute2"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     auto prog = program::build_program(engine, topology, config, false, true);
 
@@ -76,7 +76,7 @@ TEST(prepare_buffer_fusing, static_node_after_optimized_out_dyn_reshape) {
     topology.add(fully_connected("fc", input_info("reshape"), "weights", "", {}, 2));
     topology.add(reorder("reorder", input_info("fc"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     auto prog = program::build_program(engine, topology, config, false, true);
     ASSERT_NE(prog, nullptr);

--- a/src/plugins/intel_gpu/tests/passes/prepare_primitive_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/passes/prepare_primitive_fusing_test.cpp
@@ -35,7 +35,7 @@ TEST(prepare_primitive_fusing, fuse_activation_to_fc_dyn) {
     topology.add(activation("act", input_info("fc"), activation_func::relu));
     topology.add(reorder("reorder", input_info("act"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     auto prog = program::build_program(engine, topology, config, false, true);
 
@@ -61,7 +61,7 @@ TEST(prepare_primitive_fusing, dont_fuse_incompatible_eltwise) {
     topology.add(eltwise("eltw", { input_info("input"), input_info("reduce") }, eltwise_mode::sum));
     topology.add(reorder("reorder", input_info("eltw"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     auto prog = program::build_program(engine, topology, config, false, true);
 
@@ -87,7 +87,7 @@ TEST(prepare_primitive_fusing, fuse_eltwise_to_fc_dyn_legal) {
     topology.add(eltwise("eltw", { input_info("fc"), input_info("extra_input") }, eltwise_mode::sum));
     topology.add(reorder("reorder", input_info("eltw"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     auto prog = program::build_program(engine, topology, config, false, true);
@@ -129,7 +129,7 @@ TEST(prepare_primitive_fusing, fuse_eltwise_to_fc_dyn_illegal) {
     topology.add(eltwise("eltw", { input_info("fc"), input_info("extra_input")}, eltwise_mode::sum));
     topology.add(reorder("reorder", input_info("eltw"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     auto prog = program::build_program(engine, topology, config, false, true);
@@ -185,7 +185,7 @@ TEST(prepare_primitive_fusing, fuse_eltwise_to_fc_dyn_illegal_const) {
     topology.add(eltwise("eltw", { input_info("fc"), input_info("extra_input") }, eltwise_mode::sum));
     topology.add(reorder("reorder", input_info("eltw"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     auto prog = program::build_program(engine, topology, config, false, true);
@@ -239,7 +239,7 @@ TEST(prepare_primitive_fusing, fuse_eltwise_to_fc_dyn_legal_scalar_const_broadca
     topology.add(eltwise("eltw", { input_info("fc"), input_info("extra_input") }, eltwise_mode::sum));
     topology.add(reorder("reorder", input_info("eltw"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     auto prog = program::build_program(engine, topology, config, false, true);
@@ -296,7 +296,7 @@ TEST(prepare_primitive_fusing, fuse_eltwise_to_fc_dyn_illegal_1) {
     topology.add(activation("act_fc2", input_info("eltw"), activation_func::relu));
     topology.add(reorder("reorder", input_info("act_fc2"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     auto prog = program::build_program(engine, topology, config, false, true);
@@ -365,7 +365,7 @@ TEST(prepare_primitive_fusing, fuse_eltwise_to_fc_dyn_illegal_2) {
     topology.add(activation("act_fc3", input_info("eltw"), activation_func::relu));
     topology.add(reorder("reorder", input_info("act_fc3"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     auto prog = program::build_program(engine, topology, config, false, true);
@@ -428,7 +428,7 @@ TEST(prepare_primitive_fusing, dont_remove_only_dep_reshape) {
     topology.add(reshape("reshape2", input_info("reshape1"), true, output_pattern, ov::PartialShape::dynamic(4)));
     topology.add(gemm("gemm", { input_info("reshape2"), input_info("input2") }, data_types::f32, false, false));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     auto prog = program::build_program(engine, topology, config, false, true);

--- a/src/plugins/intel_gpu/tests/passes/remove_redundant_reorders_tests.cpp
+++ b/src/plugins/intel_gpu/tests/passes/remove_redundant_reorders_tests.cpp
@@ -45,7 +45,7 @@ TEST(remove_redundant_reorders, remove_dep_dynamic) {
     topology.add(reorder("reorder", input_info("conv"), format::any, data_types::f32));
     topology.add(softmax("softmax", input_info("reorder"), 1));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);

--- a/src/plugins/intel_gpu/tests/passes/reorder_inputs_test.cpp
+++ b/src/plugins/intel_gpu/tests/passes/reorder_inputs_test.cpp
@@ -42,7 +42,7 @@ TEST(reorder_inputs, propagation) {
     topology.add(pooling("pool", input_info("conv1"), pooling_mode::max, { 1, 1 }, { 1, 1 }));
     topology.add(convolution("conv2", input_info("pool"), { "weights" }));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     auto prog = program::build_program(engine, topology, config);
 
@@ -79,7 +79,7 @@ TEST(reorder_inputs, impl_forcing_basic_format) {
 
     ov::intel_gpu::ImplementationDesc pool_impl = { format::yxfb, "" };
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"pool", pool_impl} }));
 
     network network(engine, topology, config);
@@ -117,7 +117,7 @@ TEST(reorder_inputs, impl_forcing_not_existing) {
 
     ov::intel_gpu::ImplementationDesc pool_impl = { format::any, "NOT_EXISTING" };
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"pool", pool_impl} }));
 
     ASSERT_ANY_THROW(network network(engine, topology, config));
@@ -133,7 +133,7 @@ TEST(reorder_inputs, impl_forcing_basic_format_kernel) {
 
     ov::intel_gpu::ImplementationDesc actv_impl = { format::yxfb, "activation_ref" };
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"actv", actv_impl} }));
 
     network network(engine, topology, config);
@@ -189,7 +189,7 @@ TEST(reorder_inputs, impl_forcing_basic_format_kernel) {
 //    for (auto impl : possible_impls) {
 //        SCOPED_TRACE(to_string(impl));
 //
-//        ExecutionConfig config;
+//        ExecutionConfig config = get_test_default_config(engine);
 //        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"conv", impl} }));
 //
 //        network network(engine, topology, config);

--- a/src/plugins/intel_gpu/tests/passes/select_preferred_formats_test.cpp
+++ b/src/plugins/intel_gpu/tests/passes/select_preferred_formats_test.cpp
@@ -33,7 +33,7 @@ TEST(test_select_preferred_formats, setting_target_conv_format) {
     topology.add(reorder("reorder", input_info("input"), format::b_fs_yx_fsv16, data_types::f16));
     topology.add(convolution("conv1", input_info("reorder"), { "weights" }));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     ov::intel_gpu::ImplementationDesc impl = { format::b_fs_yx_fsv16, std::string(""), impl_types::onednn };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"conv1", impl} }));

--- a/src/plugins/intel_gpu/tests/passes/test_module_fusing_reorder.cpp
+++ b/src/plugins/intel_gpu/tests/passes/test_module_fusing_reorder.cpp
@@ -63,7 +63,8 @@ TEST(test_can_fuse_reorder, reorder_for_mixed_type_convolution_fsv32_onednn)
     topology.add(cldnn::convolution("conv", { input_info("reorder_input") }, { "weights" }, { "bias"}, 1, {1, 1}, {0, 0}, {1, 1}, {1, 32, 2, 2}, data_types::f32, false));
     topology.add(reorder("reorder_conv", input_info("conv"), reorder_layout));
 
-    ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::in_order));
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     program::ptr prog = program::build_program(engine, topology, cfg, false, true);
     layout_optimizer lo = layout_optimizer();
     lo.set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, true);
@@ -100,7 +101,8 @@ TEST(test_can_fuse_reorder, reorder_for_mixed_type_convolution_fsv32_cldnn)
     topology.add(cldnn::convolution("conv", { input_info("reorder_input") }, { "weights" }, { "bias"}, 1, {1, 1}, {0, 0}, {1, 1}, {1, 32, 2, 2}, data_types::f32, false));
     topology.add(reorder("reorder_conv", input_info("conv"), reorder_layout));
 
-    ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::in_order));
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     program::ptr prog = program::build_program(engine, topology, cfg, false, true);
     layout_optimizer lo = layout_optimizer();
     lo.set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, false);
@@ -172,7 +174,8 @@ TEST_P(test_fused_reorder_deep_depth, no_removal_for_deep_depth_conv)
     topology.add(cldnn::convolution("conv", { input_info("reorder_input") }, { "weights" }));
     topology.add(reorder("reorder_conv", input_info("conv"), reorder_layout));
 
-    ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::in_order));
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     program::ptr prog = program::build_program(engine, topology, cfg, false, true);
     layout_optimizer lo = layout_optimizer();
     lo.set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, true);
@@ -223,7 +226,13 @@ TEST_P(test_can_fuse_reorder_cldnn, reorder_for_firstconv_cldnn)
     topology.add(cldnn::convolution("conv2", { input_info("reorder_input") }, { "weights" }, { "bias"}, 1, {1, 1}, {0, 0}, {1, 1}, p.out_shape, p.input_data_type, false));
     topology.add(reorder("reorder_conv", input_info("conv2"), reorder_layout));
 
-    ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+    if (engine.get_device_info().supports_immad) {
+        // Enable this test for out_of_order queue-type if Onednn supports out_of_order
+        return;
+    }
+
     program::ptr prog = program::build_program(engine, topology, cfg, false, true);
     layout_optimizer lo = layout_optimizer();
     lo.set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, false);
@@ -269,7 +278,8 @@ TEST_P(test_can_fuse_reorder_onednn, reorder_for_firstconv_onednn)
     topology.add(cldnn::convolution("conv", { input_info("reorder_input") }, { "weights" }));
     topology.add(reorder("reorder_result", input_info("conv"), reorder_layout));
 
-    ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::in_order));
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     program::ptr prog = program::build_program(engine, topology, cfg, false, true);
     layout_optimizer lo = layout_optimizer();
     lo.set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, true);
@@ -326,7 +336,12 @@ TEST_P(can_fuse_reorder, surface_input_reorder) {
 
     topology.add(input_layout_prim, weights_data_prim, surface_input_reorder_prim, conv_input_reorder_prim, conv_prim);
 
-    ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+    if (engine.get_device_info().supports_immad) {
+        // Enable this test for out_of_order queue-type if Onednn supports out_of_order
+        return;
+    }
     program::ptr prog = program::build_program(engine, topology, cfg, false, true);
     layout_optimizer lo = layout_optimizer();
     program_wrapper::apply_opt_pass<remove_redundant_reorders>(*prog, lo);
@@ -384,7 +399,13 @@ TEST_P(can_fuse_reorder, surface_input_reorder_batched) {
                  surface_input_reorder_prim1, surface_input_reorder_prim2,
                  conv_input_reorder_prim, concat, conv_prim);
 
-    ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+    if (engine.get_device_info().supports_immad) {
+        // Enable this test for out_of_order queue-type if Onednn supports out_of_order
+        return;
+    }
+
     program::ptr prog = program::build_program(engine, topology, cfg, false, true);
     layout_optimizer lo = layout_optimizer();
     program_wrapper::apply_opt_pass<remove_redundant_reorders>(*prog, lo);
@@ -437,7 +458,8 @@ TEST_P(test_can_fuse_reorder_onednn_errata, errata_case_for_conv) {
     topology.add(convolution("conv", { input_info("reorder_conv") }, { "weights" }));
     topology.add(reorder("reorder_result", input_info("conv"), p.conv_layout));
 
-    ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::in_order));
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     program::ptr prog = program::build_program(engine, topology, cfg, false, true);
     layout_optimizer lo = layout_optimizer();
     lo.set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, true);

--- a/src/plugins/intel_gpu/tests/passes/test_module_fusing_reorder.cpp
+++ b/src/plugins/intel_gpu/tests/passes/test_module_fusing_reorder.cpp
@@ -64,7 +64,6 @@ TEST(test_can_fuse_reorder, reorder_for_mixed_type_convolution_fsv32_onednn)
     topology.add(reorder("reorder_conv", input_info("conv"), reorder_layout));
 
     ExecutionConfig cfg = get_test_default_config(engine);
-    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     program::ptr prog = program::build_program(engine, topology, cfg, false, true);
     layout_optimizer lo = layout_optimizer();
     lo.set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, true);
@@ -102,7 +101,6 @@ TEST(test_can_fuse_reorder, reorder_for_mixed_type_convolution_fsv32_cldnn)
     topology.add(reorder("reorder_conv", input_info("conv"), reorder_layout));
 
     ExecutionConfig cfg = get_test_default_config(engine);
-    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     program::ptr prog = program::build_program(engine, topology, cfg, false, true);
     layout_optimizer lo = layout_optimizer();
     lo.set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, false);
@@ -175,7 +173,6 @@ TEST_P(test_fused_reorder_deep_depth, no_removal_for_deep_depth_conv)
     topology.add(reorder("reorder_conv", input_info("conv"), reorder_layout));
 
     ExecutionConfig cfg = get_test_default_config(engine);
-    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     program::ptr prog = program::build_program(engine, topology, cfg, false, true);
     layout_optimizer lo = layout_optimizer();
     lo.set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, true);
@@ -279,7 +276,6 @@ TEST_P(test_can_fuse_reorder_onednn, reorder_for_firstconv_onednn)
     topology.add(reorder("reorder_result", input_info("conv"), reorder_layout));
 
     ExecutionConfig cfg = get_test_default_config(engine);
-    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     program::ptr prog = program::build_program(engine, topology, cfg, false, true);
     layout_optimizer lo = layout_optimizer();
     lo.set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, true);
@@ -459,7 +455,6 @@ TEST_P(test_can_fuse_reorder_onednn_errata, errata_case_for_conv) {
     topology.add(reorder("reorder_result", input_info("conv"), p.conv_layout));
 
     ExecutionConfig cfg = get_test_default_config(engine);
-    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     program::ptr prog = program::build_program(engine, topology, cfg, false, true);
     layout_optimizer lo = layout_optimizer();
     lo.set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, true);

--- a/src/plugins/intel_gpu/tests/shape_infer/broadcast_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/shape_infer/broadcast_si_test.cpp
@@ -104,10 +104,9 @@ TEST_P(broadcast_test_two_inputs_blocked_format, shape_infer) {
                 broadcast("output", input_info("data"), input_info("target_shape"), p.axes_mapping_data, p.mode)
     );
 
-    ExecutionConfig config {
-        ov::intel_gpu::optimize_data(true),
-        ov::intel_gpu::allow_new_shape_infer(true)
-    };
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
 
     std::vector<int32_t> input_data(p.data_layout.get_linear_size(), 1);
 

--- a/src/plugins/intel_gpu/tests/test_cases/activation_simple_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/activation_simple_gpu_test.cpp
@@ -36,7 +36,7 @@ TEST(activation_f32_fw_gpu, dynamic) {
         topology topology(input_layout("input", in_layout));
         topology.add(activation("activation", input_info("input"), func));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
         network network(engine, topology, config);
 
@@ -121,7 +121,7 @@ TEST(activation_f32_fw_gpu, not_basic_yxfb) {
     topology topology(
         input_layout("input", input->get_layout()),
         activation("not", input_info("input"), activation_func::negation));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -165,7 +165,7 @@ TEST(activation_f32_fw_gpu, erf_basic_yxfb) {
     topology topology(
             input_layout("input", input->get_layout()),
             activation("not", input_info("input"), activation_func::erf));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -211,7 +211,7 @@ TEST(activation_f32_fw_gpu, hard_sigmoid_basic_yxfb) {
     topology topology(
             input_layout("input", input->get_layout()),
             activation("not", input_info("input"), activation_func::hard_sigmoid, params));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -257,7 +257,7 @@ TEST(activation_f32_fw_gpu, reciprocal_basic_yxfb) {
     topology topology(
             input_layout("input", input->get_layout()),
             activation("not", input_info("input"), activation_func::reciprocal));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -304,7 +304,7 @@ TEST(activation_f32_fw_gpu, selu_basic_yxfb) {
     topology topology(
             input_layout("input", input->get_layout()),
             activation("not", input_info("input"), activation_func::selu, params));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -351,7 +351,7 @@ TEST(activation_f32_fw_gpu, softplus_basic_yxfb) {
     topology topology(
             input_layout("input", input->get_layout()),
             activation("not", input_info("input"), activation_func::softplus));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -397,7 +397,7 @@ TEST(activation_f32_fw_gpu, softsign_basic_yxfb) {
     topology topology(
             input_layout("input", input->get_layout()),
             activation("not", input_info("input"), activation_func::softsign));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -433,7 +433,7 @@ TEST(activation_f16_fw_gpu, softsign_basic_yxfb) {
 
     topology topology(input_layout("input", input->get_layout()),
                       activation("not", input_info("input"), activation_func::softsign));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -478,7 +478,7 @@ TEST(activation_f32_fw_gpu, sign_basic_yxfb) {
     topology topology(
             input_layout("input", input->get_layout()),
             activation("not", input_info("input"), activation_func::sign));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -516,7 +516,7 @@ TEST(activation_f32_fw_gpu, pow_basic_yxfb) {
     topology topology(
         input_layout("input", input->get_layout()),
         activation("pow", input_info("input"), activation_func::pow, { 2.0f, 0.0f }));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -552,7 +552,7 @@ TEST(activation_f16_fw_gpu, pow_basic_yxfb) {
     topology topology(
         input_layout("input", input->get_layout()),
         activation("pow", input_info("input"), activation_func::pow, { FLOAT16(3.0f), FLOAT16(0.0f) }));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -609,7 +609,7 @@ TEST(activation_f32_fw_gpu, relu_basic_yxfb) {
     topology topology(
         input_layout("input", input->get_layout()),
         activation("relu", input_info("input"), activation_func::relu_negative_slope, { 0.5f, 0.f }, padding{ { 0, 0, 0, 0 }, 0 }));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -685,7 +685,7 @@ TEST(activation_f32_fw_gpu, relu_basic_bfzyx) {
     topology topology(
         input_layout("input", input->get_layout()),
         activation("relu", input_info("input"), activation_func::relu_negative_slope, { 0.5f, 0.f }, padding{ { 0, 0, 0, 0, 0 }, 0 }));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -782,7 +782,7 @@ TEST(activation_f32_fw_gpu, basic_yxfb_all_functions)
                 topology.add(activation("activation", input_info("input"), "input_params", func));
             }
 
-            network network(engine, topology);
+            network network(engine, topology, get_test_default_config(engine));
             network.set_input_data("input", input);
             auto outputs = network.execute();
             ASSERT_EQ(outputs.size(), size_t(1));
@@ -932,7 +932,7 @@ TEST(activation_f16_fw_gpu, basic_bfyx_all_functions)
                 topology.add(activation("activation", input_info("input"), "input_params", func));
             }
 
-            network network(engine, topology);
+            network network(engine, topology, get_test_default_config(engine));
             network.set_input_data("input", input);
             auto outputs = network.execute();
             ASSERT_EQ(outputs.size(), size_t(1));
@@ -1010,7 +1010,7 @@ TEST(activation_f32_fw_gpu, basic_yxfb_asin_acos_log_atan)
         topology topology(input_layout("input", input->get_layout()));
         topology.add(activation("activation", input_info("input"), func));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
         network.set_input_data("input", input);
         auto outputs = network.execute();
         ASSERT_EQ(outputs.size(), size_t(1));
@@ -1096,7 +1096,7 @@ TEST(activation_f32_fw_gpu, relu_basic_acosh_yxfb) {
             input_layout("input", input->get_layout()),
             reorder("reorder", input_info("input"), input->get_layout().with_padding(padding{ { 0, 0, 2, 1 }, 0 })),
             activation("relu", input_info("reorder"), activation_func::acosh, {0.5f, 0.f}, padding{ { 0, 0, 0, 0 }, 0 }));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.begin()->first, "relu");
@@ -1162,7 +1162,7 @@ TEST(activation_f32_fw_gpu, relu_basic_input_padding_yxfb) {
         input_layout("input", input->get_layout()),
         reorder("reorder", input_info("input"), input->get_layout().with_padding(padding{ { 0, 0, 2, 1 }, 0 })),
         activation("relu", input_info("reorder"), activation_func::relu_negative_slope, { 0.5f, 0.f }, padding{ { 0, 0, 0, 0 }, 0 }));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.begin()->first, "relu");
@@ -1249,7 +1249,7 @@ TEST(activation_f32_fw_gpu, relu_basic_input_padding_bfzyx) {
         input_layout("input", input->get_layout()),
         reorder("reorder", input_info("input"), input->get_layout().with_padding(padding{ { 0, 0, 2, 1, 0 }, 0 })),
         activation("relu", input_info("reorder"), activation_func::relu_negative_slope, { 0.5f, 0.f }, padding{ { 0, 0, 0, 0, 0 }, 0 }));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.begin()->first, "relu");
@@ -1322,7 +1322,7 @@ TEST(activation_f32_fw_gpu, relu_basic_output_padding_yxfb) {
     topology topology(
         input_layout("input", input->get_layout()),
         activation("relu", input_info("input"), activation_func::relu_negative_slope, { 0.5f, 0.f }, padding{ { 0, 0, 3, 3 }, 0 }));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -1365,7 +1365,7 @@ TEST(activation_f32_fw_gpu, basic_yxfb_floor_ceil)
         topology topology(input_layout("input", input->get_layout()));
         topology.add(activation("activation", input_info("input"), func));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
         network.set_input_data("input", input);
         auto outputs = network.execute();
         ASSERT_EQ(outputs.size(), size_t(1));
@@ -1429,7 +1429,7 @@ TEST(activation_i8_fw_gpu, basic_yxfb_all_funcs)
         topology.add(input_layout("input", input->get_layout()));
         topology.add(activation("activation", input_info("input"), func));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
         network.set_input_data("input", input);
         auto outputs = network.execute();
 
@@ -1487,7 +1487,7 @@ TEST(activation_i32_fw_gpu, basic_yxfb_i32_funcs) {
         topology.add(input_layout("input", input->get_layout()));
         topology.add(activation("activation", input_info("input"), func, params));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
         network.set_input_data("input", input);
         auto outputs = network.execute();
 
@@ -1553,7 +1553,7 @@ TEST(activation_f32_fw_gpu, b_fs_yx_fsv16_prelu) {
         cldnn::reorder("out", input_info("actv"), cldnn::format::bfyx, cldnn::data_types::f32)
     );
 
-    cldnn::network net(eng, topo);
+    cldnn::network net(eng, topo, get_test_default_config(eng));
     set_values(in_mem, flatten_4d(format::bfyx, in_data));
     net.set_input_data("in", in_mem);
 
@@ -1693,7 +1693,8 @@ struct activation_random_test : testing::TestWithParam<activation_random_test_pa
         prim.additional_params = additional_params;
         topo.add(prim);
 
-        ExecutionConfig config{ov::intel_gpu::custom_outputs(std::vector<std::string>{"activation"})};
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"activation"}));
 
         cldnn::network::ptr net = get_network(engine, topo, config, get_test_stream_ptr(), is_caching_test);
 
@@ -1714,10 +1715,10 @@ struct activation_random_test : testing::TestWithParam<activation_random_test_pa
 
         auto activation_impl_desc = ov::intel_gpu::ImplementationDesc();
         activation_impl_desc.output_format = input_format;
-        ExecutionConfig config_opt{
-            ov::intel_gpu::custom_outputs(std::vector<std::string>{"activation_blocked", "res_to_input_format"}),
-            ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"activation_blocked", {input_format, "activation_ref"}}})
-        };
+        ExecutionConfig config_opt = get_test_default_config(engine);
+        config_opt.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"activation_blocked", "res_to_input_format"}));
+        config_opt.set_property(ov::intel_gpu::force_implementations(
+                            ov::intel_gpu::ImplForcingMap{{"activation_blocked", {input_format, "activation_ref"}}}));
 
         network net_opt(engine, topo_opt, config_opt);
 

--- a/src/plugins/intel_gpu/tests/test_cases/activation_simple_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/activation_simple_gpu_test.cpp
@@ -1693,8 +1693,8 @@ struct activation_random_test : testing::TestWithParam<activation_random_test_pa
         prim.additional_params = additional_params;
         topo.add(prim);
 
-        ExecutionConfig config = get_test_default_config(engine);
-        config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"activation"}));
+        ExecutionConfig config = get_test_default_config(engine,
+                                    ov::intel_gpu::custom_outputs(std::vector<std::string>{"activation"}));
 
         cldnn::network::ptr net = get_network(engine, topo, config, get_test_stream_ptr(), is_caching_test);
 
@@ -1715,10 +1715,9 @@ struct activation_random_test : testing::TestWithParam<activation_random_test_pa
 
         auto activation_impl_desc = ov::intel_gpu::ImplementationDesc();
         activation_impl_desc.output_format = input_format;
-        ExecutionConfig config_opt = get_test_default_config(engine);
-        config_opt.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"activation_blocked", "res_to_input_format"}));
-        config_opt.set_property(ov::intel_gpu::force_implementations(
-                            ov::intel_gpu::ImplForcingMap{{"activation_blocked", {input_format, "activation_ref"}}}));
+        ExecutionConfig config_opt = get_test_default_config(engine,
+                                        {ov::intel_gpu::custom_outputs(std::vector<std::string>{"activation_blocked", "res_to_input_format"}),
+                                        ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"activation_blocked", {input_format, "activation_ref"}}})});
 
         network net_opt(engine, topo_opt, config_opt);
 

--- a/src/plugins/intel_gpu/tests/test_cases/adaptive_avg_pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/adaptive_avg_pooling_gpu_test.cpp
@@ -135,7 +135,7 @@ public:
         topology.add(adaptive_pooling("adaptive_avg_pooling_blocked", input_info("input_reordered"), params.outputTensor));
         topology.add(reorder("adaptive_avg_pooling", input_info("adaptive_avg_pooling_blocked"), plain_layout, data_type));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 

--- a/src/plugins/intel_gpu/tests/test_cases/adaptive_max_pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/adaptive_max_pooling_gpu_test.cpp
@@ -162,7 +162,7 @@ public:
             result_id = reorder_result_id;
         }
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data(input_data_id, input_mem);
 
@@ -192,7 +192,7 @@ public:
             cldnn::topology reorder_topology;
             reorder_topology.add(input_layout("indices", indices_layout));
             reorder_topology.add(reorder("plane_indices", input_info("indices"), plain_layout, data_types::i32));
-            cldnn::network reorder_net{engine, reorder_topology};
+            cldnn::network reorder_net{engine, reorder_topology, get_test_default_config(engine)};
             reorder_net.set_input_data("indices", indices_mem);
             const auto second_output_result = reorder_net.execute();
             const auto plane_indices_mem = second_output_result.at("plane_indices").get_memory();

--- a/src/plugins/intel_gpu/tests/test_cases/add_reorders_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/add_reorders_gpu_test.cpp
@@ -24,7 +24,7 @@ add_reorders optimization pass.
 //concatenation of incompatible convolutions
 TEST(add_reorders_gpu, two_convolutions_and_concatenation) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(false));
 
     auto input = engine.allocate_memory({ data_types::f32, format::yxfb,{ 1, 1, 2, 2 } });
@@ -123,7 +123,7 @@ void test_add_reorders_gpu_basic_reshape_and_tile(bool is_caching_test) {
     set_values(input, input_vec);
     tile_ref<T>(input, output_ref, 2, 4);
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
 

--- a/src/plugins/intel_gpu/tests/test_cases/arg_max_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/arg_max_gpu_test.cpp
@@ -83,7 +83,7 @@ TYPED_TEST(argmax_gpu_test, base) {
                                     /*b1f3*/ 4.f,  0.5f,  8.f,   8.2f};
     set_values(input, this->getTypedVector(input_vec));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -127,7 +127,7 @@ TEST(arg_max_gpu_min_axis_batch_bfzyx, i32) {
 
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -194,7 +194,7 @@ TEST(arg_max_gpu_min_axis_y_yxfb, f32) {
 
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -259,7 +259,7 @@ TEST(arg_max_gpu_min_axis_batch_yxfb, f32) {
 
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -316,7 +316,7 @@ TEST(arg_max_gpu_min_axis_y_yxfb_topk_2, f32) {
 
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -360,7 +360,7 @@ TEST(top_k_layer_tests, second_output) {
                                     /*b1f3*/ 4.f,  0.5f,  8.f,   8.2f};
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -454,7 +454,7 @@ TEST(top_k_layer_tests, second_output2) {
 
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -539,7 +539,7 @@ TEST(top_k_layer_tests, multiple_outputs) {
 
     set_values(input, input_vec);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
@@ -601,7 +601,7 @@ TEST(arg_max_gpu_min_axis_y_yxfb_topk_2, sort_by_values) {
 
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -658,7 +658,7 @@ TEST(arg_max_gpu_min_axis_y_yxfb_topk_2, sort_by_indices) {
 
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -701,7 +701,7 @@ void test_top_k_layer_tests_sort_probabilities_by_indices(bool is_caching_test) 
 
     set_values(input, input_vec);
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
     auto outputs = network->execute();
@@ -851,7 +851,7 @@ void test_top_k_layer_md_sync(bool is_caching_test) {
                              true));
     topology.add(mutable_data("arg_max.1", { input_info("arg_max.0") }, shared_memory));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input1", input1);
     auto outputs = network->execute();

--- a/src/plugins/intel_gpu/tests/test_cases/barriers_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/barriers_test.cpp
@@ -41,7 +41,13 @@ TEST(DISABLED_oooq_test, simple) {
     tpl.add(reorder("r8", input_info("c6"), concat_layout, std::vector<float>{ 8 }));
     tpl.add(concatenation("c9", { input_info("r7"), input_info("r8") }, 2));
 
-    ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+    ExecutionConfig cfg = get_test_default_config(*eng);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+    if (eng->get_device_info().supports_immad) {
+        // Onednn currently does NOT support out_of_order queue-type
+        return;
+    }
+
     network net{ *eng, tpl, cfg };
 
     net.set_input_data("in", input_mem);

--- a/src/plugins/intel_gpu/tests/test_cases/batch_to_space_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/batch_to_space_gpu_test.cpp
@@ -38,7 +38,7 @@ TEST(batch_to_space_fp16_gpu, i8111_bs1222_cb0000_ce0000) {
                                                                        tensor(format::bfyx, {0,0,0,0}, 0),
                                                                        tensor(format::bfyx, {0,0,0,0}, 0),
                                                                        tensor(format::bfyx, {1,2,2,2}, 1)));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input);
 
@@ -85,7 +85,7 @@ TEST(batch_to_space_fp16_gpu, i4321_bs1212_cb0000_ce0000) {
                                                                        tensor(format::bfyx, {0,0,0,0}, 0),
                                                                        tensor(format::bfyx, {0,0,0,0}, 0),
                                                                        tensor(format::bfyx, {1,6,2,2}, 1)));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input);
 
@@ -135,7 +135,7 @@ TEST(batch_to_space_fp16_gpu, i4321_bs1212_cb0010_ce0101) {
                                                                        tensor(format::bfyx, {0,0,1,0}, 0),
                                                                        tensor(format::bfyx, {0,1,0,1}, 0),
                                                                        tensor(format::bfyx, {1,5,1,1}, 1)));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input);
 
@@ -182,7 +182,7 @@ TEST(batch_to_space_fp16_gpu, i62121_bs12311_cb02000_ce00110) {
                                                                        tensor(format::bfzyx, {0,2,0,0,0}, 0),
                                                                        tensor(format::bfzyx, {0,0,1,1,0}, 0),
                                                                        tensor(format::bfzyx, {1,2,2,1,1}, 1)));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input);
 
@@ -231,7 +231,7 @@ TEST(batch_to_space_fp16_gpu, i1212112_bs112321_cb02000_ce00110) {
                                                                        tensor(format::bfwzyx, {0,0,1,0,0,0}, 0),
                                                                        tensor(format::bfwzyx, {0,0,0,2,0,0}, 0),
                                                                        tensor(format::bfwzyx, {1,1,3,1,2,2}, 1)));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input);
 
@@ -281,7 +281,7 @@ TEST(batch_to_space_fp16_gpu, i21611_bs1112_cb0000_ce0000_b_fs_yx_fsv16) {
                                                                            tensor(format::bfyx, {1,16,1,2}, 1)));
     topology.add(reorder("bts_to_bfyx", input_info("batch_to_space"), format::bfyx, data_types::f16));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input);
 
@@ -332,7 +332,7 @@ TEST(batch_to_space_fp16_gpu, i2812_bs1112_cb0000_ce0000_b_fs_yx_fsv16) {
                                                                            tensor(format::bfyx, {1,6,1,4}, 1)));
     topology.add(reorder("bts_to_bfyx", input_info("batch_to_space"), format::bfyx, data_types::f16));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input);
 
@@ -377,7 +377,7 @@ TEST(batch_to_space_fp32_gpu, i8111_bs1222_cb0000_ce0000) {
                                                                        tensor(format::bfyx, {0,0,0,0}, 0),
                                                                        tensor(format::bfyx, {0,0,0,0}, 0),
                                                                        tensor(format::bfyx, {1,2,2,2}, 1)));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input);
 
@@ -424,7 +424,7 @@ TEST(batch_to_space_fp32_gpu, i4321_bs1212_cb0000_ce0000) {
                                                                        tensor(format::bfyx, {0,0,0,0}, 0),
                                                                        tensor(format::bfyx, {0,0,0,0}, 0),
                                                                        tensor(format::bfyx, {1,6,2,2}, 1)));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input);
 
@@ -474,7 +474,7 @@ TEST(batch_to_space_fp32_gpu, i4321_bs1212_cb0010_ce0101) {
                                                                        tensor(format::bfyx, {0,0,1,0}, 0),
                                                                        tensor(format::bfyx, {0,1,0,1}, 0),
                                                                        tensor(format::bfyx, {1,5,1,1}, 1)));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input);
 
@@ -521,7 +521,7 @@ TEST(batch_to_space_fp32_gpu, i62121_bs12311_cb02000_ce00110) {
                                                                        tensor(format::bfzyx, {0,2,0,0,0}, 0),
                                                                        tensor(format::bfzyx, {0,0,1,1,0}, 0),
                                                                        tensor(format::bfzyx, {1,2,2,1,1}, 1)));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input);
 
@@ -570,7 +570,7 @@ TEST(batch_to_space_fp32_gpu, i1212112_bs112321_cb02000_ce00110) {
                                                                        tensor(format::bfwzyx, {0,0,1,0,0,0}, 0),
                                                                        tensor(format::bfwzyx, {0,0,0,2,0,0}, 0),
                                                                        tensor(format::bfwzyx, {1,1,3,1,2,2}, 1)));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input);
 
@@ -624,7 +624,7 @@ TEST(batch_to_space_fp32_gpu, i21621_bs1112_cb0201_ce0810_b_fs_yx_fsv16) {
                                                                            tensor(format::bfyx, {1,6,1,1}, 1)));
     topology.add(reorder("bts_to_bfyx", input_info("batch_to_space"), format::bfyx, data_types::f32));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input);
 
@@ -677,7 +677,7 @@ void test_batch_to_space_fp32_gpu_i41021_bs1221_cb0201_ce0810_b_fs_yx_fsv16(bool
                                                                            tensor(format::bfyx, {1,8,3,1}, 1)));
     topology.add(reorder("bts_to_bfyx", input_info("batch_to_space"), format::bfyx, data_types::f32));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("Input", input);
 

--- a/src/plugins/intel_gpu/tests/test_cases/binary_convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/binary_convolution_gpu_test.cpp
@@ -185,7 +185,7 @@ TEST_P(binary_convolution_test, conv) {
     if(engine.get_device_info().supports_immad)
         return;
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     topology topology_bin;
 
@@ -382,7 +382,7 @@ TEST(binary_convolution, basic_convolution_1x1_single_packed_channel) {
                                padding{ { 0,0,0,0 }, 0 })
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network network(engine, topology, config);
@@ -468,7 +468,7 @@ TEST(binary_convolution, basic_convolution_1x1_single_packed_channel_fp16) {
                                padding{ { 0,0,0,0 }, 0 })
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network network(engine, topology, config);

--- a/src/plugins/intel_gpu/tests/test_cases/border_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/border_gpu_test.cpp
@@ -87,7 +87,7 @@ public:
                                    pad_mode,
                                    pad_value),
                             reorder("output", input_info("border"), cldnn::format::bfyx, T_dt));
-        cldnn::network::ptr target_network = get_network(engine, target_topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr target_network = get_network(engine, target_topology,  get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         target_network->set_input_data("input", input);
         auto target_output = target_network->execute().at("output").get_memory();
         cldnn::mem_lock<T> target_output_ptr(target_output, get_test_stream());
@@ -102,7 +102,7 @@ public:
                                  pad_mode,
                                  pad_value));
 
-        cldnn::network base_network(engine, base_topology);
+        cldnn::network base_network(engine, base_topology, get_test_default_config(engine));
         base_network.set_input_data("input", input);
         auto base_output = base_network.execute().at("border").get_memory();
         cldnn::mem_lock<T> base_output_ptr(base_output, get_test_stream());
@@ -233,7 +233,7 @@ TEST(border_gpu, bsv16fsv16_without_reorder) {
                                ov::CoordinateDiff(cd_rb.begin(), cd_rb.end()),
                                pad_mode,
                                pad_value));
-    cldnn::network target_network(engine, target_topology);
+    cldnn::network target_network(engine, target_topology, get_test_default_config(engine));
     target_network.set_input_data("input", input_b16f16);
     auto target_output = target_network.execute().at("border").get_memory();
     cldnn::mem_lock<T> target_output_ptr(target_output, get_test_stream());
@@ -247,7 +247,7 @@ TEST(border_gpu, bsv16fsv16_without_reorder) {
                              ov::CoordinateDiff(cd_rb.begin(), cd_rb.end()),
                              pad_mode,
                              pad_value));
-    cldnn::network base_network(engine, base_topology);
+    cldnn::network base_network(engine, base_topology, get_test_default_config(engine));
     base_network.set_input_data("input", input);
     auto base_output = base_network.execute().at("border").get_memory();
     cldnn::mem_lock<T> base_output_ptr(base_output, get_test_stream());
@@ -290,7 +290,7 @@ TEST(border_gpu, zyx_bsv16fsv16) {
                                pad_mode,
                                pad_value),
                         reorder("output", input_info("border"), cldnn::format::bfzyx, T_dt));
-    cldnn::network target_network(engine, target_topology);
+    cldnn::network target_network(engine, target_topology, get_test_default_config(engine));
     target_network.set_input_data("input", input);
     auto target_output = target_network.execute().at("output").get_memory();
     cldnn::mem_lock<T> target_output_ptr(target_output, get_test_stream());
@@ -304,7 +304,7 @@ TEST(border_gpu, zyx_bsv16fsv16) {
                              ov::CoordinateDiff(cd_rb.begin(), cd_rb.end()),
                              pad_mode,
                              pad_value));
-    cldnn::network base_network(engine, base_topology);
+    cldnn::network base_network(engine, base_topology, get_test_default_config(engine));
     base_network.set_input_data("input", input);
     auto base_output = base_network.execute().at("border").get_memory();
     cldnn::mem_lock<T> base_output_ptr(base_output, get_test_stream());
@@ -364,7 +364,7 @@ TEST(border_gpu, basic_yxfb_0x0x1x2_0x0x3x4_border_constant) {
     };
     set_values(input, input_data);
 
-    cldnn::network network(engine, topology);
+    cldnn::network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -441,7 +441,7 @@ TEST(border_gpu, basic_fsv16_0x0x1x2_0x0x3x4_border_constant) {
     };
     set_values(input, input_data);
 
-    cldnn::network network(engine, topology);
+    cldnn::network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -541,7 +541,7 @@ TEST(border_gpu, basic_bfzyx_0x0x1x01_0x0x0x0x3_border_constant) {
     };
     set_values(input, input_data);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -647,7 +647,7 @@ TEST(border_gpu, basic_bfwzyx_0x0x0x1x0x1_0x0x0x1x0x1_border_constant) {
     };
     set_values(input, input_data);
 
-    cldnn::network network(engine, topology);
+    cldnn::network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -725,7 +725,7 @@ TEST(border_gpu, basic_yxfb_0x0x1x2_0x0x3x4_border_constant_non_constant) {
     };
     set_values(input, input_data);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -798,7 +798,7 @@ TEST(border_gpu, basic_yxfb_0x0x1x2_0x0x3x4_border_mirror) {
     };
     set_values(input, input_data);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -862,7 +862,7 @@ TEST(border_gpu, basic_bfzyx_0x0x0x0x1_0x0x0x0x1_border_mirror) {
     std::vector<float> input_data = generate_rnd_real_input<float>(sizes, -8.0f, 8.0f);
     set_values(input, input_data);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -940,7 +940,7 @@ TEST(border_gpu, basic_bfzyxw_0x0x0x0x1_0x0x0x0x1_border_mirror) {
     std::vector<float> input_data = generate_rnd_real_input<float>(sizes, -8.0f, 8.0f);
     set_values(input, input_data);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -1026,7 +1026,7 @@ TEST(border_gpu, basic_yxfb_0x0x1x2_0x0x3x4_border_mirror_101) {
     };
     set_values(input, input_data);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -1103,7 +1103,7 @@ TEST(border_gpu, basic_bfzyx_0x0x0x0x1_0x0x0x0x1_border_mirror_101) {
     };
     set_values(input, input_data);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -1197,7 +1197,7 @@ TEST(border_gpu, basic_bfwzyx_0x0x0x0x1x1_0x0x0x0x1x1_border_mirror_101) {
     };
     set_values(input, input_data);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -1276,7 +1276,7 @@ TEST(border_gpu, basic_yxfb_0x0x1x2_0x0x3x4_border_edge) {
     };
     set_values(input, input_data);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -1336,7 +1336,7 @@ TEST(border_gpu, basic_bfyx_2x1x2x3_1x2x3x4_border_constant) {
     std::vector<float> input_data = generate_rnd_real_input<float>(sizes, -8.0f, 8.0f);
     set_values(input, input_data);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -1401,7 +1401,7 @@ TEST(border_gpu, basic_bfyx_2x1x2x3_1x2x3x4_border_mirror) {
     std::vector<float> input_data = generate_rnd_real_input<float>(sizes, -8.0f, 8.0f);
     set_values(input, input_data);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -1464,7 +1464,7 @@ TEST(border_gpu, basic_bfyx_2x1x2x3_1x2x3x4_border_mirror_101) {
     std::vector<float> input_data = generate_rnd_real_input<float>(sizes, -8.0f, 8.0f);
     set_values(input, input_data);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -1527,7 +1527,7 @@ TEST(border_gpu, basic_bfyx_2x1x2x3_1x2x3x4_border_edge) {
     std::vector<float> input_data = generate_rnd_real_input<float>(sizes, -8.0f, 8.0f);
     set_values(input, input_data);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -1594,7 +1594,7 @@ TEST(border_gpu, basic_bfyx_2x1x2x3_1x2x3x4_border_constant_dynamic) {
     std::vector<float> input_data = generate_rnd_real_input<float>(sizes, -8.0f, 8.0f);
     set_values(input, input_data);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);

--- a/src/plugins/intel_gpu/tests/test_cases/broadcast_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/broadcast_gpu_test.cpp
@@ -64,7 +64,8 @@ void start_broadcast_test(format cldnn_format, data_types cldnn_data_type, std::
 
     set_values(input, input_data);
 
-    network network(engine, topology);
+    ExecutionConfig cfg = get_test_default_config(engine);
+    network network(engine, topology, cfg);
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -140,7 +141,7 @@ void start_broadcast_test_dynamic(format input_format,
         set_values<int32_t>(target_shape_mem, target_shape_data);
     }
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     set_values(input, input_data);
@@ -215,7 +216,7 @@ void start_broadcast_test_5d(format cldnn_format, data_types cldnn_data_type, st
 
     set_values(input, input_data);
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
     auto outputs = network->execute();

--- a/src/plugins/intel_gpu/tests/test_cases/bucketize_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/bucketize_gpu_test.cpp
@@ -59,7 +59,7 @@ struct bucketize_test : testing::TestWithParam<bucketize_test_params<I, B, O>> {
         topology.add(
             reorder("plane_bucketize_left_bound", input_info("bucketize_left_bound"), format::bfyx, type_to_data_type<O>::value));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
         network->set_input_data("buckets", buckets);

--- a/src/plugins/intel_gpu/tests/test_cases/cl_mem_input_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/cl_mem_input_test.cpp
@@ -127,7 +127,7 @@ void start_cl_mem_check_2_inputs(bool is_caching_test) {
     topology.add(input2);
     topology.add(reorder("reorder", input_info("input"), input_info("input2"), output_layout));
 
-    cldnn::network::ptr network = get_network(*engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(*engine, topology, get_test_default_config(*engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input_memory);
     network->set_input_data("input2", input_memory2);
@@ -249,7 +249,7 @@ TEST(cl_mem_check, check_input) {
     topology.add(input);
     topology.add(reorder("reorder", input_info("input"), output_layout));
 
-    network network(*engine, topology);
+    network network(*engine, topology, get_test_default_config(*engine));
     network.set_input_data("input", input_memory);
 
     auto outputs = network.execute();

--- a/src/plugins/intel_gpu/tests/test_cases/command_queue_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/command_queue_test.cpp
@@ -57,31 +57,55 @@ void exexute_network(cldnn::engine& engine, const ExecutionConfig& cfg, bool is_
 }  // namespace
 
 TEST(command_queue_test, test_priority_hints) {
-    ExecutionConfig cfg{ov::intel_gpu::queue_type(QueueTypes::out_of_order),
-                        ov::intel_gpu::hint::queue_priority(ov::hint::Priority::LOW)};
     auto engine = engine::create(engine_types::ocl, runtime_types::ocl);
+    ExecutionConfig cfg = get_test_default_config(*engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+    cfg.set_property(ov::intel_gpu::hint::queue_priority(ov::hint::Priority::LOW));
+    if (engine->get_device_info().supports_immad) {
+        // Onednn currently does NOT support out_of_order queue-type
+        return;
+    }
+
     exexute_network(*engine, cfg);
 }
 
 TEST(command_queue_test, test_throttle_hints) {
-    ExecutionConfig cfg{ov::intel_gpu::queue_type(QueueTypes::out_of_order),
-                        ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::HIGH)};
     auto engine = engine::create(engine_types::ocl, runtime_types::ocl);
+    ExecutionConfig cfg = get_test_default_config(*engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+    cfg.set_property(ov::intel_gpu::hint::queue_priority(ov::intel_gpu::hint::ThrottleLevel::HIGH));
+    if (engine->get_device_info().supports_immad) {
+        // Onednn currently does NOT support out_of_order queue-type
+        return;
+    }
+
     exexute_network(*engine, cfg);
 }
 
 TEST(command_queue_test, test_priority_and_throttle_hints) {
-    ExecutionConfig cfg{ov::intel_gpu::queue_type(QueueTypes::out_of_order),
-                        ov::intel_gpu::hint::queue_priority(ov::hint::Priority::HIGH),
-                        ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::LOW)};
     auto engine = engine::create(engine_types::ocl, runtime_types::ocl);
+    ExecutionConfig cfg = get_test_default_config(*engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+    cfg.set_property(ov::intel_gpu::hint::queue_priority(ov::hint::Priority::HIGH));
+    cfg.set_property(ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::LOW));
+    if (engine->get_device_info().supports_immad) {
+        // Onednn currently does NOT support out_of_order queue-type
+        return;
+    }
+
     exexute_network(*engine, cfg);
 }
 
 TEST(export_import_command_queue_test, test_priority_and_throttle_hints) {
-    ExecutionConfig cfg{ov::intel_gpu::queue_type(QueueTypes::out_of_order),
-                        ov::intel_gpu::hint::queue_priority(ov::hint::Priority::HIGH),
-                        ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::LOW)};
     auto engine = engine::create(engine_types::ocl, runtime_types::ocl);
+    ExecutionConfig cfg = get_test_default_config(*engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+    cfg.set_property(ov::intel_gpu::hint::queue_priority(ov::hint::Priority::HIGH));
+    cfg.set_property(ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::LOW));
+    if (engine->get_device_info().supports_immad) {
+        // Onednn currently does NOT support out_of_order queue-type
+        return;
+    }
+
     exexute_network(*engine, cfg, true);
 }

--- a/src/plugins/intel_gpu/tests/test_cases/command_queue_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/command_queue_test.cpp
@@ -58,9 +58,9 @@ void exexute_network(cldnn::engine& engine, const ExecutionConfig& cfg, bool is_
 
 TEST(command_queue_test, test_priority_hints) {
     auto engine = engine::create(engine_types::ocl, runtime_types::ocl);
-    ExecutionConfig cfg = get_test_default_config(*engine);
-    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
-    cfg.set_property(ov::intel_gpu::hint::queue_priority(ov::hint::Priority::LOW));
+    ExecutionConfig cfg = get_test_default_config(*engine,
+                        {ov::intel_gpu::queue_type(QueueTypes::out_of_order),
+                        ov::intel_gpu::hint::queue_priority(ov::hint::Priority::LOW)});
     if (engine->get_device_info().supports_immad) {
         // Onednn currently does NOT support out_of_order queue-type
         return;
@@ -71,9 +71,9 @@ TEST(command_queue_test, test_priority_hints) {
 
 TEST(command_queue_test, test_throttle_hints) {
     auto engine = engine::create(engine_types::ocl, runtime_types::ocl);
-    ExecutionConfig cfg = get_test_default_config(*engine);
-    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
-    cfg.set_property(ov::intel_gpu::hint::queue_priority(ov::intel_gpu::hint::ThrottleLevel::HIGH));
+    ExecutionConfig cfg = get_test_default_config(*engine,
+                        {ov::intel_gpu::queue_type(QueueTypes::out_of_order),
+                        ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::HIGH)});
     if (engine->get_device_info().supports_immad) {
         // Onednn currently does NOT support out_of_order queue-type
         return;
@@ -84,10 +84,10 @@ TEST(command_queue_test, test_throttle_hints) {
 
 TEST(command_queue_test, test_priority_and_throttle_hints) {
     auto engine = engine::create(engine_types::ocl, runtime_types::ocl);
-    ExecutionConfig cfg = get_test_default_config(*engine);
-    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
-    cfg.set_property(ov::intel_gpu::hint::queue_priority(ov::hint::Priority::HIGH));
-    cfg.set_property(ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::LOW));
+    ExecutionConfig cfg = get_test_default_config(*engine,
+                        {ov::intel_gpu::queue_type(QueueTypes::out_of_order),
+                        ov::intel_gpu::hint::queue_priority(ov::hint::Priority::HIGH),
+                        ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::LOW)});
     if (engine->get_device_info().supports_immad) {
         // Onednn currently does NOT support out_of_order queue-type
         return;
@@ -98,10 +98,10 @@ TEST(command_queue_test, test_priority_and_throttle_hints) {
 
 TEST(export_import_command_queue_test, test_priority_and_throttle_hints) {
     auto engine = engine::create(engine_types::ocl, runtime_types::ocl);
-    ExecutionConfig cfg = get_test_default_config(*engine);
-    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
-    cfg.set_property(ov::intel_gpu::hint::queue_priority(ov::hint::Priority::HIGH));
-    cfg.set_property(ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::LOW));
+    ExecutionConfig cfg = get_test_default_config(*engine,
+                        {ov::intel_gpu::queue_type(QueueTypes::out_of_order),
+                        ov::intel_gpu::hint::queue_priority(ov::hint::Priority::HIGH),
+                        ov::intel_gpu::hint::queue_throttle(ov::intel_gpu::hint::ThrottleLevel::LOW)});
     if (engine->get_device_info().supports_immad) {
         // Onednn currently does NOT support out_of_order queue-type
         return;

--- a/src/plugins/intel_gpu/tests/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/concatenation_gpu_test.cpp
@@ -1286,7 +1286,6 @@ TEST(concat_gpu_onednn, basic_input_types) {
     ov::intel_gpu::ImplementationDesc impl = { format::bfyx, std::string(""), impl_types::onednn };
 
     ExecutionConfig cfg = get_test_default_config(engine);
-    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     cfg.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "concat" }));
     cfg.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"concat", impl} }));
     network network(engine, topology, cfg);
@@ -1430,7 +1429,6 @@ public:
         config1.set_property(ov::intel_gpu::optimize_data(true));
         ov::intel_gpu::ImplementationDesc impl = { fmt, std::string(""), impl_types::onednn };
         config1.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"conv", impl} }));
-        config1.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
 
         auto out_mem1 = run_concat_network(input, fmt, config1);
         cldnn::mem_lock<Type> out_ptr1(out_mem1, stream);
@@ -1438,7 +1436,6 @@ public:
         // explicit concat
         ExecutionConfig config2 = get_test_default_config(engine);
         config2.set_property(ov::intel_gpu::optimize_data(false));
-        config2.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
         auto out_mem2 = run_concat_network(input, fmt, config2);
         cldnn::mem_lock<Type> out_ptr2(out_mem2, stream);
 
@@ -1599,7 +1596,6 @@ public:
         config1.set_property(ov::intel_gpu::optimize_data(true));
         ov::intel_gpu::ImplementationDesc impl = { fmt, std::string(""), impl_types::onednn };
         config1.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"conv", impl}}));
-        config1.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
 
         auto out_mem1 = run_concat_network(input, fmt, config1);
         cldnn::mem_lock<Type> out_ptr1(out_mem1, stream);
@@ -1607,7 +1603,6 @@ public:
         // explicit concat
         ExecutionConfig config2 = get_test_default_config(engine);
         config2.set_property(ov::intel_gpu::optimize_data(false));
-        config2.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
         auto out_mem2 = run_concat_network(input, fmt, config2);
         cldnn::mem_lock<Type> out_ptr2(out_mem2, stream);
 

--- a/src/plugins/intel_gpu/tests/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/concatenation_gpu_test.cpp
@@ -59,7 +59,7 @@ TEST(concat_gpu, mixed_input_types) {
                           padding{ { 0,0,0,0 }, 0 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input0", input0);
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -326,7 +326,7 @@ TEST(concat_gpu, mixed_input_types_5d) {
                           padding{ { 0,0,0,0 }, 0 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input0", input0);
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -399,7 +399,7 @@ TEST(concat_gpu, i8_optimization_with_pool) {
                                     data_types::i8,
                                     padding{{0, 0, 0, 0}, 0}),
                       reorder("reorder", input_info("concat"), reorder_layout));
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input0", input0);
@@ -501,7 +501,7 @@ TEST(concat_gpu, i8_optimization_with_conv) {
                       data("weights", weights),
                       convolution("conv", input_info("concat"), { "weights" }, { 2, 1 }),
                       reorder("output", input_info("conv"), reorder_layout));
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input0", input0);
@@ -602,7 +602,7 @@ TEST(concat_gpu, i8_optimization_with_pool_conv) {
                       data("weights", weights),
                       convolution("conv", input_info("concat"), {"weights"}, {1, 1}, {0, 1}),
                       reorder("output", input_info("conv"), reorder_layout) );
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input0", input0);
@@ -775,7 +775,7 @@ public:
 
         topology.add(concatenation("concat", input_ids, 1));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
         network network(engine, topology, config);
 
@@ -861,7 +861,7 @@ public:
 
         topology.add(concatenation("concat", input_ids, 3));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
         network network(engine, topology, config);
 
@@ -1025,7 +1025,7 @@ public:
         topology.add(data("weights", weights_mem));
         topology.add(convolution("conv", input_info("concat"), { "weights" }));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
         auto conv_forcing = ov::intel_gpu::ImplementationDesc{ fmt, std::string() };
         config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {primitive_id("conv"), conv_forcing} }));
@@ -1198,13 +1198,13 @@ public:
         auto input = generate_input();
 
         // implicit concat
-        ExecutionConfig config1;
+        ExecutionConfig config1 = get_test_default_config(get_test_engine());
         config1.set_property(ov::intel_gpu::optimize_data(true));
         auto out_mem1 = run_concat_network(input, fmt, config1);
         cldnn::mem_lock<Type> out_ptr1(out_mem1, get_test_stream());
 
         // explicit concat
-        ExecutionConfig config2;
+        ExecutionConfig config2 = get_test_default_config(get_test_engine());
         config2.set_property(ov::intel_gpu::optimize_data(false));
         auto out_mem2 = run_concat_network(input, fmt, config2);
         cldnn::mem_lock<Type> out_ptr2(out_mem2, get_test_stream());
@@ -1285,9 +1285,10 @@ TEST(concat_gpu_onednn, basic_input_types) {
 
     ov::intel_gpu::ImplementationDesc impl = { format::bfyx, std::string(""), impl_types::onednn };
 
-    ExecutionConfig cfg{ov::intel_gpu::queue_type(QueueTypes::in_order),
-                        ov::intel_gpu::custom_outputs(std::vector<std::string>{ "concat" }),
-                        ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"concat", impl} })};
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
+    cfg.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "concat" }));
+    cfg.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"concat", impl} }));
     network network(engine, topology, cfg);
     network.set_input_data("input0", input0);
     network.set_input_data("input1", input1);
@@ -1425,7 +1426,7 @@ public:
         auto input = generate_input();
 
         // implicit concat
-        ExecutionConfig config1;
+        ExecutionConfig config1 = get_test_default_config(engine);
         config1.set_property(ov::intel_gpu::optimize_data(true));
         ov::intel_gpu::ImplementationDesc impl = { fmt, std::string(""), impl_types::onednn };
         config1.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"conv", impl} }));
@@ -1435,7 +1436,7 @@ public:
         cldnn::mem_lock<Type> out_ptr1(out_mem1, stream);
 
         // explicit concat
-        ExecutionConfig config2;
+        ExecutionConfig config2 = get_test_default_config(engine);
         config2.set_property(ov::intel_gpu::optimize_data(false));
         config2.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
         auto out_mem2 = run_concat_network(input, fmt, config2);
@@ -1594,7 +1595,7 @@ public:
         auto input = generate_input();
 
         // implicit concat when batch size is 1.
-        ExecutionConfig config1;
+        ExecutionConfig config1 = get_test_default_config(engine);
         config1.set_property(ov::intel_gpu::optimize_data(true));
         ov::intel_gpu::ImplementationDesc impl = { fmt, std::string(""), impl_types::onednn };
         config1.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"conv", impl}}));
@@ -1604,7 +1605,7 @@ public:
         cldnn::mem_lock<Type> out_ptr1(out_mem1, stream);
 
         // explicit concat
-        ExecutionConfig config2;
+        ExecutionConfig config2 = get_test_default_config(engine);
         config2.set_property(ov::intel_gpu::optimize_data(false));
         config2.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
         auto out_mem2 = run_concat_network(input, fmt, config2);

--- a/src/plugins/intel_gpu/tests/test_cases/condition_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/condition_gpu_test.cpp
@@ -87,7 +87,7 @@ std::pair<std::vector<float>, std::vector<float>> get_values_to_compare(const cl
 
 TEST(DISABLED_condition_gpu, basic_equal_comp) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     auto input = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 4, 1 } });
     auto compare = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 1, 1 } });
@@ -139,7 +139,7 @@ TEST(DISABLED_condition_gpu, basic_equal_comp) {
 
 TEST(DISABLED_condition_gpu, basic_range_equal_comp) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     auto input0 = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 4, 1 } });
     auto input1 = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 4, 1 } });
@@ -212,7 +212,7 @@ TEST(DISABLED_condition_gpu, basic_range_equal_comp) {
 
 TEST(DISABLED_condition_gpu, generic_test_true_false) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     auto input = engine.allocate_memory({ data_types::f32, format::bfyx,{ 5, 2, 5, 1 } });
     std::vector<float> input_data(50);
@@ -321,7 +321,7 @@ TEST(DISABLED_condition_gpu, basic_stacked_ifs) {
         <prims...>
     */
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     auto input = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 4, 1 } });
     auto compare = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 1, 1 } });
@@ -391,7 +391,7 @@ TEST(DISABLED_condition_gpu, basic_nested_ifs) {
     <prims...>
     */
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     auto input = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 4, 1 } });
     auto compare = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 1, 1 } });
@@ -473,7 +473,7 @@ TEST(DISABLED_condition_gpu, basic_nested_ifs) {
 
 TEST(DISABLED_condition_gpu, negative_compare_wrong_layout) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     auto input = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 4, 1 } });
     auto compare = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 5, 1 } });
@@ -497,7 +497,7 @@ TEST(DISABLED_condition_gpu, negative_compare_wrong_layout) {
 
 TEST(DISABLED_condition_gpu, negative_too_big_offset) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     auto input = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 4, 1 } });
     auto compare = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 3, 1 } });
@@ -521,7 +521,7 @@ TEST(DISABLED_condition_gpu, negative_too_big_offset) {
 
 TEST(DISABLED_condition_gpu, negative_not_same_layouts) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     auto input = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 4, 1 } });
     auto compare = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 1, 1 } });
@@ -552,7 +552,7 @@ TEST(DISABLED_condition_gpu, negative_not_same_layouts) {
 
 TEST(DISABLED_condition_gpu, negative_same_names_within_different_networks) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     auto input = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 4, 1 } });
     auto compare = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 1, 1 } });

--- a/src/plugins/intel_gpu/tests/test_cases/convert_color_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/convert_color_gpu_test.cpp
@@ -81,7 +81,7 @@ TEST(convert_color, nv12_to_rgb_two_planes_buffer_fp32) {
     topology.add(convert_color("convert_color", { input_info("input_y"), input_info("input_uv") }, cldnn::convert_color::color_format::NV12, cldnn::convert_color::color_format::RGB,
                                cldnn::convert_color::memory_type::buffer, output_layout));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input_y", input_y);
     network.set_input_data("input_uv", input_uv);
 
@@ -120,7 +120,7 @@ TEST(convert_color, nv12_to_bgr_two_planes_buffer_fp32) {
     topology.add(convert_color("convert_color", { input_info("input_y"), input_info("input_uv") }, cldnn::convert_color::color_format::NV12, cldnn::convert_color::color_format::BGR,
                                cldnn::convert_color::memory_type::buffer, output_layout));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input_y", input_y);
     network.set_input_data("input_uv", input_uv);
 
@@ -160,7 +160,7 @@ TEST(convert_color, nv12_to_rgb_two_planes_buffer_u8) {
     topology.add(convert_color("convert_color", { input_info("input_y"), input_info("input_uv") }, cldnn::convert_color::color_format::NV12, cldnn::convert_color::color_format::RGB,
                                cldnn::convert_color::memory_type::buffer, output_layout));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input_y", input_y);
     network.set_input_data("input_uv", input_uv);
 
@@ -200,7 +200,7 @@ TEST(convert_color, nv12_to_rgb_two_planes_buffer_fp16) {
     topology.add(convert_color("convert_color", { input_info("input_y"), input_info("input_uv") }, cldnn::convert_color::color_format::NV12, cldnn::convert_color::color_format::RGB,
                                cldnn::convert_color::memory_type::buffer, output_layout));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input_y", input_y);
     network.set_input_data("input_uv", input_uv);
 
@@ -238,7 +238,7 @@ TEST(convert_color, nv12_to_rgb_single_plane_buffer_fp32) {
     topology.add(convert_color("convert_color", { input_info("input") }, cldnn::convert_color::color_format::NV12, cldnn::convert_color::color_format::RGB,
                                cldnn::convert_color::memory_type::buffer, output_layout));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -274,7 +274,7 @@ TEST(convert_color, nv12_to_rgb_single_plane_buffer_u8) {
     topology.add(convert_color("convert_color", { input_info("input") }, cldnn::convert_color::color_format::NV12, cldnn::convert_color::color_format::RGB,
                                cldnn::convert_color::memory_type::buffer, output_layout));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -350,7 +350,7 @@ TEST(convert_color, nv12_to_rgb_two_planes_surface_u8) {
     topology.add(convert_color("convert_color", { input_info("input"), input_info("input2") }, cldnn::convert_color::color_format::NV12, cldnn::convert_color::color_format::RGB,
                                cldnn::convert_color::memory_type::image, output_layout));
 
-    network network(*engine, topology);
+    network network(*engine, topology, get_test_default_config(*engine));
     network.set_input_data("input", input_memory);
     network.set_input_data("input2", input_memory2);
 
@@ -414,7 +414,7 @@ TEST(convert_color, nv12_to_rgb_single_plane_surface_u8) {
     topology.add(convert_color("convert_color", { input_info("input") }, cldnn::convert_color::color_format::NV12, cldnn::convert_color::color_format::RGB,
                                cldnn::convert_color::memory_type::image, output_layout));
 
-    network network(*engine, topology);
+    network network(*engine, topology, get_test_default_config(*engine));
     network.set_input_data("input", input_memory);
 
     auto outputs = network.execute();
@@ -507,7 +507,7 @@ TEST(convert_color, i420_to_rgb_three_planes_buffer_fp32) {
     topology.add(convert_color("convert_color", { input_info("input_y"), input_info("input_u"), input_info("input_v") }, cldnn::convert_color::color_format::I420, cldnn::convert_color::color_format::RGB,
                                cldnn::convert_color::memory_type::buffer, output_layout));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input_y", input_y);
     network.set_input_data("input_u", input_u);
     network.set_input_data("input_v", input_v);
@@ -593,7 +593,7 @@ void test_convert_color_i420_to_rgb_three_planes_surface_u8(bool is_caching_test
     topology.add(convert_color("convert_color", { input_info("input"), input_info("input2"), input_info("input3") }, cldnn::convert_color::color_format::I420, cldnn::convert_color::color_format::RGB,
                                cldnn::convert_color::memory_type::image, output_layout));
 
-    cldnn::network::ptr network = get_network(*engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(*engine, topology, get_test_default_config(*engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input_memory);
     network->set_input_data("input2", input_memory2);

--- a/src/plugins/intel_gpu/tests/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/convolution_gpu_test.cpp
@@ -339,7 +339,7 @@ TEST(deformable_convolution_f32_fw_gpu, basic_deformable_convolution_def_group1_
                     { 1, 4, 4, 4 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     network.set_input_data("trans", trans);
 
@@ -470,7 +470,7 @@ TEST(deformable_convolution_f32_fw_gpu, basic_deformable_convolution_def_group1)
                     { 1, 4, 4, 4 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     network.set_input_data("trans", trans);
 
@@ -633,7 +633,7 @@ TEST(deformable_convolution_f32_fw_gpu, basic_deformable_convolution) {
                     { 1, 4, 4, 4 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     network.set_input_data("trans", trans);
 
@@ -696,7 +696,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution_no_bias) {
         data("weights", weights),
         convolution("conv", input_info("input"), { "weights" }, { 2, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -773,7 +773,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution_int8_no_bias) {
         convolution("conv", input_info("to_int"), { "weights" }, {2, 1 }),
         reorder("output", input_info("conv"), { data_types::f32, format::bfyx, { 1, 1, 3, 2 } }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -825,7 +825,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution3D_no_bias) {
         data("weights", weights),
         convolution("conv", input_info("input"), { "weights" }, { 2, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -961,7 +961,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution3D) {
         data("biases", biases),
         convolution("conv", input_info("input"), { "weights" }, { "biases" }, {1, 1, 1}, {0, 0, 0}, {1, 1, 1}));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1091,7 +1091,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution3D_group2) {
         data("biases", biases),
         convolution("conv", input_info("input"), { "weights" }, { "biases" }, 2, {1, 1, 1}, {0, 0, 0}, {1, 1, 1}));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1140,7 +1140,7 @@ TEST(convolution_f32_fw_gpu, with_output_size_same_input) {
         convolution::create_with_output_size("conv2", input_info("input"), { "weights2" }, { 1, 64, 320, 320 }, { 1, 1 }, { 3, 3 })
         );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1181,7 +1181,7 @@ TEST(convolution_f32_fw_gpu, three_convolutions_same_weights) {
         convolution("conv3", input_info("conv2"), { "weights" })
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -1252,7 +1252,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution) {
         data("biases", biases),
         convolution( "conv", input_info("input"), { "weights" }, { "biases" }, {2, 1}));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1310,7 +1310,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution_bfyx_weights_as_input_layout) {
         input_layout("weights", weights->get_layout()),
         input_layout("biases", biases->get_layout()),
         convolution("conv", input_info("input"), { "weights" }, { "biases" }, { 2, 1 }, { 0, 0 }));
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -1371,7 +1371,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution_bfyx_weights_as_input_layout_non_
         input_layout("weights", weights->get_layout()),
         data("biases", biases),
         convolution("conv", input_info("input"), { "weights" }, { "biases" }, { 2, 1 }, { 0, 0 }));
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(false));
     network network(engine, topology, config, true);
     network.set_input_data("input", input);
@@ -1464,7 +1464,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution_input_padding) {
             padding{ { 0, 0, 0, 0 }, 0 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1566,7 +1566,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution_sym_input_padding) {
             padding{ { 0, 0, 0, 0 }, 0 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1662,7 +1662,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution_asym_input_padding) {
             { 3, 2 },
             padding{ { 0, 0, 0, 0 }, 0 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1769,7 +1769,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution_sym_input_padding_with_pad) {
             padding{ { 0, 0, 0, 0 }, 0 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1878,7 +1878,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution_asym_input_padding_with_pad) {
             { 3, 2 },
             padding{ { 0, 0, 0, 0 }, 0 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1976,7 +1976,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution_input_and_output_padding) {
             padding{ { 0,0,x_pad,y_pad }, 0 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2077,7 +2077,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x1x1_nopad_random) {
         convolution("conv", input_info("input"), { "weights" }, { "biases" }, { 2, 2 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2147,7 +2147,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in2x2x1x2_nopad_random) {
         convolution("conv", input_info("input"), { "weights" }, { "biases" }, { 2, 2 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2205,7 +2205,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x1x1_nopad) {
         convolution("conv", input_info("input"), { "weights" }, { "biases" }, { 2, 2 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2259,7 +2259,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in2x2x1x2_nopad) {
         convolution("conv", input_info("input"), { "weights" }, { "biases" }, { 2, 2 } )
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2311,7 +2311,7 @@ TEST(convolution_f32_fw_gpu, basic_ofm_wsiz2x1x2x1_in1x2x1_nopad) {
         convolution("conv", input_info("input"), { "weights" }, { "biases" }, { 5, 5 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2370,7 +2370,7 @@ TEST(convolution_f32_fw_gpu, basic_ofm_wsiz3x2x2x1_in2x2x1_nopad) {
         convolution("conv", input_info("input"), { "weights" }, { "biases" }, { 5, 5 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2426,7 +2426,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2x1x3_wstr2x2_in2x2x1x1_nopad) {
         convolution("conv", input_info("input"), { "weights" }, { "biases" }, { 2, 2 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2482,7 +2482,7 @@ TEST(convolution_f32_fw_gpu, wsiz3x3_wstr2x2_in2x2x1x1_zeropad) {
         convolution("conv", input_info("input"), { "weights" }, { "biases" }, { 2, 2 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2547,7 +2547,7 @@ TEST(convolution_f32_fw_gpu, offsets_wsiz3x3_wstr2x2_in2x2x1x1_zeropad) {
             padding{ { 0, 0, 1, 1 }, 0 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2627,7 +2627,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x1_nopad_split2) {
             { 1, 1 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2725,7 +2725,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_split2) {
             { 1, 1 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2789,7 +2789,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x1_nopad_group2) {
             { 1, 1 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2847,7 +2847,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x1_nopad_group2_bfyx) 
             { 1, 1 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2904,7 +2904,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_group2) {
             { 1, 1 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -2999,7 +2999,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_split2_depthw
                 { 1, 1 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -3088,7 +3088,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_split2_depthw
             { 1, 1 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -3187,7 +3187,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_group16) {
             { 1, 1 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -3282,7 +3282,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_group16_bfyx)
             { 1, 1 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -3377,7 +3377,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz2x2_wstr2x2_in4x4x2x2_nopad_group16_bfyx)
             { 1, 1, 1, 1 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -3458,7 +3458,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz1x1_wstr2x2_in1x1x2x1_nopad_split2) {
             { 1, 1, 1, 1 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -3545,7 +3545,7 @@ TEST(convolution_f32_fw_gpu, basic_wsiz1x1_wstr2x2_in1x1x4x1_filter_1x3x2x1x1_no
             { 1, 1, 1, 1 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -3624,7 +3624,7 @@ TEST(convolution_gpu, trivial_convolution_relu) {
         )
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -3702,7 +3702,7 @@ TEST(convolution_gpu, relu_with_negative_slope) {
         )
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -3751,7 +3751,7 @@ TEST(convolution_gpu, DISABLED_two_1x1_kernels_after_each_other) {
         conv_2
     );
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -3930,7 +3930,7 @@ TEST(convolution_gpu, basic_yxfb_4_4_yxfb_2_2_b16_if2_of16_st2_2_p0_sp1_fp32)
             )
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -4005,7 +4005,7 @@ TEST(convolution_f32_fw_gpu, byte_activation) {
             { 0, 0, 0 }
         } };
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     set_values<int8_t>(input, {  1,  2, -3,  4, -5,
@@ -4080,7 +4080,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_symmetric) {
         convolution("conv", input_info("input"), { "weights" }, { "biases" }, { 2, 2 }, {0, 0}, { 1, 1 }, tensor{ 1, 2, 3, 2 }),
         reorder("out", input_info("conv"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -4154,7 +4154,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_weight_an
                     { 2, 2 }, { 0, 0 }, { 1, 1 }, tensor{ 1, 2, 3, 2 }, false),
         reorder("out", input_info("conv"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -4225,7 +4225,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
                     { 2, 2 }, { 0, 0 }, { 1, 1 }, tensor{ 1, 2, 3, 2 }, false),
         reorder("out", input_info("conv"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -4310,7 +4310,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
                     { 2, 2 }, { 0, 0 }, { 1, 1 }, tensor{ 1, 2, 3, 2 }, false),
         reorder("out", input_info("conv"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -4411,7 +4411,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_activatio
                     { 2, 2 }, { 0, 0 }, { 1, 1 }, tensor{ 1, 2, 3, 2 }, data_types::f32, false),
         reorder("out", input_info("conv"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -4482,7 +4482,7 @@ TEST(convolution_int8_fw_gpu, quantized_convolution_u8s8f32_asymmetric_weights_p
                     { 2, 2 }, { 0, 0 }, { 1, 1 }, tensor{ 1, 2, 3, 2 }, false),
         reorder("out", input_info("conv"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -4680,7 +4680,7 @@ TEST(convolution_gpu, basic_yxfb_4_4_yxfb_2_2_b16_if2_of16_st2_2_p0_sp1_fp16)
         reorder("output", input_info("conv"), { data_types::f32, output_format, output_size })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -5033,7 +5033,7 @@ TEST_P(convolution_gpu_fs_byx_fsv32, fs_byx_fsv32)
     }
 
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "" };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_fsv", conv_impl } }));
     config.set_property(ov::intel_gpu::optimize_data(true));
@@ -5134,7 +5134,7 @@ TEST(convolution_f16_fsv_gpu, convolution_f16_fsv_gpu_padding) {
 
     topology.add(conv_fsv);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "convolution_gpu_bfyx_to_fs_byx_fsv32" };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_fsv", conv_impl } }));
     config.set_property(ov::intel_gpu::optimize_data(true));
@@ -5341,7 +5341,7 @@ TEST_P(convolution_gpu_fs_byx_fsv32_crop, fs_byx_fsv32_crop)
         }
     }
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "convolution_gpu_bfyx_to_fs_byx_fsv32" };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_fsv", conv_impl } }));
     config.set_property(ov::intel_gpu::optimize_data(true));
@@ -5415,7 +5415,7 @@ TEST(convolution_f32_fw_gpu, convolution_int8_b_fs_yx_fsv4_to_bfyx) {
                     padding{ { 0, 0, output_padding, output_padding }, 0 }),
         reorder("output", input_info("conv"), { data_types::f32, format::bfyx, { batch_num, input_f, input_size_x, input_size_y } }));
 
-    ExecutionConfig config_ref;
+    ExecutionConfig config_ref = get_test_default_config(engine);
 
     network network_ref(engine, topology_ref, config_ref);
     network_ref.set_input_data("input", input);
@@ -5437,7 +5437,7 @@ TEST(convolution_f32_fw_gpu, convolution_int8_b_fs_yx_fsv4_to_bfyx) {
             padding{ { 0, 0, output_padding, output_padding }, 0 }),
         reorder("output", input_info("conv"), { data_types::f32,format::bfyx, { batch_num, input_f, input_size_x, input_size_y } }));
 
-    ExecutionConfig config_act;
+    ExecutionConfig config_act = get_test_default_config(engine);
 
     config_act.set_property(ov::intel_gpu::optimize_data(true));
 
@@ -5577,7 +5577,7 @@ TEST(convolution_gpu, bfyx_iyxo_5x5_fp16)
     }
 
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc conv_impl = { format::bfyx, "" };
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
@@ -5804,7 +5804,7 @@ TEST_P(convolution_gpu_block_layout3D, bfzyx_bsv16_fsv16_fp32)
 
     topology.add(reorder("reorder_bfzyx", input_info("conv_bsv16_fsv16"), format::bfzyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "conv_bsv16_fsv16", "reorder_bfzyx" }));
     network network(engine, topology, config);
@@ -5941,7 +5941,7 @@ TEST_P(convolution_gpu_block_layout3D, bfzyx_bsv16_fsv16_fp16)
 
     topology.add(reorder("reorder_bfzyx", input_info("conv_bsv16_fsv16"), format::bfzyx, data_types::f16));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "conv_bsv16_fsv16", "reorder_bfzyx" }));
     network network(engine, topology, config);
@@ -6077,7 +6077,7 @@ TEST_P(convolution_gpu_block_layout3D, bfzyx_bsv16_fsv16_fp32_fused_ops)
 
     topology.add(reorder("reorder_bfzyx", input_info("scale"), format::bfzyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "conv_bsv16_fsv16", "reorder_bfzyx" }));
     network network(engine, topology, config);
@@ -6238,7 +6238,7 @@ TEST_P(convolution_gpu_block_layout, bfyx_bsv16_fsv16_fp32)
 
     topology.add(reorder("reorder_bfyx", input_info("conv_bsv16_fsv16"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "conv_bsv16_fsv16", "reorder_bfyx" }));
     ov::intel_gpu::ImplementationDesc conv_impl = { format::bs_fs_yx_bsv16_fsv16, "" };
@@ -6378,7 +6378,7 @@ TEST_P(convolution_gpu_block_layout, bfyx_bsv16_fsv16_fp16)
 
     topology.add(reorder("reorder_bfyx", input_info("conv_bsv16_fsv16"), format::bfyx, data_types::f16));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "conv_bsv16_fsv16", "reorder_bfyx" }));
     ov::intel_gpu::ImplementationDesc conv_impl = { format::bs_fs_yx_bsv16_fsv16, "" };
@@ -6516,7 +6516,7 @@ TEST_P(convolution_gpu_block_layout, bfyx_bsv16_fsv16_fp32_fused_ops)
 
     topology.add(reorder("reorder_bfyx", input_info("scale"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "conv_bsv16_fsv16", "reorder_bfyx" }));
     ov::intel_gpu::ImplementationDesc conv_impl = { format::bs_fs_yx_bsv16_fsv16, "" };
@@ -6654,7 +6654,7 @@ TEST_P(convolution_depthwise_gpu, depthwise_conv_fs_b_yx_fsv32)
 
     topology.add(conv_fsv);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "" };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_fsv", conv_impl } }));
@@ -6797,7 +6797,7 @@ TEST_P(convolution_depthwise_gpu_fsv16, depthwise_conv_b_fs_yx_fsv16)
 
     topology.add(conv_fsv);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "" };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_fsv", conv_impl } }));
@@ -6928,7 +6928,7 @@ TEST_P(convolution_depthwise_gpu_fsv16_xy, depthwise_conv_b_fs_yx_fsv16)
 
     topology.add(conv_fsv);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "convolution_gpu_bfyx_f16_depthwise" };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_fsv", conv_impl } }));
@@ -7018,7 +7018,7 @@ TEST(convolution_depthwise_gpu_fsv16, depthwise_conv_b_fs_yx_fsv16_in_feature_pa
         convolution("conv", input_info("input_reordered"), { "weights" }, { "bias" }, num_groups, stride, pad, dilation, output_size, data_types::f32, true),
         reorder("out", input_info("conv"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "" };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", conv_impl } }));
@@ -7131,7 +7131,7 @@ TEST_P(convolution_depthwise_gpu_bfyx, depthwise_conv_bfyx)
 
     topology.add(conv_fsv);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     ov::intel_gpu::ImplementationDesc conv_impl = { format::bfyx, "" };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", conv_impl } }));
@@ -7452,7 +7452,7 @@ TEST_P(convolution_grouped_gpu, base) {
     if (has_comp)
         topology.add(data(comp_prim_name[0], comp));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "conv", "out" }));
     ov::intel_gpu::ImplementationDesc conv_impl = { input_data_format, impl_name };
@@ -7613,7 +7613,7 @@ TEST_P(convolution_general_gpu, conv_fp16_cases) {
         conv_fsv.output_paddings = {padding({ 0, 0, output_padding, output_padding }, 0.f)};
         topology.add(conv_fsv);
     }
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     ov::intel_gpu::ImplementationDesc conv_impl = { input_data_format, impl_name };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_fsv", conv_impl } }));
@@ -7721,7 +7721,7 @@ TEST_P(convolution_gpu_fsv16_to_bfyx, conv_b_fs_yx_fsv16_to_bfyx_padding)
     topology.add(reorder_bfyx);                                                                             // format 8 to 3 -> after fusing, removed
 
     // Exec ref network (non-fusing)
-    ExecutionConfig config_ref;
+    ExecutionConfig config_ref = get_test_default_config(engine);
     config_ref.set_property(ov::intel_gpu::optimize_data(false));
     config_ref.set_property(ov::intel_gpu::allow_static_input_reorder(true));
 
@@ -7733,7 +7733,7 @@ TEST_P(convolution_gpu_fsv16_to_bfyx, conv_b_fs_yx_fsv16_to_bfyx_padding)
     cldnn::mem_lock<FLOAT16> ref_out_ptr(ref_out_mem, get_test_stream());
 
     // Exec target network (fusing: conv+reorder)
-    ExecutionConfig config_target;
+    ExecutionConfig config_target = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "convolution_gpu_bfyx_f16" };
     config_target.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_fsv", conv_impl } }));
     config_target.set_property(ov::intel_gpu::optimize_data(true));
@@ -7817,7 +7817,7 @@ TEST_P(convolution_gpu_fsv16_to_bfyx, conv_b_fs_yx_fsv16_to_bfyx_different_type)
     topology.add(reorder_bfyx);                                                                             // format 8 to 3 -> after fusing, removed
 
     // Exec ref network (non-fusing)
-    ExecutionConfig config_ref;
+    ExecutionConfig config_ref = get_test_default_config(engine);
     config_ref.set_property(ov::intel_gpu::optimize_data(false));
     config_ref.set_property(ov::intel_gpu::allow_static_input_reorder(true));
 
@@ -7829,7 +7829,7 @@ TEST_P(convolution_gpu_fsv16_to_bfyx, conv_b_fs_yx_fsv16_to_bfyx_different_type)
     cldnn::mem_lock<float> ref_out_ptr(ref_out_mem, get_test_stream());
 
     // Exec target network (fusing: conv+reorder)
-    ExecutionConfig config_target;
+    ExecutionConfig config_target = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "convolution_gpu_bfyx_f16" };
     config_target.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_fsv", conv_impl } }));
     config_target.set_property(ov::intel_gpu::optimize_data(true));
@@ -7935,10 +7935,10 @@ public:
 
         auto topo = build_topology(engine);
 
-        ExecutionConfig config{
-            ov::intel_gpu::optimize_data(true),
-            ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", { input_format(), "" } } })
-        };
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", { input_format(), "" } } }));
+
         auto prog = program::build_program(engine, topo, config);
 
         cldnn::network net(prog, 0);
@@ -8295,10 +8295,10 @@ public:
 
         auto topo = this->build_topology(engine);
 
-        ExecutionConfig config{
-            ov::intel_gpu::optimize_data(true),
-            ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", { this->input_format(), "" } } })
-        };
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", { this->input_format(), "" } } }));
+
         auto prog = program::build_program(engine, topo, config);
 
         cldnn::network net(prog, 0);
@@ -8691,7 +8691,7 @@ public:
         for (cldnn::data_types data_type : data_types) {
             for (cldnn::format input_format : input_formats) {
                 for (cldnn::format weights_format : weights_formats) {
-                    ExecutionConfig network_build_config;
+                    ExecutionConfig network_build_config = get_test_default_config(get_test_engine());
                     if (input_format == cldnn::format::bfyx) {
                         network_build_config.set_property(ov::intel_gpu::optimize_data(true));
                     }
@@ -9066,7 +9066,7 @@ TEST_P(convolution_gpu_onednn, conv_onednn_cases) {
         topology.add(conv_fsv);
     }
     topology.add(reorder("reorder_bfyx", input_info("conv_fsv"), format::bfyx, data_types::f32));
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"conv_fsv","reorder_bfyx"}));
@@ -9134,14 +9134,14 @@ TEST(convolution_gpu_onednn, padding_for_cldnn_kernel_after_onednn) {
     topology topology_test(input, weights, input_reorder, conv1, conv2, output_reorder);
     topology topology_ref(input, weights, input_reorder, conv1, conv2, output_reorder);
 
-    ExecutionConfig config_test;
+    ExecutionConfig config_test = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc conv1_impl_test = { format::byxf, "", impl_types::onednn };
     ov::intel_gpu::ImplementationDesc conv2_impl_test = { format::b_fs_yx_fsv16, "convolution_gpu_bfyx_f16", impl_types::ocl };
     config_test.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv1", conv1_impl_test }, { "conv2", conv2_impl_test } }));
     config_test.set_property(ov::intel_gpu::optimize_data(true));
     config_test.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
 
-    ExecutionConfig config_ref;
+    ExecutionConfig config_ref = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc conv1_impl_ref = { format::bfyx, "", impl_types::ocl };
     ov::intel_gpu::ImplementationDesc conv2_impl_ref = { format::bfyx, "", impl_types::ocl };
     config_ref.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv1", conv1_impl_ref }, { "conv2", conv2_impl_ref } }));
@@ -9228,7 +9228,7 @@ TEST(convolution_gpu_onednn, quantized_onednn_convolution_u8s8f32_asymmetric_act
                     { 2, 2 }, { 0, 0 }, { 1, 1 }, tensor{ 1, 2, 3, 2 }, false),
         reorder("out", input_info("conv"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc conv_impl = { format::byxf, "", impl_types::onednn };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", conv_impl }}));
     config.set_property(ov::intel_gpu::optimize_data(true));
@@ -9319,7 +9319,7 @@ TEST(convolution_gpu_onednn, quantized_onednn_convolution_u8s8f32_asymmetric_act
                     { 2, 2 }, { 0, 0 }, { 1, 1 }, tensor{ 1, 2, 3, 2 }, false),
         reorder("out", input_info("conv"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc conv_impl = { format::byxf, "", impl_types::onednn };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", conv_impl }}));
     config.set_property(ov::intel_gpu::optimize_data(true));
@@ -9421,7 +9421,7 @@ void test_convolution_f32_gpu_convolution_gpu_bfyx_f16_depthwise_x_bloxk_size_1(
 
     topology.add(conv_fsv);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "convolution_gpu_bfyx_f16_depthwise" };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_fsv", conv_impl } }));
@@ -9502,7 +9502,7 @@ TEST(convolution_f32_fw_gpu, basic_convolution_no_bias_swap_xy) {
         data("weights", weights),
         convolution("conv", input_info("input"), { "weights" }, { 1, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();

--- a/src/plugins/intel_gpu/tests/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/convolution_gpu_test.cpp
@@ -9068,7 +9068,6 @@ TEST_P(convolution_gpu_onednn, conv_onednn_cases) {
     topology.add(reorder("reorder_bfyx", input_info("conv_fsv"), format::bfyx, data_types::f32));
     ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
-    config.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"conv_fsv","reorder_bfyx"}));
     network network(engine, topology, config);
 
@@ -9139,14 +9138,12 @@ TEST(convolution_gpu_onednn, padding_for_cldnn_kernel_after_onednn) {
     ov::intel_gpu::ImplementationDesc conv2_impl_test = { format::b_fs_yx_fsv16, "convolution_gpu_bfyx_f16", impl_types::ocl };
     config_test.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv1", conv1_impl_test }, { "conv2", conv2_impl_test } }));
     config_test.set_property(ov::intel_gpu::optimize_data(true));
-    config_test.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
 
     ExecutionConfig config_ref = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc conv1_impl_ref = { format::bfyx, "", impl_types::ocl };
     ov::intel_gpu::ImplementationDesc conv2_impl_ref = { format::bfyx, "", impl_types::ocl };
     config_ref.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv1", conv1_impl_ref }, { "conv2", conv2_impl_ref } }));
     config_ref.set_property(ov::intel_gpu::optimize_data(true));
-    config_ref.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
 
     network network_test(engine, topology_test, config_test);
     network network_ref(engine, topology_ref, config_ref);
@@ -9232,7 +9229,6 @@ TEST(convolution_gpu_onednn, quantized_onednn_convolution_u8s8f32_asymmetric_act
     ov::intel_gpu::ImplementationDesc conv_impl = { format::byxf, "", impl_types::onednn };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", conv_impl }}));
     config.set_property(ov::intel_gpu::optimize_data(true));
-    config.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
 
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -9323,7 +9319,6 @@ TEST(convolution_gpu_onednn, quantized_onednn_convolution_u8s8f32_asymmetric_act
     ov::intel_gpu::ImplementationDesc conv_impl = { format::byxf, "", impl_types::onednn };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", conv_impl }}));
     config.set_property(ov::intel_gpu::optimize_data(true));
-    config.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
 
     network network(engine, topology, config);
     network.set_input_data("input", input);

--- a/src/plugins/intel_gpu/tests/test_cases/crop_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/crop_gpu_test.cpp
@@ -57,7 +57,7 @@ TEST(crop_gpu, basic_in2x3x2x2_crop_all) {
     std::vector<float> input_vec = generate_random_input<float>(batch_num, feature_num, y_size, x_size, -10, 10);
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -103,7 +103,7 @@ TEST(crop_gpu, basic_in2x2x2x3_crop_all) {
         input_vec.push_back(static_cast<float>(i));
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -152,7 +152,7 @@ TEST(crop_gpu, basic_i32_in2x3x2x2_crop_all) {
     std::vector<int32_t> input_vec = generate_random_input<int32_t>(batch_num, feature_num, y_size, x_size, -10, 10);
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -200,7 +200,7 @@ TEST(crop_gpu, basic_i64_in2x3x2x2_crop_all) {
     std::vector<int64_t> input_vec = generate_random_input<int64_t>(batch_num, feature_num, y_size, x_size, -10, 10);
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -248,7 +248,7 @@ TEST(crop_gpu, basic_in2x3x2x2_crop_all_bfyx) {
     std::vector<float> input_vec = generate_random_input<float>(batch_num, feature_num, y_size, x_size, -10, 10);
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -297,7 +297,7 @@ TEST(crop_gpu, basic_i32_in2x3x2x2_crop_all_bfyx) {
     std::vector<int32_t> input_vec = generate_random_input<int32_t>(batch_num, feature_num, y_size, x_size, -10, 10);
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -346,7 +346,7 @@ TEST(crop_gpu, basic_i64_in2x3x2x2_crop_all_bfyx) {
     std::vector<int64_t> input_vec = generate_random_input<int64_t>(batch_num, feature_num, y_size, x_size, -10, 10);
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -395,7 +395,7 @@ TEST(crop_gpu, basic_in2x3x2x2_crop_all_fyxb) {
     std::vector<float> input_vec = generate_random_input<float>(batch_num, feature_num, y_size, x_size, -10, 10);
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -442,7 +442,7 @@ TEST(crop_gpu, basic_i32_in2x3x2x2_crop_all_fyxb) {
     std::vector<int32_t> input_vec = generate_random_input<int32_t>(batch_num, feature_num, y_size, x_size, -10, 10);
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -489,7 +489,7 @@ TEST(crop_gpu, basic_i64_in2x3x2x2_crop_all_fyxb) {
     std::vector<int64_t> input_vec = generate_random_input<int64_t>(batch_num, feature_num, y_size, x_size, -10, 10);
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -553,7 +553,7 @@ TEST(crop_gpu, basic_in2x3x2x2_crop_offsets) {
         -14.f, -15.f, -16.f, -17.f };
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -618,7 +618,7 @@ TEST(crop_gpu, basic_i32_in2x3x2x2_crop_offsets) {
         -14, -15, -16, -17 };
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -683,7 +683,7 @@ TEST(crop_gpu, basic_i64_in2x3x2x2_crop_offsets) {
         -14, -15, -16, -17 };
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -759,7 +759,7 @@ TEST(crop_gpu, basic_in1x4x1x1_split) {
     std::vector<float> out1 = { -1.f, 2.f,-3.f };
     std::vector<float> out2 = { 4.f, };
     set_values(input, input_vec);
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::custom_outputs(topology.get_primitives_ids()));
 
@@ -807,7 +807,7 @@ TEST(crop_gpu, basic_in1x4x1x1_crop_pad) {
     std::vector<float> input_vec = { -1.f, 2.f, -3.f, 4.f };
     std::vector<float> out1 = { -1.f, 2.f,-3.f };
     set_values(input, input_vec);
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network network(engine, topology, config);
@@ -875,7 +875,7 @@ TEST(crop_gpu, basic_i32_in1x4x1x1_split) {
     std::vector<int32_t> out1 = { -1, 2,-3 };
     std::vector<int32_t> out2 = { 4, };
     set_values(input, input_vec);
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::custom_outputs(topology.get_primitives_ids()));
 
@@ -950,7 +950,7 @@ TEST(crop_gpu, basic_i64_in1x4x1x1_split) {
     std::vector<int64_t> out1 = { -1, 2,-3 };
     std::vector<int64_t> out2 = { 4, };
     set_values(input, input_vec);
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::custom_outputs(topology.get_primitives_ids()));
 
@@ -1028,10 +1028,10 @@ TEST(crop_gpu, basic_in1x4x1x1_split_w_relu) {
     std::vector<float> out2 = { 4.f, };
     set_values(input, input_vec);
 
-    ExecutionConfig cfg{
-        ov::intel_gpu::enable_memory_pool(false),
-        ov::intel_gpu::optimize_data(true)
-    };
+    ExecutionConfig cfg = get_test_default_config(*engine);
+    cfg.set_property(ov::intel_gpu::enable_memory_pool(false));
+    cfg.set_property(ov::intel_gpu::optimize_data(true));
+
     network network(*engine, topology, cfg);
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -1081,7 +1081,7 @@ TEST(crop_gpu, basic_in3x1x2x2x1_crop_all_bfzyx) {
     std::vector<float> input_vec = generate_random_input<float>(batch_num, feature_num, y_size, x_size, -10, 10);
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1137,7 +1137,7 @@ TEST(crop_gpu, basic_in3x1x3x2x2x1_crop_all_bfwzyx) {
     VF<float> input_vec = flatten_6d<float>(format::bfwzyx, input_rnd);
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1212,7 +1212,7 @@ TEST_P(crop_gpu, pad_test) {
         res.insert(res.end(), res_data.begin(), res_data.end());
     }
     set_values(input, input_vec);
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
@@ -1289,7 +1289,7 @@ TEST(crop_gpu, dynamic_i32_in2x3x2x2_crop_offsets) {
         4, -5, 8, 8,
         -14, -15, -16, -17 };
     set_values(input, input_vec);
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
 
@@ -1348,7 +1348,7 @@ TEST(crop_gpu, dynamic_in1x4x1x1_split) {
     std::vector<float> out1 = { -1.0f, 2.0f };
     std::vector<float> out2 = { -3.0f, 4.0f };
     set_values(input_mem, input_vec);
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::custom_outputs(topology.get_primitives_ids()));
@@ -1417,7 +1417,7 @@ TEST(crop_gpu, dynamic_in1x4x1x1_varaidic_split) {
     set_values(axis_mem, {1});
     set_values(splits_length_mem, splits_vec);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::custom_outputs(topology.get_primitives_ids()));
@@ -1470,7 +1470,7 @@ TEST(crop_gpu, static_split_batch) {
 
     set_values(input_mem, input_vec);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::custom_outputs(topology.get_primitives_ids()));
 
@@ -1525,7 +1525,7 @@ TEST(crop_gpu, optimized_out_crop) {
     topology.add(crop("crop2", { input_info("crop1") }, tensor(5, 4, 1, 1), { tensor(0, 0, 0, 0) }, padding({0, 0, 0, 0}, {0, 0, 0, 0})));
     topology.add(reorder("reorder_out", input_info("crop2"), layout{ ov::PartialShape{5, 4, 1, 1}, data_types::f32, format::bfyx }));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network network(engine, topology, config);

--- a/src/plugins/intel_gpu/tests/test_cases/ctc_loss_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/ctc_loss_gpu_test.cpp
@@ -104,7 +104,7 @@ public:
         topology.add(ctc_loss("ctc_loss", inputs_ids, p.preprocess_collapse_repeated, p.ctc_merge_repeated, p.unique));
         topology.add(reorder("reordered_ctc_loss", input_info("ctc_loss"), plane_format, float_data_type));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         for (auto& input : inputs) {
             network->set_input_data(std::get<0>(input), std::get<1>(input));

--- a/src/plugins/intel_gpu/tests/test_cases/cum_sum_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/cum_sum_gpu_test.cpp
@@ -185,7 +185,7 @@ public:
         topology.add(input_layout("Input0", input->get_layout()));
         topology.add(cum_sum("cum_sum", input_info("Input0"), axis, exclusive, reverse));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input);
 
@@ -282,7 +282,7 @@ TEST(cum_sum_gpu_f16, DISABLED_basic_1d) {
     topology.add(input_layout("Input0", input->get_layout()));
     topology.add(cum_sum("cum_sum", input_info("Input0")));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input);
 
@@ -317,7 +317,7 @@ TEST(cum_sum_gpu_fp32, dynamic) {
     topology.add(input_layout("input", in_layout));
     topology.add(cum_sum("cum_sum", input_info("input")));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);

--- a/src/plugins/intel_gpu/tests/test_cases/custom_gpu_primitive_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/custom_gpu_primitive_test.cpp
@@ -82,7 +82,7 @@ TEST(custom_gpu_primitive_f32, add_basic_in2x2x2x2) {
         15.f,  17.f,    8.f,  10.f,
         -2.f,  6.5f,  -0.5f, -2.5f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -188,7 +188,7 @@ void add_basic_in2x2x2x2_with_reorder()
         15.f,  17.f,    8.f,  10.f,
         -2.f,  6.f,  0.f, -2.f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -288,7 +288,7 @@ TEST(custom_gpu_primitive_f32, eltwise_add_basic_in2x2x2x2) {
         15.f,  17.f,    8.f,  10.f,
         -2.f,  6.5f,  -0.5f, -2.5f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -381,7 +381,7 @@ TEST(custom_gpu_primitive_f32, add_eltwise_basic_in2x2x2x2) {
         15.f,  17.f,    8.f,  10.f,
         -2.f,  6.5f,  -0.5f, -2.5f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -483,7 +483,7 @@ TEST(custom_gpu_primitive_f32, two_kernels_with_same_entry_point_basic_in2x2x2x2
         4.f, -0.5f, 8.f,  8.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -547,7 +547,7 @@ void test_custom_gpu_primitive_u8_add_basic_in2x2x2x2(bool is_caching_test) {
          2, 60,  0, 20
     });
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
     network->set_input_data("input2", input2);

--- a/src/plugins/intel_gpu/tests/test_cases/deconvolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/deconvolution_gpu_test.cpp
@@ -175,7 +175,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x1_nopad) {
         reorder("plane_output", input_info("deconv"), format::bfyx, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -235,7 +235,7 @@ TYPED_TEST(deconvolution_basic, no_bias_basic_wsiz2x2_in2x2x1x1_nopad) {
         reorder("plane_output", input_info("deconv"), format::bfyx, data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -297,7 +297,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x1_nopad_bfyx) {    //  Fil
         reorder("plane_output", input_info("deconv"), format::bfyx, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -359,7 +359,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x1_pad1) {
         reorder("plane_output", input_info("deconv"), format::bfyx, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -410,7 +410,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x1_stride2_nopad) {
         reorder("plane_output", input_info("deconv"), format::bfyx, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -475,7 +475,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x1_stride4_pad2) {
         reorder("plane_output", input_info("deconv"), format::bfyx, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -537,7 +537,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x2_stride2_pad1) {
         reorder("plane_output", input_info("deconv"), format::yxfb, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -584,7 +584,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2x2_in2x2x1x1_stride2_pad1) {
     //  f1: 17 - 13
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     auto input = engine.allocate_memory({ data_types::f32, format::yxfb, { 1, 1, 2, 2 } });
@@ -665,7 +665,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x2_bfyx_stride2_pad1) {
         reorder("plane_output", input_info("deconv"), format::bfyx, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -726,7 +726,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x2_bfyx_stride2_pad1_input_p
         deconvolution("deconv", input_info("reorder"), { "weights" }, { "biases" }, { 2, 2 }, { 1, 1 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -776,7 +776,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2x2_in2x2x1x1_stride2_pad1_input_padd
     //  f1: 17 - 13
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     auto input = engine.allocate_memory({ data_types::f32, format::yxfb,{ 1, 1, 2, 2 } });
@@ -858,7 +858,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in2x2x1x2_bfyx_yxfb_stride2_pad1) 
         reorder("plane_output", input_info("deconv"), format::bfyx, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -907,7 +907,7 @@ TYPED_TEST(deconvolution_basic, basic_f16_wsiz2x2_in2x2x1x2_bfyx_yxfb_stride2_pa
     auto weights = engine.allocate_memory({ data_types::f32, format::oiyx,{ 1, 1, 2, 2 } });
     auto biases = engine.allocate_memory({ data_types::f32, format::bfyx,{ 1, 1, 1, 1 } });
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     set_values(input, { FLOAT16(8.f), FLOAT16(0.5f),
@@ -996,7 +996,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in1x2x2x2_bfyx_stride2_pad1_split2
         reorder("plane_output", input_info("deconv"), format::bfyx, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1041,7 +1041,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in1x2x2x2_bfyx_stride2_pad1_group2
         reorder("plane_output", input_info("deconv"), format::bfyx, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1118,7 +1118,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in1x2x2x2_bfyx_stride2_pad1_group1
         deconvolution("deconv", input_info("reordered_input"), { "weights" }, { "bias" }, 16, { 2, 2 }, { 1, 1 }),
         reorder("plane_output", input_info("deconv"), format::bfyx, cldnn::data_types::f32));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1208,7 +1208,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in1x2x2x2_bfyx_stride2_pad1_group1
         deconvolution("deconv", input_info("reordered_input"), { "weights" }, { "bias" }, 16, { 2, 2 }, { 1, 1 }),
         reorder("plane_output", input_info("deconv"), format::bfyx, cldnn::data_types::f32));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1264,7 +1264,7 @@ TYPED_TEST(deconvolution_basic, basic_wsiz2x2_in1x6x1x1_bfyx_stride2_pad1_group2
         reorder("plane_output", input_info("deconv"), format::bfyx, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1337,7 +1337,7 @@ TYPED_TEST(deconvolution_basic_3d, basic3D_wsiz2x2x1_in1x1x2x2x1_nopad) {
         reorder("plane_output", input_info("deconv"), format::bfzyx, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1489,7 +1489,7 @@ TYPED_TEST(deconvolution_basic_3d, basic3D_wsiz3x3x3_in1x1x4x4x4_nopad) {
         reorder("plane_output", input_info("deconv"), format::bfzyx, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1583,7 +1583,7 @@ TYPED_TEST(deconvolution_basic_3d, basic3D_wsiz2x2x2_in1x1x2x2x2_stride2_nopad) 
         reorder("plane_output", input_info("deconv"), format::bfzyx, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1656,7 +1656,7 @@ TYPED_TEST(deconvolution_basic_3d, basic3D_wsiz2x2x2_in1x1x2x2x2_stride2_pad1) {
         reorder("plane_output", input_info("deconv"), format::bfzyx, cldnn::data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1719,7 +1719,7 @@ TYPED_TEST(deconvolution_basic, basic_f16_k9x9_s2x2_pad4x4) {
         reorder("plane_output", input_info("deconv"), format::bfyx, cldnn::data_types::f16)
     );
 
-    network network_ref(engine, topology_ref);
+    network network_ref(engine, topology_ref, get_test_default_config(engine));
     network_ref.set_input_data("input", input);
 
     auto outputs_ref = network_ref.execute();
@@ -1739,7 +1739,7 @@ TYPED_TEST(deconvolution_basic, basic_f16_k9x9_s2x2_pad4x4) {
         reorder("out", input_info("deconv_act"), format::bfyx, data_types::f16)
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network_act(engine, topology_act, config);
     network_act.set_input_data("input_act", input);
@@ -1797,7 +1797,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x2_b_fs_yx_fsv16_stride2_pad
             reorder("out", input_info("deconv"), format::bfyx, data_types::f32)
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc impl = { format::b_fs_yx_fsv16, "" };
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"deconv", impl} }));
@@ -1868,7 +1868,7 @@ TEST(deconvolution_f16_fw_gpu, basic_wsiz2x2_in2x2x1x2_b_fs_yx_fsv16_stride2_pad
             reorder("out", input_info("deconv"), format::bfyx, data_types::f16)
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc impl = { format::b_fs_yx_fsv16, "" };
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"deconv", impl} }));
@@ -1917,7 +1917,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in1x2x2x2_b_fs_yx_fsv16_stride2_pad
             reorder("out", input_info("deconv"), format::bfyx, data_types::f32)
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc impl = { format::b_fs_yx_fsv16, "" };
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"deconv", impl} }));
@@ -1965,7 +1965,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in1x2x2x2_b_fs_yx_fsv16_stride2_pad
             reorder("out", input_info("deconv"), format::bfyx, data_types::f32)
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc impl = { format::b_fs_yx_fsv16, "" };
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"deconv", impl} }));
@@ -2011,7 +2011,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_nopad_b_fs_yx_fsv16_dw) {
             reorder("out", input_info("deconv"), format::bfyx, data_types::f32)
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc impl = { format::b_fs_yx_fsv16, "" };
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"deconv", impl} }));
@@ -2065,7 +2065,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_pad1_b_fs_yx_fsv16_dw) {
             reorder("out", input_info("deconv"), format::bfyx, data_types::f32)
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc impl = { format::b_fs_yx_fsv16, "" };
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"deconv", impl} }));
@@ -2107,7 +2107,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_stride2_nopad_b_fs_yx_fsv
         reorder("out", input_info("deconv"), format::bfyx, data_types::f32)
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc impl = { format::b_fs_yx_fsv16, "" };
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"deconv", impl} }));
@@ -2163,7 +2163,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_stride4_pad2_b_fs_yx_fsv1
             reorder("out", input_info("deconv"), format::bfyx, data_types::f32)
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc impl = { format::b_fs_yx_fsv16, "" };
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"deconv", impl} }));
@@ -2219,7 +2219,7 @@ TEST(deconvolution_f32_fw_gpu, basic_wsiz2x2_in2x2x1x1_stride4_pad2_b_fs_yx_fsv1
             reorder("out", input_info("deconv"), format::bfyx, data_types::f32)
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc impl = { format::b_fs_yx_fsv16, "" };
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"deconv", impl} }));
@@ -2304,7 +2304,7 @@ TEST(deconvolution_f32_fw_gpu, bs_fs_zyx_bsv16_fsv16_wsiz2x2x2_in1x1x2x2x2_strid
             reorder("out", input_info("deconv"), format::bfzyx, data_types::f32)
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc impl = { format::bs_fs_zyx_bsv16_fsv16, "" };
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"deconv", impl} }));
@@ -2357,7 +2357,7 @@ void test_deconvolution_f16_fw_gpu_basic_wsiz2x2_in1x2x2x2_fs_b_yx_fsv32_stride1
             reorder("out", input_info("deconv"), format::bfyx, data_types::f32)
     );
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
@@ -2714,7 +2714,7 @@ protected:
         }
     }
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(get_test_engine());
 
 private:
     template <typename InputT, typename WeightsT, typename OutputT>
@@ -2971,8 +2971,9 @@ TEST(deconvolution_f32_fw_gpu_onednn, basic_wsiz2x2_in2x2x1x1_stride2_nopad) {
 
     ov::intel_gpu::ImplementationDesc conv_impl = { format::yxfb, "", impl_types::onednn };
 
-    ExecutionConfig cfg{ov::intel_gpu::queue_type(QueueTypes::in_order),
-                        ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"deconv", conv_impl} })};
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
+    cfg.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"deconv", conv_impl} }));
     network network(engine, topology, cfg);
     network.set_input_data("input", input);
 

--- a/src/plugins/intel_gpu/tests/test_cases/depth_concatenate_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/depth_concatenate_gpu_test.cpp
@@ -65,7 +65,7 @@ TEST(depth_concatenate_f32_gpu, test01) {
     topology.add(input_layout("input2", input2->get_layout()));
     topology.add(concatenation("depth1", { input_info("input1"), input_info("input2") }, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -127,7 +127,7 @@ void concat_basic_with_reorder() {
     topology.add(concatenation("depth1", { input_info("to_int1"), input_info("to_int2") }, 1));
     topology.add(reorder("to_float", input_info("depth1"), {data_types::f32, format::yxfb, {2, 5, 1, 1}}));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -203,7 +203,7 @@ TEST(depth_concatenate_f32_gpu, test02) {
     topology.add(input_layout("input3", input3->get_layout()));
     topology.add(concatenation("depth1", { input_info("input1"), input_info("input2"), input_info("input3") }, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -253,7 +253,7 @@ TEST(concatenate_f32_gpu, test_concatenation_of_pool_and_unpool) {
     topology.add(data("weights", weights));
     topology.add(convolution("conv", input_info("concat1"), {"weights"}));
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input1", input1);
@@ -288,7 +288,7 @@ TEST(depth_concatenate_f32_gpu, test03_cascade_concat_opt) {
     topology.add(concatenation("depth3", { input_info("relu4"), input_info("depth2") }, 1));
     topology.add(activation("relu5", input_info("depth3"), activation_func::relu));
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
 
@@ -340,7 +340,7 @@ TEST(depth_concatenate_f32_gpu, test04_fused_relu) {
     topology.add(concatenation("depth1", { input_info("input1"), input_info("input2") }, 1));
     topology.add(activation("relu1", input_info("depth1"), activation_func::relu));
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
 
@@ -394,7 +394,7 @@ TEST(depth_concatenate_f32_gpu, test05_different_formats) {
     topology.add(concatenation("depth1", { input_info("reshape1"), input_info("reshape2") }, 1));
     topology.add(reorder("output", input_info("depth1"), format::bfyx, data_types::f32));
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
 
@@ -453,7 +453,7 @@ TEST(depth_concatenate_f32_gpu, test06_padded_input) {
     topology.add(concatenation("depth2", { input_info("depth1"), input_info("conv") }, 1));
     topology.add(reorder("output", input_info("depth2"), format::bfyx, data_types::f32));
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"conv", ov::intel_gpu::ImplementationDesc{format::fs_b_yx_fsv32, ""} } }));
     network network(engine, topology, config);
@@ -529,7 +529,7 @@ TEST(depth_concatenate_f32_gpu, test07_padded_output) {
     topology.add(convolution("conv", input_info("depth1"), { "weights" }, {1, 1}, {1, 1}));
     topology.add(reorder("output", input_info("conv"), format::bfyx, data_types::f32));
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"conv", ov::intel_gpu::ImplementationDesc{format::fs_b_yx_fsv32, ""} } }));
     network network(engine, topology, config);
@@ -589,7 +589,7 @@ TEST(depth_concatenate_f32_gpu, test07_concat_is_output) {
     topology.add(activation("actv2", input_info("input2"), activation_func::linear, { 0.5f, 0.0f }));
     topology.add(concatenation("depth1", { input_info("actv1"), input_info("actv2") }, 1));
 
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
 
@@ -620,7 +620,7 @@ TEST(depth_concatenate_f32_gpu, test07_concat_is_output) {
 
 TEST(depth_concatenate_f32_gpu, concat_with_different_format_inputs) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     const int in1_f = 2, in2_f = 1;
     const int b = 2, x = 2, y = 4;
     auto input1 = engine.allocate_memory({ data_types::f32, format::yxfb,{ b, in1_f, y, x } });
@@ -704,7 +704,7 @@ TEST(depth_concatenate_f32_gpu, concat_with_different_format_inputs) {
 TEST(depth_concatenate_f32_gpu, concat_with_reshape_input) {
 
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     auto input1 = engine.allocate_memory({ data_types::f32, format::bfyx,{ 2,4,1,2 } });
 
     std::vector<float> values = {
@@ -742,7 +742,7 @@ TEST(depth_concatenate_f32_gpu, concat_with_reshape_input) {
 
 TEST(depth_concatenate_i32_gpu, optimize_data01) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     auto input = engine.allocate_memory({data_types::i32, format::bfyx, {1, 1, 1, 1}});
 
     topology topology;
@@ -769,7 +769,7 @@ TEST(depth_concatenate_i32_gpu, optimize_data01) {
 
 TEST(depth_concatenate_i32_gpu, optimize_data02) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     auto input1 = engine.allocate_memory({data_types::i32, format::bfyx, {1, 1, 2, 2}});
     auto input2 = engine.allocate_memory({data_types::i32, format::bfyx, {1, 1, 2, 2}});
     auto input3 = engine.allocate_memory({data_types::i32, format::bfyx, {1, 1, 2, 2}});
@@ -836,7 +836,7 @@ TEST(depth_concatenate_i32_gpu, optimize_data02) {
 
 TEST(depth_concatenate_i32_gpu, optimize_data03) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     auto input1 = engine.allocate_memory({data_types::i32, format::bfyx, {1, 1, 2, 2}});
 
     topology topology;
@@ -876,7 +876,7 @@ TEST(depth_concatenate_i32_gpu, optimize_data03) {
 
 TEST(depth_concatenate_i32_gpu, optimize_data04) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     auto input1 = engine.allocate_memory({data_types::i32, format::bfyx, {1, 1, 2, 2}});
 
     topology topology;
@@ -916,7 +916,7 @@ TEST(depth_concatenate_i32_gpu, optimize_data04) {
 
 TEST(depth_concatenate_i32_gpu, optimize_data05) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     auto input1 = engine.allocate_memory({data_types::i32, format::bfyx, {1, 1, 2, 2}});
 
     topology topology;
@@ -990,7 +990,7 @@ void test_depth_concatenate_f32_gpu_basic_bfwzyx_along_w(bool is_caching_test) {
 
     set_values(input1, input_data);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
 
@@ -1042,7 +1042,7 @@ static network::ptr setup_depth_concatatenate_network(const std::vector<data_typ
     //TODO: ask Uzi if something tests cases where there's missing input_names (nodes not present in the topology, etc.)
     topology.add(concatenation("depth_concat_node", input_names, 1));
 
-    return network::build_network(engine, topology);
+    return network::build_network(engine, topology, get_test_default_config(engine));
 }
 
 TEST(NegativeDepthConcatenateTest, DISABLED_TestAll) {

--- a/src/plugins/intel_gpu/tests/test_cases/depth_to_space_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/depth_to_space_gpu_test.cpp
@@ -37,7 +37,7 @@ TEST(depth_to_space_fp16_gpu, d1411_bs2) {
         depth_to_space("depth_to_space", input_info("Input0"), block_size, depth_to_space_mode::blocks_first)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input1);
 
@@ -79,7 +79,7 @@ TEST(depth_to_space_fp16_gpu, d1421_bs2) {
         depth_to_space("depth_to_space", input_info("Input0"), block_size, depth_to_space_mode::blocks_first)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input1);
 
@@ -134,7 +134,7 @@ TEST(depth_to_space_fp16_gpu, d1933_bs3) {
             depth_to_space("depth_to_space", input_info("Input0"), block_size, depth_to_space_mode::blocks_first)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input1);
 
@@ -181,7 +181,7 @@ TEST(depth_to_space_fp32_gpu, d1411_bs2) {
         depth_to_space("depth_to_space", input_info("Input0"), block_size, depth_to_space_mode::blocks_first)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input1);
 
@@ -220,7 +220,7 @@ TEST(depth_to_space_fp32_gpu, d112960540_bs2) {
         depth_to_space("depth_to_space", input_info("Input0"), block_size, depth_to_space_mode::blocks_first)
     );
 
-    network network_act(engine, topology_act);
+    network network_act(engine, topology_act, get_test_default_config(engine));
 
     network_act.set_input_data("Input0", input1);
 
@@ -288,7 +288,7 @@ TEST(depth_to_space_fp32_gpu, d1933_bs3) {
         depth_to_space("depth_to_space", input_info("Input0"), block_size, depth_to_space_mode::blocks_first)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input1);
 
@@ -343,7 +343,7 @@ TEST(depth_to_space_fp32_gpu, d1822_bs2_blocks_first) {
         depth_to_space("depth_to_space", input_info("Input0"), block_size, depth_to_space_mode::blocks_first)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input1);
 
@@ -393,7 +393,7 @@ void test_depth_to_space_fp32_gpu_d1822_bs2_depth_first(bool is_caching_test) {
         depth_to_space("depth_to_space", input_info("Input0"), block_size, depth_to_space_mode::depth_first)
     );
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("Input0", input1);
 

--- a/src/plugins/intel_gpu/tests/test_cases/detection_output_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/detection_output_test.cpp
@@ -147,7 +147,7 @@ public:
 
         topology.add(detection_output("detection_output", input_info("input_location"), input_info("input_confidence"), input_info("input_prior_box"), this->num_classes, keep_top_k));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input_location", input_location);
         network->set_input_data("input_confidence", input_confidence);
@@ -182,7 +182,7 @@ public:
         topology.add(detection_output("detection_output_1", input_info("input_location"), input_info("input_confidence"), input_info("input_prior_box"), this->num_classes, keep_top_k));
         topology.add(detection_output("detection_output_2", input_info("input_location"), input_info("input_confidence"), input_info("input_prior_box"), this->num_classes, keep_top_k));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input_location", input_location);
         network->set_input_data("input_confidence", input_confidence);
@@ -224,7 +224,7 @@ public:
 
         topology.add(detection_output("detection_output", input_info("input_location"), input_info("input_confidence"), input_info("input_prior_box"), this->num_classes, keep_top_k, share_location, background_label_id, this->nms_threshold));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input_location", input_location);
         network->set_input_data("input_confidence", input_confidence);
@@ -272,7 +272,7 @@ public:
 
         topology.add(detection_output("detection_output", input_info("input_location"), input_info("input_confidence"), input_info("input_prior_box"), this->num_classes, keep_top_k, share_location, background_label_id, this->nms_threshold));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input_location", input_location);
         network->set_input_data("input_confidence", input_confidence);
@@ -314,7 +314,7 @@ public:
 
         topology.add(detection_output("detection_output", input_info("input_location"), input_info("input_confidence"), input_info("input_prior_box"), this->num_classes, keep_top_k, share_location, background_label_id, this->nms_threshold));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input_location", input_location);
         network->set_input_data("input_confidence", input_confidence);
@@ -367,7 +367,7 @@ public:
 
         topology.add(detection_output("detection_output", input_info("input_location"), input_info("input_confidence"), input_info("input_prior_box"), this->num_classes, keep_top_k, share_location, background_label_id, this->nms_threshold, top_k));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input_location", input_location);
         network->set_input_data("input_confidence", input_confidence);
@@ -430,7 +430,7 @@ public:
             prior_coordinates_offset, prior_is_normalized, input_width, input_height, decrease_label_id
         ));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input_location", input_location);
         network->set_input_data("input_confidence", input_confidence);
@@ -480,7 +480,7 @@ public:
 
         topology.add(detection_output("detection_output", input_info("input_location"), input_info("input_confidence"), input_info("input_prior_box"), this->num_classes, keep_top_k, share_location, background_label_id, this->nms_threshold));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input_location", input_location);
         network->set_input_data("input_confidence", input_confidence);
@@ -541,7 +541,7 @@ public:
 
         topology.add(detection_output("detection_output", input_info("input_location"), input_info("input_confidence"), input_info("input_prior_box"), this->num_classes, keep_top_k, share_location, background_label_id, this->nms_threshold, top_k));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input_location", input_location);
         network->set_input_data("input_confidence", input_confidence);
@@ -589,7 +589,7 @@ public:
 
         topology.add(detection_output("detection_output", input_info("input_location"), input_info("input_confidence"), input_info("input_prior_box"), this->num_classes, keep_top_k, share_location, background_label_id, this->nms_threshold));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input_location", input_location);
         network->set_input_data("input_confidence", input_confidence);
@@ -640,7 +640,7 @@ public:
 
         topology.add(detection_output("detection_output", input_info("input_location"), input_info("input_confidence"), input_info("input_prior_box"), this->num_classes, keep_top_k, share_location, background_label_id, this->nms_threshold, top_k));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input_location", input_location);
         network->set_input_data("input_confidence", input_confidence);
@@ -686,7 +686,7 @@ public:
 
         topology.add(detection_output("detection_output", input_info("input_location_padded"), input_info("input_confidence_padded"), input_info("input_prior_box"), this->num_classes, keep_top_k, share_location, background_label_id, this->nms_threshold, top_k));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input_location", input_location);
         network->set_input_data("input_confidence", input_confidence);
@@ -749,7 +749,7 @@ public:
             prior_is_normalized, this->img_size, this->img_size
         ));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input_location", input_location);
         network->set_input_data("input_confidence", input_confidence);

--- a/src/plugins/intel_gpu/tests/test_cases/dft_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/dft_gpu_test.cpp
@@ -118,7 +118,7 @@ public:
         // It's simpler to use "bfwzyx" format for all cases, as input and output can have different ranks
         topology.add(reorder("out", input_info("dft"), format::bfwzyx, data_type));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
         const auto outputs = network->execute();
@@ -2054,7 +2054,7 @@ TEST(dft_gpu_test, irdft_output_shape) {
         topology.add(dft("dft", input_info("reorder_input"), p.axes, p.signal_size, p.output_shape, type.direction, type.mode));
 
         {
-            network network(engine, topology);
+            network network(engine, topology, get_test_default_config(engine));
             network.set_input_data("input", input);
             const auto outputs = network.execute();
 
@@ -2069,7 +2069,7 @@ TEST(dft_gpu_test, irdft_output_shape) {
 
         topology.add(reorder("out", input_info("dft"), format::bfwzyx, data_type));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
         network.set_input_data("input", input);
         const auto outputs = network.execute();
 

--- a/src/plugins/intel_gpu/tests/test_cases/eltwise_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/eltwise_gpu_test.cpp
@@ -102,7 +102,7 @@ void generic_eltwise_test(cldnn::format test_input_fmt, int input_b, int input_f
         topology.add(activation("out", out_id, activation_func::relu, { slope, 0.0f }));
         out_id = "out";
     }
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
@@ -240,7 +240,7 @@ void generic_eltwise_bool_test(cldnn::format test_input_fmt, int input_b, int in
     topology.add(reorder("reorder1", input_info("input1"), input1->get_layout().with_padding(padding{{ 0, 0, input_padding_x, input_padding_y }, 0 })));
     topology.add(eltwise("eltwise", { input_info("reorder1"), input_info("input2") }, mode, DEFAULT_BROADCAST_SPEC, padding{ { 0, 0, output_padding_x, output_padding_y }, 0 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
     auto outputs = network.execute();
@@ -343,7 +343,7 @@ TEST(eltwise_gpu_f32, equal_in2_float_out1_int) {
     topology.add(input_layout("input2", input2->get_layout()));
     topology.add(eltwise("eltwise", { input_info("input"), input_info("input2") }, eltwise_mode::eq));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input1);
     network.set_input_data("input2", input2);
@@ -413,7 +413,7 @@ TEST(eltwise_gpu_f32, not_equal_in2_float_out1_int) {
     topology.add(input_layout("input2", input2->get_layout()));
     topology.add(eltwise("eltwise", { input_info("input"), input_info("input2") }, eltwise_mode::ne));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input1);
     network.set_input_data("input2", input2);
@@ -483,7 +483,7 @@ TEST(eltwise_gpu_f32, less_in2_float_out1_int) {
     topology.add(input_layout("input2", input2->get_layout()));
     topology.add(eltwise("eltwise", { input_info("input"), input_info("input2") }, eltwise_mode::lt));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input1);
     network.set_input_data("input2", input2);
@@ -553,7 +553,7 @@ TEST(eltwise_gpu_f32, less_equal_in2_float_out1_int) {
     topology.add(input_layout("input2", input2->get_layout()));
     topology.add(eltwise("eltwise", { input_info("input"), input_info("input2") }, eltwise_mode::le));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input1);
     network.set_input_data("input2", input2);
@@ -623,7 +623,7 @@ TEST(eltwise_gpu_f32, greater_in2_float_out1_int) {
     topology.add(input_layout("input2", input2->get_layout()));
     topology.add(eltwise("eltwise", { input_info("input"), input_info("input2") }, eltwise_mode::gt));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input1);
     network.set_input_data("input2", input2);
@@ -693,7 +693,7 @@ TEST(eltwise_gpu_f32, greater_equal_in2_float_out1_int) {
     topology.add(input_layout("input2", input2->get_layout()));
     topology.add(eltwise("eltwise", { input_info("input"), input_info("input2") }, eltwise_mode::ge));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input1);
     network.set_input_data("input2", input2);
@@ -763,7 +763,7 @@ TEST(eltwise_gpu_f32, logicalAND_in2_float_out1_int) {
     topology.add(input_layout("input2", input2->get_layout()));
     topology.add(eltwise("eltwise", { input_info("input"), input_info("input2") }, eltwise_mode::logic_and));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input1);
     network.set_input_data("input2", input2);
@@ -849,7 +849,7 @@ TEST(eltwise_gpu_f32, logicalAND_in3_float_out1_int) {
     topology.add(input_layout("input3", input2->get_layout()));
     topology.add(eltwise("eltwise", { input_info("input"), input_info("input2"), input_info("input3") }, eltwise_mode::logic_and));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input1);
     network.set_input_data("input2", input2);
@@ -920,7 +920,7 @@ TEST(eltwise_gpu_f32, logicalOR_in2_float_out1_int) {
     topology.add(input_layout("input2", input2->get_layout()));
     topology.add(eltwise("eltwise", { input_info("input"), input_info("input2") }, eltwise_mode::logic_or));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input1);
     network.set_input_data("input2", input2);
@@ -1006,7 +1006,7 @@ TEST(eltwise_gpu_f32, logicalOR_in3_float_out1_int) {
     topology.add(input_layout("input3", input2->get_layout()));
     topology.add(eltwise("eltwise", { input_info("input"), input_info("input2"), input_info("input3") }, eltwise_mode::logic_or));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input1);
     network.set_input_data("input2", input2);
@@ -1077,7 +1077,7 @@ TEST(eltwise_gpu_f32, logicalXOR_in2_float_out1_int) {
     topology.add(input_layout("input2", input2->get_layout()));
     topology.add(eltwise("eltwise", { input_info("input"), input_info("input2") }, eltwise_mode::logic_xor));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input1);
     network.set_input_data("input2", input2);
@@ -1128,7 +1128,7 @@ TEST(eltwise_gpu_f32, isfinite_in1_float_out1_int) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(eltwise("eltwise", {input_info("input")}, eltwise_mode::is_finite));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     const auto outputs = network.execute();
@@ -1183,7 +1183,7 @@ TEST(eltwise_gpu_f32, isinf_in1_float_out1_int) {
         topology.add(input_layout("input", input->get_layout()));
         topology.add(eltwise("eltwise", {input_info("input")}, eltwise_mode::is_inf, coefficients, data_types::i8));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
         network.set_input_data("input", input);
 
         const auto outputs = network.execute();
@@ -1227,7 +1227,7 @@ TEST(eltwise_gpu_f32, isnan_in1_float_out1_int) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(eltwise("eltwise", {input_info("input")}, eltwise_mode::is_nan));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     const auto outputs = network.execute();
@@ -1270,7 +1270,7 @@ TEST(eltwise_gpu_f32, dynamic_kernel_no_broadcast) {
         15.f,  17.f,    8.f,  10.f,
         -2.f,  6.5f,  -0.5f, -2.5f });
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
     network.set_input_data("input1", input1);
@@ -1326,7 +1326,7 @@ TEST(eltwise_gpu_f32, dynamic_kernel_broadcast) {
 
     set_values(input2, { 0.5f, -0.5f });
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
     network.set_input_data("input1", input1);
@@ -1403,7 +1403,7 @@ TEST(eltwise_gpu_f32, add_basic_in4x4x2x2) {
         15.f,  17.f,    8.f,  10.f,
         -2.f,  6.5f,  -0.5f, -2.5f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1459,7 +1459,7 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_channel) {
          -2.f,  6.5f,
         -0.5f, -2.5f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1528,7 +1528,7 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_x) {
         -0.5f,
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1591,7 +1591,7 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_y) {
         4.f, -0.5f,
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1656,7 +1656,7 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_batch) {
         4.f, -0.5f,
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1715,7 +1715,7 @@ TEST(eltwise_gpu_f32, add_in2x2x2x2_broadcast_multiple_dims) {
             1.f,
             2.f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1772,7 +1772,7 @@ TEST(eltwise_gpu_f32, pow_in2x2x2x2_broadcast_all) {
 
     set_values(input2, { 2.0f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1849,7 +1849,7 @@ TEST(eltwise_gpu_f32, add_basic_in2x2x2x2_broadcast_2_inputs_same_dim) {
         -4.f, 0.5f,
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1925,7 +1925,7 @@ TEST(eltwise_gpu_f32, add_basic_in2x2x2x2_broadcast_2_inputs_diff_dim) {
         -4.f, 0.5f,
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2003,7 +2003,7 @@ TEST(eltwise_gpu_f32, max_basic_in4x4x4x4) {
         15.f,  17.f,   8.f,  10.f,
          6.f,   8.f, -0.5f, -2.5f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2074,7 +2074,7 @@ TEST(eltwise_gpu_f32, sub_basic_in4x4x4x4) {
        15.f,  17.f,   8.f,   8.5f,
         6.f,   8.f, -0.5f,  10.5f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2145,7 +2145,7 @@ TEST(eltwise_gpu_int, basic_in4x4x4x4) {
                 6.f,   8.f, 0.f,  10.f };
             set_values(input2, input_2_vec);
 
-            network network(engine, topology);
+            network network(engine, topology, get_test_default_config(engine));
             network.set_input_data("input", input);
             network.set_input_data("input2", input2);
             auto outputs = network.execute();
@@ -2223,7 +2223,7 @@ TEST(eltwise_gpu_f32_int, basic_in4x4x4x4) {
                 6.f,   8.f, 0.f,  10.f };
             set_values(input2, input_2_vec);
 
-            network network(engine, topology);
+            network network(engine, topology, get_test_default_config(engine));
             network.set_input_data("input", input);
             network.set_input_data("input2", input2);
             auto outputs = network.execute();
@@ -2304,7 +2304,7 @@ TEST(eltwise_gpu_f32, prod_basic_in4x4x4x4) {
         2.5f,   7.f,  17.f,    8.f,
         2.5f,   4.f,  10.f,   -2.5f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2378,7 +2378,7 @@ TEST(eltwise_gpu_f32, max_basic_in4x4x4x4_input_padding) {
         15.f,  17.f,   8.f,  10.f,
         6.f,   8.f, -0.5f, -2.5f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2450,7 +2450,7 @@ TEST(eltwise_gpu_f32, add_basic_in4x4x2x2_with_coefficients) {
             15.f,  17.f,    8.f,  10.f,
             -2.f,  6.5f,  -0.5f, -2.5f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2566,7 +2566,7 @@ TEST(eltwise_gpu_f32, add_basic_in4x4x2x2_with_coefficients_3inputs) {
             6.f,  0.f,  2.f, 0.f,
             5.f,  1.f,  1.f, 1.f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2656,7 +2656,7 @@ TEST(eltwise_gpu_f32, max_3inputs_in4x4x4x4_input_padding) {
         15.f,  3.f,  9.f, 1.f,
         -1.f,  6.f, 0.5f, 8.f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2746,7 +2746,7 @@ TEST(eltwise_gpu_f32, stride_test_2x2) {
         15, 31, 47, 63,
         16, 32, 48, 64 });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2814,7 +2814,7 @@ TEST(eltwise_gpu_f32, broadcast_test_in4x4x2x2) {
         0.5f,   2.5f,  0.5f,  2.5f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2882,7 +2882,7 @@ TEST(eltwise_gpu_f16, fs_b_yx_fsv32_basic)
     golden_topology.add(input_layout("input2", input2->get_layout()));
     golden_topology.add(eltwise("eltwise", input_info("input1"), input_info("input2"), eltwise_mode::sum));
 
-    network golden_network(engine, golden_topology);
+    network golden_network(engine, golden_topology, get_test_default_config(engine));
     golden_network.set_input_data("input1", input1);
     golden_network.set_input_data("input2", input2);
 
@@ -2899,7 +2899,7 @@ TEST(eltwise_gpu_f16, fs_b_yx_fsv32_basic)
     FSV32_topology.add(eltwise("eltwise", input_info("reorder1"), input_info("reorder2"), eltwise_mode::sum));
     FSV32_topology.add(reorder("reorderOutput", input_info("eltwise"), layout(data_types::f16, format::bfyx, input_tensor)));
 
-    network FSV32_network(engine, FSV32_topology);
+    network FSV32_network(engine, FSV32_topology, get_test_default_config(engine));
     FSV32_network.set_input_data("input1", input1);
     FSV32_network.set_input_data("input2", input2);
 
@@ -2949,7 +2949,7 @@ TEST(eltwise_gpu_f16, fs_b_yx_fsv32_broadcast)
     ref_topology.add(input_layout("input2", input2->get_layout()));
     ref_topology.add(eltwise("eltwise", input_info("input1"), input_info("input2"), eltwise_mode::prod));
 
-    network ref_network(engine, ref_topology);
+    network ref_network(engine, ref_topology, get_test_default_config(engine));
     ref_network.set_input_data("input1", input1);
     ref_network.set_input_data("input2", input2);
 
@@ -2965,7 +2965,7 @@ TEST(eltwise_gpu_f16, fs_b_yx_fsv32_broadcast)
     fsv32_topology.add(eltwise("eltwise", input_info("reorder1"), input_info("reorder2"), eltwise_mode::prod));
     fsv32_topology.add(reorder("reorder_bfyx", input_info("eltwise"), layout(data_types::f16, format::bfyx, input1_tensor)));
 
-    network fsv32_network(engine, fsv32_topology);
+    network fsv32_network(engine, fsv32_topology, get_test_default_config(engine));
     fsv32_network.set_input_data("input1", input1);
     fsv32_network.set_input_data("input2", input2);
 
@@ -3013,7 +3013,7 @@ TEST(eltwise_gpu_f16, fs_b_yx_fsv32_broadcast_bfyx)
     ref_topology.add(input_layout("input2", input2->get_layout()));
     ref_topology.add(eltwise("eltwise", input_info("input1"), input_info("input2"), eltwise_mode::prod));
 
-    network ref_network(engine, ref_topology);
+    network ref_network(engine, ref_topology, get_test_default_config(engine));
     ref_network.set_input_data("input1", input1);
     ref_network.set_input_data("input2", input2);
 
@@ -3028,7 +3028,7 @@ TEST(eltwise_gpu_f16, fs_b_yx_fsv32_broadcast_bfyx)
     fsv32_topology.add(eltwise("eltwise", input_info("reorder1"), input_info("input2"), eltwise_mode::prod));
     fsv32_topology.add(reorder("reorder_bfyx", input_info("eltwise"), layout(data_types::f16, format::bfyx, input1_tensor)));
 
-    network fsv32_network(engine, fsv32_topology);
+    network fsv32_network(engine, fsv32_topology, get_test_default_config(engine));
     fsv32_network.set_input_data("input1", input1);
     fsv32_network.set_input_data("input2", input2);
 
@@ -3067,7 +3067,7 @@ TEST(eltwise_gpu_f32, broadcast_test_in4x4x2x2x2) {
 
     set_values(input2, { 0.5f, 2.5f, 0.5f, 2.5f, 1.f, 2.f, 3.f, 4.f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -3124,7 +3124,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_basic)
     golden_topology.add(input_layout("input2", input2->get_layout()));
     golden_topology.add(eltwise("eltwise", input_info("input1"), input_info("input2"), eltwise_mode::sum));
 
-    network golden_network(engine, golden_topology);
+    network golden_network(engine, golden_topology, get_test_default_config(engine));
     golden_network.set_input_data("input1", input1);
     golden_network.set_input_data("input2", input2);
 
@@ -3141,7 +3141,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_basic)
     FS_B_YX_FSV32_OUTPUT_topology.add(eltwise("eltwise", input_info("reorder1"), input_info("reorder2"), eltwise_mode::sum));
     FS_B_YX_FSV32_OUTPUT_topology.add(reorder("reorderOutput", input_info("eltwise"), layout(data_types::f16, format::bfyx, input_tensor)));
 
-    network FS_B_YX_FSV32_OUTPUT_network(engine, FS_B_YX_FSV32_OUTPUT_topology);
+    network FS_B_YX_FSV32_OUTPUT_network(engine, FS_B_YX_FSV32_OUTPUT_topology, get_test_default_config(engine));
     FS_B_YX_FSV32_OUTPUT_network.set_input_data("input1", input1);
     FS_B_YX_FSV32_OUTPUT_network.set_input_data("input2", input2);
 
@@ -3158,7 +3158,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_basic)
     BYXF_OUTPUT_topology.add(eltwise("eltwise", input_info("reorder1"), input_info("reorder2"), eltwise_mode::sum));
     BYXF_OUTPUT_topology.add(reorder("reorderOutput", input_info("eltwise"), layout(data_types::f16, format::bfyx, input_tensor)));
 
-    network BYXF_OUTPUT_network(engine, BYXF_OUTPUT_topology);
+    network BYXF_OUTPUT_network(engine, BYXF_OUTPUT_topology, get_test_default_config(engine));
     BYXF_OUTPUT_network.set_input_data("input1", input1);
     BYXF_OUTPUT_network.set_input_data("input2", input2);
 
@@ -3204,7 +3204,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_output_padding) {
     golden_topology.add(input_layout("input2", input2->get_layout()));
     golden_topology.add(eltwise("eltwise", input_info("input1"), input_info("input2"), eltwise_mode::sum, DEFAULT_BROADCAST_SPEC, padding{ {0,0,5,10} , 0 }));
 
-    network golden_network(engine, golden_topology);
+    network golden_network(engine, golden_topology, get_test_default_config(engine));
     golden_network.set_input_data("input1", input1);
     golden_network.set_input_data("input2", input2);
 
@@ -3222,7 +3222,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_output_padding) {
     FS_B_YX_FSV32_OUTPUT_topology.add(reorder("reorderOutput", input_info("eltwise"), layout(data_types::f16, format::bfyx, input_tensor,
                                               padding{ {0,0,5,10} , 0 })));
 
-    network FS_B_YX_FSV32_OUTPUT_network(engine, FS_B_YX_FSV32_OUTPUT_topology);
+    network FS_B_YX_FSV32_OUTPUT_network(engine, FS_B_YX_FSV32_OUTPUT_topology, get_test_default_config(engine));
     FS_B_YX_FSV32_OUTPUT_network.set_input_data("input1", input1);
     FS_B_YX_FSV32_OUTPUT_network.set_input_data("input2", input2);
 
@@ -3240,7 +3240,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_output_padding) {
     BYXF_OUTPUT_topology.add(reorder("reorderOutput", input_info("eltwise"), layout(data_types::f16, format::bfyx, input_tensor,
                                      padding{ {0,0,5,10} , 0 })));
 
-    network BYXF_OUTPUT_network(engine, BYXF_OUTPUT_topology);
+    network BYXF_OUTPUT_network(engine, BYXF_OUTPUT_topology, get_test_default_config(engine));
     BYXF_OUTPUT_network.set_input_data("input1", input1);
     BYXF_OUTPUT_network.set_input_data("input2", input2);
 
@@ -3289,7 +3289,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_input_padding)
     golden_topology.add(reorder("reorder2", input_info("input2"), layout(data_types::f16, format::bfyx, input_tensor, padding{ {0,0,5,7},0.0f })));
     golden_topology.add(eltwise("eltwise", input_info("input1"), input_info("input2"), eltwise_mode::sum));
 
-    network golden_network(engine, golden_topology);
+    network golden_network(engine, golden_topology, get_test_default_config(engine));
     golden_network.set_input_data("input1", input1);
     golden_network.set_input_data("input2", input2);
 
@@ -3306,7 +3306,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_input_padding)
     FS_B_YX_FSV32_OUTPUT_topology.add(eltwise("eltwise", input_info("reorder1"), input_info("reorder2"), eltwise_mode::sum));
     FS_B_YX_FSV32_OUTPUT_topology.add(reorder("reorderOutput", input_info("eltwise"), layout(data_types::f16, format::bfyx, input_tensor)));
 
-    network FS_B_YX_FSV32_OUTPUT_network(engine, FS_B_YX_FSV32_OUTPUT_topology);
+    network FS_B_YX_FSV32_OUTPUT_network(engine, FS_B_YX_FSV32_OUTPUT_topology, get_test_default_config(engine));
     FS_B_YX_FSV32_OUTPUT_network.set_input_data("input1", input1);
     FS_B_YX_FSV32_OUTPUT_network.set_input_data("input2", input2);
 
@@ -3323,7 +3323,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_input_padding)
     BYXF_OUTPUT_topology.add(eltwise("eltwise", input_info("reorder1"), input_info("reorder2"), eltwise_mode::sum));
     BYXF_OUTPUT_topology.add(reorder("reorderOutput", input_info("eltwise"), layout(data_types::f16, format::bfyx, input_tensor)));
 
-    network BYXF_OUTPUT_network(engine, BYXF_OUTPUT_topology);
+    network BYXF_OUTPUT_network(engine, BYXF_OUTPUT_topology, get_test_default_config(engine));
     BYXF_OUTPUT_network.set_input_data("input1", input1);
     BYXF_OUTPUT_network.set_input_data("input2", input2);
 
@@ -3455,7 +3455,7 @@ TEST(eltwise_gpu, b_fs_yx_fsv4_wo_callib) {
                          eltw, actv);
 
             // Network processing
-            network network(engine, topology);
+            network network(engine, topology, get_test_default_config(engine));
             network.set_input_data("input1", input1);
             network.set_input_data("input2", input2);
             network.set_input_data("input3", input3);
@@ -3511,7 +3511,7 @@ TEST(eltwise_gpu, b_fs_yx_fsv4_wo_callib) {
                                      { in_B, in_F, in_X, in_Y })));
 
             // Network processing
-            network network(engine, topology);
+            network network(engine, topology, get_test_default_config(engine));
             network.set_input_data("input1", input1);
             network.set_input_data("input2", input2);
             network.set_input_data("input3", input3);
@@ -3671,7 +3671,7 @@ struct eltwise_same_input_test : testing::TestWithParam<eltwise_same_input_test_
         auto prim = eltwise("eltwise", { input_info("input1"), input_info("input2") }, eltwise_mode::sum);
         topo.add(prim);
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"eltwise"}));
 
         cldnn::network net(engine, topo, config);
@@ -3835,7 +3835,7 @@ TEST_P(eltwise_test, fsv16) {
     topology.add(reorder("out", input_info("eltwise"), fmt_pln, data_types::f32));
     primitive_id out_id = "out";
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
 
@@ -3941,7 +3941,7 @@ TEST_P(eltwise_test_6d, bfwzyx) {
     topology.add(reorder("out", input_info("eltwise"), format::bfwzyx, data_types::f32));
     primitive_id out_id = "out";
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
 
@@ -4026,7 +4026,7 @@ TEST_P(eltwise_test_mixed_precision, fsv16) {
     topology.add(reorder("out", input_info("eltwise"), fmt_pln, data_types::f32));
     primitive_id out_id = "out";
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
 
@@ -4131,7 +4131,7 @@ TEST_P(eltwise_test_mixed_layout, mixed_layout) {
     topology.add(reorder("out", input_info("eltwise"), format::bfyx, data_types::f32));
     primitive_id out_id = "out";
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -4278,7 +4278,7 @@ struct eltwise_random_test : testing::TestWithParam<eltwise_random_test_params>
         auto prim = eltwise("eltwise", { input_info("input1"), input_info("input2") }, params.mode);
         topo.add(prim);
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"eltwise"}));
         config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"eltwise", {params.in_format, "generic_eltwise_ref"}} }));
 
@@ -4295,7 +4295,7 @@ struct eltwise_random_test : testing::TestWithParam<eltwise_random_test_params>
         auto prim_opt = eltwise("eltwise_opt", { input_info("input1"), input_info("input2") }, params.mode);
         topo_opt.add(prim_opt);
 
-        ExecutionConfig config_opt;
+        ExecutionConfig config_opt = get_test_default_config(engine);
         config_opt.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"eltwise_opt"}));
 
         cldnn::network::ptr net_opt = get_network(engine, topo_opt, config_opt, get_test_stream_ptr(), is_caching_test);

--- a/src/plugins/intel_gpu/tests/test_cases/embedding_bag_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/embedding_bag_gpu_test.cpp
@@ -53,7 +53,7 @@ TEST(embedding_bag_fp16_gpu, packed_sum_basic) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2") }, type, output_shape)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -106,7 +106,7 @@ TEST(embedding_bag_fp16_gpu, packed_sum_basic_without_weights) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1") }, type, output_shape)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -187,7 +187,7 @@ TEST(embedding_bag_fp16_gpu, packed_sum_dim2) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2") }, type, output_shape)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -310,7 +310,7 @@ TEST(embedding_bag_fp16_gpu, packed_sum_dim3) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2") }, type, output_shape)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -404,7 +404,7 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_basic) {
     topology.add(
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2"), input_info("Input3") }, type, output_shape, 0)
     );
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -469,7 +469,7 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_basic_first_empty) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2"), input_info("Input3") }, type, output_shape, 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -534,7 +534,7 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_basic_last_empty) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2"), input_info("Input3") }, type, output_shape, 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -592,7 +592,7 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_without_weights_and_def_index) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2") }, type, output_shape)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -707,7 +707,7 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_dim3) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2"), input_info("Input3") }, type, output_shape, 0)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -803,7 +803,7 @@ TEST(embedding_bag_fp16_gpu, segments_sum_basic) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2"), input_info("Input3") }, type, output_shape, 0)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -868,7 +868,7 @@ TEST(embedding_bag_fp16_gpu, segments_sum_basic_first_empty) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2"), input_info("Input3") }, type, output_shape, 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -933,7 +933,7 @@ TEST(embedding_bag_fp16_gpu, segments_sum_basic_last_empty) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2"), input_info("Input3") }, type, output_shape, 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -991,7 +991,7 @@ TEST(embedding_bag_fp16_gpu, segments_sum_without_weights_and_def_index) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2") }, type, output_shape)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -1106,7 +1106,7 @@ TEST(embedding_bag_fp16_gpu, segments_sum_dim3) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2"), input_info("Input3") }, type, output_shape, 0)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -1199,7 +1199,7 @@ TEST(embedding_bag_fp32_gpu, packed_sum_basic) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2") }, type, output_shape)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -1309,7 +1309,7 @@ TEST(embedding_bag_fp32_gpu, packed_sum_dim3) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2") }, type, output_shape)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
     network.set_input_data("Input1", indices);
@@ -1394,7 +1394,7 @@ void test_embedding_bag_fp32_gpu_extended5_6(bool is_caching_test) {
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2") }, type, output_shape)
     );
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("Input0", emb_table);
     network->set_input_data("Input1", indices);

--- a/src/plugins/intel_gpu/tests/test_cases/empty_tensor_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/empty_tensor_gpu_test.cpp
@@ -44,7 +44,7 @@ TEST_P(test_empty_tensor, concat_two_inputs) {
     topology.add(gather_nonzero("gather_nonzero", input_info("nonzero_input"), input_info("count_nonzero")));
     topology.add(concatenation("concat", { input_info("gather_nonzero"), input_info("concat_data") }, p.concat_axis));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);

--- a/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_detection_output_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_detection_output_gpu_test.cpp
@@ -143,7 +143,7 @@ public:
         const primitive_id eddo_id = "experimental_detectron_detection_output";
         topology.add(reorder(eddo_id, input_info(b_eddo_primitive) /*b_eddo_id*/, format::bfyx, data_type));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data(input_boxes_id, input_boxes);
         network->set_input_data(input_deltas_id, input_deltas);
@@ -159,7 +159,7 @@ public:
         cldnn::topology reorder_score_topology;
         reorder_score_topology.add(input_layout(b_output_scores_id, output_scores_layout));
         reorder_score_topology.add(reorder(output_scores_id, input_info(b_output_scores_id), format::bfyx, data_type));
-        cldnn::network reorder_score_net{engine, reorder_score_topology};
+        cldnn::network reorder_score_net{engine, reorder_score_topology, get_test_default_config(engine)};
         reorder_score_net.set_input_data(b_output_scores_id, b_output_scores);
         const auto score_result = reorder_score_net.execute();
         const auto output_scores = score_result.at(output_scores_id).get_memory();
@@ -170,7 +170,7 @@ public:
         cldnn::topology reorder_classes_topology;
         reorder_classes_topology.add(input_layout(b_output_classes_id, output_classes_layout));
         reorder_classes_topology.add(reorder(output_classes_id, input_info(b_output_classes_id), format::bfyx, data_types::i32));
-        cldnn::network reorder_classes_net{engine, reorder_classes_topology};
+        cldnn::network reorder_classes_net{engine, reorder_classes_topology, get_test_default_config(engine)};
         reorder_classes_net.set_input_data(b_output_classes_id, b_output_classes);
         const auto classes_result = reorder_classes_net.execute();
         const auto output_classes = classes_result.at(output_classes_id).get_memory();

--- a/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_generate_proposals_single_image_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_generate_proposals_single_image_gpu_test.cpp
@@ -241,7 +241,7 @@ public:
         const primitive_id reorder_result_id = edgpsi_id + "Reordered";
         topology.add(reorder(reorder_result_id, input_info(edgpsi_primitive), format::bfyx, data_type));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data(input_im_info_id, input_im_info);
         network->set_input_data(input_anchors_id, input_anchors);
@@ -258,7 +258,7 @@ public:
         cldnn::topology reorder_topology;
         reorder_topology.add(input_layout("scores", rois_scores_layout));
         reorder_topology.add(reorder("plane_scores", input_info("scores"), format::bfyx, data_type));
-        cldnn::network reorder_net{engine, reorder_topology};
+        cldnn::network reorder_net{engine, reorder_topology, get_test_default_config(engine)};
         reorder_net.set_input_data("scores", output_roi_scores);
         const auto second_output_result = reorder_net.execute();
         const auto plane_data_mem = second_output_result.at("plane_scores").get_memory();

--- a/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_prior_grid_generator_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_prior_grid_generator_gpu_test.cpp
@@ -62,7 +62,7 @@ public:
                                                                  params.imageShape.first,
                                                                  params.imageShape.second));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), params.is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), params.is_caching_test);
 
         network->set_input_data(priors_id, prior_input);
 

--- a/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_roi_feature_extractor_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_roi_feature_extractor_gpu_test.cpp
@@ -53,7 +53,7 @@ void test_experimental_detectron_roi_feature_extractor_gpu_fp32_one_level(bool i
     topology.add(activation(activation_abs_id, feature_extractor_id,  activation_func::abs));
     topology.add(mutable_data(second_output_r_id, {feature_extractor_id}, second_output));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data(input_rois_id, roi_input);
     network->set_input_data(input_level_1_id, level_1);
@@ -150,7 +150,7 @@ TEST(experimental_detectron_roi_feature_extractor_gpu_fp32, two_levels) {
     topology.add(activation(activation_abs_id, feature_extractor_id, activation_func::abs));
     topology.add(mutable_data(second_output_r_id, {feature_extractor_id}, second_output));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data(input_rois_id, roi_input);
     network.set_input_data(input_level_1_id, level_1);
@@ -246,7 +246,7 @@ TEST(experimental_detectron_roi_feature_extractor_gpu_fp32, multiple_feature_ext
     topology.add(activation(activation_abs_second_instance_id, input_info(feature_extractor_second_instance_id),  activation_func::abs));
     topology.add(mutable_data(second_output_r_second_instance_id, { input_info(feature_extractor_second_instance_id) }, second_output_second_instance));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data(input_rois_first_instance_id, roi_input_first_instance);
     network.set_input_data(input_rois_second_instance_id, roi_input_second_instance);

--- a/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_topk_rois_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/experimental_detectron_topk_rois_gpu_test.cpp
@@ -80,7 +80,7 @@ TYPED_TEST(experimental_detectron_topk_rois_gpu_test, check_set_indices_layer) {
                                                   rois_num));
     topology.add(reorder("plane_output", experimental_detectron_topk_rois_id, format::bfyx, this->data_type));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data(input_rois_id, roi_input);
     network.set_input_data(input_indices_id, roi_indices);
@@ -118,7 +118,7 @@ TYPED_TEST(experimental_detectron_topk_rois_gpu_test, check_set_indices_layer_mo
                                                   rois_num));
     topology.add(reorder("plane_output", input_info(experimental_detectron_topk_rois_id), format::bfyx, this->data_type));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data(input_rois_id, roi_input);
     network.set_input_data(input_indices_id, roi_indices);
@@ -159,7 +159,7 @@ TEST(experimental_detectron_topk_rois_gpu_test, export_import) {
                                                   rois_num));
     topology.add(reorder("plane_output", input_info(experimental_detectron_topk_rois_id), format::bfyx, test_data_type));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), true);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), true);
 
     network->set_input_data(input_rois_id, roi_input);
     network->set_input_data(input_indices_id, roi_indices);

--- a/src/plugins/intel_gpu/tests/test_cases/extract_image_patches_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/extract_image_patches_gpu_test.cpp
@@ -41,7 +41,7 @@ TEST(extract_image_patches_gpu, basic) {
     topology.add(input_layout("Input0", input->get_layout()));
     topology.add(extract_image_patches("extract_image_patches", input_info("Input0"), sizes, strides, rates, auto_pad, output_shape));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("Input0", input);
     auto outputs = network.execute();
 
@@ -115,7 +115,7 @@ TEST(extract_image_patches_gpu, basic2) {
     topology.add(input_layout("Input0", input->get_layout()));
     topology.add(extract_image_patches("extract_image_patches", input_info("Input0"), sizes, strides, rates, auto_pad, output_shape));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("Input0", input);
     auto outputs = network.execute();
 
@@ -179,7 +179,7 @@ TEST(extract_image_patches_gpu, basic3) {
     topology.add(input_layout("Input0", input->get_layout()));
     topology.add(extract_image_patches("extract_image_patches", input_info("Input0"), sizes, strides, rates, auto_pad, output_shape));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("Input0", input);
     auto outputs = network.execute();
 
@@ -274,7 +274,7 @@ TEST(extract_image_patches_gpu, basic3_same_lower) {
     topology.add(input_layout("Input0", input->get_layout()));
     topology.add(extract_image_patches("extract_image_patches", input_info("Input0"), sizes, strides, rates, auto_pad, output_shape));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("Input0", input);
     auto outputs = network.execute();
 
@@ -369,7 +369,7 @@ TEST(extract_image_patches_gpu, basic3_enough_space) {
     topology.add(input_layout("Input0", input->get_layout()));
     topology.add(extract_image_patches("extract_image_patches", input_info("Input0"), sizes, strides, rates, auto_pad, output_shape));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("Input0", input);
     auto outputs = network.execute();
 
@@ -443,7 +443,7 @@ TEST(extract_image_patches_gpu, basic4) {
     topology.add(input_layout("Input0", input->get_layout()));
     topology.add(extract_image_patches("extract_image_patches", input_info("Input0"), sizes, strides, rates, auto_pad, output_shape));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("Input0", input);
     auto outputs = network.execute();
 
@@ -518,7 +518,7 @@ void test_extract_image_patches_gpu_basic5(bool is_caching_test) {
     topology.add(input_layout("Input0", input->get_layout()));
     topology.add(extract_image_patches("extract_image_patches", input_info("Input0"), sizes, strides, rates, auto_pad, output_shape));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("Input0", input);
     auto outputs = network->execute();

--- a/src/plugins/intel_gpu/tests/test_cases/eye.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/eye.cpp
@@ -85,7 +85,7 @@ public:
             tp.add(reorder("output", input_info("eye"), oupput_fmt, type_to_data_type<OutputType>::value));
         }
 
-        cldnn::network::ptr network = get_network(engine_, tp, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine_, tp, get_test_default_config(engine_), get_test_stream_ptr(), is_caching_test);
 
         auto outputs = network->execute();
 

--- a/src/plugins/intel_gpu/tests/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/fully_connected_gpu_test.cpp
@@ -88,7 +88,7 @@ void generic_fully_connected_test(cldnn::format test_input_fmt, cldnn::format te
         topology.add(activation("out", input_info(out_id), activation_func::relu, { slope, 0.0f }));
         out_id = "out";
     }
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -209,7 +209,7 @@ TEST(fully_connected_gpu, no_biases) {
     topology.add(w_data);
     topology.add(fc);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
@@ -269,7 +269,7 @@ TEST(fully_connected_gpu, no_biases_int8) {
     topology.add(fc);
     topology.add(ri);
     topology.add(rf);
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
@@ -328,7 +328,7 @@ TEST(fully_connected_gpu, xb_f32_batch_1) {
         fully_connected("fc_prim", input_info("input"), "weights", "bias")
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
@@ -388,7 +388,7 @@ TEST(fully_connected_gpu, xb_f32_batch_2) {
         fully_connected("fc_prim", input_info("input"), "weights", "bias")
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
@@ -450,7 +450,7 @@ TEST(fully_connected_gpu, x_f32) {
         fully_connected("fc_prim", input_info("input"), "weights", "bias")
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
@@ -511,7 +511,7 @@ TEST(fully_connected_gpu, xb_f32_batch_1_relu) {
         activation("out", input_info("fc_prim"), activation_func::relu)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
@@ -573,7 +573,7 @@ TEST(fully_connected_gpu, xb_f32_batch_2_relu) {
         activation("out", input_info("fc_prim"), activation_func::relu)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
@@ -636,7 +636,7 @@ TEST(fully_connected_gpu, x_f32_relu) {
         activation("out", input_info("fc_prim"), activation_func::relu)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
@@ -696,7 +696,7 @@ TEST(fully_connected_gpu, x_f32_relu_with_negative_slope) {
         activation("out", input_info("fc_prim"), activation_func::relu_negative_slope, { 0.1f })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_prim);
 
     auto outputs = network.execute();
@@ -799,7 +799,7 @@ TEST(fully_connected_gpu, b_fs_yx_fsv4)
     topology.add(reorder_gold, reorder_imad);
 
     // Network build
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
 
@@ -868,7 +868,7 @@ TEST(fully_connected_gpu, DISABLED_fs_byx_fsv32_b12) {
     );
 
     // Set data optimization to allow weights reordering to optimal format
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network network(engine, topology, config);
@@ -944,7 +944,7 @@ TEST(fully_connected_gpu, DISABLED_fs_byx_fsv32_b34)
     );
 
     // Set data optimization to allow weights reordering to optimal format
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network network(engine, topology, config);
@@ -1006,7 +1006,9 @@ struct fully_connected_random_test : ::testing::TestWithParam<fully_connected_te
         auto bias = net.add_data<BiasT, 2>("bias", format::bfyx, std::move(bias_data));
         auto fc = net.add_fully_connected<OutputT>("fc_prim", input, weights, bias, ov::intel_gpu::ImplementationDesc{ output_format, kernel });
 
-        net.run(ExecutionConfig(ov::intel_gpu::optimize_data(true)), is_caching_test);
+        ExecutionConfig config = get_test_default_config(eng);
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        net.run(config, is_caching_test);
     }
 };
 
@@ -1129,7 +1131,9 @@ struct fully_connected_random_test_3d : ::testing::TestWithParam<fully_connected
         auto bias = net.add_data<BiasT, 2>("bias", format::bfyx, std::move(bias_data));
         auto fc = net.add_fully_connected_3d<OutputT>("fc_prim", input, weights, bias, ov::intel_gpu::ImplementationDesc{ output_format, kernel }, 3);
 
-        net.run(ExecutionConfig(ov::intel_gpu::optimize_data(true)), is_caching_test);
+        ExecutionConfig config = get_test_default_config(eng);
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        net.run(config, is_caching_test);
     }
 };
 
@@ -1393,7 +1397,7 @@ public:
 
         topo.add(reorder("output", input_info("quantization_prim"), format::bfyx, output_data_type()));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
 
         network net(engine, topo, config);
@@ -1686,9 +1690,9 @@ TEST(fully_connected_onednn_gpu, no_biases_int8) {
 
     ov::intel_gpu::ImplementationDesc fc_impl = { format::bfyx, "", impl_types::onednn };
 
-    ExecutionConfig cfg{ov::intel_gpu::queue_type(QueueTypes::in_order),
-                        ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"fc_prim", fc_impl} })
-    };
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
+    cfg.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"fc_prim", fc_impl} }));
     network network(engine, topology, cfg);
     network.set_input_data("input", input_prim);
 
@@ -1738,7 +1742,9 @@ TEST(fully_connected_3d_onednn_gpu, no_biases_int8) {
     topology.add(rf);
 
     ov::intel_gpu::ImplementationDesc fc_impl = { format::bfyx, "", impl_types::onednn };
-    ExecutionConfig cfg{ov::intel_gpu::queue_type(QueueTypes::in_order), ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "fc_prim", fc_impl } })};
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
+    cfg.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"fc_prim", fc_impl} }));
 
     network network(engine, topology, cfg);
     network.set_input_data("input", input_prim);
@@ -1778,7 +1784,7 @@ TEST(fully_connected_gpu, dynamic) {
         fully_connected("fc", input_info("input"), "weights")
     };
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
@@ -1828,7 +1834,7 @@ TEST(fully_connected_gpu, dynamic_multi_inference_same_shape) {
         fully_connected("fc", input_info("input"), "weights")
     };
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
@@ -1908,7 +1914,7 @@ TEST(fully_connected_gpu, dynamic_multi_inference_different_shape) {
         fully_connected("fc", input_info("input"), "weights")
     };
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
@@ -1998,7 +2004,7 @@ TEST(fully_connected_gpu, dynamic_multi_inference_multiple_shapes) {
         fully_connected("fc", input_info("input"), "weights")
     };
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
@@ -2133,7 +2139,7 @@ struct dynamic_fully_connected_gpu : ::testing::TestWithParam<fully_connected_dy
         else
             topology.add(fully_connected("fc", input_info("input"), "weights", "bias"));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
         config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
         network network(engine, topology, config);

--- a/src/plugins/intel_gpu/tests/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/fully_connected_gpu_test.cpp
@@ -1006,9 +1006,7 @@ struct fully_connected_random_test : ::testing::TestWithParam<fully_connected_te
         auto bias = net.add_data<BiasT, 2>("bias", format::bfyx, std::move(bias_data));
         auto fc = net.add_fully_connected<OutputT>("fc_prim", input, weights, bias, ov::intel_gpu::ImplementationDesc{ output_format, kernel });
 
-        ExecutionConfig config = get_test_default_config(eng);
-        config.set_property(ov::intel_gpu::optimize_data(true));
-        net.run(config, is_caching_test);
+        net.run(get_test_default_config(eng, ov::intel_gpu::optimize_data(true)), is_caching_test);
     }
 };
 
@@ -1691,7 +1689,6 @@ TEST(fully_connected_onednn_gpu, no_biases_int8) {
     ov::intel_gpu::ImplementationDesc fc_impl = { format::bfyx, "", impl_types::onednn };
 
     ExecutionConfig cfg = get_test_default_config(engine);
-    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     cfg.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"fc_prim", fc_impl} }));
     network network(engine, topology, cfg);
     network.set_input_data("input", input_prim);
@@ -1743,7 +1740,6 @@ TEST(fully_connected_3d_onednn_gpu, no_biases_int8) {
 
     ov::intel_gpu::ImplementationDesc fc_impl = { format::bfyx, "", impl_types::onednn };
     ExecutionConfig cfg = get_test_default_config(engine);
-    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     cfg.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"fc_prim", fc_impl} }));
 
     network network(engine, topology, cfg);

--- a/src/plugins/intel_gpu/tests/test_cases/gather_elements_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/gather_elements_gpu_test.cpp
@@ -32,7 +32,7 @@ inline void DoTest(engine& engine,
         gather_elements("gather_elements", input_info("InputData"), input_info("InputIndices"), input1->get_layout().format, output_tensor, axis)
     );
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("InputData", input0);
     network->set_input_data("InputIndices", input1);
@@ -1294,7 +1294,7 @@ TEST(gather_elements_gpu, dynamic) {
     topology.add(input_layout("InputIndices", in1_dyn_layout));
     topology.add(gather_elements("gather_elements", input_info("InputData"), input_info("InputIndices"), axis));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
 

--- a/src/plugins/intel_gpu/tests/test_cases/gather_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/gather_gpu_test.cpp
@@ -90,7 +90,7 @@ public:
                                 batch_dim,
                                 true));
         reorder_topo.add(reorder("reorder2", input_info("gather"), format::type::bfwzyx, T_dat_dt));
-        network reorder_network(engine, reorder_topo);
+        network reorder_network(engine, reorder_topo, get_test_default_config(engine));
         reorder_network.set_input_data("input0", input0);
         reorder_network.set_input_data("input1", input1);
         auto reorder_output = reorder_network.execute().at("reorder2").get_memory();
@@ -101,7 +101,7 @@ public:
         planar_topo.add(input_layout("input1", input1->get_layout()));
         planar_topo.add(
             gather("gather", input_info("input0"), input_info("input1"), axis, ov::Shape(shape_out.begin(), shape_out.end()), batch_dim, true));
-        network planar_network(engine, planar_topo);
+        network planar_network(engine, planar_topo, get_test_default_config(engine));
         planar_network.set_input_data("input0", input0);
         planar_network.set_input_data("input1", input1);
         auto planar_output = planar_network.execute().at("gather").get_memory();
@@ -358,7 +358,7 @@ TEST(gather8_gpu_fp16, d323_axisY_bdim_m1) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 2, 3, 3, 2}, batch_dim, negative_indexes)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -465,7 +465,7 @@ TEST(gather7_gpu_fp16, d222_axisX_bdim_m1) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2, 2, 2}, batch_dim)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -576,7 +576,7 @@ TEST(gather7_gpu_fp16, d323_axisY_bdim_m1) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 2, 3, 3, 2}, batch_dim)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -680,7 +680,7 @@ TEST(gather7_gpu_fp16, d44_axisY_bdim1) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{4, 3, 4, 1}, batch_dim)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -755,7 +755,7 @@ TEST(gather7_gpu_fp16, d32_axisF_bdim_m1) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 2, 1, 1}, batch_dim)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -818,7 +818,7 @@ TEST(gather7_gpu_fp16, d32_axisF_bdim1) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 2, 1, 1}, batch_dim)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -880,7 +880,7 @@ TEST(gather7_gpu_fp16, d32_axisF_bdim0) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 3, 2, 1}, batch_dim)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -948,7 +948,7 @@ TEST(gather_gpu_fp16, d14_axisB) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{1, 4, 2, 1})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1010,7 +1010,7 @@ TEST(gather_gpu_fp16, d222_axisB) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1071,7 +1071,7 @@ TEST(gather_gpu_fp16, d22_axisY) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1132,7 +1132,7 @@ TEST(gather_gpu_fp16, d22_axisF) {
             gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1190,7 +1190,7 @@ TEST(gather_gpu_fp32, d14_axisB) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{1, 4, 2, 1})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1251,7 +1251,7 @@ TEST(gather_gpu_fp32, d222_axisB) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1312,7 +1312,7 @@ TEST(gather_gpu_fp32, d22_axisY) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1373,7 +1373,7 @@ TEST(gather_gpu_fp32, d22_axisF) {
             gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1434,7 +1434,7 @@ TEST(gather_gpu_int32, d22_axisF) {
             gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1492,7 +1492,7 @@ TEST(gather_gpu_int32, d14_axisB) {
             gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{1, 4, 2, 1})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1553,7 +1553,7 @@ TEST(gather_gpu_int32, d222_axisB) {
             gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1614,7 +1614,7 @@ TEST(gather_gpu_int32, d22_axisY) {
             gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 2, 2})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1678,7 +1678,7 @@ TEST(gather_gpu_fp32, d41_axisB) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{4, 1, 2, 3})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1741,7 +1741,7 @@ TEST(gather_gpu_fp32, d41_axisF) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 4, 1, 2})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1800,7 +1800,7 @@ TEST(gather_gpu_fp32, d2_axisX) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{2, 2, 1, 2})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1850,7 +1850,7 @@ TEST(gather_gpu_fp32, 322_axisF) {
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 2, 2, 1})
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputDictionary", input1);
     network.set_input_data("InputText", input2);
@@ -1889,7 +1889,7 @@ TEST(gather_gpu_fp32, dynamic_322_axisF) {
     topology.add(input_layout("input2", in2_layout));
     topology.add(gather("gather", input_info("input1"), input_info("input2"), axis, ov::Shape{}));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
     network.set_input_data("input1", input1);
@@ -1938,7 +1938,7 @@ void test_gather_gpu_u8_322_axisF(bool is_caching_test) {
     topology.add(
         gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 2, 2, 1}));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("InputDictionary", input1);
     network->set_input_data("InputText", input2);

--- a/src/plugins/intel_gpu/tests/test_cases/gather_nd_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/gather_nd_gpu_test.cpp
@@ -39,7 +39,7 @@ inline void DoTestBase(engine& engine,
     topology.add(input_layout("InputIndices", input1->get_layout()));
     topology.add(gather_nd_inst);
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("InputData", input0);
     network->set_input_data("InputIndices", input1);

--- a/src/plugins/intel_gpu/tests/test_cases/gather_tree_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/gather_tree_gpu_test.cpp
@@ -213,7 +213,7 @@ public:
         const primitive_id reorder_result_id = result_id + "_reordered";
         topology.add(reorder(reorder_result_id, input_info(result_id), plain_layout, data_type));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data(step_id, step_input);
         network->set_input_data(parent_id, parent_input);

--- a/src/plugins/intel_gpu/tests/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/gemm_gpu_test.cpp
@@ -129,7 +129,7 @@ public:
             std::cout << "cached" << std::endl;
             membuf mem_buf;
             {
-                cldnn::network _network(engine, tp);
+                cldnn::network _network(engine, tp, get_test_default_config(engine));
                 process_program(_network.get_program());
                 std::ostream out_mem(&mem_buf);
                 BinaryOutputBuffer ob = BinaryOutputBuffer(out_mem);
@@ -141,7 +141,7 @@ public:
                 network = std::make_shared<cldnn::network>(ib, get_test_stream_ptr(), engine);
             }
         } else {
-            network = std::make_shared<cldnn::network>(engine, tp);
+            network = std::make_shared<cldnn::network>(engine, tp, get_test_default_config(engine));
             process_program(network->get_program());
         }
 
@@ -292,7 +292,7 @@ void test_basic_bfyx_t2_inplace_crop_with_pad(bool is_caching_test) {
         gemm("output", { input_info("crop.1"), input_info("input2") }, data_types::f32, false, true)
     );
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input);
@@ -343,7 +343,7 @@ TEST(gemm_gpu, dynamic) {
                  gemm("gemm", { input_info("input1"), input_info("input2") }, data_types::f32, false, true, 1.0f, 0.0f, 4, 2)
     );
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
@@ -412,7 +412,7 @@ TEST(gemm_gpu, dynamic_multi_inference_same_shape) {
                  gemm("gemm", { input_info("input1"), input_info("input2") }, data_types::f32, false, false, 1.0f, 0.0f, 4, 2)
     );
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
@@ -501,7 +501,7 @@ TEST(gemm_gpu, dynamic_multi_inference_different_shape) {
                  gemm("gemm", { input_info("input1"), input_info("input2") }, data_types::f32, false, false, 1.0f, 0.0f, 4, 2)
     );
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
@@ -1311,11 +1311,11 @@ public:
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
         ov::intel_gpu::ImplementationDesc gemm_impl = { format::bfyx, "", impl_types::onednn };
-        ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::in_order));
 #else
         ov::intel_gpu::ImplementationDesc gemm_impl = { format::bfyx, p.kernel_name };
-        ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
 #endif
+
+        ExecutionConfig cfg = get_test_default_config(engine);
         cfg.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"gemm_bfyx", gemm_impl} }));
 
         cldnn::network::ptr network = get_network(engine, topology, cfg, get_test_stream_ptr(), is_caching_test);

--- a/src/plugins/intel_gpu/tests/test_cases/generate_proposals_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/generate_proposals_gpu_test.cpp
@@ -291,11 +291,6 @@ public:
 
         auto& engine = get_test_engine();
         std::shared_ptr<cldnn::stream> stream = get_test_stream_ptr();;
-        if (engine.get_device_info().supports_immad) {
-            // Expected to test out-of-order queue-type
-            return;
-        }
-
         const primitive_id input_im_info_id = "InputImInfo";
         const auto input_im_info = engine.allocate_memory({data_type, format::bfyx, tensor{batch(num_batches), feature(3)}});
         set_values(input_im_info, getValues<T>(im_info));

--- a/src/plugins/intel_gpu/tests/test_cases/generate_proposals_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/generate_proposals_gpu_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "intel_gpu/runtime/execution_config.hpp"
 #include "test_utils.h"
 
 #include <intel_gpu/primitives/generate_proposals.hpp>
@@ -289,6 +290,11 @@ public:
         const auto rois_num_type = type_to_data_type<ROIS_NUM_T>::value;
 
         auto& engine = get_test_engine();
+        std::shared_ptr<cldnn::stream> stream = get_test_stream_ptr();;
+        if (engine.get_device_info().supports_immad) {
+            // Expected to test out-of-order queue-type
+            return;
+        }
 
         const primitive_id input_im_info_id = "InputImInfo";
         const auto input_im_info = engine.allocate_memory({data_type, format::bfyx, tensor{batch(num_batches), feature(3)}});
@@ -355,7 +361,7 @@ public:
         const primitive_id reorder_result_id = generate_proposals_id + "Reordered";
         topology.add(reorder(reorder_result_id, input_info(generate_proposals_id), format::bfyx, data_type));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), stream, is_caching_test);
 
         network->set_input_data(input_im_info_id, input_im_info);
         network->set_input_data(input_anchors_id, input_anchors);
@@ -366,7 +372,7 @@ public:
 
         const auto rois = outputs.at(reorder_result_id).get_memory();
 
-        const cldnn::mem_lock<T> rois_ptr(rois, get_test_stream());
+        const cldnn::mem_lock<T> rois_ptr(rois, *stream);
         ASSERT_EQ(rois_ptr.size(), num_batches * param.post_nms_count * 4);
 
         const auto get_plane_data = [&](const memory::ptr& mem, const data_types data_type, const layout& from_layout) {
@@ -376,7 +382,7 @@ public:
             cldnn::topology reorder_topology;
             reorder_topology.add(input_layout("data", from_layout));
             reorder_topology.add(reorder("plane_data", input_info("data"), format::bfyx, data_type));
-            cldnn::network reorder_net{engine, reorder_topology};
+            cldnn::network reorder_net{engine, reorder_topology, get_test_default_config(engine)};
             reorder_net.set_input_data("data", mem);
             const auto second_output_result = reorder_net.execute();
             const auto plane_data_mem = second_output_result.at("plane_data").get_memory();
@@ -384,11 +390,11 @@ public:
         };
 
         const cldnn::mem_lock<T> roi_scores_ptr(
-                get_plane_data(output_roi_scores, data_type, rois_scores_layout), get_test_stream());
+                get_plane_data(output_roi_scores, data_type, rois_scores_layout), *stream);
         ASSERT_EQ(roi_scores_ptr.size(), num_batches * param.post_nms_count);
 
         const cldnn::mem_lock<ROIS_NUM_T> rois_num_ptr(
-                get_plane_data(output_rois_num, rois_num_type, rois_num_layout), get_test_stream());
+                get_plane_data(output_rois_num, rois_num_type, rois_num_layout), *stream);
         ASSERT_EQ(rois_num_ptr.size(), num_batches);
 
         const auto& expected_rois = param.expected_rois;

--- a/src/plugins/intel_gpu/tests/test_cases/grid_sample_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/grid_sample_gpu_test.cpp
@@ -75,7 +75,7 @@ public:
         topology.add(grid_sample("grid_sample", { input_info("reordered_data"), input_info("reordered_grid") }, p.attributes));
         topology.add(reorder("plane_grid_sample", input_info("grid_sample"), plane_format, data_data_type));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         network->set_input_data("data", data);
         network->set_input_data("grid", grid);
         const auto outputs = network->execute();

--- a/src/plugins/intel_gpu/tests/test_cases/hash_key_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/hash_key_gpu_test.cpp
@@ -35,7 +35,7 @@ TEST(check_hash_value, eltwise_basic) {
     topology.add(input_layout("input2", input2->get_layout()));
     topology.add(eltwise(key_prim_id, { input_info("input"), input_info("input2") }, eltwise_mode::sum));
 
-    auto prog = program::build_program(engine, topology, ExecutionConfig{});
+    auto prog = program::build_program(engine, topology, get_test_default_config(engine));
     network net(prog, 0);
     const auto  prim_inst = net.get_primitive(key_prim_id);
     const auto  primitve  = prim_inst->desc();
@@ -65,7 +65,7 @@ TEST(check_hash_value, fc_basic) {
         fully_connected(key_prim_id, input_info("input"), "weights", "bias")
     );
 
-    auto prog = program::build_program(engine, topology, ExecutionConfig{});
+    auto prog = program::build_program(engine, topology, get_test_default_config(engine));
     network net(prog, 0);
     const auto  prim_inst = net.get_primitive(key_prim_id);
     const auto  primitve  = prim_inst->desc();
@@ -96,7 +96,7 @@ TEST(check_hash_value, gather_basic) {
         gather(key_prim_id, input_info("InputDictionary"), input_info("InputText"), axis, ov::Shape{3, 2, 3, 3, 2}, batch_dim, negative_indexes)
     );
 
-    auto prog = program::build_program(engine, topology, ExecutionConfig{});
+    auto prog = program::build_program(engine, topology, get_test_default_config(engine));
     network net(prog, 0);
     const auto  prim_inst = net.get_primitive(key_prim_id);
     const auto  primitve  = prim_inst->desc();
@@ -122,7 +122,7 @@ TEST(check_hash_value, gemm_basic) {
     topology.add(crop("crop.1", input_info("input"), { 1, 1, 4, 3 }, { 0, 1, 0, 0 }));
     topology.add(gemm(key_prim_id, { input_info("crop.1"), input_info("input2") }, data_types::f32, false, true));
 
-    auto prog = program::build_program(engine, topology, ExecutionConfig{});
+    auto prog = program::build_program(engine, topology, get_test_default_config(engine));
     network net(prog, 0);
     const auto  prim_inst = net.get_primitive(key_prim_id);
     const auto  primitve  = prim_inst->desc();
@@ -145,7 +145,7 @@ TEST(check_hash_value, permute_basic) {
         input_layout("input", input->get_layout()),
         permute(key_prim_id, input_info("input"), { 0, 1, 2, 3 }));
 
-    auto prog = program::build_program(engine, topology, ExecutionConfig{});
+    auto prog = program::build_program(engine, topology, get_test_default_config(engine));
     network net(prog, 0);
     const auto  prim_inst = net.get_primitive(key_prim_id);
     const auto  primitve  = prim_inst->desc();
@@ -174,7 +174,7 @@ TEST(check_hash_value, reorder_basic) {
         input_layout("input", input->get_layout()),
         reorder(key_prim_id, input_info("input"), output_layout));
 
-    auto prog = program::build_program(engine, topology, ExecutionConfig{});
+    auto prog = program::build_program(engine, topology, get_test_default_config(engine));
     network net(prog, 0);
     const auto  prim_inst = net.get_primitive(key_prim_id);
     const auto  primitve  = prim_inst->desc();
@@ -200,7 +200,7 @@ TEST(check_hash_value, reshape_basic) {
     topology.add(reorder("reorder", input_info("input"), padded_input_layout));
     topology.add(reshape(key_prim_id, input_info("reorder"), tensor( 1, 1, 4, 1 ), cldnn::reshape::reshape_mode::base, padding({0, 0, 2, 2})));
 
-    auto prog = program::build_program(engine, topology, ExecutionConfig{});
+    auto prog = program::build_program(engine, topology, get_test_default_config(engine));
     network net(prog, 0);
     const auto  prim_inst = net.get_primitive(key_prim_id);
     const auto  primitve  = prim_inst->desc();
@@ -227,7 +227,7 @@ TEST(check_hash_value, conv_basic) {
         data("biases", biases),
         convolution(key_prim_id, input_info("input"), { "weights" }, { "biases" }, {1, 1, 1}, {0, 0, 0}, {1, 1, 1}));
 
-    auto prog = program::build_program(engine, topology, ExecutionConfig{});
+    auto prog = program::build_program(engine, topology, get_test_default_config(engine));
     network net(prog, 0);
     const auto  prim_inst = net.get_primitive(key_prim_id);
     const auto  primitve  = prim_inst->desc();
@@ -260,7 +260,7 @@ TEST(check_hash_value, quantize_basic) {
         quantize(key_prim_id, input_info("input"), input_info("input_low"), input_info("input_high"), input_info("output_low"), input_info("output_high"), 256, data_types::u8)
     );
 
-    auto prog = program::build_program(engine, topology, ExecutionConfig{});
+    auto prog = program::build_program(engine, topology, get_test_default_config(engine));
     network net(prog, 0);
     const auto  prim_inst = net.get_primitive(key_prim_id);
     const auto  primitve  = prim_inst->desc();

--- a/src/plugins/intel_gpu/tests/test_cases/loop_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/loop_gpu_test.cpp
@@ -73,7 +73,7 @@ void test_loop_gpu_basic_no_concat(bool is_caching_test)
              input_primitive_maps, output_primitive_maps, back_edges, 8)
     );
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input_mem);
     network->set_input_data("trip_count", trip_count_mem);
@@ -174,7 +174,7 @@ void test_loop_gpu_basic_concat(bool is_caching_test)
              input_primitive_maps, output_primitive_maps, back_edges, trip_count)
     );
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input_mem);
     network->set_input_data("trip_count", trip_count_mem);
     network->set_input_data("initial_condition", initial_condition_mem);
@@ -314,7 +314,7 @@ void test_loop_gpu_basic_concat_nested(bool is_caching_test)
     /////////////////////////////////
     // network execution
     /////////////////////////////////
-    cldnn::network::ptr network = get_network(engine, main_topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, main_topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input_mem);
     network->set_input_data("trip_count", trip_count_mem);
     network->set_input_data("initial_condition", initial_condition_mem);

--- a/src/plugins/intel_gpu/tests/test_cases/lrn_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/lrn_gpu_test.cpp
@@ -37,7 +37,7 @@ void test_fp32_basic(bool is_caching_test) {
     float beta = 1.f;
     topology.add(lrn("lrn", input_info("input"), size, k, alpha, beta, cldnn::lrn_norm_region_across_channel));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
 
@@ -89,7 +89,7 @@ void test_fp32_basic2(bool is_caching_test) {
     float beta = 1.f;
     topology.add(lrn("lrn", input_info("input"), size, k, alpha, beta, cldnn::lrn_norm_region_across_channel));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
 
@@ -141,7 +141,7 @@ void test_fp16_basic1(bool is_caching_test) {
     float beta = 1.f;
     topology.add(lrn("lrn", input_info("input"), size, k, alpha, beta, cldnn::lrn_norm_region_across_channel));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
 
@@ -193,7 +193,7 @@ void test_fp32_basic3(bool is_caching_test) {
     float beta = 0.75f;
     topology.add(lrn("lrn", input_info("input"), size, k, alpha, beta, cldnn::lrn_norm_region_across_channel));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
 

--- a/src/plugins/intel_gpu/tests/test_cases/lstm_dynamic_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/lstm_dynamic_gpu_test.cpp
@@ -245,7 +245,7 @@ struct lstm_dynamic_input_layer_test : public ::testing::Test
             "weights",
             bias_id));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
         network network(engine, topology, config);
 
@@ -407,7 +407,7 @@ struct lstm_dynamic_single_layer_test : public ::testing::Test
             initial_hidden_id,
             initial_cell_id));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
         network network(engine, topology, config);
         network.set_input_data("input", input_mem);
@@ -888,7 +888,7 @@ TEST(lstm_dynamic_negative, wrong_weights_size) {
         "dyn_len",
         "weights",
         "recurrent"));
-    ASSERT_ANY_THROW(network network(engine, topology));
+    ASSERT_ANY_THROW(network network(engine, topology, get_test_default_config(engine)));
 }
 
 TEST(lstm_dynamic_negative, wrong_recurrent_size_0) {
@@ -913,7 +913,7 @@ TEST(lstm_dynamic_negative, wrong_recurrent_size_0) {
         "dyn_len",
         "weights",
         "recurrent"));
-    ASSERT_ANY_THROW(network network(engine, topology));
+    ASSERT_ANY_THROW(network network(engine, topology, get_test_default_config(engine)));
 }
 
 TEST(lstm_dynamic_negative, wrong_recurrent_size_1) {
@@ -938,7 +938,7 @@ TEST(lstm_dynamic_negative, wrong_recurrent_size_1) {
         "dyn_len",
         "weights",
         "recurrent"));
-    ASSERT_ANY_THROW(network network(engine, topology));
+    ASSERT_ANY_THROW(network network(engine, topology, get_test_default_config(engine)));
 }
 
 TEST(lstm_dynamic_negative, wrong_dynamic_length_size_0) {
@@ -963,7 +963,7 @@ TEST(lstm_dynamic_negative, wrong_dynamic_length_size_0) {
         "dyn_len",
         "weights",
         "recurrent"));
-    ASSERT_ANY_THROW(network network(engine, topology));
+    ASSERT_ANY_THROW(network network(engine, topology, get_test_default_config(engine)));
 }
 
 TEST(lstm_dynamic_negative, wrong_dynamic_length_size_1) {
@@ -988,5 +988,5 @@ TEST(lstm_dynamic_negative, wrong_dynamic_length_size_1) {
         "dyn_len",
         "weights",
         "recurrent"));
-    ASSERT_ANY_THROW(network network(engine, topology));
+    ASSERT_ANY_THROW(network network(engine, topology, get_test_default_config(engine)));
 }

--- a/src/plugins/intel_gpu/tests/test_cases/lstm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/lstm_gpu_test.cpp
@@ -244,7 +244,7 @@ void generic_lstm_gemm_gpu_test(int sequence_len, int direction, int batch_size,
 
     topology.add(lstm_gemm("lstm_gemm", input_info("input"), "weights", "recurrent", hasBias ? "biases" : "", hasHidden ? "hidden" : ""));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input);
     if (hasHidden) {
         network->set_input_data("hidden", hidden);
@@ -307,7 +307,7 @@ void generic_lstm_elt_gpu_test(int /* sequence_len */, int direction, int batch_
     }
     topology.add(lstm_elt("lstm_elt", input_info("tempGEMM"), hasCell ? "cell" : "", clip_threshold, input_forget));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
     network->set_input_data("tempGEMM", tempGEMM);
     if (hasCell) {
         network->set_input_data("cell", cell);
@@ -430,7 +430,7 @@ void generic_lstm_custom_gpu_test(int sequence_len, int direction, int batch_siz
     generate_lstm_topology(topology, input, hidden, cell, weights, recurrent, biases, sequence_len,
         hasBias, hasInitialHidden, hasInitialCell);
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input);
     if (hasInitialHidden) network->set_input_data("hidden", hidden);
     if (hasInitialCell) network->set_input_data("cell", cell);
@@ -596,7 +596,7 @@ void generic_lstm_gpu_test(int layers, int sequence_len, int direction, int batc
         prev_lstm_id = lstm_id;
     }
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input);
     for (int i = 0; i < layers; ++i) {
         std::string sid = get_string_id(i);
@@ -722,7 +722,7 @@ void lstm_gpu_output_test(const lstm_output_selection& output_selection, int dir
         topology.add(crop("crop:last_cell", input_info("lstm"), cell_tensor, tensor{0, concatenation_len - 1, 0, 0}));
     }
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input);
     network->set_input_data("hidden", hidden);
     network->set_input_data("cell", cell);
@@ -886,7 +886,7 @@ void lstm_gpu_format_test(const cldnn::format& format, int directions, bool is_c
         topology.add(crop("crop:last_cell", input_info("lstm"), cell_tensor, tensor{0, concatenation_len - 1, 0, 0}));
     }
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     std::map<primitive_id, network_output> outputs;
 
@@ -1053,7 +1053,7 @@ void lstm_gpu_users_test(bool is_caching_test = false) {
     std::vector<input_info> output_ids_offsets { input_info("lstm"), input_info("hidden") };
     topology.add(concatenation("concatenation", output_ids_offsets, 1));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     std::map<primitive_id, network_output> outputs;
 
@@ -1212,7 +1212,7 @@ void lstm_gpu_concatenated_input_test(int layers, int sequence_len, int directio
 		prev_node_id = output_crop_id;
 	}
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 	network->set_input_data("input", input);
 	for (int i = 0; i < layers; ++i) {
 		std::string sid = get_string_id(i);
@@ -1555,7 +1555,7 @@ void lstm_gpu_chain_test(int batch_size, int input_size, int hidden_size,
     }
 
     // Creating network out of the above designed topology
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input);
     for (size_t layer = 0; layer < layers; layer++) {
         std::string sid = get_string_id(layer);

--- a/src/plugins/intel_gpu/tests/test_cases/matrix_nms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/matrix_nms_gpu_test.cpp
@@ -107,7 +107,7 @@ public:
                                 attrs));
         topology.add(reorder("matrix_nms", input_info("reordered_matrix_nms"), plain_format, data_type));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("boxes", boxes);
         network->set_input_data("scores", scores);

--- a/src/plugins/intel_gpu/tests/test_cases/memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/memory_test.cpp
@@ -77,7 +77,7 @@ TEST(memory_pool, basic_non_padded_relu_pipe) {
 
     std::vector<float> input_vec = { -1.f, 2.f, -3.f, 4.f };
     set_values(input, input_vec);
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(*engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network network(*engine, topology, config);
@@ -109,7 +109,7 @@ TEST(memory_pool, basic_non_padded_relu_and_pooling_pipe) {
     topology.add(activation("relu4", input_info("relu3"), activation_func::relu));
     topology.add(activation("relu5", input_info("relu4"), activation_func::relu));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(*engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network network(*engine, topology, config);
@@ -144,7 +144,7 @@ TEST(memory_pool, multi_outputs_network) {
     topology.add(activation("relu6", input_info("relu5"), activation_func::relu));
     topology.add(activation("relu7", input_info("relu6"), activation_func::relu));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(*engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network network(*engine, topology, config);
@@ -182,7 +182,7 @@ TEST(memory_pool, oooq) {
     topology.add(concatenation("concat2", { input_info("relu4"), input_info("relu5") }, 1));
     topology.add(activation("relu6", input_info("concat2"), activation_func::relu));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(*engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network network(*engine, topology, config);
@@ -227,7 +227,7 @@ TEST(memory_pool, DISABLED_shared_mem_pool_same_topology_twice) {
     topology.add(concatenation("concat2", { input_info("relu4"), input_info("relu5") }, 1));
     topology.add(activation("relu6", input_info("concat2"), activation_func::linear, { 1.0f, 0.5f }));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(*engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network network_first(*engine, topology, config);
@@ -302,7 +302,7 @@ TEST(memory_pool, DISABLED_shared_mem_pool_same_topology_twice_weights) {
         convolution("conv", input_info("input"), { "weights" }, { 1, 1, 1, 2 }),
         softmax("softmax", input_info("conv")));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(*engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network network_first(*engine, topology, config);
@@ -388,7 +388,7 @@ TEST(memory_pool, shared_mem_pool_diff_batches) {
         convolution("conv", input_info("input"), { "weights" }, { 2, 1 }),
         softmax("softmax", input_info("conv")));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(*engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network network_first(*engine, topo, config);
@@ -421,7 +421,7 @@ TEST(memory_pool, shared_dep_two_output) {
     topo.add(cldnn::concatenation("result_1_0", { input_info("constant_0_0") }, 0));
     topo.add(cldnn::concatenation("result_2_0", { input_info("constant_0_0") }, 0));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(*engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network network(*engine, topo, config);
@@ -462,7 +462,9 @@ TEST(memory_pool, non_opt_intermidate_opt_after) {
         data_memory
     );
 
-    ExecutionConfig config(ov::intel_gpu::optimize_data(false));
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(false));
+
     network network(engine, topology, config);
     network.set_input_data("input1", input_memory1);
     network.set_input_data("input2", input_memory2);
@@ -510,7 +512,7 @@ TEST(memory_pool, add_mem_dep_test) {
         actv3, actv4
     );
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input1", input_memory1);

--- a/src/plugins/intel_gpu/tests/test_cases/multiclass_nms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/multiclass_nms_gpu_test.cpp
@@ -170,7 +170,7 @@ public:
 
             topology.add(primitive);
             topology.add(reorder("multiclass_nms", input_info("multiclass_nms_reordered"), plain_format, data_type));
-            ExecutionConfig config;
+            ExecutionConfig config = get_test_default_config(engine);
             config.set_property(ov::intel_gpu::optimize_data(false));
 
             cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), param.is_caching_test);
@@ -195,7 +195,7 @@ public:
                 cldnn::topology reorder_topology;
                 reorder_topology.add(input_layout("data", from_layout));
                 reorder_topology.add(reorder("plane_data", input_info("data"), plain_format, data_type));
-                cldnn::network reorder_net{engine, reorder_topology};
+                cldnn::network reorder_net{engine, reorder_topology, get_test_default_config(engine)};
                 reorder_net.set_input_data("data", mem);
                 const auto second_output_result = reorder_net.execute();
                 const auto plane_data_mem = second_output_result.at("plane_data").get_memory();

--- a/src/plugins/intel_gpu/tests/test_cases/multiple_streams_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/multiple_streams_gpu_test.cpp
@@ -24,7 +24,7 @@ TEST(multistream_gpu, basic) {
     auto task_executor = std::make_shared<InferenceEngine::CPUStreamsExecutor>(task_config);
     auto& engine = get_test_engine();
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     auto input1_dyn_layout = layout{ ov::PartialShape::dynamic(3), data_types::f16,format::bfyx };

--- a/src/plugins/intel_gpu/tests/test_cases/mvn_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/mvn_gpu_test.cpp
@@ -122,7 +122,7 @@ void test_mvn_test_across_channels_outside_sqrt_bfyx(bool is_caching_test) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mvn("mvn", input_info("input"), false, 1e-10f, false, true));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
 
@@ -156,7 +156,7 @@ void test_mvn_test_across_channels_inside_sqrt_bfyx(bool is_caching_test) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mvn("mvn", input_info("input"), false, 1e-10f, true, true));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
 
@@ -195,7 +195,7 @@ TEST(mvn_gpu_test, mvn_test_across_channels_outside_sqrt_bfyx_normalize_variance
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mvn("mvn", input_info("input"), true, 1e-10f, false, true));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -222,7 +222,7 @@ TEST(mvn_gpu_test, mvn_test_across_channels_inside_sqrt_bfyx_normalize_variance)
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mvn("mvn", input_info("input"), true, 1e-10f, true, true));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -249,7 +249,7 @@ TEST(mvn_gpu_test, mvn_test_across_channels_outside_sqrt_bfyx_normalize_variance
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mvn("mvn", input_info("input"), true, 1e-10f, false, true));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -276,7 +276,7 @@ TEST(mvn_gpu_test, mvn_test_across_channels_inside_sqrt_bfyx_normalize_variance_
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mvn("mvn", input_info("input"), true, 1e-10f, true, true));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -305,7 +305,7 @@ TEST(mvn_gpu_test, dynamic_across_channels_inside_sqrt_bfyx_normalize_variance_f
     topology.add(input_layout("input", in_layout));
     topology.add(mvn("mvn", input_info("input"), true, 1e-10f, true, true));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -338,7 +338,7 @@ TEST(mvn_gpu_test, mvn_test_within_channels_outside_sqrt_bfyx) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mvn("mvn", input_info("input"), false, 1e-10f, false, false));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -365,7 +365,7 @@ TEST(mvn_gpu_test, mvn_test_within_channels_inside_sqrt__bfyx) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mvn("mvn", input_info("input"), false, 1e-10f, true, false));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -392,7 +392,7 @@ TEST(mvn_gpu_test, mvn_test_within_channels_outside_sqrt_bfyx_fp16) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mvn("mvn", input_info("input"), false, 1e-10f, false, false));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -419,7 +419,7 @@ TEST(mvn_gpu_test, mvn_test_within_channels_inside_sqrt_bfyx_fp16) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mvn("mvn", input_info("input"), false, 1e-10f, true, false));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -446,7 +446,7 @@ TEST(mvn_gpu_test, mvn_test_within_channels_outside_sqrt_bfyx_normalize_variance
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mvn("mvn", input_info("input"), true, 1e-10f, false, false));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -473,7 +473,7 @@ TEST(mvn_gpu_test, mvn_test_within_channels_inside_sqrt_bfyx_normalize_variance)
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mvn("mvn", input_info("input"), true, 1e-10f, true, false));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -500,7 +500,7 @@ TEST(mvn_gpu_test, mvn_test_within_channels_outside_sqrt_bfyx_normalize_variance
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mvn("mvn", input_info("input"), true, 1e-10f, false, false));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -527,7 +527,7 @@ TEST(mvn_gpu_test, mvn_test_within_channels_inside_sqrt_bfyx_normalize_variance_
     topology.add(input_layout("input", input->get_layout()));
     topology.add(mvn("mvn", input_info("input"), true, 1e-10f, true, false));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -556,7 +556,7 @@ TEST(mvn_gpu_test, dynamic_within_channels_inside_sqrt_bfyx_normalize_variance_f
     topology.add(input_layout("input", in_layout));
     topology.add(mvn("mvn", input_info("input"), true, 1e-10f, true, false));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -663,7 +663,7 @@ struct mvn_random_test : ::testing::TestWithParam<mvn_basic_test_params> {
         prim.output_paddings = {output_pad};
         topo.add(prim);
 
-        cldnn::network::ptr net = get_network(eng, topo, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr net = get_network(eng, topo, get_test_default_config(eng), get_test_stream_ptr(), is_caching_test);
 
         net->set_input_data("input", input);
 
@@ -852,7 +852,7 @@ struct mvn_random_test_bsv32 : ::testing::TestWithParam<mvn_basic_test_params> {
         auto prim = mvn("mvn", input_info("input"), params.normalize_variance, 1e-10f, false, params.across_channels);
         prim.output_paddings = {output_pad};
         topo.add(prim);
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"mvn"}));
         config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"mvn", {format::type::bfyx, "mvn_gpu_bfyx_opt"}} }));
 
@@ -869,7 +869,7 @@ struct mvn_random_test_bsv32 : ::testing::TestWithParam<mvn_basic_test_params> {
         auto prim_opt = mvn("mvn_opt", input_info("input_to_target_layout"), params.normalize_variance, 1e-10f, false, params.across_channels);
         prim_opt.output_paddings = {output_pad};
         topo_opt.add(prim_opt);
-        ExecutionConfig config_opt;
+        ExecutionConfig config_opt = get_test_default_config(engine);
         config_opt.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"mvn_opt", "input_to_target_layout"}));
         config_opt.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"mvn_opt", {params.input_format, "mvn_gpu_b_fs_yx_fsv16_imad"}} }));
 

--- a/src/plugins/intel_gpu/tests/test_cases/non_max_suppression_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/non_max_suppression_test.cpp
@@ -125,7 +125,7 @@ struct non_max_suppression_basic : public testing::Test {
         topo.add(non_max_suppression("nms", input_info("reformat_boxes"), input_info("reformat_scores"), 6, false, true));
         topo.add(reorder("plane_nms", input_info("nms"), format::bfyx, cldnn::data_types::i32));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
 
         cldnn::network::ptr net = get_network(engine, topo, config, get_test_stream_ptr(), is_caching_test);
@@ -186,7 +186,7 @@ struct non_max_suppression_basic : public testing::Test {
                                     "num_per_class"));
         topo.add(reorder("plane_nms", input_info("nms"), format::bfyx, cldnn::data_types::i32));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
 
         cldnn::network::ptr net = get_network(engine, topo, config, get_test_stream_ptr(), is_caching_test);
@@ -257,7 +257,7 @@ struct non_max_suppression_basic : public testing::Test {
         topo.add(reorder("plane_nms", input_info("nms"), format::bfyx, cldnn::data_types::i32));
         topo.add(reorder("plane_scores", input_info("selected_scores"), format::bfyx, this->data_type));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
 
         cldnn::network::ptr net = get_network(engine, topo, config, get_test_stream_ptr(), is_caching_test);
@@ -317,7 +317,7 @@ struct non_max_suppression_basic : public testing::Test {
         second_output_topology.add(input_layout("num_outputs", this->valid_outputs_layout));
         second_output_topology.add(reorder("plane_scores", input_info("selected_scores"), format::bfyx, this->data_type));
         second_output_topology.add(reorder("plane_num", input_info("num_outputs"), format::bfyx, cldnn::data_types::i32));
-        network second_output_net{engine, second_output_topology};
+        network second_output_net{engine, second_output_topology, get_test_default_config(engine)};
         second_output_net.set_input_data("selected_scores", selected_scores_mem);
         second_output_net.set_input_data("num_outputs", valid_outputs_mem);
         auto second_output_result = second_output_net.execute();
@@ -375,7 +375,7 @@ struct non_max_suppression_basic : public testing::Test {
         topo.add(reorder("plane_scores", input_info("nms", 1), format::bfyx, this->data_type));
         topo.add(reorder("plane_outputs", input_info("nms", 2), format::bfyx, cldnn::data_types::i32));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
         config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
@@ -437,7 +437,7 @@ struct non_max_suppression_basic : public testing::Test {
         second_output_topology.add(input_layout("num_outputs", valid_outputs_mem->get_layout()));
         second_output_topology.add(reorder("plane_scores", input_info("selected_scores"), format::bfyx, this->data_type));
         second_output_topology.add(reorder("plane_num", input_info("num_outputs"), format::bfyx, cldnn::data_types::i32));
-        network second_output_net{engine, second_output_topology};
+        network second_output_net{engine, second_output_topology, get_test_default_config(engine)};
         second_output_net.set_input_data("selected_scores", selected_scores_mem);
         second_output_net.set_input_data("num_outputs", valid_outputs_mem);
         auto second_output_result = second_output_net.execute();
@@ -485,7 +485,7 @@ struct non_max_suppression_basic : public testing::Test {
                                     "iou_threshold"));
         topo.add(reorder("plane_nms", input_info("nms"), format::bfyx, cldnn::data_types::i32));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
 
         cldnn::network::ptr net = get_network(engine, topo, config, get_test_stream_ptr(), is_caching_test);
@@ -542,7 +542,7 @@ struct non_max_suppression_basic : public testing::Test {
                                     "score_threshold"));
         topo.add(reorder("plane_nms", input_info("nms"), format::bfyx, cldnn::data_types::i32));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
 
         cldnn::network::ptr net = get_network(engine, topo, config, get_test_stream_ptr(), is_caching_test);
@@ -603,7 +603,7 @@ struct non_max_suppression_basic : public testing::Test {
                                     "soft_nms_sigma"));
         topo.add(reorder("plane_nms", input_info("nms"), format::bfyx, cldnn::data_types::i32));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
 
         cldnn::network::ptr net = get_network(engine, topo, config, get_test_stream_ptr(), is_caching_test);

--- a/src/plugins/intel_gpu/tests/test_cases/non_zero_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/non_zero_gpu_test.cpp
@@ -60,7 +60,7 @@ void test_count_non_zero(layout in_layout, std::vector<T> in_data) {
     topology.add(count_nonzero("count_nonzero", input_info("InputData"))
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("InputData", input_mem);
     auto outputs = network.execute();
     auto output = outputs.at("count_nonzero").get_memory();
@@ -132,7 +132,7 @@ TEST(test_count_non_zero, dynamic_2d_f32_bfyx) {
     topology.add(input_layout("InputData", in_dyn_layout));
     topology.add(count_nonzero("count_nonzero", input_info("InputData")));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     std::vector<size_t> input_shapes = {171, 531, 168, 169, 174, 172, 168, 167, 1169, 16, 677};
@@ -180,7 +180,7 @@ void test_gather_non_zero(layout in_layout, std::vector<T> in_data) {
         gather_nonzero("gather_nonzero", input_info("InputData"), input_info("OutputShape"))
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputData", input_mem);
     auto outputs = network.execute();
@@ -290,7 +290,7 @@ TEST(non_zero_gpu, dynamic) {
     topology.add(count_nonzero("count_nonzero", input_info("InputData")));
     topology.add(gather_nonzero("gather_nonzero", input_info("InputData"), input_info("count_nonzero")));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
@@ -335,7 +335,7 @@ void test_non_zero(layout in_layout, std::vector<T> in_data) {
     topology.add(count_nonzero("count_nonzero", input_info("InputData")));
     topology.add(gather_nonzero("gather_nonzero", input_info("InputData"), input_info("count_nonzero")));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("InputData", input_mem);
     auto outputs = network.execute();

--- a/src/plugins/intel_gpu/tests/test_cases/normalizel2_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/normalizel2_gpu_test.cpp
@@ -83,7 +83,7 @@ struct normalize_basic : public testing::Test {
         topology.add(normalize("normalize2", input_info("reordered_Input0"), "reordered_Input1", this->across_spatial));
         topology.add(reorder("plane_normalize2", input_info("normalize2"), format::bfyx, this->output_data_type));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input);
 

--- a/src/plugins/intel_gpu/tests/test_cases/one_hot_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/one_hot_gpu_test.cpp
@@ -84,7 +84,7 @@ void generic_one_hot_test_int(cldnn::format test_input_fmt, int input_b, int inp
     topology.add(input_layout("input", input->get_layout()));
     topology.add(one_hot("output", input_info("input"), shape, one_hot_axis, one_hot_limit));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input);
     auto outputs = network->execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -183,7 +183,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax4) {
 
     set_values(input, input_rnd_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -242,7 +242,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax4) {
 
     set_values(input, input_rnd_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -301,7 +301,7 @@ TEST(one_hot_gpu_i32_to_f32, bfyx_ax4) {
 
     set_values(input, input_rnd_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -354,7 +354,7 @@ TEST(one_hot_gpu_i64_to_f32, bfyx_ax4) {
 
     set_values(input, input_rnd_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -405,7 +405,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax0) {
 
     set_values(input, input_rnd_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -460,7 +460,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax0) {
 
     set_values(input, input_rnd_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -515,7 +515,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax1) {
 
     set_values(input, input_rnd_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -570,7 +570,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax1) {
 
     set_values(input, input_rnd_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -625,7 +625,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax2) {
 
     set_values(input, input_rnd_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -680,7 +680,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax2) {
 
     set_values(input, input_rnd_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -735,7 +735,7 @@ TEST(one_hot_gpu_i32, bfzyx_ax3) {
 
     set_values(input, input_rnd_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));
@@ -790,7 +790,7 @@ TEST(one_hot_gpu_i64, bfzyx_ax3) {
 
     set_values(input, input_rnd_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
     ASSERT_EQ(outputs.size(), size_t(1));

--- a/src/plugins/intel_gpu/tests/test_cases/permute_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/permute_gpu_test.cpp
@@ -58,7 +58,7 @@ TEST(permute_gpu_f32, output_ordering_test)
                     input_layout("input", input->get_layout()),
                     permute("permute", input_info("input"), perm));
 
-                network network(engine, topology);
+                network network(engine, topology, get_test_default_config(engine));
                 network.set_input_data("input", input);
                 auto outputs = network.execute();
                 auto output = outputs.at("permute");
@@ -113,7 +113,7 @@ TEST(permute_gpu_f32, basic_bfyx_permute_0_1_2_3)
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 1, 2, 3 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -172,7 +172,7 @@ TEST(permute_gpu_f32, basic_bfyx_permute_0_1_3_2)
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 1, 3, 2 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -219,7 +219,7 @@ TEST(permute_gpu_f32, basic_yxfb_permute_1_0_2_3)
         input_layout("input", input_mem->get_layout()),
         permute("permute", input_info("input"), { 1, 0, 2, 3 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_mem);
 
     auto outputs = network.execute();
@@ -281,7 +281,7 @@ TEST(permute_gpu_f32, basic_bfyx_permute_0_1_3_2_input_padding)
         reorder("reorder", input_info("input"), input->get_layout().with_padding(padding{ { 0, 0, 2, 1 }, 0 })),
         permute("permute", input_info("reorder"), { 0, 1, 3, 2 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -338,7 +338,7 @@ TEST(permute_gpu_f32, basic_yxfb_permute_batch_with_feature)
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 1, 0, 2, 3 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -393,7 +393,7 @@ TEST(permute_gpu_f32, basic_bfyx_permute_batch_with_feature)
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 1, 0, 2, 3 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -453,7 +453,7 @@ void permute_test_with_reorder()
         permute("permute", input_info("reorder"), { 0, 1, 3, 2 }),
         reorder("reorder_out", input_info("permute"), { data_types::f32, format::bfyx,{ 2, 2, 3, 2 } }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -552,7 +552,7 @@ TEST(permute_fuse_reorder_gpu_f32, basic_b_fs_yx_fsv4_permute_1_8_16_1)
         reorder("reorder2", input_info("permute"), format::bfyx, data_types::f32),
         permute("out", input_info("reorder2"), { 0, 3, 1, 2}));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(false));
     config.set_property(ov::intel_gpu::allow_static_input_reorder(true));
 
@@ -567,7 +567,7 @@ TEST(permute_fuse_reorder_gpu_f32, basic_b_fs_yx_fsv4_permute_1_8_16_1)
         reorder("reorder2", input_info("permute"), format::bfyx, data_types::f32), // to be fused to previous permute
         permute("out", input_info("reorder2"), { 0, 3, 1, 2})); // return to original value
 
-    ExecutionConfig config_fused;
+    ExecutionConfig config_fused = get_test_default_config(engine);
     config_fused.set_property(ov::intel_gpu::optimize_data(true));
     network fused(engine, topology_fused, config_fused);
     fused.set_input_data("input", input);
@@ -602,7 +602,7 @@ TEST(fc_permute_crop_gpu, basic_permute_yxfb)
         permute("permute", input_info("input"), { 1, 0, 2, 3 }) // yxfb {5, 1, 1, 512}  --- without permute fix yxfb {1, 5, 512, 1}
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_mem);
 
     auto outputs = network.execute();
@@ -637,7 +637,7 @@ TEST(fc_permute_crop_gpu, basic_0)
         crop("crop", input_info("permute"), { 1, 1, 1, 512 }, { 4, 0, 0 ,0 })       // without permute fix it will fail "Tensor pitches didn't set correctly"
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_mem);
 
     auto outputs = network.execute();
@@ -667,7 +667,7 @@ TEST(fc_permute_gpu, basic_permute_bfyx)
         permute("permute", input_info("input"), { 1, 0, 2, 3 })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_mem);
 
     auto outputs = network.execute();
@@ -727,7 +727,7 @@ TEST(permute_gpu_f32, permute_bfwzyx)
         permute("permute", input_info("input"), permute_order)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_mem);
 
     auto outputs = network.execute();
@@ -819,7 +819,7 @@ TEST(permute_gpu_f32, 6D_reshape_permute_reshape)
         reorder("output_4d", input_info("reshape_6_to_4"), { data_types::f32, format::bfyx, cldnn::tensor(batch(b), feature(f), spatial(x, y)) })
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input_mem);
 
     auto outputs = network.execute();
@@ -870,7 +870,7 @@ TEST(permute_gpu_f32, basic_bfzyx_permute_0_4_1_2_3)
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 4, 1, 2, 3 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -937,7 +937,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, normal_bfyx_0_2_3_1) {
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 2, 3, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -993,7 +993,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, f_remainder_bfyx_0_2_3_1) {
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 2, 3, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1049,7 +1049,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, x_remainder_bfyx_0_2_3_1) {
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 2, 3, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1099,7 +1099,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, xf_remainder_bfyx_0_2_3_1) {
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 2, 3, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1149,7 +1149,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, normal_bfzyx_0_2_3_4_1) {
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 2, 3, 4, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1211,7 +1211,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, f_remainder_bfzyx_0_2_3_4_1) {
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 2, 3, 4, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1265,7 +1265,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, x_remainder_bfzyx_0_2_3_4_1) {
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 2, 3, 4, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1319,7 +1319,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, xf_remainder_bfzyx_0_2_3_4_1) {
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 2, 3, 4, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1373,7 +1373,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, normal_bfwzyx_0_2_3_4_5_1) {
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 2, 3, 4, 5, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1445,7 +1445,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, f_remainder_bfwzyx_0_2_3_4_5_1) {
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 2, 3, 4, 5, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1505,7 +1505,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, x_remainder_bfwzyx_0_2_3_4_5_1) {
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 2, 3, 4, 5, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1565,7 +1565,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, xf_remainder_bfwzyx_0_2_3_4_5_1) {
         input_layout("input", input->get_layout()),
         permute("permute", input_info("input"), { 0, 2, 3, 4, 5, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
 
     auto outputs = network.execute();
@@ -1686,7 +1686,7 @@ void TiledPermuteTest::run_test(const std::vector<cldnn::tensor::value_type>& si
     );
 
     // run with permute_ref
-    ov::intel_gpu::ExecutionConfig config_ref;
+    ov::intel_gpu::ExecutionConfig config_ref = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc permute_ref = { format_fsv, "permute_ref" };
     config_ref.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"output", permute_ref} }));
 
@@ -1697,7 +1697,7 @@ void TiledPermuteTest::run_test(const std::vector<cldnn::tensor::value_type>& si
     cldnn::mem_lock<type> output_ref_ptr(output_ref, get_test_stream());
 
     // run with optimized kernel, e.g. permute_tile_8x8_4x4_fsv16
-    ExecutionConfig config_tile;
+    ExecutionConfig config_tile = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc permute_tile_opt = { format_fsv, permute_opt };
     config_tile.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"output", permute_tile_opt} }));
 
@@ -1872,7 +1872,7 @@ TEST(permute_gpu_f32_dynamic, bfyx_0_2_3_1) {
         input_layout("input", input_layout_dynamic),
         permute("permute", input_info("input"), { 0, 2, 3, 1 }));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);

--- a/src/plugins/intel_gpu/tests/test_cases/pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/pooling_gpu_test.cpp
@@ -210,7 +210,7 @@ TEST(pooling_forward_gpu, basic_max_byxf_f32_wsiz3x3_wstr1x1_i1x3x3x8_nopad) {
     topology topology;
     topology.add(input_layout("input_prim", input_prim->get_layout()));
     topology.add(pooling("pool_prim", input_info("input_prim"), pooling_mode::max, { 3, 3 }, { 1, 1 }));
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     set_values(input_prim, { 0.5f, -0.5f, -0.5f, -0.5f, 0.5f, -0.5f, -0.5f, -0.5f,
         1.0f, 0.0f, 0.0f, 0.0f, 0.5f, -0.5f, -0.5f, -0.5f,
         2.0f, 0.0f, 0.0f, 0.0f, 0.5f, -0.5f, -0.5f, -0.5f,
@@ -256,7 +256,7 @@ TEST(pooling_forward_gpu, basic_max_yxfb_f32_wsiz3x3_wstr1x1_i3x3x1x1_nopad) {
     topology.add(input_layout("input_prim", input_prim->get_layout()));
     topology.add(pooling("pool_prim", input_info("input_prim"), pooling_mode::max, { 3, 3 }, { 1, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     set_values(input_prim, { -0.5f, 1.0f, 0.5f, 2.0f, 1.5f, -0.5f, 0.0f, -1.0f, 0.5f });
     network.set_input_data("input_prim", input_prim);
 
@@ -297,12 +297,9 @@ TEST(pooling_forward_gpu, basic_max_pooling_int8) {
         reorder("reorder2", input_info("pool1"), out_layout)
     );
 
-    network network(
-        engine,
-        topology,
-        ExecutionConfig{
-            ov::intel_gpu::custom_outputs(std::vector<std::string>{ "reorder2" })
-        });
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "reorder2" }));
+    network network(engine, topology, cfg);
 
     network.set_input_data("input", input_memory);
 
@@ -349,12 +346,9 @@ TEST(pooling_forward_gpu, basic_avg_pooling_int8) {
         reorder("reorder2", input_info("pool1"), out_layout)
     );
 
-    network network(
-        engine,
-        topology,
-        ExecutionConfig{
-            ov::intel_gpu::custom_outputs(std::vector<std::string>{ "reorder2" })
-        });
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "reorder2" }));
+    network network(engine, topology, cfg);
 
     network.set_input_data("input", input_memory);
 
@@ -390,7 +384,7 @@ TEST(pooling_forward_gpu, basic_max_yxfb_f32_wsiz2x2_wstr1x1_i3x3x1x1_nopad) {
     topology.add(input_layout("input_prim", input_prim->get_layout()));
     topology.add(pooling("pool_prim", input_info("input_prim"), pooling_mode::max, { 2, 2 }, { 1, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     set_values(input_prim, { -0.5f, 1.0f, 0.5f, 2.0f, 1.5f, -0.5f, 0.0f, -1.0f, 0.5f });
     network.set_input_data("input_prim", input_prim);
 
@@ -434,7 +428,7 @@ TEST(pooling_forward_gpu, basic_max_yxfb_f32_wsiz2x2_wstr2x2_i4x4x1x1_nopad) {
     topology.add(input_layout("input_prim", input_prim->get_layout()));
     topology.add(pooling("pool_prim", input_info("input_prim"), pooling_mode::max, { 2, 2 }, { 2, 2 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     set_values(input_prim, { -0.25f, 1.00f, 0.50f, 0.25f, 2.00f, 1.50f, -0.50f, -0.75f, 0.00f, -1.00f, 0.50f, 0.25f, 0.50f, -2.00f, -1.50f, -2.50f });
     network.set_input_data("input_prim", input_prim);
 
@@ -488,7 +482,7 @@ TEST(pooling_forward_gpu, basic_max_yxfb_f32_wsiz2x2_wstr1x1_i3x3x2x2_nopad) {
     topology.add(input_layout("input_prim", input_prim->get_layout()));
     topology.add(pooling("pool_prim", input_info("input_prim"), pooling_mode::max, { 2, 2 }, { 1, 1 }));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     set_values(input_prim, { -0.5f, 0.5f, -1.5f, 0.0f, 0.5f, 0.0f, -0.5f, 0.5f, 0.0f, -0.5f, 0.0f, -0.5f, 1.0f, -2.0f, 0.0f, 1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -2.0f, 1.0f, 1.5f, 0.0f, -1.0f, -0.5f, -2.0f, 0.5f, -0.5f, -1.0f, 1.0f, -0.5f, -0.5f, 1.5f, -0.5f, 0.0f });
     network.set_input_data("input_prim", input_prim);
 
@@ -538,7 +532,7 @@ TEST(pooling_forward_gpu, offsets_max_yxfb_f32_wsiz2x2_wstr2x2_i2x2x1x1_zeropad)
     topology.add(input_layout("input_prim", input_prim->get_layout()));
     topology.add(pooling("pool_prim", input_info("input_prim"), pooling_mode::max, {2, 2}, {2, 2}, {1, 1}));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     set_values(input_prim, { 1.50f, -0.50f, -1.00f, 0.50f });
     network.set_input_data("input_prim", input_prim);
 
@@ -583,7 +577,7 @@ TEST(pooling_forward_gpu, offsets_max_yxfb_f32_wsiz2x2_wstr2x2_i3x3x1x1_zeropad)
     topology.add(input_layout("input_prim", input_prim->get_layout()));
     topology.add(pooling("pool_prim", input_info("input_prim"), pooling_mode::max, {2, 2}, {2, 2}, {1, 1}));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     set_values(input_prim, {
         1.50f, -1.00f, -0.50f,
@@ -632,7 +626,7 @@ TEST(pooling_forward_gpu, basic_avg_yxfb_f32_wsiz2x2_wstr1x1_i3x3x1x1_nopad) {
     topology.add(input_layout("input_prim", input_prim->get_layout()));
     topology.add(pooling("pool_prim", input_info("input_prim"), pooling_mode::average, {2, 2}, {1, 1}));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     set_values(input_prim, { -0.5f, 1.0f, 0.5f, 2.0f, 1.5f, -0.5f, 4.0f, -1.0f, 3.5f });
     network.set_input_data("input_prim", input_prim);
 
@@ -677,7 +671,7 @@ TEST(pooling_forward_gpu, offsets_avg_yxfb_f32_wsiz2x2_wstr2x2_i2x2x1x1_zeropad)
     topology.add(input_layout("input_prim", input_prim->get_layout()));
     topology.add(pooling("pool_prim", input_info("input_prim"), pooling_mode::average, {2, 2}, {2, 2}, {1, 1}));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     set_values(input_prim, { 1.5f, -0.5f, -1.0f, 0.5f });
     network.set_input_data("input_prim", input_prim);
 
@@ -722,7 +716,7 @@ TEST(pooling_forward_gpu, offsets_avg_bfyx_f32_wsiz3x3_wstr3x3_i1x1x3x3_zeropad)
     topology.add(input_layout("input_prim", input_prim->get_layout()));
     topology.add(pooling("pool_prim", input_info("input_prim"), pooling_mode::average, { 3, 3 }, { 3, 3 }, {1, 1}));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     std::vector<float> input_vec = { 1.5f, -0.5f, -1.0f, 0.5f, 0.1f, 0.2f, 0.9f, 1.1f, 2.2f };
     set_values(input_prim, input_vec);
@@ -770,7 +764,7 @@ TEST(pooling_forward_gpu, offsets_avg_yxfb_f32_wsiz2x2_wstr2x2_i3x3x1x1_zeropad)
     topology.add(input_layout("input_prim", input_prim->get_layout()));
     topology.add(pooling("pool_prim", input_info("input_prim"), pooling_mode::average, {2, 2}, {2, 2}, {1, 1}));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     set_values(input_prim, { 1.5f, -0.5f, 2.5f, -1.0f, 0.5f, 3.0f, 0.5f, 0.0f, -8.0f });
     network.set_input_data("input_prim", input_prim);
 
@@ -825,7 +819,7 @@ TEST(pooling_forward_gpu, offsets_avg_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i2x2x1x1_out
         topology.add(input_layout("input_prim", input_prim->get_layout()));
         topology.add(pooling("pool_prim", input_info("input_prim"), pooling_mode::average, {2, 2}, {2, 2}, {1, 1}, {1, 1}, ov::op::PadType::EXPLICIT, ov::op::RoundingType::FLOOR, padding{{0, 0, 2, 2}, 0}));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
         set_values(input_prim, { 1.5f, -0.5f, -1.0f, 0.5f });
         network.set_input_data("input_prim", input_prim);
 
@@ -886,7 +880,7 @@ TEST(pooling_forward_gpu, offsets_max_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i3x3x1x1_out
         topology.add(input_layout("input_prim", input_prim->get_layout()));
         topology.add(pooling("pool_prim", input_info("input_prim"), pooling_mode::max, {2, 2}, {2, 2}, {1, 1}, {1, 1}, ov::op::PadType::EXPLICIT, ov::op::RoundingType::FLOOR, padding{{0, 0, 1, 1}, 0}));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
         set_values(input_prim, {
             1.50f, -1.00f, -0.50f,
@@ -957,7 +951,7 @@ TEST(pooling_forward_gpu, offsets_avg_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i2x2x1x1_inp
         topology.add(reorder("reorder", input_info("input_prim"), input_prim->get_layout().with_padding(padding{ {0,0,1,2}, 0 })));
         topology.add(pooling("pool_prim", input_info("reorder"), pooling_mode::average, {2, 2}, {2, 2}, {1, 1}, {1, 1}, ov::op::PadType::EXPLICIT, ov::op::RoundingType::FLOOR, padding{{0, 0, 2, 2}, 0}));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
         set_values(input_prim, { 1.5f, -0.5f, -1.0f, 0.5f });
         network.set_input_data("input_prim", input_prim);
 
@@ -1020,7 +1014,7 @@ TEST(pooling_forward_gpu, offsets_max_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i3x3x1x1_inp
         topology.add(reorder("reorder", input_info("input_prim"), input_prim->get_layout().with_padding(padding{ { 0, 0, 1, 2 }, 0 })));
         topology.add(pooling("pool_prim", input_info("reorder"), pooling_mode::max, {2, 2}, {2, 2}, {1, 1}, {1, 1}, ov::op::PadType::EXPLICIT, ov::op::RoundingType::FLOOR, padding{{0, 0, 1, 1}, 0}));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
         set_values(input_prim, {
             1.50f, -1.00f, -0.50f,
@@ -1091,7 +1085,7 @@ TEST(pooling_forward_gpu, avg_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i2x2x1x1_inpad2x1_ou
         topology.add(reorder("reorder", input_info("input_prim"), input_prim->get_layout().with_padding(padding{ { 0, 0, 2, 1 }, 0 })));
         topology.add(pooling("pool_prim", input_info("reorder"), pooling_mode::average, { 2, 2 }, { 2, 2 }, { 0, 0 }, { 0, 0 }, ov::op::PadType::EXPLICIT, ov::op::RoundingType::FLOOR, padding{ { 0, 0, 2, 2 }, 0 }));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
         set_values(input_prim, {
             1.f, 2.f, 3.f, 4.f,
             5.f, 1.5f, -0.5f, 6.f,
@@ -1159,7 +1153,7 @@ TEST(pooling_forward_gpu, max_yxfb_bfyx_f32_wsiz2x2_wstr2x2_i3x3x1x1_inpad2x1_ou
         topology.add(reorder("reorder", input_info("input_prim"), input_prim->get_layout().with_padding(padding{ { 0, 0, 2, 1 }, 0 })));
         topology.add(pooling("pool_prim", input_info("reorder"), pooling_mode::max, { 2, 2}, { 2, 2}, {1, 1}, {1, 1}, ov::op::PadType::EXPLICIT, ov::op::RoundingType::FLOOR, padding{{0, 0, 1, 1}, 0}));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
         set_values(input_prim, {
             1.f, 2.f, 3.f, 4.f, 5.f,
@@ -1426,7 +1420,7 @@ TEST(pooling_forward_gpu, b_fs_yx_fsv4)
                               pool);
 
             // Network processing
-            network network(engine, topology);
+            network network(engine, topology, get_test_default_config(engine));
             network.set_input_data("input", input);
             //network_exe(network, vGoldOutput, "pool_GOLD");
             auto outputs = network.execute();
@@ -1475,7 +1469,7 @@ TEST(pooling_forward_gpu, b_fs_yx_fsv4)
                                         format::bfyx,
                                         { in_B, in_F, in_X, in_Y })));
 
-            network network(engine, topology);
+            network network(engine, topology, get_test_default_config(engine));
             network.set_input_data("input", input);
             //network_exe(network, vTestOutput, "reorder_UnSwizzelled");
             auto outputs = network.execute();
@@ -1529,7 +1523,7 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_avg_3x3_input_2x2_pool_1x1_stride_2x2_ou
     topology.add(pooling("avg_pooling", input_info("reorder_input"), pooling_mode::average, { 2, 2 }, { 1, 1 }));
     topology.add(reorder("reorder_after_pooling", input_info("avg_pooling"), layout(data_types::f16, format::bfyx, { 1, 1, 2, 2 })));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     set_values(input_prim, { FLOAT16(-0.5f), FLOAT16(1.0f), FLOAT16(0.5f), FLOAT16(2.0f), FLOAT16(1.5f), FLOAT16(-0.5f), FLOAT16(4.0f), FLOAT16(-1.0f), FLOAT16(3.5f) });
     network.set_input_data("input", input_prim);
 
@@ -1581,7 +1575,7 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_avg_3x3_input_2x2_pool_2x2_stride)
     topology.add(pooling("avg_pooling", input_info("reorder_input"), pooling_mode::average, { 2, 2 }, { 2, 2 }));
     topology.add(reorder("reorder_after_pooling", input_info("avg_pooling"), layout(data_types::f16, format::bfyx, { 1, 1, 3, 3 })));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     set_values(input_prim, { FLOAT16(-0.5f), FLOAT16(1.0f), FLOAT16(0.5f), FLOAT16(2.0f), FLOAT16(1.5f), FLOAT16(-0.5f), FLOAT16(4.0f), FLOAT16(-1.0f), FLOAT16(3.5f) });
     network.set_input_data("input", input_prim);
 
@@ -1647,7 +1641,7 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_avg_2x2x3x3_input_2x2_pool_2x2_stride)
     topology.add(pooling("avg_pooling", input_info("reorder_input"), pooling_mode::average, { 2, 2 }, { 2, 2 }));
     topology.add(reorder("reorder_after_pooling", input_info("avg_pooling"), layout(data_types::f16, format::bfyx, { batch_count, features_count, out_y, out_x })));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     set_values(input_prim, { FLOAT16(-0.5f), FLOAT16(1.0f), FLOAT16(0.5f), FLOAT16(2.0f), FLOAT16(1.5f), FLOAT16(-0.5f), FLOAT16(4.0f), FLOAT16(-1.0f), FLOAT16(3.5f),   //B0F0
                              FLOAT16(-0.5f), FLOAT16(1.0f), FLOAT16(0.5f), FLOAT16(2.0f), FLOAT16(1.5f), FLOAT16(-0.5f), FLOAT16(4.0f), FLOAT16(-1.0f), FLOAT16(3.5f),   //B0F1
                              FLOAT16(-0.5f), FLOAT16(1.0f), FLOAT16(0.5f), FLOAT16(2.0f), FLOAT16(1.5f), FLOAT16(-0.5f), FLOAT16(4.0f), FLOAT16(-1.0f), FLOAT16(3.5f),   //B1F0
@@ -1718,7 +1712,7 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_max_1x1x3x3_input_2x2_pool_2x2_stride_2x
         topology.add(pooling("pool_prim", input_info("reorder_input"), pooling_mode::max, {2, 2}, {2, 2}, {1, 1}, {1, 1}, ov::op::PadType::EXPLICIT, ov::op::RoundingType::FLOOR, padding{{0, 0, 1, 1}, 0}));
         topology.add(reorder("reorder_pooling", input_info("pool_prim"), layout(data_types::f16, format::bfyx, { 1,1,4,4 }, padding{ { 0, 0, 1, 1 }, 0 })));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
         set_values(input_prim, {
             FLOAT16(1.50f), FLOAT16(-1.00f), FLOAT16(-0.50f),
@@ -1791,7 +1785,7 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_max_1x1x5x5_input_2x2_pool_2x2_stride_2x
     topology.add(pooling("pool_prim", input_info("reorder_input"), pooling_mode::max, {2, 2}, {2, 2}, {1, 1}, {1, 1}, ov::op::PadType::EXPLICIT, ov::op::RoundingType::FLOOR, padding{{0, 0, 1, 1}, 0}));
     topology.add(reorder("reorder_pooling", input_info("pool_prim"), layout(data_types::f16, format::bfyx, input_tensor, padding{ { 0, 0, 1, 1 }, 0 })));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     set_values(input_prim, {
         FLOAT16(1.f),  FLOAT16(2.f),    FLOAT16(3.f),    FLOAT16(4.f),    FLOAT16(5.f),
@@ -1867,7 +1861,7 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_avg_65x5x6x7_input_3x3_pool_4x4_stride_3
         golden_topology.add(reorder("reorder_input", input_info("input"), input_prim->get_layout().with_padding(padding{ {0,0,x_in_pad,y_in_pad},0 })));
         golden_topology.add(pooling("golden_pooling", input_info("reorder_input"), pooling_mode::average, { pool_size, pool_size }, { stride_size, stride_size }, { 0, 0 }, { 0, 0 }, ov::op::PadType::EXPLICIT, ov::op::RoundingType::FLOOR, padding{ { 0, 0, x_out_pad, y_out_pad }, 0 }));
 
-        network golden_network(engine, golden_topology);
+        network golden_network(engine, golden_topology, get_test_default_config(engine));
         golden_network.set_input_data("input", input_prim);
 
         auto outputs = golden_network.execute();
@@ -1885,7 +1879,7 @@ TEST(pooling_forward_gpu, fs_b_yx_fsv32_avg_65x5x6x7_input_3x3_pool_4x4_stride_3
         golden_topology.add(pooling("fsv32_pooling", input_info("reorder_input"), pooling_mode::average, { pool_size, pool_size }, { stride_size, stride_size }, { 0, 0 }, { 0, 0 }, ov::op::PadType::EXPLICIT, ov::op::RoundingType::FLOOR, padding{ { 0, 0, x_out_pad, y_out_pad }, 0 }));
         golden_topology.add(reorder("reorder_pooling", input_info("fsv32_pooling"), layout(data_types::f16, format::bfyx, input_tensor, padding{ { 0,0,x_out_pad,y_out_pad },0 })));
 
-        network fsv32_network(engine, golden_topology);
+        network fsv32_network(engine, golden_topology, get_test_default_config(engine));
         fsv32_network.set_input_data("input", input_prim);
 
         auto outputs = fsv32_network.execute();
@@ -1936,7 +1930,8 @@ public:
     virtual void run_expect(const VVVVVF<output_t>& expected, bool is_caching_test) {
         auto& eng = get_test_engine();
         auto topo = build_topology(eng);
-        ExecutionConfig config(ov::intel_gpu::optimize_data(true));
+        ExecutionConfig config = get_test_default_config(eng);
+        config.set_property(ov::intel_gpu::optimize_data(true));
 
         cldnn::network::ptr net = get_network(eng, topo, config, get_test_stream_ptr(), is_caching_test);
 
@@ -2314,7 +2309,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_16x16x8x8_input_2x2_pool_2x2_stride)
         golden_topology.add(pooling("golden_pooling", input_info("reorder_input"), pooling_mode::max, {pool_size, pool_size},
                                     {stride_size, stride_size},{y_in_pad, x_in_pad}));
 
-        network golden_network(engine, golden_topology);
+        network golden_network(engine, golden_topology, get_test_default_config(engine));
         golden_network.set_input_data("input", input_prim);
 
         auto outputs = golden_network.execute();
@@ -2336,7 +2331,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_16x16x8x8_input_2x2_pool_2x2_stride)
         tested_topology.add(reorder("reorder_pooling", input_info("bsv16_fsv16_pooling"),
                                     layout(data_types::f32, format::bfyx, input_tensor)));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"bsv16_fsv16_pooling", "reorder_pooling"}));
         network bsv16_fsv16_network(engine, tested_topology, config);
         bsv16_fsv16_network.set_input_data("input", input_prim);
@@ -2399,7 +2394,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_16x16x2x2_input_4x4_pool_1x1_stride_1x
                 pooling("golden_pooling", input_info("reorder_input"), pooling_mode::max, {pool_size, pool_size},
                         {stride_size, stride_size}, {y_in_pad, x_in_pad}));
 
-        network golden_network(engine, golden_topology);
+        network golden_network(engine, golden_topology, get_test_default_config(engine));
         golden_network.set_input_data("input", input_prim);
 
         auto outputs = golden_network.execute();
@@ -2420,7 +2415,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_16x16x2x2_input_4x4_pool_1x1_stride_1x
                     {stride_size, stride_size}, {y_in_pad, x_in_pad}));
         tested_topology.add(reorder("reorder_pooling", input_info("bsv16_fsv16_pooling"), layout(data_types::f32, format::bfyx, input_tensor)));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"bsv16_fsv16_pooling", "reorder_pooling"}));
         network bsv16_fsv16_network(engine, tested_topology, config);
         bsv16_fsv16_network.set_input_data("input", input_prim);
@@ -2481,7 +2476,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_avg_16x16x20x20_input_5x5_pool_3x3_stride)
         golden_topology.add(pooling("golden_pooling", input_info("reorder_input"), pooling_mode::average, {pool_size, pool_size},
                                     {stride_size, stride_size}, {y_in_pad, x_in_pad}));
 
-        network golden_network(engine, golden_topology);
+        network golden_network(engine, golden_topology, get_test_default_config(engine));
         golden_network.set_input_data("input", input_prim);
 
         auto outputs = golden_network.execute();
@@ -2504,7 +2499,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_avg_16x16x20x20_input_5x5_pool_3x3_stride)
         tested_topology.add(reorder("reorder_pooling", input_info("bsv16_fsv16_pooling"),
                                     layout(data_types::f32, format::bfyx, input_tensor)));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"bsv16_fsv16_pooling", "reorder_pooling"}));
         network bsv16_fsv16_network(engine, tested_topology, config);
         bsv16_fsv16_network.set_input_data("input", input_prim);
@@ -2566,7 +2561,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_avg_16x16x20x20_input_5x5_pool_3x1_stride)
         golden_topology.add(pooling("golden_pooling", input_info("reorder_input"), pooling_mode::average, {pool_size, pool_size},
                                     {stride_size_y, stride_size_x}, {y_in_pad, x_in_pad}));
 
-        network golden_network(engine, golden_topology);
+        network golden_network(engine, golden_topology, get_test_default_config(engine));
         golden_network.set_input_data("input", input_prim);
 
         auto outputs = golden_network.execute();
@@ -2587,7 +2582,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_avg_16x16x20x20_input_5x5_pool_3x1_stride)
                                     {stride_size_y, stride_size_x}, {y_in_pad, x_in_pad}));
         tested_topology.add(reorder("reorder_pooling", input_info("bsv16_fsv16_pooling"), layout(data_types::f32, format::bfyx, input_tensor)));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"bsv16_fsv16_pooling", "reorder_pooling"}));
         network bsv16_fsv16_network(engine, tested_topology, config);
         bsv16_fsv16_network.set_input_data("input", input_prim);
@@ -2649,7 +2644,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_16x16x20x20_input_5x5_pool_3x1_stride)
         golden_topology.add(pooling("golden_pooling", input_info("reorder_input"), pooling_mode::max, {pool_size, pool_size},
                                     {stride_size_y, stride_size_x}, {y_in_pad, x_in_pad}));
 
-        network golden_network(engine, golden_topology);
+        network golden_network(engine, golden_topology, get_test_default_config(engine));
         golden_network.set_input_data("input", input_prim);
 
         auto outputs = golden_network.execute();
@@ -2672,7 +2667,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_16x16x20x20_input_5x5_pool_3x1_stride)
                         {stride_size_y, stride_size_x}, {y_in_pad, x_in_pad}));
         tested_topology.add(reorder("reorder_pooling", input_info("bsv16_fsv16_pooling"), layout(data_types::f32, format::bfyx, input_tensor)));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"bsv16_fsv16_pooling", "reorder_pooling"}));
         network bsv16_fsv16_network(engine, tested_topology, config);
         bsv16_fsv16_network.set_input_data("input", input_prim);
@@ -2734,7 +2729,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_32x32x20x20_input_5x5_pool_3x1_stride)
         golden_topology.add(pooling("golden_pooling", input_info("reorder_input"), pooling_mode::max, {pool_size, pool_size},
                                     {stride_size_y, stride_size_x}, {y_in_pad, x_in_pad}));
 
-        network golden_network(engine, golden_topology);
+        network golden_network(engine, golden_topology, get_test_default_config(engine));
         golden_network.set_input_data("input", input_prim);
 
         auto outputs = golden_network.execute();
@@ -2757,7 +2752,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_32x32x20x20_input_5x5_pool_3x1_stride)
                         {stride_size_y, stride_size_x}, {y_in_pad, x_in_pad}));
         tested_topology.add(reorder("reorder_pooling", input_info("bsv16_fsv16_pooling"), layout(data_types::f32, format::bfyx, input_tensor)));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"bsv16_fsv16_pooling", "reorder_pooling"}));
         network bsv16_fsv16_network(engine, tested_topology, config);
         bsv16_fsv16_network.set_input_data("input", input_prim);
@@ -2823,7 +2818,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_32x16x20x20_input_5x5_pool_3x1_stride)
         golden_topology.add(pooling("golden_pooling", input_info("reorder_input"), pooling_mode::max, {pool_size, pool_size},
                                     {stride_size_y, stride_size_x}, {y_in_pad, x_in_pad}));
 
-        network golden_network(engine, golden_topology);
+        network golden_network(engine, golden_topology, get_test_default_config(engine));
         golden_network.set_input_data("input", input_prim);
 
         auto outputs = golden_network.execute();
@@ -2846,7 +2841,7 @@ TEST(pooling_forward_gpu, bsv16_fsv16_max_32x16x20x20_input_5x5_pool_3x1_stride)
                         {stride_size_y, stride_size_x}, {y_in_pad, x_in_pad}));
         tested_topology.add(reorder("reorder_pooling", input_info("bsv16_fsv16_pooling"), layout(data_types::f32, format::bfyx, input_tensor)));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"bsv16_fsv16_pooling", "reorder_pooling"}));
         network bsv16_fsv16_network(engine, tested_topology, config);
         bsv16_fsv16_network.set_input_data("input", input_prim);
@@ -3231,10 +3226,10 @@ TEST(pooling_forward_gpu_onednn, basic_max_pooling_int8) {
     );
 
     ov::intel_gpu::ImplementationDesc impl = {format::bfyx, std::string(""), impl_types::onednn};
-    ExecutionConfig cfg{ov::intel_gpu::queue_type(QueueTypes::in_order),
-                        ov::intel_gpu::custom_outputs(std::vector<std::string>{ "reorder2" }),
-                        ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"pool1", impl}}),
-    };
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
+    cfg.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "reorder2" }));
+    cfg.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"pool1", impl}}));
 
     network network(
         engine,

--- a/src/plugins/intel_gpu/tests/test_cases/pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/pooling_gpu_test.cpp
@@ -3227,7 +3227,6 @@ TEST(pooling_forward_gpu_onednn, basic_max_pooling_int8) {
 
     ov::intel_gpu::ImplementationDesc impl = {format::bfyx, std::string(""), impl_types::onednn};
     ExecutionConfig cfg = get_test_default_config(engine);
-    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     cfg.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "reorder2" }));
     cfg.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"pool1", impl}}));
 

--- a/src/plugins/intel_gpu/tests/test_cases/prior_box_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/prior_box_gpu_test.cpp
@@ -90,7 +90,7 @@ public:
         topo.add(prior_box);
         topo.add(reorder("prior_box", input_info("blocked_prior_box"), plain_format, output_data_type));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(false));
 
         cldnn::network::ptr network = get_network(engine, topo, config, get_test_stream_ptr(), is_caching_test);

--- a/src/plugins/intel_gpu/tests/test_cases/propagate_constants_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/propagate_constants_gpu_test.cpp
@@ -18,7 +18,7 @@ using namespace ::tests;
 template <typename T>
 void test_copy_dependecies_from_nodes(bool is_caching_test) {
     auto& engine = get_test_engine();
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     auto input = engine.allocate_memory({ data_types::f16, format::yxfb,{ 1, 1, 2, 2 } });

--- a/src/plugins/intel_gpu/tests/test_cases/pyramid_roi_align_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/pyramid_roi_align_gpu_test.cpp
@@ -100,7 +100,7 @@ struct pyramid_roi_align_typed_test : testing::Test {
                                 { P2_scale, P3_scale, P4_scale, P5_scale },
                                 starting_level));
 
-        cldnn::network::ptr net = get_network(engine, topo, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr net = get_network(engine, topo, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         net->set_input_data("rois", rois_mem);
 

--- a/src/plugins/intel_gpu/tests/test_cases/quantize_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/quantize_gpu_test.cpp
@@ -84,7 +84,7 @@ TEST(quantize_gpu, quantize_levels_2_output_broadcast_inputs_1) {
         quantize("quantize", input_info("input"), input_info("input_low"), input_info("input_high"), input_info("output_low"), input_info("output_high"), 2, data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -148,7 +148,7 @@ TEST(quantize_gpu, quantize_levels_2_output_broadcast_inputs_1_ch8) {
         quantize("quantize", input_info("input"), input_info("input_low"), input_info("input_high"), input_info("output_low"), input_info("output_high"), 2, data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -212,7 +212,7 @@ TEST(quantize_gpu, quantize_levels_2_output_broadcast_inputs_1_ch8_binary_pack) 
         reorder("reorder", input_info("quantize"), layout{data_types::f32, format::bfyx, tensor{1,8,2,2}})
     );
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -292,7 +292,7 @@ TEST(quantize_gpu, quantize_levels_2_output_broadcast_inputs_2) {
         quantize("quantize", input_info("input"), input_info("input_low"), input_info("input_high"), input_info("output_low"), input_info("output_high"), 2, data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -381,7 +381,7 @@ TEST(quantize_gpu, quantize_levels_3) {
         quantize("quantize", input_info("input"), input_info("input_low"), input_info("input_high"), input_info("output_low"), input_info("output_high"), 3, data_types::f32)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -472,7 +472,7 @@ TEST(quantize_gpu, quantize_levels_256_2d_unsigned) {
         quantize("quantize", input_info("input"), input_info("input_low"), input_info("input_high"), input_info("output_low"), input_info("output_high"), 256, data_types::u8)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -564,7 +564,7 @@ TEST(quantize_gpu, quantize_levels_256_3d_unsigned) {
         reorder("out", input_info("quantize"), format::bfzyx, data_types::u8)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
     network.set_input_data("input", input);
     auto outputs = network.execute();
 
@@ -658,7 +658,7 @@ TEST(quantize_gpu, dynamic) {
         quantize("quantize", input_info("input"), input_info("input_low"), input_info("input_high"), input_info("output_low"), input_info("output_high"), 2, data_types::f32)
     );
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -837,7 +837,7 @@ struct quantize_random_test : testing::TestWithParam<quantize_random_test_params
             FAIL() << "Not supported inputs number: " << params.inputs_num;
         }
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"quantize"}));
 
         cldnn::network::ptr net = get_network(engine, topo, config, get_test_stream_ptr(), is_caching_test);
@@ -877,7 +877,7 @@ struct quantize_random_test : testing::TestWithParam<quantize_random_test_params
         }
 
 
-        network net_opt(engine, topo_opt, ExecutionConfig{});
+        network net_opt(engine, topo_opt, get_test_default_config(engine));
         net_opt.set_input_data("input_opt", input_opt);
 
         auto result_opt = net_opt.execute();

--- a/src/plugins/intel_gpu/tests/test_cases/random_uniform_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/random_uniform_gpu_test.cpp
@@ -53,7 +53,7 @@ public:
         topology.add(input_layout("shape", shape->get_layout()));
         topology.add(input_layout("min_val", min_val->get_layout()));
         topology.add(input_layout("max_val", max_val->get_layout()));
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
 
         cldnn::network::ptr net = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);

--- a/src/plugins/intel_gpu/tests/test_cases/range_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/range_gpu_test.cpp
@@ -44,9 +44,11 @@ struct RangeArgs {
         step.addTo(topology);
         topology.add(range { "range", { input_info(start.name), input_info(stop.name), input_info(step.name) }, { dt, format::bfyx, tensor{batch(outLen)} } });
 
-        ExecutionConfig config(ov::intel_gpu::allow_new_shape_infer(use_new_shape_infer));
+        auto& engine = get_test_engine();
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(use_new_shape_infer));
 
-        network network { tests::get_test_engine(), topology, config };
+        network network { engine, topology, config };
 
         start.setData(network);
         stop.setData(network);
@@ -207,7 +209,7 @@ TEST(range_gpu_test, range_with_select) {
     set_values<int32_t>(input0, {start_val});
     set_values<int32_t>(input2, {step_val});
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     network network { tests::get_test_engine(), topology, config };
@@ -243,7 +245,7 @@ TEST(range_gpu_test, constant_folding) {
     topology.add(data("input2", input2));
     topology.add(range{ "range", { input_info("input0"), input_info("input1"), input_info("input2") }, data_types::i32});
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     network network(engine, topology, config);
@@ -281,7 +283,7 @@ TEST(range_gpu_test, dynamic_all) {
     topology.add(input_layout("input2", dynamic_input_layout));
     topology.add(range{ "range", { input_info("input0"), input_info("input1"), input_info("input2") }, data_types::i32});
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     network network(engine, topology, config);
@@ -327,7 +329,7 @@ TEST(range_gpu_test, dynamic_stop) {
     topology.add(data("input2", input2));
     topology.add(range{ "range", { input_info("input0"), input_info("input1"), input_info("input2") }, data_types::i32});
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     network network(engine, topology, config);

--- a/src/plugins/intel_gpu/tests/test_cases/reduce_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reduce_gpu_test.cpp
@@ -526,7 +526,7 @@ public:
         }
         topology.add(input_layout("input", input_mem->get_layout()));
         topology.add(red);
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
         ov::intel_gpu::ImplementationDesc reduce_impl = {input_format, kernel_name};
         config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"reduce", reduce_impl}}));
@@ -780,7 +780,7 @@ void test_common_bfyx(bool is_caching_test) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::sum, {0}, 0));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
 
@@ -814,7 +814,7 @@ TEST(reduce_gpu, common_bfyx_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::sum, {3, 2}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -844,7 +844,7 @@ TEST(reduce_gpu, regr_bfyx_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::sum, { 0, 3 }, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -874,7 +874,7 @@ TEST(reduce_gpu, common_bfzyx) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::sum, {0}, 0));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -904,7 +904,7 @@ TEST(reduce_gpu, common_bfzyx_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::sum, {0}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -934,7 +934,7 @@ TEST(reduce_gpu, common_bfwzyx) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::sum, {2, 3, 4, 5}, 0));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -964,7 +964,7 @@ TEST(reduce_gpu, common_bfwzyx_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::sum, {1, 2, 3}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -995,7 +995,7 @@ TEST(reduce_gpu, common_bfwzyx_max_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::max, {0, 1}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1025,7 +1025,7 @@ TEST(reduce_gpu, common_bfwzyx_min) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::min, {1, 2}, 0));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1055,7 +1055,7 @@ TEST(reduce_gpu, common_bfwzyx_min_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::min, {1, 2}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1085,7 +1085,7 @@ TEST(reduce_gpu, common_bfwzyx_mean) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::mean, {1, 2}, 0));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1115,7 +1115,7 @@ TEST(reduce_gpu, common_bfwzyx_mean_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::mean, {1, 2}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1145,7 +1145,7 @@ TEST(reduce_gpu, common_bfwzyx_prod) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::prod, {1, 2}, 0));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1175,7 +1175,7 @@ TEST(reduce_gpu, common_bfwzyx_prod_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::prod, {1, 2}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1206,7 +1206,7 @@ TEST(reduce_gpu, common_bfwzyx_sum_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::sum, {0, 1}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1236,7 +1236,7 @@ TEST(reduce_gpu, common_bfwzyx_logical_and) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::logical_and, {1, 2}, 0));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1266,7 +1266,7 @@ TEST(reduce_gpu, common_bfwzyx_logical_and_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::logical_and, {1, 2}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1296,7 +1296,7 @@ TEST(reduce_gpu, common_bfwzyx_logical_or) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::logical_or, {1, 2}, 0));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1326,7 +1326,7 @@ TEST(reduce_gpu, common_bfwzyx_logical_or_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::logical_or, {1, 2}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1356,7 +1356,7 @@ TEST(reduce_gpu, common_bfwzyx_sum_square) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::sum_square, {1, 2}, 0));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1386,7 +1386,7 @@ TEST(reduce_gpu, common_bfwzyx_sum_square_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::sum_square, {1, 2}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1416,7 +1416,7 @@ TEST(reduce_gpu, common_bfwzyx_l1) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::l1, {1, 2}, 0));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1446,7 +1446,7 @@ TEST(reduce_gpu, common_bfwzyx_l1_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::l1, {1, 2}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1476,7 +1476,7 @@ TEST(reduce_gpu, common_bfwzyx_l2) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::l2, {1, 2}, 0));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1506,7 +1506,7 @@ TEST(reduce_gpu, common_bfwzyx_l2_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::l2, {1, 2}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1536,7 +1536,7 @@ TEST(reduce_gpu, common_bfwzyx_log_sum) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::log_sum, {1, 2}, 0));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1566,7 +1566,7 @@ TEST(reduce_gpu, common_bfwzyx_log_sum_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::log_sum, {1, 2}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1596,7 +1596,7 @@ TEST(reduce_gpu, common_bfwzyx_log_sum_exp) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::log_sum_exp, {1, 2}, 0));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1626,7 +1626,7 @@ TEST(reduce_gpu, common_bfwzyx_log_sum_exp_keepdims) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::log_sum_exp, {1, 2}, 1));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -1658,7 +1658,7 @@ TEST(reduce_gpu, dynamic) {
     topology.add(input_layout("input", in_dyn_layout));
     topology.add(reduce("reduce", input_info("input"), reduce_mode::prod, {1, 2}, 1));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -1715,7 +1715,7 @@ TEST(reduce_gpu, b_fs_yx_fsv16_min_dynamic) {
     topology.add(reorder("reorder", input_info("input"), used_layout));
     topology.add(reduce("reduce", input_info("reorder"), reduce_mode::min, {1}, 0));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     network network(engine, topology, config);
@@ -1770,7 +1770,7 @@ TEST(reduce_gpu, b_fs_yx_fsv16_max_dynamic) {
     topology.add(reorder("reorder", input_info("input"), used_layout));
     topology.add(reduce("reduce", input_info("reorder"), reduce_mode::max, {1}, 0)); 
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     network network(engine, topology, config);
@@ -1891,7 +1891,7 @@ public:
             }
             topology.add(input_layout("input", input_mem->get_layout()));
             topology.add(red);
-            ExecutionConfig config;
+            ExecutionConfig config = get_test_default_config(engine);
             config.set_property(ov::intel_gpu::optimize_data(true));
             ov::intel_gpu::ImplementationDesc reduce_impl = {input_format, kernel_name};
             config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"reduce", reduce_impl}}));
@@ -2045,7 +2045,7 @@ public:
         }
         topology.add(input_layout("input", input_mem->get_layout()));
         topology.add(red);
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
         ov::intel_gpu::ImplementationDesc reduce_impl = {input_format, kernel_name, impl_types::onednn};
         config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"reduce", reduce_impl}}));

--- a/src/plugins/intel_gpu/tests/test_cases/region_yolo_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/region_yolo_gpu_test.cpp
@@ -180,7 +180,7 @@ void runRegionTest(region_yolo_test_params& params, bool is_caching_test = false
                              params.regionNum, static_cast<uint32_t>(params.mask.size()), params.softMax));
     topology.add(reorder("reorder_post", input_info("region_yolo"), format::bfyx, params.dataType));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("InputData", inputPrim);
 

--- a/src/plugins/intel_gpu/tests/test_cases/removing_output_node_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/removing_output_node_test.cpp
@@ -63,7 +63,7 @@ void test_multiple_outputs(bool is_caching_test) {
     std::vector<T> out_vec = { 0.0f, 3.0f, 1.0f, 4.0f, 2.0f, 5.0f };
     set_values(input, input_vec);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "shuffle_channels", "reshape", "strided_slice" }));
 
     cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
@@ -131,7 +131,7 @@ void test_output_node_optimization(bool is_caching_test) {
     topology.add(convolution("conv", input_info("input"), { "weights" }, { 2, 1 }));
     topology.add(activation("relu", input_info("conv"), activation_func::relu));
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input);
 
     // checking the output node has the same name after output node deleting due to ReLU optimization

--- a/src/plugins/intel_gpu/tests/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reorder_gpu_test.cpp
@@ -2951,6 +2951,8 @@ TEST(reorder_onednn_gpu, basic_convert_int8) {
 
 #ifdef RUN_ALL_MODEL_CACHING_TESTS
 TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv32_to_bfyx_f32_cached) {
+    if (get_test_engine().get_device_info().supports_immad)
+        return;
     // b_fs_yx_fsv32 -> bfyx
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::f32, format::b_fs_yx_fsv32, format::bfyx, 3, 64 + 5, 16 + 11, 3, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::f32, format::b_fs_yx_fsv32, format::bfyx, 3, 96 - 12, 16 + 4, 3, 0, 0, true);
@@ -2964,6 +2966,8 @@ TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv32_to_bfyx_f32_cache
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv32_to_bfyx_different_datatype_cached) {
+    if (get_test_engine().get_device_info().supports_immad)
+        return;
     // f32 -> other types
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::u8, format::b_fs_yx_fsv32, format::bfyx, 2, 64, 8 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::i64, format::b_fs_yx_fsv32, format::bfyx, 2, 64, 16 + 2, 2, 0, 0, true);
@@ -2975,6 +2979,8 @@ TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv32_to_bfyx_different
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv16_to_bfyx_f32_cached) {
+    if (get_test_engine().get_device_info().supports_immad)
+        return;
     // u-net
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::f32, format::b_fs_yx_fsv16, format::bfyx, 1, 64, 388, 388, 0, 0, true);
     // b_fs_yx_fsv16 -> bfyx
@@ -2990,6 +2996,8 @@ TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv16_to_bfyx_f32_cache
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv16_to_bfyx_different_datatype_cached) {
+    if (get_test_engine().get_device_info().supports_immad)
+        return;
     // f32 -> other types
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::u8, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::i8, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, true);
@@ -3005,6 +3013,8 @@ TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv16_to_bfyx_different
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_blocked_f32_cached) {
+    if (get_test_engine().get_device_info().supports_immad)
+        return;
     // bfyx_to_b_fs_yx_fsv4
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfyx, format::b_fs_yx_fsv4, 4, 32, 16, 4, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfyx, format::b_fs_yx_fsv4, 3, 32 + 2, 32 + 3, 4, 0, 0, true);
@@ -3026,6 +3036,8 @@ TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_blocked_f32_cached) {
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_cached) {
+    if (get_test_engine().get_device_info().supports_immad)
+        return;
     // bfyx to double blocked format (bs_fs_yx_bsv16_fsv16)
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfyx, format::bs_fs_yx_bsv16_fsv16, 32, 48, 8, 4, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfyx, format::bs_fs_yx_bsv16_fsv16, 32 + 2, 48, 16, 4, 0, 0, true);
@@ -3041,6 +3053,8 @@ TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_cach
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv16_fsv32_cached) {
+    if (get_test_engine().get_device_info().supports_immad)
+        return;
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv16_fsv32, 3, 16, 4, 5, 7, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv16_fsv32, 1, 1, 1, 1, 1, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv16_fsv32, 32 + 2, 48, 16, 4, 2, 0, true);
@@ -3051,6 +3065,8 @@ TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv1
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv32_fsv16_cached) {
+    if (get_test_engine().get_device_info().supports_immad)
+        return;
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv32_fsv16, 1, 1, 1, 1, 1, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv32_fsv16, 32 + 2, 48, 16, 4, 2, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv32_fsv16, 32, 48 + 5, 16, 4, 3, 0, true);
@@ -3059,6 +3075,8 @@ TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv3
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv32_fsv32_cached) {
+    if (get_test_engine().get_device_info().supports_immad)
+        return;
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv32_fsv32, 1, 1, 1, 1, 1, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv32_fsv32, 32 + 2, 48, 16, 4, 2, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv32_fsv32, 32, 48 + 5, 16, 4, 3, 0, true);
@@ -3067,6 +3085,8 @@ TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv3
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_blocked_format_different_datatype_cached) {
+    if (get_test_engine().get_device_info().supports_immad)
+        return;
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f16, format::bfyx, format::b_fs_yx_fsv16, 3, 32 + 4, 16 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::i8, data_types::f32, format::bfyx, format::b_fs_yx_fsv16, 3, 32 + 4, 16 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::i64, data_types::f32, format::bfyx, format::b_fs_yx_fsv16, 3, 32 + 4, 16 + 7, 2, 0, 0, true);

--- a/src/plugins/intel_gpu/tests/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reorder_gpu_test.cpp
@@ -2718,7 +2718,6 @@ TEST_P(testing_removal_reorder, removal_no_padded_reorder) {
 
     ov::intel_gpu::ImplementationDesc impl = { format::b_fs_yx_fsv16, std::string(""), impl_types::ocl };
     ExecutionConfig config = get_test_default_config(engine);
-    config.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"conv_output", impl} }));
 
@@ -2748,7 +2747,6 @@ TEST_P(testing_removal_reorder, removal_padded_reorder) {
 
     ov::intel_gpu::ImplementationDesc impl = { format::b_fs_yx_fsv16, std::string(""), impl_types::ocl };
     ExecutionConfig config = get_test_default_config(engine);
-    config.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"conv_output", impl} }));
 
@@ -2922,7 +2920,6 @@ TEST(reorder_onednn_gpu, basic_convert_int8) {
 
     ov::intel_gpu::ImplementationDesc impl = { format::bfyx, std::string(""), impl_types::onednn };
     ExecutionConfig cfg = get_test_default_config(engine);
-    cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
     cfg.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "reorder_input", "reorder2"}));
     cfg.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{ "reorder_input", impl }}));
 
@@ -2947,8 +2944,6 @@ TEST(reorder_onednn_gpu, basic_convert_int8) {
 
 #ifdef RUN_ALL_MODEL_CACHING_TESTS
 TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv32_to_bfyx_f32_cached) {
-    if (get_test_engine().get_device_info().supports_immad)
-        return;
     // b_fs_yx_fsv32 -> bfyx
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::f32, format::b_fs_yx_fsv32, format::bfyx, 3, 64 + 5, 16 + 11, 3, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::f32, format::b_fs_yx_fsv32, format::bfyx, 3, 96 - 12, 16 + 4, 3, 0, 0, true);
@@ -2962,8 +2957,6 @@ TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv32_to_bfyx_f32_cache
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv32_to_bfyx_different_datatype_cached) {
-    if (get_test_engine().get_device_info().supports_immad)
-        return;
     // f32 -> other types
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::u8, format::b_fs_yx_fsv32, format::bfyx, 2, 64, 8 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::i64, format::b_fs_yx_fsv32, format::bfyx, 2, 64, 16 + 2, 2, 0, 0, true);
@@ -2975,8 +2968,6 @@ TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv32_to_bfyx_different
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv16_to_bfyx_f32_cached) {
-    if (get_test_engine().get_device_info().supports_immad)
-        return;
     // u-net
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::f32, format::b_fs_yx_fsv16, format::bfyx, 1, 64, 388, 388, 0, 0, true);
     // b_fs_yx_fsv16 -> bfyx
@@ -2992,8 +2983,6 @@ TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv16_to_bfyx_f32_cache
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv16_to_bfyx_different_datatype_cached) {
-    if (get_test_engine().get_device_info().supports_immad)
-        return;
     // f32 -> other types
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::u8, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::i8, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, true);
@@ -3009,8 +2998,6 @@ TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv16_to_bfyx_different
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_blocked_f32_cached) {
-    if (get_test_engine().get_device_info().supports_immad)
-        return;
     // bfyx_to_b_fs_yx_fsv4
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfyx, format::b_fs_yx_fsv4, 4, 32, 16, 4, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfyx, format::b_fs_yx_fsv4, 3, 32 + 2, 32 + 3, 4, 0, 0, true);
@@ -3032,8 +3019,6 @@ TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_blocked_f32_cached) {
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_cached) {
-    if (get_test_engine().get_device_info().supports_immad)
-        return;
     // bfyx to double blocked format (bs_fs_yx_bsv16_fsv16)
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfyx, format::bs_fs_yx_bsv16_fsv16, 32, 48, 8, 4, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfyx, format::bs_fs_yx_bsv16_fsv16, 32 + 2, 48, 16, 4, 0, 0, true);
@@ -3049,8 +3034,6 @@ TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_cach
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv16_fsv32_cached) {
-    if (get_test_engine().get_device_info().supports_immad)
-        return;
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv16_fsv32, 3, 16, 4, 5, 7, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv16_fsv32, 1, 1, 1, 1, 1, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv16_fsv32, 32 + 2, 48, 16, 4, 2, 0, true);
@@ -3061,8 +3044,6 @@ TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv1
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv32_fsv16_cached) {
-    if (get_test_engine().get_device_info().supports_immad)
-        return;
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv32_fsv16, 1, 1, 1, 1, 1, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv32_fsv16, 32 + 2, 48, 16, 4, 2, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv32_fsv16, 32, 48 + 5, 16, 4, 3, 0, true);
@@ -3071,8 +3052,6 @@ TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv3
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv32_fsv32_cached) {
-    if (get_test_engine().get_device_info().supports_immad)
-        return;
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv32_fsv32, 1, 1, 1, 1, 1, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv32_fsv32, 32 + 2, 48, 16, 4, 2, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv32_fsv32, 32, 48 + 5, 16, 4, 3, 0, true);
@@ -3081,8 +3060,6 @@ TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv3
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_blocked_format_different_datatype_cached) {
-    if (get_test_engine().get_device_info().supports_immad)
-        return;
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f16, format::bfyx, format::b_fs_yx_fsv16, 3, 32 + 4, 16 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::i8, data_types::f32, format::bfyx, format::b_fs_yx_fsv16, 3, 32 + 4, 16 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::i64, data_types::f32, format::bfyx, format::b_fs_yx_fsv16, 3, 32 + 4, 16 + 7, 2, 0, 0, true);

--- a/src/plugins/intel_gpu/tests/test_cases/reorg_yolo_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reorg_yolo_gpu_test.cpp
@@ -320,7 +320,7 @@ private:
         topology.add(reorg_yolo("reorg_yolo", input_info("input_reordered"), params.stride));
         topology.add(reorder("reorg_yolo_reordered", input_info("reorg_yolo"), plain_format, data_type));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         network->set_input_data("input", input);
         const auto result = network->execute();
 

--- a/src/plugins/intel_gpu/tests/test_cases/resample_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/resample_gpu_test.cpp
@@ -47,7 +47,7 @@ void test_basic_in2x3x2x2_nearest(bool is_caching_test) {
         12.f, 9.f, -17.f,
     });
 
-    cldnn::network::ptr net = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr net = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     net->set_input_data("input", input);
 
@@ -117,7 +117,7 @@ TEST(resample_gpu, basic_in2x3x2x2_bilinear) {
         3.f, 4.f,
     });
 
-    cldnn::network net{ engine, topology };
+    cldnn::network net{ engine, topology, get_test_default_config(engine) };
     net.set_input_data("input", input);
 
     auto outputs = net.execute();
@@ -168,7 +168,7 @@ TEST(resample_gpu, nearest_asymmetric) {
         3.f, 4.f,
     });
 
-    cldnn::network net{ engine, topology };
+    cldnn::network net{ engine, topology, get_test_default_config(engine) };
     net.set_input_data("input", input);
 
     auto outputs = net.execute();
@@ -219,7 +219,7 @@ TEST(resample_gpu, nearest_asymmetric_i8) {
             3, 4,
     });
 
-    cldnn::network net{ engine, topology };
+    cldnn::network net{ engine, topology, get_test_default_config(engine) };
     net.set_input_data("input", input);
 
     auto outputs = net.execute();
@@ -270,7 +270,7 @@ TEST(resample_gpu, bilinear_asymmetric) {
         3.f, 4.f,
                });
 
-    cldnn::network net{ engine, topology };
+    cldnn::network net{ engine, topology, get_test_default_config(engine) };
     net.set_input_data("input", input);
 
     auto outputs = net.execute();
@@ -471,7 +471,8 @@ struct resample_random_test : testing::TestWithParam<resample_random_test_params
         auto prim = resample("resample", input_info("in"), params.output_size, params.num_filter, params.operation_type);
         topo.add(prim);
 
-        ExecutionConfig config(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"resample", {params.out_format, ""}} }));
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"resample", {params.out_format, ""}} }));
         cldnn::network::ptr net = get_network(engine, topo, config, get_test_stream_ptr(), is_caching_test);
 
         auto in_mem = engine.allocate_memory(in_layout);
@@ -631,7 +632,7 @@ struct caffe_resample_random_test : testing::TestWithParam<caffe_resample_random
         prim.pads_end = params.pads_end;
         topo.add(prim);
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"resample"}));
         config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"resample", {params.in_format, "resample_ref"}} }));
 
@@ -649,7 +650,7 @@ struct caffe_resample_random_test : testing::TestWithParam<caffe_resample_random
         prim_opt.pads_end = params.pads_end;
         topo_opt.add(prim_opt);
 
-        ExecutionConfig config_opt;
+        ExecutionConfig config_opt = get_test_default_config(engine);
         config_opt.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"resample_opt"}));
         config_opt.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"resample_opt", {params.in_format, "resample_opt"}} }));
 
@@ -725,7 +726,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_nearest1) {
     //  Sample Type: Nearest
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     int b = 2;
@@ -815,7 +816,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_nearest2) {
     //  Sample Type: Nearest
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     int b = 2;
@@ -905,7 +906,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_nearest3) {
     //  Sample Type: Nearest
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     int b = 2;
@@ -995,7 +996,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_nearest4) {
     //  Sample Type: Nearest
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     int b = 2;
@@ -1085,7 +1086,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_nearest5) {
     //  Sample Type: Nearest
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     int b = 2;
@@ -1175,7 +1176,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_coord_transform_mode1) {
     //  Sample Type: Nearest
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     int b = 2;
@@ -1245,7 +1246,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_coord_transform_mode2) {
     //  Sample Type: Nearest
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     int b = 2;
@@ -1309,7 +1310,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_coord_transform_mode3) {
     //  Sample Type: Nearest
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     int b = 2;
@@ -1379,7 +1380,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_coord_transform_mode4) {
     //  Sample Type: Nearest
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     int b = 2;
@@ -1449,7 +1450,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_coord_transform_mode5) {
     //  Sample Type: Nearest
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     int b = 2;
@@ -1519,7 +1520,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_cubic) {
     //  Sample Type: Nearest
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     int b = 2;
@@ -1587,7 +1588,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_cubic2) {
     //  Sample Type: Nearest
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     int b = 1;
@@ -1640,7 +1641,7 @@ TEST(resample_gpu, interpolate_in2x2x3x2_linear) {
     //  Sample Type: Nearest
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     int b = 2;
@@ -1867,7 +1868,7 @@ TEST(resample_gpu, interpolate_in1x1x2x4_linear_scale) {
     //  Sample Type: Linear
 
     auto& engine = get_test_engine();
-    ov::intel_gpu::ExecutionConfig config;
+    ov::intel_gpu::ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     int b = 1;
@@ -2027,7 +2028,7 @@ struct resample_opt_random_test : testing::TestWithParam<resample_opt_random_tes
         prim.pads_end = params.pads_end;
         topo.add(prim);
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"resample"}));
 
         network net(engine, topo, config);
@@ -2046,7 +2047,7 @@ struct resample_opt_random_test : testing::TestWithParam<resample_opt_random_tes
         topo_opt.add(prim_opt);
         topo_opt.add(reorder("res_to_bfyx", input_info("resample_opt"), origin_format, params.input_type));
 
-        ExecutionConfig config_opt;
+        ExecutionConfig config_opt = get_test_default_config(engine);
         config_opt.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"resample_opt", "res_to_bfyx"}));
 
         cldnn::network::ptr net_opt = get_network(engine, topo_opt, config_opt, get_test_stream_ptr(), is_caching_test);
@@ -2138,10 +2139,10 @@ struct resample_opt_random_test_ext : resample_opt_random_test
         topo_opt.add(prim_opt);
         topo_opt.add(reorder("res_to_bfyx", input_info("resample_opt"), origin_format, params.input_type));
 
-        ExecutionConfig cfg{ov::enable_profiling(true),
-                            ov::intel_gpu::custom_outputs(std::vector<std::string>{"res_to_bfyx"}),
-                            ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"resample_opt", {working_format, kernel}} })
-        };
+        ExecutionConfig cfg = get_test_default_config(engine);
+        cfg.set_property(ov::enable_profiling(true));
+        cfg.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"res_to_bfyx"}));
+        cfg.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"resample_opt", {working_format, kernel}} }));
 
         network net_opt(engine, topo_opt, cfg);
 

--- a/src/plugins/intel_gpu/tests/test_cases/reshape_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reshape_gpu_test.cpp
@@ -66,7 +66,7 @@ void generic_reshape_test(format fmt, tensor const& input_size, tensor const& re
     }
     tpl.add(reshape("reshape", reshape_input, reshape_size, cldnn::reshape::reshape_mode::base, output_padd));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{reshape_input, "reshape"}));
 
     cldnn::network::ptr net = get_network(engine, tpl, config, get_test_stream_ptr(), is_caching_test);
@@ -459,7 +459,7 @@ void test_multiple_users_with_reorder(bool is_caching_test) {
     std::vector<T> out2 = {0.f, 2.f, 0.f, 4.0f};
     set_values(input, input_vec);
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input);
     auto outputs = network->execute();
 
@@ -502,7 +502,7 @@ void test_calc_output_shape(bool is_caching_test) {
 
     set_values(input, {-1.f, 2.f, -3.f, 4.f});
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input);
     auto outputs = network->execute();
 
@@ -574,7 +574,7 @@ void test_basic_bfwzyx(bool is_caching_test) {
 
     set_values(input, input_data);
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input);
     auto outputs = network->execute();
 
@@ -630,7 +630,7 @@ void test_shrink_chain_partial(bool is_caching_test) {
     std::vector<T> out = {5.f, 12.f, 15.f, 32.0f};
     set_values(input, input_vec);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input);
@@ -675,7 +675,7 @@ void test_shrink_chain_full(bool is_caching_test) {
     std::vector<T> out = {5.f, 12.f, 15.f, 32.0f};
     set_values(input, input_vec);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -715,7 +715,7 @@ void test_shrink_chain_out(bool is_caching_test) {
     std::vector<T> out = {0.f, 2.f, 0.f, 4.0f};
     set_values(input, input_vec);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input);
@@ -758,7 +758,7 @@ TEST(reshape_gpu_f32, basic_runtime_static_shape) {
 
     set_values(input, input_data);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -806,7 +806,7 @@ TEST(reshape_gpu_f32, basic_runtime_dynamic_shape) {
 
     set_values(input, input_data);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
@@ -857,7 +857,7 @@ TEST(reshape_gpu_f32, basic_runtime_dynamic_shape_with_const) {
 
     set_values(input, input_data);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
@@ -914,7 +914,7 @@ TEST(reshape_gpu_f32, basic_runtime_dynamic_shape_with_const_optimized_out) {
 
     set_values(input, input_data);
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);

--- a/src/plugins/intel_gpu/tests/test_cases/reverse_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reverse_gpu_test.cpp
@@ -76,7 +76,7 @@ public:
             tp.add(reverse(reverse_id, input_info(reverse_input_id), input_info(axes_id), mode));
         }
 
-        cldnn::network::ptr network = get_network(engine, tp, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, tp, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         network->set_input_data(reverse_input_id, reverse_input);
         network->set_input_data(axes_id, reverse_axes);
         auto result = network->execute();

--- a/src/plugins/intel_gpu/tests/test_cases/reverse_sequence_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reverse_sequence_gpu_test.cpp
@@ -36,7 +36,7 @@ void test_fp32_d2_2_ba1_sa0(bool is_caching_test) {
             reverse_sequence("reverse_sequence", input_info("input"), input_info("seq_lengths"), seq_axis, batch_axis)
     );
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
     network->set_input_data("seq_lengths", seq_lengths);
@@ -85,7 +85,7 @@ void test_fp32_d3_3_3_ba0_sa1(bool is_caching_test) {
             reverse_sequence("reverse_sequence", input_info("input"), input_info("seq_lengths"), seq_axis, batch_axis)
     );
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
     network->set_input_data("seq_lengths", seq_lengths);
@@ -135,7 +135,7 @@ TEST(reverese_sequence_gpu_test, fp32_d3_3_3_ba2_sa0) {
             reverse_sequence("reverse_sequence", input_info("input"), input_info("seq_lengths"), seq_axis, batch_axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("seq_lengths", seq_lengths);
@@ -181,7 +181,7 @@ TEST(reverese_sequence_gpu_test, fp32_d2_2_3_2ba0_sa3) {
             reverse_sequence("reverse_sequence", input_info("input"), input_info("seq_lengths"), seq_axis, batch_axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("seq_lengths", seq_lengths);
@@ -228,7 +228,7 @@ TEST(reverese_sequence_gpu_test, fp32_d2_2_3_2ba0_sa2) {
             reverse_sequence("reverse_sequence", input_info("input"), input_info("seq_lengths"), seq_axis, batch_axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("seq_lengths", seq_lengths);
@@ -275,7 +275,7 @@ TEST(reverese_sequence_gpu_test, fp32_d2_2_3_2ba2_sa0) {
             reverse_sequence("reverse_sequence", input_info("input"), input_info("seq_lengths"), seq_axis, batch_axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("seq_lengths", seq_lengths);
@@ -320,7 +320,7 @@ TEST(reverese_sequence_gpu_test, fp16_d2_2_ba1_sa0) {
             reverse_sequence("reverse_sequence", input_info("input"), input_info("seq_lengths"), seq_axis, batch_axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("seq_lengths", seq_lengths);
@@ -362,7 +362,7 @@ TEST(reverese_sequence_gpu_test, fp16x2_d2_2_ba1_sa0) {
         reverse_sequence("reverse_sequence", input_info("input"), input_info("seq_lengths"), seq_axis, batch_axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("seq_lengths", seq_lengths);
@@ -406,7 +406,7 @@ TEST(reverese_sequence_gpu_test, fp16_d3_3_3_ba0_sa1) {
             reverse_sequence("reverse_sequence", input_info("input"), input_info("seq_lengths"), seq_axis, batch_axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("seq_lengths", seq_lengths);
@@ -452,7 +452,7 @@ TEST(reverese_sequence_gpu_test, fp16_d3_3_3_ba2_sa0) {
             reverse_sequence("reverse_sequence", input_info("input"), input_info("seq_lengths"), seq_axis, batch_axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("seq_lengths", seq_lengths);
@@ -498,7 +498,7 @@ TEST(reverese_sequence_gpu_test, fp16_d2_2_3_2ba0_sa3) {
             reverse_sequence("reverse_sequence", input_info("input"), input_info("seq_lengths"), seq_axis, batch_axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("seq_lengths", seq_lengths);
@@ -545,7 +545,7 @@ TEST(reverese_sequence_gpu_test, fp16_d2_2_3_2ba0_sa2) {
             reverse_sequence("reverse_sequence", input_info("input"), input_info("seq_lengths"), seq_axis, batch_axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("seq_lengths", seq_lengths);
@@ -592,7 +592,7 @@ TEST(reverese_sequence_gpu_test, fp16_d2_2_3_2ba2_sa0) {
             reverse_sequence("reverse_sequence", input_info("input"), input_info("seq_lengths"), seq_axis, batch_axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("seq_lengths", seq_lengths);

--- a/src/plugins/intel_gpu/tests/test_cases/roi_align_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/roi_align_gpu_test.cpp
@@ -69,6 +69,12 @@ struct roi_align_test : public testing::Test {
                  roi_align::AlignedMode aligned_mode,
                  bool is_caching_test) const {
         auto& engine = get_test_engine();
+        std::shared_ptr<cldnn::stream> stream;
+        if (engine.get_device_info().supports_immad) {
+            stream = get_test_stream_ptr(get_test_default_config(engine));
+        } else {
+            stream = get_test_stream_ptr();
+        }
 
         auto input = get_memory(engine, input_lt, input_data);
         auto coords = get_memory(engine, coords_lt, coords_data);
@@ -91,7 +97,7 @@ struct roi_align_test : public testing::Test {
                                aligned_mode));
         topology.add(reorder("out", input_info("roi_align"), plain_format, device_data_type));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), stream, is_caching_test);
 
         network->set_input_data("input", input);
         network->set_input_data("coords", coords);

--- a/src/plugins/intel_gpu/tests/test_cases/roi_align_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/roi_align_gpu_test.cpp
@@ -69,12 +69,7 @@ struct roi_align_test : public testing::Test {
                  roi_align::AlignedMode aligned_mode,
                  bool is_caching_test) const {
         auto& engine = get_test_engine();
-        std::shared_ptr<cldnn::stream> stream;
-        if (engine.get_device_info().supports_immad) {
-            stream = get_test_stream_ptr(get_test_default_config(engine));
-        } else {
-            stream = get_test_stream_ptr();
-        }
+        auto stream = get_test_stream_ptr(get_test_default_config(engine));
 
         auto input = get_memory(engine, input_lt, input_data);
         auto coords = get_memory(engine, coords_lt, coords_data);

--- a/src/plugins/intel_gpu/tests/test_cases/roi_pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/roi_pooling_gpu_test.cpp
@@ -185,7 +185,7 @@ public:
 
         topology.add(reorder("reordered_roi_pooling", input_info("roi_pooling"), plane_format, type_to_data_type<T>::value));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         for (auto& input : inputs) {
             network->set_input_data(input.first, input.second);

--- a/src/plugins/intel_gpu/tests/test_cases/roll_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/roll_gpu_test.cpp
@@ -54,7 +54,7 @@ struct roll_test : testing::TestWithParam<roll_test_params<T>> {
         topology.add(roll("roll", input_info("reordered_input"), tensor(input_format, p.shift)));
         topology.add(reorder("reordered_roll", input_info("roll"), plane_format, type_to_data_type<T>::value));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         network->set_input_data("input", input);
         const auto outputs = network->execute();
 

--- a/src/plugins/intel_gpu/tests/test_cases/scatter_elements_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/scatter_elements_update_gpu_test.cpp
@@ -71,7 +71,7 @@ void test_d2411_axisF(bool is_caching_test) {
         scatter_elements_update("scatter_elements_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), axis)
     );
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("InputData", input1);
     network->set_input_data("InputIndices", input2);
@@ -296,7 +296,7 @@ public:
         );
         topology.add(reorder("ScatterEelementsUpdatePlain", input_info("ScatterEelementsUpdate"), plain_format, data_type));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Data", data);
         network->set_input_data("Indices", indices);

--- a/src/plugins/intel_gpu/tests/test_cases/scatter_nd_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/scatter_nd_update_gpu_test.cpp
@@ -146,7 +146,7 @@ struct scatter_nd_update_random_test : testing::TestWithParam<scatter_nd_update_
             reorder("out", input_info("scatter_nd_update"), params.input_format, params.input_type)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("InputData", input1);
         network->set_input_data("InputIndices", input2);
@@ -216,7 +216,7 @@ struct scatter_nd_update_random_test : testing::TestWithParam<scatter_nd_update_
             reorder("out", input_info("scatter_nd_update"), params.input_format, params.input_type)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("InputData", input1);
         network->set_input_data("InputIndices", input2);
@@ -570,7 +570,7 @@ TEST(scatter_nd_update_gpu_fp16_test15, data5_indice3_update5) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 3)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -654,7 +654,7 @@ TEST(scatter_nd_update_gpu_fp16_test14, data5_indice2_update3) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -718,7 +718,7 @@ TEST(scatter_nd_update_gpu_fp16_test13, data4_indice2_update2) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -789,7 +789,7 @@ TEST(scatter_nd_update_gpu_fp16_test12, data3_indice3_update1) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -919,7 +919,7 @@ TEST(scatter_nd_update_gpu_fp16_test11, data6_indice1_update6) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -1015,7 +1015,7 @@ TEST(scatter_nd_update_gpu_fp16_test10, data5_indice1_update5) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -1093,7 +1093,7 @@ TEST(scatter_nd_update_gpu_fp16_test9, data4_indice1_update4) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -1191,7 +1191,7 @@ TEST(scatter_nd_update_gpu_fp16_test8, data6_indice2_update5) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -1259,7 +1259,7 @@ TEST(scatter_nd_update_gpu_fp16_test7, data5_indice2_update4) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -1325,7 +1325,7 @@ TEST(scatter_nd_update_gpu_fp16_test6, data4_indice2_update3) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -1390,7 +1390,7 @@ TEST(scatter_nd_update_gpu_fp16_test5, data3_indice2_update2) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -1445,7 +1445,7 @@ TEST(scatter_nd_update_gpu_fp16_test4, data2_indice2_update1) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -1520,7 +1520,7 @@ TEST(scatter_nd_update_gpu_fp16_test3, data3_indice1_update3) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -1575,7 +1575,7 @@ TEST(scatter_nd_update_gpu_fp16_test2, data2_indice1_update2) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -1624,7 +1624,7 @@ TEST(scatter_nd_update_gpu_fp16_test1, data1_indice1_update1) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -1719,7 +1719,7 @@ TEST(scatter_nd_update_gpu_fp16, d6661_i2311) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -1858,7 +1858,7 @@ TEST(scatter_nd_update_gpu_fp16, d6661_i2211) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -2008,7 +2008,7 @@ TEST(scatter_nd_update_gpu_fp16, d6661_i2111) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -2129,7 +2129,7 @@ TEST(scatter_nd_update_gpu_fp16, d3232_i2411) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -2232,7 +2232,7 @@ TEST(scatter_nd_update_gpu_fp16, d3232_i2311) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -2341,7 +2341,7 @@ TEST(scatter_nd_update_gpu_fp16, d3232_i2211) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -2458,7 +2458,7 @@ TEST(scatter_nd_update_gpu_fp16, d3232_i2111) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -2592,7 +2592,7 @@ TEST(scatter_nd_update_gpu_fp16, d32323_i25111) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -2760,7 +2760,7 @@ TEST(scatter_nd_update_gpu_fp16, d32323_i24111) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -2931,7 +2931,7 @@ TEST(scatter_nd_update_gpu_fp16, d32323_i23111) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -3114,7 +3114,7 @@ TEST(scatter_nd_update_gpu_fp16, d32323_i22111) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -3315,7 +3315,7 @@ TEST(scatter_nd_update_gpu_fp16, d32323_i21111) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -3475,7 +3475,7 @@ TEST(scatter_nd_update_gpu_fp16, d222222_i261111) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -3628,7 +3628,7 @@ TEST(scatter_nd_update_gpu_fp16, d222222_i251111) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -3784,7 +3784,7 @@ TEST(scatter_nd_update_gpu_fp16, d222222_i241111) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -3947,7 +3947,7 @@ TEST(scatter_nd_update_gpu_fp16, d222222_i231111) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -4121,7 +4121,7 @@ TEST(scatter_nd_update_gpu_fp16, d222222_i221111) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
 
     network.set_input_data("InputData", input1);
@@ -4319,7 +4319,7 @@ void test_d222222_i211111(bool is_caching_test) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("InputData", input1);
     network->set_input_data("InputIndices", input2);
@@ -4431,7 +4431,7 @@ TEST(scatter_nd_update_gpu, dynamic) {
         scatter_nd_update("scatter_nd_update", input_info("InputData"), input_info("InputIndices"), input_info("InputUpdates"), 2)
     );
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
 

--- a/src/plugins/intel_gpu/tests/test_cases/scatter_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/scatter_update_gpu_test.cpp
@@ -95,7 +95,7 @@ void test_d2411_axisB(bool is_caching_test) {
         );
         topology.add(reorder("out", input_info("scatter_update"), plain_2d_format, data_types::f16));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("InputDictionary", input1);
         network->set_input_data("InputText", input2);
@@ -176,7 +176,7 @@ TEST(scatter_update_gpu_fp32, d8111_axisB) {
         );
         topology.add(reorder("out", input_info("scatter_update"), plain_2d_format, data_types::f32));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
 
         network.set_input_data("InputDictionary", input1);
@@ -270,7 +270,7 @@ TEST(scatter_update_gpu_fp16, d4311_axisB) {
         );
         topology.add(reorder("out", input_info("scatter_update"), plain_2d_format, data_types::f16));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
         network.set_input_data("InputDictionary", input1);
         network.set_input_data("InputText", input2);
@@ -397,7 +397,7 @@ TEST(scatter_update_gpu_fp16, d2521_axisF) {
         );
         topology.add(reorder("out", input_info("scatter_update"), plain_2d_format, data_types::f16));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
         network.set_input_data("InputDictionary", input1);
         network.set_input_data("InputText", input2);
@@ -510,7 +510,7 @@ TEST(scatter_update_gpu_fp16, d2241_axisY) {
         );
         topology.add(reorder("out", input_info("scatter_update"), plain_2d_format, data_types::f16));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
         network.set_input_data("InputDictionary", input1);
         network.set_input_data("InputText", input2);
@@ -671,7 +671,7 @@ TEST(scatter_update_gpu_fp16, d8x2x20x1_axisB) {
         );
         topology.add(reorder("out", input_info("scatter_update"), plain_2d_format, data_types::f16));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
         network.set_input_data("InputDictionary", input1);
         network.set_input_data("InputText", input2);
@@ -797,7 +797,7 @@ TEST(scatter_update_gpu_fp32, d2214_axisX) {
         );
         topology.add(reorder("out", input_info("scatter_update"), plain_2d_format, data_types::f32));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
         network.set_input_data("InputDictionary", input1);
         network.set_input_data("InputText", input2);
@@ -899,7 +899,7 @@ TEST(scatter_update_gpu_int32, d6211_axisB) {
         );
         topology.add(reorder("out", input_info("scatter_update"), plain_2d_format, data_types::i32));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
         network.set_input_data("InputDictionary", input1);
         network.set_input_data("InputText", input2);
@@ -998,7 +998,7 @@ TEST(scatter_update_gpu_int32, d3151_axisY) {
         );
         topology.add(reorder("out", input_info("scatter_update"), plain_2d_format, data_types::i32));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
         network.set_input_data("InputDictionary", input1);
         network.set_input_data("InputText", input2);
@@ -1082,7 +1082,7 @@ TEST(scatter_update_gpu_fp32, d24111_axisF_bfzyx) {
             );
             topology.add(reorder("out", input_info("scatter_update"), plain_2d_format, data_types::f32));
 
-            network network(engine, topology);
+            network network(engine, topology, get_test_default_config(engine));
 
             network.set_input_data("InputDictionary", input1);
             network.set_input_data("InputText", input2);
@@ -1188,7 +1188,7 @@ TEST(scatter_update_gpu_int32, d121251_bfwzyx_axisB) {
                 scatter_update("scatter_update", input_info("InputDictionary"), input_info("TextReordered"), input_info("InputUpdates"), axis)
         );
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
         network.set_input_data("InputDictionary", input1);
         network.set_input_data("InputText", input2);
@@ -1279,7 +1279,7 @@ TEST(scatter_update_gpu_fp32, d21511_bfzyx_axisX) {
             );
             topology.add(reorder("out", input_info("scatter_update"), plain_3d_format, data_types::f32));
 
-            network network(engine, topology);
+            network network(engine, topology, get_test_default_config(engine));
 
 
             network.set_input_data("InputDictionary", input1);
@@ -1385,7 +1385,7 @@ TEST(scatter_update_gpu_fp32, d1252_axisY_bfwzyx) {
         );
         topology.add(reorder("out", input_info("scatter_update"), plain_2d_format, data_types::f32));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
         network.set_input_data("InputDictionary", input1);
         network.set_input_data("InputText", input2);
@@ -1475,7 +1475,7 @@ TEST(scatter_update_gpu_int32, d2115_axisX_bfwzyx) {
         );
         topology.add(reorder("out", input_info("scatter_update"), plain_2d_format, data_types::i32));
 
-        network network(engine, topology);
+        network network(engine, topology, get_test_default_config(engine));
 
         network.set_input_data("InputDictionary", input1);
         network.set_input_data("InputText", input2);
@@ -1569,7 +1569,7 @@ void test_d21214_bfzyx_axisX_bfwzyx(bool is_caching_test) {
             );
             topology.add(reorder("out", input_info("scatter_update"), plain_3d_format, data_types::f16));
 
-            cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+            cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
             network->set_input_data("InputDictionary", input1);
             network->set_input_data("InputText", input2);
@@ -1656,7 +1656,7 @@ TEST(scatter_update_gpu_fp32, dynamic) {
     );
     topology.add(reorder("out", input_info("scatter_update"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
 

--- a/src/plugins/intel_gpu/tests/test_cases/select_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/select_gpu_test.cpp
@@ -45,7 +45,7 @@ void test_select_basic(bool is_caching_test) {
         0.f,   1.f,  0.f,  1.f,
         1.f,   0.f,  1.f,  0.f });
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
     network->set_input_data("input2", input2);
@@ -103,7 +103,7 @@ TEST(select_gpu_f32, select_basic_negative) {
         -0.f,   -1.f,  -0.f,  -1.f,
         -1.f,   -0.f,  -1.f,  -0.f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -180,7 +180,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_mask_2x2x1x2) {
         0.f,
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -256,7 +256,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_mask_1x1x1x1) {
         0.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -336,7 +336,7 @@ TEST(select_gpu_f32, select_basic_comma_byxf_2x2x2x2_bcast_mask_2x2x2x1) {
         -0.f,  -0.5f,
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -422,7 +422,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_in2_2x2x1x2) {
         1.f,  0.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -504,7 +504,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_in1_2x2x2x1_bcast_in2_2x2x1
         1.f,  0.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -578,7 +578,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_mask_2x1x2x2_in1_1x2x2x2_in
         0.f,  1.f,
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -654,7 +654,7 @@ TEST(select_gpu_f32, select_basic_comma_byxf_2x2x2x2_bcast_mask_2x1x2x2_in1_2x2x
         -0.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -730,7 +730,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_in2_1x1x1x1) {
         1.f,  0.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -810,7 +810,7 @@ TEST(select_gpu_f32, select_basic_comma_byxf_2x2x2x2_bcast_in2_2x2x2x1) {
         -1.5f, -0.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -896,7 +896,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_in1_2x2x1x2) {
         1.f,  0.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -972,7 +972,7 @@ TEST(select_gpu_f32, select_basic_bfyx_2x2x2x2_bcast_in1_1x1x1x1) {
         1.f,  0.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -1052,7 +1052,7 @@ TEST(select_gpu_f32, select_basic_comma_byxf_2x2x2x2_bcast_in1_2x2x2x1) {
         -1.5f, -0.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -1132,7 +1132,7 @@ TEST(select_gpu_f32, select_basic_comma_byxf_2x2x2x2_bcast_mask_2x1x2x2_in1_2x2x
         -0.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -1195,7 +1195,7 @@ TEST(select_gpu_f32, select_basic_comma) {
         -0.f,   -0.1f,  -0.f,  -0.5f,
         -0.7f,   -0.f,  -1.5f,  -0.f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1230,7 +1230,7 @@ TEST(select_gpu_f32, select_basic_error_input_sizes) {
     topology.add(input_layout("mask", mask->get_layout()));
     topology.add(cldnn::select("select", input_info("mask"), input_info("input"), input_info("input2")));
 
-    EXPECT_ANY_THROW(network(engine, topology));
+    EXPECT_ANY_THROW(network(engine, topology, get_test_default_config(engine)));
 }
 
 TEST(select_gpu_f32, select_basic_error_mask_sizes) {
@@ -1246,7 +1246,7 @@ TEST(select_gpu_f32, select_basic_error_mask_sizes) {
     topology.add(input_layout("mask", mask->get_layout()));
     topology.add(cldnn::select("select", input_info("mask"), input_info("input"), input_info("input2")));
 
-    EXPECT_ANY_THROW(network(engine, topology));
+    EXPECT_ANY_THROW(network(engine, topology, get_test_default_config(engine)));
 }
 
 TEST(select_gpu_f32, select_basic_error_input_types) {
@@ -1261,7 +1261,7 @@ TEST(select_gpu_f32, select_basic_error_input_types) {
     topology.add(input_layout("input2", input2->get_layout()));
     topology.add(input_layout("mask", mask->get_layout()));
     topology.add(cldnn::select("select", input_info("mask"), input_info("input"), input_info("input2")));
-    EXPECT_ANY_THROW(network(engine, topology));
+    EXPECT_ANY_THROW(network(engine, topology, get_test_default_config(engine)));
 }
 
 TEST(select_gpu_f32, select_basic_byxf) {
@@ -1296,7 +1296,7 @@ TEST(select_gpu_f32, select_basic_byxf) {
         0.f,   1.f,  0.f,  1.f,
         1.f,   0.f,  1.f,  0.f });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1350,7 +1350,7 @@ TEST(select_gpu_f32, select_basic_mask_f16) {
         0,   1,  0,  1,
         1,   0,  1,  0 });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1404,7 +1404,7 @@ TEST(select_gpu_f32, select_basic_mask_i8) {
         0,   1,  0,  1,
         1,   0,  1,  0 });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1458,7 +1458,7 @@ TEST(select_gpu_f32, select_basic_mask_u8) {
         0,   211,  0,  255,
         199,   0,  160,  0 });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1505,7 +1505,7 @@ TEST(select_gpu_f32, select_basic_1x1x2x2) {
         0.f,    0.f,    1.f,    1.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1554,7 +1554,7 @@ TEST(select_gpu_f32, select_basic_bfyx_1x1x2x2) {
         1.f,   1.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1604,7 +1604,7 @@ TEST(select_gpu_f32, select_basic_byxf_1x1x2x2) {
         1.f,   1.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1656,7 +1656,7 @@ void test_f16_select_basic_1x1x2x2(bool is_caching_test) {
         1,   1
     });
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
     network->set_input_data("input2", input2);
@@ -1710,7 +1710,7 @@ TEST(select_gpu_f16, select_basic_mask_f32_1x1x2x2) {
         1.5f,   0.4f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1760,7 +1760,7 @@ TEST(select_gpu_f16, select_basic_mask_i8_1x1x2x2) {
         1,   1
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1810,7 +1810,7 @@ TEST(select_gpu_f16, select_basic_mask_u8_1x1x2x2) {
         128,   255
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1862,7 +1862,7 @@ void test_i8_select_basic_1x1x2x2(bool is_caching_test) {
         3,   5
     });
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
     network->set_input_data("input2", input2);
@@ -1916,7 +1916,7 @@ TEST(select_gpu_i8, select_basic_mask_f32_1x1x2x2) {
         1.5f,  0.4f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -1966,7 +1966,7 @@ TEST(select_gpu_i8, select_basic_mask_f16_1x1x2x2) {
         3,   5
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2016,7 +2016,7 @@ TEST(select_gpu_i8, select_basic_mask_u8_1x1x2x2) {
         128,   255
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2068,7 +2068,7 @@ void test_u8_select_basic_1x1x2x2(bool is_caching_test) {
         128,   255
     });
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("input", input);
     network->set_input_data("input2", input2);
@@ -2122,7 +2122,7 @@ TEST(select_gpu_u8, select_basic_mask_f32_1x1x2x2) {
         1.5f,  0.4f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2172,7 +2172,7 @@ TEST(select_gpu_u8, select_basic_mask_f16_1x1x2x2) {
         1,   1
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2222,7 +2222,7 @@ TEST(select_gpu_u8, select_basic_mask_i8_1x1x2x2) {
         1,   1
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2269,7 +2269,7 @@ TEST(select_gpu_fp32, select_numpy_broadcast_mask_u8_1x1x3) {
         1,   0,   1
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("input2", input2);
@@ -2332,7 +2332,7 @@ TEST(select_gpu_f32, select_different_formats) {
         1.f, 1.f
     });
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input1", input1);
     network.set_input_data("input2", input2);
@@ -2419,7 +2419,7 @@ TEST(select_gpu_f32, dynamic) {
     topology.add(input_layout("mask", mask_layout));
     topology.add(cldnn::select("select", input_info("mask"), input_info("input1"), input_info("input2")));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
 

--- a/src/plugins/intel_gpu/tests/test_cases/set_output_memory_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/set_output_memory_gpu_test.cpp
@@ -46,7 +46,7 @@ void test_basic(bool is_caching_test) {
         reorder("reorder", input_info("Input"), input_data->get_layout())
     );
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("Input", input_data);
     network->set_output_memory("reorder", output_mem);
@@ -94,7 +94,7 @@ TEST(set_output_memory_gpu, basic_const) {
             reorder("reorder_const", input_info("Const"), input_data->get_layout())
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input_data);
     network.set_output_memory("reorder_dyn", output_mem);
@@ -143,7 +143,7 @@ TEST(set_output_memory_gpu, basic_mutable) {
             reorder("reorder_mutable", input_info("Mutable"), input_data->get_layout())
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input", input_data);
     network.set_output_memory("reorder_dyn", output_mem);
@@ -196,7 +196,7 @@ TEST(set_output_memory_gpu, top_k1) {
     };
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_output_memory("reorder", output_mem);
@@ -242,7 +242,7 @@ TEST(set_output_memory_gpu, top_k2) {
     };
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_output_memory("reorder", second_output_mem);
@@ -322,7 +322,7 @@ TEST(set_output_memory_gpu, basic_opt) {
     primitive_id outputID = "reorder3";
     topology.add(reorder(outputID, input_info("concat"), ol));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
 
@@ -374,7 +374,7 @@ TEST(set_output_memory_gpu, mutable_output_data) {
             /*b1f3*/4.f,  0.5f,  8.f,   8.2f
     };
     set_values(input, input_vec);
-    auto prog = program::build_program(engine, topology, ExecutionConfig{});
+    auto prog = program::build_program(engine, topology, get_test_default_config(engine));
     network network(prog, 0);
     network.set_input_data("Add_1396", input);
 

--- a/src/plugins/intel_gpu/tests/test_cases/shape_of_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/shape_of_gpu_test.cpp
@@ -25,7 +25,7 @@ TEST(shape_of_gpu, bfyx) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(shape_of("shape_of", input_info("input"), 4, data_types::i32));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -50,7 +50,7 @@ TEST(shape_of_gpu, bfyx_i64) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(shape_of("shape_of", input_info("input"), 4, data_types::i64));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -75,7 +75,7 @@ TEST(shape_of_gpu, yxfb) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(shape_of("shape_of", input_info("input"), 4, data_types::i32));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -100,7 +100,7 @@ TEST(shape_of_gpu, bfzyx) {
     topology.add(input_layout("input", input->get_layout()));
     topology.add(shape_of("shape_of", input_info("input"), 5, data_types::i32));
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -129,7 +129,7 @@ TEST(shape_of_gpu, dynamic) {
     topology.add(input_layout("input", in_layout));
     topology.add(shape_of("shape_of", input_info("input"), 5, data_types::i32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
 

--- a/src/plugins/intel_gpu/tests/test_cases/shuffle_channels_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/shuffle_channels_test.cpp
@@ -35,7 +35,7 @@ void test_d1_15_2_2_ax1_g5(bool is_caching_test) {
             shuffle_channels("shuffle_channels", input_info("Input0"), group, axis)
     );
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->set_input_data("Input0", input0);
 
@@ -81,7 +81,7 @@ TEST(shuffle_channels_fp32_gpu, d1_15_2_2_axm3_g5) {
             shuffle_channels("shuffle_channels", input_info("Input0"), group, axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input0);
 
@@ -123,7 +123,7 @@ TEST(shuffle_channels_fp32_gpu, d15_2_2_ax0_g5) {
             shuffle_channels("shuffle_channels", input_info("Input0"), group, axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input0);
 
@@ -165,7 +165,7 @@ TEST(shuffle_channels_fp32_gpu, d15_2_2_axm4_g5) {
             shuffle_channels("shuffle_channels", input_info("Input0"), group, axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input0);
 
@@ -204,7 +204,7 @@ TEST(shuffle_channels_fp32_gpu, d2_2_6_axm2_g3) {
             shuffle_channels("shuffle_channels", input_info("Input0"), group, axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input0);
 
@@ -242,7 +242,7 @@ TEST(shuffle_channels_fp32_gpu, d2_6_2_axm3_g3) {
             shuffle_channels("shuffle_channels", input_info("Input0"), group, axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input0);
 
@@ -280,7 +280,7 @@ TEST(shuffle_channels_fp32_gpu, d2_2_6_axm2_g2) {
             shuffle_channels("shuffle_channels", input_info("Input0"), group, axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input0);
 
@@ -318,7 +318,7 @@ TEST(shuffle_channels_fp32_gpu, d2_6_2_axm3_g2) {
             shuffle_channels("shuffle_channels", input_info("Input0"), group, axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input0);
 
@@ -354,7 +354,7 @@ TEST(shuffle_channels_fp32_gpu, d6_axm0_g2) {
             shuffle_channels("shuffle_channels", input_info("Input0"), group, axis)
     );
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", input0);
 

--- a/src/plugins/intel_gpu/tests/test_cases/slice.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/slice.cpp
@@ -45,7 +45,7 @@ public:
         }
         topology.add(slice("slice", inputs, tensor{output_shape_}));
 
-        cldnn::network::ptr network = get_network(engine_, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine_, topology, get_test_default_config(engine_), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 

--- a/src/plugins/intel_gpu/tests/test_cases/softmax_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/softmax_gpu_test.cpp
@@ -73,7 +73,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(softmax("softmax", input_info("input"), 3));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -108,7 +108,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(softmax("softmax", input_info("input"), 3));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         network->set_input_data("input", input);
 
         auto outputs = network->execute();
@@ -165,7 +165,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(softmax("softmax", input_info("input"), 3));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -238,7 +238,7 @@ TEST(softmax_gpu_bfyx_f32, normalize_y) {
         0.993307149f    //b=1, f=2, x=1
     };
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -318,7 +318,7 @@ TEST(softmax_gpu_bfyx_f32, normalize_f) {
         0.977054322f //b=1, y=1, x=1
     };
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -403,7 +403,7 @@ TEST(softmax_gpu_bfzyx_f32, normalize_z) {
         0.880797f, 0.952574f,
     };
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -486,7 +486,7 @@ TEST(softmax_gpu_bfyx_f32, normalize_b) {
         0.977054322f //f=1, y=1, x=1
     };
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     auto outputs = network.execute();
@@ -946,9 +946,9 @@ public:
 
         set_values(input, params.input);
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(false));
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
         const auto outputs = network->execute();
@@ -1048,7 +1048,7 @@ TEST(softmax_gpu_bfyx_f32, normalize_f_dynamic) {
         0.977054322f //b=1, y=1, x=1
     };
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -1153,7 +1153,7 @@ TEST(softmax_gpu_bfyx_f32, bf_opt_normalize_f_dynamic) {
         0.719294981f  //b=1, y=0, x=0
     };
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);

--- a/src/plugins/intel_gpu/tests/test_cases/space_to_batch_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/space_to_batch_gpu_test.cpp
@@ -40,7 +40,7 @@ public:
                                                                         tensor(format::bfyx, {0,0,0,0}, 0),
                                                                         tensor(format::bfyx, {8,1,1,1}, 1)));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input", input);
 
@@ -84,7 +84,7 @@ public:
                                                                         tensor(format::bfyx, {0,0,2,0}, 0),
                                                                         tensor(format::bfyx, {0,0,0,0}, 0),
                                                                         tensor(format::bfyx, {4,1,3,2}, 1)));
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input", input);
 
@@ -130,7 +130,7 @@ public:
                                                                         tensor(format::bfyx, {0,0,1,0}, 0),
                                                                         tensor(format::bfyx, {0,1,0,0}, 0),
                                                                         tensor(format::bfyx, {16,1,2,1}, 1)));
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input", input);
 
@@ -176,7 +176,7 @@ public:
                                                                         tensor(format::bfzyx, {0,0,0,1,0}, 0),
                                                                         tensor(format::bfzyx, {0,0,0,0,0}, 0),
                                                                         tensor(format::bfzyx, {8,1,1,2,1}, 1)));
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input", input);
 
@@ -224,7 +224,7 @@ public:
                                                                         tensor(format::bfwzyx, {0,1,0,1,0,0}, 0),
                                                                         tensor(format::bfwzyx, {0,0,0,0,0,0}, 0),
                                                                         tensor(format::bfwzyx, {16,1,2,2,1,1}, 1)));
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input", input);
 
@@ -277,7 +277,7 @@ public:
                                                                             tensor(format::bfyx, {0,0,0,1}, 0),
                                                                             tensor(format::bfyx, {8,8,1,1}, 1)));
         topology.add(reorder("stb_to_bfyx", input_info("space_to_batch"), format::bfyx, data_types::f16));
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input", input);
 
@@ -330,7 +330,7 @@ public:
                                                                             tensor(format::bfyx, {0,2,0,0}, 0),
                                                                             tensor(format::bfyx, {4,5,1,2}, 1)));
         topology.add(reorder("stb_to_bfyx", input_info("space_to_batch"), format::bfyx, data_types::f16));
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input", input);
 
@@ -406,7 +406,7 @@ public:
                                                                         tensor(format::bfyx, {0,0,0,0}, 0),
                                                                         tensor(format::bfyx, {0,0,0,0}, 0),
                                                                         tensor(format::bfyx, {8,1,1,1}, 1)));
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input", input);
 
@@ -450,7 +450,7 @@ public:
                                                                         tensor(format::bfyx, {0,0,2,0}, 0),
                                                                         tensor(format::bfyx, {0,0,0,0}, 0),
                                                                         tensor(format::bfyx, {4,1,3,2}, 1)));
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input", input);
 
@@ -496,7 +496,7 @@ public:
                                                                         tensor(format::bfyx, {0,0,1,0}, 0),
                                                                         tensor(format::bfyx, {0,1,0,0}, 0),
                                                                         tensor(format::bfyx, {16,1,2,1}, 1)));
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input", input);
 
@@ -542,7 +542,7 @@ public:
                                                                         tensor(format::bfzyx, {0,0,0,1,0}, 0),
                                                                         tensor(format::bfzyx, {0,0,0,0,0}, 0),
                                                                         tensor(format::bfzyx, {8,1,1,2,1}, 1)));
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input", input);
 
@@ -588,7 +588,7 @@ public:
                                                                         tensor(format::bfwzyx, {0,1,0,1,0,0}, 0),
                                                                         tensor(format::bfwzyx, {0,0,0,0,0,0}, 0),
                                                                         tensor(format::bfwzyx, {16,1,2,2,1,1}, 1)));
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input", input);
 
@@ -645,7 +645,7 @@ public:
                                                                             tensor(format::bfyx, {0,0,0,0}, 0),
                                                                             tensor(format::bfyx, {8,4,1,2}, 1)));
         topology.add(reorder("stb_to_bfyx", input_info("space_to_batch"), format::bfyx, data_types::f32));
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input", input);
 
@@ -699,7 +699,7 @@ public:
                                                                             tensor(format::bfyx, {0,0,0,0}, 0),
                                                                             tensor(format::bfyx, {6,2,2,2}, 1)));
         topology.add(reorder("stb_to_bfyx", input_info("space_to_batch"), format::bfyx, data_types::f32));
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input", input);
 

--- a/src/plugins/intel_gpu/tests/test_cases/space_to_depth_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/space_to_depth_gpu_test.cpp
@@ -36,7 +36,7 @@ public:
                 space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::blocks_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -78,7 +78,7 @@ public:
                 space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::blocks_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -126,7 +126,7 @@ public:
         space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::blocks_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -188,7 +188,7 @@ public:
                 space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::blocks_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -236,7 +236,7 @@ public:
                 space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::depth_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -278,7 +278,7 @@ public:
                 space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::depth_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -326,7 +326,7 @@ public:
                 space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::depth_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -388,7 +388,7 @@ public:
                 space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::depth_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -438,7 +438,7 @@ public:
                 space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::blocks_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -477,7 +477,7 @@ public:
                 space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::blocks_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -525,7 +525,7 @@ public:
             space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::blocks_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -579,7 +579,7 @@ public:
                 space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::blocks_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -626,7 +626,7 @@ public:
                 space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::depth_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -665,7 +665,7 @@ public:
                 space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::depth_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -713,7 +713,7 @@ public:
                 space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::depth_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -767,7 +767,7 @@ public:
                 space_to_depth("space_to_depth", input_info("Input0"), space_to_depth::depth_first, block_size)
         );
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -822,7 +822,7 @@ public:
         topology.add(space_to_depth("space_to_depth", input_info("reorder"), space_to_depth::depth_first, block_size));
         topology.add(reorder("reorder_out", input_info("space_to_depth"), format::bfyx, data_types::f32));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 
@@ -877,7 +877,7 @@ public:
         topology.add(space_to_depth("space_to_depth", input_info("reorder"), space_to_depth::depth_first, block_size));
         topology.add(reorder("reorder_out", input_info("space_to_depth"), format::bfyx, data_types::f32));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("Input0", input1);
 

--- a/src/plugins/intel_gpu/tests/test_cases/spatial_concatenate_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/spatial_concatenate_gpu_test.cpp
@@ -38,7 +38,7 @@ public:
         tpl.add(input_layout("in2", input2->get_layout()));
         tpl.add(concatenation("conc", { input_info("in1"), input_info("in2") }, 3));
 
-        cldnn::network::ptr net = get_network(engine, tpl, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr net = get_network(engine, tpl, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         net->set_input_data("in1", input1);
         net->set_input_data("in2", input2);
 
@@ -93,7 +93,7 @@ public:
         tpl.add(input_layout("in2", input2->get_layout()));
         tpl.add(concatenation("conc", { input_info("in1"), input_info("in2") }, 2));
 
-        cldnn::network::ptr net = get_network(engine, tpl, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr net = get_network(engine, tpl, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         net->set_input_data("in1", input1);
         net->set_input_data("in2", input2);
 
@@ -150,7 +150,7 @@ public:
         tpl.add(input_layout("in2", input2->get_layout()));
         tpl.add(concatenation("conc", { input_info("in1"), input_info("in2") }, 2, padding({ 0, 0, 1, 1 }, 0.0f)));
 
-        cldnn::network::ptr net = get_network(engine, tpl, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr net = get_network(engine, tpl, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         net->set_input_data("in1", input1);
         net->set_input_data("in2", input2);
 
@@ -205,7 +205,7 @@ public:
         tpl.add(input_layout("in2", input2->get_layout()));
         tpl.add(concatenation("conc", { input_info("in1"), input_info("in2") }, 3, padding({ 0, 0, 2, 0 }, { 0, 0, 0, 0 })));
 
-        cldnn::network::ptr net = get_network(engine, tpl, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr net = get_network(engine, tpl, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         net->set_input_data("in1", input1);
         net->set_input_data("in2", input2);
 
@@ -265,7 +265,7 @@ public:
         tpl.add(input_layout("in3", input3->get_layout()));
         tpl.add(concatenation("conc", { input_info("in1"), input_info("in2"), input_info("in3") }, 3));
 
-        cldnn::network::ptr net = get_network(engine, tpl, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr net = get_network(engine, tpl, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         net->set_input_data("in1", input1);
         net->set_input_data("in2", input2);
         net->set_input_data("in3", input3);
@@ -353,7 +353,7 @@ public:
         tpl.add(input_layout("in3", input3->get_layout()));
         tpl.add(concatenation("conc", { input_info("in1"), input_info("in2"), input_info("in3") }, 0));
 
-        cldnn::network::ptr net = get_network(engine, tpl, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr net = get_network(engine, tpl, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         net->set_input_data("in1", input1);
         net->set_input_data("in2", input2);
         net->set_input_data("in3", input3);
@@ -413,7 +413,7 @@ public:
         tpl.add(input_layout("in2", input2->get_layout()));
         tpl.add(concatenation("conc", { input_info("in1"), input_info("in2") }, 4));
 
-        cldnn::network::ptr net = get_network(engine, tpl, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr net = get_network(engine, tpl, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         net->set_input_data("in1", input1);
         net->set_input_data("in2", input2);
 
@@ -477,7 +477,7 @@ public:
         tpl.add(input_layout("in2", input2->get_layout()));
         tpl.add(concatenation("conc", { input_info("in1"), input_info("in2") }, 3));
 
-        cldnn::network::ptr net = get_network(engine, tpl, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr net = get_network(engine, tpl, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         net->set_input_data("in1", input1);
         net->set_input_data("in2", input2);
 
@@ -541,7 +541,7 @@ public:
         tpl.add(input_layout("in2", input2->get_layout()));
         tpl.add(concatenation("conc", { input_info("in1"), input_info("in2") }, 2));
 
-        cldnn::network::ptr net = get_network(engine, tpl, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr net = get_network(engine, tpl, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         net->set_input_data("in1", input1);
         net->set_input_data("in2", input2);
 
@@ -616,7 +616,7 @@ public:
         tpl.add(input_layout("in2", input2->get_layout()));
         tpl.add(concatenation("conc", { input_info("in1"), input_info("in2") }, 0));
 
-        cldnn::network::ptr net = get_network(engine, tpl, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr net = get_network(engine, tpl, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         net->set_input_data("in1", input1);
         net->set_input_data("in2", input2);
 
@@ -746,7 +746,7 @@ public:
         tpl.add(input_layout("in3", input3->get_layout()));
         tpl.add(concatenation("conc", { input_info("in1"), input_info("in2"), input_info("in3") }, 0));
 
-        cldnn::network::ptr net = get_network(engine, tpl, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr net = get_network(engine, tpl, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         net->set_input_data("in1", input1);
         net->set_input_data("in2", input2);
         net->set_input_data("in3", input3);

--- a/src/plugins/intel_gpu/tests/test_cases/split_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/split_gpu_test.cpp
@@ -74,7 +74,7 @@ void split_test(int batch_num, int feature_num, int x_size, int y_size, std::vec
     std::vector<T> input_vec = generate_random_input<T>(batch_num, feature_num, y_size, x_size, -10, 10);
     set_values(input, input_vec);
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
     network->set_input_data("input", input);
 
     auto outputs = network->execute();
@@ -225,7 +225,7 @@ TEST(split_gpu_f32, basic_split_concat_optimization) {
     topology.add(concatenation("concat", inputs, 1));
     topology.add(reorder("output", input_info("concat"), format::bfyx, data_types::f32));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
 
@@ -265,7 +265,7 @@ TEST(split_gpu_i64, basic_split_concat_optimization) {
     topology.add(concatenation("concat", inputs, 1));
     topology.add(reorder("output", input_info("concat"), format::bfyx, data_types::i64));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
 
@@ -540,7 +540,7 @@ TEST(split_gpu_f32, basic_in2x3x2x2_split_feature_bfyx) {
     std::vector<float> input_vec = generate_random_input<float>(batch_num, feature_num, y_size, x_size, -10, 10);
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -586,7 +586,7 @@ TEST(split_gpu_i64, basic_in2x3x2x2_split_feature_bfyx) {
     std::vector<int64_t> input_vec = generate_random_input<int64_t>(batch_num, feature_num, y_size, x_size, -10, 10);
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
 
@@ -649,7 +649,7 @@ TEST(split_gpu_f32, basic_in2x3x2x2_split_scale_feature_bfyx) {
     std::vector<float> input_vec = generate_random_input<float>(batch_num, feature_num, y_size, x_size, -10, 10);
     set_values(input, input_vec);
 
-    network network(engine, topology);
+    network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("input", input);
     network.set_input_data("scale_input0", scale_input0);

--- a/src/plugins/intel_gpu/tests/test_cases/streams_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/streams_test.cpp
@@ -32,7 +32,7 @@ public:
                 input_layout("input", input->get_layout()),
                 activation("relu", input_info("input"), activation_func::relu_negative_slope, activation_additional_params{ 0.5f, 0.f }, padding{ { 0, 0, 0, 0 }, 0 }));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         network->set_input_data("input", input);
         auto outputs = network->execute();
         ASSERT_EQ(outputs.size(), size_t(1));
@@ -82,7 +82,7 @@ public:
             membuf mem_buf0;
             membuf mem_buf1;
             {
-                auto prog = program::build_program(engine, topology, ExecutionConfig{});
+                auto prog = program::build_program(engine, topology, get_test_default_config(engine));
                 {
                     network0 = std::make_shared<cldnn::network>(prog, 0);
                     std::ostream out_mem0(&mem_buf0);
@@ -109,7 +109,7 @@ public:
                 }
             }
         } else {
-            auto prog = program::build_program(engine, topology, ExecutionConfig{});
+            auto prog = program::build_program(engine, topology, get_test_default_config(engine));
             network0 = std::make_shared<cldnn::network>(prog, 0);
             network1 = std::make_shared<cldnn::network>(prog, 1);
         }
@@ -185,7 +185,7 @@ public:
             membuf mem_buf0;
             membuf mem_buf1;
             {
-                auto prog = program::build_program(engine, topology, ExecutionConfig{});
+                auto prog = program::build_program(engine, topology, get_test_default_config(engine));
                 {
                     network0 = std::make_shared<cldnn::network>(prog, 0);
                     std::ostream out_mem0(&mem_buf0);
@@ -212,7 +212,7 @@ public:
                 }
             }
         } else {
-            auto prog = program::build_program(engine, topology, ExecutionConfig{});
+            auto prog = program::build_program(engine, topology, get_test_default_config(engine));
             network0 = std::make_shared<cldnn::network>(prog, 0);
             network1 = std::make_shared<cldnn::network>(prog, 1);
         }

--- a/src/plugins/intel_gpu/tests/test_cases/strided_slice_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/strided_slice_gpu_test.cpp
@@ -36,7 +36,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin_data, end_data, strides_data, {}, {}, {}, {}, {}, {2, 2, 2, 2}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -81,7 +81,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin_data, end_data, strides_data, {1, 1, 1, 1}, {1, 1, 1, 1}, {}, {}, {}, {2, 2, 2, 2}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -128,7 +128,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin_data, end_data, strides_data, {}, {}, {}, {}, {}, {1, 1, 1, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -176,7 +176,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin_data, end_data, strides_data, {1, 1, 1, 1}, {1, 1, 1, 1}, {}, {}, {}, {2, 2, 2, 3}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -240,7 +240,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin_data, end_data, strides_data, {0, 1, 1, 0}, {}, {}, {}, {}, {1, 2, 4, 2}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -292,7 +292,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin_data, end_data, strides_data, {}, {}, { 1 }, {}, {}, {2, 2, 4, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -335,7 +335,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin_data, end_data, strides_data, {}, {}, { 1, 0, 1 }, {}, {}, {2, 2, 1, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -376,7 +376,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin_data, end_data, strides_data, {1, 0}, {}, {}, {}, {}, {2, 2, 1, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -417,7 +417,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin_data, end_data, strides_data, {}, {}, {}, {}, {}, {1, 2, 2, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -458,7 +458,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin_data, end_data, strides_data, {}, {}, {}, {}, {}, {2, 1, 1, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -503,7 +503,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin_data, end_data, strides_data, {}, {}, {}, {}, {}, {2, 2, 2, 2}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -544,7 +544,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin_data, end_data, strides_data, {}, {}, {}, {}, {}, {2, 1, 1, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -590,7 +590,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {}, {}, {}, {}, {}, {}));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
         network network(engine, topology, config);
 
@@ -640,7 +640,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {}, {}, {}, {}, {}, {}));
 
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
         network network(engine, topology, config);
 
@@ -759,7 +759,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {}, {}, {}, {}, {}, {2, 2, 2, 2}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -816,7 +816,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {1, 1, 1, 1}, {1, 1, 1, 1}, {}, {}, {}, {2, 2, 2, 2}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -875,7 +875,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {}, {}, {}, {}, {}, {1, 1, 1, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -935,7 +935,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {1, 1, 1, 1}, {1, 1, 1, 1}, {}, {}, {}, {2, 2, 2, 3}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -1011,7 +1011,7 @@ public:
         topology.add(input_layout("input4", strides->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {0, 1, 1, 0}, {}, {}, {}, {}, {1, 2, 4, 2}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
         network->set_input_data("input2", begin);
@@ -1078,7 +1078,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {}, {}, { 1 }, {}, {}, {2, 2, 4, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -1133,7 +1133,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {}, {}, { 1, 0, 1 }, {}, {}, {2, 2, 1, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -1187,7 +1187,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {1, 0}, {}, {}, {}, {}, {2, 2, 1, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -1240,7 +1240,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {}, {}, {}, {}, {}, {1, 2, 2, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -1293,7 +1293,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {}, {}, {}, {}, {}, {2, 1, 1, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -1350,7 +1350,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {}, {}, {}, {}, {}, {2, 2, 2, 2}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -1401,7 +1401,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin, end, strides, {}, {}, {}, {}, {}, {1, 2, 2, 2}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -1452,7 +1452,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin, end, strides, {}, {}, {}, {}, {}, {1, 2, 2, 2}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -1505,7 +1505,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {}, {}, {}, {}, {}, {2, 1, 1, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -1563,7 +1563,7 @@ public:
         topology.add(input_layout("input4", strides->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {}, {}, { 1 }, {}, {}, {2, 2, 4, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
         network->set_input_data("input2", begin);
@@ -1621,7 +1621,7 @@ public:
         topology.add(input_layout("input4", strides->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {}, {}, { 1, 0, 1 }, {}, {}, {2, 2, 1, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
         network->set_input_data("input2", begin);
@@ -1668,7 +1668,7 @@ public:
         topology.add(input_layout("input", input->get_layout()));
         topology.add(strided_slice("strided_slice", input_info("input"), begin_data, end_data, strides_data, {}, {}, {}, {}, {}, {1, 2, 2, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 
@@ -1723,7 +1723,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {1, 0, 0, 1, 0}, {1, 0, 0, 1, 0}, {0, 1, 1, 0, 1}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {1, 1, 1, 8, 1}));
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data("input", input);
 

--- a/src/plugins/intel_gpu/tests/test_cases/test_device_mem_usage_estimation.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/test_device_mem_usage_estimation.cpp
@@ -14,8 +14,14 @@ using namespace tests;
 class test_device_mem_usage_estimation: public ::testing::Test {
 public:
     void test_basic(bool is_caching_test) {
-        ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+        ExecutionConfig cfg = get_test_default_config(get_test_engine());
+        cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+
         std::shared_ptr<cldnn::engine> engine1 = create_test_engine();
+        if (engine1->get_device_info().supports_immad) {
+            // Enable this test for out_of_order queue-type if Onednn supports out_of_order
+            return;
+        }
 
         auto input1 = engine1->allocate_memory({ data_types::f16, format::bfyx,{ 2, 2, 256, 256} });
         auto input2 = engine1->allocate_memory({ data_types::f16, format::bfyx,{ 2, 2, 256, 256} });

--- a/src/plugins/intel_gpu/tests/test_cases/tile_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/tile_gpu_test.cpp
@@ -72,7 +72,7 @@ public:
         set_values(input, input_vec);
         tile_ref<float>(input, output_ref, 0, 2);
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         network->set_input_data("input", input);
 
         auto outputs = network->execute();
@@ -104,7 +104,7 @@ public:
         set_values(input, input_vec);
         tile_ref<float>(input, output_ref, 1, 2);
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         network->set_input_data("input", input);
 
         auto outputs = network->execute();
@@ -140,7 +140,7 @@ public:
         set_values(input, input_vec);
         tile_ref<float>(input, output_ref, 2, 2);
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         network->set_input_data("input", input);
 
         auto outputs = network->execute();
@@ -172,7 +172,7 @@ public:
         set_values(input, input_vec);
         tile_ref<float>(input, output_ref, 3, 2);
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         network->set_input_data("input", input);
 
         auto outputs = network->execute();
@@ -200,7 +200,7 @@ public:
         set_values(input, input_vec);
         tile_ref<float>(input, output_ref, 3, 4);
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         network->set_input_data("input", input);
 
         auto outputs = network->execute();
@@ -237,7 +237,7 @@ public:
         set_values(input, input_vec);
         tile_ref<float>(input, output_ref, 2, 2);
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
         network->set_input_data("input", input);
 
         auto outputs = network->execute();
@@ -292,7 +292,7 @@ TEST_F(tile_gpu, dynamic) {
     topology.add(input_layout("input", input_dyn_layout));
     topology.add(tile("tile", input_info("input"), std::vector<int64_t>{ 1, 2, 1, 1 }));
 
-    ExecutionConfig config;
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
     network.set_input_data("input", input);
@@ -672,7 +672,7 @@ public:
             result_id = reorder_result_id;
         }
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->set_input_data(input_data_id, input);
 

--- a/src/plugins/intel_gpu/tests/test_cases/trim_to_outputs_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/trim_to_outputs_gpu_test.cpp
@@ -26,7 +26,7 @@ public:
     */
     void test_one_node_to_eliminate_case1(bool is_caching_test) {
         auto& engine = get_test_engine();
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "conv1" }));
         config.set_property(ov::intel_gpu::optimize_data(false));             // to avoid adding reorders
 
@@ -75,7 +75,7 @@ public:
     */
     void test_one_node_to_eliminate_case2(bool is_caching_test) {
         auto& engine = get_test_engine();
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "conv1" }));
         config.set_property(ov::intel_gpu::optimize_data(false));             // to avoid adding reorders
 
@@ -132,7 +132,7 @@ public:
     */
     void test_two_nodes_to_eliminate_case1(bool is_caching_test) {
         auto& engine = get_test_engine();
-        ExecutionConfig config;
+        ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "conv4" }));
         config.set_property(ov::intel_gpu::optimize_data(false));             // to avoid adding reorders
 

--- a/src/plugins/intel_gpu/tests/test_cases/variable.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/variable.cpp
@@ -35,7 +35,7 @@ struct variable_test : public ::testing::TestWithParam<VariableParams<T>> {
         topology.add(eltwise{"sum", { input_info("input"), input_info("read_value") }, eltwise_mode::sum, {}, variable_layout.data_type});
         topology.add(assign{"assign", { input_info("sum") }, "v0", variable_layout});
 
-        cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+        cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         network->assign_variables_memories({ { "v0", std::make_shared<network::VariableState>(engine.allocate_memory(variable_layout)) } });
         network->set_input_data("input", input_data);
@@ -123,7 +123,7 @@ void test_exception_on_wrong_layout(bool is_caching_test) {
     topology.add(input_layout("wrong_input", wrong_input_data->get_layout()));
     topology.add(assign{"assign", { input_info("wrong_input") }, "v0", wrong_layout});
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->assign_variables_memories({ { "v0", std::make_shared<network::VariableState>(engine.allocate_memory(variable_layout)) } });
     network->set_input_data("input", input_data);
@@ -179,7 +179,7 @@ void test_variables_are_preserved_across_inferences(bool is_caching_test) {
     topology.add(data("dummy2", dummy2));
     topology.add(read_value{"read_result", { input_info("dummy2") }, "v_result", variable_layout});
 
-    cldnn::network::ptr network = get_network(engine, topology, ExecutionConfig(), get_test_stream_ptr(), is_caching_test);
+    cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     network->assign_variables_memories({
         { "v1", std::make_shared<network::VariableState>(engine.allocate_memory(variable_layout)) },

--- a/src/plugins/intel_gpu/tests/test_utils/test_utils.cpp
+++ b/src/plugins/intel_gpu/tests/test_utils/test_utils.cpp
@@ -287,7 +287,16 @@ std::vector<std::shared_ptr<test_params>> generic_test::generate_generic_test_pa
 }
 
 cldnn::ExecutionConfig get_test_default_config(const cldnn::engine& engine) {
-    ExecutionConfig config;
+    return get_test_default_config(engine, {});
+}
+
+cldnn::ExecutionConfig get_test_default_config(const cldnn::engine& engine, ov::AnyMap::value_type values) {
+    return get_test_default_config(engine, {values});
+}
+
+cldnn::ExecutionConfig get_test_default_config(const cldnn::engine& engine,
+                                                std::initializer_list<ov::AnyMap::value_type> values) {
+    ExecutionConfig config(values);
 
     // Onednn engine currently does NOT support out_of_order
     if (engine.get_device_info().supports_immad) {
@@ -316,11 +325,7 @@ cldnn::engine& get_test_engine() {
 
 cldnn::stream_ptr get_test_stream_ptr() {
     // Create OOO queue for test purposes. If in-order queue is needed in a test, then it should be created there explicitly
-    cldnn::ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
-
-    // Onednn currently does NOT support out-of-order queue-type : will be removed if supported
-    if (get_test_engine().get_device_info().supports_immad)
-        cfg.set_property(ov::intel_gpu::queue_type(QueueTypes::in_order));
+    auto cfg = get_test_default_config(get_test_engine());
 
     return get_test_stream_ptr(cfg);
 }

--- a/src/plugins/intel_gpu/tests/test_utils/test_utils.cpp
+++ b/src/plugins/intel_gpu/tests/test_utils/test_utils.cpp
@@ -302,8 +302,12 @@ cldnn::engine& get_test_engine() {
 cldnn::stream_ptr get_test_stream_ptr() {
     static std::shared_ptr<cldnn::stream> test_stream = nullptr;
     if (!test_stream) {
+#ifdef ENABLE_ONEDNN_FOR_GPU
+        ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::in_order));
+#else
         // Create OOO queue for test purposes. If in-order queue is needed in a test, then it should be created there explicitly
         ExecutionConfig cfg(ov::intel_gpu::queue_type(QueueTypes::out_of_order));
+#endif
         test_stream = get_test_engine().create_stream(cfg);
     }
     return test_stream;

--- a/src/plugins/intel_gpu/tests/test_utils/test_utils.cpp
+++ b/src/plugins/intel_gpu/tests/test_utils/test_utils.cpp
@@ -288,10 +288,6 @@ std::vector<std::shared_ptr<test_params>> generic_test::generate_generic_test_pa
 
 std::shared_ptr<cldnn::engine> create_test_engine() {
     auto ret = cldnn::engine::create(engine_types::ocl, runtime_types::ocl);
-#ifdef ENABLE_ONEDNN_FOR_GPU
-    if(ret->get_device_info().supports_immad)
-        ret->create_onednn_engine({});
-#endif
     return ret;
 }
 

--- a/src/plugins/intel_gpu/tests/test_utils/test_utils.cpp
+++ b/src/plugins/intel_gpu/tests/test_utils/test_utils.cpp
@@ -288,6 +288,10 @@ std::vector<std::shared_ptr<test_params>> generic_test::generate_generic_test_pa
 
 std::shared_ptr<cldnn::engine> create_test_engine() {
     auto ret = cldnn::engine::create(engine_types::ocl, runtime_types::ocl);
+#ifdef ENABLE_ONEDNN_FOR_GPU
+    if(ret->get_device_info().supports_immad)
+        ret->create_onednn_engine({});
+#endif
     return ret;
 }
 

--- a/src/plugins/intel_gpu/tests/test_utils/test_utils.h
+++ b/src/plugins/intel_gpu/tests/test_utils/test_utils.h
@@ -9,6 +9,7 @@
 #include <intel_gpu/runtime/memory.hpp>
 #include <intel_gpu/runtime/tensor.hpp>
 #include <intel_gpu/runtime/engine.hpp>
+#include <intel_gpu/runtime/execution_config.hpp>
 #include <intel_gpu/runtime/stream.hpp>
 #include <intel_gpu/graph/program.hpp>
 #include <intel_gpu/graph/network.hpp>
@@ -55,8 +56,12 @@ namespace tests {
 
 std::shared_ptr<cldnn::engine> create_test_engine();
 cldnn::engine& get_test_engine();
+cldnn::stream_ptr get_test_stream_ptr(cldnn::ExecutionConfig cfg);
 cldnn::stream_ptr get_test_stream_ptr();
 cldnn::stream& get_test_stream();
+
+// Set default configuration for test-cases
+cldnn::ExecutionConfig get_test_default_config(const cldnn::engine&);
 
 template<typename T>
 bool has_node_with_type(cldnn::program& prog) {

--- a/src/plugins/intel_gpu/tests/test_utils/test_utils.h
+++ b/src/plugins/intel_gpu/tests/test_utils/test_utils.h
@@ -62,6 +62,10 @@ cldnn::stream& get_test_stream();
 
 // Set default configuration for test-cases
 cldnn::ExecutionConfig get_test_default_config(const cldnn::engine&);
+cldnn::ExecutionConfig get_test_default_config(const cldnn::engine&, ov::AnyMap::value_type values);
+cldnn::ExecutionConfig get_test_default_config(const cldnn::engine&,
+                                                std::initializer_list<ov::AnyMap::value_type> values);
+
 
 template<typename T>
 bool has_node_with_type(cldnn::program& prog) {


### PR DESCRIPTION
### Details:
 - Moving `_config.apply_user_properties(_engine.get_device_info());` from network.cpp(#15217) to program.cpp(#15800) cause many unit tests fails. Ideally it's recommended to fix such fails, but revert such modification for now.
 - Resolve queue-type issue

### Tickets:
 - 67491
