### PR TITLE
Fix MO IR Reader extender for StridedSlice to support empty masks

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/ir_reader/extenders/strided_slice_extender.py
+++ b/tools/mo/openvino/tools/mo/utils/ir_reader/extenders/strided_slice_extender.py
@@ -18,8 +18,6 @@ class StridedSlice_extender(Extender):
             if op.has(attr) and op[attr] != '':
                 Extender.attr_to_list(op, attr)
             else:
-                assert attr not in ['begin_mask', 'end_mask'],\
-                    '{} is not defined for the node {}'.format(attr, op.soft_get('name', op.id))
                 op[attr] = int64_array([])
 
         op.begin_mask = int64_array([1 - i for i in op.begin_mask])

--- a/tools/mo/unit_tests/mo/utils/ir_reader/ops_test.py
+++ b/tools/mo/unit_tests/mo/utils/ir_reader/ops_test.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import openvino.runtime.opset11 as opset11
 import openvino.runtime.opset10 as opset10
-from openvino.runtime import Model, serialize
+from openvino.runtime import Model, serialize, Core
 
 from openvino.tools.mo.utils.ir_reader.restore_graph import restore_graph_from_ir, save_restored_graph
 from openvino.tools.mo.utils.logger import init_logger
@@ -28,6 +28,8 @@ class TestOps(unittest.TestCase):
             save_restored_graph(graph, tmp, {}, name)
             # restore 2 times to validate that after save graph doesn't lose attributes etc.
             graph, _ = restore_graph_from_ir(model_xml, model_bin)
+            # check that re-saved model can be read in runtime
+            Core().read_model(model_xml)
             return graph
 
     def test_topk_11(self):
@@ -152,3 +154,14 @@ class TestOps(unittest.TestCase):
         _, callable_attribute = layer_info[0]
         self.assertTrue(callable(callable_attribute))
         self.assertEqual(callable_attribute(if_node), "If_opset8")
+
+    def test_strided_slice_no_begin_end_mask(self):
+        data_shape = [6, 12, 10, 24]
+        data_parameter = opset11.parameter(
+            data_shape, name="Data", dtype=np.float32)
+        strided_slice = opset11.strided_slice(data_parameter, np.int32([1, 2, 3, 4]), np.int32(
+            [3, 6, 9, 12]), np.int32([1, 1, 1, 1]), begin_mask=[], end_mask=[], name="StridedSlice_10")
+        model = Model(strided_slice, [data_parameter])
+        graph = TestOps.check_graph_can_save(model, 'strided_slice_model')
+        strided_slice_node = graph.get_op_nodes(op="StridedSlice")[0]
+        self.assertEqual(strided_slice_node["version"], "opset1")


### PR DESCRIPTION
### Details:
 - *Fix MO IR Reader extender for `StridedSlice` to support empty begin and end masks*

### Tickets:
 - *108211*
