### PR TITLE
[GNA] WA to fix config parsing of scale factor map

### DIFF
--- a/samples/cpp/speech_sample/main.cpp
+++ b/samples/cpp/speech_sample/main.cpp
@@ -215,7 +215,7 @@ int main(int argc, char* argv[]) {
                                                                           numFrames * numFrameElements);
                     slog::info << "Using scale factor of " << floatScaleFactor << " calculated from first utterance."
                                << slog::endl;
-                    scale_factors_per_input[model->input(i).get_any_name()] = floatScaleFactor;
+                    scale_factors_per_input[strip_name(model->input(i).get_any_name())] = floatScaleFactor;
                 }
                 gnaPluginConfig[ov::intel_gna::scale_factors_per_input.name()] = scale_factors_per_input;
             }

--- a/samples/cpp/speech_sample/utils.hpp
+++ b/samples/cpp/speech_sample/utils.hpp
@@ -368,6 +368,15 @@ bool check_name(const ov::OutputVector& nodes, const std::string& node_name) {
 }
 
 /**
+ * @brief Strip the name of the input to exclude ":port"
+ * @param name input name
+ * @return striped input name
+ */
+std::string strip_name(const std::string &name) {
+    return {name, 0, name.rfind(':')};
+}
+
+/**
  * @brief Parse scale factors per input
  * Format : <input_name1>=<sf1>,<input2>=<sf2> or just <sf>
  * @param inputs model inputs

--- a/samples/cpp/speech_sample/utils.hpp
+++ b/samples/cpp/speech_sample/utils.hpp
@@ -372,7 +372,7 @@ bool check_name(const ov::OutputVector& nodes, const std::string& node_name) {
  * @param name input name
  * @return striped input name
  */
-std::string strip_name(const std::string &name) {
+std::string strip_name(const std::string& name) {
     return {name, 0, name.rfind(':')};
 }
 

--- a/src/inference/include/openvino/runtime/intel_gna/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_gna/properties.hpp
@@ -37,7 +37,7 @@ static constexpr Property<std::string, PropertyMutability::RO> library_full_vers
  * This option should be used with floating point value serialized to string with . (dot) as a decimal separator
  * @ingroup ov_runtime_gna_prop_cpp_api
  * @details In the case of multiple inputs, individual scale factors can be provided using the
- *  map where key is layer name and value is scale factor
+ *  map where key is layer name and value is scale factor. The input name shall not contain symbol ":".
  * Example:
  * \code{.cpp}
  * ov::Core core;


### PR DESCRIPTION
### Details:
 - If the input tensor name contains *:port* (Parameter:0) then SF property will be incorrectly parsed by ov::util::from_string by GNA plugin because property value would be *Parameter:0:16384*.  

### Tickets:
 - 108931
