### PR TITLE
Fixed command lines in MO docs.

### DIFF
--- a/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_EfficientDet_Models.md
+++ b/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_EfficientDet_Models.md
@@ -12,55 +12,13 @@ Converting EfficientDet Model to the IR
 There are several public versions of EfficientDet model implementation available on GitHub. This tutorial explains how to
 convert models from the `repository <https://github.com/google/automl/tree/master/efficientdet>`__  (commit 96e1fee) to the OpenVINO format.
 
-Getting a Frozen TensorFlow Model
-+++++++++++++++++++++++++++++++++
-
-Follow the instructions below to get frozen TensorFlow EfficientDet model. EfficientDet-D4 model is an example:
-
-1. Clone the repository:
-
-.. code-block:: sh
-
-   git clone https://github.com/google/automl
-   cd automl/efficientdet
-
-2. (Optional) Checkout to the commit that the conversion was tested on:
-
-.. code-block:: sh
-
-   git checkout ecbc7a3
-
-3. Install required dependencies:
-
-.. code-block:: sh
-
-   python3 -m pip install --upgrade pip
-   python3 -m pip install -r requirements.txt
-   python3 -m pip install --upgrade tensorflow-model-optimization
-
-4. Download and extract the model checkpoint `efficientdet-d4.tar.gz <https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco2/efficientdet-d4.tar.gz>`__
+Download and extract the model checkpoint `efficientdet-d4.tar.gz <https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco2/efficientdet-d4.tar.gz>`__
 referenced in the **"Pretrained EfficientDet Checkpoints"** section of the model repository:
 
 .. code-block:: sh
 
    wget https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco2/efficientdet-d4.tar.gz
    tar zxvf efficientdet-d4.tar.gz
-
-5. Freeze the model:
-
-.. code-block:: sh
-
-    python3 model_inspect.py --runmode=saved_model --model_name=efficientdet-d4  --ckpt_path=efficientdet-d4 --saved_model_dir=savedmodeldir
-
-As a result, the frozen model file ``savedmodeldir/efficientdet-d4_frozen.pb`` will be generated.
-
-.. note::
-
-    For custom trained models, specify ``--hparams`` flag to ``config.yaml`` which was used during training.
-
-.. note::
-
-    If you see an error *AttributeError: module 'tensorflow_core.python.keras.api._v2.keras.initializers' has no attribute 'variance_scaling'*, apply the fix from the `patch <https://github.com/google/automl/pull/846>`__.
 
 Converting an EfficientDet TensorFlow Model to the IR
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -70,8 +28,7 @@ To generate the IR of the EfficientDet TensorFlow model, run:
 .. code-block:: sh
 
    mo \
-   --input_model savedmodeldir/efficientdet-d4_frozen.pb \
-   --transformations_config front/tf/automl_efficientdet.json \
+   --input_meta_graph efficientdet-d4/model.meta \
    --input_shape [1,$IMAGE_SIZE,$IMAGE_SIZE,3] \
    --reverse_input_channels
 
@@ -80,10 +37,6 @@ Where ``$IMAGE_SIZE`` is the size that the input image of the original TensorFlo
 EfficientDet models were trained with different input image sizes. To determine the right one, refer to the ``efficientdet_model_param_dict``
 dictionary in the `hparams_config.py <https://github.com/google/automl/blob/96e1fee/efficientdet/hparams_config.py#L304>`__ file.
 The attribute ``image_size`` specifies the shape to be defined for the model conversion.
-
-The ``transformations_config`` command line parameter specifies the configuration json file containing hints for the Model Optimizer on how to convert the model and trigger transformations implemented in the ``<PYTHON_SITE_PACKAGES>/openvino/tools/mo/front/tf/AutomlEfficientDet.py``. The json file contains some parameters which must be changed if you
-train the model yourself and modified the ``hparams_config`` file or the parameters are different from the ones used for EfficientDet-D4.
-The attribute names are self-explanatory or match the name in the ``hparams_config`` file.
 
 .. note::
 

--- a/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_EfficientDet_Models.md
+++ b/docs/MO_DG/prepare_model/convert_model/tf_specific/Convert_EfficientDet_Models.md
@@ -28,7 +28,7 @@ Follow the instructions below to get frozen TensorFlow EfficientDet model. Effic
 
 .. code-block:: sh
 
-   git checkout 96e1fee
+   git checkout ecbc7a3
 
 3. Install required dependencies:
 
@@ -50,7 +50,7 @@ referenced in the **"Pretrained EfficientDet Checkpoints"** section of the model
 
 .. code-block:: sh
 
-    mo --runmode=saved_model --model_name=efficientdet-d4  --ckpt_path=efficientdet-d4 --saved_model_dir=savedmodeldir
+    python3 model_inspect.py --runmode=saved_model --model_name=efficientdet-d4  --ckpt_path=efficientdet-d4 --saved_model_dir=savedmodeldir
 
 As a result, the frozen model file ``savedmodeldir/efficientdet-d4_frozen.pb`` will be generated.
 

--- a/docs/dev/installing.md
+++ b/docs/dev/installing.md
@@ -148,12 +148,12 @@ omz_downloader --name googlenet-v1 --output_dir %USERPROFILE%\Documents\models
 Linux and macOS:
 ```sh
 mkdir ~/ir
-mo --input_model ~/models/public/googlenet-v1/googlenet-v1.caffemodel --data_type FP16 --output_dir ~/ir
+mo --input_model ~/models/public/googlenet-v1/googlenet-v1.caffemodel --compress_to_fp16 --output_dir ~/ir
 ```
 Windows:
 ```bat
 mkdir %USERPROFILE%\Documents\ir
-mo --input_model %USERPROFILE%\Documents\models\public\googlenet-v1\googlenet-v1.caffemodel --data_type FP16 --output_dir %USERPROFILE%\Documents\ir
+mo --input_model %USERPROFILE%\Documents\models\public\googlenet-v1\googlenet-v1.caffemodel --compress_to_fp16 --output_dir %USERPROFILE%\Documents\ir
 ```
 
 5. Run Inference on the Sample


### PR DESCRIPTION
Description:
Corrected command in Convert_EfficientDet_Models.md.
Updated missed data_type=True to 'compress_to_fp16'

Ticket: -


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update