### PR TITLE
[GPU] Fix for softmax unaligned leftovers

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_bf.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_bf.cl
@@ -61,7 +61,7 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     __local INPUT0_TYPE lg_storage[SLM_SIZE];
 
     uint i=0;
-    if (workers_per_data_set > SUB_GROUP_SIZE)
+    if (workers_per_data_set >= SUB_GROUP_SIZE && (leftovers % (16 / sizeof(INPUT0_TYPE))) == 0)
     {
         for (; i<items_num - (items_num % SUBGROUP_BLOCK_SIZE); i+=SUBGROUP_BLOCK_SIZE)
         {
@@ -145,7 +145,7 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     i=0;
 
 #if HAS_FUSED_OPS
-    if (workers_per_data_set > SUB_GROUP_SIZE)
+    if (workers_per_data_set >= SUB_GROUP_SIZE && (leftovers % (16 / sizeof(INPUT0_TYPE))) == 0)
     {
         for (; i < items_num - (items_num % SUBGROUP_BLOCK_SIZE); i+=SUBGROUP_BLOCK_SIZE)
         {
@@ -178,7 +178,7 @@ KERNEL (softmax_gpu_continuous_bfyx)(
         output[data_set_offset + workers_per_data_set * items_num + in_data_set_idx] = FUSED_OPS_RESULT_LEFTOVERS;
     }
 #else
-    if (workers_per_data_set > SUB_GROUP_SIZE)
+    if (workers_per_data_set >= SUB_GROUP_SIZE && (leftovers % (16 / sizeof(INPUT0_TYPE))) == 0)
     {
         for (; i<items_num - (items_num % SUBGROUP_BLOCK_SIZE); i+=SUBGROUP_BLOCK_SIZE)
         {

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/softmax.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/softmax.cpp
@@ -20,7 +20,9 @@ const std::vector<ov::Shape> inputShapes2D = {
     {1, 100},
     {100, 1},
     {10, 10},
-    {100, 10}
+    {100, 10},
+    {1024, 300},
+    {1024, 306}
 };
 
 const std::vector<int64_t> axis2D = {


### PR DESCRIPTION
### Details:
 - *https://github.com/openvinotoolkit/openvino/pull/15863 doesn't handle use case where leftovers introduce unaligned memory offset*
 - *This PR aims to disable blocking reads and writes for cases where leftovers cause unaligned memory offset*

### Tickets:
 - *[CVS-91171](https://jira.devtools.intel.com/browse/CVS-91171)*
