### PR TITLE
Luwei/merge lpt add

### DIFF
--- a/src/common/low_precision_transformations/include/low_precision/markup_bias.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/markup_bias.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <low_precision/lpt_visibility.hpp>
+#include <memory>
+#include <openvino/pass/graph_rewrite.hpp>
+#include <openvino/pass/pattern/matcher.hpp>
+
+namespace ngraph {
+namespace pass {
+namespace low_precision {
+
+/**
+ * @ingroup ie_transformation_common_api
+ * @brief MarkupBias transformation marks biases after target layers.
+ *
+ * For more details about the transformation, refer to
+ * [MarkupBias](@ref openvino_docs_OV_UG_lpt_MarkupBias) page
+ * in the Inference Engine Developer Guide.
+ */
+class LP_TRANSFORMATIONS_API MarkupBias : public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("MarkupBias", "0");
+    MarkupBias();
+};
+
+}  // namespace low_precision
+}  // namespace pass
+}  // namespace ngraph

--- a/src/common/low_precision_transformations/include/low_precision/rt_info/bias_attribute.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/rt_info/bias_attribute.hpp
@@ -16,6 +16,6 @@ LP_TRANSFORMATIONS_API bool marked_as_bias(const std::shared_ptr<const Node>& no
 class LP_TRANSFORMATIONS_API BiasAttribute : public ov::RuntimeAttribute {
 public:
     OPENVINO_RTTI("LowPrecision::Bias", "", ov::RuntimeAttribute);
-    bool is_copyable() const override { return false; }
+    bool is_copyable(const std::shared_ptr<Node>& to) const override;
 };
 } // namespace ov

--- a/src/common/low_precision_transformations/include/low_precision/rt_info/bias_attribute.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/rt_info/bias_attribute.hpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <low_precision/lpt_visibility.hpp>
+#include <ngraph/node.hpp>
+#include <openvino/core/runtime_attribute.hpp>
+
+namespace ov {
+LP_TRANSFORMATIONS_API void mark_as_bias(const std::shared_ptr<Node>& node);
+
+LP_TRANSFORMATIONS_API bool marked_as_bias(const std::shared_ptr<const Node>& node);
+
+class LP_TRANSFORMATIONS_API BiasAttribute : public ov::RuntimeAttribute {
+public:
+    OPENVINO_RTTI("LowPrecision::Bias", "", ov::RuntimeAttribute);
+    bool is_copyable() const override { return false; }
+};
+} // namespace ov

--- a/src/common/low_precision_transformations/src/fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/fake_quantize.cpp
@@ -10,6 +10,7 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 
 #include "low_precision/network_helper.hpp"
+#include "low_precision/rt_info/bias_attribute.hpp"
 #include "itt.hpp"
 
 namespace ngraph {
@@ -191,17 +192,8 @@ std::shared_ptr<opset1::FakeQuantize> FakeQuantizeTransformation::fuseElementwis
 
         inputLowConst_f32 = fq::updateShape(fold<opset1::Add>(inputLowConst_f32, value), fakeQuantize->get_output_partial_shape(0));
         inputHighConst_f32 = fq::updateShape(fold<opset1::Add>(inputHighConst_f32, value), fakeQuantize->get_output_partial_shape(0));
-    } else if (ov::is_type<opset1::Add>(eltwise) && checkElementwise(eltwise)) {
-        if (ov::is_type<opset1::Convolution>(fq::getDataNode(eltwise)) ||
-            ov::is_type<opset1::GroupConvolution>(fq::getDataNode(eltwise)) ||
-            ov::is_type<opset1::ConvolutionBackpropData>(fq::getDataNode(eltwise)) ||
-            ov::is_type<opset1::MatMul>(fq::getDataNode(eltwise)) ||
-            ov::is_type<opset1::GroupConvolutionBackpropData>(fq::getDataNode(eltwise))) {
-            return nullptr;
-        }
-
+    } else if (ov::is_type<opset1::Add>(eltwise) && checkElementwise(eltwise) && !ov::marked_as_bias(eltwise)) {
         const auto value = foldConvert(constant, element::f32);
-
         inputLowConst_f32 = fq::updateShape(fold<opset1::Subtract>(inputLowConst_f32, value), fakeQuantize->get_output_partial_shape(0));
         inputHighConst_f32 = fq::updateShape(fold<opset1::Subtract>(inputHighConst_f32, value), fakeQuantize->get_output_partial_shape(0));
     } else if (ov::is_type<opset1::Convert>(eltwise)) {

--- a/src/common/low_precision_transformations/src/low_precision.cpp
+++ b/src/common/low_precision_transformations/src/low_precision.cpp
@@ -19,6 +19,7 @@
 
 #include "low_precision/align_quantization_intervals.hpp"
 #include "low_precision/fake_quantize_decomposition.hpp"
+#include "low_precision/markup_bias.hpp"
 #include "low_precision/markup_precisions.hpp"
 #include "low_precision/markup_can_be_quantized.hpp"
 #include "low_precision/markup_avg_pool_precision_preserved.hpp"
@@ -201,6 +202,7 @@ bool ngraph::pass::low_precision::MarkupOptimizations::run_on_model(const std::s
         markup.register_pass<low_precision::AlignQuantizationIntervals>(params.defaultPrecisions);
         markup.register_pass<low_precision::AlignQuantizationParameters>(params.defaultPrecisions);
     }
+    markup.register_pass<low_precision::MarkupBias>();
     markup.run_passes(f);
     return false;
 }

--- a/src/common/low_precision_transformations/src/markup_bias.cpp
+++ b/src/common/low_precision_transformations/src/markup_bias.cpp
@@ -1,0 +1,41 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "low_precision/markup_bias.hpp"
+
+#include <memory>
+#include <openvino/opsets/opset1.hpp>
+#include <openvino/pass/pattern/op/wrap_type.hpp>
+
+#include "itt.hpp"
+#include "low_precision/rt_info/bias_attribute.hpp"
+
+using namespace ngraph::pass::low_precision;
+
+MarkupBias::MarkupBias() {
+    MATCHER_SCOPE(MarkupBias);
+    auto layer_m = ov::pass::pattern::wrap_type<ov::opset1::Convolution,
+                                                ov::opset1::GroupConvolution,
+                                                ov::opset1::ConvolutionBackpropData,
+                                                ov::opset1::GroupConvolutionBackpropData,
+                                                ov::opset1::MatMul>(ov::pass::pattern::has_static_rank());
+    auto bias_const_m = ov::pass::pattern::wrap_type<ov::opset1::Constant>();
+    auto bias_m = ov::pass::pattern::wrap_type<ov::opset1::Add>({layer_m, bias_const_m});
+
+    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        const auto& const_shape = pattern_map.at(bias_const_m).get_shape();
+
+        const bool per_channel = std::count_if(const_shape.begin(), const_shape.end(), [](size_t x) { return x > 1; }) == 1;
+        if (ov::shape_size(const_shape) == 1 || per_channel) {
+            const auto bias = pattern_map.at(bias_m).get_node_shared_ptr();
+            ov::mark_as_bias(bias);
+        }
+
+        return false;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(bias_m, matcher_name);
+    register_matcher(m, callback);
+}

--- a/src/common/low_precision_transformations/src/network_helper.cpp
+++ b/src/common/low_precision_transformations/src/network_helper.cpp
@@ -1286,7 +1286,14 @@ FakeQuantizeDequantization NetworkHelper::getDequantization(const std::shared_pt
         return 1ul;
     };
 
-    Output<Node> dataNode = inPlace ? std::const_pointer_cast<Node>(node)->output(0) : node->input_value(parentIndex);
+    Output<Node> dataNode;
+    if (inPlace) {
+        dataNode = std::const_pointer_cast<Node>(node);
+    } else {
+        if (parentIndex >= node->get_input_size())
+            return FakeQuantizeDequantization();
+        dataNode = node->input_value(parentIndex);
+    }
 
     const std::shared_ptr<ngraph::opset1::Multiply> multiply = ov::as_type_ptr<ngraph::opset1::Multiply>(dataNode.get_node_shared_ptr());
     std::shared_ptr<opset1::Constant> multiplyConstant;

--- a/src/common/low_precision_transformations/src/rt_info/bias_attribute.cpp
+++ b/src/common/low_precision_transformations/src/rt_info/bias_attribute.cpp
@@ -3,11 +3,13 @@
 //
 
 #include "low_precision/rt_info/bias_attribute.hpp"
+#include "low_precision/network_helper.hpp"
 
+#include <iterator>
 #include <memory>
+#include <openvino/opsets/opset1.hpp>
 #include <string>
 #include <unordered_map>
