### PR TITLE
Resolve eltwise kernel build failure

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.cpp
@@ -12,9 +12,9 @@
 namespace kernel_selector {
 static inline bool InputHasFeatureBroadcast(const eltwise_params& params, const size_t op_num, const size_t input_idx);
 static inline bool IsBroadcastingPossibleInput(const DataTensor& input, const DataTensor& output);
-static inline int SelectVecSizeFromFormat(const eltwise_params& params, size_t index);
-static inline int GetInnerFeatureBlockSize(const eltwise_params& arg, size_t index);
-static inline int GetInnerBatchBlockSize(const eltwise_params& arg, size_t index);
+static inline int SelectVecSizeFromFormat(const DataTensor&);
+static inline int GetInnerFeatureBlockSize(const DataTensor&);
+static inline int GetInnerBatchBlockSize(const DataTensor&);
 static inline size_t CalculateTotalWorkItemCount(const eltwise_params& params);
 
 
@@ -105,13 +105,13 @@ bool EltwiseKernel_blocked_opt::Validate(const Params& params, const optional_pa
         return false;
 
     for (size_t i = 0; i < ewParams.inputs.size(); i++) {
-        if ((SelectVecSizeFromFormat(ewParams, i) == 1) &&
+        if ((SelectVecSizeFromFormat(ewParams.inputs[i]) == 1) &&
             !IsBroadcastingPossibleInput(ewParams.inputs[i], ewParams.outputs[0])) {
             return false;
         }
     }
 
-    const auto vec_size = SelectVecSizeFromFormat(ewParams, 0);
+    const auto vec_size = SelectVecSizeFromFormat(ewParams.outputs[0]);
     const auto input0 = ewParams.inputs[0];
     const auto& output = ewParams.outputs[0];
     // Check that padding before features doesn't mis-align the blocks
@@ -148,7 +148,7 @@ bool EltwiseKernel_blocked_opt::Validate(const Params& params, const optional_pa
 }
 
 JitConstants EltwiseKernel_blocked_opt::MakeLoadJitConstants(const eltwise_params& params, bool /*use_vload*/) const {
-    const auto vec_size = SelectVecSizeFromFormat(params, 0);
+    const auto vec_size = SelectVecSizeFromFormat(params.outputs[0]);
     JitConstants jit = {};
     std::string vload_decls;
 
@@ -179,7 +179,7 @@ JitConstants EltwiseKernel_blocked_opt::MakeLoadJitConstants(const eltwise_param
             bool feature_broadcasting = (params.inputs[input_idx].Feature().v == 1 && params.outputs[0].Feature().v != 1);
             bool spatial_broadcasting = (params.inputs[input_idx].LogicalSize() == params.outputs[0].Feature().v &&
                                         params.inputs[input_idx].LogicalSize() == params.inputs[input_idx].Feature().v &&
-                                        GetInnerBatchBlockSize(params, input_idx) == 1 && !Padded(params.inputs[input_idx]));
+                                        GetInnerBatchBlockSize(params.inputs[input_idx]) == 1 && !Padded(params.inputs[input_idx]));
             bool full_tensor = (params.inputs[input_idx].LogicalSize() == params.outputs[0].LogicalSize() && !Padded(params.inputs[input_idx]));
 
             // Based on dimension, get a string of indexing for formmatted GET_INDEX
@@ -278,9 +278,9 @@ JitConstants EltwiseKernel_blocked_opt::MakeLoadJitConstants(const eltwise_param
 
 JitConstants EltwiseKernel_blocked_opt::GetJitConstants(const eltwise_params& params) const {
     JitConstants jit = MakeBaseParamsJitConstants(params);
-    const auto vec_size = SelectVecSizeFromFormat(params, 0);
-    const auto inner_feature_blk_size = GetInnerFeatureBlockSize(params, 0);
-    const auto inner_batch_blk_size = GetInnerBatchBlockSize(params, 0);
+    const auto vec_size = SelectVecSizeFromFormat(params.outputs[0]);
+    const auto inner_feature_blk_size = GetInnerFeatureBlockSize(params.outputs[0]);
+    const auto inner_batch_blk_size = GetInnerBatchBlockSize(params.outputs[0]);
 
     jit.Merge(MakeTypeJitConstants(GetAccumulatorType(params), "ACCUMULATOR"));
     jit.AddConstant(MakeJitConstant("BLOCK_SIZE", vec_size));
@@ -376,7 +376,7 @@ EltwiseKernelBase::DispatchData EltwiseKernel_blocked_opt::SetDefault(const eltw
     // so that each global id can be an index of each work group.
     // It also makes an index for fomatted GET_INDEX macro if needed(e.g. feature broadcasting, fusing).
     KernelData kd = KernelData::Default<eltwise_params>(params);
-    dispatchData.gws = {std::max(CalculateTotalWorkItemCount(params) / SelectVecSizeFromFormat(params, 0), (size_t)1), 1, 1};
+    dispatchData.gws = {std::max(CalculateTotalWorkItemCount(params) / SelectVecSizeFromFormat(params.outputs[0]), (size_t)1), 1, 1};
     dispatchData.lws = GetOptimalLocalWorkGroupSizes(dispatchData.gws, params.engineInfo);
 
     return dispatchData;
@@ -384,8 +384,8 @@ EltwiseKernelBase::DispatchData EltwiseKernel_blocked_opt::SetDefault(const eltw
 
 // Local
 static inline size_t CalculateTotalWorkItemCount(const eltwise_params& params) {
-    auto feature = Align(params.outputs[0].Feature().v, GetInnerFeatureBlockSize(params, 0));
-    auto batch = Align(params.outputs[0].Batch().v, GetInnerBatchBlockSize(params, 0));
+    auto feature = Align(params.outputs[0].Feature().v, GetInnerFeatureBlockSize(params.outputs[0]));
+    auto batch = Align(params.outputs[0].Batch().v, GetInnerBatchBlockSize(params.outputs[0]));
     size_t spatial = 0;
     if (DataTensor::ChannelsCount(params.outputs[0].GetLayout()) == 5)
         spatial = params.outputs[0].X().v * params.outputs[0].Y().v * params.outputs[0].Z().v;
@@ -395,10 +395,10 @@ static inline size_t CalculateTotalWorkItemCount(const eltwise_params& params) {
     return (feature * batch * spatial);
 }
 
-static inline int SelectVecSizeFromFormat(const eltwise_params& arg, size_t index) {
+static inline int SelectVecSizeFromFormat(const DataTensor& tensor) {
     // No feature inner block : not acceptable for calculation of ordered index
-    auto in_layout = arg.inputs[index].GetLayout();
-    switch (in_layout) {
+    auto layout = tensor.GetLayout();
+    switch (layout) {
     case DataLayout::b_fs_yx_fsv4:
         return 4;
     case DataLayout::b_fs_yx_fsv16:
@@ -419,9 +419,9 @@ static inline int SelectVecSizeFromFormat(const eltwise_params& arg, size_t inde
     }
 }
 
-static inline int GetInnerBatchBlockSize(const eltwise_params& arg, size_t index) {
-    auto in_layout = arg.inputs[index].GetLayout();
-    switch (in_layout) {
+static inline int GetInnerBatchBlockSize(const DataTensor& tensor) {
+    auto layout = tensor.GetLayout();
+    switch (layout) {
     case DataLayout::b_fs_yx_fsv4:
     case DataLayout::b_fs_yx_fsv16:
     case DataLayout::b_fs_zyx_fsv16:
@@ -445,9 +445,9 @@ static inline int GetInnerBatchBlockSize(const eltwise_params& arg, size_t index
     return 1;
 }
 
-static inline int GetInnerFeatureBlockSize(const eltwise_params& arg, size_t index) {
-    auto in_layout = arg.inputs[index].GetLayout();
-    switch (in_layout) {
+static inline int GetInnerFeatureBlockSize(const DataTensor& tensor) {
+    auto layout = tensor.GetLayout();
+    switch (layout) {
     case DataLayout::b_fs_yx_fsv4:
         return 4;
     case DataLayout::b_fs_yx_fsv16:

--- a/src/plugins/intel_gpu/tests/test_cases/eltwise_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/eltwise_gpu_test.cpp
@@ -4331,10 +4331,11 @@ struct eltwise_random_test_param_generator : std::vector<eltwise_random_test_par
 
     eltwise_random_test_param_generator& broadcast_params(data_types type, format::type input_format, format::type output_format) {
         push_back(eltwise_random_test_params{ type, {1, 1, 48, 64},  {1, 10, 48, 64}, input_format, input_format, output_format, eltwise_mode::sum, false });
-        push_back(eltwise_random_test_params{ type, {1, 16, 8, 8},   {1, 1, 8, 8},  input_format, input_format, output_format, eltwise_mode::sum, false });
-        push_back(eltwise_random_test_params{ type, {1, 36, 8, 16},  {1, 36, 1, 1},  input_format, input_format, output_format, eltwise_mode::sum, false });
+        push_back(eltwise_random_test_params{ type, {1, 16, 8, 8},   {1, 1, 8, 8},    input_format, input_format, output_format, eltwise_mode::sum, false });
+        push_back(eltwise_random_test_params{ type, {1, 36, 8, 16},  {1, 36, 1, 1},   input_format, input_format, output_format, eltwise_mode::sum, false });
         push_back(eltwise_random_test_params{ type, {1, 36, 4, 4},   {1, 1, 4, 4},    input_format, input_format, output_format, eltwise_mode::sum, false });
         push_back(eltwise_random_test_params{ type, {1, 8, 4, 4},    {1, 1, 1, 1},    input_format, format::bfyx, output_format, eltwise_mode::sum, false });
+        push_back(eltwise_random_test_params{ type, {1, 1, 1, 1},    {1, 8, 4, 4},    input_format, format::bfyx, output_format, eltwise_mode::sum, false });
         return *this;
     }
 
@@ -4360,6 +4361,7 @@ struct eltwise_random_test_param_generator : std::vector<eltwise_random_test_par
     eltwise_random_test_param_generator& broadcast_params_zyx(data_types type, format::type input_format, format::type output_format) {
         push_back(eltwise_random_test_params{ type, {1, 1,  4, 4, 8},  {1, 10, 4, 4, 8}, input_format, input_format, output_format, eltwise_mode::sum, false });
         push_back(eltwise_random_test_params{ type, {1, 36, 8, 8, 16}, {1, 36, 1, 1, 1}, input_format, input_format, output_format, eltwise_mode::sum, false });
+        push_back(eltwise_random_test_params{ type, {1, 1,  1, 1, 1},  {1, 16, 4, 4, 2}, input_format, input_format, output_format, eltwise_mode::sum, false });
         return *this;
     }
 
@@ -4371,6 +4373,7 @@ struct eltwise_random_test_param_generator : std::vector<eltwise_random_test_par
     eltwise_random_test_param_generator& broadcast_params_bsv_zyx(data_types type, format::type input_format, format::type output_format) {
         push_back(eltwise_random_test_params{ type, {32, 1,  4, 4, 8}, {32, 10, 4, 4, 8}, input_format, input_format, output_format, eltwise_mode::sum, false });
         push_back(eltwise_random_test_params{ type, {32, 36, 4, 4, 4}, {32, 36, 1, 1, 1}, input_format, input_format, output_format, eltwise_mode::sum, false });
+        push_back(eltwise_random_test_params{ type, {1,  1,  1, 1, 1}, {32, 16, 4, 4, 4}, input_format, input_format, output_format, eltwise_mode::sum, false });
         return *this;
     }
 };


### PR DESCRIPTION
### Details:
 - Fix eltwise_blocked_opt kernel for byxf+fsv16 to fsv16

### Tickets:
 - 106465
