### PR TITLE
Fix MO Reader for Squeeze without axes

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/ir_reader/internal_ops/squeeze.py
+++ b/tools/mo/openvino/tools/mo/utils/ir_reader/internal_ops/squeeze.py
@@ -21,5 +21,5 @@ class SqueezeInternal(Squeeze):
             assert is_fully_defined(
                 input_shape), 'Squeeze dimensions are not defined for op "{}"'.format(node_name)
             output_shape = [s for s in shape_array(input_shape).tolist() if s != 1]
-            node.out_port(0).data.set_shape(output_shape)
+            node.out_port(0).data.set_shape(shape_array(output_shape))
 

--- a/tools/mo/openvino/tools/mo/utils/ir_reader/internal_ops/squeeze.py
+++ b/tools/mo/openvino/tools/mo/utils/ir_reader/internal_ops/squeeze.py
@@ -3,12 +3,23 @@
 
 from openvino.tools.mo.graph.graph import Node
 from openvino.tools.mo.ops.squeeze import Squeeze
+from openvino.tools.mo.front.common.partial_infer.utils import shape_array, dynamic_dimension, shape_delete, is_fully_defined, \
+    undefined_shape_of_rank
 
 
 class SqueezeInternal(Squeeze):
     @staticmethod
     def infer(node: Node):
-        axis_value = node.in_port(1).data.get_value()
-        Squeeze.infer(node)
-        # preserve initial axis value
-        node.in_port(1).data.set_value(axis_value)
+        if node.is_in_port_connected(1):
+            axis_value = node.in_port(1).data.get_value()
+            Squeeze.infer(node)
+            # preserve initial axis value
+            node.in_port(1).data.set_value(axis_value)
+        else:
+            # Squeeze without axes provided
+            node_name = node.soft_get('name', node.id)
+            input_shape = node.in_port(0).data.get_shape()
+            assert is_fully_defined(input_shape), 'Squeeze dimensions are not defined for op "{}"'.format(node_name)
+            output_shape = [s for s in shape_array(input_shape).tolist() if s != 1]
+            node.out_port(0).data.set_shape(output_shape)
+

--- a/tools/mo/openvino/tools/mo/utils/ir_reader/internal_ops/squeeze.py
+++ b/tools/mo/openvino/tools/mo/utils/ir_reader/internal_ops/squeeze.py
@@ -3,8 +3,7 @@
 
 from openvino.tools.mo.graph.graph import Node
 from openvino.tools.mo.ops.squeeze import Squeeze
-from openvino.tools.mo.front.common.partial_infer.utils import shape_array, dynamic_dimension, shape_delete, is_fully_defined, \
-    undefined_shape_of_rank
+from openvino.tools.mo.front.common.partial_infer.utils import shape_array, is_fully_defined
 
 
 class SqueezeInternal(Squeeze):
@@ -19,7 +18,8 @@ class SqueezeInternal(Squeeze):
             # Squeeze without axes provided
             node_name = node.soft_get('name', node.id)
             input_shape = node.in_port(0).data.get_shape()
-            assert is_fully_defined(input_shape), 'Squeeze dimensions are not defined for op "{}"'.format(node_name)
+            assert is_fully_defined(
+                input_shape), 'Squeeze dimensions are not defined for op "{}"'.format(node_name)
             output_shape = [s for s in shape_array(input_shape).tolist() if s != 1]
             node.out_port(0).data.set_shape(output_shape)
 

--- a/tools/mo/unit_tests/mo/utils/ir_reader/layer_to_class_test.py
+++ b/tools/mo/unit_tests/mo/utils/ir_reader/layer_to_class_test.py
@@ -70,7 +70,8 @@ class TestFunction(unittest.TestCase):
         else:
             edges.append(('weights_data', 'group_conv'))
 