-#include <iterator>
 #include <vector>
 
 void ov::mark_as_bias(const std::shared_ptr<ov::Node>& node) {
@@ -18,4 +20,8 @@ void ov::mark_as_bias(const std::shared_ptr<ov::Node>& node) {
 bool ov::marked_as_bias(const std::shared_ptr<const ov::Node>& node) {
     const auto& rt_info = node->get_rt_info();
     return rt_info.find(ov::BiasAttribute::get_type_info_static()) != rt_info.end();
+}
+
+bool ov::BiasAttribute::is_copyable(const std::shared_ptr<ov::Node>& to) const {
+    return ov::is_type<ov::opset1::Add>(to) && ngraph::pass::low_precision::NetworkHelper::getConstantInput(to) != nullptr;
 }

--- a/src/common/low_precision_transformations/src/rt_info/bias_attribute.cpp
+++ b/src/common/low_precision_transformations/src/rt_info/bias_attribute.cpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "low_precision/rt_info/bias_attribute.hpp"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <iterator>
+#include <vector>
+
+void ov::mark_as_bias(const std::shared_ptr<ov::Node>& node) {
+    auto& rt = node->get_rt_info();
+    rt[ov::BiasAttribute::get_type_info_static()] = ov::BiasAttribute();
+}
+
+bool ov::marked_as_bias(const std::shared_ptr<const ov::Node>& node) {
+    const auto& rt_info = node->get_rt_info();
+    return rt_info.find(ov::BiasAttribute::get_type_info_static()) != rt_info.end();
+}

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
@@ -17,36 +17,68 @@ DnnlPostOpsComposer::DnnlPostOpsComposer(const dnnl::engine& engine,
                                          std::unordered_map<int, MemoryPtr>& args,
                                          const VectorDims& outputDims,
                                          int indexOfOutputChannelDim,
+                                         bool isI8,
                                          const int weightScaleMaskPerChannel,
-                                         bool isINT8)
+                                         const std::vector<float>& scalesBeforeBias)
     : engine(engine),
       attr(attr),
       ops(ops),
       args(args),
       outputDims(outputDims),
       idxOC(indexOfOutputChannelDim),
+      isINT8(isI8),
       weightScaleMaskPerChannel(weightScaleMaskPerChannel),
-      isINT8(isINT8) {
+      weightScaleAvailable(isI8 && scalesBeforeBias.empty()) {
     IE_ASSERT(idxOC >= 0 && idxOC < outputDims.size());
+    if (!isINT8 && !scalesBeforeBias.empty()) {
+        IE_THROW() << "weight scale attribute can only set on INT8";
+    }
     OC = outputDims[idxOC];
     dimsPerOC = dimsPerTensor = VectorDims(outputDims.size(), 1);
     dimsPerOC[idxOC] = OC;
-    oscale_mask = 0;
-    oscale_values = {1.0f};
+    wei_scale_mask = 0;
+    wei_scale_values = {1.0f};
+    dst_scale_val = 1.0;
+    if (!scalesBeforeBias.empty()) {
+        DEBUG_LOG("Set scales mask ", "DNNL_ARG: ", DNNL_ARG_WEIGHTS, " mask: ", wei_scale_mask);
+        const auto wei_mask = scalesBeforeBias.size() == 1 ? 0 : weightScaleMaskPerChannel;
+        attr.set_scales_mask(DNNL_ARG_WEIGHTS, wei_mask);
+        DnnlBlockedMemoryDesc memoryDesc(InferenceEngine::Precision::FP32, Shape({scalesBeforeBias.size()}));
+        auto mem = std::make_shared<Memory>(engine);
+        mem->Create(memoryDesc);
+        memcpy(mem->GetPtr(), scalesBeforeBias.data(), scalesBeforeBias.size() * sizeof(float));
+        args[DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS] = mem;
+    }
 }
 
-void DnnlPostOpsComposer::updateOutputScales() {
-    if (oscale_mask == 0 && oscale_values[0] == 1.0f)
+void DnnlPostOpsComposer::updateWeiScales() {
+    if (wei_scale_mask == 0 && wei_scale_values[0] == 1.0f)
         return;
 
-    DEBUG_LOG("Set scales mask ", "DNNL_ARG: ", DNNL_ARG_DST, " mask: ", oscale_mask);
-    attr.set_scales_mask(DNNL_ARG_WEIGHTS, oscale_mask);
+    DEBUG_LOG("Set scales mask ", "DNNL_ARG: ", DNNL_ARG_WEIGHTS, " mask: ", wei_scale_mask);
+    attr.set_scales_mask(DNNL_ARG_WEIGHTS, wei_scale_mask);
 
-    DnnlBlockedMemoryDesc memoryDesc(InferenceEngine::Precision::FP32, Shape({oscale_values.size()}));
+    DnnlBlockedMemoryDesc memoryDesc(InferenceEngine::Precision::FP32, Shape({wei_scale_values.size()}));
     auto mem = std::make_shared<Memory>(engine);
     mem->Create(memoryDesc);
-    memcpy(mem->GetPtr(), oscale_values.data(), oscale_values.size() * sizeof(float));
+    memcpy(mem->GetPtr(), wei_scale_values.data(), wei_scale_values.size() * sizeof(float));
     args[DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS] = mem;
+}
+
+void DnnlPostOpsComposer::updateDestScales() {
+    if (args.count(DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST))
+        IE_THROW() << "BUG: Dest scale is set for multiple times.";
+    if (dst_scale_val == 1.0f)
+        return;
+
+    DEBUG_LOG("Set scales mask ", "DNNL_ARG: ", DNNL_ARG_DST, " mask: ", 0);
+    attr.set_scales_mask(DNNL_ARG_DST, 0);
+
+    DnnlBlockedMemoryDesc memoryDesc(InferenceEngine::Precision::FP32, Shape({1}));
+    auto mem = std::make_shared<Memory>(engine);
+    mem->Create(memoryDesc);
+    memcpy(mem->GetPtr(), &dst_scale_val, sizeof(float));
+    args[DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST] = mem;
 }
 
 void DnnlPostOpsComposer::appendBinary(const dnnl::algorithm alg, const std::vector<float>& data) {
@@ -79,36 +111,41 @@ void DnnlPostOpsComposer::appendRoundHTE() {
 
 bool DnnlPostOpsComposer::appendScale(const std::vector<float>& scale, bool isLastPostOp, bool allowBinary) {
     IE_ASSERT(scale.size() == OC || scale.size() == 1);
-    // there are so many possible optimizations can be done, for example:
-    //
-    // we can switch the existing postOps's order to take
-    // advantage of output scale if it's available:
-    //    relu(x)*scale = relu(x*scale)
-    // or we can fuse it into previous one as long as they are
-    // compatible in shape
-    //    x*A*s = x*(A*s)
-    // or even with add:
-    //    (x*A + B)*s = x*(A*s) + (B*s)
-    // or we can combine these two tricks:
-    //    relu(x*A)*s = relu(x*(A*s))
-    //
-    // we cannot implement all of them, so we just add the one
-    // that we observed in real models.
 
-    // fuse into existing output scale (only when isINT8)
-    bool can_fuse_into_oscale = false;
-    if (isINT8) { // oneDNN v3.* limitation does not allow per-channel dst scales
-        if (ops.len() == 0)
-            can_fuse_into_oscale = true;
+    bool fuseIntoWeiScale = false;
+    if ((isINT8 && isLastPostOp && scale.size() == 1)) {
+        dst_scale_val = 1.0 / scale[0];
+        updateDestScales();
+        return true;
+    }
+    if (weightScaleAvailable) {
+        //oneDNN v3.* weight scale can be the same with oscale before ONEDNN 3.0 only when there is no dequantization before bias.
 
-#if 1
+        // there are so many possible optimizations can be done, for example:
+        //
+        // we can switch the existing postOps's order to take
+        // advantage of output scale if it's available:
+        //    relu(x)*scale = relu(x*scale)
+        // or we can fuse it into previous one as long as they are
+        // compatible in shape
+        //    x*A*s = x*(A*s)
+        // or even with add:
+        //    (x*A + B)*s = x*(A*s) + (B*s)
+        // or we can combine these two tricks:
+        //    relu(x*A)*s = relu(x*(A*s))
+        //
+        // we cannot implement all of them, so we just add the one
+        // that we observed in real models.
+        if ((ops.len() == 0))
+            fuseIntoWeiScale = true;
+
         // relu(x)*s = relu(x*s)
         // prelu(x)*s = prelu(x*s)
         if (ops.len() == 1) {
             auto& cur_op = ops.get()->entry_[0];
             if ((cur_op.kind == dnnl::impl::primitive_kind::eltwise && cur_op.eltwise.alg == dnnl_eltwise_relu) ||
                 (cur_op.kind == dnnl::impl::primitive_kind::binary && cur_op.binary.alg == dnnl_binary_prelu)) {
-                can_fuse_into_oscale = true;
+                fuseIntoWeiScale = true;
             }
         }
 
@@ -117,54 +154,52 @@ bool DnnlPostOpsComposer::appendScale(const std::vector<float>& scale, bool isLa
             auto& cur_op = ops.get()->entry_.back();
             if (cur_op.kind == dnnl::impl::primitive_kind::sum) {
                 cur_op.sum.scale *= scale[0];
-                can_fuse_into_oscale = true;
+                fuseIntoWeiScale = true;
             }
         }
-#endif
     }
-
-    if (can_fuse_into_oscale) {
+    if (fuseIntoWeiScale) {
         if (scale.size() > 1) {
-            if (oscale_mask == 0)
-                oscale_values.resize(scale.size(), oscale_values[0]);
+            if (wei_scale_mask == 0)
+                wei_scale_values.resize(scale.size(), wei_scale_values[0]);
             else
-                IE_ASSERT(oscale_values.size() == OC);
+                IE_ASSERT(wei_scale_values.size() == OC);
 
             for (int j = 0; j < OC; j++)
-                oscale_values[j] *= scale[j];
+                wei_scale_values[j] *= scale[j];
         } else {
-            for (int j = 0; j < oscale_values.size(); j++)
-                oscale_values[j] *= scale[0];
+            for (int j = 0; j < wei_scale_values.size(); j++)
+                wei_scale_values[j] *= scale[0];
         }
 
-        if (oscale_values.size() == 1)
-            oscale_mask = 0;
+        if (wei_scale_values.size() == 1)
+            wei_scale_mask = 0;
         else
-            oscale_mask = weightScaleMaskPerChannel;
-        updateOutputScales();
+            wei_scale_mask = weightScaleMaskPerChannel;
+        updateWeiScales();
         return true;
     }
 
-    // (eltwise(x, scale, alpha, beta) + dst[:])*s = (eltwise(x, scale*s, alpha, beta) + s*dst[:])
-    if (scale.size() == 1 && ops.len() > 1) {
-        auto N = ops.len();
-        auto& cur_op = ops.get()->entry_[N-1];
-        auto& prev_op = ops.get()->entry_[N-2];
-        if (cur_op.kind == dnnl::impl::primitive_kind::sum && prev_op.is_eltwise()) {
-            cur_op.sum.scale *= scale[0];
-            prev_op.eltwise.scale *= scale[0];
-            return true;
-        }
-    }
+    // // (eltwise(x, scale, alpha, beta) + dst[:])*s = (eltwise(x, scale*s, alpha, beta) + s*dst[:])
+    // if (scale.size() == 1 && ops.len() > 1) {
+    //     auto N = ops.len();
+    //     auto& cur_op = ops.get()->entry_[N-1];
+    //     auto& prev_op = ops.get()->entry_[N-2];
+    //     if (cur_op.kind == dnnl::impl::primitive_kind::sum && prev_op.is_eltwise()) {
+    //         cur_op.sum.scale *= scale[0];
+    //         prev_op.eltwise.scale *= scale[0];
+    //         return true;
+    //     }
+    // }
 
-    // eltwise(x, scale, alpha, beta)*s = eltwise(x, (scale*s), alpha, beta)
-    if (scale.size() == 1 && ops.len() > 0) {
-        auto& cur_op = ops.get()->entry_.back();
-        if (cur_op.kind == dnnl::impl::primitive_kind::eltwise) {
-            cur_op.eltwise.scale *= scale[0];
-            return true;
-        }
-    }
+    // // eltwise(x, scale, alpha, beta)*s = eltwise(x, (scale*s), alpha, beta)
+    // if (scale.size() == 1 && ops.len() > 0) {
+    //     auto& cur_op = ops.get()->entry_.back();
+    //     if (cur_op.kind == dnnl::impl::primitive_kind::eltwise) {
+    //         cur_op.eltwise.scale *= scale[0];
+    //         return true;
+    //     }
+    // }
 
     // final fallback
     if (scale.size() == 1) {

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.h
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.h
@@ -30,8 +30,9 @@ public:
                         const VectorDims& outputDims,
                         int indexOfOutputChannelDim,
                         bool isINT8,
-                        const int weightScaleMaskPerChannel,
-                        const std::vector<float>& ScalesBeforeBias);
+                        int weiScaleMaskPerChannel,
+                        const std::vector<float>& DQScales,
+                        bool hasBias);
 
     void appendBinary(const dnnl::algorithm alg, const std::vector<float>& data);
     void appendEltwise(const dnnl::algorithm alg, float alpha, float beta);
@@ -54,12 +55,13 @@ private:
     int idxOC;
     const bool isINT8;  // only INT8 primitive support output scale
     const int weightScaleMaskPerChannel;
-    const bool weightScaleAvailable;
+    const bool withBias;
+    bool weightScaleAvailable = false;
 
     VectorDims dimsPerTensor;
     VectorDims dimsPerOC;
     Dim OC;
-    int wei_scale_mask;
+    int wei_scale_mask = -1;
     std::vector<float> wei_scale_values;
     float dst_scale_val;
 

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.h
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.h
@@ -29,8 +29,9 @@ public:
                         std::unordered_map<int, MemoryPtr>& args,
                         const VectorDims& outputDims,
                         int indexOfOutputChannelDim,
+                        bool isINT8,
                         const int weightScaleMaskPerChannel,
-                        bool isINT8);
+                        const std::vector<float>& ScalesBeforeBias);
 
     void appendBinary(const dnnl::algorithm alg, const std::vector<float>& data);
     void appendEltwise(const dnnl::algorithm alg, float alpha, float beta);
@@ -51,15 +52,19 @@ private:
     std::unordered_map<int, MemoryPtr>& args;
     const VectorDims outputDims;
     int idxOC;
+    const bool isINT8;  // only INT8 primitive support output scale
     const int weightScaleMaskPerChannel;
+    const bool weightScaleAvailable;
+
     VectorDims dimsPerTensor;
     VectorDims dimsPerOC;
     Dim OC;
-    const bool isINT8;  // only INT8 primitive support output scale
-    int oscale_mask;
-    std::vector<float> oscale_values;
+    int wei_scale_mask;
+    std::vector<float> wei_scale_values;
+    float dst_scale_val;
 
-    void updateOutputScales();
+    void updateWeiScales();
+    void updateDestScales();
 };
 
 }  // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.h
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.h
@@ -29,6 +29,7 @@ public:
                         std::unordered_map<int, MemoryPtr>& args,
                         const VectorDims& outputDims,
                         int indexOfOutputChannelDim,
+                        const int weightScaleMaskPerChannel,
                         bool isINT8);
 
     void appendBinary(const dnnl::algorithm alg, const std::vector<float>& data);
@@ -50,6 +51,7 @@ private:
     std::unordered_map<int, MemoryPtr>& args;
     const VectorDims outputDims;
     int idxOC;
+    const int weightScaleMaskPerChannel;
     VectorDims dimsPerTensor;
     VectorDims dimsPerOC;
     Dim OC;

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -436,7 +436,6 @@ void Graph::InitDescriptors() {
             if (inputNode)
                 inputNode->withMeanImage();
         }
-
         OV_ITT_SCOPE_NEXT(FIRST_INFERENCE, taskChain, node->profiling.getSupportedDescriptors);
         DEBUG_LOG("Get supported primitive descriptors for node: ", node->getName());
         node->getSupportedDescriptors();

--- a/src/plugins/intel_cpu/src/graph_optimizer.h
+++ b/src/plugins/intel_cpu/src/graph_optimizer.h
@@ -20,7 +20,7 @@ public:
     void ApplyImplSpecificGraphOptimizations(Graph& graph);
 
 private:
-    void FuseConvMatmulDeconvAndDQScales(Graph &graph);
+    void FuseConvMatmulFCDeconvAndDQScales(Graph &graph);
     void FuseConvolutionMatMulDeconvAndBias(Graph &graph);
     void FuseDeconvolutionAndSimpleOperation(Graph &graph);
     void FuseMultiplyAndAdd(Graph &graph);

--- a/src/plugins/intel_cpu/src/graph_optimizer.h
+++ b/src/plugins/intel_cpu/src/graph_optimizer.h
@@ -20,6 +20,7 @@ public:
     void ApplyImplSpecificGraphOptimizations(Graph& graph);
 
 private:
+    void FuseConvolutionAndScale(Graph &graph);
     void FuseConvolutionMatMulDeconvAndBias(Graph &graph);
     void FuseDeconvolutionAndSimpleOperation(Graph &graph);
     void FuseMultiplyAndAdd(Graph &graph);

--- a/src/plugins/intel_cpu/src/graph_optimizer.h
+++ b/src/plugins/intel_cpu/src/graph_optimizer.h
@@ -20,7 +20,7 @@ public:
     void ApplyImplSpecificGraphOptimizations(Graph& graph);
 
 private:
-    void FuseConvolutionAndScale(Graph &graph);
+    void FuseConvMatmulDeconvAndDQScales(Graph &graph);
     void FuseConvolutionMatMulDeconvAndBias(Graph &graph);
     void FuseDeconvolutionAndSimpleOperation(Graph &graph);
     void FuseMultiplyAndAdd(Graph &graph);

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -1638,6 +1638,8 @@ void Node::initializeDQScales(const float* scaleData, const size_t scaleSize) {
         if (scaleData[i] != scaleData[0])
             DQScalesType = scalesType::PerChannel;
     }
+    if (DQScalesType == scalesType::PerTensor)
+        DQScales.resize(1);
 }
 
 

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -1626,5 +1626,21 @@ void Node::addSupportedPrimDesc(const std::vector<PortConfigurator>& inPortConfi
     supportedPrimitiveDescriptors.push_back({config, implType});
 }
 
+void Node::initializeDQScales(const float* scaleData, const size_t scaleSize) {
+    if (!DQScales.empty())
+        IE_THROW() << "DQ scales vector is not empty '" << getName() << "'";
+    if (scaleSize) {
+        DQScales.reserve(scaleSize);
+        DQScalesType = scalesType::PerTensor;
+    }
+    for (size_t i = 0; i < scaleSize; i++) {
+        DQScales.push_back(scaleData[i]);
+        if (scaleData[i] != scaleData[0])
+            DQScalesType = scalesType::PerChannel;
+    }
+}
+
+
+
 }   // namespace intel_cpu
 }   // namespace ov

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -519,7 +519,7 @@ public:
     std::pair<std::vector<float>, std::vector<float>> getScalesAndShifts(const Node *parentNode) const;
 
     void initializeDQScales(const float* scaleData, const size_t scaleSize);
