### PR TITLE
[GPU] change activation position in reorder_data_bfyx_to_blocked_format kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_bfyx_to_blocked_format.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_bfyx_to_blocked_format.cl
@@ -22,7 +22,7 @@
                                         INPUTVTYPE read_data = AS_INPUTVTYPE(VLOAD(0, input + input_idx)); \
                                         unroll_for (uint lw = 0; lw < inner; ++lw) { \
                                             const uint dst = local_buf_offset + lw; \
-                                            transpose_buf[dst][lh] = ACTIVATION(read_data[lw], ACTIVATION_PARAMS); \
+                                            transpose_buf[dst][lh] = read_data[lw]; \
                                         } \
                                     }
 
@@ -34,7 +34,7 @@
 #define FUNC_WRITE(inner, outer)    unroll_for (uint lw = 0; lw < outer; ++lw) { \
                                         const uint output_idx = output_idx_tile + (lw * x_pitch); \
                                         unroll_for (uint i = 0; i < inner; ++i) { \
-                                            output[output_idx + i] = TO_OUTPUT_TYPE(transpose_buf[local_buf_offset + lw][i]); \
+                                            output[output_idx + i] = ACTIVATION(TO_OUTPUT_TYPE(transpose_buf[local_buf_offset + lw][i]), ACTIVATION_PARAMS); \
                                         } \
                                     }
 


### PR DESCRIPTION
### Details:
 - Change activation position in reorder_data_bfyx_to_blocked_format kernel. Activation in load function causes ambiguous call error of fmax/fmin when input/output data type are different.

### Tickets:
 - 103092