### PR TITLE
[TF FE] Fix problems with invalidation of decoders

### DIFF
--- a/src/frontends/tensorflow/src/decoder_argdef.hpp
+++ b/src/frontends/tensorflow/src/decoder_argdef.hpp
@@ -10,6 +10,8 @@
 #include "openvino/frontend/tensorflow/decoder.hpp"
 
 namespace tensorflow {
+class GraphDef;
+class FunctionDef;
 class OpDef_ArgDef;
 }  // namespace tensorflow
 
@@ -19,14 +21,23 @@ namespace tensorflow {
 
 class DecoderArgDef : public ov::frontend::tensorflow::DecoderBase {
 public:
-    explicit DecoderArgDef(const ::tensorflow::OpDef_ArgDef* arg_def, const std::string& op_type)
+    explicit DecoderArgDef(const ::tensorflow::OpDef_ArgDef* arg_def,
+                           const std::shared_ptr<::tensorflow::GraphDef>& graph_def,
+                           const std::shared_ptr<::tensorflow::FunctionDef>& func_def,
+                           const std::string& op_type)
         : m_arg_def(arg_def),
+          m_graph_def(graph_def),
+          m_func_def(func_def),
           m_op_type(op_type) {}
 
     explicit DecoderArgDef(const ::tensorflow::OpDef_ArgDef* arg_def,
+                           const std::shared_ptr<::tensorflow::GraphDef>& graph_def,
+                           const std::shared_ptr<::tensorflow::FunctionDef>& func_def,
                            const std::string& op_type,
                            const std::string& producer_name)
         : m_arg_def(arg_def),
+          m_graph_def(graph_def),
+          m_func_def(func_def),
           m_op_type(op_type),
           m_producer_name(producer_name) {}
 
@@ -49,6 +60,12 @@ public:
 
 private:
     const ::tensorflow::OpDef_ArgDef* m_arg_def;
+    // For existence of NodeDef object corresponding to the main graph node,
+    // GraphDef object must live in the memory
+    const std::shared_ptr<::tensorflow::GraphDef> m_graph_def;
+    // For existence of NodeDef object corresponding to the body graph node,
+    // both GraphDef and FunctionDef objects must be alive in the memory
+    const std::shared_ptr<::tensorflow::FunctionDef> m_func_def;
     const std::string m_op_type;
     const std::string m_producer_name;
 };

--- a/src/frontends/tensorflow/src/decoder_argdef.hpp
+++ b/src/frontends/tensorflow/src/decoder_argdef.hpp
@@ -60,10 +60,10 @@ public:
 
 private:
     const ::tensorflow::OpDef_ArgDef* m_arg_def;
-    // For existence of NodeDef object corresponding to the main graph node,
+    // For existence of OpDef_ArgDef object corresponding to the main graph node,
     // GraphDef object must live in the memory
     const std::shared_ptr<::tensorflow::GraphDef> m_graph_def;
-    // For existence of NodeDef object corresponding to the body graph node,
+    // For existence of OpDef_ArgDef object corresponding to the body graph node,
     // both GraphDef and FunctionDef objects must be alive in the memory
     const std::shared_ptr<::tensorflow::FunctionDef> m_func_def;
     const std::string m_op_type;

--- a/src/frontends/tensorflow/src/decoder_proto.hpp
+++ b/src/frontends/tensorflow/src/decoder_proto.hpp
@@ -12,6 +12,8 @@
 #include "types.pb.h"
 
 namespace tensorflow {
+class GraphDef;
+class FunctionDef;
 class NodeDef;
 class AttrValue;
 }  // namespace tensorflow
@@ -29,7 +31,18 @@ void parse_producer_name(const std::string& producer_port_name,
 
 class DecoderProto : public ov::frontend::tensorflow::DecoderBase {
 public:
-    explicit DecoderProto(const ::tensorflow::NodeDef* node_def) : m_node_def(node_def) {}
+    explicit DecoderProto(const ::tensorflow::NodeDef* node_def,
+                          const std::shared_ptr<::tensorflow::GraphDef>& graph_def)
+        : m_node_def(node_def),
+          m_graph_def(graph_def),
+          m_func_def(nullptr) {}
+
+    explicit DecoderProto(const ::tensorflow::NodeDef* node_def,
+                          const std::shared_ptr<::tensorflow::GraphDef>& graph_def,
+                          const std::shared_ptr<::tensorflow::FunctionDef>& func_def)
+        : m_node_def(node_def),
+          m_graph_def(graph_def),
+          m_func_def(func_def) {}
 
     ov::Any get_attribute(const std::string& name) const override;
 
@@ -51,6 +64,12 @@ public:
 private:
     std::vector<::tensorflow::AttrValue> decode_attribute_helper(const std::string& name) const;
     const ::tensorflow::NodeDef* m_node_def;
+    // For existence of NodeDef object corresponding to the main graph node,
+    // GraphDef object must live in the memory
+    const std::shared_ptr<::tensorflow::GraphDef> m_graph_def;
+    // For existence of NodeDef object corresponding to the body graph node,
+    // both GraphDef and FunctionDef objects must be alive in the memory
+    const std::shared_ptr<::tensorflow::FunctionDef> m_func_def;
 };
 }  // namespace tensorflow
 }  // namespace frontend