-    const std::vector<float>& getOutputScales() const {
+    const std::vector<float>& getDQScales() const {
         return DQScales;
     }
     const scalesType& getDQScaleType() const {

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -104,6 +104,11 @@ public:
     Node & operator = (const Node &) = delete;
 
     using AttrPtr = std::shared_ptr<dnnl::primitive_attr>;
+    enum class scalesType {
+        None,
+        PerTensor,
+        PerChannel
+    };
 
 public:
     template<typename T, int N>
@@ -513,6 +518,14 @@ public:
     */
     std::pair<std::vector<float>, std::vector<float>> getScalesAndShifts(const Node *parentNode) const;
 
+    void initializeDQScales(const float* scaleData, const size_t scaleSize);
+    const std::vector<float>& getOutputScales() const {
+        return DQScales;
+    }
+    const scalesType& getDQScaleType() const {
+        return DQScalesType;
+    }
+
     /**
      * @brief Appends new item into ops list with the information on how the node should be executed as post operation.
      * Seed node should call this routine and pass its post operations list as parameter.
@@ -686,6 +699,9 @@ private:
 
     enum LOOK { LOOK_UP = 1, LOOK_DOWN = 2 };
     ConstantType checkConstant(LOOK look, std::vector<NodePtr>& checkNodes);
+    // Hold output scales
+    std::vector<float> DQScales;
+    scalesType DQScalesType = scalesType::None;
 
 #ifdef CPU_DEBUG_CAPS
     friend class Verbose;

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -601,7 +601,7 @@ void Convolution::setPostOps(dnnl::primitive_attr& attr,
     auto& args = convPostOpsArgs[useLegacyPostOps];
     bool isINT8 = canBeExecutedInInt8();
 
-    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, args, dims, 1, isINT8, isGrouped ? 3 : 1 << 0, getDQScales());
+    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, args, dims, 1, isINT8, isGrouped ? 3 : 1 << 0, getDQScales(), withBiases);
 
     DEBUG_LOG(getName(), " useLegacyPostOps=", useLegacyPostOps, " initWeights=", initWeights);
 

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -601,7 +601,7 @@ void Convolution::setPostOps(dnnl::primitive_attr& attr,
     auto& args = convPostOpsArgs[useLegacyPostOps];
     bool isINT8 = canBeExecutedInInt8();
 
-    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, args, dims, 1, isGrouped ? 3 : 1 << 0, isINT8);
+    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, args, dims, 1, isINT8, isGrouped ? 3 : 1 << 0, getDQScales());
 
     DEBUG_LOG(getName(), " useLegacyPostOps=", useLegacyPostOps, " initWeights=", initWeights);
 

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -955,18 +955,18 @@ void Convolution::addLegacyZeroPoints(dnnl::primitive_attr& attr) {
     }
 }
 
-void Convolution::addOutputScales(dnnl::primitive_attr& attr) {
-    if (outputScales.empty())
-        return;
-    DEBUG_LOG("Set original output scales");
-    // attr.set_scales_mask(DNNL_ARG_DST, 0);
+// void Convolution::addOutputScales(dnnl::primitive_attr& attr) {
+//     if (outputScales.empty())
+//         return;
+//     DEBUG_LOG("Set original output scales");
+//     // attr.set_scales_mask(DNNL_ARG_DST, 0);
 
-    // if (!outScaleMemPtr) {
-    //     outScaleMemPtr.reset(new Memory(getEngine()));
-    //     DnnlBlockedMemoryDesc memoryDesc(Precision::FP32, {outputScales.size()});
-    //     outScaleMemPtr->Create(memoryDesc, outputScales.data());
-    // }
-}
+//     // if (!outScaleMemPtr) {
+//     //     outScaleMemPtr.reset(new Memory(getEngine()));
+//     //     DnnlBlockedMemoryDesc memoryDesc(Precision::FP32, {outputScales.size()});
+//     //     outScaleMemPtr->Create(memoryDesc, outputScales.data());
+//     // }
+// }
 
 static bool attrContainsPostOp(const dnnl::primitive_attr& attr, const dnnl::impl::primitive_kind_t kind) {
     const auto ops = attr.get_post_ops();
@@ -979,7 +979,7 @@ void Convolution::SetPostOpsAndZeroPoints(std::vector<dnnl::primitive_attr> &att
     auto outputShape = outputStaticShape();
     // attr[0] - Legacy post ops + Legacy zero points.
     DEBUG_LOG(getName(), ": set post ops, attr 0, useLegacyPostOps=true");
-    addOutputScales(attrs[0]);
+    // addOutputScales(attrs[0]);
     setPostOps(attrs[0], outputShape, true);
     addLegacyZeroPoints(attrs[0]);
 
@@ -1680,18 +1680,18 @@ void Convolution::initializeInputZeroPoints(const uint8_t* inputZpData, const si
         inputZeroPoints.push_back(static_cast<int32_t>(inputZpData[0]));
 }
 
-void Convolution::initializeOutputScales(const float* outputScalesData, const size_t outputScalesSize) {
-    if (!outputScales.empty())
-        IE_THROW() << "Output scales vector is not empty '" << getName() << "'";
+// void Convolution::initializeOutputScales(const float* outputScalesData, const size_t outputScalesSize) {
+//     if (!outputScales.empty())
+//         IE_THROW() << "Output scales vector is not empty '" << getName() << "'";
 
-    if (outputScalesSize)
-        outputScalesType = scalesType::PerTensor;
-    for (size_t i = 0; i < outputScalesSize; i++) {
-        outputScales.push_back(outputScalesData[i]);
-        if (outputScalesData[i] != outputScalesData[0])
-            outputScalesType = scalesType::PerChannel;
-    }
-}
+//     if (outputScalesSize)
+//         outputScalesType = scalesType::PerTensor;
+//     for (size_t i = 0; i < outputScalesSize; i++) {
+//         outputScales.push_back(outputScalesData[i]);
+//         if (outputScalesData[i] != outputScalesData[0])
+//             outputScalesType = scalesType::PerChannel;
+//     }
+// }
 
 VectorDims Convolution::makeInputDummyShape(const Shape& inpShape) const {
     // There are a bunch of heuristics mostly aimed to guess the most appropriate oneDNN implementation, to reduce the

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -601,7 +601,7 @@ void Convolution::setPostOps(dnnl::primitive_attr& attr,
     auto& args = convPostOpsArgs[useLegacyPostOps];
     bool isINT8 = canBeExecutedInInt8();
 
-    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, args, dims, 1, isINT8);
+    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, args, dims, 1, isGrouped ? 3 : 1 << 0, isINT8);
 
     DEBUG_LOG(getName(), " useLegacyPostOps=", useLegacyPostOps, " initWeights=", initWeights);
 

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -955,6 +955,19 @@ void Convolution::addLegacyZeroPoints(dnnl::primitive_attr& attr) {
     }
 }
 
+void Convolution::addOutputScales(dnnl::primitive_attr& attr) {
+    if (outputScales.empty())
+        return;
+    DEBUG_LOG("Set original output scales");
+    // attr.set_scales_mask(DNNL_ARG_DST, 0);
+
+    // if (!outScaleMemPtr) {
+    //     outScaleMemPtr.reset(new Memory(getEngine()));
+    //     DnnlBlockedMemoryDesc memoryDesc(Precision::FP32, {outputScales.size()});
+    //     outScaleMemPtr->Create(memoryDesc, outputScales.data());
+    // }
+}
+
 static bool attrContainsPostOp(const dnnl::primitive_attr& attr, const dnnl::impl::primitive_kind_t kind) {
     const auto ops = attr.get_post_ops();
     return ops.get()->find(kind) != -1;
@@ -966,6 +979,7 @@ void Convolution::SetPostOpsAndZeroPoints(std::vector<dnnl::primitive_attr> &att
     auto outputShape = outputStaticShape();
     // attr[0] - Legacy post ops + Legacy zero points.
     DEBUG_LOG(getName(), ": set post ops, attr 0, useLegacyPostOps=true");
+    addOutputScales(attrs[0]);
     setPostOps(attrs[0], outputShape, true);
     addLegacyZeroPoints(attrs[0]);
 
@@ -1664,6 +1678,19 @@ void Convolution::initializeInputZeroPoints(const uint8_t* inputZpData, const si
     if (inputZeroPointType == zpType::PerTensor &&
         (impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core_amx) || impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core_vnni)))
         inputZeroPoints.push_back(static_cast<int32_t>(inputZpData[0]));
+}
+
+void Convolution::initializeOutputScales(const float* outputScalesData, const size_t outputScalesSize) {
+    if (!outputScales.empty())
+        IE_THROW() << "Output scales vector is not empty '" << getName() << "'";
+
+    if (outputScalesSize)
+        outputScalesType = scalesType::PerTensor;
+    for (size_t i = 0; i < outputScalesSize; i++) {
+        outputScales.push_back(outputScalesData[i]);
+        if (outputScalesData[i] != outputScalesData[0])
+            outputScalesType = scalesType::PerChannel;
+    }
 }
 
 VectorDims Convolution::makeInputDummyShape(const Shape& inpShape) const {

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -57,8 +57,8 @@ public:
     void initializeInputZeroPoints(const uint8_t* inputZpData, const size_t inputZpSize);
 
     // Hold output scales
-    std::vector<float> outputScales;
-    void initializeOutputScales(const float* outputScalesData, const size_t outputScalesSize);
+    // std::vector<float> DQScales;
+    // void initializeDQScales(const float* scaleData, const size_t scaleSize);
 
     const InferenceEngine::SizeVector &getWeightDims() { return weightDims; }
     const std::vector<size_t> &getStride() { return stride; }
@@ -87,11 +87,11 @@ private:
         PerTensor,
         PerChannel
     };
-    enum class scalesType {
-        None,
-        PerTensor,
-        PerChannel
-    };
+    // enum class scalesType {
+    //     None,
+    //     PerTensor,
+    //     PerChannel
+    // };
     class FusedSubgraph;
     using FusedSubgraphPtr = std::shared_ptr<FusedSubgraph>;
     using executorPtr = std::shared_ptr<DnnlExecutor>;
@@ -111,7 +111,7 @@ private:
     void executeDynamicImpl(dnnl::stream strm) override;
     void addLegacyZeroPoints(dnnl::primitive_attr& attr);
     void addZeroPoints(dnnl::primitive_attr& attr);
-    void addOutputScales(dnnl::primitive_attr& attr);
+    // void addOutputScales(dnnl::primitive_attr& attr);
     void setPostOps(dnnl::primitive_attr &attr, const VectorDims &dims, bool useLegacyPostOps, bool initWeights = false);
     void SetPostOpsAndZeroPoints(std::vector<dnnl::primitive_attr> &attrs);
     void filterSupportedDescriptors();
@@ -137,7 +137,7 @@ private:
     bool preferLegacyPostOps = false;
     bool preferLegacyZeroPoint = false;
     zpType inputZeroPointType = zpType::None;
-    scalesType outputScalesType = scalesType::None;
+    // scalesType outputScalesType = scalesType::None;
     // maps each supportedPrimitiveDescriptor to corresponding desc from descs
     std::vector<size_t> descIdx;
 

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -56,6 +56,10 @@ public:
     std::vector<int32_t> inputZeroPoints;
     void initializeInputZeroPoints(const uint8_t* inputZpData, const size_t inputZpSize);
 
+    // Hold output scales
+    std::vector<float> outputScales;
+    void initializeOutputScales(const float* outputScalesData, const size_t outputScalesSize);
+
     const InferenceEngine::SizeVector &getWeightDims() { return weightDims; }
     const std::vector<size_t> &getStride() { return stride; }
     const std::vector<ptrdiff_t> &getDilation() { return dilation; }
@@ -83,6 +87,11 @@ private:
         PerTensor,
         PerChannel
     };
+    enum class scalesType {
+        None,
+        PerTensor,
+        PerChannel
+    };
     class FusedSubgraph;
     using FusedSubgraphPtr = std::shared_ptr<FusedSubgraph>;
     using executorPtr = std::shared_ptr<DnnlExecutor>;
@@ -102,6 +111,7 @@ private:
     void executeDynamicImpl(dnnl::stream strm) override;
     void addLegacyZeroPoints(dnnl::primitive_attr& attr);
     void addZeroPoints(dnnl::primitive_attr& attr);
+    void addOutputScales(dnnl::primitive_attr& attr);
     void setPostOps(dnnl::primitive_attr &attr, const VectorDims &dims, bool useLegacyPostOps, bool initWeights = false);
     void SetPostOpsAndZeroPoints(std::vector<dnnl::primitive_attr> &attrs);
     void filterSupportedDescriptors();
@@ -127,6 +137,7 @@ private:
     bool preferLegacyPostOps = false;
     bool preferLegacyZeroPoint = false;
     zpType inputZeroPointType = zpType::None;
+    scalesType outputScalesType = scalesType::None;
     // maps each supportedPrimitiveDescriptor to corresponding desc from descs
     std::vector<size_t> descIdx;
 
@@ -167,6 +178,7 @@ private:
     MemoryPtr legacyWeightsZeroPointsMemPtr;
     MemoryPtr legacyOutputCompensationMemPtr;
     MemoryPtr stockInputZeroPointsMemPtr;
+    MemoryPtr outScaleMemPtr;
     dnnl::memory::data_type outputDataType;
     InferenceEngine::Precision sumPrc = InferenceEngine::Precision::UNSPECIFIED;
 };

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -471,7 +471,7 @@ void Deconvolution::initPaddingR(const Shape &inShape, const Shape &outShape) {
 void Deconvolution::setPostOps(dnnl::primitive_attr& attr, const VectorDims& dims) {
     dnnl::post_ops ops;
 
-    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, 1, isInt8);
+    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, 1, withGroups ? 3 : 1 << 0, isInt8);
 
     for (int i = 0; i < fusedWith.size(); ++i) {
         auto& node = fusedWith[i];

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -471,7 +471,7 @@ void Deconvolution::initPaddingR(const Shape &inShape, const Shape &outShape) {
 void Deconvolution::setPostOps(dnnl::primitive_attr& attr, const VectorDims& dims) {
     dnnl::post_ops ops;
 
-    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, 1, isInt8, withGroups ? 3 : 1 << 0,  getDQScales());
+    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, 1, isInt8, withGroups ? 3 : 1 << 0,  getDQScales(), withBiases);
 
     for (int i = 0; i < fusedWith.size(); ++i) {
         auto& node = fusedWith[i];

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -471,7 +471,7 @@ void Deconvolution::initPaddingR(const Shape &inShape, const Shape &outShape) {
 void Deconvolution::setPostOps(dnnl::primitive_attr& attr, const VectorDims& dims) {
     dnnl::post_ops ops;
 
-    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, 1, withGroups ? 3 : 1 << 0, isInt8);
+    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, 1, isInt8, withGroups ? 3 : 1 << 0,  getDQScales());
 
     for (int i = 0; i < fusedWith.size(); ++i) {
         auto& node = fusedWith[i];

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -2186,10 +2186,12 @@ bool Eltwise::canBeInPlace() const {
 
 void Eltwise::fuseInto(NodePtr& parentNode) {
     // Handling Convolution custom Add node fusing case which is processed via dnnl append_sum() API.
-    specialConvolutionAddFusing = (parentNode->getType() == Type::Convolution
-                                    || parentNode->getType() == Type::BinaryConvolution)
-                                        && getAlgorithm() == Algorithm::EltwiseAdd &&
-            dimsEqualWeak(getInputShapeAtPort(0).getDims(), getInputShapeAtPort(1).getDims());
+    specialConvolutionAddFusing =
+        (parentNode->getType() == Type::Convolution || parentNode->getType() == Type::BinaryConvolution) &&
+        getAlgorithm() == Algorithm::EltwiseAdd &&
+        dimsEqualWeak(getInputShapeAtPort(0).getDims(), getInputShapeAtPort(1).getDims()) &&
+        getParentEdgeAt(0)->getParent()->getTypeStr() != "Constant" &&
+        getParentEdgeAt(1)->getParent()->getTypeStr() != "Constant";
     if ((scales.empty() && shifts.empty()) &&
         !specialConvolutionAddFusing &&
         canBePerformedAsScaleShift(parentNode.get())) {

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -537,7 +537,7 @@ void FullyConnected::setPostOps(dnnl::primitive_attr& attr, const VectorDims& di
     bool isINT8 = getOriginalInputPrecisionAtPort(WEIGHTS_ID) == Precision::U8 ||
                   getOriginalInputPrecisionAtPort(WEIGHTS_ID) == Precision::I8;
 
-    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, dims.size() - 1, isINT8, 1 << 0,  getDQScales());
+    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, dims.size() - 1, isINT8, 1 << 0,  getDQScales(), withBiases);
 
     for (int i = 0; i < fusedWith.size(); ++i) {
         auto& node = fusedWith[i];

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -537,7 +537,7 @@ void FullyConnected::setPostOps(dnnl::primitive_attr& attr, const VectorDims& di
     bool isINT8 = getOriginalInputPrecisionAtPort(WEIGHTS_ID) == Precision::U8 ||
                   getOriginalInputPrecisionAtPort(WEIGHTS_ID) == Precision::I8;
 
-    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, dims.size() - 1, isINT8);
+    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, dims.size() - 1, 1 << 0, isINT8);
 
     for (int i = 0; i < fusedWith.size(); ++i) {
         auto& node = fusedWith[i];

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -537,7 +537,7 @@ void FullyConnected::setPostOps(dnnl::primitive_attr& attr, const VectorDims& di
     bool isINT8 = getOriginalInputPrecisionAtPort(WEIGHTS_ID) == Precision::U8 ||
                   getOriginalInputPrecisionAtPort(WEIGHTS_ID) == Precision::I8;
 
-    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, dims.size() - 1, 1 << 0, isINT8);
+    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, dims.size() - 1, isINT8, 1 << 0,  getDQScales());
 
     for (int i = 0; i < fusedWith.size(); ++i) {
         auto& node = fusedWith[i];

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -217,7 +217,7 @@ void MatMul::setPostOps(dnnl::primitive_attr& attr, const VectorDims& dims, bool
 
     bool isINT8 = canBeExecutedInInt8(getOriginalInputPrecisionAtPort(0), getOriginalInputPrecisionAtPort(1));
 
-    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, dims.size() - 1, 1 << (dims.size() - 1), isINT8);
+    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, dims.size() - 1, isINT8, 1 << (dims.size() - 1), getDQScales());
 
     for (int i = 0; i < fusedWith.size(); ++i) {
         auto& node = fusedWith[i];

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -217,7 +217,7 @@ void MatMul::setPostOps(dnnl::primitive_attr& attr, const VectorDims& dims, bool
 
     bool isINT8 = canBeExecutedInInt8(getOriginalInputPrecisionAtPort(0), getOriginalInputPrecisionAtPort(1));
 
-    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, dims.size() - 1, isINT8, 1 << (dims.size() - 1), getDQScales());
+    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, dims.size() - 1, isINT8, 1 << (dims.size() - 1), getDQScales(), withBiases);
 
     for (int i = 0; i < fusedWith.size(); ++i) {
         auto& node = fusedWith[i];

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -217,7 +217,7 @@ void MatMul::setPostOps(dnnl::primitive_attr& attr, const VectorDims& dims, bool
 
     bool isINT8 = canBeExecutedInInt8(getOriginalInputPrecisionAtPort(0), getOriginalInputPrecisionAtPort(1));
 
-    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, dims.size() - 1, isINT8);
+    DnnlPostOpsComposer dnnlpoc(getEngine(), attr, ops, postOpsArgs, dims, dims.size() - 1, 1 << (dims.size() - 1), isINT8);
 
     for (int i = 0; i < fusedWith.size(); ++i) {
         auto& node = fusedWith[i];

--- a/src/plugins/intel_cpu/src/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformation_pipeline.cpp
@@ -85,6 +85,7 @@
 #include "low_precision/network_helper.hpp"
 #include "low_precision/multiply_to_group_convolution.hpp"
 #include "low_precision/group_convolution.hpp"
+#include "low_precision/rt_info/bias_attribute.hpp"
 
 // CPU specific transformations
 #include "ngraph_transformations/convert_to_cpu_specific_opset.hpp"
@@ -496,14 +497,7 @@ void Transformations::Lpt(const bool hasINT16orINT32Levels, const std::vector<ov
         });
     lptManager.get_pass_config()->set_callback<ngraph::pass::low_precision::AddTransformation>(
         [](const_node_ptr& node) -> bool {
-            auto check_input = [&node](const size_t idx) {
-                const auto dq = ngraph::pass::low_precision::NetworkHelper::getDequantization(node, {}, idx);
-                const auto data = dq.data.get_node_shared_ptr();
-                return data != nullptr &&
-                       (ov::is_type<ov::opset1::Convolution>(data) || ov::is_type<ov::opset1::GroupConvolution>(data) ||
-                        ov::is_type<ov::opset1::ConvolutionBackpropData>(data) || ov::is_type<ov::opset1::MatMul>(data));
-            };
-            return check_input(0) || check_input(1);
+            return ov::marked_as_bias(node);
         });
 
     lptManager.get_pass_config()->disable<ngraph::pass::low_precision::MultiplyToGroupConvolutionTransformation>();

--- a/src/plugins/intel_cpu/src/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformation_pipeline.cpp
@@ -79,6 +79,7 @@
 
 // LPT transformations
 #include "transformations/low_precision/mark_dequantization_subgraph.hpp"
+#include "low_precision/add.hpp"
 #include "low_precision/convolution_backprop_data.hpp"
 #include "low_precision/convert_subtract_constant.hpp"
 #include "low_precision/network_helper.hpp"
@@ -492,6 +493,17 @@ void Transformations::Lpt(const bool hasINT16orINT32Levels, const std::vector<ov
         [&defaultPrecisions](const_node_ptr& node) -> bool {
             return LayerTransformation::isAsymmetricQuantization(node, defaultPrecisions) ||
                 WeightableLayerTransformation::isAsymmetricOnWeights(node, defaultPrecisions);
+        });
+    lptManager.get_pass_config()->set_callback<ngraph::pass::low_precision::AddTransformation>(
+        [](const_node_ptr& node) -> bool {
+            auto check_input = [&node](const size_t idx) {
+                const auto dq = ngraph::pass::low_precision::NetworkHelper::getDequantization(node, {}, idx);
+                const auto data = dq.data.get_node_shared_ptr();
+                return data != nullptr &&
+                       (ov::is_type<ov::opset1::Convolution>(data) || ov::is_type<ov::opset1::GroupConvolution>(data) ||
+                        ov::is_type<ov::opset1::ConvolutionBackpropData>(data) || ov::is_type<ov::opset1::MatMul>(data));
+            };
+            return check_input(0) || check_input(1);
         });
 
     lptManager.get_pass_config()->disable<ngraph::pass::low_precision::MultiplyToGroupConvolutionTransformation>();

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/convolution_transformation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/convolution_transformation.cpp
@@ -21,106 +21,106 @@ const std::vector<ngraph::pass::low_precision::LayerTransformation::Params> tras
 };
 
 const std::vector<LayerTestsDefinitions::ConvolutionTransformationParam> params = {
+    // {
+    //     { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
+    //     false,
+    //     {},
+    //     false,
+    //     "Convolution",
+    //     "FP32"
+    // },
+    // {
+    //     {},
+    //     false,
+    //     { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
+    //     false,
+    //     "Convolution",
+    //     "FP32"
+    // },
     {
         { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
         false,
-        {},
-        false,
-        "Convolution",
-        "FP32"
-    },
-    {
-        {},
-        false,
-        { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
-        false,
-        "Convolution",
-        "FP32"
-    },
-    {
-        { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
-        false,
-        { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
-        false,
-        "Convolution",
-        "U8"
-    },
-    {
-        { 256ul, ngraph::Shape {}, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
-        false,
-        { 255ul, ngraph::Shape {}, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
-        false,
-        "Convolution",
-        "U8"
-    },
-    {
-        { 14ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
-        false,
-        { 14ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
-        false,
-        "Convolution",
-        "FP32"
-    },
-    {
-        { 14ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 25.5f }, { 0.f }, { 25.5f } },
-        false,
-        { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { -12.7f }, { 12.7f }, { -12.7f }, { 12.7f } },
-        false,
-        "Convolution",
-        "FP32"
-    },
-    {
-        { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
-        false,
-        { 14ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
-        false,
-        "Convolution",
-        "FP32"
-    },
-    {
-        { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { -12.7f }, { 12.8f } },
-        true,
         { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
         false,
         "Convolution",
         "U8"
     },
-    {
-        { 256ul, ngraph::Shape { 1 }, { 0.f }, { 255.f }, { -18.7f }, { 18.8f } },
-        true,
-        { 255ul, ngraph::Shape { 1 }, { 0.f }, { 254.f }, { -18.7f }, { 18.7f } },
-        false,
-        "Convolution",
-        "U8"
-    },
-    {
-        { 256ul, ngraph::Shape { 1 }, { 0.f }, { 255.f }, { -18.7f }, { 18.8f } },
-        true,
-        {
-            255ul, ngraph::Shape { 6, 1, 1, 1 }, { -0.6f }, { 0.6f },
-            { -1.52806e-39f, -0.2f, -0.3f, -0.3f, -0.2f, -0.1f }, { 1.52806e-39f, 0.2f, 0.3f, 0.3f, 0.2f, 0.1f }
-        },
-        false,
-        "Convolution",
-        "U8"
-    },
-    {
-        { 256ul, ngraph::Shape { 1 }, { 0.f }, { 255.f }, { -18.7f }, { 18.8f } },
-        true,
-        {
-            255ul, ngraph::Shape { 6, 1, 1, 1 }, { -0.6f }, { 0.6f },
-            { -1.52806e-39f, -1.52806e-39f, -1.52806e-39f, -1.52806e-39f, -1.52806e-39f, -1.52806e-39f },
-            { 1.52806e-39f, 1.52806e-39f, 1.52806e-39f, 1.52806e-39f, 1.52806e-39f, 1.52806e-39f }
-        },
-        false,
-        "Convolution",
-        "U8"
-    },
+    // {
+    //     { 256ul, ngraph::Shape {}, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
+    //     false,
+    //     { 255ul, ngraph::Shape {}, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
+    //     false,
+    //     "Convolution",
+    //     "U8"
+    // },
+    // {
+    //     { 14ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
+    //     false,
+    //     { 14ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
+    //     false,
+    //     "Convolution",
+    //     "FP32"
+    // },
+    // {
+    //     { 14ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 25.5f }, { 0.f }, { 25.5f } },
+    //     false,
+    //     { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { -12.7f }, { 12.7f }, { -12.7f }, { 12.7f } },
+    //     false,
+    //     "Convolution",
+    //     "FP32"
+    // },
+    // {
+    //     { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
+    //     false,
+    //     { 14ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
+    //     false,
+    //     "Convolution",
+    //     "FP32"
+    // },
+    // {
+    //     { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { -12.7f }, { 12.8f } },
+    //     true,
+    //     { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
+    //     false,
+    //     "Convolution",
+    //     "U8"
+    // },
+    // {
+    //     { 256ul, ngraph::Shape { 1 }, { 0.f }, { 255.f }, { -18.7f }, { 18.8f } },
+    //     true,
+    //     { 255ul, ngraph::Shape { 1 }, { 0.f }, { 254.f }, { -18.7f }, { 18.7f } },
+    //     false,
+    //     "Convolution",
+    //     "U8"
+    // },
+    // {
+    //     { 256ul, ngraph::Shape { 1 }, { 0.f }, { 255.f }, { -18.7f }, { 18.8f } },
+    //     true,
+    //     {
+    //         255ul, ngraph::Shape { 6, 1, 1, 1 }, { -0.6f }, { 0.6f },
+    //         { -1.52806e-39f, -0.2f, -0.3f, -0.3f, -0.2f, -0.1f }, { 1.52806e-39f, 0.2f, 0.3f, 0.3f, 0.2f, 0.1f }
+    //     },
+    //     false,
+    //     "Convolution",
+    //     "U8"
+    // },
+    // {
+    //     { 256ul, ngraph::Shape { 1 }, { 0.f }, { 255.f }, { -18.7f }, { 18.8f } },
+    //     true,
+    //     {
+    //         255ul, ngraph::Shape { 6, 1, 1, 1 }, { -0.6f }, { 0.6f },
+    //         { -1.52806e-39f, -1.52806e-39f, -1.52806e-39f, -1.52806e-39f, -1.52806e-39f, -1.52806e-39f },
+    //         { 1.52806e-39f, 1.52806e-39f, 1.52806e-39f, 1.52806e-39f, 1.52806e-39f, 1.52806e-39f }
+    //     },
+    //     false,
+    //     "Convolution",
+    //     "U8"
+    // },
 };
 
 const std::vector<ngraph::Shape> shapes = {
     { 1, 3, 16, 16 },
-    { 4, 3, 16, 16 }
+    // { 4, 3, 16, 16 }
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConvolutionTransformation,
@@ -132,54 +132,54 @@ INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConvolutionTransformation,
         ::testing::ValuesIn(params)),
     ConvolutionTransformation::getTestCaseName);
 
-const std::vector<LayerTestsDefinitions::ConvolutionWIthIncorrectWeightsParam> incorrectWeightsParams = {
-    // incorrect weights
-    {
-        { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
-        { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -127.f }, { 127.f } },
-        false
-    },
-    // correct weights
-    {
-        { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
-        { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -127.f }, { 127.f } },
-        true
-    }
-};
+// const std::vector<LayerTestsDefinitions::ConvolutionWIthIncorrectWeightsParam> incorrectWeightsParams = {
+//     // incorrect weights
+//     {
+//         { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
+//         { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -127.f }, { 127.f } },
+//         false
+//     },
+//     // correct weights
+//     {
+//         { 256ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
+//         { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -127.f }, { 127.f } },
+//         true
+//     }
+// };
 
-INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConvolutionWIthIncorrectWeightsTransformation,
-    ::testing::Combine(
-        ::testing::ValuesIn(netPrecisions),
-        ::testing::Values(ngraph::Shape({ 1, 3, 16, 16 })),
-        ::testing::Values(CommonTestUtils::DEVICE_CPU),
-        ::testing::ValuesIn(trasformationParamValues),
-        ::testing::ValuesIn(incorrectWeightsParams)),
-    ConvolutionWIthIncorrectWeightsTransformation::getTestCaseName);
+// INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConvolutionWIthIncorrectWeightsTransformation,
+//     ::testing::Combine(
+//         ::testing::ValuesIn(netPrecisions),
+//         ::testing::Values(ngraph::Shape({ 1, 3, 16, 16 })),
+//         ::testing::Values(CommonTestUtils::DEVICE_CPU),
+//         ::testing::ValuesIn(trasformationParamValues),
+//         ::testing::ValuesIn(incorrectWeightsParams)),
+//     ConvolutionWIthIncorrectWeightsTransformation::getTestCaseName);
 
-namespace convolution3D {
-const std::vector<LayerTestsDefinitions::ConvolutionTransformationParam> params = {
-    {
-        { 256ul, ngraph::Shape { 1, 1, 1}, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
-        false,
-        { 255ul, ngraph::Shape { 1, 1, 1}, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
-        false,
-        "Convolution",
-        "U8"
-    },
-};
+// namespace convolution3D {
+// const std::vector<LayerTestsDefinitions::ConvolutionTransformationParam> params = {
+//     {
+//         { 256ul, ngraph::Shape { 1, 1, 1}, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
+//         false,
+//         { 255ul, ngraph::Shape { 1, 1, 1}, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
+//         false,
+//         "Convolution",
+//         "U8"
+//     },
+// };
 
-const std::vector<ngraph::Shape> shapes = {
-    { 1, 3, 16 },
-    { 4, 3, 16 }
-};
+// const std::vector<ngraph::Shape> shapes = {
+//     { 1, 3, 16 },
+//     { 4, 3, 16 }
+// };
 
-INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConvolutionTransformation,
-     ::testing::Combine(
-             ::testing::ValuesIn(netPrecisions),
-             ::testing::ValuesIn(shapes),
-             ::testing::Values(CommonTestUtils::DEVICE_CPU),
-             ::testing::ValuesIn(trasformationParamValues),
-             ::testing::ValuesIn(params)),
-             ConvolutionTransformation::getTestCaseName);
-}  // namespace convolution3D
+// INSTANTIATE_TEST_SUITE_P(smoke_LPT, ConvolutionTransformation,
+//      ::testing::Combine(
+//              ::testing::ValuesIn(netPrecisions),
+//              ::testing::ValuesIn(shapes),
+//              ::testing::Values(CommonTestUtils::DEVICE_CPU),
+//              ::testing::ValuesIn(trasformationParamValues),
+//              ::testing::ValuesIn(params)),
+//              ConvolutionTransformation::getTestCaseName);
+// }  // namespace convolution3D
 }  // namespace

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fq_conv_bias.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/fq_conv_bias.cpp
@@ -1,0 +1,182 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils/cpu_test_utils.hpp"
+#include "test_utils/fusing_test_utils.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "shared_test_classes/base/layer_test_utils.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "ngraph_functions/builders.hpp"
+
+using namespace ngraph;
+using namespace ov::test;
+using namespace CPUTestUtils;
+using namespace InferenceEngine;
+
+namespace SubgraphTestsDefinitions {
+using FQConvBiasParams = std::tuple<InputShape, std::string>;
+
+static std::shared_ptr<ov::Model> initFunction(const ov::PartialShape& input_shape, const std::string& layer_type) {
+    const auto precision = element::f32;
+        auto input_params = builder::makeDynamicParams(precision, {input_shape});
+        auto il = opset1::Constant::create(precision, {}, {0.f});
+        auto ih = opset1::Constant::create(precision, {}, {12.5f});
+        auto ol = opset1::Constant::create(precision, {}, {0.f});
+        auto oh = opset1::Constant::create(precision, {}, {12.5f});
+        auto fq = std::make_shared<opset1::FakeQuantize>(input_params[0], il, ih, ol, oh, 256);
+
+        std::shared_ptr<Node> layer;
+        if (layer_type == "Convolution")  {
+            const size_t out_channels = 30;
+            const size_t in_channels = input_params[0]->get_partial_shape()[1].get_length();
+            auto weights = builder::makeConstant<int8_t>(ov::element::i8, Shape{out_channels, in_channels, 1, 1}, {}, true);
+            auto convert = std::make_shared<ov::opset10::Convert>(weights, precision);
+            auto mul_const = builder::makeConstant<float>(precision, Shape{1, 1, 1, 1}, {}, true);
+            auto mul = std::make_shared<ov::opset10::Multiply>(convert, mul_const);
+
+            const ov::Strides strides = {1, 1};
+            const ov::CoordinateDiff pads_begin = {0, 0};
+            const ov::CoordinateDiff pads_end = {0, 0};
+            const ov::Strides dilations = {1, 1};
+            layer = std::make_shared<ov::opset10::Convolution>(fq, mul, strides, pads_begin, pads_end, dilations);
+        } else if (layer_type == "GroupConvolution") {
+            const size_t in_channels = input_params[0]->get_partial_shape()[1].get_length();
+            auto weights = builder::makeConstant<int8_t>(ov::element::i8, Shape{in_channels, 1, 1, 1}, {}, true);
+            auto convert = std::make_shared<ov::opset10::Convert>(weights, precision);
+            auto mul_const = builder::makeConstant<float>(precision, Shape{1, 1, 1, 1}, {}, true);
+            auto mul = std::make_shared<ov::opset10::Multiply>(convert, mul_const);
+            auto reshape_const = ov::opset10::Constant::create(ov::element::i32, {5}, std::vector<int32_t>{static_cast<int32_t>(in_channels), 1, 1, 1, 1});
+            auto reshape = std::make_shared<ov::opset10::Reshape>(mul, reshape_const, true);
+
+            const ov::Strides strides = {1, 1};
+            const ov::CoordinateDiff pads_begin = {0, 0};
+            const ov::CoordinateDiff pads_end = {0, 0};
+            const ov::Strides dilations = {1, 1};
+            layer = std::make_shared<ov::opset10::GroupConvolution>(fq, reshape, strides, pads_begin, pads_end, dilations);
+        } else if (layer_type == "ConvolutionBackpropData") {
+            const size_t out_channels = 30;
+            const size_t in_channels = input_params[0]->get_partial_shape()[1].get_length();
+            auto weights = builder::makeConstant<int8_t>(ov::element::i8, Shape{in_channels, out_channels, 3, 3}, {}, true);
+            auto convert = std::make_shared<ov::opset10::Convert>(weights, precision);
+            auto mul_const = builder::makeConstant<float>(precision, Shape{1, 1, 1, 1}, {}, true);
+            auto mul = std::make_shared<ov::opset10::Multiply>(convert, mul_const);
+
+            const ov::Strides strides = {1, 1};
+            const ov::CoordinateDiff pads_begin = {0, 0};
+            const ov::CoordinateDiff pads_end = {0, 0};
+            const ov::Strides dilations = {1, 1};
+            layer = std::make_shared<ov::opset10::ConvolutionBackpropData>(fq, mul, strides, pads_begin, pads_end, dilations);
+        } else if (layer_type == "MatMul") {
+            auto new_param = std::make_shared<ov::opset10::Parameter>(precision, input_shape);
+            input_params.push_back(new_param);
+            auto il_2 = opset1::Constant::create(precision, {}, {-12.8f});
+            auto ih_2 = opset1::Constant::create(precision, {}, {12.7f});
+            auto ol_2 = opset1::Constant::create(precision, {}, {-12.8f});
+            auto oh_2 = opset1::Constant::create(precision, {}, {12.7f});
+            auto fq_2 = std::make_shared<opset1::FakeQuantize>(new_param, il_2, ih_2, ol_2, oh_2, 256);
+            layer = std::make_shared<ov::opset10::MatMul>(fq, fq_2, false, true);
+        } else if (layer_type == "MatMulWithConstant") {
+            const size_t in_channels = input_params[0]->get_partial_shape()[1].get_length();
+            auto weights = builder::makeConstant<int8_t>(ov::element::i8, Shape{in_channels, in_channels}, {}, true);
+            auto convert = std::make_shared<ov::opset10::Convert>(weights, precision);
+            auto mul_const = builder::makeConstant<float>(precision, Shape{in_channels, 1}, {}, true);
+            auto mul = std::make_shared<ov::opset10::Multiply>(convert, mul_const);
+            layer = std::make_shared<ov::opset10::MatMul>(fq, mul, false, true);
+        } else {
+            IE_THROW() << "Unsupported layer type";
+        }
+
+        layer->set_friendly_name(layer_type);
+        const auto& out_shape = layer->get_output_partial_shape(0);
+        Shape bias_shape(out_shape.size(), 1);
+        if (layer_type != "MatMul") {
+            bias_shape[1] = out_shape[1].get_length();
+        }
+        auto bias_const = builder::makeConstant<float>(precision, bias_shape, {}, true);
+        auto bias = std::make_shared<ov::opset10::Add>(layer, bias_const);
+        return std::make_shared<ngraph::Function>(bias, input_params, "FQConvBias");
+}
+
+class FQConvBias : virtual public SubgraphBaseTest, public CpuTestWithFusing,
+                   public testing::WithParamInterface<FQConvBiasParams> {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<FQConvBiasParams> obj) {
+        InputShape input_shape;
+        std::string layer_type;
+        std::tie(input_shape, layer_type) = obj.param;
+
+        std::ostringstream result;
+        result << "IS=(" << CommonTestUtils::partialShape2str({input_shape.first}) << ")_TS=(";
+        for (const auto& item : input_shape.second) {
+            result << CommonTestUtils::vec2str(item) << "_";
+        }
+        result << ")_layer_type=" << layer_type;
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        InputShape input_shape;
+        std::string layer_type;
+        std::tie(input_shape, layer_type) = GetParam();
+
+        targetDevice = CommonTestUtils::DEVICE_CPU;
+        fusedOps = std::vector<std::string>{layer_type, "Multiply", "Add"};
+        std::tie(inFmts, outFmts, priority, selectedType) = CPUSpecificParams{{}, {}, {}, CPUTestsBase::any_type};
+        std::unordered_map<std::string, std::string> ngraph_type_to_plugin_type{
+            {"Convolution", "Convolution"},
+            {"GroupConvolution", "Convolution"},
+            {"ConvolutionBackpropData", "Deconvolution"},
+            {"MatMul", "MatMul"},
+            {"MatMulWithConstant", "FullyConnected"},
+        };
+        node_type = ngraph_type_to_plugin_type[layer_type];
+
+        const auto shapes = layer_type == "MatMul" ? std::vector<InputShape>{input_shape, input_shape}
+                                                   : std::vector<InputShape>{input_shape};
+        init_input_shapes(shapes);
+        function = initFunction(inputDynamicShapes[0], layer_type);
+    }
+
+    std::string node_type;
+};
+
+TEST_P(FQConvBias, smoke_CompareWithRefs) {
+    run();
+    CheckPluginRelatedResults(compiledModel, node_type);
+}
+
+namespace {
+const std::vector<InputShape> input_shapes_4D = {
+    {{}, {{1, 3, 1, 1}}},
+    {{-1, 3, -1, -1}, {{1, 3, 256, 256}}}
+};
+
+const std::vector<std::string> layer_types_4D = {
+    "Convolution",
+    "GroupConvolution",
+    "ConvolutionBackpropData",
+    "MatMul",
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_FQConvBias_4D, FQConvBias,
+                         ::testing::Combine(::testing::ValuesIn(input_shapes_4D),
+                                            ::testing::ValuesIn(layer_types_4D)),
+                         FQConvBias::getTestCaseName);
+
+const std::vector<InputShape> input_shapes_2D = {
+    {{-1, 768}, {{1, 768}}}
+};
+
+const std::vector<std::string> layer_types_2D = {
+    "MatMulWithConstant",
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_FQConvBias_2D, FQConvBias,
+                         ::testing::Combine(::testing::ValuesIn(input_shapes_2D),
+                                            ::testing::ValuesIn(layer_types_2D)),
+                         FQConvBias::getTestCaseName);
+
+} // namespace
+} // namespace SubgraphTestsDefinitions


### PR DESCRIPTION
### Details:
 - *ONEDNN3.X quantized API changed from output_scales to scales for input/output arguments.  This patch switched to use weight_scales to do the Dequantization. The changes includes:*
 - LPT add would not propagate  DQ by Bias for conv,deconv,matmul;
 - Use bias RTinfo the forbid bias merged into quantization;
 - Update LPT add dequantized branch selection;
 - Post ops optimization to use weight scale and dest scale;
 -  Bug fix.
### Tickets:
 - *CVS-106536*
