### PR TITLE
[MO] bump MXNet dependency version

### DIFF
--- a/tools/constraints.txt
+++ b/tools/constraints.txt
@@ -3,7 +3,7 @@
 # files because the version differs between them:
 # tensorflow, numpy
 mxnet~=1.2.0; sys_platform == 'win32'
-mxnet>=1.7.0.post2,<=1.9.1; sys_platform != 'win32'
+mxnet==1.9.1; sys_platform != 'win32'
 onnx>=1.8.1,<=1.13.1
 networkx<=2.8.8
 pytest>=6.2.4; python_version < '3.10'


### PR DESCRIPTION
### Details:
 - Bumping MXNet minimal required version to 1.9.1 because of the security problems with older versions. 
 - Done only for Linux, because for windows latest version available from pip is 1.7.0.post2

### Tickets:
 - xxx-106522
