### PR TITLE
Fix ITT build fail

### DIFF
--- a/src/plugins/template/src/plugin.cpp
+++ b/src/plugins/template/src/plugin.cpp
@@ -163,7 +163,7 @@ std::shared_ptr<ov::ICompiledModel> ov::template_plugin::Plugin::import_model(st
 // ! [plugin:query_model]
 ov::SupportedOpsMap ov::template_plugin::Plugin::query_model(const std::shared_ptr<const ov::Model>& model,
                                                              const ov::AnyMap& properties) const {
-    OV_ITT_SCOPED_TASK(TemplatePlugin::itt::domains::TemplatePlugin, "Plugin::query_model");
+    OV_ITT_SCOPED_TASK(itt::domains::TemplatePlugin, "Plugin::query_model");
 
     Configuration fullConfig{properties, m_cfg, false};
 


### PR DESCRIPTION
### Details:
OpenVino build fails when enabling the ITT Traces flag with the following message:
_**C:\Users\bpereanu\WORK\OpenVinoSources\openvino\src\plugins\template\src\plugin.cpp(166): error C2653: 'TemplatePlugin': is not a class or namespace name**_

Still waiting for the build to finish, I will update the PR when it finishes and can confirm that this fixes the issue.

### Tickets:
 - *C[VS-107186](https://jira.devtools.intel.com/browse/CVS-107186)*
