### PR TITLE
Fixing run_timest python script for input and output precision

### DIFF
--- a/tests/time_tests/scripts/run_timetest.py
+++ b/tests/time_tests/scripts/run_timetest.py
@@ -61,8 +61,8 @@ def prepare_executable_cmd(args: dict):
         str(args["executable"].resolve(strict=True)),
         "-m", str(args["model"].resolve(strict=True)),
         "-d", args["device"],
-        "-ip", args.get("input_precision", ""),
-        "-op", args.get("output_precision", ""),
+        *["-ip", args["input_precision"] if args["input_precision"] else ""],
+        *["-op", args["output_precision"] if args["output_precision"] else ""],
         "-c" if args["model_cache"] else ""
     ]
 
@@ -149,12 +149,12 @@ def cli_parser():
                         default="",
                         dest="input_precision",
                         type=str,
-                        help="Model input precision")
+                        help="Change input model precision")
     parser.add_argument("-op",
                         default="",
                         dest="output_precision",
                         type=str,
-                        help="Model output precision")
+                        help="Change output model precision")
 
     args = parser.parse_args()
 

--- a/tests/time_tests/scripts/run_timetest.py
+++ b/tests/time_tests/scripts/run_timetest.py
@@ -61,8 +61,10 @@ def prepare_executable_cmd(args: dict):
         str(args["executable"].resolve(strict=True)),
         "-m", str(args["model"].resolve(strict=True)),
         "-d", args["device"],
-        "-ip", args["input_precision"],
-        "-op", args["output_precision"],
+        "-ip", args["input_precision"] if "input_precision" in args.keys(
+        ) and args["input_precision"] else "",
+        "-op", args["output_precision"] if "output_precision" in args.keys(
+        ) and args["output_precision"] else "",
         "-c" if args["model_cache"] else ""
     ]
 

--- a/tests/time_tests/scripts/run_timetest.py
+++ b/tests/time_tests/scripts/run_timetest.py
@@ -61,10 +61,8 @@ def prepare_executable_cmd(args: dict):
         str(args["executable"].resolve(strict=True)),
         "-m", str(args["model"].resolve(strict=True)),
         "-d", args["device"],
-        "-ip", args["input_precision"] if "input_precision" in args.keys(
-        ) and args["input_precision"] else "",
-        "-op", args["output_precision"] if "output_precision" in args.keys(
-        ) and args["output_precision"] else "",
+        "-ip", args.get("input_precision", ""),
+        "-op", args.get("output_precision", ""),
         "-c" if args["model_cache"] else ""
     ]
 
@@ -148,10 +146,12 @@ def cli_parser():
                         action="store_true",
                         help="Enable model cache usage")
     parser.add_argument("-ip",
+                        default="",
                         dest="input_precision",
                         type=str,
                         help="Model input precision")
     parser.add_argument("-op",
+                        default="",
                         dest="output_precision",
                         type=str,
                         help="Model output precision")

