### PR TITLE
[GNA] Fix tests configuration to ensure that 3_5 target is tested too

### DIFF
--- a/src/plugins/intel_gna/tests/functional/limitations/layers_limit.cpp
+++ b/src/plugins/intel_gna/tests/functional/limitations/layers_limit.cpp
@@ -72,12 +72,13 @@ protected:
 };
 
 class GNALayersLimit20Test : public GNALayersLimitTest {};
-class GNALayersLimit30Test : public GNALayersLimitTest {};
+class GNALayersLimit3XTest : public GNALayersLimitTest {};
 
 TEST_P(GNALayersLimit20Test, CompareWithRefs) {
     Run();
 }
-TEST_P(GNALayersLimit30Test, CompareWithRefs) {
+
+TEST_P(GNALayersLimit3XTest, CompareWithRefs) {
     Run();
 }
 
@@ -86,13 +87,15 @@ std::map<std::string, std::string> common_config{{"GNA_DEVICE_MODE", "GNA_SW_EXA
 std::vector<std::map<std::string, std::string>> configs_20{{{"GNA_EXEC_TARGET", "GNA_TARGET_2_0"}},
                                                            {{"GNA_COMPILE_TARGET", "GNA_TARGET_2_0"}}};
 
-std::vector<std::map<std::string, std::string>> configs_30{{{"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}},
-                                                           {{"GNA_COMPILE_TARGET", "GNA_TARGET_3_0"}}};
+std::vector<std::map<std::string, std::string>> configs_3X{{{"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}},
+                                                           {{"GNA_COMPILE_TARGET", "GNA_TARGET_3_0"}},
+                                                           {{"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}},
+                                                           {{"GNA_COMPILE_TARGET", "GNA_TARGET_3_5"}}};
 
 // for GNA v2.0 limit is 4096
 std::vector<size_t> layer_limits_20{64, 4096, 4160};
-// for GNA v3.0 limit is 8191
-std::vector<size_t> layer_limits_30{64, 8192, 8200};
+// for GNA >= v3.0 limit is 8192
+std::vector<size_t> layer_limits_3X{64, 8192, 8200};
 
 INSTANTIATE_TEST_SUITE_P(smoke_GNALimits,
                          GNALayersLimit20Test,
@@ -103,10 +106,11 @@ INSTANTIATE_TEST_SUITE_P(smoke_GNALimits,
                          GNALayersLimitTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_GNALimits,
-                         GNALayersLimit30Test,
+                         GNALayersLimit3XTest,
                          ::testing::Combine(::testing::Values(CommonTestUtils::DEVICE_GNA),
                                             ::testing::Values(common_config),
-                                            ::testing::ValuesIn(configs_30),
-                                            ::testing::ValuesIn(layer_limits_30)),
+                                            ::testing::ValuesIn(configs_3X),
+                                            ::testing::ValuesIn(layer_limits_3X)),
                          GNALayersLimitTest::getTestCaseName);
+
 }  // namespace LayerTestsDefinitions

--- a/src/plugins/intel_gna/tests/functional/pass_tests/conv_with_padding.cpp
+++ b/src/plugins/intel_gna/tests/functional/pass_tests/conv_with_padding.cpp
@@ -69,9 +69,6 @@ protected:
         std::tie(precision, targetDevice, configuration, input_shape, filter_shape, padding_size) = this->GetParam();
 
         GnaLayerTestCheck::SetUp(targetDevice);
-        if (GnaLayerTestCheck::gnaLibVersionLessThan("3.5")) {
-            GTEST_SKIP() << GnaLayerTestCheck::getLastCmpResultMsg() << std::endl;
-        }
 
         auto ng_precision = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(precision);
         auto input = std::make_shared<ngraph::opset8::Parameter>(ng_precision, ngraph::Shape{input_shape});

--- a/src/plugins/intel_gna/tests/functional/pass_tests/convert_padded_to_valid_conv.cpp
+++ b/src/plugins/intel_gna/tests/functional/pass_tests/convert_padded_to_valid_conv.cpp
@@ -217,17 +217,7 @@ protected:
     }
 };
 
-using Gna35PaddedToValidConvTest = PaddedToValidConvTest;
-
 TEST_P(PaddedToValidConvTest, CompareWithRefs) {
-    Run();
-}
-
-TEST_P(Gna35PaddedToValidConvTest, CompareWithRefs) {
-    if (gnaVersionCheck.gnaLibVersionLessThan("3.5")) {
-        GTEST_SKIP() << gnaVersionCheck.getLastCmpResultMsg() << std::endl;
-        return;
-    }
     Run();
 }
 
@@ -236,15 +226,11 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::
 
 const std::vector<std::map<std::string, std::string>> configs1D = {
     {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "1"}, {"GNA_EXEC_TARGET", "GNA_TARGET_2_0"}},
-    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "1"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}}};
-
-const std::vector<std::map<std::string, std::string>> configs1D_Gna35 = {
+    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "1"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}},
     {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "1"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}}};
 
 const std::vector<std::map<std::string, std::string>> configs2D = {
-    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "1"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}}};
-
-const std::vector<std::map<std::string, std::string>> configs2D_Gna35 = {
+    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "1"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}},
     {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "1"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}}};
 
 const std::vector<op::PadType> padTypes = {op::PadType::VALID,
@@ -322,37 +308,15 @@ INSTANTIATE_TEST_SUITE_P(smoke_1DPaddedToValid,
                                             ::testing::ValuesIn(models)),
                          PaddedToValidConvTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_1DPaddedToValid,
-                         Gna35PaddedToValidConvTest,
-                         ::testing::Combine(conv1DParams,
-                                            misc1DParams,
-                                            ::testing::ValuesIn(netPrecisions),
-                                            ::testing::Values(CommonTestUtils::DEVICE_GNA),
-                                            ::testing::ValuesIn(configs1D_Gna35),
-                                            ::testing::ValuesIn(input1DNHWC),
-                                            ::testing::ValuesIn(models)),
-                         Gna35PaddedToValidConvTest::getTestCaseName);
-
 INSTANTIATE_TEST_SUITE_P(smoke_2DPaddedToValid,
                          PaddedToValidConvTest,
                          ::testing::Combine(conv2DParams,
                                             misc2DParams,
                                             ::testing::ValuesIn(netPrecisions),
                                             ::testing::Values(CommonTestUtils::DEVICE_GNA),
-                                            ::testing::ValuesIn(configs2D_Gna35),
+                                            ::testing::ValuesIn(configs2D),
                                             ::testing::ValuesIn(input2DNHWC),
                                             ::testing::ValuesIn(models)),
                          PaddedToValidConvTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_2DPaddedToValid,
-                         Gna35PaddedToValidConvTest,
-                         ::testing::Combine(conv2DParams,
-                                            misc2DParams,
-                                            ::testing::ValuesIn(netPrecisions),
-                                            ::testing::Values(CommonTestUtils::DEVICE_GNA),
-                                            ::testing::ValuesIn(configs2D_Gna35),
-                                            ::testing::ValuesIn(input2DNHWC),
-                                            ::testing::ValuesIn(models)),
-                         Gna35PaddedToValidConvTest::getTestCaseName);
 
 }  // namespace LayerTestsDefinitions

