### PR TITLE
[GPU] Fix Interpolate assert

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
@@ -79,7 +79,7 @@ struct resample : public primitive_base<resample> {
           cube_coeff(cube_coeff),
           coord_trans_mode(ctm),
           round_mode(nm) {
-        if (scales.size() != axes.size())
+        if (scales.size() != axes.size() && shape_calc_mode == InterpolateOp::ShapeCalcMode::SCALES)
             throw std::runtime_error("Resample's scales/axes count does not match");
     }
 

--- a/src/plugins/intel_gpu/src/graph/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/resample.cpp
@@ -61,7 +61,7 @@ std::vector<layout> resample_inst::calc_output_layouts(resample_node const& /*no
 
     if (((sizes_data.empty() && !memory_deps.count(1)) || !sizes_calc_mod) &&
         ((scales_data.empty() && !memory_deps.count(2)) || sizes_calc_mod)) {
-       return { layout{ShapeType::dynamic(input_rank), input_layout.data_type, input_layout.format} };
+        return { layout{ShapeType::dynamic(input_rank), input_layout.data_type, input_layout.format} };
     }
 
     auto axes_data = desc->axes;

--- a/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
@@ -49,10 +49,9 @@ static void CreateInterpolateOp(Program& p, const std::shared_ptr<ngraph::op::v4
         }
     }
 
-    bool correct_params = !scales_constant;
-    correct_params |= axes.size() == scales.size();
-    correct_params |= attrs.shape_calculation_mode == ov::op::v4::Interpolate::ShapeCalcMode::SIZES;
-    OPENVINO_ASSERT(correct_params, "[GPU] Incorrect axes and scales values for Interpolate operation with id ", op->get_friendly_name());
+    if (attrs.shape_calculation_mode == ov::op::v4::Interpolate::ShapeCalcMode::SCALES && scales_constant) {
+        OPENVINO_ASSERT(axes.size() == scales.size(), "[GPU] Incorrect axes and scales values for Interpolate operation with id ", op->get_friendly_name());
+    }
 
     // TODO shouldn't be all this checking done in ngraph::op::v4::Interpolate?
     auto interpolateMode = attrs.mode;

--- a/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
@@ -49,7 +49,10 @@ static void CreateInterpolateOp(Program& p, const std::shared_ptr<ngraph::op::v4
         }
     }
 
-    OPENVINO_ASSERT(!scales_constant || axes.size() == scales.size(), op->get_friendly_name(), " Incorrect axes and scales should be the same size");
+    bool correct_params = !scales_constant;
+    correct_params |= axes.size() == scales.size();
+    correct_params |= attrs.shape_calculation_mode == ov::op::v4::Interpolate::ShapeCalcMode::SIZES;
+    OPENVINO_ASSERT(correct_params, "[GPU] Incorrect axes and scales values for Interpolate operation with id ", op->get_friendly_name());
 
     // TODO shouldn't be all this checking done in ngraph::op::v4::Interpolate?
     auto interpolateMode = attrs.mode;

--- a/src/plugins/template/backend/evaluates_map.cpp
+++ b/src/plugins/template/backend/evaluates_map.cpp
@@ -4272,7 +4272,7 @@ bool evaluate_interpolate(const shared_ptr<op::v11::Interpolate>& op,
         padded_input_shape.emplace_back(m_attrs.pads_begin[i] + m_attrs.pads_end[i] + input_shape[i].get_length());
     }
 
-    auto axes = get_axes_vector(inputs, inputs[1]->get_shape().size(), axes_port, max_num_of_ports);
+    auto axes = get_axes_vector(inputs, input_shape.size(), axes_port, max_num_of_ports);
     auto scales = get_scales_vector(inputs, padded_input_shape, m_attrs, axes, scales_sizes_port);
 
     ov::PartialShape output_shape{padded_input_shape};

--- a/src/plugins/template/backend/evaluates_map.cpp
+++ b/src/plugins/template/backend/evaluates_map.cpp
@@ -4272,7 +4272,7 @@ bool evaluate_interpolate(const shared_ptr<op::v11::Interpolate>& op,
         padded_input_shape.emplace_back(m_attrs.pads_begin[i] + m_attrs.pads_end[i] + input_shape[i].get_length());
     }
 
-    auto axes = get_axes_vector(inputs, input_shape.size(), axes_port, max_num_of_ports);
+    auto axes = get_axes_vector(inputs, inputs[1]->get_shape()[0], axes_port, max_num_of_ports);
     auto scales = get_scales_vector(inputs, padded_input_shape, m_attrs, axes, scales_sizes_port);
 
     ov::PartialShape output_shape{padded_input_shape};


### PR DESCRIPTION
### Details:
 - Relaxed restrictions for Interpolate operation with `SIZES` shapes calculation mode (ShapeCalcMode::SIZES), because scales input may not be fully configured during InterpolateV11 -> InterpolateV4 conversion, but GPU Plugin can handle such cases
 - Added new tests cases
 - Fixed evaluation function for InterpolateV11

### Tickets:
 - 106893
