### PR TITLE
Fixed parsing of 'layout' param

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/cli_parser.py
+++ b/tools/mo/openvino/tools/mo/utils/cli_parser.py
@@ -1354,10 +1354,10 @@ def parse_layouts_by_destination(s: str, parsed: dict, parsed_list: list, dest: 
     else:
         for idx, layout_str in enumerate(list_s):
             # case for: "name1(nhwc->[n,c,h,w])"
-            p1 = re.compile(r'([^\[\]]*)\((\S+)\)')
+            p1 = re.compile(r'([^\[\]\(\)]*)\((\S+)\)')
             m1 = p1.match(layout_str)
             # case for: "name1[n,h,w,c]->[n,c,h,w]"
-            p2 = re.compile(r'([^\[\]]*)(\[\S*\])')
+            p2 = re.compile(r'([^\[\]\(\)]*)(\[\S*\])')
             m2 = p2.match(layout_str)
             if m1:
                 found_g = m1.groups()

--- a/tools/mo/openvino/tools/mo/utils/cli_parser.py
+++ b/tools/mo/openvino/tools/mo/utils/cli_parser.py
@@ -1354,10 +1354,10 @@ def parse_layouts_by_destination(s: str, parsed: dict, parsed_list: list, dest: 
     else:
         for idx, layout_str in enumerate(list_s):
             # case for: "name1(nhwc->[n,c,h,w])"
-            p1 = re.compile(r'([\w.:/\\]*)\((\S+)\)')
+            p1 = re.compile(r'([^\[\]]*)\((\S+)\)')
             m1 = p1.match(layout_str)
             # case for: "name1[n,h,w,c]->[n,c,h,w]"
-            p2 = re.compile(r'([\w.:/\\]*)(\[\S*\])')
+            p2 = re.compile(r'([^\[\]]*)(\[\S*\])')
             m2 = p2.match(layout_str)
             if m1:
                 found_g = m1.groups()

--- a/tools/mo/unit_tests/mo/utils/cli_parser_test.py
+++ b/tools/mo/unit_tests/mo/utils/cli_parser_test.py
@@ -1354,7 +1354,6 @@ class TestLayoutParsing(unittest.TestCase):
         for i in exp_res.keys():
             assert np.array_equal(result[i], exp_res[i])
 
-
     def test_get_layout_4(self):
         argv_layout = "nhwc"
         result = get_layout_values(argv_layout)

--- a/tools/mo/unit_tests/mo/utils/cli_parser_test.py
+++ b/tools/mo/unit_tests/mo/utils/cli_parser_test.py
@@ -1354,6 +1354,7 @@ class TestLayoutParsing(unittest.TestCase):
         for i in exp_res.keys():
             assert np.array_equal(result[i], exp_res[i])
 
+
     def test_get_layout_4(self):
         argv_layout = "nhwc"
         result = get_layout_values(argv_layout)
@@ -1382,6 +1383,15 @@ class TestLayoutParsing(unittest.TestCase):
         argv_layout = "[n,h,w,c]->[n,c,h,w]"
         result = get_layout_values(argv_layout)
         exp_res = {'': {'source_layout': '[n,h,w,c]', 'target_layout': '[n,c,h,w]'}}
+        self.assertEqual(list(exp_res.keys()), list(result.keys()))
+        for i in exp_res.keys():
+            assert np.array_equal(result[i], exp_res[i])
+
+    def test_get_layout_8(self):
+        argv_layout = "name1-0(n...c),name2-0(n...c->nc...)"
+        result = get_layout_values(argv_layout)
+        exp_res = {'name1-0': {'source_layout': 'n...c', 'target_layout': None},
+                   'name2-0': {'source_layout': 'n...c', 'target_layout': 'nc...'}}
         self.assertEqual(list(exp_res.keys()), list(result.keys()))
         for i in exp_res.keys():
             assert np.array_equal(result[i], exp_res[i])
@@ -1571,6 +1581,16 @@ class TestLayoutParsing(unittest.TestCase):
         result = get_layout_values(argv_source_layout=argv_source_layout, argv_target_layout=argv_target_layout)
         exp_res = {'name1.0:a/b': {'source_layout': 'nhwc', 'target_layout': 'nchw'},
                    'name2\\d\\': {'source_layout': '[n,h,w,c]', 'target_layout': '[n,c,h,w]'}}
+        self.assertEqual(list(exp_res.keys()), list(result.keys()))
+        for i in exp_res.keys():
+            assert np.array_equal(result[i], exp_res[i])
+
+    def test_get_layout_source_target_layout_7(self):
+        argv_source_layout = "name1-0[n,h,w,c],name2-1(?c??)"
+        argv_target_layout = "name1-0(nchw),name2-1[?,?,?,c]"
+        result = get_layout_values(argv_source_layout=argv_source_layout, argv_target_layout=argv_target_layout)
+        exp_res = {'name1-0': {'source_layout': '[n,h,w,c]', 'target_layout': 'nchw'},
+                   'name2-1': {'source_layout': '?c??', 'target_layout': '[?,?,?,c]'}}
         self.assertEqual(list(exp_res.keys()), list(result.keys()))
         for i in exp_res.keys():
             assert np.array_equal(result[i], exp_res[i])


### PR DESCRIPTION
Root cause analysis: 
Model conversion fails if '-' symbol is in input name in 'layout' parameter. 
It happens because regular expression for layout parsing expects input name to have unicode symbols or one of ":", "\","/".
So '-' is not expected.

Solution:
Change regular expression to expect in input name any symbols except of '[', ']','(', ')', because in braces layout values are set. 

Ticket: 105919


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests - Tests for this case will be done in separate PR to MO args tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update
