### PR TITLE
Fix ONNX-CPU test Linkage

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_cpu/tests/functional/CMakeLists.txt
@@ -16,7 +16,7 @@ set(LINK_LIBRARIES funcSharedTests cpuSpecificRtInfo inference_engine_snippets)
 if(ENABLE_OV_ONNX_FRONTEND)
     list(APPEND DEFINES TEST_MODELS="${TEST_MODEL_ZOO}")
 else()
-    set(EXCLUDED_SOURCE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/extension ${CMAKE_CURRENT_SOURCE_DIR}/onnx)
+    set(EXCLUDED_SOURCE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/extension ${CMAKE_CURRENT_SOURCE_DIR}/shared_tests_instances/onnx)
 endif()
 
 if(NOT X86_64)


### PR DESCRIPTION
### Details:
Fix `error LNK2019: unresolved external symbol "public: static class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl ONNXTestsDefinitions::QuantizedModelsTests::getTestCaseName` while `-D ENABLE_OV_ONNX_FRONTEND=OFF`

### Tickets:
 - *ticket-id*
