### PR TITLE
Fix of groupconv_to_conv() in MO IR reader

### DIFF
--- a/tools/mo/openvino/tools/mo/utils/ir_reader/layer_to_class.py
+++ b/tools/mo/openvino/tools/mo/utils/ir_reader/layer_to_class.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from openvino.tools.mo.back.MaxPool import MaxPool
 from openvino.tools.mo.back.TopKNormalizer import TopKNormalizer
-from openvino.tools.mo.front.common.partial_infer.utils import int64_array
+from openvino.tools.mo.front.common.partial_infer.utils import int64_array, strict_compare_tensors
 from openvino.tools.mo.graph.graph import Graph, Node
 from openvino.tools.mo.ops.Cast import Cast
 from openvino.tools.mo.ops.GRU import GRU
@@ -195,7 +195,7 @@ def groupconv_to_conv(op: Node):
         weights_node.value = np.reshape(weights_node.value, new_shape)
     elif weights_node.type == 'Reshape':
         # We remove reshape node added in ConvolutionWithGroupsResolver pass
-        assert weights_node.in_port(0).get_source().data.get_shape() == new_shape, \
+        assert strict_compare_tensors(weights_node.in_port(0).get_source().data.get_shape(), new_shape), \
             'Weight shape and calculated shape mismatch in GroupConv node {}.'.format(op.name)
         op.in_port(1).disconnect()
         # We use add_destination method here to support case with multiple destinations of source port
@@ -210,7 +210,7 @@ def groupconv_to_conv(op: Node):
         const_node.value = np.reshape(const_node.value, new_shape)
 
     else:
-        assert op.in_port(1).get_source().data.get_shape() == new_shape, \
+        assert strict_compare_tensors(op.in_port(1).get_source().data.get_shape(), op.in_port(1).get_source().data.get_shape()), \
             'Weight shape and calculated shape mismatch in GroupConv node {}.'.format(op.name)
     # We need to set this attrs for correct shape infer as convolution
     op['group'] = group
@@ -342,6 +342,9 @@ def copy_graph_with_ops(graph: Graph) -> Graph:
     for op in graph.get_op_nodes():
         if op.soft_get('type') != 'Const' and op.soft_get('type') in preprocessing_op_nodes:
             preprocessing_op_nodes[op.type](op)
+
+    # clean up graph before coping nodes to the new graph
+    graph.clean_up()
 
     # Create a new copy of graph with correct attributes (shape & type infer, backend attrs etc.)
     for op in graph.get_op_nodes():

--- a/tools/mo/unit_tests/mo/utils/ir_reader/layer_to_class_test.py
+++ b/tools/mo/unit_tests/mo/utils/ir_reader/layer_to_class_test.py
@@ -6,85 +6,62 @@ import unittest
 import numpy as np
 from generator import generator, generate
 
+import openvino.tools.mo.graph.graph
 from openvino.tools.mo.graph.graph import Node
 from openvino.tools.mo.utils.ir_engine.compare_graphs import compare_graphs
 from openvino.tools.mo.utils.ir_reader.internal_ops.squeeze import SqueezeInternal
 from openvino.tools.mo.utils.ir_reader.internal_ops.unsqueeze import UnsqueezeInternal
 from openvino.tools.mo.utils.ir_reader.layer_to_class import groupconv_to_conv, restore_tensor_names
 from unit_tests.utils.graph import build_graph
+from unit_tests.utils.graph import connect_data,shaped_parameter, regular_op_with_shaped_data, connect, valued_const_with_data, shaped_const_with_data, result
+from openvino.tools.mo.ops.op import Op
 
 
 @generator
 class TestFunction(unittest.TestCase):
-
     @generate(*[([1, 32, 112, 112], [32, 1, 1, 3], [32, 1, 1, 1, 3], 32),
                 ([1, 32, 112, 112], [32, 1, 1, 1, 3], None, 32),
                 ])
     def test_groupconv_to_conv(self, shape, weights_shape, reshape_shape, group):
