### PR TITLE
[GPU] add condition for activation ceil so it works when data type is fp32 or fp16 only

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -1140,7 +1140,10 @@ JitConstants MakeActivationJitConstants(ActivationFunction activation_function,
                 jitConstants.AddConstant(MakeJitConstant(macro_def, "(input)"));
             break;
         case ActivationFunction::CEIL:
-            jitConstants.AddConstant(MakeJitConstant(macro_def, "(ceil(input))"));
+            if (out_dt == Datatype::F32 || out_dt == Datatype::F16)
+                jitConstants.AddConstant(MakeJitConstant(macro_def, "(ceil(input))"));
+            else
+                jitConstants.AddConstant(MakeJitConstant(macro_def, "(input)"));
             break;
         case ActivationFunction::NEGATIVE:
             jitConstants.AddConstant(MakeJitConstant(macro_def, "(-input)"));


### PR DESCRIPTION
### Details:
 - Add condition for activation ceil so it works when data type is fp32 or fp16 only

### Tickets:
 - 105337
