### PR TITLE
[GPU] Fix softmax perf of stable diffusion

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.cpp
@@ -54,9 +54,9 @@ SoftmaxKernel_bf::Parent::DispatchData SoftmaxKernel_bf::SetDefault(const softma
         }
 
         dispatchData.leftovers = dispatchData.dataSetSize % dispatchData.lws[0];
-        //if (dispatchData.leftovers % subgroup_size) {
         // To use subgroup read/write, the starting address should be aligned to 128 bit
-        if ((dispatchData.dataSetSize * params.inputs[0].ElementSize()) >> 4) {
+        size_t dataSetSizeInByte = dispatchData.dataSetSize * params.inputs[0].ElementSize();
+        if ((dispatchData.dataSetsCount > 1) && ((dataSetSizeInByte - ((dataSetSizeInByte >> 4) << 4)))) {
             dispatchData.subgroupBlockSize = 1;
         } else {
             if (dispatchData.itemsNum >> 3)


### PR DESCRIPTION
### Details:
 - This is to fix unexpected change in https://github.com/openvinotoolkit/openvino/pull/16818
 - The PR 16818 was for fixing accuracy, but resulted in perf degradation due to the incomplete condition in https://github.com/openvinotoolkit/openvino/blob/63b16baa7eff6cbaab5463bdfd0535c2ce567cef/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.cpp#L59 which enforces too many cases to have block size 1 
 - Stable diffusion originally had block size 8, so I fixed the condition to restore the performance 
 - Since it is not about the functional behavior, unittest cannot cover this change. So I checked the target networks' block size locally.


