### PR TITLE
[GPU] Remove unused constants from the graph

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/graph_initializations.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/graph_initializations.cpp
@@ -408,7 +408,7 @@ void graph_initializations::set_outputs(program& p) {
         }
     } else {
         for (auto& node : p.nodes_map)
-            if (node.second->is_endpoint()) {
+            if (node.second->is_endpoint() && !node.second->is_type<data>()) {
                 node.second->set_output(true);
                 p.outputs.push_back(node.second.get());
             }

--- a/src/plugins/intel_gpu/tests/test_utils/test_utils.h
+++ b/src/plugins/intel_gpu/tests/test_utils/test_utils.h
@@ -769,7 +769,6 @@ inline cldnn::network::ptr get_network(cldnn::engine& engine,
                                 const bool is_caching_test) {
     cldnn::network::ptr network;
     if (is_caching_test) {
-        std::cout << "cached" << std::endl;
         cldnn::membuf mem_buf;
         {
             cldnn::network _network(engine, topology, config);


### PR DESCRIPTION
### Details:
 - In some cases `data` primitives created to handle `Constant` operations may become dangling as several operations read the value of such constants on creation and don't use const inputs on inference at all. Such dangling `data` primitives can be removed, but previously all nodes with 0 users were marked as outputs which prevented removal. With this PR dangling `data` primitives are not marked as outputs, so `trim_to_outputs` pass can remove them.
