### PR TITLE
[apiConformance] Refactor io_tensor tests

### DIFF
--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
@@ -32,38 +32,6 @@ std::vector<ov::element::Type> prcs = {
 
 std::vector<ov::element::Type> supported_input_prcs = {ov::element::f32, ov::element::i16, ov::element::u8};
 
-class OVInferRequestCheckTensorPrecisionGNA : public OVInferRequestCheckTensorPrecision {
-public:
-    void SetUp() override {
-        try {
-            OVInferRequestCheckTensorPrecision::SetUp();
-            if (std::count(supported_input_prcs.begin(), supported_input_prcs.end(), element_type) == 0) {
-                FAIL() << "Precision " << element_type.c_type_string()
-                       << " is marked as unsupported but the network was loaded successfully";
-            }
-        } catch (std::runtime_error& e) {
-            const std::string errorMsg = e.what();
-            const auto expectedMsg = exp_error_str_;
-            ASSERT_STR_CONTAINS(errorMsg, expectedMsg);
-            EXPECT_TRUE(errorMsg.find(expectedMsg) != std::string::npos)
-                << "Wrong error message, actual error message: " << errorMsg << ", expected: " << expectedMsg;
-            if (std::count(supported_input_prcs.begin(), supported_input_prcs.end(), element_type) == 0) {
-                GTEST_SKIP_(expectedMsg.c_str());
-            } else {
-                FAIL() << "Precision " << element_type.c_type_string()
-                       << " is marked as supported but the network was not loaded";
-            }
-        }
-    }
-
-private:
-    std::string exp_error_str_ = "The plugin does not support input precision";
-};
-
-TEST_P(OVInferRequestCheckTensorPrecisionGNA, CheckInputsOutputs) {
-    Run();
-}
-
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
                          OVInferRequestIOTensorTest,
                          ::testing::Combine(::testing::Values(CommonTestUtils::DEVICE_GNA),
@@ -78,10 +46,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
                          OVInferRequestIOTensorSetPrecisionTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
-                         OVInferRequestCheckTensorPrecisionGNA,
-                         ::testing::Combine(::testing::ValuesIn(prcs),
+                         OVInferRequestCheckTensorPrecision,
+                         ::testing::Combine(::testing::ValuesIn(supported_input_prcs),
                                             ::testing::Values(CommonTestUtils::DEVICE_GNA),
                                             ::testing::ValuesIn(configs)),
-                         OVInferRequestCheckTensorPrecisionGNA::getTestCaseName);
+                         OVInferRequestCheckTensorPrecision::getTestCaseName);
 
 }  // namespace

--- a/src/plugins/template/tests/functional/skip_tests_config.cpp
+++ b/src/plugins/template/tests/functional/skip_tests_config.cpp
@@ -133,6 +133,7 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*InferRequestIOBBlobTest.*canProcessDeallocatedOutputBlobAfterGetAndSetBlob.*)",
         // Why query state should throw an exception
         R"(.*InferRequestQueryStateExceptionTest.*inferreq_smoke_QueryState_ExceptionTest.*)",
+        R"(.*OVInferRequestCheckTensorPrecision.*get(Input|Output|Inputs|Outputs)From.*FunctionWith(Single|Several).*type=(u4|u1|i4|boolean).*)",
     };
 
 #ifdef _WIN32

--- a/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/behavior/ov_infer_request/io_tensor.cpp
@@ -43,4 +43,11 @@ INSTANTIATE_TEST_SUITE_P(ov_infer_request, OVInferRequestIOTensorSetPrecisionTes
                                  ::testing::ValuesIn(return_all_possible_device_combination()),
                                  ::testing::Values(pluginConfig)),
                          OVInferRequestIOTensorSetPrecisionTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(ov_infer_request, OVInferRequestCheckTensorPrecision,
+                         ::testing::Combine(
+                                 ::testing::ValuesIn(ovIOTensorElemTypes),
+                                 ::testing::ValuesIn(return_all_possible_device_combination()),
+                                 ::testing::Values(pluginConfig)),
+                         OVInferRequestCheckTensorPrecision::getTestCaseName);
 }  // namespace

