### PR TITLE
[ONNX tests] Set ONNX opset in Reduce ops layer tests

### DIFF
--- a/tests/layer_tests/onnx_tests/test_reduce.py
+++ b/tests/layer_tests/onnx_tests/test_reduce.py
@@ -23,7 +23,7 @@ class TestReduce(OnnxRuntimeLayerTest):
 
         import onnx
         from onnx import helper
-        from onnx import TensorProto
+        from onnx import TensorProto, OperatorSetIdProto
 
         if op not in ['ReduceMin', 'ReduceMax', 'ReduceMean', 'ReduceProd', 'ReduceSum']:
             raise ValueError("Operation has to be either Reduce(Min or Max or Mean or Sum or Prod")
@@ -54,8 +54,14 @@ class TestReduce(OnnxRuntimeLayerTest):
             [output],
         )
 
+        # Set ONNX Opset
+        onnx_opset = OperatorSetIdProto()
+        onnx_opset.domain = ""
+        # ONNX opset with `axes` as attribute in ONNX Reduce ops
+        onnx_opset.version = 11
+
         # Create the model (ModelProto)
-        onnx_net = helper.make_model(graph_def, producer_name='test_model')
+        onnx_net = helper.make_model(graph_def, producer_name='test_model', opset_imports=[onnx_opset])
 
         #
         #   Create reference IR net
