### PR TITLE
[POT] POT deprecation warning

### DIFF
--- a/tools/pot/compression/__init__.py
+++ b/tools/pot/compression/__init__.py
@@ -2,15 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import sys
-import warnings
 
 import openvino.tools.pot.api
 import openvino.tools.pot.engines
 import openvino.tools.pot.graph
 import openvino.tools.pot.pipeline
+from openvino.tools.pot.utils.logger import get_logger
 
 
-warnings.warn('Import compression is deprecated. Please use openvino.tools.pot instead', DeprecationWarning)
+logger = get_logger(__name__)
+logger.warning('Import compression is deprecated. Please use openvino.tools.pot instead')
+
 
 sys.modules["compression.api"] = openvino.tools.pot.api
 sys.modules["compression.engines"] = openvino.tools.pot.engines

--- a/tools/pot/openvino/tools/pot/algorithms/quantization/optimization/algorithm.py
+++ b/tools/pot/openvino/tools/pot/algorithms/quantization/optimization/algorithm.py
@@ -19,13 +19,17 @@ from ....graph.model_utils import save_model
 from ....samplers.creator import create_sampler
 from ....utils.logger import get_logger
 
+
+logger = get_logger(__name__)
+
+
 try:
     import nevergrad as ng
 
     NEVERGRAD_AVAILABLE = True
 except ImportError:
     NEVERGRAD_AVAILABLE = False
-    warnings.warn(
+    logger.warning(
         'Nevergrad package could not be imported. If you are planning to use '
         'any hyperparameter optimization algo, consider installing it '
         'using pip. This implies advanced usage of the tool. '
@@ -38,8 +42,6 @@ try:
     SKOPT_AVAILABLE = True
 except ImportError:
     SKOPT_AVAILABLE = False
-
-logger = get_logger(__name__)
 
 
 @COMPRESSION_ALGORITHMS.register('OptimizationAlgorithm')

--- a/tools/pot/openvino/tools/pot/api/__init__.py
+++ b/tools/pot/openvino/tools/pot/api/__init__.py
@@ -4,6 +4,14 @@
 from .data_loader import DataLoader
 from .engine import Engine
 from .metric import Metric
+from openvino.tools.pot.utils.logger import get_logger
+
+
+logger = get_logger(__name__)
+logger.warning('Post-training Optimization Tool is deprecated and will be removed in the future.'
+               ' Please use Neural Network Compression Framework'
+               ' instead: https://github.com/openvinotoolkit/nncf')
+
 
 __all__ = [
     'Metric', 'DataLoader', 'Engine'

--- a/tools/pot/openvino/tools/pot/app/run.py
+++ b/tools/pot/openvino/tools/pot/app/run.py
@@ -27,6 +27,9 @@ def main():
 
 
 def app(argv):
+    logger.warning('Post-training Optimization Tool is deprecated and will be removed in the future.'
+                   ' Please use Neural Network Compression Framework'
+                   ' instead: https://github.com/openvinotoolkit/nncf')
     telemetry = start_session_telemetry()
     parser = get_common_argument_parser()
     args = parser.parse_args(args=argv)


### PR DESCRIPTION
POT deprecation warning  is added.

Example:
```
$ pot
/home/dlyakhov/env/tmp/lib/python3.8/site-packages/openvino/offline_transformations/__init__.py:10: FutureWarning: The module is private and following namespace `offline_transformations` will be removed in the future, use `openvino.runtime.passes` instead!
  warnings.warn(
Post-training Optimization Tool is deprecated and will be removed in future.```