--- a/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_executable_network/exec_network_base.hpp
@@ -52,26 +52,6 @@ public:
         APIBaseTest::TearDown();
     }
 
-    bool compareTensors(const ov::Tensor& t1, const ov::Tensor& t2) {
-        void* data1;
-        void* data2;
-        try {
-            data1 = t1.data();
-        } catch (const ov::Exception&) {
-            // Remote tensor
-            data1 = nullptr;
-        }
-        try {
-            data2 = t2.data();
-        } catch (const ov::Exception&) {
-            // Remote tensor
-            data2 = nullptr;
-        }
-        return t1.get_element_type() == t2.get_element_type() && t1.get_shape() == t2.get_shape() &&
-               t1.get_byte_size() == t2.get_byte_size() && t1.get_size() == t2.get_size() &&
-               t1.get_strides() == t2.get_strides() && data1 == data2;
-    }
-
 protected:
     std::shared_ptr<ov::Core> core = utils::PluginCache::get().core();
     ov::AnyMap configuration;
@@ -395,8 +375,6 @@ TEST_P(OVExecutableNetworkBaseTest, pluginDoesNotChangeOriginalNetwork) {
 }
 
 TEST_P(OVExecutableNetworkBaseTest, getInputFromFunctionWithSingleInput) {
-    // Skip test according to plugin specific disabledTestPatterns() (if any)
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     ov::CompiledModel execNet;
 
     execNet = core->compile_model(function, target_device, configuration);
@@ -406,24 +384,9 @@ TEST_P(OVExecutableNetworkBaseTest, getInputFromFunctionWithSingleInput) {
     EXPECT_EQ(function->input().get_tensor().get_names(), execNet.input().get_tensor().get_names());
     EXPECT_EQ(function->input().get_tensor().get_partial_shape(), execNet.input().get_tensor().get_partial_shape());
     EXPECT_EQ(function->input().get_tensor().get_element_type(), execNet.input().get_tensor().get_element_type());
-
-    ov::InferRequest request = execNet.create_infer_request();
-
-    ov::Tensor tensor1, tensor2;
-    EXPECT_NO_THROW(tensor1 = request.get_tensor(execNet.input()));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->input()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(execNet.input().get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->input().get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_input_tensor(0));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
 }
 
 TEST_P(OVExecutableNetworkBaseTest, getOutputFromFunctionWithSingleInput) {
-    // Skip test according to plugin specific disabledTestPatterns() (if any)
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     ov::CompiledModel execNet;
 
     execNet = core->compile_model(function, target_device, configuration);
@@ -433,23 +396,9 @@ TEST_P(OVExecutableNetworkBaseTest, getOutputFromFunctionWithSingleInput) {
     EXPECT_EQ(function->output().get_tensor().get_names(), execNet.output().get_tensor().get_names());
     EXPECT_EQ(function->output().get_tensor().get_partial_shape(), execNet.output().get_tensor().get_partial_shape());
     EXPECT_EQ(function->output().get_tensor().get_element_type(), execNet.output().get_tensor().get_element_type());
-
-    ov::InferRequest request = execNet.create_infer_request();
-    ov::Tensor tensor1, tensor2;
-    EXPECT_NO_THROW(tensor1 = request.get_tensor(execNet.output()));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->output()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(execNet.output().get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->output().get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_output_tensor(0));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
 }
 
 TEST_P(OVExecutableNetworkBaseTest, getInputsFromFunctionWithSeveralInputs) {
-    // Skip test according to plugin specific disabledTestPatterns() (if any)
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     ov::CompiledModel execNet;
 
     // Create simple function
@@ -488,34 +437,6 @@ TEST_P(OVExecutableNetworkBaseTest, getInputsFromFunctionWithSeveralInputs) {
     EXPECT_NE(function->input(1).get_node(), function->input("data1").get_node());
     EXPECT_EQ(function->input(1).get_node(), function->input("data2").get_node());
     EXPECT_NE(function->input(0).get_node(), function->input("data2").get_node());
-
-    ov::InferRequest request = execNet.create_infer_request();
-
-    ov::Tensor tensor1, tensor2;
-    EXPECT_NO_THROW(tensor1 = request.get_tensor(execNet.input(0)));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->input(0)));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(execNet.input(0).get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->input(0).get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_input_tensor(0));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor1 = request.get_tensor(execNet.input(1)));
-    try {
-        // To avoid case with remote tensors
-        tensor1.data();
-        EXPECT_FALSE(compareTensors(tensor1, tensor2));
-    } catch (const ov::Exception&) {
-    }
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->input(1)));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(execNet.input(1).get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->input(1).get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_input_tensor(1));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
 }
 
 TEST_P(OVExecutableNetworkBaseTest, getOutputsFromFunctionWithSeveralOutputs) {
@@ -559,41 +480,10 @@ TEST_P(OVExecutableNetworkBaseTest, getOutputsFromFunctionWithSeveralOutputs) {
     EXPECT_NE(function->output(1).get_node(), function->output("relu").get_node());
     EXPECT_EQ(function->output(1).get_node(), function->output("concat").get_node());
     EXPECT_NE(function->output(0).get_node(), function->output("concat").get_node());
-
-    ov::InferRequest request = execNet.create_infer_request();
-
-    ov::Tensor tensor1, tensor2;
-    EXPECT_NO_THROW(tensor1 = request.get_tensor(execNet.output(0)));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->output(0)));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(execNet.output(0).get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->output(0).get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_output_tensor(0));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor1 = request.get_tensor(execNet.output(1)));
-    try {
-        // To avoid case with remote tensors
-        tensor1.data();
-        EXPECT_FALSE(compareTensors(tensor1, tensor2));
-    } catch (const ov::Exception&) {
-    }
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->output(1)));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(execNet.output(1).get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->output(1).get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_output_tensor(1));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
 }
 
 TEST_P(OVExecutableNetworkBaseTest, getOutputsFromSplitFunctionWithSeveralOutputs) {
-    // Skip test according to plugin specific disabledTestPatterns() (if any)
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     ov::CompiledModel execNet;
-
     // Create simple function
     {
         auto param1 = std::make_shared<ov::opset8::Parameter>(ov::element::Type_t::f32, ngraph::Shape({1, 4, 24, 24}));
@@ -626,34 +516,6 @@ TEST_P(OVExecutableNetworkBaseTest, getOutputsFromSplitFunctionWithSeveralOutput
     EXPECT_NE(function->output(1).get_node(), function->output("tensor_split_1").get_node());
     EXPECT_EQ(function->output(1).get_node(), function->output("tensor_split_2").get_node());
     EXPECT_NE(function->output(0).get_node(), function->output("tensor_split_2").get_node());
-
-    ov::InferRequest request = execNet.create_infer_request();
-
-    ov::Tensor tensor1, tensor2;
-    EXPECT_NO_THROW(tensor1 = request.get_tensor(execNet.output(0)));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->output(0)));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(execNet.output(0).get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->output(0).get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_output_tensor(0));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor1 = request.get_tensor(execNet.output(1)));
-    try {
-        // To avoid case with remote tensors
-        tensor1.data();
-        EXPECT_FALSE(compareTensors(tensor1, tensor2));
-    } catch (const ov::Exception&) {
-    }
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->output(1)));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(execNet.output(1).get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_tensor(function->output(1).get_any_name()));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
-    EXPECT_NO_THROW(tensor2 = request.get_output_tensor(1));
-    EXPECT_TRUE(compareTensors(tensor1, tensor2));
 }
 
 // Load correct network to Plugin to get executable network

