### PR TITLE
Moved heavy OVInferConsistencyTest tests to nightly

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/ov_infer_request/infer_consistency.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/ov_infer_request/infer_consistency.cpp
@@ -63,21 +63,21 @@ std::vector<Configs> MultiConfigs = {
 
 
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferConsistencyTest,
+INSTANTIATE_TEST_SUITE_P(BehaviorTests, OVInferConsistencyTest,
     ::testing::Combine(
         ::testing::Values(10),// inferRequest num
         ::testing::Values(50),// infer counts
         ::testing::ValuesIn(configs)),
     OVInferConsistencyTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, OVInferConsistencyTest,
+INSTANTIATE_TEST_SUITE_P(Auto_BehaviorTests, OVInferConsistencyTest,
     ::testing::Combine(
         ::testing::Values(10),// inferRequest num
         ::testing::Values(50),// infer counts
         ::testing::ValuesIn(AutoConfigs)),
     OVInferConsistencyTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Multi_BehaviorTests, OVInferConsistencyTest,
+INSTANTIATE_TEST_SUITE_P(Multi_BehaviorTests, OVInferConsistencyTest,
     ::testing::Combine(
         ::testing::Values(10),// inferRequest num
         ::testing::Values(50),// infer counts

--- a/src/tests/functional/plugin/gpu/shared_tests_instances/behavior/ov_infer_request/infer_consistency.cpp
+++ b/src/tests/functional/plugin/gpu/shared_tests_instances/behavior/ov_infer_request/infer_consistency.cpp
@@ -94,35 +94,35 @@ auto AutoBindConfigs = []() {
                                  {CommonTestUtils::DEVICE_GPU, {}}}};
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVInferConsistencyTest,
+INSTANTIATE_TEST_SUITE_P(BehaviorTests, OVInferConsistencyTest,
     ::testing::Combine(
         ::testing::Values(10),// inferRequest num
         ::testing::Values(50),// infer counts
         ::testing::ValuesIn(configs())),
     OVInferConsistencyTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests, OVInferConsistencyTest,
+INSTANTIATE_TEST_SUITE_P(Auto_BehaviorTests, OVInferConsistencyTest,
     ::testing::Combine(
         ::testing::Values(10),// inferRequest num
         ::testing::Values(50),// infer counts
         ::testing::ValuesIn(AutoConfigs())),
     OVInferConsistencyTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Multi_BehaviorTests, OVInferConsistencyTest,
+INSTANTIATE_TEST_SUITE_P(Multi_BehaviorTests, OVInferConsistencyTest,
     ::testing::Combine(
         ::testing::Values(10),// inferRequest num
         ::testing::Values(50),// infer counts
         ::testing::ValuesIn(MultiConfigs())),
     OVInferConsistencyTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Auto_Bind_BehaviorTests, OVInferConsistencyTest,
+INSTANTIATE_TEST_SUITE_P(Auto_Bind_BehaviorTests, OVInferConsistencyTest,
     ::testing::Combine(
         ::testing::Values(0),// inferRequest num, will use optimal request number if set 0
         ::testing::Values(100),// infer counts
         ::testing::ValuesIn(AutoBindConfigs())),
     OVInferConsistencyTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Multi_Bind_BehaviorTests, OVInferConsistencyTest,
+INSTANTIATE_TEST_SUITE_P(Multi_Bind_BehaviorTests, OVInferConsistencyTest,
     ::testing::Combine(
         ::testing::Values(0),// inferRequest num, will use optimal request number if set 0
         ::testing::Values(100),// infer counts


### PR DESCRIPTION
### Details:
 - These tests are very heavy and each instantiation on ARM Rasb PI takes 10 mins, 90 secs on macOS arm64, also it takes a lot on GPU.
 - Introduced here https://github.com/openvinotoolkit/openvino/pull/11492
 - @peterchen-intel @wgzintel  please, optimize these tests
