### PR TITLE
[CORE] Disable fp32->fp16 optimized constant conversion impl

### DIFF
--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -843,26 +843,6 @@ std::shared_ptr<Node> change_constant_precision<ov::element::Type_t::f16, ov::el
     return new_constant;
 }
 
-template <>
-std::shared_ptr<Node> change_constant_precision<ov::element::Type_t::f32, ov::element::Type_t::f16>(
-    std::shared_ptr<opset4::Constant>& constant) {
-    using src_type = typename element_type_traits<ov::element::Type_t::f32>::value_type;
-    using dst_type = typename element_type_traits<ov::element::Type_t::f16>::value_type;
-
-    const auto* src_data = constant->get_data_ptr<src_type>();
-    const auto size = shape_size(constant->get_shape());
-
-    auto new_constant = std::make_shared<opset4::Constant>(ov::element::Type_t::f16, constant->get_shape());
-    new_constant->output(0).set_names(constant->output(0).get_names());
-    auto* dst_data = const_cast<dst_type*>(reinterpret_cast<const dst_type*>(new_constant->get_data_ptr()));
-    if (dst_data == nullptr)
-        OPENVINO_THROW("Can't get destination data pointer");
-
-    ngraph::runtime::reference::convert<src_type, dst_type>(src_data, dst_data, size);
-
-    return new_constant;
-}
-
 /**
  * @brief Method converts low precision integer types
  * The method uses the next logic for conversion:


### PR DESCRIPTION
### Details:
 - Change constant precision routine cannot use ngraph::runtime::reference::convert as underling impl fpr fp32->fp16 case due to missed lower/upper bounds (+-fp16 max) clamp logic. 
 - Partially reverts logic added here: https://github.com/openvinotoolkit/openvino/pull/16672/

### Tickets:
 - *CVS-108209*
