### PR TITLE
making hash generation deterministic

### DIFF
--- a/src/core/src/util.cpp
+++ b/src/core/src/util.cpp
@@ -82,9 +82,9 @@ size_t ngraph::hash_combine(const std::vector<size_t>& list) {
 }
 
 void* ngraph::ngraph_malloc(size_t size) {
-    auto ptr = malloc(size);
+    auto ptr = calloc(size, 1);
     if (size != 0 && !ptr) {
-        NGRAPH_ERR << "malloc failed to allocate memory of size " << size;
+        NGRAPH_ERR << "calloc failed to allocate memory of size " << size;
         throw std::bad_alloc();
     }
     return ptr;

--- a/src/core/tests/pass/serialization/deterministicity.cpp
+++ b/src/core/tests/pass/serialization/deterministicity.cpp
@@ -10,6 +10,7 @@
 #include "openvino/pass/serialize.hpp"
 #include "openvino/util/file_util.hpp"
 #include "read_ir.hpp"
+#include "transformations/hash.hpp"
 #include "util/test_common.hpp"
 
 class SerializationDeterministicityTest : public ov::test::TestsCommon {
@@ -83,6 +84,23 @@ TEST_F(SerializationDeterministicityTest, ModelWithMultipleLayers) {
     ASSERT_TRUE(files_equal(bin_1, bin_2));
 }
 
+TEST_F(SerializationDeterministicityTest, Hash) {
+    const std::string model =
+        CommonTestUtils::getModelFromTestModelZoo(ov::util::path_join({SERIALIZED_ZOO, "ir/addmul_abc.onnx"}));
+
+    uint64_t seed1 = 0;
+    uint64_t seed2 = 0;
+    {
+        auto expected = ov::test::readModel(model, "");
+        ov::pass::Hash(seed1).run_on_model(expected);
+    }
+    {
+        auto expected = ov::test::readModel(model, "");
+        ov::pass::Hash(seed2).run_on_model(expected);
+    }
+
+    ASSERT_TRUE(seed1 == seed2);
+}
 #endif
 
 TEST_F(SerializationDeterministicityTest, ModelWithMultipleOutputs) {


### PR DESCRIPTION
### Details:
 - https://github.com/openvinotoolkit/openvino/pull/16330
 - Hash generation from onnx file is not deterministic on Windows
 - This PR makes it deterministic by memory initialization.

### Tickets:
 - 105515
