### PR TITLE
[CPU] Remove memory allocation by the dynamic shape upper bound

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -56,11 +56,9 @@ void Memory::Create(MemoryDescPtr desc, const void* data, bool pads_zeroing) {
     padsZeroing = pads_zeroing;
     dnnlMemHandle.resetDnnlPrim();
 
-    size_t memSize = MemoryDesc::UNDEFINED_SIZE;
+    size_t memSize = 0;
     if (pMemDesc->isDefined()) {
         memSize = pMemDesc->getCurrentMemSize();
-    } else {
-        memSize = pMemDesc->hasDefinedMaxSize() ? pMemDesc->getMaxMemSize() : 0;
     }
 
     if (nullptr != data) {
@@ -93,7 +91,7 @@ void Memory::SetData(const Memory& src, bool ftz) const {
 void Memory::FillZero() {
     void* dataPtr = GetData();
     if (dataPtr != nullptr)
-        memset(dataPtr, 0, getDesc().getMaxMemSize());
+        memset(dataPtr, 0, getDesc().getCurrentMemSize());
 }
 
 void *Memory::GetPtr() const  {
@@ -122,7 +120,7 @@ void Memory::setDataHandle(void *data) {
             this);
     }
 
-    size_t maxMemSize = pMemDesc->hasDefinedMaxSize() ?  pMemDesc->getMaxMemSize() : 0;
+    size_t maxMemSize = pMemDesc->isDefined() ?  pMemDesc->getCurrentMemSize() : 0;
     mgrHandle->setExtBuff(data, maxMemSize);
     if (dnnlMemHandle.isInit()) {
         auto prim = dnnlMemHandle.getPrim();

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -728,8 +728,8 @@ void Graph::AllocateWithReuse() {
             int e_start = edge->getParent()->execIndex;
             int e_finish = edge->getChild()->execIndex;
 
-            if (boxSize != -1 && edge->getDesc().hasDefinedMaxSize()) {
-                int64_t e_size = edge->getDesc().getMaxMemSize();  // size in bytes (from the beginning of data to the last element)
+            if (boxSize != -1 && edge->getDesc().isDefined()) {
+                int64_t e_size = edge->getDesc().getCurrentMemSize();  // size in bytes (from the beginning of data to the last element)
                 boxSize = std::max(e_size, boxSize);
             } else {
                 boxSize = -1;

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -41,6 +41,10 @@ std::vector<std::vector<ov::test::InputShape>> inShapesDynamic = {
          {{ngraph::Dimension(1, 10), 200}, {{2, 200}, {5, 200}}}},
 };
 
+std::vector<std::vector<ov::test::InputShape>> inShapesDynamicLargeUpperBound = {
+        {{{ngraph::Dimension(1, 1000000000000), 200}, {{2, 200}, {5, 200}}}},
+};
+
 std::vector<ov::test::ElementType> netPrecisions = {
         ov::element::f32,
         ov::element::f16,
@@ -117,9 +121,24 @@ const auto multiply_params_dynamic = ::testing::Combine(
         ::testing::Values(CommonTestUtils::DEVICE_CPU),
         ::testing::Values(additional_config));
 
+const auto multiply_params_dynamic_large_upper_bound = ::testing::Combine(
+        ::testing::ValuesIn(inShapesDynamicLargeUpperBound),
+        ::testing::Values(ngraph::helpers::EltwiseTypes::ADD),
+        ::testing::ValuesIn(secondaryInputTypesDynamic),
+        ::testing::ValuesIn(opTypesDynamic),
+        ::testing::Values(ov::element::f32),
+        ::testing::Values(ov::element::undefined),
+        ::testing::Values(ov::element::undefined),
+        ::testing::Values(CommonTestUtils::DEVICE_CPU),
+        ::testing::Values(additional_config));
+
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_static, EltwiseLayerTest, multiply_params, EltwiseLayerTest::getTestCaseName);
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_static_check_collapsing, EltwiseLayerTest, collapsing_params, EltwiseLayerTest::getTestCaseName);
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_dynamic, EltwiseLayerTest, multiply_params_dynamic, EltwiseLayerTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_dynamic_large_upper_bound,
+                         EltwiseLayerTest,
+                         multiply_params_dynamic_large_upper_bound,
+                         EltwiseLayerTest::getTestCaseName);
 
 
 std::vector<std::vector<ov::Shape>> inShapesSingleThread = {


### PR DESCRIPTION
### Details:
Before introducing the memory reuse for dynamic shapes, we allocated memory by the defined upper bound of partially defined tensor dimensions, if there were any. It allowed to use the static memory solver. But, user can set any size for the upper bound and it does not necessary mean that this size of the input tensor will ever be requested. Thus, this is more of a hint than a requirement. On the other hand, with the memory reuse for the dynamic shapes inference, memory allocation by the upper bound simply does not bring any significant memory/performance gain anymore. Therefore, it is more safe to treat tensors with partially defined shapes as undefined in terms of memory allocation.

### Tickets:
 - 98727
