### PR TITLE
Fix sanitizer out-of-memory error

### DIFF
--- a/thirdparty/cnpy/cnpy.h
+++ b/thirdparty/cnpy/cnpy.h
@@ -47,7 +47,7 @@ namespace cnpy {
             num_vals = 1;
             for(size_t i = 0;i < shape.size();i++) num_vals *= shape[i];
             if (word_size &&
-                num_vals > (0.9 * GetFreeMemorySize() / sizeof(char) / word_size))
+                num_vals > (GetFreeMemorySize() / word_size))
                 throw std::length_error("NpyArray of " + std::to_string(num_vals) +
                                         "*" + std::to_string(word_size) +
                                         " elements is too big.");

--- a/thirdparty/cnpy/cnpy.h
+++ b/thirdparty/cnpy/cnpy.h
@@ -19,6 +19,7 @@
 #include<stdint.h>
 #include<numeric>
 #if defined(_WIN32)
+    #define NOMINMAX
     #include <windows.h>
 #else
     #include <sys/sysinfo.h>

--- a/thirdparty/cnpy/cnpy.h
+++ b/thirdparty/cnpy/cnpy.h
@@ -22,7 +22,7 @@
     #define NOMINMAX
     #include <windows.h>
 #else
-    #include <sys/sysinfo.h>
+    #include <unistd.h>
 #endif
 
 namespace cnpy {
@@ -35,10 +35,9 @@ namespace cnpy {
             GlobalMemoryStatusEx(&status);
             return status.ullAvailPhys;
 #else
-            struct sysinfo info{};
-            if (sysinfo(&info))
-                return 0;
-            return info.freeram;
+            long pages = sysconf(_SC_AVPHYS_PAGES);
+            long page_size = sysconf(_SC_PAGE_SIZE);
+            return pages * page_size;
 #endif
         }
 

--- a/thirdparty/cnpy/cnpy.h
+++ b/thirdparty/cnpy/cnpy.h
@@ -18,16 +18,27 @@
 #include<memory>
 #include<stdint.h>
 #include<numeric>
-#include <sys/sysinfo.h>
+#if defined(_WIN32)
+    #include <windows.h>
+#else
+    #include <sys/sysinfo.h>
+#endif
 
 namespace cnpy {
 
     struct NpyArray {
-        unsigned long GetFreeMemorySize() {
+        unsigned long long GetFreeMemorySize() {
+#if defined(_WIN32)
+            MEMORYSTATUSEX status;
+            status.dwLength = sizeof(status);
+            GlobalMemoryStatusEx(&status);
+            return status.ullAvailPhys;
+#else
             struct sysinfo info{};
             if (sysinfo(&info))
                 return 0;
             return info.freeram;
+#endif
         }
 
         NpyArray(const std::vector<size_t>& _shape, size_t _word_size, bool _fortran_order) :


### PR DESCRIPTION
### Details:
 - Change max array element check in cnpy to avoid out-of-memory error in sanitizer tests


### Tickets:
 - CVS-105669
