### PR TITLE
[GPU] Use unique symbol name for typedef

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/experimental_detectron_generate_proposals_single_image_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/experimental_detectron_generate_proposals_single_image_ref.cl
@@ -86,7 +86,7 @@ KERNEL(edgpsi_ref_stage_0)
 #endif /* EDGPSI_STAGE_0 */
 
 #ifdef EDGPSI_STAGE_1
-
+#define Box FUNC(_Box)
 typedef struct __attribute__((__packed__)) {
     INPUT0_TYPE x0;
     INPUT0_TYPE y0;
@@ -181,6 +181,7 @@ KERNEL(edgpsi_ref_stage_1)(__global OUTPUT_TYPE* proposals) {
 
     FUNC_CALL(quickSortIterative)(boxes, 0, NUM_PROPOSALS-1);
 }
+#undef Box
 #endif /* EDGPSI_STAGE_1 */
 
 #ifdef EDGPSI_STAGE_2

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/generate_proposals_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/generate_proposals_ref.cl
@@ -92,7 +92,7 @@ KERNEL(generate_proposals_ref_stage_0)
 #endif /* GENERATE_PROPOSALS_STAGE_0 */
 
 #ifdef GENERATE_PROPOSALS_STAGE_1
-
+#define Box FUNC(__Box)
 typedef struct __attribute__((__packed__)) {
     INPUT0_TYPE x0;
     INPUT0_TYPE y0;
@@ -190,6 +190,7 @@ KERNEL(generate_proposals_ref_stage_1)(__global OUTPUT_TYPE* proposals) {
 
     FUNC_CALL(quickSortIterative)(boxes, 0, NUM_PROPOSALS-1);
 }
+#undef Box
 #endif /* GENERATE_PROPOSALS_STAGE_1 */
 
 #ifdef GENERATE_PROPOSALS_STAGE_2


### PR DESCRIPTION
### Details:
- OpenCL kernel should use unique symbol name
- These two kernels were not using unique name
- Test is unnecessary as the test will be very specific to this change.

### Tickets:
 - 107132
