### PR TITLE
[GPU] Improve shape infer performance 

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -94,7 +94,7 @@ public:
                 if (u->is_fused_dep(dep_idx)) {
                     continue;
                 }
-                if (u->get_dependency(dep_idx).get_unique_id() == unique_id) {
+                if (u->get_dependencies().at(dep_idx).first == this) {
                     return true;
                 }
             }

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -879,7 +879,8 @@ memory::ptr primitive_inst::allocate_output(engine& _engine, memory_pool& pool, 
     // Also if the successor of a node is an cpu, then memory needs to be lockable.
     bool is_cpu = _node.get_selected_impl() ? _node.get_selected_impl()->is_cpu() : false;
     auto use_lockable_memory = is_output_buffer(_node) || is_cpu || is_any_user_cpu(_node.get_users()) ||
-                               !_engine.supports_allocation(allocation_type::usm_device);
+                               !_engine.supports_allocation(allocation_type::usm_device) ||
+                               (_node.is_shape_infer_dep() && _engine.get_device_info().dev_type == device_type::integrated_gpu);
     const auto& lockable_mem_type = _engine.get_lockable_preferred_memory_allocation_type(layout.format.is_image_2d());
 
     auto alloc_type = use_lockable_memory ? lockable_mem_type


### PR DESCRIPTION
### Details:
 - For iGPU, using usm_device for shape_infer_dep memory causes memcpy from device to host 
-  This PR prevents such copy to improve shape infer performance in dynamic shape execution for iGPU
-  Also fixed is_shape_infer_dep to use pointer instead of unique id (unique id is not set before compile_graph stage)
