### PR TITLE
[DOCS] `ov::hint::num_requests` - not shown in documentation - fix for 22.3

### DIFF
--- a/docs/Doxyfile.config
+++ b/docs/Doxyfile.config
@@ -1010,7 +1010,6 @@ EXCLUDE_SYMBOLS        = InferenceEngine::details \
                          ie_api::BlobBuffer \
                          *impl* \
                          *device_name* \
-                         *num_requests* \
                          *exec_net* \
                          *c_config* \
                          *ie_core_impl* \


### PR DESCRIPTION
Porting:
https://github.com/openvinotoolkit/openvino/pull/16564

The `ov::hint::num_requests` property key is not shown in documentation. It is not displayed on the Device Properties list: https://docs.openvino.ai/nightly/groupov_runtime_cpp_prop_api.html