--- a/src/plugins/intel_gna/tests/functional/pass_tests/convolution_crop_axis_h.cpp
+++ b/src/plugins/intel_gna/tests/functional/pass_tests/convolution_crop_axis_h.cpp
@@ -116,6 +116,7 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
 
 const std::vector<std::map<std::string, std::string>> configs = {
     {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}},
+    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}},
     {{"GNA_DEVICE_MODE", "GNA_SW_FP32"}}};
 
 const std::vector<std::vector<size_t>> input_shapes{

--- a/src/plugins/intel_gna/tests/functional/pass_tests/decompose_2d_conv.cpp
+++ b/src/plugins/intel_gna/tests/functional/pass_tests/decompose_2d_conv.cpp
@@ -216,17 +216,7 @@ protected:
     }
 };
 
-using Gna35Decompose2DConvTest = Decompose2DConvTest;
-
 TEST_P(Decompose2DConvTest, CompareWithRefs) {
-    Run();
-}
-
-TEST_P(Gna35Decompose2DConvTest, CompareWithRefs) {
-    if (gnaVersionCheck.gnaLibVersionLessThan("3.5")) {
-        GTEST_SKIP() << gnaVersionCheck.getLastCmpResultMsg() << std::endl;
-        return;
-    }
     Run();
 }
 
