### PR TITLE
flush subnorms to zero by recreating constants

### DIFF
--- a/src/bindings/python/tests/test_transformations/test_offline_api.py
+++ b/src/bindings/python/tests/test_transformations/test_offline_api.py
@@ -354,5 +354,6 @@ def test_flush_fp32_subnormals_to_zero():
 
     apply_moc_transformations(model, cf=False, smart_reshape=True)  # apply_flush_fp32_subnormals_to_zero is called inside
 
-    assert np.all(weights.data[4:8] != subnorm_val)
-    assert np.all(weights.data[4:8] == 0.0)
+    new_weights = add_node.input_value(1).get_node()
+    assert np.all(new_weights.data[4:8] != subnorm_val)
+    assert np.all(new_weights.data[4:8] == 0.0)


### PR DESCRIPTION
### Details:
 - In order to turn on mmap allocator https://github.com/openvinotoolkit/openvino/pull/12673 for constants read our from IR no in place changes for should be done. Therefore changes should be done by recreating constants. Flush to zero should be corrected for such recreating.
 - No significant changes in performance occur because most of the constants are normal and are not recreated.

### Tickets:
 - xxx-104573