--- a/src/tests/functional/plugin/shared/include/behavior/ov_infer_request/io_tensor.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_infer_request/io_tensor.hpp
@@ -47,14 +47,35 @@ struct OVInferRequestCheckTensorPrecision : public testing::WithParamInterface<O
     static std::string getTestCaseName(const testing::TestParamInfo<OVInferRequestCheckTensorPrecisionParams>& obj);
     void SetUp() override;
     void TearDown() override;
-    void Run();
+    bool compareTensors(const ov::Tensor& t1, const ov::Tensor& t2);
+    void createInferRequest();
 
     std::shared_ptr<ov::Core> core = utils::PluginCache::get().core();
     std::shared_ptr<ov::Model> model;
     CompiledModel compModel;
-    InferRequest req;
+    InferRequest request;
     AnyMap  config;
     element::Type  element_type;
+
+    std::vector<ov::element::Type> precisions = {
+        ov::element::boolean,
+        ov::element::bf16,
+        ov::element::f16,
+        ov::element::f32,
+        ov::element::f64,
+        ov::element::i4,
+        ov::element::i8,
+        ov::element::i16,
+        ov::element::i32,
+        ov::element::i64,
+        ov::element::u1,
+        ov::element::u4,
+        ov::element::u8,
+        ov::element::u16,
+        ov::element::u32,
+        ov::element::u64,
+    };
+    std::string exp_error_str_ = "The plugin does not support input precision";
 };
 
 } // namespace behavior

