### PR TITLE
[GPU] Fix i8/u8 representation error for clamp due to overflow

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -1524,15 +1524,11 @@ JitConstants MakeActivationJitConstants(std::vector<kernel_selector::base_activa
         std::string nl_n = toCodeString(params[i].n);
         if (params[i].function == ActivationFunction::CLAMP) {
             if (out_dt == Datatype::INT8) {
-                float max_i8 = 127.f;
-                float min_i8 = -128.f;
-                nl_m = "fmax(" + nl_m + ", " + toCodeString(min_i8) + ")";
-                nl_n = "fmin(" + nl_n + ", " + toCodeString(max_i8) + ")";
+                nl_m = toCodeString(std::max(params[i].m, static_cast<float>(SCHAR_MIN)));
+                nl_n = toCodeString(std::min(params[i].n, static_cast<float>(SCHAR_MAX)));
             } else if (out_dt == Datatype::UINT8) {
-                float max_u8 = 255.f;
-                float min_u8 = 0.f;
-                nl_m = "fmax(" + nl_m + ", " + toCodeString(min_u8) + ")";
-                nl_n = "fmin(" + nl_n + ", " + toCodeString(max_u8) + ")";
+                nl_m = toCodeString(std::max(params[i].m, 0.0f));
+                nl_n = toCodeString(std::min(params[i].n, static_cast<float>(UCHAR_MAX)));
             }
         }
         auto jitConstants = JitConstants{MakeJitConstant("NL_M" + activation_suffix, nl_m),
@@ -1910,15 +1906,11 @@ JitConstants FusedOpsCodeGenerator::MakeOpJitConstants(const FusedOpsConfigurati
 
                 if (activation_p.function == ActivationFunction::CLAMP) {
                     if (out_type == Datatype::INT8) {
-                        float max_i8 = 127.f;
-                        float min_i8 = -128.f;
-                        nl_m = "fmax(" + nl_m + ", " + toCodeString(min_i8) + ")";
-                        nl_n = "fmin(" + nl_n + ", " + toCodeString(max_i8) + ")";
+                        nl_m = toCodeString(std::max(activation_p.m, static_cast<float>(SCHAR_MIN)));
+                        nl_n = toCodeString(std::min(activation_p.n, static_cast<float>(SCHAR_MAX)));
                     } else if (out_type == Datatype::UINT8) {
-                        float max_u8 = 255.f;
-                        float min_u8 = 0.f;
-                        nl_m = "fmax(" + nl_m + ", " + toCodeString(min_u8) + ")";
-                        nl_n = "fmin(" + nl_n + ", " + toCodeString(max_u8) + ")";
+                        nl_m = toCodeString(std::max(activation_p.m, 0.0f));
+                        nl_n = toCodeString(std::min(activation_p.n, static_cast<float>(UCHAR_MAX)));
                     }
                 }
 


### PR DESCRIPTION
### Details:
 - jitter saves all compile time constants as `float`. So if the activation function is clamp and the output data type size is 1, values for min/max are converted to output type(`i8`or`u8`). At this time, `i8` or `u8` representation error occurs due to overflow.
 - Fix jitter to clamp original min/max to output type range and adjust them to input value

### Tickets:
 - 100877
