### PR TITLE
query capacity before popping

### DIFF
--- a/src/inference/dev_api/threading/ie_thread_safe_containers.hpp
+++ b/src/inference/dev_api/threading/ie_thread_safe_containers.hpp
@@ -62,7 +62,9 @@ public:
         return false;
     }
     bool try_pop(T& value) {
-        return _pqueue.try_pop(value);
+        if (_capacity)
+            return _pqueue.try_pop(value);
+        return false;
     }
     void set_capacity(std::size_t newCapacity) {
         _capacity = newCapacity;

--- a/src/inference/dev_api/threading/ie_thread_safe_containers.hpp
+++ b/src/inference/dev_api/threading/ie_thread_safe_containers.hpp
@@ -62,9 +62,7 @@ public:
         return false;
     }
     bool try_pop(T& value) {
-        if (_capacity)
-            return _pqueue.try_pop(value);
-        return false;
+        return _capacity ? _pqueue.try_pop(value) : false;
     }
     void set_capacity(std::size_t newCapacity) {
         _capacity = newCapacity;


### PR DESCRIPTION
### Details:
 - do not pop from idle queue if capacity been cleared

### Tickets:
 - 107970