--- a/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/io_tensor.cpp
@@ -114,21 +114,21 @@ TEST_P(OVInferRequestIOTensorTest, secondCallGetOutputDoNotReAllocateData) {
 }
 
 TEST_P(OVInferRequestIOTensorTest, secondCallGetInputAfterInferSync) {
+    ov::Tensor tensor1, tensor2;
     OV_ASSERT_NO_THROW(req.infer());
+    OV_ASSERT_NO_THROW(tensor1 = req.get_tensor(input));
     OV_ASSERT_NO_THROW(req.start_async());
     OV_ASSERT_NO_THROW(req.wait());
-    ov::Tensor tensor1, tensor2;
-    OV_ASSERT_NO_THROW(tensor1 = req.get_tensor(input));
     OV_ASSERT_NO_THROW(tensor2 = req.get_tensor(input));
     ASSERT_EQ(tensor1.data(), tensor2.data());
 }
 
 TEST_P(OVInferRequestIOTensorTest, secondCallGetOutputAfterInferSync) {
+    ov::Tensor tensor1, tensor2;
     OV_ASSERT_NO_THROW(req.infer());
+    OV_ASSERT_NO_THROW(tensor1 = req.get_tensor(output));
     OV_ASSERT_NO_THROW(req.start_async());
     OV_ASSERT_NO_THROW(req.wait());
-    ov::Tensor tensor1, tensor2;
-    OV_ASSERT_NO_THROW(tensor1 = req.get_tensor(output));
     OV_ASSERT_NO_THROW(tensor2 = req.get_tensor(output));
     ASSERT_EQ(tensor1.data(), tensor2.data());
 }
