### PR TITLE
Remove vopset typo

### DIFF
--- a/src/core/src/node.cpp
+++ b/src/core/src/node.cpp
@@ -389,7 +389,7 @@ std::ostream& ov::Node::write_description(std::ostream& out, uint32_t depth) con
         if (version)
             out << version << "::" << get_type_info().name << " " << get_friendly_name() << " (";
         else
-            out << "::" << get_type_info().name << " " << get_friendly_name() << " (";
+            out << get_type_info().name << " " << get_friendly_name() << " (";
         string sep = "";
         for (const auto& arg : input_values()) {
             out << sep << arg;

--- a/src/core/src/node.cpp
+++ b/src/core/src/node.cpp
@@ -387,11 +387,9 @@ std::ostream& ov::Node::write_description(std::ostream& out, uint32_t depth) con
     } else {
         auto version = get_type_info().version_id;
         if (version)
-            out << "v" << version << "::" << get_type_info().name << " " << get_friendly_name() << " (";
+            out << version << "::" << get_type_info().name << " " << get_friendly_name() << " (";
         else
-            out << "v"
-                << " "
-                << "::" << get_type_info().name << " " << get_friendly_name() << " (";
+            out << "::" << get_type_info().name << " " << get_friendly_name() << " (";
         string sep = "";
         for (const auto& arg : input_values()) {
             out << sep << arg;

--- a/src/plugins/intel_gna/legacy/tests/convert_ngraph_to_cnn_network_tests.cpp
+++ b/src/plugins/intel_gna/legacy/tests/convert_ngraph_to_cnn_network_tests.cpp
@@ -234,10 +234,10 @@ TEST(ConvertFunctionToCNNNetworkTests, UnsupportedDynamicOps) {
     } catch (InferenceEngine::Exception& e) {
         EXPECT_THAT(e.what(),
                     testing::HasSubstr(std::string("Unsupported dynamic ops: \n"
-                                                   "vopset1::Parameter param () -> (f32[...])\n"
-                                                   "vopset1::Relu relu (param[0]:f32[...]) -> (f32[...])\n"
-                                                   "vopset3::NonZero non_zero (relu[0]:f32[...]) -> (i64[?,?])\n"
-                                                   "vopset1::Result result (non_zero[0]:i64[?,?]) -> (i64[?,?])")));
+                                                   "opset1::Parameter param () -> (f32[...])\n"
+                                                   "opset1::Relu relu (param[0]:f32[...]) -> (f32[...])\n"
+                                                   "opset3::NonZero non_zero (relu[0]:f32[...]) -> (i64[?,?])\n"
+                                                   "opset1::Result result (non_zero[0]:i64[?,?]) -> (i64[?,?])")));
     }
 }
 


### PR DESCRIPTION
### Details:
 - Remove incorrect opset version if print the operation:
 `vopset1::...` -> `opset1::...`

### Tickets:
 - *ticket-id*
