### PR TITLE
Resolved failed unit-tests

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1286,7 +1286,7 @@ bool layout_optimizer::is_primitive_implemented_for_onednn(program_node& node) {
     if (node.is_type<fully_connected>() || node.is_type<gemm>() || node.is_type<pooling>() ||
         node.is_type<convolution>() || node.is_type<deconvolution>() ||
         node.is_type<reduce>() || node.is_type<reorder>() || node.is_type<concatenation>()) {
-            return true;
+        return true;
     }
 
     return false;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_mmad_b_fs_yx_fsv32.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_mmad_b_fs_yx_fsv32.cl
@@ -84,7 +84,7 @@ KERNEL(convolution_mmad_b_fs_yx_fsv32)(
     ACCUMULATOR_TYPE_VEC acc_assym_weights = 0;
 #endif
 
-    const uint input_offset = b*INPUT0_BATCH_PITCH + INPUT0_OFFSET*ISV_SIZE;
+    const uint input_offset = INPUT0_GET_INDEX(b,0,0,0);
 
     uint filter_idx = fg * FILTER_SIZE_X * FILTER_SIZE_Y * FILTER_SIZE_Z * ISV_SIZE * OSV_SIZE * IFM_BLOCKS;
 

--- a/src/plugins/intel_gpu/tests/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/convolution_gpu_test.cpp
@@ -6930,7 +6930,12 @@ TEST_P(convolution_depthwise_gpu_fsv16_xy, depthwise_conv_b_fs_yx_fsv16)
 
     ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::optimize_data(true));
-    ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "convolution_gpu_bfyx_f16_depthwise" };
+    ov::intel_gpu::ImplementationDesc conv_impl;
+    if (engine.get_device_info().supports_immad) {
+        conv_impl = { format::b_fs_yx_fsv16, "", impl_types::onednn };
+    } else {
+        conv_impl = { format::b_fs_yx_fsv16, "convolution_gpu_bfyx_f16_depthwise" };
+    }
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_fsv", conv_impl } }));
     network network(engine, topology, config);
 

--- a/src/plugins/intel_gpu/tests/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/fully_connected_gpu_test.cpp
@@ -1591,10 +1591,10 @@ INSTANTIATE_TEST_SUITE_P(
     fully_connected_i8_u8_test,
     testing::Combine(
         testing::Values(1, 2),
-        testing::Values(3, 64),
+        testing::Values(16, 64),
         testing::Values(1),
         testing::Values(1),
-        testing::Values(3, 32),
+        testing::Values(16, 32),
         testing::Values(format::bfyx, format::b_fs_yx_fsv4, format::b_fs_yx_fsv16, format::b_fs_yx_fsv32)
     ),
     fully_connected_i8_u8_test::PrintToStringParamName

--- a/src/plugins/intel_gpu/tests/test_utils/test_utils.cpp
+++ b/src/plugins/intel_gpu/tests/test_utils/test_utils.cpp
@@ -332,7 +332,10 @@ cldnn::stream_ptr get_test_stream_ptr() {
 
 cldnn::stream_ptr get_test_stream_ptr(cldnn::ExecutionConfig cfg) {
     static std::shared_ptr<cldnn::stream> test_stream = nullptr;
-    test_stream = get_test_engine().create_stream(cfg);
+    if (!test_stream) {
+        test_stream = get_test_engine().create_stream(cfg);
+    }
+
     return test_stream;
 }
 


### PR DESCRIPTION
+ Resolve TCs' failure of oneDNN tests

### Details:
 - Bugfix in convolution_gpu_mmad_b_fs_yx_fsv32 kernel (invalid index calculation)
 - depthwise_conv_b_fs_yx_fsv16 tested a given clDNN kernel. But it could not be applied for oneDNN execution.
   Added a logic for oneDNN execution in the test.
 - Added func to check possible implementation for a certain imple type (e.g. impl_types::onednn)
 - Resolve TCs' failure of oneDNN tests

### Tickets:
 - 107829, 67491