-        graph = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
+        graph = build_graph(nodes_attributes, edges,
+                            nodes_with_edges_only=True)
 
         graph_ref = build_graph(nodes_attributes,
                                 [('input', 'input_data'),
@@ -94,7 +95,8 @@ class TestFunction(unittest.TestCase):
             node = Node(graph_ref, 'weights')
             node.value = weights_const
 
-        (flag, resp) = compare_graphs(graph, graph_ref, 'result', check_op_attrs=True)
+        (flag, resp) = compare_graphs(
+            graph, graph_ref, 'result', check_op_attrs=True)
         self.assertTrue(flag, resp)
 
     def test_restore_tensor_names(self):
@@ -119,7 +121,8 @@ class TestFunction(unittest.TestCase):
                  ('add_data', 'result'),
                  ]
 
-        graph = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
+        graph = build_graph(nodes_attributes, edges,
+                            nodes_with_edges_only=True)
 
         for op in graph.get_op_nodes():
             restore_tensor_names(op)
@@ -128,8 +131,10 @@ class TestFunction(unittest.TestCase):
         node_2 = Node(graph, 'add_data')
         node_3 = Node(graph, 'add_const_data')
 
-        assert node_1['fw_tensor_debug_info'] == [('abc', 'abc'), ('def', 'def')], 'Restored debug info is wrong!'
-        assert node_2['fw_tensor_debug_info'] == [('ghi,jkl', 'ghi,jkl')], 'Restored debug info is wrong!'
+        assert node_1['fw_tensor_debug_info'] == [
+            ('abc', 'abc'), ('def', 'def')], 'Restored debug info is wrong!'
+        assert node_2['fw_tensor_debug_info'] == [
+            ('ghi,jkl', 'ghi,jkl')], 'Restored debug info is wrong!'
         assert node_3['fw_tensor_debug_info'] == [('mno', 'mno'), ('pqr,stu', 'pqr,stu')], \
             'Restored debug info is wrong!'
 
@@ -155,15 +160,49 @@ class TestFunction(unittest.TestCase):
                  ('squeeze_data', 'result'),
                  ]
 
-        graph = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
+        graph = build_graph(nodes_attributes, edges,
+                            nodes_with_edges_only=True)
 
         squeeze_node = Node(graph, 'squeeze')
         SqueezeInternal.infer(squeeze_node)
 
-        graph_ref = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
+        graph_ref = build_graph(nodes_attributes, edges,
+                                nodes_with_edges_only=True)
 
         # Check that graph wasn't changed after shape infer
-        (flag, resp) = compare_graphs(graph, graph_ref, 'result', check_op_attrs=True)
+        (flag, resp) = compare_graphs(
+            graph, graph_ref, 'result', check_op_attrs=True)
+        self.assertTrue(flag, resp)
+
+    def test_squeeze_no_axes(self):
+        nodes_attributes = {
+            'input': {'kind': 'op', 'type': 'Parameter'},
+            'input_data': {'shape': [2, 1, 3], 'kind': 'data'},
+
+            'squeeze': {'kind': 'op', 'type': 'Squeeze'},
+            'squeeze_data': {'shape': [2, 3], 'kind': 'data', 'value': None},
+
+            'result': {'kind': 'op', 'type': 'Result'}
+        }
+
+        edges = [('input', 'input_data'),
+                 ('input_data', 'squeeze'),
+                 ('squeeze', 'squeeze_data'),
+                 ('squeeze_data', 'result'),
+                 ]
+
+        graph = build_graph(nodes_attributes, edges,
+                            nodes_with_edges_only=True)
+
+        squeeze_node = Node(graph, 'squeeze')
+        SqueezeInternal.infer(squeeze_node)
+
+        graph_ref = build_graph(nodes_attributes, edges,
+                                nodes_with_edges_only=True)
+
+        # Check that graph wasn't changed after shape infer
+        (flag, resp) = compare_graphs(
+            graph, graph_ref, 'result', check_op_attrs=True)
         self.assertTrue(flag, resp)
 
     def test_unsqueeze(self):
@@ -188,13 +227,16 @@ class TestFunction(unittest.TestCase):
                  ('unsqueeze_data', 'result'),
                  ]
 
-        graph = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
+        graph = build_graph(nodes_attributes, edges,
+                            nodes_with_edges_only=True)
 
         unsqueeze_node = Node(graph, 'unsqueeze')
         UnsqueezeInternal.infer(unsqueeze_node)
 
-        graph_ref = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
+        graph_ref = build_graph(nodes_attributes, edges,
+                                nodes_with_edges_only=True)
 
         # Check that graph wasn't changed after shape infer
-        (flag, resp) = compare_graphs(graph, graph_ref, 'result', check_op_attrs=True)
+        (flag, resp) = compare_graphs(
+            graph, graph_ref, 'result', check_op_attrs=True)
         self.assertTrue(flag, resp)

--- a/tools/mo/unit_tests/mo/utils/ir_reader/layer_to_class_test.py
+++ b/tools/mo/unit_tests/mo/utils/ir_reader/layer_to_class_test.py
@@ -70,8 +70,7 @@ class TestFunction(unittest.TestCase):
         else:
             edges.append(('weights_data', 'group_conv'))
 