@@ -139,6 +139,11 @@ TEST_P(OVInferRequestIOTensorTest, canInferWithSetInOutBlobs) {
     auto output_tensor = utils::create_and_fill_tensor(output.get_element_type(), output.get_shape());
     OV_ASSERT_NO_THROW(req.set_tensor(output, output_tensor));
     OV_ASSERT_NO_THROW(req.infer());
+
+    auto actual_input_tensor = req.get_tensor(input);
+    ASSERT_EQ(actual_input_tensor.data(), input_tensor.data());
+    auto actual_output_tensor = req.get_tensor(output);
+    ASSERT_EQ(actual_output_tensor.data(), output_tensor.data());
 }
 
 TEST_P(OVInferRequestIOTensorTest, canInferWithGetIn) {
@@ -170,16 +175,7 @@ TEST_P(OVInferRequestIOTensorTest, canInferAfterIOBlobReallocation) {
     OV_ASSERT_NO_THROW(req.get_tensor(output));
 }
 
-TEST_P(OVInferRequestIOTensorTest, canInferWithGetOut) {
-    ov::Tensor output_tensor;
-    OV_ASSERT_NO_THROW(output_tensor = req.get_tensor(output));
-    OV_ASSERT_NO_THROW(req.infer());
-    OV_ASSERT_NO_THROW(req.start_async());
-    OV_ASSERT_NO_THROW(req.wait());
-    OV_ASSERT_NO_THROW(req.get_tensor(output));
-}
-
-TEST_P(OVInferRequestIOTensorTest, InferStaticNetworkSetInputTensor) {
+TEST_P(OVInferRequestIOTensorTest, InferStaticNetworkSetChangedInputTensorThrow) {
     const ov::Shape shape1 = {1, 1, 32, 32};
     const ov::Shape shape2 = {1, 1, 40, 40};
     std::map<std::string, ov::PartialShape> shapes;
@@ -200,7 +196,7 @@ TEST_P(OVInferRequestIOTensorTest, InferStaticNetworkSetInputTensor) {
     ASSERT_ANY_THROW(req.infer());
 }
 
-TEST_P(OVInferRequestIOTensorTest, InferStaticNetworkSetOutputTensor) {
+TEST_P(OVInferRequestIOTensorTest, InferStaticNetworkSetChangedOutputTensorThrow) {
     const ov::Shape shape1 = {1, 1, 32, 32};
     ov::Shape shape2;
     if (target_device.find(CommonTestUtils::DEVICE_BATCH) == std::string::npos)
@@ -306,34 +302,179 @@ void OVInferRequestCheckTensorPrecision::SetUp() {
     std::tie(element_type, target_device, config) = this->GetParam();
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
     APIBaseTest::SetUp();
-    {
-        auto parameter1 = std::make_shared<ov::op::v0::Parameter>(element_type, ov::PartialShape{1, 3, 2, 2});
-        auto parameter2 = std::make_shared<ov::op::v0::Parameter>(element_type, ov::PartialShape{1, 3, 2, 2});
-        auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{parameter1, parameter2}, 1);
-        auto result = std::make_shared<ov::op::v0::Result>(concat);
-        model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{parameter1, parameter2});
+}
+
+bool OVInferRequestCheckTensorPrecision::compareTensors(const ov::Tensor& t1, const ov::Tensor& t2) {
+    void* data1;
+    void* data2;
+    try {
+        data1 = t1.data();
+    } catch (const ov::Exception&) {
+        // Remote tensor
+        data1 = nullptr;
     }
-    compModel = core->compile_model(model, target_device, config);
-    req = compModel.create_infer_request();
+    try {
+        data2 = t2.data();
+    } catch (const ov::Exception&) {
+        // Remote tensor
+        data2 = nullptr;
+    }
+    return t1.get_element_type() == t2.get_element_type() && t1.get_shape() == t2.get_shape() &&
+           t1.get_byte_size() == t2.get_byte_size() && t1.get_size() == t2.get_size() &&
+           t1.get_strides() == t2.get_strides() && data1 == data2;
+}
+
+void OVInferRequestCheckTensorPrecision::createInferRequest() {
+    try {
+        compModel = core->compile_model(model, target_device, config);
+        request = compModel.create_infer_request();
+
+        if (std::count(precisions.begin(), precisions.end(), element_type) == 0) {
+            FAIL() << "Precision " << element_type.c_type_string()
+                    << " is marked as unsupported but the network was loaded successfully";
+        }
+    } catch (std::runtime_error& e) {
+        const std::string errorMsg = e.what();
+        const auto expectedMsg = exp_error_str_;
+        ASSERT_STR_CONTAINS(errorMsg, expectedMsg);
+        EXPECT_TRUE(errorMsg.find(expectedMsg) != std::string::npos)
+            << "Wrong error message, actual error message: " << errorMsg << ", expected: " << expectedMsg;
+        if (std::count(precisions.begin(), precisions.end(), element_type) == 0) {
+            GTEST_SKIP_(expectedMsg.c_str());
+        } else {
+            FAIL() << "Precision " << element_type.c_type_string()
+                    << " is marked as supported but the network was not loaded";
+        }
+    }
 }
 
 void OVInferRequestCheckTensorPrecision::TearDown() {
-    compModel = {};
-    req = {};
     APIBaseTest::TearDown();
 }
 
-void OVInferRequestCheckTensorPrecision::Run() {
-    EXPECT_EQ(element_type, compModel.input(0).get_element_type());
-    EXPECT_EQ(element_type, compModel.input(1).get_element_type());
-    EXPECT_EQ(element_type, compModel.output().get_element_type());
-    EXPECT_EQ(element_type, req.get_input_tensor(0).get_element_type());
-    EXPECT_EQ(element_type, req.get_input_tensor(1).get_element_type());
-    EXPECT_EQ(element_type, req.get_output_tensor().get_element_type());
+TEST_P(OVInferRequestCheckTensorPrecision, getInputFromFunctionWithSingleInput) {
+    model = ngraph::builder::subgraph::makeSplitConcat({1, 4, 24, 24}, element_type);
+    createInferRequest();
+
+    ov::Tensor tensor1, tensor2;
+    EXPECT_NO_THROW(tensor1 = request.get_tensor(compModel.input()));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->input()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(compModel.input().get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->input().get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_input_tensor(0));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
 }
 
-TEST_P(OVInferRequestCheckTensorPrecision, CheckInputsOutputs) {
-    Run();
+TEST_P(OVInferRequestCheckTensorPrecision, getOutputFromFunctionWithSingleInput) {
+    model = ngraph::builder::subgraph::makeSplitConcat({1, 4, 24, 24}, element_type);
+    createInferRequest();
+
+    ov::Tensor tensor1, tensor2;
+    EXPECT_NO_THROW(tensor1 = request.get_tensor(compModel.output()));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->output()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(compModel.output().get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->output().get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_output_tensor(0));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+}
+
+TEST_P(OVInferRequestCheckTensorPrecision, getInputsFromFunctionWithSeveralInputs) {
+    model = ngraph::builder::subgraph::makeMultipleInputOutputSplitConcat({1, 1, 32, 32}, element_type);
+    createInferRequest();
+
+    ov::Tensor tensor1, tensor2;
+    EXPECT_NO_THROW(tensor1 = request.get_tensor(compModel.input(0)));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->input(0)));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(compModel.input(0).get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->input(0).get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_input_tensor(0));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor1 = request.get_tensor(compModel.input(1)));
+    try {
+        // To avoid case with remote tensors
+        tensor1.data();
+        EXPECT_FALSE(compareTensors(tensor1, tensor2));
+    } catch (const ov::Exception&) {
+    }
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->input(1)));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(compModel.input(1).get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->input(1).get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_input_tensor(1));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+}
+
+TEST_P(OVInferRequestCheckTensorPrecision, getOutputsFromFunctionWithSeveralOutputs) {
+    model = ngraph::builder::subgraph::makeMultipleInputOutputSplitConcat({1, 1, 32, 32}, element_type);
+    createInferRequest();
+
+    ov::Tensor tensor1, tensor2;
+    EXPECT_NO_THROW(tensor1 = request.get_tensor(compModel.output(0)));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->output(0)));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(compModel.output(0).get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->output(0).get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_output_tensor(0));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor1 = request.get_tensor(compModel.output(1)));
+    try {
+        // To avoid case with remote tensors
+        tensor1.data();
+        EXPECT_FALSE(compareTensors(tensor1, tensor2));
+    } catch (const ov::Exception&) {
+    }
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->output(1)));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(compModel.output(1).get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->output(1).get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_output_tensor(1));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+}
+
+TEST_P(OVInferRequestCheckTensorPrecision, getOutputsFromSplitFunctionWithSeveralOutputs) {
+    model = ngraph::builder::subgraph::makeSingleSplit({1, 4, 24, 24}, element_type);
+    createInferRequest();
+
+    ov::Tensor tensor1, tensor2;
+    EXPECT_NO_THROW(tensor1 = request.get_tensor(compModel.output(0)));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->output(0)));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(compModel.output(0).get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->output(0).get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_output_tensor(0));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor1 = request.get_tensor(compModel.output(1)));
+    try {
+        // To avoid case with remote tensors
+        tensor1.data();
+        EXPECT_FALSE(compareTensors(tensor1, tensor2));
+    } catch (const ov::Exception&) {
+    }
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->output(1)));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(compModel.output(1).get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_tensor(model->output(1).get_any_name()));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
+    EXPECT_NO_THROW(tensor2 = request.get_output_tensor(1));
+    EXPECT_TRUE(compareTensors(tensor1, tensor2));
 }
 
 }  // namespace behavior