-
         weights_const = np.random.randn(*weights_shape).astype(np.float32)
 
         nodes_attributes = {
-            'input': {'kind': 'op', 'type': 'Parameter'},
-            'input_data': {'shape': shape, 'kind': 'data'},
-
-            'group_conv': {'kind': 'op', 'type': 'GroupConvolution'},
-            'group_conv_data': {'shape': shape, 'kind': 'data'},
-
-            'conv': {'kind': 'op', 'type': 'Convolution', 'group': group},
-            'conv_data': {'shape': shape, 'kind': 'data'},
-
-            'weights': {'kind': 'op', 'type': 'Const', 'value': weights_const},
-            'weights_data': {'shape': weights_shape, 'kind': 'data'},
-
-            'reshape': {'kind': 'op', 'type': 'Reshape'},
-            'reshape_data': {'shape': reshape_shape, 'kind': 'data'},
-            'reshape_const': {'kind': 'op', 'type': 'Const'},
-            'reshape_const_data': {'shape': len(reshape_shape) if reshape_shape is not None else None, 'kind': 'data'},
-
-            'add': {'kind': 'op', 'type': 'Add'},
-            'add_data': {'shape': shape, 'kind': 'data'},
-            'add_const': {'kind': 'op', 'type': 'Const'},
-            'add_const_data': {'shape': [1, 32, 1, 1], 'kind': 'data'},
-            'result': {'kind': 'op', 'type': 'Result'}
+            **shaped_parameter('input', shape),
+            **regular_op_with_shaped_data('group_conv', shape, {'type': 'GroupConvolution'}),
+            **regular_op_with_shaped_data('conv', shape, {'type': 'Convolution'}),
+            **valued_const_with_data('weights', weights_const, weights_shape, {'type': 'Const'}),
+            **regular_op_with_shaped_data('reshape', reshape_shape, {'type': 'Reshape'}),
+            **shaped_const_with_data('reshape_const', len(reshape_shape) if reshape_shape is not None else None, {'type': 'Const'}),
+            **regular_op_with_shaped_data('add', shape, {'type': 'Add'}),
+            **shaped_const_with_data('add_const', [1, 32, 1, 1], {'type': 'Const'}),
+            **result("result")
         }
 
-        edges = [('input', 'input_data'),
-                 ('input_data', 'group_conv'),
-                 ('weights', 'weights_data'),
-                 ('group_conv', 'group_conv_data'),
-                 ('group_conv_data', 'add'),
-                 ('add_const', 'add_const_data'),
-                 ('add_const_data', 'add'),
-                 ('add', 'add_data'),
-                 ('add_data', 'result'),
+        edges = [*connect('input:0', 'group_conv:0'),
+                 *connect('group_conv:0', 'add:0'),
+                 *connect('add_const:0', 'add:1'),
+                 *connect('add:0', 'result:0'),
                  ]
 
         if reshape_shape is not None:
 
-            edges += [('weights_data', 'reshape'),
-                      ('reshape_const', 'reshape_const_data'),
-                      ('reshape_const_data', 'reshape'),
-                      ('reshape', 'reshape_data'),
-                      ('reshape_data', 'group_conv')]
+            edges += [*connect('weights:0', 'reshape:0'),
+                      *connect('reshape_const:0', 'reshape:1'),
+                      *connect('reshape:0', 'group_conv:1')]
         else:
-            edges.append(('weights_data', 'group_conv'))
+            edges += [*connect('weights:0', 'group_conv:1')]
 
-        graph = build_graph(nodes_attributes, edges, nodes_with_edges_only=True)
+        graph = build_graph(nodes_attributes, edges)
+        for op in graph.get_op_nodes(type='GroupConvolution'):
+            groupconv_to_conv(op)
 
         graph_ref = build_graph(nodes_attributes,
-                                [('input', 'input_data'),
-                                 ('input_data', 'conv'),
-                                 ('weights', 'weights_data'),
-                                 ('weights_data', 'conv'),
-                                 ('conv', 'conv_data'),
-                                 ('conv_data', 'add'),
-                                 ('add_const', 'add_const_data'),
-                                 ('add_const_data', 'add'),
-                                 ('add', 'add_data'),
-                                 ('add_data', 'result'),
-                                 ], nodes_with_edges_only=True)
-
+                                [*connect('input:0', 'conv:0'),
+                                 *connect('weights:0', 'conv:1'),
+                                 *connect('conv:0', 'add:0'),
+                                 *connect('add_const:0', 'add:1'),
+                                 *connect('add:0', 'result:0'),
+                                 ])
         for op in graph.get_op_nodes(type='GroupConvolution'):
             groupconv_to_conv(op)
 


### PR DESCRIPTION
Root cause analysis: 
groupconv_to_conv() uses incorrect methods to compare shapes which do not work for numpy.masked_array. 
groupconv_to_conv() disconnects reshape node while transforming GroupConvolution to Convolution. The disconnected reshape breaks Op.normalize_outputs() pass of MO IR reader which results in adding wrong Result node after reshape.

Solution: 
Use strict_compare_tensors() for shapes comparison.
Add graph.clean_up() after groupconv_to_conv().

Ticket: 89007


Code:
* [x]  Comments
* [x]  Code style (PEP8)
* [x]  Transformation generates reshape-able IR
* [x]  Transformation preserves original framework node names
* [x]  Transformation preserves tensor names


Validation:
* [x]  Unit tests - Tests for this case will be done in separate PR to MO args tests
* [x]  Framework operation tests
* [x]  Transformation tests
* [x]  Model Optimizer IR Reader check

Documentation:
* [x]  Supported frameworks operations list
* [x]  Guide on how to convert the **public** model
* [x]  User guide update