-        graph = build_graph(nodes_attributes, edges,
-                            nodes_with_edges_only=True)
+        graph = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
 
         graph_ref = build_graph(nodes_attributes,
                                 [('input', 'input_data'),
@@ -95,8 +94,7 @@ class TestFunction(unittest.TestCase):
             node = Node(graph_ref, 'weights')
             node.value = weights_const
 
-        (flag, resp) = compare_graphs(
-            graph, graph_ref, 'result', check_op_attrs=True)
+        (flag, resp) = compare_graphs(graph, graph_ref, 'result', check_op_attrs=True)
         self.assertTrue(flag, resp)
 
     def test_restore_tensor_names(self):
@@ -121,8 +119,7 @@ class TestFunction(unittest.TestCase):
                  ('add_data', 'result'),
                  ]
 
-        graph = build_graph(nodes_attributes, edges,
-                            nodes_with_edges_only=True)
+        graph = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
 
         for op in graph.get_op_nodes():
             restore_tensor_names(op)
@@ -131,10 +128,8 @@ class TestFunction(unittest.TestCase):
         node_2 = Node(graph, 'add_data')
         node_3 = Node(graph, 'add_const_data')
 
-        assert node_1['fw_tensor_debug_info'] == [
-            ('abc', 'abc'), ('def', 'def')], 'Restored debug info is wrong!'
-        assert node_2['fw_tensor_debug_info'] == [
-            ('ghi,jkl', 'ghi,jkl')], 'Restored debug info is wrong!'
+        assert node_1['fw_tensor_debug_info'] == [('abc', 'abc'), ('def', 'def')], 'Restored debug info is wrong!'
+        assert node_2['fw_tensor_debug_info'] == [('ghi,jkl', 'ghi,jkl')], 'Restored debug info is wrong!'
         assert node_3['fw_tensor_debug_info'] == [('mno', 'mno'), ('pqr,stu', 'pqr,stu')], \
             'Restored debug info is wrong!'
 
@@ -160,18 +155,15 @@ class TestFunction(unittest.TestCase):
                  ('squeeze_data', 'result'),
                  ]
 
-        graph = build_graph(nodes_attributes, edges,
-                            nodes_with_edges_only=True)
+        graph = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
 
         squeeze_node = Node(graph, 'squeeze')
         SqueezeInternal.infer(squeeze_node)
 
-        graph_ref = build_graph(nodes_attributes, edges,
-                                nodes_with_edges_only=True)
+        graph_ref = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
 
         # Check that graph wasn't changed after shape infer
-        (flag, resp) = compare_graphs(
-            graph, graph_ref, 'result', check_op_attrs=True)
+        (flag, resp) = compare_graphs(graph, graph_ref, 'result', check_op_attrs=True)
         self.assertTrue(flag, resp)
 
     def test_squeeze_no_axes(self):
@@ -191,18 +183,15 @@ class TestFunction(unittest.TestCase):
                  ('squeeze_data', 'result'),
                  ]
 
-        graph = build_graph(nodes_attributes, edges,
-                            nodes_with_edges_only=True)
+        graph = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
 
         squeeze_node = Node(graph, 'squeeze')
         SqueezeInternal.infer(squeeze_node)
 
-        graph_ref = build_graph(nodes_attributes, edges,
-                                nodes_with_edges_only=True)
+        graph_ref = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
 
         # Check that graph wasn't changed after shape infer
-        (flag, resp) = compare_graphs(
-            graph, graph_ref, 'result', check_op_attrs=True)
+        (flag, resp) = compare_graphs(graph, graph_ref, 'result', check_op_attrs=True)
         self.assertTrue(flag, resp)
 
     def test_unsqueeze(self):
@@ -227,16 +216,13 @@ class TestFunction(unittest.TestCase):
                  ('unsqueeze_data', 'result'),
                  ]
 
-        graph = build_graph(nodes_attributes, edges,
-                            nodes_with_edges_only=True)
+        graph = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
 
         unsqueeze_node = Node(graph, 'unsqueeze')
         UnsqueezeInternal.infer(unsqueeze_node)
 
-        graph_ref = build_graph(nodes_attributes, edges,
-                                nodes_with_edges_only=True)
+        graph_ref = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
 
         # Check that graph wasn't changed after shape infer
-        (flag, resp) = compare_graphs(
-            graph, graph_ref, 'result', check_op_attrs=True)
+        (flag, resp) = compare_graphs(graph, graph_ref, 'result', check_op_attrs=True)
         self.assertTrue(flag, resp)


### PR DESCRIPTION
### Details:
 - *Legacy MO never had Squeeze without second input, while frontend can generate such Squeeze. Fix MO Reader to support this case.*

### Tickets:
 - *104158*
