### PR TITLE
[CPU] Fixed unused-private-field compilation errors

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
@@ -1093,6 +1093,7 @@ void BinaryConvolution::createPrimitive() {
     if (!args_ok)
         IE_THROW() << "BinaryConvolution with name '" << getName() << "' has unsupported parameters";
 #if defined(OPENVINO_ARCH_X86_64)
+    jit_dw_conv_params jcp_dw_conv = {};
     if (implType == impl_desc_type::jit_avx512) {
         bin_conv_kernel.reset(new jit_uni_bin_conv_kernel_f32<x64::avx512_core>(jcp, jcp_dw_conv, *attr.get()));
     } else if (implType == impl_desc_type::jit_avx2) {

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.h
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.h
@@ -107,7 +107,6 @@ private:
     std::vector<ptrdiff_t> paddingR;
 
     jit_bin_conv_params jcp = {};
-    jit_dw_conv_params jcp_dw_conv = {};
     std::shared_ptr<jit_uni_bin_conv_kernel> bin_conv_kernel = nullptr;
 
     dnnl::primitive_attr attr;

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.hpp
@@ -29,7 +29,6 @@ private:
     InterpolateAttrs aclInterpolateAttrs;
     arm_compute::SamplingPolicy acl_coord;
     arm_compute::InterpolationPolicy acl_policy;
-    bool antialias{};
     arm_compute::Tensor srcTensor, dstTensor;
     std::unique_ptr<arm_compute::NEScale> acl_scale;
 };


### PR DESCRIPTION
### Details:
 - Fixes for android-arm postcommit build 
  
Link on failed build: https://dev.azure.com/openvinoci/dldt/_build/results?buildId=539767&view=logs&j=92ba3447-fcaa-530d-6438-b829fe1e7d1d&t=b0a91e75-8666-5718-e63e-df215ecb48f9&l=5653
