### PR TITLE
Revert "Fix C API unite test case error"

### DIFF
--- a/src/bindings/c/tests/ie_c_api_test.cpp
+++ b/src/bindings/c/tests/ie_c_api_test.cpp
@@ -144,11 +144,6 @@ TEST_P(ie_c_api_test, ie_core_register_plugins) {
 
     IE_EXPECT_OK(ie_core_register_plugins(core, plugins_xml.c_str()));
 
-    // Trigger plugin loading
-    ie_core_versions_t versions = {0};
-    IE_EXPECT_OK(ie_core_get_versions(core, "CUSTOM", &versions));
-    ie_core_versions_free(&versions);
-
     ie_core_free(&core);
     TestDataHelpers::delete_test_xml_file();
 }


### PR DESCRIPTION
Reverts openvinotoolkit/openvino#17012

Reason: failed post commit https://dev.azure.com/openvinoci/dldt/_build/results?buildId=547018&view=logs&j=e0e676f4-9664-538a-6d6b-aa53516aa09f&t=accf7040-0790-5a3c-3c61-9d660941426c&l=263