### PR TITLE
[CPU] Enable Python test test_infer_request.test_infer_mixed_values with bool for ARM

### DIFF
--- a/src/bindings/python/tests/test_runtime/test_infer_request.py
+++ b/src/bindings/python/tests/test_runtime/test_infer_request.py
@@ -206,9 +206,6 @@ def test_set_tensors(device):
 
 def test_batched_tensors(device):
     core = Core()
-    if device == "CPU":
-        if "Intel" not in core.get_property(device, "FULL_DEVICE_NAME"):
-            pytest.skip("Can't run on ARM plugin")
 
     batch = 4
     one_shape = [1, 2, 2, 2]
@@ -643,9 +640,6 @@ def test_infer_queue_get_idle_handle(device):
 )
 def test_query_state_write_buffer(device, input_shape, data_type, mode):
     core = Core()
-    if device == "CPU":
-        if core.get_property(device, "FULL_DEVICE_NAME") == "arm_compute::NEON":
-            pytest.skip("Can't run on ARM plugin")
 
     from openvino.runtime import Tensor
     from openvino.runtime.utils.types import get_dtype
@@ -891,8 +885,6 @@ def test_invalid_inputs(device, shared_flag):
 
 def test_infer_dynamic_model(device):
     core = Core()
-    if device == "CPU" and "Intel" not in core.get_property(device, "FULL_DEVICE_NAME"):
-        pytest.skip("This test fails on ARM plugin because it doesn't support dynamic shapes.")
 
     param = ops.parameter(PartialShape([-1, -1]))
     model = Model(ops.relu(param), [param])
@@ -1093,8 +1085,6 @@ def test_mixed_scalar_infer(device, shared_flag, input_data):
 ])
 def test_mixed_dynamic_infer(device, shared_flag, input_data):
     core = Core()
-    if device == "CPU" and "Intel" not in core.get_property(device, "FULL_DEVICE_NAME"):
-        pytest.skip("This test fails on ARM plugin because it doesn't support dynamic shapes.")
     param0 = ops.parameter([], np.float32, name="data0")
     param1 = ops.parameter(["?"], np.float32, name="data1")
     add = ops.add(param0, param1, name="add")

--- a/src/bindings/python/tests/test_runtime/test_infer_request.py
+++ b/src/bindings/python/tests/test_runtime/test_infer_request.py
@@ -50,9 +50,6 @@ def create_simple_request_and_inputs(device):
 
 def concat_model_with_data(device, ov_type, numpy_dtype):
     core = Core()
-    # todo: remove as 101726 will be fixed.
-    if ov_type == Type.boolean and device == "CPU" and "Intel" not in core.get_property(device, "FULL_DEVICE_NAME"):
-        pytest.skip("This test runs only on openvino intel cpu plugin")
 
     input_shape = [5]
 

--- a/src/bindings/python/tests_compatibility/test_inference_engine/test_Blob.py
+++ b/src/bindings/python/tests_compatibility/test_inference_engine/test_Blob.py
@@ -100,9 +100,6 @@ def test_incompatible_input_precision():
 def test_buffer_values_after_add_outputs(device):
     test_net_xml_fp16, test_net_bin_fp16 = model_path(is_fp16=True)
     ie_core = IECore()
-    if device == "CPU":
-        if ie_core.get_metric(device, "FULL_DEVICE_NAME") == "arm_compute::NEON":
-            pytest.skip("Can't run on ARM plugin due-to ngraph")
     net = ie_core.read_network(model=test_net_xml_fp16, weights=test_net_bin_fp16)
     output_layer = "22"
     net.add_outputs(output_layer)

--- a/src/bindings/python/tests_compatibility/test_inference_engine/test_ExecutableNetwork.py
+++ b/src/bindings/python/tests_compatibility/test_inference_engine/test_ExecutableNetwork.py
@@ -205,9 +205,6 @@ def test_plugin_accessible_after_deletion(device):
 
 def test_exec_graph(device):
     ie_core = ie.IECore()
-    if device == "CPU":
-        if ie_core.get_metric(device, "FULL_DEVICE_NAME") == "arm_compute::NEON":
-            pytest.skip("Can't run on ARM plugin due-to get_exec_graph_info method isn't implemented")
     net = ie_core.read_network(model=test_net_xml, weights=test_net_bin)
     exec_net = ie_core.load_network(net, device)
     img = generate_image()
@@ -313,9 +310,6 @@ def test_outputs_deallocation(device):
 
 def test_exec_graph_info_deallocation(device):
     ie_core = ie.IECore()
-    if device == "CPU":
-        if ie_core.get_metric(device, "FULL_DEVICE_NAME") == "arm_compute::NEON":
-            pytest.skip("Can't run on ARM plugin due-to get_exec_graph_info method isn't implemented")
     net = ie_core.read_network(model=test_net_xml, weights=test_net_bin)
     exec_net = ie_core.load_network(net, device)
     exec_graph_info = exec_net.get_exec_graph_info()

--- a/src/bindings/python/tests_compatibility/test_inference_engine/test_InferRequest.py
+++ b/src/bindings/python/tests_compatibility/test_inference_engine/test_InferRequest.py
@@ -430,9 +430,6 @@ def test_set_negative_batch_size(device):
 
 def test_blob_setter(device):
     ie_core = ie.IECore()
-    if device == "CPU":
-        if ie_core.get_metric(device, "FULL_DEVICE_NAME") == "arm_compute::NEON":
-            pytest.skip("Can't run on ARM plugin")
     net = ie_core.read_network(test_net_xml, test_net_bin)
     exec_net_1 = ie_core.load_network(network=net, device_name=device, num_requests=1)
 
@@ -510,9 +507,6 @@ def test_resize_algorithm_work(device):
                     "Memory layers fully supported only on CPU")
 def test_query_state_write_buffer(device, input_shape, data_type, mode):
     ie_core = ie.IECore()
-    if device == "CPU":
-        if ie_core.get_metric(device, "FULL_DEVICE_NAME") == "arm_compute::NEON":
-            pytest.skip("Can't run on ARM plugin")
 
     layout = ["C", "HW", "CHW", "NCHW"]
 


### PR DESCRIPTION
bool tests were skipped because legacy ARM plugin does not support bool: CVS-101726