### PR TITLE
[CPU] Fix data race in concurrent compile_model calls

### DIFF
--- a/src/inference/src/system_conf.cpp
+++ b/src/inference/src/system_conf.cpp
@@ -185,7 +185,7 @@ void set_cpu_used(const std::vector<int>& cpu_ids, const int used) {}
 
 #else
 
-static CPU cpu;
+static thread_local CPU cpu;
 
 #    ifndef _WIN32
 int get_number_of_cpu_cores(bool bigCoresOnly) {


### PR DESCRIPTION
Otherwise, multiple threads (parallel compile_model()) are accessing and changing the static object concurrently.
Reproduces sporadically be the following test:
- CoreThreadingTestsWithIterations

### Tickets:
 - 109210