@@ -124,7 +130,6 @@ class TestReduce(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.precommit
-    @pytest.mark.skip(reason='ONNX Runtime error: Error Unrecognized attribute: axes for operator ReduceMax, ticket: 107652')
     def test_reduce_max_precommit(self, params, keep_dims, ie_device, precision, ir_version,
                                   temp_dir, use_old_api):
         self._test(*self.create_reduce(**params, op='ReduceMax', keep_dims=keep_dims,
@@ -134,7 +139,6 @@ class TestReduce(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.nightly
-    @pytest.mark.skip(reason='ONNX Runtime error: Error Unrecognized attribute: axes for operator ReduceMax, ticket: 107652')
     def test_reduce_max(self, params, keep_dims, ie_device, precision, ir_version, temp_dir, use_old_api):
         self._test(*self.create_reduce(**params, op='ReduceMax', keep_dims=keep_dims,
                                        ir_version=ir_version),
@@ -162,7 +166,6 @@ class TestReduce(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.precommit
-    @pytest.mark.skip(reason='ONNX Runtime error: Error Unrecognized attribute: axes for operator ReduceMean, ticket: 107652')
     def test_reduce_mean_precommit(self, params, keep_dims, ie_device, precision, ir_version,
                                    temp_dir, use_old_api):
         self._test(*self.create_reduce(**params, op='ReduceMean', keep_dims=keep_dims,
@@ -173,7 +176,6 @@ class TestReduce(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.nightly
     @pytest.mark.precommit
-    @pytest.mark.skip(reason='ONNX Runtime error: Error Unrecognized attribute: axes for operator ReduceMean, ticket: 107652')
     def test_reduce_mean(self, params, keep_dims, ie_device, precision, ir_version, temp_dir,
                          use_old_api):
         self._test(*self.create_reduce(**params, op='ReduceMean', keep_dims=keep_dims,
@@ -183,7 +185,6 @@ class TestReduce(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data_precommit)
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.precommit
-    @pytest.mark.skip(reason='ONNX Runtime error: Error Unrecognized attribute: axes for operator ReduceMin, ticket: 107652')
     def test_reduce_min_precommit(self, params, keep_dims, ie_device, precision, ir_version,
                                   temp_dir, use_old_api):
         self._test(*self.create_reduce(**params, op='ReduceMin', keep_dims=keep_dims,
@@ -193,7 +194,6 @@ class TestReduce(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("params", test_data)
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.nightly
-    @pytest.mark.skip(reason='ONNX Runtime error: Error Unrecognized attribute: axes for operator ReduceMin, ticket: 107652')
     def test_reduce_min(self, params, keep_dims, ie_device, precision, ir_version, temp_dir, use_old_api):
         self._test(*self.create_reduce(**params, op='ReduceMin', keep_dims=keep_dims,
                                        ir_version=ir_version),

--- a/tests/layer_tests/onnx_tests/test_reduce_lp.py
+++ b/tests/layer_tests/onnx_tests/test_reduce_lp.py
@@ -24,7 +24,7 @@ class TestReduceL1L2(OnnxRuntimeLayerTest):
 
         import onnx
         from onnx import helper
-        from onnx import TensorProto
+        from onnx import TensorProto, OperatorSetIdProto
 
         output_shape = shape.copy()
         _axes = axes.copy() if axes is not None else list(range(len(shape)))
@@ -55,8 +55,14 @@ class TestReduceL1L2(OnnxRuntimeLayerTest):
             [output],
         )
 
+        # Set ONNX Opset
+        onnx_opset = OperatorSetIdProto()
+        onnx_opset.domain = ""
+        # ONNX opset with `axes` as attribute in ONNX Reduce ops
+        onnx_opset.version = 11
+
         # Create the model (ModelProto)
-        onnx_net = helper.make_model(graph_def, producer_name='test_model')
+        onnx_net = helper.make_model(graph_def, producer_name='test_model', opset_imports=[onnx_opset])
 
         #
         #   Create reference IR net
@@ -103,7 +109,7 @@ class TestReduceL1L2(OnnxRuntimeLayerTest):
 
         import onnx
         from onnx import helper
-        from onnx import TensorProto
+        from onnx import TensorProto, OperatorSetIdProto
 
         output_shape = shape.copy()
         _axes = axes.copy() if axes is not None else list(range(len(shape)))
@@ -161,8 +167,14 @@ class TestReduceL1L2(OnnxRuntimeLayerTest):
             [output],
         )
 
+        # Set ONNX Opset
+        onnx_opset = OperatorSetIdProto()
+        onnx_opset.domain = ""
+        # ONNX opset with `axes` as attribute in ONNX Reduce ops
+        onnx_opset.version = 11
+
         # Create the model (ModelProto)
-        onnx_net = helper.make_model(graph_def, producer_name='test_model')
+        onnx_net = helper.make_model(graph_def, producer_name='test_model', opset_imports=[onnx_opset])
 
         #
         #   Create reference IR net
@@ -220,7 +232,6 @@ class TestReduceL1L2(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.parametrize("reduce_p", [1, 2])
     @pytest.mark.precommit
-    @pytest.mark.skip(reason='ONNX Runtime error: Error Unrecognized attribute: axes for operator ReduceL1/ReduceL2, ticket: 107652')
     def test_reduce_lp_precommit(self, params, keep_dims, reduce_p, ie_device, precision,
                                  ir_version, temp_dir, use_old_api):
         self._test(*self.create_reduce_lp(**params, keep_dims=keep_dims, reduce_p=reduce_p,
@@ -231,7 +242,6 @@ class TestReduceL1L2(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.parametrize("reduce_p", [1, 2])
     @pytest.mark.nightly
-    @pytest.mark.skip(reason='ONNX Runtime error: Error Unrecognized attribute: axes for operator ReduceL1/ReduceL2, ticket: 107652')
     def test_reduce_lp(self, params, keep_dims, reduce_p, ie_device, precision, ir_version,
                        temp_dir, use_old_api):
         if ie_device == 'GPU':
@@ -244,7 +254,6 @@ class TestReduceL1L2(OnnxRuntimeLayerTest):
     @pytest.mark.parametrize("keep_dims", [True, False])
     @pytest.mark.parametrize("reduce_p", [1, 2])
     @pytest.mark.precommit
-    @pytest.mark.skip(reason='ONNX Runtime error: Error Unrecognized attribute: axes for operator ReduceL1/ReduceL2, ticket: 107652')
     def test_reduce_lp_const_precommit(self, params, keep_dims, reduce_p, ie_device, precision,
                                        ir_version, temp_dir, use_old_api):
         self._test(


### PR DESCRIPTION
[ONNX Tests update only]
### Details:
 - Set ONNX opset in Reduce ops layer tests to fix version incompatibilities 
 (enable tests skipped by https://github.com/openvinotoolkit/openvino/pull/16730)
 - Generation of reference values for Reduce ops tests started failing after upgrade onnx version to 1.13 (onnx opset 18), 
 where `axes` is no longer attribute but input. The solution is to use for testing any of the previous onnx opsets supporting `axes` as attribute. 
 - Support of the ONNX Reduce*-18 ops with `axes` as input should be considered as a feature to support and covered by corresponding tests (ticket: 99962) 

-------------
✔️   layer_ubuntu20_release CI check passed ([test_reduce* logs](https://openvino-ci.toolbox.iotg.sclab.intel.com/job/private-ci/job/ie/job/e2e-tests-linux-ubuntu20-layer/46173/consoleText))
### Tickets:
 - 107652, 107644
