### PR TITLE
TopK v11 usage in ONNX FE

### DIFF
--- a/src/frontends/onnx/frontend/src/op/hardmax.cpp
+++ b/src/frontends/onnx/frontend/src/op/hardmax.cpp
@@ -4,6 +4,8 @@
 
 #include "op/hardmax.hpp"
 
+#include <openvino/opsets/opset11.hpp>
+
 #include "exceptions.hpp"
 #include "ngraph/builder/reshape.hpp"
 #include "ngraph/op/one_hot.hpp"
@@ -37,11 +39,11 @@ OutputVector hardmax(const Node& node) {
 
     const auto indices_axis = 1;
     const auto topk =
-        std::make_shared<default_opset::TopK>(coerced_tensor,
-                                              default_opset::Constant::create(ngraph::element::i64, Shape{}, {1}),
-                                              indices_axis,
-                                              default_opset::TopK::Mode::MAX,
-                                              default_opset::TopK::SortType::NONE);
+        std::make_shared<ov::opset11::TopK>(coerced_tensor,
+                                            default_opset::Constant::create(ngraph::element::i64, Shape{}, {1}),
+                                            indices_axis,
+                                            ov::opset11::TopK::Mode::MAX,
+                                            ov::opset11::TopK::SortType::NONE);
 
     const auto on_value = default_opset::Constant::create(ngraph::element::i64, Shape{}, {1});
     const auto off_value = default_opset::Constant::create(ngraph::element::i64, Shape{}, {0});
@@ -71,11 +73,11 @@ OutputVector hardmax(const Node& node) {
     row_size = ngraph::onnx_import::reshape::interpret_as_scalar(row_size);
 
     const auto topk =
-        std::make_shared<default_opset::TopK>(input,
-                                              default_opset::Constant::create(ngraph::element::i64, Shape{}, {1}),
-                                              axis,
-                                              default_opset::TopK::Mode::MAX,
-                                              default_opset::TopK::SortType::NONE);
+        std::make_shared<ov::opset11::TopK>(input,
+                                            default_opset::Constant::create(ngraph::element::i64, Shape{}, {1}),
+                                            axis,
+                                            ov::opset11::TopK::Mode::MAX,
+                                            ov::opset11::TopK::SortType::NONE);
 
     const auto on_value = default_opset::Constant::create(ngraph::element::i64, Shape{}, {1});
     const auto off_value = default_opset::Constant::create(ngraph::element::i64, Shape{}, {0});

--- a/src/frontends/onnx/frontend/src/op/topk.cpp
+++ b/src/frontends/onnx/frontend/src/op/topk.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <openvino/opsets/opset11.hpp>
 
 #include "default_opset.hpp"
 #include "ngraph/node.hpp"
@@ -37,13 +38,12 @@ OutputVector topk(const Node& node) {
     const auto k_node = node.get_attribute_as_constant<std::int64_t>("k");
     const std::int64_t axis{node.get_attribute_value<std::int64_t>("axis", -1)};
 
-    std::shared_ptr<ngraph::Node> top_k =
-        std::make_shared<default_opset::TopK>(data,
-                                              k_node,
-                                              axis,
-                                              default_opset::TopK::Mode::MAX,
-                                              default_opset::TopK::SortType::SORT_VALUES,
-                                              element::i64);
+    std::shared_ptr<ngraph::Node> top_k = std::make_shared<ov::opset11::TopK>(data,
+                                                                              k_node,
+                                                                              axis,
+                                                                              ov::opset11::TopK::Mode::MAX,
+                                                                              ov::opset11::TopK::SortType::SORT_VALUES,
+                                                                              element::i64);
 
     return {top_k->output(0), top_k->output(1)};
 }
@@ -55,13 +55,12 @@ OutputVector topk(const Node& node) {
     auto k = get_k(node);
     const std::int64_t axis{node.get_attribute_value<std::int64_t>("axis", -1)};
 
-    std::shared_ptr<ngraph::Node> top_k =
-        std::make_shared<default_opset::TopK>(data,
-                                              k,
-                                              axis,
-                                              default_opset::TopK::Mode::MAX,
-                                              default_opset::TopK::SortType::SORT_VALUES,
-                                              element::i64);
+    std::shared_ptr<ngraph::Node> top_k = std::make_shared<ov::opset11::TopK>(data,
+                                                                              k,
+                                                                              axis,
+                                                                              ov::opset11::TopK::Mode::MAX,
+                                                                              ov::opset11::TopK::SortType::SORT_VALUES,
+                                                                              element::i64);
 
     return {top_k->output(0), top_k->output(1)};
 }
@@ -79,13 +78,13 @@ OutputVector topk(const Node& node) {
     const auto sorted = node.get_attribute_value<std::int64_t>("sorted", 1);
 
     // Map attribute values to nGraph enums
-    const auto sort_type = sorted ? default_opset::TopK::SortType::SORT_VALUES : default_opset::TopK::SortType::NONE;
+    const auto sort_type = sorted ? ov::opset11::TopK::SortType::SORT_VALUES : ov::opset11::TopK::SortType::NONE;
 
     const auto compute_max = static_cast<bool>(largest);
-    const auto mode = compute_max ? default_opset::TopK::Mode::MAX : default_opset::TopK::Mode::MIN;
+    const auto mode = compute_max ? ov::opset11::TopK::Mode::MAX : ov::opset11::TopK::Mode::MIN;
 
     std::shared_ptr<ngraph::Node> top_k =
-        std::make_shared<default_opset::TopK>(data, k, axis, mode, sort_type, element::i64);
+        std::make_shared<ov::opset11::TopK>(data, k, axis, mode, sort_type, element::i64);
 
     return {top_k->output(0), top_k->output(1)};
 }

--- a/src/frontends/onnx/frontend/src/utils/arg_min_max_factory.cpp
+++ b/src/frontends/onnx/frontend/src/utils/arg_min_max_factory.cpp
@@ -4,6 +4,8 @@
 
 #include "utils/arg_min_max_factory.hpp"
 
+#include <openvino/opsets/opset11.hpp>
+
 #include "default_opset.hpp"
 #include "ngraph/opsets/opset1.hpp"
 #include "ngraph/validation_util.hpp"
@@ -18,14 +20,14 @@ ArgMinMaxFactory::ArgMinMaxFactory(const Node& node)
       m_select_last_index{node.get_attribute_value<std::int64_t>("select_last_index", 0)} {}
 
 std::shared_ptr<ngraph::Node> ArgMinMaxFactory::make_arg_max() const {
-    return make_topk_subgraph(default_opset::TopK::Mode::MAX);
+    return make_topk_subgraph(ov::opset11::TopK::Mode::MAX);
 }
 
 std::shared_ptr<ngraph::Node> ArgMinMaxFactory::make_arg_min() const {
-    return make_topk_subgraph(default_opset::TopK::Mode::MIN);
+    return make_topk_subgraph(ov::opset11::TopK::Mode::MIN);
 }
 
-std::shared_ptr<ngraph::Node> ArgMinMaxFactory::make_topk_subgraph(default_opset::TopK::Mode mode) const {
+std::shared_ptr<ngraph::Node> ArgMinMaxFactory::make_topk_subgraph(ov::opset11::TopK::Mode mode) const {
     const auto k_node = default_opset::Constant::create(ngraph::element::i64, Shape{}, {1});
 
     if (m_select_last_index == 1) {
@@ -59,11 +61,11 @@ std::shared_ptr<ngraph::Node> ArgMinMaxFactory::make_topk_subgraph(default_opset
         const auto axis_node = default_opset::Constant::create(ngraph::element::i64, Shape{1}, {normalized_axis});
         const auto reverse = std::make_shared<opset1::Reverse>(m_input_node, axis_node, opset1::Reverse::Mode::INDEX);
 
-        const auto topk = std::make_shared<default_opset::TopK>(reverse,
-                                                                k_node,
-                                                                normalized_axis,
-                                                                mode,
-                                                                default_opset::TopK::SortType::NONE);
+        const auto topk = std::make_shared<ov::opset11::TopK>(reverse,
+                                                              k_node,
+                                                              normalized_axis,
+                                                              mode,
+                                                              ov::opset11::TopK::SortType::NONE);
 
         const auto data_shape = std::make_shared<default_opset::ShapeOf>(m_input_node);
         const auto dims_on_axis = std::make_shared<default_opset::Gather>(
@@ -88,7 +90,7 @@ std::shared_ptr<ngraph::Node> ArgMinMaxFactory::make_topk_subgraph(default_opset
     }
 
     const auto topk =
-        std::make_shared<default_opset::TopK>(m_input_node, k_node, m_axis, mode, default_opset::TopK::SortType::NONE);
+        std::make_shared<ov::opset11::TopK>(m_input_node, k_node, m_axis, mode, ov::opset11::TopK::SortType::NONE);
 
     const auto result = std::make_shared<default_opset::Convert>(topk->output(1), element::i64);
 


### PR DESCRIPTION
### Details:
 - Switch to TopK v11 in ONNX FE code
 - The "default_opset" will be updated to opset11 when https://github.com/openvinotoolkit/openvino/pull/16448 is merged which should unblock the switch to Interpolate v11 in ONNX FE

### Tickets:
 - 101502
