### PR TITLE
[GNA] Enable GNA 3.5 part 3 -  Fix 1D Pooling realized as part of 2D Convolution

### DIFF
--- a/src/plugins/intel_gna/src/backend/gna_limitations.cpp
+++ b/src/plugins/intel_gna/src/backend/gna_limitations.cpp
@@ -599,6 +599,12 @@ std::string Validator_35::ValidatePooling(const CnnLimits& limits,
     auto error = limits.kPoolingWindowHWLimit.GetErrorOrEmpty(windowH, windowW);
     error += limits.kPoolingStrideHWLimit.GetErrorOrEmpty(strideH, strideW);
 
+    const RangeLimit poolingStrideHLimit{1, windowH, "pooling stride height (must be up to pooling window height)"};
+    const RangeLimit poolingStrideWLimit{1, windowW, "pooling stride width (must be up to pooling window width)"};
+
+    error += poolingStrideHLimit.GetErrorOrEmpty(strideH);
+    error += poolingStrideWLimit.GetErrorOrEmpty(strideW);
+
     return error;
 }
 

--- a/src/plugins/intel_gna/src/gna_graph_compiler.cpp
+++ b/src/plugins/intel_gna/src/gna_graph_compiler.cpp
@@ -342,7 +342,7 @@ void GNAGraphCompiler::ConvolutionPrimitive(InferenceEngine::CNNLayerPtr layer) 
     auto out_height = InferenceEngine::GetDataDimByName(outputs, InferenceEngine::DataDimName::H);
     auto out_width = InferenceEngine::GetDataDimByName(outputs, InferenceEngine::DataDimName::W);
 
-    if (in_height > 1 && in_width == 1) {
+    if (in_height > 1 && in_width == 1 && !ShouldUseOnlyConv2DGnaIface()) {
         std::swap(in_height, in_width);
         std::swap(out_height, out_width);
         std::swap(convolution._kernel_x, convolution._kernel_y);
@@ -980,13 +980,6 @@ void GNAGraphCompiler::PoolingPrimitive(InferenceEngine::CNNLayerPtr layer) {
     uint32_t h_dim_out = InferenceEngine::GetDataDimByName(outputs, InferenceEngine::DataDimName::H);
     const uint32_t c_dim_out = InferenceEngine::GetDataDimByName(outputs, InferenceEngine::DataDimName::C);
 
-    if (w_dim_in == 1) {  // swap dimensions if needed to support swapped 1D case
-        std::swap(h_dim_in, w_dim_in);
-        std::swap(h_dim_out, w_dim_out);
-        std::swap(pooling._kernel[X_AXIS], pooling._kernel[Y_AXIS]);
-        std::swap(pooling._stride[X_AXIS], pooling._stride[Y_AXIS]);
-    }
-
     void* ptr_inputs = nullptr;
     void* ptr_outputs = nullptr;
 
@@ -999,6 +992,13 @@ void GNAGraphCompiler::PoolingPrimitive(InferenceEngine::CNNLayerPtr layer) {
             const auto& prev2 = *std::prev(dnnComponents.components.cend(), 2);
             is2DPooling = prev2.dnnComponent.operation == kDnnConvolutional2dOp;
         }
+    }
+
+    if (w_dim_in == 1 && !ShouldUseOnlyConv2DGnaIface()) {  // swap dimensions if needed to support swapped 1D case
+        std::swap(h_dim_in, w_dim_in);
+        std::swap(h_dim_out, w_dim_out);
+        std::swap(pooling._kernel[X_AXIS], pooling._kernel[Y_AXIS]);
+        std::swap(pooling._stride[X_AXIS], pooling._stride[Y_AXIS]);
     }
 
     if (is2DPooling) {

--- a/src/plugins/intel_gna/tests/functional/pass_tests/remove_permutations_NHWC_to_NCHW_pass.cpp
+++ b/src/plugins/intel_gna/tests/functional/pass_tests/remove_permutations_NHWC_to_NCHW_pass.cpp
@@ -649,7 +649,9 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::
                                                                InferenceEngine::Precision::FP16};
 
 const std::vector<std::map<std::string, std::string>> configs = {
-    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "327.67"}},
+    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "327.67"}, {"GNA_EXEC_TARGET", "GNA_TARGET_2_0"}},
+    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "327.67"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}},
+    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "327.67"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}},
     {{"GNA_DEVICE_MODE", "GNA_SW_FP32"}}};
 
 const std::vector<std::vector<size_t>> inputShapes{


### PR DESCRIPTION
### Details:
 - avoid swap of H with W in pooling when Convolution 2D is not enforced

### Tickets:
 - 105916
