### PR TITLE
[GPU] Use hash of test name for random generator initialization

### DIFF
--- a/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
+++ b/src/plugins/intel_gpu/tests/fusions/fusion_test_common.hpp
@@ -30,7 +30,14 @@ public:
     static const int min_random = -200;
     static const int max_random = 200;
 
+    std::default_random_engine generator{0};
+
     void SetUp() override {
+        std::string suite_name = std::string(::testing::UnitTest::GetInstance()->current_test_info()->test_suite_name()) +
+                                 std::string(::testing::UnitTest::GetInstance()->current_test_info()->name());
+        auto seed = std::hash<std::string>{}(suite_name);
+
+        generator = std::default_random_engine{static_cast<uint32_t>(seed)};
         cfg_fused = get_test_default_config(engine);
         cfg_not_fused = get_test_default_config(engine);
 
@@ -107,20 +114,63 @@ public:
         }
     }
 
+    template<typename ReturnType>
+    std::vector<ReturnType> generate_random(size_t a, int min, int max, int k = 8) {
+        // 1/k is the resolution of the floating point numbers
+        std::uniform_int_distribution<int> distribution(k * min, k * max);
+        std::vector<ReturnType> v(a);
+
+        for (size_t i = 0; i < a; ++i) {
+            v[i] = (ReturnType)distribution(this->generator);
+            v[i] /= k;
+        }
+        return v;
+    }
+
+    template<typename ReturnType>
+    std::vector<ReturnType> generate_random_norepetitions(size_t size, int min, int max, float bound = 0.45) {
+        // Rerurn repeatless vector with size = size in range(min, max)
+        std::uniform_int_distribution<int> distribution(min, max);
+        std::uniform_real_distribution<float> to_bound_dist(0, bound);
+        std::set<int> repeatless;
+        std::vector<float> v(size, 0);
+        std::vector<ReturnType> res(size);
+        int i = 0;
+        int temp;
+        if (max - min >= int(size) - 1){
+            while (repeatless.size() < size) {
+                temp = distribution(this->generator);
+                if (repeatless.find(temp) == repeatless.end()) {
+                    repeatless.insert(temp);
+                    v[i] = (float)temp;
+                    i++;
+                }
+            }
+            for (size_t k = 0; k < v.size(); k++) {
+                v[k] += to_bound_dist(this->generator);
+                res[k] = static_cast<ReturnType>(v[k]);
+            }
+        } else {
+            throw "Array size is bigger than size of range(min, max). Unable to generate array of unique integer numbers";
+        }
+        return res;
+    }
+
+
     cldnn::memory::ptr get_mem(cldnn::layout l) {
         auto prim = engine.allocate_memory(l);
         tensor s = l.get_tensor();
         if (l.data_type == data_types::bin) {
-            VF<int32_t> rnd_vec = generate_random_1d<int32_t>(s.count() / 32, min_random, max_random);
+            VF<int32_t> rnd_vec = generate_random<int32_t>(s.count() / 32, min_random, max_random);
             set_values(prim, rnd_vec);
         } else if (l.data_type == data_types::i8 || l.data_type == data_types::u8) {
-            VF<uint8_t> rnd_vec = generate_random_1d<uint8_t>(s.count(), min_random, max_random);
+            VF<uint8_t> rnd_vec = generate_random<uint8_t>(s.count(), min_random, max_random);
             set_values(prim, rnd_vec);
         } else if (l.data_type == data_types::f16) {
-            VF<uint16_t> rnd_vec = generate_random_1d<uint16_t>(s.count(), -1, 1);
+            VF<uint16_t> rnd_vec = generate_random<uint16_t>(s.count(), -1, 1);
             set_values(prim, rnd_vec);
         } else {
-            VF<float> rnd_vec = generate_random_1d<float>(s.count(), -1, 1);
+            VF<float> rnd_vec = generate_random<float>(s.count(), -1, 1);
             set_values(prim, rnd_vec);
         }
 
@@ -156,17 +206,17 @@ public:
         auto prim = engine.allocate_memory(l);
         tensor s = l.get_tensor();
         if (l.data_type == data_types::f32) {
-            VF<float> rnd_vec = generate_random_norepetitions_1d<float>(s.count(), min, max);
+            VF<float> rnd_vec = generate_random_norepetitions<float>(s.count(), min, max);
             set_values(prim, rnd_vec);
         } else if (l.data_type == data_types::f16) {
-            VF<FLOAT16> rnd_vec = generate_random_norepetitions_1d<FLOAT16>(s.count(), min, max);
+            VF<FLOAT16> rnd_vec = generate_random_norepetitions<FLOAT16>(s.count(), min, max);
             set_values(prim, rnd_vec);
         } else if (l.data_type == data_types::i8) {
-            VF<int8_t> rnd_vec = generate_random_norepetitions_1d<int8_t>(s.count(), min, max);
+            VF<int8_t> rnd_vec = generate_random_norepetitions<int8_t>(s.count(), min, max);
             set_values(prim, rnd_vec);
         }
         else if (l.data_type == data_types::bin) {
-            VF<int32_t> rnd_vec = generate_random_norepetitions_1d<int32_t>(s.count(), min, max);
+            VF<int32_t> rnd_vec = generate_random_norepetitions<int32_t>(s.count(), min, max);
             set_values(prim, rnd_vec);
         }
 
@@ -177,19 +227,19 @@ public:
         auto prim = engine.allocate_memory(l);
         tensor s = l.get_tensor();
         if (l.data_type == data_types::f32) {
-            VF<float> rnd_vec = generate_random_1d<float>(s.count(), min, max);
+            VF<float> rnd_vec = generate_random<float>(s.count(), min, max);
             set_values(prim, rnd_vec);
         } else if (l.data_type == data_types::f16) {
-            VF<FLOAT16> rnd_vec = generate_random_1d<FLOAT16>(s.count(), min, max);
+            VF<FLOAT16> rnd_vec = generate_random<FLOAT16>(s.count(), min, max);
             set_values(prim, rnd_vec);
         } else if (l.data_type == data_types::i8) {
-            VF<int8_t> rnd_vec = generate_random_1d<int8_t>(s.count(), min, max);
+            VF<int8_t> rnd_vec = generate_random<int8_t>(s.count(), min, max);
             set_values(prim, rnd_vec);
         } else if (l.data_type == data_types::u8) {
-            VF<uint8_t> rnd_vec = generate_random_1d<uint8_t>(s.count(), min, max);
+            VF<uint8_t> rnd_vec = generate_random<uint8_t>(s.count(), min, max);
             set_values(prim, rnd_vec);
         } else if (l.data_type == data_types::bin) {
-            VF<int32_t> rnd_vec = generate_random_1d<int32_t>(s.count() / 32, min, max);
+            VF<int32_t> rnd_vec = generate_random<int32_t>(s.count() / 32, min, max);
             set_values(prim, rnd_vec);
         }
 

--- a/src/plugins/intel_gpu/tests/fusions/scatter_nd_update_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/fusions/scatter_nd_update_fusion_test.cpp
@@ -71,10 +71,9 @@ public:
 
     template<typename T>
     T generate_random_val(int min, int max, int k = 8) {
-        static std::default_random_engine generator(random_seed);
         // 1/k is the resolution of the floating point numbers
         std::uniform_int_distribution<int> distribution(k * min, k * max);
-        T val = (T)distribution(generator);
+        T val = (T)distribution(this->generator);
         val /= k;
 
         return val;

--- a/src/plugins/intel_gpu/tests/test_utils/test_utils.h
+++ b/src/plugins/intel_gpu/tests/test_utils/test_utils.h
@@ -233,36 +233,6 @@ std::vector<T> generate_random_1d(size_t a, int min, int max, int k = 8) {
     return v;
 }
 
-template<typename Type>
-std::vector<Type> generate_random_norepetitions_1d(size_t size, int min, int max, float bound = 0.45) {
-    // Rerurn repeatless vector with size = size in range(min, max)
-    static std::default_random_engine generator(random_seed);
-    std::uniform_int_distribution<int> distribution(min, max);
-    std::uniform_real_distribution<float> to_bound_dist(0, bound);
-    std::set<int> repeatless;
-    std::vector<float> v(size, 0);
-    std::vector<Type> res(size);
-    int i = 0;
-    int temp;
-    if (max - min >= int(size) - 1){
-        while (repeatless.size() < size) {
-            temp = distribution(generator);
-            if (repeatless.find(temp) == repeatless.end()) {
-                repeatless.insert(temp);
-                v[i] = (float)temp;
-                i++;
-            }
-        }
-        for (size_t k = 0; k < v.size(); k++) {
-            v[k] += to_bound_dist(generator);
-            res[k] = static_cast<Type>(v[k]);
-        }
-    } else {
-        throw "Array size is bigger than size of range(min, max). Unable to generate array of unique integer numbers";
-    }
-    return res;
-}
-
 template<typename T>
 std::vector<std::vector<T>> generate_random_2d(size_t a, size_t b, int min, int max, int k = 8) {
     std::vector<std::vector<T>> v(a);


### PR DESCRIPTION
### Details:
 - Currently random generator for unit tests is initialized once on test binary startup, so the actual data generated in each test depends on the order of tests and sensitive to adding/removing of test cases. This patch changes fusion tests to initialize random generator on test startup with seed computed as hash of test case name. So the generated data is supposed to be same regardless filters or tests scope updates.
 - This patch impacts only fusion tests, so in the future we'll need to update some other unit tests that call `generate_random_*`  functions

### Tickets:
 - *109336*
