### PR TITLE
Fix sporadic fails when beta==0 in baddmm

### DIFF
--- a/tests/layer_tests/pytorch_tests/test_addmm.py
+++ b/tests/layer_tests/pytorch_tests/test_addmm.py
@@ -94,6 +94,5 @@ class TestBAddBMM(PytorchLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     def test_baddbmm(self, kwargs_to_prepare_input, alpha, beta, ie_device, precision, ir_version):
-      for i in range(100):
         self._test(*self.create_model(alpha, beta), ie_device, precision, ir_version,
                    kwargs_to_prepare_input=kwargs_to_prepare_input)


### PR DESCRIPTION
### Details:
 - *If beta is 0 torch.baddmm can produce nan in some cases*

### Tickets:
 - *CVS-107053*
