### PR TITLE
[CORE] Added optimized fp32->fp16 precision conversion implementation

### DIFF
--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -823,6 +823,26 @@ std::shared_ptr<Node> change_constant_precision<ov::element::Type_t::f16, ov::el
     return new_constant;
 }
 
+template <>
+std::shared_ptr<Node> change_constant_precision<ov::element::Type_t::f32, ov::element::Type_t::f16>(
+    std::shared_ptr<opset4::Constant>& constant) {
+    using src_type = typename element_type_traits<ov::element::Type_t::f32>::value_type;
+    using dst_type = typename element_type_traits<ov::element::Type_t::f16>::value_type;
+
+    const auto* src_data = constant->get_data_ptr<src_type>();
+    const auto size = shape_size(constant->get_shape());
+
+    auto new_constant = std::make_shared<opset4::Constant>(ov::element::Type_t::f16, constant->get_shape());
+    new_constant->output(0).set_names(constant->output(0).get_names());
+    auto* dst_data = const_cast<dst_type*>(reinterpret_cast<const dst_type*>(new_constant->get_data_ptr()));
+    if (dst_data == nullptr)
+        throw Exception("Can't get destination data pointer");
+
+    ngraph::runtime::reference::convert<src_type, dst_type>(src_data, dst_data, size);
+
+    return new_constant;
+}
+
 /**
  * @brief Method converts low precision integer types
  * The method uses the next logic for conversion:

--- a/src/core/reference/include/ngraph/runtime/reference/convert.hpp
+++ b/src/core/reference/include/ngraph/runtime/reference/convert.hpp
@@ -107,6 +107,8 @@ void convert<uint8_t, float16>(const uint8_t* arg, float16* out, size_t count);
 template <>
 void convert<float16, float>(const float16* arg, float* out, size_t count);
 template <>
+void convert<float, float16>(const float* arg, float16* out, size_t count);
+template <>
 void convert<float, int8_t>(const float* arg, int8_t* out, size_t count);
 template <>
 void convert<float16, int8_t>(const float16* arg, int8_t* out, size_t count);

--- a/src/core/reference/src/runtime/reference/convert.cpp
+++ b/src/core/reference/src/runtime/reference/convert.cpp
@@ -44,6 +44,16 @@ void jit_convert_vec<float16, float>(jit::Generator& gen, const Xbyak::RegExp& s
 }
 
 template <>
+void jit_convert_vec<float, float16>(jit::Generator& gen, const Xbyak::RegExp& src, const Xbyak::RegExp& dst) {
+    auto f16vec = gen.xmm3;
+    auto f32vec = gen.ymm4;
+
+    gen.vmovups(f32vec, gen.yword[src]);
+    gen.vcvtps2ph(f16vec, f32vec, 0);
+    gen.vmovdqu(gen.xword[dst], f16vec);
+}
+
+template <>
 void jit_convert_vec_prepare<float, int8_t>(jit::Generator& gen) {
     auto order = gen.ymm1;
     auto addr = gen.r15;
@@ -203,6 +213,11 @@ void convert<uint8_t, float16>(const uint8_t* arg, float16* out, size_t count) {
 
 template <>
 void convert<float16, float>(const float16* arg, float* out, size_t count) {
+    convert_impl(arg, out, count);
+}
+
+template <>
+void convert<float, float16>(const float* arg, float16* out, size_t count) {
     convert_impl(arg, out, count);
 }
 


### PR DESCRIPTION
### Details:
GPU pugin enabled ov::hint:inference_precision property suppport which alllows OV users to launch FP16 inference on FP32 models. In that scenario we are facing bad model compilation time due to slow FP32->FP16 precision conversion procedure.

The PR adds optimized implementation for FP32->FP16 conversion routine that allows to significantly speedup (up to several times) FP32 model compilation stage in case of FP16 inference.