### PR TITLE
Enable nop elimination for f16 type

### DIFF
--- a/src/common/transformations/src/transformations/utils/utils.cpp
+++ b/src/common/transformations/src/transformations/utils/utils.cpp
@@ -271,6 +271,9 @@ bool can_eliminate_eltwise_node(const std::shared_ptr<Node>& eltwise,
     case element::f32:
         actual_const = reinterpret_cast<const float*>(data_ptr)[0];
         break;
+    case element::f16:
+        actual_const = reinterpret_cast<const ov::float16*>(data_ptr)[0];
+        break;
     case element::i32:
         actual_const = static_cast<float>(reinterpret_cast<const int32_t*>(data_ptr)[0]);
         break;

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -971,6 +971,7 @@ public:
 
 std::vector<element::Type> types{
     element::f32,
+    element::f16,
     element::f64,
     element::i32,
     element::u32,


### PR DESCRIPTION
### Details:
 - Helps to avoid nops for fp16 models (SD2.1 specifically) on GPU
