### PR TITLE
Upper-bound for patchelf

### DIFF
--- a/src/bindings/python/wheel/requirements-dev.txt
+++ b/src/bindings/python/wheel/requirements-dev.txt
@@ -1,3 +1,3 @@
 setuptools>=65.6.1
 wheel>=0.38.1
-patchelf; sys_platform == 'linux' and platform_machine == 'x86_64'
+patchelf<=0.17.2.1; sys_platform == 'linux' and platform_machine == 'x86_64'


### PR DESCRIPTION
### Details:
Using freshly released patchelf 0.18 causes "ELF load command address/offset not properly aligned" error

### Tickets:
 - 109159
