### PR TITLE
[GNA] Fix issues with GNA 3.5 - Fix pooling for Convolution1D and Convolution2D

### DIFF
--- a/src/plugins/intel_gna/src/backend/gna_limitations.cpp
+++ b/src/plugins/intel_gna/src/backend/gna_limitations.cpp
@@ -606,6 +606,12 @@ std::string Validator_35::ValidatePooling(const CnnLimits& limits,
     auto error = limits.kPoolingWindowHWLimit.GetErrorOrEmpty(windowH, windowW);
     error += limits.kPoolingStrideHWLimit.GetErrorOrEmpty(strideH, strideW);
 
+    const RangeLimit poolingStrideHLimit{1, windowH, "pooling stride height (must be up to pooling window height)"};
+    const RangeLimit poolingStrideWLimit{1, windowW, "pooling stride width (must be up to pooling window width)"};
+
+    error += poolingStrideHLimit.GetErrorOrEmpty(strideH);
+    error += poolingStrideWLimit.GetErrorOrEmpty(strideW);
+
     return error;
 }
 

--- a/src/plugins/intel_gna/src/runtime/cnn.cpp
+++ b/src/plugins/intel_gna/src/runtime/cnn.cpp
@@ -317,8 +317,12 @@ bool is2D(T&& vec) {
 }
 }  // namespace
 
