### PR TITLE
Remove warnings during cython call

### DIFF
--- a/src/bindings/python/src/compatibility/openvino/inference_engine/constants.pyx
+++ b/src/bindings/python/src/compatibility/openvino/inference_engine/constants.pyx
@@ -1,6 +1,8 @@
 # Copyright (C) 2018-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+#cython: language_level=3
+
 from .cimport ie_api_impl_defs as C
 
 import numpy as np

--- a/src/bindings/python/src/compatibility/openvino/inference_engine/ie_api.pxd
+++ b/src/bindings/python/src/compatibility/openvino/inference_engine/ie_api.pxd
@@ -1,6 +1,8 @@
 # Copyright (C) 2018-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+#cython: language_level=3
+
 from .cimport ie_api_impl_defs as C
 from .ie_api_impl_defs cimport CBlob, CTensorDesc, InputInfo, CPreProcessChannel, CPreProcessInfo, CExecutableNetwork, CVariableState
 
@@ -84,7 +86,7 @@ cdef class InputInfoCPtr:
 cdef class PreProcessInfo:
     cdef CPreProcessInfo* _ptr
     cdef const CPreProcessInfo* _cptr
-    cpdef object _user_data
+    cdef object _user_data
 
 cdef class PreProcessChannel:
     cdef CPreProcessChannel.Ptr _ptr

--- a/src/bindings/python/src/compatibility/openvino/inference_engine/ie_api.pyx
+++ b/src/bindings/python/src/compatibility/openvino/inference_engine/ie_api.pyx
@@ -3,6 +3,7 @@
 
 #distutils: language=c++
 #cython: embedsignature=True
+#cython: language_level=3
 
 from cython.operator cimport dereference as deref
 from libcpp.string cimport string


### PR DESCRIPTION
### Details:
```
/home/AzDevOps/.local/lib/python3.8/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /agent/_work/1/openvino/src/bindings/python/src/compatibility/openvino/inference_engine/constants.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
```