### PR TITLE
[GPU] Fix remove redundant reorder to skip reorder fusing when sibling node doesn't support fused padding

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -495,7 +495,7 @@ void remove_redundant_reorders::run(program& p) {
                         return false;
 
                     auto node_format = node->get_output_layout().format;
-                    for (int axis = 0; axis < node->get_dependency(0).get_output_layout().data_padding.lower_size().sizes(node_format).size(); axis++) {
+                    for (size_t axis = 0; axis < node->get_dependency(0).get_output_layout().data_padding.lower_size().sizes(node_format).size(); axis++) {
                         if (!user->is_padding_supported(axis, node->get_dependency(0).get_output_layout().data_padding.lower_size().sizes(node_format)[axis]))
                             return false;
                     }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -496,7 +496,8 @@ void remove_redundant_reorders::run(program& p) {
 
                     auto node_format = node->get_output_layout().format;
                     for (size_t axis = 0; axis < node->get_dependency(0).get_output_layout().data_padding.lower_size().sizes(node_format).size(); axis++) {
-                        if (!user->is_padding_supported(axis, node->get_dependency(0).get_output_layout().data_padding.lower_size().sizes(node_format)[axis]))
+                        if (!user->is_padding_supported(static_cast<int>(axis),
+                            node->get_dependency(0).get_output_layout().data_padding.lower_size().sizes(node_format)[axis]))
                             return false;
                     }
                 }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -495,7 +495,7 @@ void remove_redundant_reorders::run(program& p) {
                         return false;
 
                     auto node_format = node->get_output_layout().format;
-                    for (size_t axis = 0; axis < node->get_dependency(0).get_output_layout().data_padding.lower_size().sizes(node_format).size(); axis++) {
+                    for (int axis = 0; axis < node->get_dependency(0).get_output_layout().data_padding.lower_size().sizes(node_format).size(); axis++) {
                         if (!user->is_padding_supported(axis, node->get_dependency(0).get_output_layout().data_padding.lower_size().sizes(node_format)[axis]))
                             return false;
                     }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -313,6 +313,17 @@ void remove_redundant_reorders::run(program& p) {
         if (!o_layout.compatible(i_layout))
             continue;
 
+        // Check peer node which is reorder with padding. The reorder will cause layout incompatible.
+        // So r_node shouldn't be opt out in this case.
+        auto& dep = r_node.get_dependency(0);
+        auto will_dependency_have_padding = false;
+        for (auto user : dep.get_users()) {
+            if ((user != node) && (user->is_type<reorder>()) && (user->get_output_layout().data_padding))
+                will_dependency_have_padding = true;
+        }
+        if (will_dependency_have_padding == true)
+            continue;
+
         if (r_node.is_output() && i_layout.get_linear_size() != o_layout.get_linear_size())
             continue;
 


### PR DESCRIPTION
### Details:
 - Fix remove redundant reorder to skip reorder fusing when sibling node doesn't support fused padding
 
### Tickets:
 - 57614
