### PR TITLE
[GPU] Fix a bug of fusing eltwise sum post-op.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_helpers.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_helpers.cpp
@@ -114,6 +114,7 @@ add_fusing_type onednn_add_fusing_helpers::get_add_fusing_type(
             && p_layout.format == d_layout.format && p_layout.get_tensor() == d_layout.get_tensor()
             && p_layout.data_padding == d_layout.data_padding
             && dep_node.get_users().size() == 1
+            && !dep_node.is_constant()
             && !p_node.is_type<pooling>()) {
             return add_fusing_type::sum;
         } else if (p_layout.get_tensor() == d_layout.get_tensor()) {


### PR DESCRIPTION
+ When input of eltwise is full-tensor constant layer, use binary add instead of sum as post-op on oneDNN.

### Tickets:
 - *104840*, 105495
