### PR TITLE
Fix Cast util functor when cast from floating point to integer

### DIFF
--- a/src/core/shape_inference/include/shape_infer_type_utils.hpp
+++ b/src/core/shape_inference/include/shape_infer_type_utils.hpp
@@ -29,7 +29,9 @@ struct Cast {
     template <class U,
               typename std::enable_if<std::is_integral<T>::value && std::is_floating_point<U>::value>::type* = nullptr>
     constexpr T operator()(const U u) const {
-        return u < std::numeric_limits<T>::max() ? static_cast<T>(u) : std::numeric_limits<T>::max();
+        return cmp::lt(u, std::numeric_limits<T>::max())
+                   ? cmp::lt(u, std::numeric_limits<T>::min()) ? std::numeric_limits<T>::min() : static_cast<T>(u)
+                   : std::numeric_limits<T>::max();
     }
 };
 

--- a/src/core/shape_inference/include/shape_infer_type_utils.hpp
+++ b/src/core/shape_inference/include/shape_infer_type_utils.hpp
@@ -11,7 +11,7 @@ namespace ov {
 namespace util {
 
 /**
- * \brief Trnsform tensor data by cast them to type T
+ * \brief Transform tensor data by cast them to type T
  *
  * \tparam T Type of returned value.
  */
@@ -19,9 +19,17 @@ template <class T>
 struct Cast {
     constexpr Cast() = default;
 
-    template <class U>
+    template <
+        class U,
+        typename std::enable_if<!std::is_integral<T>::value || !std::is_floating_point<U>::value>::type* = nullptr>
     constexpr T operator()(const U u) const {
         return static_cast<T>(u);
+    }
+
+    template <class U,
+              typename std::enable_if<std::is_integral<T>::value && std::is_floating_point<U>::value>::type* = nullptr>
+    constexpr T operator()(const U u) const {
+        return u < std::numeric_limits<T>::max() ? static_cast<T>(u) : std::numeric_limits<T>::max();
     }
 };
 


### PR DESCRIPTION
### Details:
 - Fix `Cast` functor when perform cast from floating point to integer when floating point value is out of integer range.
 - Fix sanitizer `float-cast-overflow` runtime error message .

### Tickets:
 - 105002