-void CNNMaxPool(intel_dnn_component_t* component, intel_dnn_number_type_t number_type, const bool sumPoolingOverRide) {
-    if (is2D(component->op.maxpool.poolingStrideXY) || is2D(component->op.maxpool.poolingWindowXY)) {
+void CNNMaxPool(intel_dnn_component_t* component,
+                intel_dnn_number_type_t number_type,
+                const bool fused_with_convolution_2d,
+                const bool sumPoolingOverRide) {
+    if (fused_with_convolution_2d || is2D(component->op.maxpool.poolingStrideXY) ||
+        is2D(component->op.maxpool.poolingWindowXY)) {
         if (!sumPoolingOverRide) {
             CNNMaxPool2DFloat(component);
         } else {

--- a/src/plugins/intel_gna/src/runtime/cnn.h
+++ b/src/plugins/intel_gna/src/runtime/cnn.h
@@ -14,6 +14,7 @@
 void CNNFilter32(intel_dnn_component_t* component);
 void CNNMaxPool(intel_dnn_component_t* component,
                 intel_dnn_number_type_t number_type,
+                const bool fused_with_convolution_2d,
                 const bool sumPoolingOverRide = false);
 
 void CNN2DFilter32(intel_dnn_component_t* component);

--- a/src/plugins/intel_gna/src/runtime/gna_float_runtime.cpp
+++ b/src/plugins/intel_gna/src/runtime/gna_float_runtime.cpp
@@ -71,7 +71,12 @@ void FP::infer() {
             break;
         }
         case kDnnMaxPoolOp: {
-            ApplyMaxPoolTransform(comp, kDnnFloat);
+            bool is_fused_with_convolution_2d = false;
+            if (i > 0 && dnn->component[i - 1].operation == kDnnConvolutional2dOp) {
+                is_fused_with_convolution_2d = true;
+            }
+
+            ApplyMaxPoolTransform(comp, kDnnFloat, is_fused_with_convolution_2d);
             break;
         }
         case kDnnInterleaveOp: {

--- a/src/plugins/intel_gna/src/runtime/gna_float_runtime.hpp
+++ b/src/plugins/intel_gna/src/runtime/gna_float_runtime.hpp
@@ -35,7 +35,9 @@ public:
                                               intel_dnn_number_type_t number_type,
                                               uint32_t listsize,
                                               uint32_t num_row);
-    static void ApplyMaxPoolTransform(intel_dnn_component_t* component, intel_dnn_number_type_t number_type);
+    static void ApplyMaxPoolTransform(intel_dnn_component_t* component,
+                                      intel_dnn_number_type_t number_type,
+                                      const bool fused_with_convolution_2d);
     static void ApplyTranspose(intel_dnn_component_t* component);
     static void ApplyCopy(intel_dnn_component_t* component);
 };

--- a/src/plugins/intel_gna/src/runtime/gna_float_runtime_op.cpp
+++ b/src/plugins/intel_gna/src/runtime/gna_float_runtime_op.cpp
@@ -140,11 +140,13 @@ void FP::ApplyPiecewiseLinearTransform(intel_dnn_component_t* component,
     PwlApply32(component, num_row, num_row, 0, listsize - 1);
 }
 
-void FP::ApplyMaxPoolTransform(intel_dnn_component_t* component, intel_dnn_number_type_t number_type) {
+void FP::ApplyMaxPoolTransform(intel_dnn_component_t* component,
+                               intel_dnn_number_type_t number_type,
+                               const bool fused_with_convolution_2d) {
     if (4 != component->num_bytes_per_input) {
         THROW_GNA_EXCEPTION << "Bad data width: " << component->num_bytes_per_input;
     }
-    CNNMaxPool(component, number_type);
+    CNNMaxPool(component, number_type, fused_with_convolution_2d);
 }
 
 void FP::ApplyTranspose(intel_dnn_component_t* component) {

--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/subgraph_tests/convolution_relu_sequence.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/subgraph_tests/convolution_relu_sequence.cpp
@@ -165,6 +165,10 @@ const std::vector<std::map<std::string, std::string>> configs = {
     {{InferenceEngine::GNAConfigParams::KEY_GNA_DEVICE_MODE, InferenceEngine::GNAConfigParams::GNA_SW_FP32}},
     {{InferenceEngine::GNAConfigParams::KEY_GNA_DEVICE_MODE, InferenceEngine::GNAConfigParams::GNA_SW_EXACT}}};
 
+const std::vector<std::map<std::string, std::string>> cofigs_exec_targets_supporting_legacy_convolution = {
+    {{InferenceEngine::GNAConfigParams::KEY_GNA_DEVICE_MODE, InferenceEngine::GNAConfigParams::GNA_SW_EXACT},
+     {InferenceEngine::GNAConfigParams::KEY_GNA_EXEC_TARGET, InferenceEngine::GNAConfigParams::GNA_TARGET_2_0}}};
+
 // Enable when using GNA 2.1 library
 INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionReluSequenceTest,
                          GnaConvolutionReluSequenceTest,
@@ -236,34 +240,45 @@ const std::vector<convReluSpecificParams> poolingStrideAboveWindow = {
     },
 };
 
-const std::vector<convReluSpecificParamsAll> poolingStrideNotEqualWindowAll = {
-    {inputShape1Even, poolingStrideBelowWindow},
-    {inputShape1DOneAbove, poolingStrideBelowWindow},
-    {inputShape1DOneBelow, poolingStrideBelowWindow},
+const std::vector<convReluSpecificParamsAll> poolingStrideNotEqualWindow_Above = {
     {inputShape1Even, poolingStrideAboveWindow},
     {inputShape1DOneAbove, poolingStrideAboveWindow},
     {inputShape1DOneBelow, poolingStrideAboveWindow},
-    {inputShape1DMultichannel4, poolingStrideBelowWindow},
     {inputShape1DMultichannel4, poolingStrideAboveWindow},
-    {inputShape1DMultichannel5, poolingStrideBelowWindow},
     {inputShape1DMultichannel5, poolingStrideAboveWindow},
-    {inputShape1DMultichannel6, poolingStrideBelowWindow},
     {inputShape1DMultichannel6, poolingStrideAboveWindow},
-    {inputShape1DMultichannel7, poolingStrideBelowWindow},
     {inputShape1DMultichannel7, poolingStrideAboveWindow},
-    {inputShape1DMultichannel8, poolingStrideBelowWindow},
     {inputShape1DMultichannel8, poolingStrideAboveWindow},
-    {inputShape1DMultichannel9, poolingStrideBelowWindow},
     {inputShape1DMultichannel9, poolingStrideAboveWindow}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionPoolingStrideNotEqualWindowTest,
+INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionPoolingStrideNotEqualWindowTest_Above,
                          ConvolutionReluSequenceTest,
-                         ::testing::Combine(::testing::ValuesIn(poolingStrideNotEqualWindowAll),
+                         ::testing::Combine(::testing::ValuesIn(poolingStrideNotEqualWindow_Above),
+                                            ::testing::ValuesIn(netPrecisions),
+                                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
+                                            ::testing::Values(CommonTestUtils::DEVICE_GNA),
+                                            ::testing::ValuesIn(cofigs_exec_targets_supporting_legacy_convolution)),
+                         ConvolutionReluSequenceTest::getTestCaseName);
+
+const std::vector<convReluSpecificParamsAll> poolingStrideNotEqualWindow_Below = {
+    {inputShape1Even, poolingStrideBelowWindow},
+    {inputShape1DOneAbove, poolingStrideBelowWindow},
+    {inputShape1DOneBelow, poolingStrideBelowWindow},
+    {inputShape1DMultichannel4, poolingStrideBelowWindow},
+    {inputShape1DMultichannel5, poolingStrideBelowWindow},
+    {inputShape1DMultichannel6, poolingStrideBelowWindow},
+    {inputShape1DMultichannel7, poolingStrideBelowWindow},
+    {inputShape1DMultichannel8, poolingStrideBelowWindow},
+    {inputShape1DMultichannel9, poolingStrideBelowWindow}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionPoolingStrideNotEqualWindowTest_Below,
+                         ConvolutionReluSequenceTest,
+                         ::testing::Combine(::testing::ValuesIn(poolingStrideNotEqualWindow_Below),
                                             ::testing::ValuesIn(netPrecisions),
                                             ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
                                             ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
                                             ::testing::Values(CommonTestUtils::DEVICE_GNA),
                                             ::testing::ValuesIn(configs)),
-
                          ConvolutionReluSequenceTest::getTestCaseName);
 }  // namespace


### PR DESCRIPTION
### Details:
 - avoid swap of H with W in pooling when Convolution 2D is not enforced 
 - add enforcing of Pooling2D for FP32
 - reconfigured tests for  window/stride of pooling

### Tickets:
 - 105916