@@ -236,10 +226,14 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::
 const std::vector<std::map<std::string, std::string>> configs = {
     {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "1"}, {"GNA_EXEC_TARGET", "GNA_TARGET_2_0"}}};
 
-const std::vector<std::map<std::string, std::string>> configsExec30Compile20 = {
+const std::vector<std::map<std::string, std::string>> configsExec3XCompile20 = {
     {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
      {"GNA_SCALE_FACTOR_0", "1"},
      {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"},
+     {"GNA_COMPILE_TARGET", "GNA_TARGET_2_0"}},
+    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"},
+     {"GNA_SCALE_FACTOR_0", "1"},
+     {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"},
      {"GNA_COMPILE_TARGET", "GNA_TARGET_2_0"}}};
 
 const std::vector<op::PadType> padTypes = {op::PadType::VALID,
@@ -298,13 +292,13 @@ INSTANTIATE_TEST_SUITE_P(smoke_Decompose2DConv,
 // These tests flow compile the model for GNA 2.0
 // and load by GNA Library for GNA 3.0 execution target
 // They assure that the W/A for pooling output differences btw GNA 2.0 / 3.0 is properly working
-INSTANTIATE_TEST_CASE_P(smoke_Decompose2DConv_Exec30Compile20,
+INSTANTIATE_TEST_CASE_P(smoke_Decompose2DConv_Exec3XCompile20,
                         Decompose2DConvTest,
                         ::testing::Combine(conv2DParams,
                                            miscParams,
                                            ::testing::ValuesIn(netPrecisions),
                                            ::testing::Values(CommonTestUtils::DEVICE_GNA),
-                                           ::testing::ValuesIn(configsExec30Compile20),
+                                           ::testing::ValuesIn(configsExec3XCompile20),
                                            ::testing::ValuesIn(input2DNHWC),
                                            ::testing::ValuesIn(modelsWithPool)),
                         Decompose2DConvTest::getTestCaseName);
@@ -349,63 +343,50 @@ INSTANTIATE_TEST_SUITE_P(smoke_Decompose2DConvStridesDilations,
 
 /* ============= GNA 3.0 Supported Convolutions Combination ============= */
 
-const std::vector<std::map<std::string, std::string>> configsGNA30 = {
-    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "1"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}}};
-
-const std::vector<std::map<std::string, std::string>> configsGNA35 = {
+const std::vector<std::map<std::string, std::string>> configsGNA3X = {
+    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "1"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}},
     {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_SCALE_FACTOR_0", "1"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}}};
 
-const std::vector<op::PadType> padTypesGNA30 = {
+const std::vector<op::PadType> padTypesGNA3X = {
     op::PadType::VALID,
 };
 
-const std::vector<modelType> modelsGNA30 = {
+const std::vector<modelType> modelsGNA3X = {
     modelType::TranspConvBcastAddMaxPoolTransp,
 };
 
-const std::vector<std::vector<size_t>> input2DNHWCGNA30 = {{1, 16, 16, 32}};
-const std::vector<std::vector<size_t>> kernels2DGNA30 = {{1, 2}, {1, 4}};
-const std::vector<std::vector<size_t>> strides2DGNA30 = {{1, 1}};
-const std::vector<std::vector<size_t>> dilations2DGNA30 = {{1, 1}, {1, 2}};
-const std::vector<size_t> numOutChannels2DGNA30 = {8};
-const std::vector<std::vector<size_t>> biases2DGNA30 = {{1, 8, 1, 1}};
-const std::vector<std::vector<size_t>> transpBiases2DGNA30 = {{1, 1, 1, 8}};
-const std::vector<std::vector<size_t>> maxpool2DPoolsGNA30 = {{1, 1}, {1, 2}};
-const std::vector<std::vector<size_t>> maxpoo2DStridesGNA30 = {{1, 1}};
+const std::vector<std::vector<size_t>> input2DNHWCGNA3X = {{1, 16, 16, 32}};
+const std::vector<std::vector<size_t>> kernels2DGNA3X = {{1, 2}, {1, 4}};
+const std::vector<std::vector<size_t>> strides2DGNA3X = {{1, 1}};
+const std::vector<std::vector<size_t>> dilations2DGNA3X = {{1, 1}, {1, 2}};
+const std::vector<size_t> numOutChannels2DGNA3X = {8};
+const std::vector<std::vector<size_t>> biases2DGNA3X = {{1, 8, 1, 1}};
+const std::vector<std::vector<size_t>> transpBiases2DGNA3X = {{1, 1, 1, 8}};
+const std::vector<std::vector<size_t>> maxpool2DPoolsGNA3X = {{1, 1}, {1, 2}};
+const std::vector<std::vector<size_t>> maxpoo2DStridesGNA3X = {{1, 1}};
 
-const auto conv2DParamsGNA30 = ::testing::Combine(::testing::ValuesIn(kernels2DGNA30),
-                                                  ::testing::ValuesIn(strides2DGNA30),
+const auto conv2DParamsGNA3X = ::testing::Combine(::testing::ValuesIn(kernels2DGNA3X),
+                                                  ::testing::ValuesIn(strides2DGNA3X),
                                                   ::testing::ValuesIn(padBegins2D),
                                                   ::testing::ValuesIn(padEnds2D),
-                                                  ::testing::ValuesIn(dilations2DGNA30),
-                                                  ::testing::ValuesIn(numOutChannels2DGNA30),
-                                                  ::testing::ValuesIn(padTypesGNA30));
+                                                  ::testing::ValuesIn(dilations2DGNA3X),
+                                                  ::testing::ValuesIn(numOutChannels2DGNA3X),
+                                                  ::testing::ValuesIn(padTypesGNA3X));
 
-const auto miscParamsGNA30 = ::testing::Combine(::testing::ValuesIn(biases2DGNA30),
-                                                ::testing::ValuesIn(transpBiases2DGNA30),
-                                                ::testing::ValuesIn(maxpool2DPoolsGNA30),
-                                                ::testing::ValuesIn(maxpoo2DStridesGNA30));
+const auto miscParamsGNA3X = ::testing::Combine(::testing::ValuesIn(biases2DGNA3X),
+                                                ::testing::ValuesIn(transpBiases2DGNA3X),
+                                                ::testing::ValuesIn(maxpool2DPoolsGNA3X),
+                                                ::testing::ValuesIn(maxpoo2DStridesGNA3X));
 
-INSTANTIATE_TEST_SUITE_P(smoke_Decompose2DConvGNA30,
+INSTANTIATE_TEST_SUITE_P(smoke_Decompose2DConvGNA3X,
                          Decompose2DConvTest,
-                         ::testing::Combine(conv2DParamsGNA30,
-                                            miscParamsGNA30,
+                         ::testing::Combine(conv2DParamsGNA3X,
+                                            miscParamsGNA3X,
                                             ::testing::ValuesIn(netPrecisions),
                                             ::testing::Values(CommonTestUtils::DEVICE_GNA),
-                                            ::testing::ValuesIn(configsGNA30),
-                                            ::testing::ValuesIn(input2DNHWCGNA30),
-                                            ::testing::ValuesIn(modelsGNA30)),
+                                            ::testing::ValuesIn(configsGNA3X),
+                                            ::testing::ValuesIn(input2DNHWCGNA3X),
+                                            ::testing::ValuesIn(modelsGNA3X)),
                          Decompose2DConvTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_Decompose2DConvGNA35,
-                         Gna35Decompose2DConvTest,
-                         ::testing::Combine(conv2DParamsGNA30,
-                                            miscParamsGNA30,
-                                            ::testing::ValuesIn(netPrecisions),
-                                            ::testing::Values(CommonTestUtils::DEVICE_GNA),
-                                            ::testing::ValuesIn(configsGNA35),
-                                            ::testing::ValuesIn(input2DNHWCGNA30),
-                                            ::testing::ValuesIn(modelsGNA30)),
-                         Gna35Decompose2DConvTest::getTestCaseName);
 
 }  // namespace LayerTestsDefinitions

--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
@@ -223,11 +223,23 @@ TEST(OVClassBasicPropsTest, smoke_SetConfigAfterCreatedTargetDevice) {
     OV_ASSERT_NO_THROW(compile_target = core.get_property("GNA", ov::intel_gna::compile_target));
     ASSERT_EQ(ov::intel_gna::HWGeneration::GNA_2_0, compile_target);
 
+    OV_ASSERT_NO_THROW(core.set_property("GNA", ov::intel_gna::execution_target(ov::intel_gna::HWGeneration::GNA_3_5)));
+    OV_ASSERT_NO_THROW(execution_target = core.get_property("GNA", ov::intel_gna::execution_target));
+    ASSERT_EQ(ov::intel_gna::HWGeneration::GNA_3_5, execution_target);
+    OV_ASSERT_NO_THROW(compile_target = core.get_property("GNA", ov::intel_gna::compile_target));
+    ASSERT_EQ(ov::intel_gna::HWGeneration::GNA_2_0, compile_target);
+
     OV_ASSERT_NO_THROW(core.set_property("GNA", ov::intel_gna::compile_target(ov::intel_gna::HWGeneration::GNA_3_0)));
     OV_ASSERT_NO_THROW(execution_target = core.get_property("GNA", ov::intel_gna::execution_target));
-    ASSERT_EQ(ov::intel_gna::HWGeneration::GNA_3_0, execution_target);
+    ASSERT_EQ(ov::intel_gna::HWGeneration::GNA_3_5, execution_target);
     OV_ASSERT_NO_THROW(compile_target = core.get_property("GNA", ov::intel_gna::compile_target));
     ASSERT_EQ(ov::intel_gna::HWGeneration::GNA_3_0, compile_target);
+
+    OV_ASSERT_NO_THROW(core.set_property("GNA", ov::intel_gna::compile_target(ov::intel_gna::HWGeneration::GNA_3_5)));
+    OV_ASSERT_NO_THROW(execution_target = core.get_property("GNA", ov::intel_gna::execution_target));
+    ASSERT_EQ(ov::intel_gna::HWGeneration::GNA_3_5, execution_target);
+    OV_ASSERT_NO_THROW(compile_target = core.get_property("GNA", ov::intel_gna::compile_target));
+    ASSERT_EQ(ov::intel_gna::HWGeneration::GNA_3_5, compile_target);
 
     OV_ASSERT_NO_THROW(
         core.set_property("GNA", ov::intel_gna::execution_target(ov::intel_gna::HWGeneration::UNDEFINED)));
@@ -246,6 +258,16 @@ TEST(OVClassBasicPropsTest, smoke_SetConfigAfterCreatedTargetDevice) {
                                    {ov::intel_gna::compile_target(ov::intel_gna::HWGeneration::GNA_2_0),
                                     {GNA_CONFIG_KEY(COMPILE_TARGET), "GNA_TARGET_3_0"}}),
                  ov::Exception);
+
+    ASSERT_THROW(core.set_property("GNA",
+                                   {ov::intel_gna::execution_target(ov::intel_gna::HWGeneration::GNA_2_0),
+                                    {GNA_CONFIG_KEY(EXEC_TARGET), "GNA_TARGET_3_5"}}),
+                 ov::Exception);
+    ASSERT_THROW(core.set_property("GNA",
+                                   {ov::intel_gna::compile_target(ov::intel_gna::HWGeneration::GNA_2_0),
+                                    {GNA_CONFIG_KEY(COMPILE_TARGET), "GNA_TARGET_3_5"}}),
+                 ov::Exception);
+
     ASSERT_THROW(core.set_property("GNA", {{ov::intel_gna::execution_target.name(), "ABC"}}), ov::Exception);
     ASSERT_THROW(core.set_property("GNA", {{ov::intel_gna::compile_target.name(), "ABC"}}), ov::Exception);
 }

--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/single_layer_tests/conv_low_precision.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/single_layer_tests/conv_low_precision.cpp
@@ -121,32 +121,18 @@ protected:
     }
 };
 
-using ConvLowPrecisionTestLib35 = ConvLowPrecisionTest;
-
 TEST_P(ConvLowPrecisionTest, CompareWithRefs) {
-    Run();
-};
-
-TEST_P(ConvLowPrecisionTestLib35, CompareWithRefs) {
-    if (gnaVersionCheck.gnaLibVersionLessThan("3.5")) {
-        GTEST_SKIP() << gnaVersionCheck.getLastCmpResultMsg() << std::endl;
-        return;
-    }
     Run();
 };
 
 const vector<InferenceEngine::Precision> netPrecisions = {InferenceEngine::Precision::FP16,
                                                           InferenceEngine::Precision::FP32};
 
-const vector<map<string, string>> configs_3_0 = {
+const vector<map<string, string>> configs_3_X = {
     {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_PRECISION", "I8"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}},
     {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_PRECISION", "I16"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}},
-};
-
-const vector<map<string, string>> configs_3_5 = {
     {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_PRECISION", "I8"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}},
-    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_PRECISION", "I16"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}},
-};
+    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_PRECISION", "I16"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}}};
 
 const vector<map<string, string>> configs_2_0 = {
     {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_PRECISION", "I8"}, {"GNA_EXEC_TARGET", "GNA_TARGET_2_0"}},
@@ -172,23 +158,14 @@ INSTANTIATE_TEST_SUITE_P(smoke_LowPrecision20,
                                             ::testing::ValuesIn(levels)),
                          ConvLowPrecisionTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_LowPrecision30,
+INSTANTIATE_TEST_SUITE_P(smoke_LowPrecision3X,
                          ConvLowPrecisionTest,
                          ::testing::Combine(::testing::ValuesIn(netPrecisions),
                                             ::testing::Values(CommonTestUtils::DEVICE_GNA),
-                                            ::testing::ValuesIn(configs_3_0),
+                                            ::testing::ValuesIn(configs_3_X),
                                             ::testing::ValuesIn(inputShapes),
                                             ::testing::ValuesIn(fqMinMax),
                                             ::testing::ValuesIn(levels)),
                          ConvLowPrecisionTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_LowPrecision35,
-                         ConvLowPrecisionTestLib35,
-                         ::testing::Combine(::testing::ValuesIn(netPrecisions),
-                                            ::testing::Values(CommonTestUtils::DEVICE_GNA),
-                                            ::testing::ValuesIn(configs_3_5),
-                                            ::testing::ValuesIn(inputShapes),
-                                            ::testing::ValuesIn(fqMinMax),
-                                            ::testing::ValuesIn(levels)),
-                         ConvLowPrecisionTest::getTestCaseName);
 }  // namespace ConvLowPrecicionTestNs

--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/subgraph_tests/convolution_relu_sequence.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/subgraph_tests/convolution_relu_sequence.cpp
@@ -161,13 +161,12 @@ const std::vector<convReluSpecificParamsAll> convReluSpecificParamsAllAll = {
     {inputShapeSimpleWithPooling, convReluSpecificParamsSimpleSeqWithPooling}};
 
 const std::vector<std::map<std::string, std::string>> configs = {
-    {{InferenceEngine::GNAConfigParams::KEY_GNA_DEVICE_MODE, InferenceEngine::GNAConfigParams::GNA_SW_FP32}},
-    {{InferenceEngine::GNAConfigParams::KEY_GNA_DEVICE_MODE, InferenceEngine::GNAConfigParams::GNA_SW_EXACT},
-     {InferenceEngine::GNAConfigParams::KEY_GNA_EXEC_TARGET, InferenceEngine::GNAConfigParams::GNA_TARGET_3_0}}};
+    {{"GNA_DEVICE_MODE", "GNA_SW_FP32"}},
+    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}},
+    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}}};
 
 const std::vector<std::map<std::string, std::string>> configs_allowing_pooling_stride_above_window = {
-    {{InferenceEngine::GNAConfigParams::KEY_GNA_DEVICE_MODE, InferenceEngine::GNAConfigParams::GNA_SW_EXACT},
-     {InferenceEngine::GNAConfigParams::KEY_GNA_EXEC_TARGET, InferenceEngine::GNAConfigParams::GNA_TARGET_2_0}}};
+    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_EXEC_TARGET", "GNA_TARGET_2_0"}}};
 
 INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionReluSequenceTest,
                          GnaConvolutionReluSequenceTest,

--- a/src/plugins/intel_gna/tests/functional/subgraph_tests/add_transpose_detection.cpp
+++ b/src/plugins/intel_gna/tests/functional/subgraph_tests/add_transpose_detection.cpp
@@ -110,6 +110,7 @@ const InferenceEngine::Precision net_precisions{InferenceEngine::Precision::FP32
 
 const std::vector<std::map<std::string, std::string>> configs = {
     {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_0"}},
+    {{"GNA_DEVICE_MODE", "GNA_SW_EXACT"}, {"GNA_EXEC_TARGET", "GNA_TARGET_3_5"}},
     {{"GNA_DEVICE_MODE", "GNA_SW_FP32"}}};
 
 const std::vector<std::vector<size_t>> input_shapes{{1, 8, 32, 16}};


### PR DESCRIPTION
### Details:
 - fixed configuration to ensure that tests will be also executed for 3_5
     when specific exec targets are set.

### Tickets:
 - 105916