### PR TITLE
[CPU] layout alignment to improve perf for interpolate pillow modes

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.hpp
@@ -66,6 +66,7 @@ struct InterpolateAttrs {
     InterpolateLayoutType layout;
     std::vector<float> dataScales;
     bool hasPad = false;
+    bool NCHWAsNHWC = false;
 };
 
 inline SizeVector getPaddedInputShape(const VectorDims &srcDims,

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.hpp
@@ -66,7 +66,6 @@ struct InterpolateAttrs {
     InterpolateLayoutType layout;
     std::vector<float> dataScales;
     bool hasPad = false;
-    bool NCHWAsNHWC = false;
 };
 
 inline SizeVector getPaddedInputShape(const VectorDims &srcDims,

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -159,10 +159,6 @@ struct jit_uni_interpolate_kernel_f32 : public jit_uni_interpolate_kernel, publi
             case InterpolateMode::bilinear_pillow:
             case InterpolateMode::bicubic_pillow: {
                 switch (jcp_.layout) {
-                    case InterpolateLayoutType::planar: {
-                        pillow_planar();
-                        break;
-                    }
                     case InterpolateLayoutType::by_channel: {
                         pillow_by_channel();
                         break;
@@ -478,14 +474,6 @@ private:
                 }
                 add(reg_weights, jcp_.filterLenY * sizeof(float));
             }
-        }
-    }
-
-    void pillow_planar() {
-        if (jcp_.NCHWAsNHWC) {
-            pillow_by_channel();
-        } else {
-            assert(!"unsupported memory layout for interpolate layer jit kernel with bilinear_pillow and bicubic_pillow modes.");
         }
     }
 
@@ -1590,7 +1578,6 @@ size_t InterpolateKey::hash() const {
 
     seed = hash_combine(seed, nodeAttrs.inPrc.getPrecVal());
     seed = hash_combine(seed, nodeAttrs.outPrc.getPrecVal());
-    seed = hash_combine(seed, nodeAttrs.NCHWAsNHWC);
 
     seed = get_vector_hash(seed, srcDims);
     seed = get_vector_hash(seed, dstDims);
@@ -1620,8 +1607,6 @@ bool InterpolateKey::operator==(const InterpolateKey &rhs) const {
     if (nodeAttrs.inPrc != rhs.nodeAttrs.inPrc)
         return false;
     if (nodeAttrs.outPrc != rhs.nodeAttrs.outPrc)
-        return false;
-    if (nodeAttrs.NCHWAsNHWC != rhs.nodeAttrs.NCHWAsNHWC)
         return false;
 
     if (srcDims != rhs.srcDims)
@@ -1972,7 +1957,7 @@ Interpolate::Interpolate(const std::shared_ptr<ngraph::Node>& op, const GraphCon
             if (isAxesSpecified) {
                 axes = std::dynamic_pointer_cast<const ngraph::opset1::Constant>(interp->get_input_node_shared_ptr(AXES_ID_V11))->cast_vector<int>();
                 if (dataRank == 4 && axes.size() == 2 && axes[0] == 1 && axes[1] == 2 && mayiuse(cpu::x64::sse41)) {
-                    interpAttrs.NCHWAsNHWC = true;
+                    NCHWAsNHWC = true;
                     axes[0] = 2;
                     axes[1] = 3;
                 }
@@ -2013,7 +1998,7 @@ void Interpolate::getSupportedDescriptors() {
     }
     //correct pad
     if (hasPad) {
-        interpAttrs.NCHWAsNHWC = false;
+        NCHWAsNHWC = false;
         auto correctPad = [&](std::vector<int> pad, int rank) {
             int padLen = pad.size();
             if (padLen == rank) {
@@ -2122,9 +2107,10 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
     if (is_version11) {
 #if defined (OV_CPU_WITH_ACL)
         interpAttrs.hasPad = hasPad;
-                //TODO: Fix NHWC case in ACL executor
-                //Interpolate ACL executor produces incorrect result in NHWC case
-                //pushDesc(LayoutType::nspc, undef, true, true);
+        //TODO: Fix NHWC case in ACL executor
+        //Interpolate ACL executor produces incorrect result in NHWC case
+        //pushDesc(LayoutType::nspc, undef, true, true);
+        pushDesc(LayoutType::ncsp, undef, true, true);
         canUseAclExecutor = !supportedPrimitiveDescriptors.empty();
         if (canUseAclExecutor)
             return;
@@ -2132,17 +2118,17 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
 
         if (getInputShapeAtPort(DATA_ID).getRank() == 4) {
             if (mayiuse(cpu::x64::avx512_core)) {
-                if (interpAttrs.NCHWAsNHWC)
+                if (NCHWAsNHWC)
                     pushDesc(LayoutType::ncsp, jit_avx512, true);
                 else
                     pushDesc(LayoutType::nspc, jit_avx512, true);
             } else if (mayiuse(cpu::x64::avx2)) {
-                if (interpAttrs.NCHWAsNHWC)
+                if (NCHWAsNHWC)
                     pushDesc(LayoutType::ncsp, jit_avx2, true);
                 else
                     pushDesc(LayoutType::nspc, jit_avx2, true);
             } else if (mayiuse(cpu::x64::sse41)) {
-                if (interpAttrs.NCHWAsNHWC)
+                if (NCHWAsNHWC)
                     pushDesc(LayoutType::ncsp, jit_sse42, true);
                 else
                     pushDesc(LayoutType::nspc, jit_sse42, true);
@@ -2158,6 +2144,7 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
         //TODO: Fix NHWC case in ACL executor
         //Interpolate ACL executor produces incorrect result in NHWC case
         //pushDesc(LayoutType::nspc, undef, false, true);
+        pushDesc(LayoutType::ncsp, undef, false, true);
         canUseAclExecutor = !supportedPrimitiveDescriptors.empty();
         if (canUseAclExecutor)
             return;
@@ -2289,16 +2276,17 @@ void Interpolate::prepareParams() {
     VectorDims srcDims = srcDimsOrign;
     VectorDims dstDims = dstDimsOrign;
 
-    if ((interpAttrs.layout == InterpolateLayoutType::planar) && interpAttrs.NCHWAsNHWC) {
-        // layoutAlign
-        auto layoutAlign = [] (VectorDims& Dims) {
+    // layoutAlignment
+    if (NCHWAsNHWC && srcMemPtr->getDesc().hasLayoutType(LayoutType::ncsp)) {
+        auto logicalShapeAlign = [] (VectorDims& Dims) {
             size_t C = Dims[3];
             Dims[3] = Dims[2];
             Dims[2] = Dims[1];
             Dims[1] = C;
         };
-        layoutAlign(srcDims);
-        layoutAlign(dstDims);
+        logicalShapeAlign(srcDims);
+        logicalShapeAlign(dstDims);
+        interpAttrs.layout = InterpolateLayoutType::by_channel;
     }
 
     if (shapeCalcMode == InterpolateShapeCalcMode::scales) {
@@ -2310,7 +2298,7 @@ void Interpolate::prepareParams() {
     }
 
     std::vector<float> dataScales = getScales(getPaddedInputShape(srcDims, interpAttrs.padBegin, interpAttrs.padEnd), dstDims);
-    if (!interpAttrs.NCHWAsNHWC && (getOutputShapeAtPort(0).getRank() > 2 && (dataScales[0] != 1.f || dataScales[1] != 1.f))) {
+    if (!NCHWAsNHWC && (getOutputShapeAtPort(0).getRank() > 2 && (dataScales[0] != 1.f || dataScales[1] != 1.f))) {
         IE_THROW() << "Interpolate layer only supports resize on spatial dimensions(depth, height and width)";
     }
 
@@ -2346,7 +2334,7 @@ void Interpolate::prepareParams() {
                                                                key.dataScales,
                                                                key.attr);
         } else if ((key.nodeAttrs.mode == InterpolateMode::bilinear_pillow || key.nodeAttrs.mode == InterpolateMode::bicubic_pillow) &&
-            (key.nodeAttrs.layout == InterpolateLayoutType::by_channel || (key.nodeAttrs.layout == InterpolateLayoutType::planar && interpAttrs.NCHWAsNHWC))) {
+            (key.nodeAttrs.layout == InterpolateLayoutType::by_channel)) {
             executor = std::make_shared<InterpolateJitExecutor>(key.nodeAttrs,
                                                                key.srcDims,
                                                                key.dstDims,
@@ -3766,14 +3754,14 @@ void Interpolate::InterpolateExecutorBase::create_pillow_working_buf(Interpolate
         return;
     size_t bufSize = srcDimPad5d[3] * dstDim5d[4] * srcDataSize; // IH * OW
     size_t threadsNum = parallel_get_num_threads();
-    if (layout == InterpolateLayoutType::by_channel || NCHWAsNHWC) {
+    if (layout == InterpolateLayoutType::planar) {
+        // B and C execute in parallel, need separate buf
+        size_t parallelNum = srcDimPad5d[0] * srcDimPad5d[1];
+        bufSize *= std::min(threadsNum, parallelNum);
+    } else {
         bufSize *= srcDimPad5d[1]; // *C
         // B execute in parallel, need separate buf
         size_t parallelNum = srcDimPad5d[0];
-        bufSize *= std::min(threadsNum, parallelNum);
-    } else {
-        // B and C execute in parallel, need separate buf
-        size_t parallelNum = srcDimPad5d[0] * srcDimPad5d[1];
         bufSize *= std::min(threadsNum, parallelNum);
     }
     pillow_working_buf.resize(bufSize);
@@ -3784,7 +3772,7 @@ Interpolate::InterpolateExecutorBase::InterpolateExecutorBase(const InterpolateA
                                                       const VectorDims &dstDims,
                                                       const std::vector<float> &dataScales) :
         mode(interpAttrs.mode), coordTransMode(interpAttrs.coordTransMode), configured_for_layout(interpAttrs.layout),
-        inputPrec(interpAttrs.inPrc), outputPrec(interpAttrs.outPrc), NCHWAsNHWC(interpAttrs.NCHWAsNHWC) {
+        inputPrec(interpAttrs.inPrc), outputPrec(interpAttrs.outPrc) {
     srcDimPad5d = to5Dim(getPaddedInputShape(srcDims, interpAttrs.padBegin, interpAttrs.padEnd));
     dstDim5d = to5Dim(dstDims);
     srcDataSize = interpAttrs.inPrc.size();
@@ -3851,10 +3839,9 @@ Interpolate::InterpolateJitExecutor::InterpolateJitExecutor(const InterpolateAtt
         jcp.filterLenX = auxTable[0];
         jcp.filterLenY = auxTable[1];
         jcp.bound = static_cast<int*>(&auxTable[2 + jcp.OW * jcp.filterLenX + jcp.OH * jcp.filterLenY]);
-        jcp.NCHWAsNHWC = interpAttrs.NCHWAsNHWC;
     }
 #if defined(OPENVINO_ARCH_X86_64)
-    if (jcp.layout != InterpolateLayoutType::planar || interpAttrs.NCHWAsNHWC) {
+    if (jcp.layout != InterpolateLayoutType::planar) {
         if (mayiuse(cpu::x64::avx512_core)) {
             interpolateKernel.reset(new jit_uni_interpolate_kernel_f32<cpu::x64::avx512_core>(jcp, *attr.get()));
         } else if (mayiuse(cpu::x64::avx2)) {
@@ -3910,7 +3897,7 @@ void Interpolate::InterpolateJitExecutor::exec(const uint8_t *in_ptr_, uint8_t *
         }
         case InterpolateMode::bilinear_pillow:
         case InterpolateMode::bicubic_pillow: {
-            if (configured_for_layout == InterpolateLayoutType::by_channel || NCHWAsNHWC) {
+            if (configured_for_layout == InterpolateLayoutType::by_channel) {
                 pillowCGathered(in_ptr_, out_ptr_, post_ops_data_, N, C, IH, IW, OH, OW);
             } else {
                 IE_THROW() << "Only channel_first jit kernel is supported for pillow mode" << mode;

--- a/src/plugins/intel_cpu/src/nodes/interpolate.h
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.h
@@ -34,6 +34,7 @@ struct jit_interpolate_config_params {
     int filterLenX;
     int filterLenY;
     int* bound;
+    bool NCHWAsNHWC;
 };
 
 struct jit_interpolate_call_args {
@@ -146,6 +147,13 @@ private:
             size_t dataRank;
             std::vector<int> auxTable;
             std::vector<uint8_t> pillow_working_buf;
+            // Some FEs or preprocessing step resize spatial dimenion for tensor with NHWC layout memory,
+            // but imported as planar layout[abcd] with axis[1,2] for convinence. In this case, for pillow modes and no pad for now,
+            // nhwc layout pass and kernel can be used for this planar layout and axis settings(NCHWAsNHWC is true) to get higher perf with
+            // 1. logical shape alignment [abcd-nhwc] to [adbc-nchw].
+            // 2. axis alignment [1,2] to [2,3].
+            // 3. config planar layout support and treated it as channel_first layout.
+            bool NCHWAsNHWC = false;
     };
     std::shared_ptr<InterpolateExecutorBase> execPtr = nullptr;
 

--- a/src/plugins/intel_cpu/src/nodes/interpolate.h
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.h
@@ -34,7 +34,6 @@ struct jit_interpolate_config_params {
     int filterLenX;
     int filterLenY;
     int* bound;
-    bool NCHWAsNHWC;
 };
 
 struct jit_interpolate_call_args {
@@ -104,6 +103,13 @@ public:
 private:
     bool is_version11 = true;
     InterpolateAttrs interpAttrs;
+    // Some FEs or preprocessing step resize spatial dimenion for tensor with NHWC layout memory,
+    // but imported as planar layout[abcd] with axis[1,2] for convinence. In this case, for pillow modes and no pad for now,
+    // nhwc layout pass and kernel can be used for this planar layout and axis settings(NCHWAsNHWC is true) to get higher perf with
+    // 1. logical shape alignment [abcd-nhwc] to [adbc-nchw].
+    // 2. axis alignment [1,2] to [2,3].
+    // 3. config planar layout support and treated it as channel_first layout.
+    bool NCHWAsNHWC = false;
 
     class InterpolateExecutorBase {
         public:
@@ -147,13 +153,6 @@ private:
             size_t dataRank;
             std::vector<int> auxTable;
             std::vector<uint8_t> pillow_working_buf;
-            // Some FEs or preprocessing step resize spatial dimenion for tensor with NHWC layout memory,
-            // but imported as planar layout[abcd] with axis[1,2] for convinence. In this case, for pillow modes and no pad for now,
-            // nhwc layout pass and kernel can be used for this planar layout and axis settings(NCHWAsNHWC is true) to get higher perf with
-            // 1. logical shape alignment [abcd-nhwc] to [adbc-nchw].
-            // 2. axis alignment [1,2] to [2,3].
-            // 3. config planar layout support and treated it as channel_first layout.
-            bool NCHWAsNHWC = false;
     };
     std::shared_ptr<InterpolateExecutorBase> execPtr = nullptr;
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/interpolate.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/interpolate.cpp
@@ -925,6 +925,96 @@ INSTANTIATE_TEST_SUITE_P(smoke_InterpolateBicubicPillow_Layout_Test, Interpolate
             ::testing::ValuesIn(filterPillowAdditionalConfig())),
     InterpolateLayerCPUTest::getTestCaseName);
 
+// pillow modes: planar layout with axis[1,2] executed as nhwc layout case
+const std::vector<std::vector<int64_t>> defaultAxes4D_pillow_nchw_as_nhwc = {
+    {1, 2}
+};
+
+const std::vector<ShapeParams> shapeParams4D_Pillow_Smoke_nchw_as_nhwc = {
+    ShapeParams{
+        ov::op::v11::Interpolate::ShapeCalcMode::SCALES,
+        InputShape{{}, {{1, 4, 4, 3}}},
+        ngraph::helpers::InputLayerType::CONSTANT,
+        {{2.0f, 4.0f}},
+        defaultAxes4D_pillow_nchw_as_nhwc.front()
+    },
+    ShapeParams{
+        ov::op::v11::Interpolate::ShapeCalcMode::SIZES,
+        InputShape{{}, {{2, 16, 16, 4}}},
+        ngraph::helpers::InputLayerType::CONSTANT,
+        {{2, 8}},
+        defaultAxes4D_pillow_nchw_as_nhwc.front()
+    },
+    ShapeParams{
+        ov::op::v11::Interpolate::ShapeCalcMode::SCALES,
+        InputShape{{-1, -1, -1, {2, 20}}, {{1, 4, 4, 11}, {2, 6, 5, 7}, {1,  4, 4, 11}}},
+        ngraph::helpers::InputLayerType::CONSTANT,
+        {{1.25f, 0.75f}},
+        defaultAxes4D_pillow_nchw_as_nhwc.front()
+    },
+    ShapeParams{
+        ov::op::v11::Interpolate::ShapeCalcMode::SIZES,
+        InputShape{{-1, -1, -1, {2, 20}}, {{1, 4, 4, 17}, {2, 10, 12, 3}, {1, 4, 4, 17}}},
+        ngraph::helpers::InputLayerType::CONSTANT,
+        {{6, 8}},
+        defaultAxes4D_pillow_nchw_as_nhwc.front()
+    }
+};
+
+const std::vector<std::vector<size_t>> pads4D_nchw_as_nhwc = {
+        {0, 0, 0, 0}
+};
+
+std::vector<CPUSpecificParams> filterCPUInfoForDevice_pillow_nchw_as_nhwc() {
+    std::vector<CPUSpecificParams> resCPUParams;
+    if (InferenceEngine::with_cpu_x86_avx512f()) {
+        resCPUParams.push_back(CPUSpecificParams{{nchw, x, x}, {nchw}, {"jit_avx512"}, "jit_avx512"});
+    } else if (InferenceEngine::with_cpu_x86_avx2()) {
+        resCPUParams.push_back(CPUSpecificParams{{nchw, x, x}, {nchw}, {"jit_avx2"}, "jit_avx2"});
+    } else if (InferenceEngine::with_cpu_x86_sse42()) {
+        resCPUParams.push_back(CPUSpecificParams{{nchw, x, x}, {nchw}, {"jit_sse42"}, "jit_sse42"});
+    }
+    return resCPUParams;
+}
+
+const auto interpolateCasesBilinearPillow_Smoke_nchw_as_nhwc = ::testing::Combine(
+        ::testing::Values(ov::op::v11::Interpolate::InterpolateMode::BILINEAR_PILLOW),
+        ::testing::ValuesIn(coordinateTransformModesPillow_Smoke),
+        ::testing::ValuesIn(defNearestModes),
+        ::testing::ValuesIn(antialias),
+        ::testing::ValuesIn(pads4D_nchw_as_nhwc),
+        ::testing::ValuesIn(pads4D_nchw_as_nhwc),
+        ::testing::ValuesIn(cubeCoefsPillow));
+
+INSTANTIATE_TEST_SUITE_P(smoke_InterpolateBilinearPillow_LayoutAlign_Test, InterpolateLayerCPUTest,
+        ::testing::Combine(
+            interpolateCasesBilinearPillow_Smoke_nchw_as_nhwc,
+            ::testing::ValuesIn(shapeParams4D_Pillow_Smoke_nchw_as_nhwc),
+            ::testing::Values(ElementType::f32),
+            ::testing::ValuesIn(filterCPUInfoForDevice_pillow_nchw_as_nhwc()),
+            ::testing::ValuesIn(interpolateFusingPillowParamsSet),
+            ::testing::ValuesIn(filterPillowAdditionalConfig())),
+    InterpolateLayerCPUTest::getTestCaseName);
+
+const auto interpolateCasesBicubicPillow_Smoke_nchw_as_nhwc = ::testing::Combine(
+        ::testing::Values(ov::op::v11::Interpolate::InterpolateMode::BICUBIC_PILLOW),
+        ::testing::ValuesIn(coordinateTransformModesPillow_Smoke),
+        ::testing::ValuesIn(defNearestModes),
+        ::testing::ValuesIn(antialias),
+        ::testing::ValuesIn(pads4D_nchw_as_nhwc),
+        ::testing::ValuesIn(pads4D_nchw_as_nhwc),
+        ::testing::ValuesIn(cubeCoefsPillow));
+
+INSTANTIATE_TEST_SUITE_P(smoke_InterpolateBicubicPillow_LayoutAlign_Test, InterpolateLayerCPUTest,
+        ::testing::Combine(
+            interpolateCasesBicubicPillow_Smoke_nchw_as_nhwc,
+            ::testing::ValuesIn(shapeParams4D_Pillow_Smoke_nchw_as_nhwc),
+            ::testing::Values(ElementType::f32),
+            ::testing::ValuesIn(filterCPUInfoForDevice_pillow_nchw_as_nhwc()),
+            ::testing::ValuesIn(interpolateFusingPillowParamsSet),
+            ::testing::ValuesIn(filterPillowAdditionalConfig())),
+    InterpolateLayerCPUTest::getTestCaseName);
+
 } // namespace
 
 } // namespace CPULayerTestsDefinitions


### PR DESCRIPTION
### Details:
 -*Some FEs or preprocessing step resize spatial dimenion for tensor with NHWC layout memory, but imported as planar layout[abcd] with axis[1,2] for convinence. In this case, for pillow modes and no pad for now, nhwc layout pass and kernel can be used for this planar layout and axis settings(flag NCHWAsNHWC is true) to get higher perf with: 
 1. logical shape alignment [abcd-nhwc] to [adbc-nchw].
 2. axis alignment [1,2] to [2,3].
 3. config planar layout support and treated it as channel_first layout.*