### PR TITLE
[POC] Add `malloc_trim` to `~CompiledModel()`

### DIFF
--- a/src/inference/src/compiled_model.cpp
+++ b/src/inference/src/compiled_model.cpp
@@ -8,6 +8,19 @@
 #include "openvino/runtime/icompiled_model.hpp"
 #include "openvino/runtime/properties.hpp"
 
+#ifdef __GLIBC__
+#    include <malloc.h>
+namespace {
+void release_memory_to_os() {
+    malloc_trim(0);
+}
+}  // namespace
+#else
+namespace {
+void release_memory_to_os() {}
+}  // namespace
+#endif
+
 #define OV_COMPILED_MODEL_CALL_STATEMENT(...)                                \
     OPENVINO_ASSERT(_impl != nullptr, "CompiledModel was not initialized."); \
     try {                                                                    \
@@ -22,6 +35,7 @@ namespace ov {
 
 CompiledModel::~CompiledModel() {
     _impl = {};
+    release_memory_to_os();
 }
 
 CompiledModel::CompiledModel(const std::shared_ptr<ov::ICompiledModel>& impl, const std::shared_ptr<void>& so)


### PR DESCRIPTION
### Details:
GLibc allocator aggressively consumes memory and rarely returns it to OS. It leads to significant increase of RSS after each iteration of `READ+LOAD+INFER+FREE`, and RSS will never return to values after very first iteration. For end users it means that, starting from some iteration, model recompilation may fail due out of memory (process will be killed by OOMKiller). General recommendations of GNU contributors are `glibc.malloc.*` tunable options or `malloc_trim()` GNU-specific function (details in https://sourceware.org/pipermail/libc-help/2020-September/005472.html)

To tune OpenVINO behavior, `malloc_trim()` is an optimal solution. Because `compile_model()` stage is the most memory consuming function, `~CompiledModel()` is the best place/object to include `malloc_trim()` call (call when `CompiledModel` is alive has no visible effect on CPU/GPU and may lead to FIL degradation). Anyway, in multi-thread application with "model per thread" design, `malloc_trim()` may affect FIL of other threads because it releases memory from all arenas and thread caches (according to man `malloc_trim()` is thread-safe)

For next pipeline:
 ```
ov::Core ieCore;
auto model = ieCore.read_model(MODEL_PATH);
for (int i = 0; i < N; i++)
    ov::CompiledModel compiledModel = ieCore.compile_model(model, "CPU");
 ```
call of `malloc_trim(0)` add **10%** for `resnet-50-pytorch` and **1.6%** for `bert-large` execution time increase (same increase per iteration or full pipeline)

### Tickets:
 - CVS-103986