--- a/src/frontends/tensorflow/src/graph_iterator_proto.hpp
+++ b/src/frontends/tensorflow/src/graph_iterator_proto.hpp
@@ -45,12 +45,13 @@ public:
         for (int input_ind = 0; input_ind < input_size; ++input_ind) {
             auto input_arg = &m_func_def->signature().input_arg(input_ind);
             m_input_names.push_back(input_arg->name());
-            m_decoders.push_back(std::make_shared<DecoderArgDef>(input_arg, "input_arg"));
+            m_decoders.push_back(std::make_shared<DecoderArgDef>(input_arg, m_graph_def, m_func_def, "input_arg"));
         }
 
         // fill all node defs from library functions
         for (int node_ind = 0; node_ind < nodes_size; ++node_ind) {
-            m_decoders.push_back(std::make_shared<DecoderProto>(&(m_func_def->node_def(node_ind))));
+            m_decoders.push_back(
+                std::make_shared<DecoderProto>(&(m_func_def->node_def(node_ind)), m_graph_def, m_func_def));
         }
 
         // fill all outputs from library functions
@@ -60,7 +61,8 @@ public:
             auto output_arg = &m_func_def->signature().output_arg(output_ind);
             m_output_names.push_back(output_arg->name());
             auto producer_name = ret_map.at(output_arg->name());
-            m_decoders.push_back(std::make_shared<DecoderArgDef>(output_arg, "output_arg", producer_name));
+            m_decoders.push_back(
+                std::make_shared<DecoderArgDef>(output_arg, m_graph_def, m_func_def, "output_arg", producer_name));
         }
     }
 
@@ -76,7 +78,7 @@ public:
         auto nodes_size = m_graph_def->node_size();
         m_decoders.resize(static_cast<size_t>(nodes_size));
         for (int node_ind = 0; node_ind < nodes_size; ++node_ind) {
-            m_decoders[node_ind] = std::make_shared<DecoderProto>(&m_graph_def->node(node_ind));
+            m_decoders[node_ind] = std::make_shared<DecoderProto>(&m_graph_def->node(node_ind), m_graph_def);
         }
 
         // initialize a library map


### PR DESCRIPTION
**Details:** TF FE decoders can be invalidated in case destruction of `GraphIteratorProto` or `GraphDef`. It leads to loss of `NodeDef` object in the memory and invalidation of decoders. So we should care of lifetime of `GraphDef` while decoder is alive.

**Ticket:** TBD
