### PR TITLE
[GPU] Minor fixes for dynamic model in dGPU

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_helpers.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_helpers.cpp
@@ -105,6 +105,10 @@ add_fusing_type onednn_add_fusing_helpers::get_add_fusing_type(
     auto p_layout = p_node.get_output_layout();
     auto d_layout = dep_node.get_output_layout();
 
+    if (p_node.is_dynamic() || dep_node.is_dynamic()) {
+        return add_fusing_type::not_supported;
+    }
+
     if (is_full_tensor(p_layout) && is_full_tensor(d_layout)) {
         if (data_type_traits::size_of(p_layout.data_type) == data_type_traits::size_of(d_layout.data_type)
             && p_layout.format == d_layout.format && p_layout.get_tensor() == d_layout.get_tensor()

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_pooling_to_reduce.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_pooling_to_reduce.cpp
@@ -25,8 +25,12 @@ ov::intel_gpu::ConvertAvgPoolingToReduce::ConvertAvgPoolingToReduce() {
         auto pads_begin = pool->get_pads_begin();
         auto pads_end = pool->get_pads_end();
 
-        int64_t rank = pool->get_input_partial_shape(0).size();
-        auto input_shape = pool->get_input_shape(0);
+        auto input = pool->input_value(0);
+        const auto input_shape = input.get_partial_shape();
+        if (input_shape.is_dynamic() || input_shape.rank().is_dynamic()) {
+            return false;
+        }
+        const auto rank = input_shape.rank().get_length();
         // Check if input spatial size is same with kernel size.
         bool has_same_spatial_size = rank > 2 && std::equal(input_shape.end() - (rank - 2), input_shape.end(), kernel.end() - (rank - 2));
         // Check if pads are zeros.


### PR DESCRIPTION
### Details:
 - Fix to skip `ConvertAvgPoolingToReduce` matcher pass for dynamic shape
 - Fix to skip `onednn_add_fusing_helpers::get_add_fusing_type` to check fusing type for post-op input format 
