### PR TITLE
[VPUX] - failures : [ ERROR ] Source and destination tensors shapes and byte sizes are expected to be equal for data copying

### DIFF
--- a/src/inference/src/dev/iremote_tensor.cpp
+++ b/src/inference/src/dev/iremote_tensor.cpp
@@ -62,7 +62,7 @@ public:
     }
 
     const Shape& get_shape() const override {
-        m_shape = blob->getTensorDesc().getBlockingDesc().getBlockDims();
+        m_shape = blob->getTensorDesc().getDims();
         return m_shape;
     }
 


### PR DESCRIPTION
**Description:** After updating the `master` commit of Openvino, a new error appeared on the models that were fine before (during benchmark_app run):
`[ ERROR ] Source and destination tensors shapes and byte sizes are expected to be equal for data copying`

**Ticket:** E-72838


