### PR TITLE
[GPU] Resolve failed onednn tests

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -283,7 +283,8 @@ void remove_redundant_reorders::run(program& p) {
             i_layout.data_padding.upper_size().spatial[0] == 0 && i_layout.data_padding.lower_size().spatial[0] == 0 &&
             i_layout.data_padding.upper_size().spatial[1] == 0 && i_layout.data_padding.lower_size().spatial[1] == 0 &&
             o_layout.data_padding.upper_size() == (tensor)0 && o_layout.data_padding.lower_size() == (tensor)0 &&
-            i_layout.data_type == o_layout.data_type) {
+            i_layout.data_type == o_layout.data_type &&
+            !layout_optimizer::onednn_check_preferred_impl_type_of_users(r_node)) {
             // If the newly aligned pad is merged into output layout during post_optimize_graph phase
             // and then buffer is reinterpreted, user node cannot handle pad properly for kernel execution
             if (!update_implementations || (i_layout.feature() % 16 == 0 &&

--- a/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
+++ b/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
@@ -192,6 +192,7 @@ public:
     static bool onednn_check_data_types_for_pooling(data_types in_dt, data_types out_dt);
     static bool onednn_check_data_types_for_convolution(data_types in_dt, data_types wei_dt, data_types out_dt);
     static bool onednn_check_data_types_for_fc_gemm(data_types in_dt, data_types wei_dt, data_types out_dt);
+    static bool onednn_check_preferred_impl_type_of_users(program_node& node);
     bool is_primitive_implemented_for_onednn(program_node& node);
     bool is_format_supported(program_node& node, format::type fmt);
 

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1304,6 +1304,18 @@ bool layout_optimizer::is_primitive_implemented_for_onednn(program_node& node) {
     return false;
 }
 
+bool layout_optimizer::onednn_check_preferred_impl_type_of_users(program_node& node) {
+    if (node.get_users().size() == 0)
+        return false;
+
+    for (auto& user : node.get_users()) {
+        if (user->get_preferred_impl_type() == impl_types::onednn)
+            return true;
+    }
+
+    return false;
+}
+
 impl_types layout_optimizer::get_forced_impl_type_by_config(program_node& node) {
 #ifdef GPU_DEBUG_CONFIG
     GPU_DEBUG_GET_INSTANCE(debug_config);

--- a/src/plugins/intel_gpu/tests/test_cases/depth_concatenate_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/depth_concatenate_gpu_test.cpp
@@ -501,6 +501,11 @@ TEST(depth_concatenate_f32_gpu, test07_padded_output) {
     const int32_t output_f = 2 * input_f;
 
     auto& engine = get_test_engine();
+    if (engine.get_device_info().supports_immad) {
+        // Currently, oneDNN does NOT support input/output padding
+        return;
+    }
+
     auto input1 = engine.allocate_memory({ data_types::f16, format::fs_b_yx_fsv32, {1, input_f, 1, 1} });
     auto input2 = engine.allocate_memory({ data_types::f16, format::fs_b_yx_fsv32, {1, input_f, 1, 1} });
 

--- a/src/plugins/intel_gpu/tests/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/fully_connected_gpu_test.cpp
@@ -728,6 +728,8 @@ TEST(fully_connected_gpu, b_fs_yx_fsv4)
     const int W_Y = in_Y;
     const int W_X = in_X;
 
+    const int O_F = W_B;
+
     // Input data
     std::vector<char> Data(in_F * in_B); // in_X = in_Y = 1
     int i = 0;
@@ -757,10 +759,10 @@ TEST(fully_connected_gpu, b_fs_yx_fsv4)
     set_values(weights_imad, std::move(Weights));
     topology.add(data("weights_gold", weights_gold), data("weights_imad", weights_imad));
 
-    auto bias_gold = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, in_F, 1, 1 } });
-    auto bias_imad = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, in_F, 1, 1 } });
+    auto bias_gold = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, O_F, 1, 1 } });
+    auto bias_imad = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, O_F, 1, 1 } });
 
-    std::vector<float> bias_data(in_F, 0);
+    std::vector<float> bias_data(O_F, 0);
     set_values(bias_gold, bias_data);
     set_values(bias_imad, bias_data);
 

--- a/src/plugins/intel_gpu/tests/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/reorder_gpu_test.cpp
@@ -1616,7 +1616,6 @@ TEST(reorder_gpu_opt, non_trivial_remove_redundant)
     };
 
     ExecutionConfig config = get_test_default_config(engine);
-
     config.set_property(ov::intel_gpu::optimize_data(true));
 
     network net(engine, tpl, config);
@@ -1625,8 +1624,12 @@ TEST(reorder_gpu_opt, non_trivial_remove_redundant)
     auto executed_primitives = net.get_executed_primitives();
     auto all_primitives = net.get_all_primitives();
 
+    if (engine.get_device_info().supports_immad) {
+        // Currently, oneDNN only supports in_order_queue
+        return;
+    }
+
     ASSERT_TRUE(executed_primitives.count("in") == 1);
-    //ASSERT_TRUE(all_primitives.at("r1") == "_optimized_");
     ASSERT_TRUE(executed_primitives.at("in") != outputs.at("r1").get_event());
     ASSERT_TRUE(outputs.count("r1") == 1);
     ASSERT_TRUE(outputs.at("r1").get_memory()->get_layout().format == format::bfyx);


### PR DESCRIPTION
### Details:
 - Modified unit-tests of asymetric conv with per channel(WA for oneDNN issue)
 - Bugfix for reorder opt out related to padding
 - Reorder from fsv16 to bfyx should not be optimized out if not aligned by 16
 - Modified accuracy checking logic in unit-test
 - currently, oneDNN conv has an issue on a certain tensor size e.g.) ic2oc2. Reported a ticket and modified tests to be enabled for original purpose of the test


### Tickets:
 - 107829, 67491
