### PR TITLE
[VPUX] - Tensor data with element type f16, is not representable as pointer to i16

### DIFF
--- a/samples/cpp/benchmark_app/inputs_filling.cpp
+++ b/samples/cpp/benchmark_app/inputs_filling.cpp
@@ -563,7 +563,7 @@ ov::Tensor get_random_tensor(const std::pair<std::string, benchmark_app::InputIn
     } else if (type == ov::element::f64) {
         return create_tensor_random<double, double>(inputInfo.second);
     } else if (type == ov::element::f16) {
-        return create_tensor_random<short, short>(inputInfo.second);
+        return create_tensor_random<ov::float16, short>(inputInfo.second);
     } else if (type == ov::element::i32) {
         return create_tensor_random<int32_t, int32_t>(inputInfo.second);
     } else if (type == ov::element::i64) {

--- a/samples/cpp/benchmark_app/inputs_filling.cpp
+++ b/samples/cpp/benchmark_app/inputs_filling.cpp
@@ -563,7 +563,7 @@ ov::Tensor get_random_tensor(const std::pair<std::string, benchmark_app::InputIn
     } else if (type == ov::element::f64) {
         return create_tensor_random<double, double>(inputInfo.second);
     } else if (type == ov::element::f16) {
-        return create_tensor_random<ov::float16, short>(inputInfo.second);
+        return create_tensor_random<ov::float16, float>(inputInfo.second);
     } else if (type == ov::element::i32) {
         return create_tensor_random<int32_t, int32_t>(inputInfo.second);
     } else if (type == ov::element::i64) {


### PR DESCRIPTION
A few networks fail (on benchmark_app) with the following errors:
```
[Step 9/11] Creating infer requests and preparing input tensors
[ WARNING ] No input files were given: all inputs will be filled with random values!
[ ERROR ] Check 'false' failed at C:\jenkins\workspace\openVINO-builder-ws\dldt\src\core\src\runtime\ov_tensor.cpp:217:
Check 'element_type == get_element_type()' failed at C:\jenkins\workspace\openVINO-builder-ws\dldt\src\core\src\runtime\itensor.cpp:46:
Tensor data with element type f16, is not representable as pointer to i16 
```