### PR TITLE
[GPU] Disable oneDNN post-op Prelu in FC,gemm

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -707,6 +707,10 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
 
                 // Activation should not be fused if oneDNN does NOT support it
                 if (_lo.is_primitive_implemented_for_onednn(input))  {
+                    auto activation_func = activation_node.get_primitive()->activation_function;
+                    // onednn post-op relu has a functional issue
+                    if (activation_func == cldnn::activation_func::relu_negative_slope)
+                        return;
                     #ifdef ENABLE_ONEDNN_FOR_GPU
                     try {
                         onednn::convert_activation_func(activation_node.get_primitive()->activation_function);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -707,7 +707,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                     return;
                 if (activation_func == cldnn::activation_func::relu_negative_slope &&
                     (input.is_type<fully_connected>() || input.is_type<gemm>())) {
-                    // prelu fusion is not implemented in oneDNN3.1 (https://jira.devtools.intel.com/browse/MFDNN-9898)
+                    // prelu fusion is not implemented in oneDNN3.1 (CVS-108233)
                     return;
                 }
                 // Activation should not be fused if oneDNN does NOT support it

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -705,7 +705,8 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             if (_lo.get_optimization_attributes().use_onednn_impls) {
                 if (input.is_type<reshape>() || input.is_type<concatenation>())
                     return;
-                if (activation_func == cldnn::activation_func::relu_negative_slope &&
+                auto additional_params_input = activation_node.get_primitive()->additional_params_input;
+                if (activation_func == cldnn::activation_func::relu_negative_slope && !additional_params_input.empty() &&
                     (input.is_type<fully_connected>() || input.is_type<gemm>())) {
                     // prelu fusion is not implemented in oneDNN3.1 (CVS-108233)
                     return;


### PR DESCRIPTION
oneDNN fc(ip) and gemm does not support pot-op Prelu, so disable fusing it until implement it.


### Tickets:
 - *108233*
