### PR TITLE
Fix numpy requirements for onnx

### DIFF
--- a/model-optimizer/requirements.txt
+++ b/model-optimizer/requirements.txt
@@ -2,7 +2,7 @@ tensorflow~=2.4.1
 mxnet~=1.2.0; sys_platform == 'win32'
 mxnet~=1.7.0.post2; sys_platform != 'win32'
 networkx~=2.5
-numpy>=1.16.6,<1.20
+numpy>=1.16.6,<1.25.0
 protobuf>=3.15.6
 onnx>=1.8.1
 defusedxml>=0.7.1


### PR DESCRIPTION
### Details:
 - onnx 1.13.1 requires numpy >1.21.6

### Tickets:
 - *ticket-id*
