### PR TITLE
Fixed clearing of pipeline config params and TF session in convert_model()

### DIFF
--- a/tools/mo/openvino/tools/mo/front/tf/loader.py
+++ b/tools/mo/openvino/tools/mo/front/tf/loader.py
@@ -324,6 +324,9 @@ def load_tf_graph_def(graph_file_name: str = "", is_binary: bool = True, checkpo
 
 def convert_to_pb(argv: argparse.Namespace):
     from openvino.tools.mo.utils.cli_parser import get_model_name
+    env_setup = get_environment_setup("tf")
+    if "tensorflow" in env_setup and env_setup["tensorflow"] >= LooseVersion("2.0.0"):
+        tf.keras.backend.clear_session()
 
     # if this is already binary frozen format .pb, there is no need to create auxiliary binary frozen protobuf
     # the main thing is to differentiate this format from text frozen format and checkpoint

--- a/tools/mo/openvino/tools/mo/utils/pipeline_config.py
+++ b/tools/mo/openvino/tools/mo/utils/pipeline_config.py
@@ -75,10 +75,10 @@ class PipelineConfig:
     The class that parses pipeline.config files used to generate TF models generated using Object Detection API.
     The class stores data read from the file in a plain dictionary for easier access using the get_param function.
     """
-    _raw_data_dict = dict()
-    _model_params = dict()
 
     def __init__(self, file_name: str):
+        self._raw_data_dict = dict()
+        self._model_params = dict()
         self._raw_data_dict = SimpleProtoParser().parse_file(file_name)
         if not self._raw_data_dict:
             raise Error('Failed to parse pipeline.config file {}'.format(file_name))

--- a/tools/mo/unit_tests/mo/front/tf/ObjectDetectionAPI_test.py
+++ b/tools/mo/unit_tests/mo/front/tf/ObjectDetectionAPI_test.py
@@ -4,6 +4,7 @@
 import unittest
 from argparse import Namespace
 from unittest.mock import patch
+import os
 
 from generator import generator, generate
 
@@ -331,3 +332,19 @@ class TestObjectDetectionAPIPreprocessor2Replacement(unittest.TestCase):
 
         (flag, resp) = compare_graphs(graph, self.build_ref_graph(False), 'result', check_op_attrs=True)
         self.assertTrue(flag, resp)
+
+
+class TestPipelineConfig(unittest.TestCase):
+    def test_pipeline_config_loading(self):
+        from openvino.tools.mo.utils.pipeline_config import PipelineConfig
+        pipeline_config = PipelineConfig(os.path.join(os.path.dirname(__file__), "test_configs/config1.config"))
+        assert pipeline_config.get_param('ssd_anchor_generator_num_layers') == 6
+        assert pipeline_config.get_param('num_classes') == 90
+        assert pipeline_config.get_param('resizer_image_width') == 300
+        assert pipeline_config.get_param('resizer_image_height') == 300
+
+        pipeline_config = PipelineConfig(os.path.join(os.path.dirname(__file__), "test_configs/config2.config"))
+        assert pipeline_config.get_param('ssd_anchor_generator_num_layers') is None
+        assert pipeline_config.get_param('num_classes') == 10
+        assert pipeline_config.get_param('resizer_image_width') == 640
+        assert pipeline_config.get_param('resizer_image_height') == 640

--- a/tools/mo/unit_tests/mo/front/tf/test_configs/config1.config
+++ b/tools/mo/unit_tests/mo/front/tf/test_configs/config1.config
@@ -1,0 +1,17 @@
+model {
+  ssd {
+    num_classes: 90
+    image_resizer {
+      fixed_shape_resizer {
+        height: 300
+        width: 300
+      }
+    }
+    anchor_generator {
+      ssd_anchor_generator {
+        num_layers: 6
+      }
+    }
+  }
+}
+

--- a/tools/mo/unit_tests/mo/front/tf/test_configs/config2.config
+++ b/tools/mo/unit_tests/mo/front/tf/test_configs/config2.config
@@ -1,0 +1,11 @@
+model {
+  ssd {
+    num_classes: 10
+    image_resizer {
+      fixed_shape_resizer {
+        height: 640
+        width: 640
+      }
+    }
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/openvinotoolkit/openvino/pull/16191

Root cause analysis: 
After loading of Meta Graph with tf_v1.train.import_meta_graph() models TF2 keeps loaded graph in memory in global keras session. So next loading may fail if graphs contain nodes with different names. This leads to failing of convert_model() if used twice or more for Meta Graph's. 

Another problem is that PipelineConfig keeps internal values from previous convert_model() runs. This leads to failing  of convert_model() if used twice or more for models with pipeline configs.

Solution: 
Clear TF session for TF2. For TF1 problem does not reproduce.
Clear PipelineConfig before every config reading.

Ticket: 105439, 104381


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update
