### PR TITLE
[GPU] Fix dump graph failure issue in levit-128s model.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
@@ -136,7 +136,16 @@ void close_stream(std::ofstream& graph) { graph.close(); }
 
 std::string get_node_id(const program_node* ptr) { return "node_" + std::to_string(reinterpret_cast<uintptr_t>(ptr)); }
 
-void dump_full_node(std::ofstream& out, const program_node* node) { out << node->type()->to_string(*node); }
+void dump_full_node(std::ofstream& out, const program_node* node) {
+    GPU_DEBUG_GET_INSTANCE(debug_config);
+    try {
+        out << node->type()->to_string(*node);
+    } catch(const std::exception& e) {
+        GPU_DEBUG_IF(debug_config->verbose >= 2) {
+            std::cerr << node->id() << " to_string() error: " << e.what() << '\n';
+        }
+    }
+}
 }  // namespace
 
 std::string get_dir_path(const ExecutionConfig& config) {

--- a/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
@@ -6,6 +6,7 @@
 #include "to_string_utils.h"
 #include "data_inst.h"
 #include "condition_inst.h"
+#include "json_object.h"
 
 #include <algorithm>
 #include <vector>
@@ -141,9 +142,14 @@ void dump_full_node(std::ofstream& out, const program_node* node) {
     try {
         out << node->type()->to_string(*node);
     } catch(const std::exception& e) {
-        GPU_DEBUG_IF(debug_config->verbose >= 2) {
-            std::cerr << node->id() << " to_string() error: " << e.what() << '\n';
-        }
+        auto node_info = std::shared_ptr<json_composite>(new json_composite());
+        node_info->add("id", node->id());
+        node_info->add("error", "failed to make string from descriptor");
+        std::stringstream emtpy_desc;
+        node_info->dump(emtpy_desc);
+        out << emtpy_desc.str();
+
+        GPU_DEBUG_INFO << node->id() << " to_string() error: " << e.what() << '\n';
     }
 }
 }  // namespace

--- a/src/plugins/intel_gpu/src/graph/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/strided_slice.cpp
@@ -114,9 +114,10 @@ std::string strided_slice_inst::to_string(strided_slice_node const& node) {
 
     json_composite strided_slice_info;
     strided_slice_info.add("input id", input.id());
-    strided_slice_info.add("begin_param id", node.get_dependency(1).id());
-    strided_slice_info.add("end_param id", node.get_dependency(2).id());
-    strided_slice_info.add("stride_param id", node.get_dependency(3).id());
+    std::vector<std::string> dependencies_info = {"begin_param id", "end_param id", "stride_param id"};
+    for (size_t i = 0; i < node.get_dependencies().size(); ++i) {
+        strided_slice_info.add(dependencies_info[i], node.get_dependency(i).id());
+    }
     strided_slice_info.add("begin", node.get_primitive()->begin);
     strided_slice_info.add("end", node.get_primitive()->end);
     strided_slice_info.add("strides", node.get_primitive()->strides);


### PR DESCRIPTION
1. to_string() in strided_slice always access begin/end/stride param id from dependencies regardless max dependencies. Fix only for vaild.
2. Add an exception in dump_full_node(). It helps below.
- Avoid a dump failure. Usually, graph dump are used during debugging, which reduces unnecessary debugging time due to graph dump failure.
- You can immediately see which node has failed, making it easy to find it.


### Tickets:
 - *108865*
