### PR TITLE
[CPU] Correct crop in FQ optimized formula

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -1993,6 +1993,9 @@ void FakeQuantize::updateOptimizedFormula(bool do_rounding) {
             // merged with inputScale/inputShift with updated cropLow/cropHigh
             clo = clo * osc + osh;
             chi = chi * osc + osh;
+            if (clo > chi)
+                std::swap(clo, chi);
+
             //  crop(x*isc + ish, a, b)*osc + osh
             //  crop(x*isc*osc + ish*osc + osh, a', b')
             isc = isc * osc;


### PR DESCRIPTION
### Tickets:
 - 99838
 
 ### Details:
 - Output scale can be negative, so crop high and crop low can be swapped when multiplied.