### PR TITLE
[conformance] Fix iteration of ops_list when recalculating tests counters

### DIFF
--- a/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/summarize.py
+++ b/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/summarize.py
@@ -61,18 +61,22 @@ def parse_arguments():
 def parse_rel_weights(rel_weights_path: os.path):
     rel_weights = dict()
     rel_weights_file_path = rel_weights_path
-    if os.path.isdir(rel_weights_path):
-        rel_weights_file_path = os.path.join(rel_weights_path, REL_WEIGHTS_FILENAME)
-    if os.path.isfile(rel_weights_file_path):
-        logger.info(f"Rel weights will be taken from {rel_weights_file_path}")
-        with open(rel_weights_path, "r") as rel_weights_file:
-            for line in rel_weights_file.readlines():
-                sep_pos = line.find(':')
-                op_name = line[:sep_pos:]
-                op_weight = float(line[sep_pos+1::].replace('\n', ''))
-                rel_weights.update({op_name: op_weight})
+    if rel_weights_path:
+        if os.path.isdir(rel_weights_path):
+            rel_weights_file_path = os.path.join(rel_weights_path, REL_WEIGHTS_FILENAME)
+        if os.path.isfile(rel_weights_file_path):
+            logger.info(f"Rel weights will be taken from {rel_weights_file_path}")
+            with open(rel_weights_path, "r") as rel_weights_file:
+                for line in rel_weights_file.readlines():
+                    sep_pos = line.find(':')
+                    op_name = line[:sep_pos:]
+                    op_weight = float(line[sep_pos+1::].replace('\n', ''))
+                    rel_weights.update({op_name: op_weight})
+        else:
+            logger.warning(f"Rel weights file does not exist! The expected passrates will be taken from runtime")
     else:
-        logger.warning(f"Rel weights file does not exist! The expected passrates will be taken from runtime")
+        logger.warning(f"Rel weights file is not specified! The expected passrates will be taken from runtime")
+
     return rel_weights
 
 

--- a/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/utils/stat_update_utils.py
+++ b/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/utils/stat_update_utils.py
@@ -80,6 +80,6 @@ def update_conformance_test_counters(results: ET.SubElement):
                     op.set("skipped", str(int(op.attrib["skipped"]) + diff))
                     conformance_utils.UTILS_LOGGER.warning(f'{device.tag}: added {diff} skipped tests for {op.tag}')
             update_rel_values(op)
-    update_passrates(results)
+    update_passrates(results.find("results"))
 
 


### PR DESCRIPTION
+ avoid failing when rel_weights_path is not defined

### Tickets:
 - *108579*
