### PR TITLE
Use OCL that is included on OpenVINO

### DIFF
--- a/samples/cpp/benchmark_app/CMakeLists.txt
+++ b/samples/cpp/benchmark_app/CMakeLists.txt
@@ -98,6 +98,8 @@ if(SAMPLES_ENABLE_OPENCL)
         HINTS
             ${opencl_root_hints}
         PATHS
+            ${CMAKE_SOURCE_DIR}/thirdparty/ocl/cl_headers
+            ${CMAKE_SOURCE_DIR}/thirdparty/ocl/clhpp_headers
             ENV "PROGRAMFILES(X86)"
             ENV AMDAPPSDKROOT
             ENV INTELOCLSDKROOT


### PR DESCRIPTION
### Details:
- ocl header files that is included in OpenVINO was not used.
