### PR TITLE
[PyOV] Dependabot - ignore `openvino-dev` dependency

### DIFF
--- a/tools/openvino_dev/requirements_dev.txt.in
+++ b/tools/openvino_dev/requirements_dev.txt.in
@@ -1,1 +1,1 @@
-openvino-dev${EXTRAS}==${WHEEL_VERSION}
+openvino-dev${EXTRAS}==${WHEEL_VERSION}  # dependabot-ignore


### PR DESCRIPTION
### Details:
 - Fix for an issue seen in https://github.com/openvinotoolkit/openvino/network/updates/636684762
 - Dependabot doesn't see environment variables
 - They can be set, but the variables in this requirement are defined during runtime
 - All the work on setting them is not worth it since dependabot will never update `openvino-dev`, as it's our own package with dynamic versioning
 - Ignoring the package will do no harm and will let us get rid of an error in workflows

### Tickets:
 - NA
