### PR TITLE
[TF FE] Implement optimal conversion of body graphs

### DIFF
--- a/src/frontends/tensorflow/src/input_model.cpp
+++ b/src/frontends/tensorflow/src/input_model.cpp
@@ -180,6 +180,19 @@ void InputModel::InputModelTFImpl::load_places() {
                 // by default, PlaceholderWithDefault is NOT used as input
                 m_inputs.push_back(tensor_place);
             }
+        } else if (op_type == "input_arg") {
+            // create a tensor place for the body graph parameter node and save it in the m_inputs
+            // it allows to set shapes for the body graph InputModel for its more optimal conversion
+            auto param_type = node_decoder->get_attribute("type");
+            ov::element::Type type = ov::element::dynamic;
+            if (param_type.is<ov::element::Type>()) {
+                type = param_type.as<ov::element::Type>();
+            }
+            auto tensor_place = std::make_shared<TensorPlace>(m_input_model,
+                                                              ov::PartialShape::dynamic(),
+                                                              type,
+                                                              std::vector<std::string>{op_name});
+            m_inputs.push_back(tensor_place);
         }
         for (size_t input_port_idx = 0; input_port_idx < node_decoder->get_input_size(); ++input_port_idx) {
             std::string producer_op_name;

--- a/src/frontends/tensorflow/src/op/partitioned_call.cpp
+++ b/src/frontends/tensorflow/src/op/partitioned_call.cpp
@@ -33,8 +33,9 @@ OutputVector translate_partitioned_call_op(const NodeContext& node) {
     // of StatefulPartitionedCall. And because otherwise they will cause a duplicates. But we need to keep them
     // for "internal functions of Saved Model", which are named "__inference_signature_wrapper" or
     // "__inference_wrapped_model".
-    auto body_model =
-        translate_session->get_body_ov_model(operation_type, operation_type.find("wrappe") == std::string::npos);
+    auto body_model = translate_session->get_body_ov_model(operation_type,
+                                                           ov_inputs,
+                                                           operation_type.find("wrappe") == std::string::npos);
     FRONT_END_OP_CONVERSION_CHECK(
         body_model,
         "[TensorFlow Frontend] Internal error or incorrect input model: body graph is not found for " + operation_type +

--- a/src/frontends/tensorflow/src/translate_session.cpp
+++ b/src/frontends/tensorflow/src/translate_session.cpp
@@ -306,7 +306,7 @@ void TranslateSession::translate_graph(const ov::frontend::InputModel::Ptr& inpu
                                                                    "Unknown exception type");
                 ov_outputs = named_from_indexed(fw_outs);
             }
-        } else if (auto body_ov_model = get_body_ov_model(operation_type)) {
+        } else if (auto body_ov_model = get_body_ov_model(operation_type, ov_inputs)) {
             OutputVector indexed_ov_outputs;
             inject_body_model(body_ov_model, operation_type, ov_inputs, indexed_ov_outputs);
 
@@ -464,18 +464,48 @@ void TranslateSession::translate_graph(const ov::frontend::InputModel::Ptr& inpu
     ov_model = std::make_shared<ov::Model>(ordered_results, ordered_params, m_model_name);
 }
 
-std::shared_ptr<ov::Model> TranslateSession::get_body_ov_model(const std::string& body_graph_name, bool clear_names) {
+std::shared_ptr<ov::Model> TranslateSession::get_body_ov_model(const std::string& body_graph_name,
+                                                               const OutputVector& ov_inputs,
+                                                               bool clear_names) {
     std::shared_ptr<ov::Model> body_model = nullptr;
     auto input_model = std::dynamic_pointer_cast<InputModel>(m_input_model);
-    if (m_cached_body_models->count(body_graph_name)) {
+    std::vector<ov::PartialShape> input_shapes;
+    input_shapes.reserve(ov_inputs.size());
+    std::vector<ov::element::Type> input_types;
+    input_types.reserve(ov_inputs.size());
+    for (const auto& ov_input : ov_inputs) {
+        input_shapes.push_back(ov_input.get_partial_shape());
+        input_types.push_back(ov_input.get_element_type());
+    }
+    CachedBodyModelSignature body_model_signature{body_graph_name, input_shapes, input_types};
+
+    if (m_cached_body_models->count(body_model_signature)) {
         // check if such body graph has been converted before
         // re-use it from the cache for further injection
 
         // create new instance of the required body model
         // since it will be modified by injection
-        auto cached_body_model = m_cached_body_models->at(body_graph_name);
+        auto cached_body_model = m_cached_body_models->at(body_model_signature);
         body_model = cached_body_model->clone();
     } else if (auto body_input_model = input_model->get_body_input_model(body_graph_name)) {
+        // set input shapes and types for InputModel of the body graph
+        // it allows to get more optimized model after the conversion,
+        // for example, to get less sub-graphs with ShapeOf and Convert operations
+        auto inputs = body_input_model->get_inputs();
+        size_t num_inputs = inputs.size();
+        FRONT_END_GENERAL_CHECK(num_inputs == ov_inputs.size(),
+                                "[TensorFlow Frontend] internal error: a number of external  and internal inputs for a "
+                                "body graph mismatch");
+        for (size_t input_ind = 0; input_ind < num_inputs; ++input_ind) {
+            auto input_place = inputs[input_ind];
+            if (input_types[input_ind].is_static()) {
+                body_input_model->set_element_type(input_place, input_types[input_ind]);
+            }
+            if (input_shapes[input_ind].rank().is_static()) {
+                body_input_model->set_partial_shape(input_place, input_shapes[input_ind]);
+            }
+        }
+
         // try to find a function by name in the model library
         translate_graph(body_input_model, body_model);
         // save new instance of body_model in the cache of body models
@@ -492,7 +522,7 @@ std::shared_ptr<ov::Model> TranslateSession::get_body_ov_model(const std::string
         }
 
         auto cached_body_model = body_model->clone();
-        update_cached_body_models(body_graph_name, cached_body_model);
+        update_cached_body_models(body_model_signature, cached_body_model);
     }
     return body_model;
 }

--- a/src/frontends/tensorflow/src/translate_session.cpp
+++ b/src/frontends/tensorflow/src/translate_session.cpp
@@ -465,7 +465,7 @@ void TranslateSession::translate_graph(const ov::frontend::InputModel::Ptr& inpu
 }
 
 std::shared_ptr<ov::Model> TranslateSession::get_body_ov_model(const std::string& body_graph_name,
-                                                               const OutputVector& ov_inputs,
+                                                               const ov::OutputVector& ov_inputs,
                                                                bool clear_names) {
     std::shared_ptr<ov::Model> body_model = nullptr;
     auto input_model = std::dynamic_pointer_cast<InputModel>(m_input_model);

--- a/src/frontends/tensorflow/src/translate_session.hpp
+++ b/src/frontends/tensorflow/src/translate_session.hpp
@@ -10,7 +10,25 @@
 namespace ov {
 namespace frontend {
 namespace tensorflow {
-using CachedBodyModelsType = std::unordered_map<std::string, std::shared_ptr<const ov::Model>>;
+
+struct CachedBodyModelSignature {
+    std::string body_name;
+    std::vector<ov::PartialShape> input_shapes;
+    std::vector<ov::element::Type> input_types;
+
+    bool operator==(const CachedBodyModelSignature& other) const {
+        return (body_name == other.body_name && input_shapes == other.input_shapes && input_types == other.input_types);
+    }
+};
+
+struct CachedBodyModelSignatureHasher {
+    std::size_t operator()(const CachedBodyModelSignature& k) const {
+        return std::hash<std::string>()(k.body_name);
+    }
+};
+
+using CachedBodyModelsType =
+    std::unordered_map<CachedBodyModelSignature, std::shared_ptr<const ov::Model>, CachedBodyModelSignatureHasher>;
 
 /// For one call of convert and decode method of Frontend, it creates one TranslateSession object to save data for the
 /// translation session: telemetry statistics, cache of convrted body graph models, operation translators (including
@@ -29,7 +47,9 @@ public:
                            const ov::OutputVector& ov_inputs,
                            ov::OutputVector& ov_outputs);
 
-    std::shared_ptr<ov::Model> get_body_ov_model(const std::string& body_graph_name, bool clear_names = true);
+    std::shared_ptr<ov::Model> get_body_ov_model(const std::string& body_graph_name,
+                                                 const OutputVector& ov_inputs,
+                                                 bool clear_names = true);
 
     ov::frontend::InputModel::Ptr get_input_model(void) const {
         return m_input_model;
@@ -40,11 +60,17 @@ private:
     const std::shared_ptr<TranslatorDictionaryType> m_translator_map;
     const std::string m_model_name;
     std::shared_ptr<ov::Model> m_ov_model;
+
+    // this is a container to cache already converted body graph models for operations
+    // such as While, If, PartitionedCall.
+    // the caching happens by body graph name (or function name) and input shapes and types
+    // specified for its conversion.
+    // the same topology can be converted with different shapes and types so it will be cached separately
     std::shared_ptr<CachedBodyModelsType> m_cached_body_models;
 
-    void update_cached_body_models(const std::string& operation_type,
+    void update_cached_body_models(const CachedBodyModelSignature& cached_body_model_signature,
                                    const std::shared_ptr<const ov::Model>& cached_body_model) {
-        m_cached_body_models->insert(std::make_pair(operation_type, cached_body_model));
+        m_cached_body_models->insert(std::make_pair(cached_body_model_signature, cached_body_model));
     }
 };
 

--- a/src/frontends/tensorflow/src/translate_session.hpp
+++ b/src/frontends/tensorflow/src/translate_session.hpp
@@ -48,7 +48,7 @@ public:
                            ov::OutputVector& ov_outputs);
 
     std::shared_ptr<ov::Model> get_body_ov_model(const std::string& body_graph_name,
-                                                 const OutputVector& ov_inputs,
+                                                 const ov::OutputVector& ov_inputs,
                                                  bool clear_names = true);
 
     ov::frontend::InputModel::Ptr get_input_model(void) const {

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_partitioned_call_with_conv.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_partitioned_call_with_conv.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2018-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+import numpy as np
+import tensorflow.compat.v1 as tf
+
+
+def main():
+    '''
+    This test model aims to test that the conversion for the body graphs is performed with set input shapes
+    that allows to get more optimized ov::Model for the body graphs.
+    In particular, we check that the resulted graph contains Convolution operation instead of GroupConvolution
+    '''
+    tf.compat.v1.reset_default_graph()
+
+    @tf.function
+    def second_func(input, filter):
+        conv = tf.raw_ops.Conv2D(input=input, filter=filter, strides=[1, 1, 1, 1], padding='SAME', data_format='NCHW')
+        return conv
+
+    @tf.function
+    def first_func(input, filter):
+        conv = second_func(input, filter)
+        return conv
+
+    input_data = np.random.rand(1, 1, 10, 10)
+    filter_data = np.random.rand(3, 3, 1, 1)
+    tf_net = first_func.get_concrete_function(tf.constant(input_data, dtype=tf.float32),
+                                              tf.constant(filter_data, dtype=tf.float32)).graph.as_graph_def()
+    tf.io.write_graph(tf_net, os.path.join(sys.argv[1], "partitioned_call_with_conv"),
+                      "partitioned_call_with_conv.pb", False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Details:** Preliminary setting input shapes and types for body graph InputModel provides more optimal conversion of body-graphs. That is because we concretize input shapes and types and it helps to avoid that translator will work with dynamic ranks and types for body graph operations. The dynamic ranks and types lead to complex sub-graphs with `Convert`, `GroupConv` sub-graphs.

**Ticket:** 109282