--- a/src/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/subgraph_builders.hpp
+++ b/src/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/subgraph_builders.hpp
@@ -747,6 +747,116 @@ inline std::shared_ptr<ngraph::Function> makeConvertTranspose(std::vector<size_t
     fn_ptr->set_friendly_name("ConvertTranspose");
     return fn_ptr;
 }
+
+inline std::shared_ptr<ngraph::Function> makeMultipleInputOutputReLU(std::vector<size_t> inputShape = {1, 1, 32, 32},
+                                                                    ngraph::element::Type_t type = ngraph::element::Type_t::f32) {
+    auto param1 = std::make_shared<ngraph::opset8::Parameter>(type, ngraph::Shape(inputShape));
+    param1->set_friendly_name("param1");
+    param1->output(0).get_tensor().set_names({"data1"});
+    auto param2 = std::make_shared<ngraph::opset8::Parameter>(type, ngraph::Shape(inputShape));
+    param2->set_friendly_name("param2");
+    param2->output(0).get_tensor().set_names({"data2"});
+    auto relu = std::make_shared<ngraph::opset8::Relu>(param1);
+    relu->set_friendly_name("relu_op");
+    relu->output(0).get_tensor().set_names({"relu"});
+    auto result1 = std::make_shared<ngraph::opset8::Result>(relu);
+    result1->set_friendly_name("result1");
+    auto concat = std::make_shared<ngraph::opset8::Concat>(OutputVector{relu, param2}, 1);
+    concat->set_friendly_name("concat_op");
+    concat->output(0).get_tensor().set_names({"concat"});
+    auto result2 = std::make_shared<ngraph::opset8::Result>(concat);
+    result2->set_friendly_name("result2");
+    auto fn_ptr = std::make_shared<ngraph::Function>(ngraph::ResultVector{result1, result2},
+                                                     ngraph::ParameterVector{param1, param2});
+    fn_ptr->set_friendly_name("MultipleInputOutputReLU");
+    return fn_ptr;
+}
+
+inline std::shared_ptr<ngraph::Function> makeMultipleInputOutputSplitConcat(std::vector<size_t> inputShape = {1, 1, 32, 32},
+                                                                            ngraph::element::Type_t type = ngraph::element::Type_t::f32) {
+    auto param1 = std::make_shared<ngraph::opset8::Parameter>(type, ngraph::Shape{inputShape});
+    param1->set_friendly_name("param1");
+    param1->output(0).get_tensor().set_names({"data1"});
+    auto param2 = std::make_shared<ngraph::opset8::Parameter>(type, ngraph::Shape(inputShape));
+    param2->set_friendly_name("param2");
+    param2->output(0).get_tensor().set_names({"data2"});
+    auto concat1 = std::make_shared<ngraph::opset8::Concat>(OutputVector{param1, param2}, 1);
+    concat1->set_friendly_name("concat_op1");
+    concat1->output(0).get_tensor().set_names({"concat1"});
+    auto result1 = std::make_shared<ngraph::opset8::Result>(concat1);
+    result1->set_friendly_name("result1");
+    auto concat2 = std::make_shared<ngraph::opset8::Concat>(OutputVector{concat1, param2}, 1);
+    concat2->set_friendly_name("concat_op2");
+    concat2->output(0).get_tensor().set_names({"concat2"});
+    auto result2 = std::make_shared<ngraph::opset8::Result>(concat2);
+    result2->set_friendly_name("result2");
+    auto fn_ptr = std::make_shared<ngraph::Function>(ngraph::ResultVector{ result1, result2 },
+                                                     ngraph::ParameterVector{ param1, param2 });
+    fn_ptr->set_friendly_name("makeMultipleInputOutputSplitConcat");
+    return fn_ptr;
+}
+
+inline std::shared_ptr<ngraph::Function> makeSingleSplit(std::vector<size_t> inputShape = {1, 4, 24, 24},
+                                                         ngraph::element::Type_t type = ngraph::element::Type_t::f32) {
+    auto param1 = std::make_shared<ngraph::opset8::Parameter>(type, ngraph::Shape{inputShape});
+    param1->set_friendly_name("param1");
+    param1->output(0).get_tensor().set_names({"data1"});
+    auto axis_node = ngraph::opset8::Constant::create(element::i64, Shape{}, {1});
+    auto split = std::make_shared<ngraph::opset8::Split>(param1, axis_node, 2);
+    split->set_friendly_name("split");
+    split->output(0).get_tensor().set_names({"tensor_split_1"});
+    split->output(1).get_tensor().set_names({"tensor_split_2"});
+    auto result1 = std::make_shared<ngraph::opset8::Result>(split->output(0));
+    result1->set_friendly_name("result1");
+    auto result2 = std::make_shared<ngraph::opset8::Result>(split->output(1));
+    result2->set_friendly_name("result2");
+    auto fn_ptr =
+        std::make_shared<ngraph::Function>(ngraph::ResultVector{result1, result2}, ngraph::ParameterVector{param1});
+    fn_ptr->set_friendly_name("SingleSplit");
+    return fn_ptr;
+}
+
+inline std::shared_ptr<ngraph::Function> makeSplitConcat(std::vector<size_t> inputShape = {1, 4, 24, 24},
+                                                         ngraph::element::Type_t type = ngraph::element::Type_t::f32) {
+    auto param1 = std::make_shared<ngraph::opset8::Parameter>(type, ngraph::Shape{inputShape});
+    param1->set_friendly_name("param1");
+    param1->output(0).get_tensor().set_names({"data1"});
+    auto axis_node = ngraph::opset8::Constant::create(element::i64, Shape{}, {1});
+    auto split = std::make_shared<ngraph::opset8::Split>(param1, axis_node, 2);
+    split->set_friendly_name("split");
+    split->output(0).get_tensor().set_names({"tensor_split_1"});
+    split->output(1).get_tensor().set_names({"tensor_split_2"});
+
+    auto concat = std::make_shared<ngraph::opset8::Concat>(OutputVector{split->output(0), split->output(1)}, 1);
+    concat->set_friendly_name("concat_op");
+    concat->output(0).get_tensor().set_names({"concat"});
+    auto result = std::make_shared<ngraph::opset8::Result>(concat);
+    result->set_friendly_name("result");
+    auto fn_ptr = std::make_shared<ngraph::Function>(ngraph::ResultVector{ result },
+                                                     ngraph::ParameterVector{ param1 });
+    fn_ptr->set_friendly_name("SplitConcat");
+    return fn_ptr;
+}
+
+inline std::shared_ptr<ngraph::Function> makeConcat(std::vector<size_t> inputShape = {1, 1, 32, 32},
+                                                    ngraph::element::Type_t type = ngraph::element::Type_t::f32) {
+    auto parameter1 = std::make_shared<ngraph::opset8::Parameter>(type, ngraph::Shape{inputShape});
+    parameter1->set_friendly_name("param1");
+    parameter1->output(0).get_tensor().set_names({"data1"});
+    auto parameter2 = std::make_shared<ngraph::opset8::Parameter>(type, ngraph::Shape{inputShape});
+    parameter2->set_friendly_name("param2");
+    parameter2->output(0).get_tensor().set_names({"data2"});
+    auto concat = std::make_shared<ngraph::opset8::Concat>(OutputVector{parameter1, parameter2}, 1);
+    concat->set_friendly_name("concat_op");
+    concat->output(0).get_tensor().set_names({"concat"});
+    auto result = std::make_shared<ngraph::opset8::Result>(concat);
+    result->set_friendly_name("result");
+    auto fn_ptr = std::make_shared<ngraph::Function>(ngraph::ResultVector{result},
+                                                     ngraph::ParameterVector{parameter1, parameter2});
+    fn_ptr->set_friendly_name("SimpleConcat");
+    return fn_ptr;
+}
+
 }  // namespace subgraph
 }  // namespace builder
 }  // namespace ngraph


### PR DESCRIPTION
Update tests according to apiConformance test review.

### Details:
 - *update  checks in secondCallGetInputAfterInferSync, secondCallGetOutputAfterInferSync, canInferWithSetInOutBlobs*
 - *update name for InferStaticNetworkSetOutputTensor and InferStaticNetworkSetInputTensor*
 - *remove canInferWithGetOut*
 - *remove from get[Input|Output]FromFunctionWith[Single|Multiple]Input from exec_network_base.hpp part with infer_requiest and move it to io_tesnsor*
 - *add to io_tesnsor get[Input|Output]FromFunctionWith[Single|Multiple]Input tests*
 - *add instantiation of OVInferRequestCheckTensorPrecision to apiConformance*

### Tickets:
 - *ticket-id*