--- a/tests/time_tests/test_runner/conftest.py
+++ b/tests/time_tests/test_runner/conftest.py
@@ -60,18 +60,6 @@ def pytest_addoption(parser):
         default=3
     )
     test_args_parser.addoption(
-        "--input_precision",
-        type=str,
-        help="Change input model precision",
-        default=""
-    )
-    test_args_parser.addoption(
-        "--output_precision",
-        type=str,
-        help="Change output model precision",
-        default=""
-    )
-    test_args_parser.addoption(
         "--model_cache",
         action='store_true',
         help="Enable model cache usage",
@@ -136,17 +124,6 @@ def niter(request):
     """Fixture function for command-line option."""
     return request.config.getoption('niter')
 
-
-@pytest.fixture(scope="session")
-def input_precision(request):
-    """Fixture function for command-line option."""
-    return request.config.getoption('input_precision')
-
-
-@pytest.fixture(scope="session")
-def output_precision(request):
-    """Fixture function for command-line option."""
-    return request.config.getoption('output_precision')
 
 @pytest.fixture(scope="session")
 def model_cache(request):

--- a/tests/time_tests/test_runner/conftest.py
+++ b/tests/time_tests/test_runner/conftest.py
@@ -60,6 +60,18 @@ def pytest_addoption(parser):
         default=3
     )
     test_args_parser.addoption(
+        "--input_precision",
+        type=str,
+        help="Change input model precision",
+        default=""
+    )
+    test_args_parser.addoption(
+        "--output_precision",
+        type=str,
+        help="Change output model precision",
+        default=""
+    )
+    test_args_parser.addoption(
         "--model_cache",
         action='store_true',
         help="Enable model cache usage",
@@ -124,6 +136,17 @@ def niter(request):
     """Fixture function for command-line option."""
     return request.config.getoption('niter')
 
+
+@pytest.fixture(scope="session")
+def input_precision(request):
+    """Fixture function for command-line option."""
+    return request.config.getoption('input_precision')
+
+
+@pytest.fixture(scope="session")
+def output_precision(request):
+    """Fixture function for command-line option."""
+    return request.config.getoption('output_precision')
 
 @pytest.fixture(scope="session")
 def model_cache(request):

--- a/tests/time_tests/test_runner/test_timetest.py
+++ b/tests/time_tests/test_runner/test_timetest.py
@@ -34,13 +34,16 @@ from scripts.run_timetest import run_timetest
 REFS_FACTOR = 1.2      # 120%
 
 
-def test_timetest(instance, executable, niter, cl_cache_dir, model_cache, model_cache_dir,
-                  test_info, temp_dir, validate_test_case, prepare_db_info):
+def test_timetest(instance, executable, niter, input_precision, output_precision,
+                  cl_cache_dir, model_cache, model_cache_dir, test_info, temp_dir,
+                  validate_test_case, prepare_db_info):
     """Parameterized test.
 
     :param instance: test instance. Should not be changed during test run
     :param executable: timetest executable to run
     :param niter: number of times to run executable
+    :param input_precision: change input model precision
+    :param output_precision: change output model precision
     :param cl_cache_dir: directory to store OpenCL cache
     :param cpu_cache: flag to enable model CPU cache
     :param vpu_compiler: flag to change VPUX compiler type
@@ -67,6 +70,8 @@ def test_timetest(instance, executable, niter, cl_cache_dir, model_cache, model_
         "model": Path(model_path),
         "device": instance["device"]["name"],
         "niter": niter,
+        "input_precision": input_precision,
+        "output_precision": output_precision,
         "model_cache": model_cache,
     }
     logging.info("Run timetest once to generate any cache")

--- a/tests/time_tests/test_runner/test_timetest.py
+++ b/tests/time_tests/test_runner/test_timetest.py
@@ -34,16 +34,13 @@ from scripts.run_timetest import run_timetest
 REFS_FACTOR = 1.2      # 120%
 
 
-def test_timetest(instance, executable, niter, input_precision, output_precision,
-                  cl_cache_dir, model_cache, model_cache_dir, test_info, temp_dir,
-                  validate_test_case, prepare_db_info):
+def test_timetest(instance, executable, niter, cl_cache_dir, model_cache, model_cache_dir,
+                  test_info, temp_dir, validate_test_case, prepare_db_info):
     """Parameterized test.
 
     :param instance: test instance. Should not be changed during test run
     :param executable: timetest executable to run
     :param niter: number of times to run executable
-    :param input_precision: change input model precision
-    :param output_precision: change output model precision
     :param cl_cache_dir: directory to store OpenCL cache
     :param cpu_cache: flag to enable model CPU cache
     :param vpu_compiler: flag to change VPUX compiler type
@@ -58,6 +55,12 @@ def test_timetest(instance, executable, niter, input_precision, output_precision
     model_path = instance["model"].get("path")
     assert model_path, "Model path is empty"
     model_path = Path(expand_env_vars(model_path))
+
+    # Prepare input precision from model configuration
+    input_precision = instance["model"].get("input_precision")
+
+    # Prepare output precision from model configuration
+    output_precision = instance["model"].get("output_precision")
 
     # Copy model to a local temporary directory
     model_dir = temp_dir / "model"


### PR DESCRIPTION
### Details:
Fixing run_timest python script for input and output precision

Errors: https://openvino-ci.toolbox.iotg.sclab.intel.com/view/Main/job/private-ci/job/developer-services/job/e2e/3743/

### Tickets:
- [CVS-104240](https://jira.devtools.intel.com/browse/CVS-104240)
