### PR TITLE
[CONFORMANCE] Fix report gewneration in case of mixed reports: rel and abs

### DIFF
--- a/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/summarize.py
+++ b/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/summarize.py
@@ -101,6 +101,9 @@ def merge_xmls(xml_paths: list):
                                     continue
                                 xml_value = None
                                 if "relative_" in attr_name:
+                                    value = op_result.attrib.get(attr_name)
+                                    if value is None:
+                                        continue
                                     xml_value = float(op_result.attrib.get(attr_name))
                                 else:
                                     xml_value = int(op_result.attrib.get(attr_name))


### PR DESCRIPTION
### Details:
 - VPUX contains abs report and other ones are based using rel: https://openvino-ci.toolbox.iotg.sclab.intel.com/blue/organizations/jenkins/private-ci%2FcustomJobs%2Fe2e-tests-linux/detail/e2e-tests-linux/10929/pipeline/

### Tickets:
 - *ticket-id*
