### PR TITLE
Pillow modes in the preprocessor's resize mechanism

### DIFF
--- a/src/core/include/openvino/core/preprocess/resize_algorithm.hpp
+++ b/src/core/include/openvino/core/preprocess/resize_algorithm.hpp
@@ -7,7 +7,13 @@
 namespace ov {
 namespace preprocess {
 
-enum class ResizeAlgorithm { RESIZE_LINEAR, RESIZE_CUBIC, RESIZE_NEAREST };
+enum class ResizeAlgorithm {
+    RESIZE_LINEAR,
+    RESIZE_CUBIC,
+    RESIZE_NEAREST,
+    RESIZE_BILINEAR_PILLOW,
+    RESIZE_BICUBIC_PILLOW
+};
 
 }  // namespace preprocess
 }  // namespace ov

--- a/src/core/src/preprocess/preprocess_steps_impl.cpp
+++ b/src/core/src/preprocess/preprocess_steps_impl.cpp
@@ -142,12 +142,12 @@ void PreStepsList::add_convert_impl(const element::Type& type) {
 }
 
 void PreStepsList::add_resize_impl(ResizeAlgorithm alg, int dst_height, int dst_width) {
-    using InterpolateMode = op::v4::Interpolate::InterpolateMode;
+    using InterpolateMode = op::util::InterpolateBase::InterpolateMode;
     std::string name;
     if (dst_width > 0 && dst_height > 0) {
         name = "resize to (" + std::to_string(dst_height) + ", " + std::to_string(dst_width) + ")";
     } else {
-        name = "resize to model width/height";
+        name = "resize to model's width/height";
     }
     m_actions.emplace_back(
         [alg, dst_width, dst_height](const std::vector<Output<Node>>& nodes,
@@ -157,48 +157,52 @@ void PreStepsList::add_resize_impl(ResizeAlgorithm alg, int dst_height, int dst_
             OPENVINO_ASSERT(nodes.size() == 1,
                             "Can't resize multi-plane input. Suggesting to convert current image to "
                             "RGB/BGR color format using 'PreProcessSteps::convert_color'");
-            auto to_mode = [](ResizeAlgorithm alg) -> InterpolateMode {
+            const auto to_mode = [](const ResizeAlgorithm alg) -> InterpolateMode {
                 switch (alg) {
                 case ResizeAlgorithm::RESIZE_NEAREST:
                     return InterpolateMode::NEAREST;
                 case ResizeAlgorithm::RESIZE_CUBIC:
                     return InterpolateMode::CUBIC;
+                case ResizeAlgorithm::RESIZE_BILINEAR_PILLOW:
+                    return InterpolateMode::BILINEAR_PILLOW;
+                case ResizeAlgorithm::RESIZE_BICUBIC_PILLOW:
+                    return InterpolateMode::BICUBIC_PILLOW;
                 case ResizeAlgorithm::RESIZE_LINEAR:
                 default:
                     return InterpolateMode::LINEAR;
                 }
             };
-            auto node = nodes.front();
-            auto layout = ctxt.layout();
+            const auto& layout = ctxt.layout();
             OPENVINO_ASSERT(ov::layout::has_height(layout) && ov::layout::has_width(layout),
                             "Can't add resize for layout without W/H specified. Use 'set_layout' API to define layout "
                             "of image data, like `NCHW`");
-            auto node_rank = node.get_partial_shape().rank();
-            OPENVINO_ASSERT(node_rank.is_static(), "Resize operation is not supported for fully dynamic shape");
+            const auto& node = nodes.front();
+            OPENVINO_ASSERT(node.get_partial_shape().rank().is_static(),
+                            "Resize operation is not supported for fully dynamic shape");
 
-            auto height_idx = static_cast<int64_t>(get_and_check_height_idx(layout, node.get_partial_shape()));
-            auto width_idx = static_cast<int64_t>(get_and_check_width_idx(layout, node.get_partial_shape()));
+            const auto height_idx = static_cast<int64_t>(get_and_check_height_idx(layout, node.get_partial_shape()));
+            const auto width_idx = static_cast<int64_t>(get_and_check_width_idx(layout, node.get_partial_shape()));
             if (dst_height < 0 || dst_width < 0) {
                 OPENVINO_ASSERT(ctxt.model_shape().rank().is_static(),
                                 "Resize is not fully specified while target model shape is dynamic");
             }
-            int new_image_width = dst_width < 0 ? static_cast<int>(ctxt.get_model_width_for_resize()) : dst_width;
-            int new_image_height = dst_height < 0 ? static_cast<int>(ctxt.get_model_height_for_resize()) : dst_height;
+            const int new_image_width = dst_width < 0 ? static_cast<int>(ctxt.get_model_width_for_resize()) : dst_width;
+            const int new_image_height =
+                dst_height < 0 ? static_cast<int>(ctxt.get_model_height_for_resize()) : dst_height;
 
-            auto target_spatial_shape =
+            const auto target_spatial_shape =
                 op::v0::Constant::create<int64_t>(element::i64, Shape{2}, {new_image_height, new_image_width});
-            auto scales = op::v0::Constant::create<float>(element::f32, Shape{2}, {1, 1});
             // In future consider replacing this to set of new OV operations like `getDimByName(node, "H")`
             // This is to allow specifying layout on 'evaluation' stage
-            auto axes = op::v0::Constant::create<int64_t>(element::i64, Shape{2}, {height_idx, width_idx});
+            const auto axes = op::v0::Constant::create<int64_t>(element::i64, Shape{2}, {height_idx, width_idx});
 
-            op::v4::Interpolate::InterpolateAttrs attrs(to_mode(alg),
-                                                        op::v4::Interpolate::ShapeCalcMode::SIZES,
-                                                        {0, 0},
-                                                        {0, 0});
+            op::util::InterpolateBase::InterpolateAttrs attrs(to_mode(alg),
+                                                              op::util::InterpolateBase::ShapeCalcMode::SIZES,
+                                                              {0, 0},
+                                                              {0, 0});
 
-            auto interp = std::make_shared<op::v4::Interpolate>(node, target_spatial_shape, scales, axes, attrs);
-            return std::make_tuple(std::vector<Output<Node>>{interp}, true);
+            const auto interp = std::make_shared<op::v11::Interpolate>(node, target_spatial_shape, axes, attrs);
+            return std::make_tuple(OutputVector{interp}, true);
         },
         name);
 }

--- a/src/core/tests/preprocess.cpp
+++ b/src/core/tests/preprocess.cpp
@@ -923,6 +923,25 @@ TEST(pre_post_process, resize_no_model_layout) {
     EXPECT_NO_THROW(p.build());
 }
 
+TEST(pre_post_process, resize_with_bilinear_pillow) {
+    const auto f = create_simple_function(element::f32, Shape{1, 3, 100, 100});
+    auto p = PrePostProcessor(f);
+    p.input().tensor().set_layout("NCHW");
+    p.input().preprocess().resize(ResizeAlgorithm::RESIZE_BILINEAR_PILLOW);
+    EXPECT_NO_THROW(p.build());
+    EXPECT_EQ(f->output().get_partial_shape(), (Shape{1, 3, 100, 100}));
+}
+
+TEST(pre_post_process, resize_with_bicubic_pillow) {
+    const auto f = create_simple_function(element::f32, Shape{1, 3, 100, 100});
+    auto p = PrePostProcessor(f);
+    p.input().tensor().set_layout("NCHW");
+    p.input().preprocess().resize(ResizeAlgorithm::RESIZE_BICUBIC_PILLOW, 200, 200);
+    p.input().preprocess().resize(ResizeAlgorithm::RESIZE_BICUBIC_PILLOW);
+    EXPECT_NO_THROW(p.build());
+    EXPECT_EQ(f->output().get_partial_shape(), (Shape{1, 3, 100, 100}));
+}
+
 // Error cases for 'resize'
 TEST(pre_post_process, tensor_spatial_shape_no_layout_dims) {
     auto f = create_simple_function(element::f32, Shape{1, 3, 224, 224});
@@ -2051,7 +2070,7 @@ TEST(pre_post_process, dump_preprocess) {
     EXPECT_TRUE(dump.find("convert type") != std::string::npos) << dump;
     EXPECT_TRUE(dump.find("convert layout (3,2,1,0):") != std::string::npos) << dump;
     EXPECT_TRUE(dump.find("resize to (480, 640):") != std::string::npos) << dump;
-    EXPECT_TRUE(dump.find("resize to model width/height:") != std::string::npos) << dump;
+    EXPECT_TRUE(dump.find("resize to model's width/height:") != std::string::npos) << dump;
     EXPECT_TRUE(dump.find("custom:") != std::string::npos) << dump;
     EXPECT_TRUE(dump.find("Implicit pre-processing steps (1):") != std::string::npos) << dump;
     EXPECT_TRUE(dump.find("convert layout") != std::string::npos) << dump;


### PR DESCRIPTION
### Details:
 - Switch to the new Interpolate op in PPP
 - Expose the new interpolation modes to PPP

### Tickets:
 - 97159
