### PR TITLE
[TF FE] Activate TopK layer test with the second output in the pre-commit

### DIFF
--- a/tests/layer_tests/tensorflow_tests/test_tf_TopKV2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TopKV2.py
@@ -38,8 +38,9 @@ class TestTopKV2(CommonTFLayerTest):
              is_second_output=False),
         dict(input_shape=[4, 12], input_type=tf.float32, k=10, sorted=True, is_first_output=True,
              is_second_output=True),
-        dict(input_shape=[5, 10], input_type=tf.int32, k=8, sorted=False, is_first_output=True,
-             is_second_output=True),
+        # Expect stable mode implementation for sort_type=indices in OpenVINO. See 101503
+        pytest.param(dict(input_shape=[5, 10], input_type=tf.int32, k=8, sorted=False, is_first_output=True,
+                          is_second_output=True), marks=pytest.mark.xfail(reason="101503")),
     ]
 
     @pytest.mark.parametrize("params", test_basic)

--- a/tests/layer_tests/tensorflow_tests/test_tf_TopKV2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TopKV2.py
@@ -36,11 +36,10 @@ class TestTopKV2(CommonTFLayerTest):
         dict(input_shape=[10], input_type=tf.float32, k=5, sorted=True, is_first_output=True, is_second_output=False),
         dict(input_shape=[2, 3, 10], input_type=tf.int32, k=10, sorted=True, is_first_output=True,
              is_second_output=False),
-        # Expect stable mode support by the CPU plugin. See 101503
-        pytest.param(dict(input_shape=[4, 12], input_type=tf.float32, k=10, sorted=True, is_first_output=True,
-                          is_second_output=True), marks=pytest.mark.xfail(reason="101503")),
-        pytest.param(dict(input_shape=[5, 10], input_type=tf.int32, k=8, sorted=False, is_first_output=True,
-                          is_second_output=True), marks=pytest.mark.xfail(reason="101503")),
+        dict(input_shape=[4, 12], input_type=tf.float32, k=10, sorted=True, is_first_output=True,
+             is_second_output=True),
+        dict(input_shape=[5, 10], input_type=tf.int32, k=8, sorted=False, is_first_output=True,
+             is_second_output=True),
     ]
 
     @pytest.mark.parametrize("params", test_basic)


### PR DESCRIPTION
**Details:** The CPU plugin recently introduced TopK-11 operation with stable mode and TF FE moved to TopK-11. So we are ready to activate it in the TF FE layer tests.

**Ticket:** TBD
