### PR TITLE
[CPU] Fixed enforcebf16 condition for transformation pipeline

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
@@ -4,6 +4,7 @@
 
 #include "snippets/mha.hpp"
 #include "common_test_utils/test_constants.hpp"
+#include "ie_plugin_config.hpp"
 
 namespace ov {
 namespace test {
@@ -24,9 +25,11 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA, MHA,
                      ::testing::Combine(
                              ::testing::ValuesIn(inputShapes),
                              ::testing::ValuesIn({false, true}),
+                             ::testing::Values(ov::element::f32),
                              ::testing::Values(1),
                              ::testing::Values(1),
-                             ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                             ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                             ::testing::Values(std::map<std::string, std::string>{})),
                      MHA::getTestCaseName);
 
 const std::vector<std::vector<ov::PartialShape>> inputShapeSelect = {
@@ -42,9 +45,11 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA, MHASelect,
                          ::testing::Combine(
                                  ::testing::ValuesIn(inputShapeSelect),
                                  ::testing::Values(false),  // Need to support True for graph builder in tests
+                                 ::testing::Values(ov::element::f32),
                                  ::testing::Values(2), // Less + MHA
                                  ::testing::Values(2),
-                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                 ::testing::Values(std::map<std::string, std::string>{})),
                          MHA::getTestCaseName);
 
 const std::vector<std::vector<ov::PartialShape>> inputShapesWOTranspose = {
@@ -55,9 +60,25 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAWOTransposeOnInputs, MHAWOTransposeOn
                          ::testing::Combine(
                                  ::testing::ValuesIn(inputShapesWOTranspose),
                                  ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
+                                 ::testing::Values(ov::element::f32),
                                  ::testing::Values(1),
                                  ::testing::Values(1),
-                                 ::testing::Values(CommonTestUtils::DEVICE_CPU)),
+                                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                 ::testing::Values(std::map<std::string, std::string>{})),
+                         MHA::getTestCaseName);
+
+const std::map<std::string, std::string> cpuBF16PluginConfig = { { InferenceEngine::PluginConfigParams::KEY_ENFORCE_BF16,
+                                                                   InferenceEngine::PluginConfigParams::YES } };
+
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHABF16, MHAWOTranspose,
+                         ::testing::Combine(
+                                 ::testing::ValuesIn(inputShapesWOTranspose),
+                                 ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
+                                 ::testing::Values(ov::element::bf16),
+                                 ::testing::Values(3),
+                                 ::testing::Values(0), // CPU plugin doesn't support MHA pattern via Snippets on bf16
+                                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                 ::testing::Values(cpuBF16PluginConfig)),
                          MHA::getTestCaseName);
 
 

--- a/src/tests/functional/plugin/shared/include/snippets/mha.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/mha.hpp
@@ -11,16 +11,17 @@ namespace test {
 namespace snippets {
 
 typedef std::tuple<
-        std::vector<ov::PartialShape>,   // Input shapes
-        bool,                            // With Multiply
-        size_t,                          // Expected num nodes
-        size_t,                          // Expected num subgraphs
-        std::string                      // Target Device
+        std::vector<ov::PartialShape>,     // Input shapes
+        bool,                              // With Multiply
+        ov::element::Type,                 // Inference precision
+        size_t,                            // Expected num nodes
+        size_t,                            // Expected num subgraphs
+        std::string,                       // Target Device
+        std::map<std::string, std::string> // Config
 > MHAParams;
 
-
 class MHA : public testing::WithParamInterface<ov::test::snippets::MHAParams>,
-        virtual public ov::test::SnippetsTestsCommon {
+            virtual public ov::test::SnippetsTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<ov::test::snippets::MHAParams> obj);
 
@@ -39,6 +40,10 @@ protected:
 
 class MHAWOTransposeOnInputs : public MHA {
 protected:
+    void SetUp() override;
+};
+
+class MHAWOTranspose : public MHA {
     void SetUp() override;
 };
 

--- a/src/tests/ngraph_helpers/snippets_ngraph_functions/include/subgraph_mha.hpp
+++ b/src/tests/ngraph_helpers/snippets_ngraph_functions/include/subgraph_mha.hpp
@@ -126,6 +126,24 @@ protected:
     std::shared_ptr<ov::Model> initOriginal() const override;
 };
 
+/* Graph:
+ *    \     /
+ *    MatMul0
+ *       |
+ *    Softmax
+ *        \      /
+ *         MatMul1
+ *           |
+ */
+class MHAWOTransposeFunction : public SnippetsFunctionBase {
+public:
+    explicit MHAWOTransposeFunction(const std::vector<PartialShape>& inputShapes) : SnippetsFunctionBase(inputShapes) {
+        NGRAPH_CHECK(input_shapes.size() == 3, "Got invalid number of input shapes");
+    }
+protected:
+    std::shared_ptr<ov::Model> initOriginal() const override;
+};
+
 }  // namespace snippets
 }  // namespace test
 }  // namespace ov

--- a/src/tests/ngraph_helpers/snippets_ngraph_functions/src/subgraph_mha.cpp
+++ b/src/tests/ngraph_helpers/snippets_ngraph_functions/src/subgraph_mha.cpp
@@ -343,6 +343,22 @@ std::shared_ptr<ov::Model> MHAWOTransposeOnInputsFunction::initOriginal() const 
     return std::make_shared<ov::Model>(results, ngraphParam, "mha");
 }
 
+std::shared_ptr<ov::Model> MHAWOTransposeFunction::initOriginal() const {
+    auto param0 = std::make_shared<ngraph::opset1::Parameter>(precision, input_shapes[0]);
+    auto param1 = std::make_shared<ngraph::opset1::Parameter>(precision, input_shapes[1]);
+    auto param2 = std::make_shared<ngraph::opset1::Parameter>(precision, input_shapes[2]);
+    ngraph::ParameterVector ngraphParam = {param0, param1, param2};
+
+    float transA = false;
+    float transB = false;
+    const auto matMul0 = std::make_shared<ngraph::opset3::MatMul>(param0, param1, transA, transB);
+    const auto softmax = std::make_shared<ngraph::opset1::Softmax>(matMul0, 3);
+    const auto matMul1 = std::make_shared<ngraph::opset3::MatMul>(softmax, param2, transA, transB);
+
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(matMul1)};
+    return std::make_shared<ov::Model>(results, ngraphParam, "mha");
+}
+
 }  // namespace snippets
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - *Added check for config parameter `inference_precision`. Before there was only `PluginConfigParams::KEY_ENFORCE_BF16`. It's not enough to know that `enforcebf16` will be really enabled. So some transformations which depend on `enforcebf16` flag, can work incorrectly.*

### Tickets:
 - *N/A*
