### PR TITLE
[VPUX] - Detected possible vulnerability with shared_ptr

### DIFF
--- a/src/inference/src/os/win/win_system_conf.cpp
+++ b/src/inference/src/os/win/win_system_conf.cpp
@@ -23,7 +23,7 @@ void CPU::init_cpu(CPU& cpu) {
         return;
     }
 
-    std::shared_ptr<char> base_shared_ptr(new char[len]);
+    std::unique_ptr<char[]> base_shared_ptr(new char[len]);
     char* base_ptr = base_shared_ptr.get();
     if (!GetLogicalProcessorInformationEx(RelationAll, (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)base_ptr, &len)) {
         return;

--- a/src/inference/tests/unit/cpu_map_parser.cpp
+++ b/src/inference/tests/unit/cpu_map_parser.cpp
@@ -618,7 +618,7 @@ public:
         const char* test_ptr = (char*)test_data.system_info.c_str();
         std::size_t test_len = test_data.system_info.length();
 
-        std::shared_ptr<char> test_info(new char[test_len / 2]);
+        std::unique_ptr<char[]> test_info(new char[test_len / 2]);
         char* test_info_ptr = test_info.get();
 
         Hex2Bin(test_ptr, test_len, test_info_ptr);


### PR DESCRIPTION
According to this https://en.cppreference.com/w/cpp/memory/shared_ptr/shared_ptr:

**(until C++17)**
If T is an array type U[N], (3-4,6) do not participate in overload resolution if Y(*)[N] is not convertible to T*. If T is an array type U[], (3-4,6) do not participate in overload resolution if Y(*)[] is not convertible to T*. Otherwise, (3-4,6) do not participate in overload resolution if Y* is not convertible to T*.

**(since C++17)**
Additionally:
Uses the delete-expression delete ptr if T is not an array type; delete[] ptr if T is an array type (since C++17) as the deleter. Y must be a complete type. The delete expression must be well-formed, have well-defined behavior and not throw any exceptions. This constructor additionally does not participate in overload resolution if the delete expression is not well-formed. 

For c++14 the simple delete would be called, from c++17 - delete[].
The first one will corrupt memory.