### PR TITLE
Remove set_element_type() from TemporaryReplaceOutputType class

### DIFF
--- a/src/common/transformations/include/ov_ops/type_relaxed.hpp
+++ b/src/common/transformations/include/ov_ops/type_relaxed.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include <openvino/op/convert.hpp>
+#include <openvino/op/parameter.hpp>
 #include <string>
 #include <transformations_visibility.hpp>
 #include <vector>
@@ -158,9 +159,10 @@ public:
     TemporaryReplaceOutputType(Output<Node> output, element::Type tmp_type) : m_output(output) {
         // save original element type in order to restore it in the destructor
         orig_type = m_output.get_element_type();
-        OPENVINO_SUPPRESS_DEPRECATED_START
-        m_output.get_tensor().set_element_type(tmp_type);
-        OPENVINO_SUPPRESS_DEPRECATED_END
+        if (auto parameter = dynamic_cast<ov::op::v0::Parameter*>(m_output.get_node())) {
+            parameter->set_element_type(tmp_type);
+            parameter->validate_and_infer_types();
+        }
     }
 
     /// Return the output port that was used in the constructor
@@ -170,9 +172,10 @@ public:
 
     /// Restores the original element type for the output
     ~TemporaryReplaceOutputType() {
-        OPENVINO_SUPPRESS_DEPRECATED_START
-        m_output.get_tensor().set_element_type(orig_type);
-        OPENVINO_SUPPRESS_DEPRECATED_END
+        if (auto parameter = dynamic_cast<ov::op::v0::Parameter*>(m_output.get_node())) {
+            parameter->set_element_type(orig_type);
+            parameter->validate_and_infer_types();
+        }
     }
 };
 

--- a/src/common/transformations/include/ov_ops/type_relaxed.hpp
+++ b/src/common/transformations/include/ov_ops/type_relaxed.hpp
@@ -8,7 +8,6 @@
 #include <memory>
 #include <mutex>
 #include <openvino/op/convert.hpp>
-#include <openvino/op/parameter.hpp>
 #include <string>
 #include <transformations_visibility.hpp>
 #include <vector>
@@ -159,10 +158,9 @@ public:
     TemporaryReplaceOutputType(Output<Node> output, element::Type tmp_type) : m_output(output) {
         // save original element type in order to restore it in the destructor
         orig_type = m_output.get_element_type();
-        if (auto parameter = dynamic_cast<ov::op::v0::Parameter*>(m_output.get_node())) {
-            parameter->set_element_type(tmp_type);
-            parameter->validate_and_infer_types();
-        }
+        OPENVINO_SUPPRESS_DEPRECATED_START
+        m_output.get_tensor().set_element_type(tmp_type);
+        OPENVINO_SUPPRESS_DEPRECATED_END
     }
 
     /// Return the output port that was used in the constructor
@@ -172,10 +170,9 @@ public:
 
     /// Restores the original element type for the output
     ~TemporaryReplaceOutputType() {
-        if (auto parameter = dynamic_cast<ov::op::v0::Parameter*>(m_output.get_node())) {
-            parameter->set_element_type(orig_type);
-            parameter->validate_and_infer_types();
-        }
+        OPENVINO_SUPPRESS_DEPRECATED_START
+        m_output.get_tensor().set_element_type(orig_type);
+        OPENVINO_SUPPRESS_DEPRECATED_END
     }
 };
 

--- a/src/tests/functional/shared_test_classes/src/subgraph/memory_LSTMCell.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/memory_LSTMCell.cpp
@@ -114,8 +114,17 @@ namespace SubgraphTestsDefinitions {
         auto out_cell = tensor_iterator->get_iter_value(C_o, -1);
 
 
-        out_hidden.get_tensor().set_element_type(ngPrc);
-        out_cell.get_tensor().set_element_type(ngPrc);
+        // out_hidden.get_tensor().set_element_type(ngPrc);
+        // out_cell.get_tensor().set_element_type(ngPrc);
+        if (auto out_hidden_parameter = dynamic_cast<ov::op::v0::Parameter*>(out_hidden.get_node())) {
+            out_hidden_parameter->set_element_type(ngPrc);
+            out_hidden_parameter->validate_and_infer_types();
+        }
+
+        if (auto out_cell_parameter = dynamic_cast<ov::op::v0::Parameter*>(out_cell.get_node())) {
+            out_cell_parameter->set_element_type(ngPrc);
+            out_cell_parameter->validate_and_infer_types();
+        }
 
         auto cell_memory_write = std::make_shared<Assign>(out_cell, var_cell);
         auto hidden_memory_write = std::make_shared<Assign>(out_hidden, var_hidden);
@@ -245,8 +254,17 @@ namespace SubgraphTestsDefinitions {
         auto out_hidden = tensor_iterator->get_iter_value(H_o, -1);
         auto out_cell = tensor_iterator->get_iter_value(C_o, -1);
 
-        out_hidden.get_tensor().set_element_type(ngPrc);
-        out_cell.get_tensor().set_element_type(ngPrc);
+        // out_hidden.get_tensor().set_element_type(ngPrc);
+        // out_cell.get_tensor().set_element_type(ngPrc);
+        if (auto out_hidden_parameter = dynamic_cast<ov::op::v0::Parameter*>(out_hidden.get_node())) {
+            out_hidden_parameter->set_element_type(ngPrc);
+            out_hidden_parameter->validate_and_infer_types();
+        }
+
+        if (auto out_cell_parameter = dynamic_cast<ov::op::v0::Parameter*>(out_cell.get_node())) {
+            out_cell_parameter->set_element_type(ngPrc);
+            out_cell_parameter->validate_and_infer_types();
+        }
 
         auto final_reshape_pattern = std::make_shared<Constant>(element::i64, Shape{4},
                                                                                 std::vector<size_t>({1, 1, 1, hiddenSize}));


### PR DESCRIPTION
### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
