### PR TITLE
Reduce the binary size of transformation lib

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/convert_broadcast3.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_broadcast3.cpp
@@ -7,13 +7,13 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/logical_and.hpp"
-#include "openvino/op/multiply.hpp"
-#include "openvino/op/broadcast.hpp"
-#include "openvino/op/constant.hpp"
 #include <vector>
 
 #include "itt.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/logical_and.hpp"
+#include "openvino/op/multiply.hpp"
 
 namespace {
 
@@ -80,9 +80,9 @@ ov::pass::ConvertBroadcast3::ConvertBroadcast3() {
             input = std::make_shared<ov::op::v1::Broadcast>(input, target_shape_input, op::AutoBroadcastType::PDPD);
         } else if (broadcast_type == op::BroadcastType::NONE) {
             input = std::make_shared<ov::op::v1::Broadcast>(input,
-                                                        target_shape_input,
-                                                        broadcast->input_value(2),
-                                                        op::AutoBroadcastType::NONE);
+                                                            target_shape_input,
+                                                            broadcast->input_value(2),
+                                                            op::AutoBroadcastType::NONE);
         } else if (broadcast_type == op::BroadcastType::BIDIRECTIONAL) {
             if (auto const_target_shape =
                     std::dynamic_pointer_cast<ov::op::v0::Constant>(target_shape_input.get_node_shared_ptr())) {
@@ -93,8 +93,8 @@ ov::pass::ConvertBroadcast3::ConvertBroadcast3() {
                     input = std::make_shared<ov::op::v1::Broadcast>(
                         input,
                         ov::op::v0::Constant::create(element::i64,
-                                                 Shape({aligned_target_shape.size()}),
-                                                 aligned_target_shape));
+                                                     Shape({aligned_target_shape.size()}),
+                                                     aligned_target_shape));
                 } else {
                     if (input_element_type == element::boolean) {
                         input = std::make_shared<ov::op::v1::LogicalAnd>(

--- a/src/common/transformations/src/transformations/op_conversions/convert_broadcast3.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_broadcast3.cpp
@@ -7,8 +7,10 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset3.hpp>
+#include "openvino/op/logical_and.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
 #include <vector>
 
 #include "itt.hpp"
@@ -59,10 +61,10 @@ bool make_compatible_shape(const ngraph::PartialShape& input_shape, std::vector<
 
 ov::pass::ConvertBroadcast3::ConvertBroadcast3() {
     MATCHER_SCOPE(ConvertBroadcast3);
-    auto broadcast = pattern::wrap_type<opset3::Broadcast>();
+    auto broadcast = pattern::wrap_type<ov::op::v3::Broadcast>();
 
     matcher_pass_callback callback = [](pattern::Matcher& m) {
-        auto broadcast = std::dynamic_pointer_cast<opset3::Broadcast>(m.get_match_root());
+        auto broadcast = std::dynamic_pointer_cast<ov::op::v3::Broadcast>(m.get_match_root());
         if (!broadcast) {
             return false;
         }
@@ -73,44 +75,44 @@ ov::pass::ConvertBroadcast3::ConvertBroadcast3() {
         const auto& input_element_type = input.get_element_type();
 
         if (broadcast_type == op::BroadcastType::NUMPY) {
-            input = std::make_shared<opset1::Broadcast>(input, target_shape_input, op::AutoBroadcastType::NUMPY);
+            input = std::make_shared<ov::op::v1::Broadcast>(input, target_shape_input, op::AutoBroadcastType::NUMPY);
         } else if (broadcast_type == op::BroadcastType::PDPD) {
-            input = std::make_shared<opset1::Broadcast>(input, target_shape_input, op::AutoBroadcastType::PDPD);
+            input = std::make_shared<ov::op::v1::Broadcast>(input, target_shape_input, op::AutoBroadcastType::PDPD);
         } else if (broadcast_type == op::BroadcastType::NONE) {
-            input = std::make_shared<opset1::Broadcast>(input,
+            input = std::make_shared<ov::op::v1::Broadcast>(input,
                                                         target_shape_input,
                                                         broadcast->input_value(2),
                                                         op::AutoBroadcastType::NONE);
         } else if (broadcast_type == op::BroadcastType::BIDIRECTIONAL) {
             if (auto const_target_shape =
-                    std::dynamic_pointer_cast<opset1::Constant>(target_shape_input.get_node_shared_ptr())) {
+                    std::dynamic_pointer_cast<ov::op::v0::Constant>(target_shape_input.get_node_shared_ptr())) {
                 const auto& input_shape = input.get_partial_shape();
                 const auto& target_shape = const_target_shape->cast_vector<size_t>();
                 std::vector<size_t> aligned_target_shape{target_shape};
                 if (make_compatible_shape(input_shape, aligned_target_shape)) {
-                    input = std::make_shared<opset1::Broadcast>(
+                    input = std::make_shared<ov::op::v1::Broadcast>(
                         input,
-                        opset1::Constant::create(element::i64,
+                        ov::op::v0::Constant::create(element::i64,
                                                  Shape({aligned_target_shape.size()}),
                                                  aligned_target_shape));
                 } else {
                     if (input_element_type == element::boolean) {
-                        input = std::make_shared<opset1::LogicalAnd>(
+                        input = std::make_shared<ov::op::v1::LogicalAnd>(
                             input,
-                            opset1::Constant::create(input_element_type, target_shape, {1}));
+                            ov::op::v0::Constant::create(input_element_type, target_shape, {1}));
                     } else {
-                        input = std::make_shared<opset1::Multiply>(
+                        input = std::make_shared<ov::op::v1::Multiply>(
                             input,
-                            opset1::Constant::create(input_element_type, target_shape, {1}));
+                            ov::op::v0::Constant::create(input_element_type, target_shape, {1}));
                     }
                 }
             } else {
-                auto constant_one = opset1::Constant::create(input_element_type, {1}, {1});
-                auto broadcast_ones = std::make_shared<opset1::Broadcast>(constant_one, target_shape_input);
+                auto constant_one = ov::op::v0::Constant::create(input_element_type, {1}, {1});
+                auto broadcast_ones = std::make_shared<ov::op::v1::Broadcast>(constant_one, target_shape_input);
                 if (input_element_type == element::boolean) {
-                    input = std::make_shared<ov::opset1::LogicalAnd>(input, broadcast_ones);
+                    input = std::make_shared<ov::op::v1::LogicalAnd>(input, broadcast_ones);
                 } else {
-                    input = std::make_shared<ov::opset1::Multiply>(input, broadcast_ones);
+                    input = std::make_shared<ov::op::v1::Multiply>(input, broadcast_ones);
                 }
                 copy_runtime_info(broadcast, broadcast_ones);
             }

--- a/src/common/transformations/src/transformations/op_conversions/convert_broadcast_to_tiles.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_broadcast_to_tiles.cpp
@@ -7,17 +7,20 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/tile.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
 #include <vector>
 
 #include "itt.hpp"
 
 ov::pass::ConvertBroadcastToTiles::ConvertBroadcastToTiles() {
     MATCHER_SCOPE(ConvertBroadcastToTiles);
-    auto broadcast = ngraph::pattern::wrap_type<ov::opset1::Broadcast>();
+    auto broadcast = ngraph::pattern::wrap_type<ov::op::v1::Broadcast>();
 
     matcher_pass_callback callback = [this](pattern::Matcher& m) {
-        auto broadcast = std::dynamic_pointer_cast<ov::opset1::Broadcast>(m.get_match_root());
+        auto broadcast = std::dynamic_pointer_cast<ov::op::v1::Broadcast>(m.get_match_root());
 
         if (!broadcast) {
             return false;
@@ -29,9 +32,9 @@ ov::pass::ConvertBroadcastToTiles::ConvertBroadcastToTiles() {
         }
 
         auto shape_node =
-            std::dynamic_pointer_cast<ov::opset1::Constant>(broadcast->input_value(1).get_node_shared_ptr());
+            std::dynamic_pointer_cast<ov::op::v0::Constant>(broadcast->input_value(1).get_node_shared_ptr());
         auto axes_node =
-            std::dynamic_pointer_cast<ov::opset1::Constant>(broadcast->input_value(2).get_node_shared_ptr());
+            std::dynamic_pointer_cast<ov::op::v0::Constant>(broadcast->input_value(2).get_node_shared_ptr());
         if (!shape_node || !axes_node)
             return false;
 
@@ -65,8 +68,8 @@ ov::pass::ConvertBroadcastToTiles::ConvertBroadcastToTiles() {
             } else {
                 return false;
             }
-            auto shape_const = std::make_shared<ov::opset1::Constant>(element::i64, Shape{shape.size()}, shape);
-            auto reshape = std::make_shared<ov::opset1::Reshape>(data_node, shape_const, true);
+            auto shape_const = std::make_shared<ov::op::v0::Constant>(element::i64, Shape{shape.size()}, shape);
+            auto reshape = std::make_shared<ov::op::v1::Reshape>(data_node, shape_const, true);
             new_ops.push_back(reshape);
             last_node = reshape;
             input_shape = shape;
@@ -89,8 +92,8 @@ ov::pass::ConvertBroadcastToTiles::ConvertBroadcastToTiles() {
             ++input_shape_it;
         }
 
-        auto const_node = std::make_shared<ov::opset1::Constant>(element::i64, Shape{dims_count}, dims);
-        auto tile = register_new_node<ov::opset1::Tile>(last_node, const_node);
+        auto const_node = std::make_shared<ov::op::v0::Constant>(element::i64, Shape{dims_count}, dims);
+        auto tile = register_new_node<ov::op::v0::Tile>(last_node, const_node);
         new_ops.push_back(tile);
         tile->set_friendly_name(broadcast->get_friendly_name());
 

--- a/src/common/transformations/src/transformations/op_conversions/convert_broadcast_to_tiles.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_broadcast_to_tiles.cpp
@@ -7,13 +7,13 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/reshape.hpp"
-#include "openvino/op/tile.hpp"
-#include "openvino/op/broadcast.hpp"
-#include "openvino/op/constant.hpp"
 #include <vector>
 
 #include "itt.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/tile.hpp"
 
 ov::pass::ConvertBroadcastToTiles::ConvertBroadcastToTiles() {
     MATCHER_SCOPE(ConvertBroadcastToTiles);

--- a/src/common/transformations/src/transformations/op_conversions/convert_convertlike.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_convertlike.cpp
@@ -7,7 +7,8 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset8.hpp>
+#include "openvino/op/convert.hpp"
+#include "openvino/op/convert_like.hpp"
 #include <vector>
 
 #include "itt.hpp"
@@ -17,10 +18,10 @@ using namespace ov;
 ov::pass::ConvertConvertLike::ConvertConvertLike() {
     MATCHER_SCOPE(ConvertConvertLike);
 
-    auto convertlike = pattern::wrap_type<opset8::ConvertLike>();
+    auto convertlike = pattern::wrap_type<ov::op::v1::ConvertLike>();
 
     matcher_pass_callback callback = [](pattern::Matcher& m) {
-        auto cvtlike = std::dynamic_pointer_cast<opset8::ConvertLike>(m.get_match_root());
+        auto cvtlike = std::dynamic_pointer_cast<ov::op::v1::ConvertLike>(m.get_match_root());
         if (!cvtlike) {
             return false;
         }
@@ -30,7 +31,7 @@ ov::pass::ConvertConvertLike::ConvertConvertLike() {
         if (dest_type == element::dynamic || dest_type == element::undefined)
             return false;
 
-        auto cvt = std::make_shared<opset8::Convert>(cvtlike->input_value(0), dest_type);
+        auto cvt = std::make_shared<ov::op::v0::Convert>(cvtlike->input_value(0), dest_type);
 
         cvt->set_friendly_name(cvtlike->get_friendly_name());
         copy_runtime_info(cvtlike, cvt);

--- a/src/common/transformations/src/transformations/op_conversions/convert_convertlike.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_convertlike.cpp
@@ -7,11 +7,11 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/convert.hpp"
-#include "openvino/op/convert_like.hpp"
 #include <vector>
 
 #include "itt.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/convert_like.hpp"
 
 using namespace ov;
 

--- a/src/common/transformations/src/transformations/op_conversions/convert_deformable_conv_v8_to_v1.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_deformable_conv_v8_to_v1.cpp
@@ -6,9 +6,9 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/deformable_convolution.hpp"
 
 #include "itt.hpp"
+#include "openvino/op/deformable_convolution.hpp"
 
 ov::pass::ConvertDeformableConv8To1::ConvertDeformableConv8To1() {
     MATCHER_SCOPE(ConvertDeformableConv8To1);

--- a/src/common/transformations/src/transformations/op_conversions/convert_deformable_conv_v8_to_v1.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_deformable_conv_v8_to_v1.cpp
@@ -6,18 +6,17 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset8.hpp>
+#include "openvino/op/deformable_convolution.hpp"
 
 #include "itt.hpp"
 
 ov::pass::ConvertDeformableConv8To1::ConvertDeformableConv8To1() {
     MATCHER_SCOPE(ConvertDeformableConv8To1);
 
-    auto deformable_conv_v8 = pattern::wrap_type<ov::opset8::DeformableConvolution>();
+    auto deformable_conv_v8 = pattern::wrap_type<ov::op::v8::DeformableConvolution>();
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        auto deformable_conv_v8_node = std::dynamic_pointer_cast<ov::opset8::DeformableConvolution>(m.get_match_root());
+        auto deformable_conv_v8_node = std::dynamic_pointer_cast<ov::op::v8::DeformableConvolution>(m.get_match_root());
         if (!deformable_conv_v8_node)
             return false;
 
@@ -29,7 +28,7 @@ ov::pass::ConvertDeformableConv8To1::ConvertDeformableConv8To1() {
         auto filters = deformable_conv_v8_node->input_value(2);
 
         auto deformable_conv_v1 =
-            std::make_shared<ov::opset1::DeformableConvolution>(arg,
+            std::make_shared<ov::op::v1::DeformableConvolution>(arg,
                                                                 offsets,
                                                                 filters,
                                                                 deformable_conv_v8_node->get_strides(),

--- a/src/common/transformations/src/transformations/op_conversions/convert_depth_to_space.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_depth_to_space.cpp
@@ -7,13 +7,13 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/constant.hpp"
-#include "openvino/op/transpose.hpp"
-#include "openvino/op/reshape.hpp"
-#include "openvino/op/depth_to_space.hpp"
 #include <vector>
 
 #include "itt.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/depth_to_space.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/transpose.hpp"
 
 ov::pass::ConvertDepthToSpace::ConvertDepthToSpace() {
     MATCHER_SCOPE(ConvertDepthToSpace);

--- a/src/common/transformations/src/transformations/op_conversions/convert_depth_to_space.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_depth_to_space.cpp
@@ -7,7 +7,10 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
+#include "openvino/op/constant.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/depth_to_space.hpp"
 #include <vector>
 
 #include "itt.hpp"
@@ -15,10 +18,10 @@
 ov::pass::ConvertDepthToSpace::ConvertDepthToSpace() {
     MATCHER_SCOPE(ConvertDepthToSpace);
     auto dts_node =
-        ngraph::pattern::wrap_type<ov::opset1::DepthToSpace>({pattern::any_input(pattern::has_static_shape())});
+        ngraph::pattern::wrap_type<ov::op::v0::DepthToSpace>({pattern::any_input(pattern::has_static_shape())});
 
     matcher_pass_callback callback = [this](pattern::Matcher& m) {
-        auto dts_node = std::dynamic_pointer_cast<ov::opset1::DepthToSpace>(m.get_match_root());
+        auto dts_node = std::dynamic_pointer_cast<ov::op::v0::DepthToSpace>(m.get_match_root());
         if (!dts_node || transformation_callback(dts_node)) {
             return false;
         }
@@ -51,10 +54,10 @@ ov::pass::ConvertDepthToSpace::ConvertDepthToSpace() {
         }
 
         switch (mode) {
-        case opset1::DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST:
+        case ov::op::v0::DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST:
             shape_begin.push_back(C);
             break;
-        case opset1::DepthToSpace::DepthToSpaceMode::DEPTH_FIRST:
+        case ov::op::v0::DepthToSpace::DepthToSpaceMode::DEPTH_FIRST:
             shape_begin.insert(shape_begin.begin() + 1, C);
             break;
         }
@@ -66,14 +69,14 @@ ov::pass::ConvertDepthToSpace::ConvertDepthToSpace() {
         // Calculate Transpose order
         std::vector<int64_t> order{0};
         switch (mode) {
-        case opset1::DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST:
+        case ov::op::v0::DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST:
             order.push_back(spatial_dims + 1);
             for (size_t i = 1; i <= spatial_dims; ++i) {
                 order.push_back(spatial_dims + 1 + i);
                 order.push_back(i);
             }
             break;
-        case opset1::DepthToSpace::DepthToSpaceMode::DEPTH_FIRST:
+        case ov::op::v0::DepthToSpace::DepthToSpaceMode::DEPTH_FIRST:
             order.push_back(1);
             for (size_t i = 1; i <= spatial_dims; ++i) {
                 order.push_back(spatial_dims + 1 + i);
@@ -88,13 +91,13 @@ ov::pass::ConvertDepthToSpace::ConvertDepthToSpace() {
             shape_end.push_back(block_size * input_shape[2 + i]);
         }
 
-        auto create_constant = [](std::vector<int64_t>& v) -> std::shared_ptr<opset1::Constant> {
-            return opset1::Constant::create(element::i64, Shape{v.size()}, v);
+        auto create_constant = [](std::vector<int64_t>& v) -> std::shared_ptr<ov::op::v0::Constant> {
+            return ov::op::v0::Constant::create(element::i64, Shape{v.size()}, v);
         };
 
-        auto reshape_begin = std::make_shared<ov::opset1::Reshape>(input, create_constant(shape_begin), true);
-        auto transpose = std::make_shared<ov::opset1::Transpose>(reshape_begin, create_constant(order));
-        auto reshape_end = std::make_shared<ov::opset1::Reshape>(transpose, create_constant(shape_end), true);
+        auto reshape_begin = std::make_shared<ov::op::v1::Reshape>(input, create_constant(shape_begin), true);
+        auto transpose = std::make_shared<ov::op::v1::Transpose>(reshape_begin, create_constant(order));
+        auto reshape_end = std::make_shared<ov::op::v1::Reshape>(transpose, create_constant(shape_end), true);
         reshape_end->set_friendly_name(dts_node->get_friendly_name());
         ngraph::copy_runtime_info(dts_node, {reshape_begin, transpose, reshape_end});
         ngraph::replace_node(dts_node, reshape_end);

--- a/src/common/transformations/src/transformations/op_conversions/convert_divide.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_divide.cpp
@@ -9,13 +9,13 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 #include <ngraph/validation_util.hpp>
-#include "openvino/op/power.hpp"
-#include "openvino/op/divide.hpp"
-#include "openvino/op/multiply.hpp"
-#include "openvino/op/constant.hpp"
 #include <vector>
 
 #include "itt.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/power.hpp"
 #include "transformations/rt_info/nonconvertible_divide.hpp"
 #include "transformations/utils/utils.hpp"
 
@@ -72,8 +72,8 @@ ov::pass::ConvertDivide::ConvertDivide() {
 
 ov::pass::ConvertDivideWithConstant::ConvertDivideWithConstant() {
     MATCHER_SCOPE(ConvertDivideWithConstant);
-    auto div =
-        ngraph::pattern::wrap_type<ov::op::v1::Divide>({pattern::any_input(), pattern::wrap_type<ov::op::v0::Constant>()});
+    auto div = ngraph::pattern::wrap_type<ov::op::v1::Divide>(
+        {pattern::any_input(), pattern::wrap_type<ov::op::v0::Constant>()});
 
     matcher_pass_callback callback = [](pattern::Matcher& m) {
         return convert_divide(m.get_match_root());

--- a/src/common/transformations/src/transformations/op_conversions/convert_divide.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_divide.cpp
@@ -9,7 +9,10 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 #include <ngraph/validation_util.hpp>
-#include <openvino/opsets/opset1.hpp>
+#include "openvino/op/power.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/constant.hpp"
 #include <vector>
 
 #include "itt.hpp"
@@ -18,13 +21,13 @@
 
 namespace {
 bool convert_divide(std::shared_ptr<ngraph::Node> node) {
-    auto div = std::dynamic_pointer_cast<ov::opset1::Divide>(node);
+    auto div = std::dynamic_pointer_cast<ov::op::v1::Divide>(node);
     // We can not apply this transformation in case with integer input data type
     if (!div || ov::divide_is_nonconvertible(div) || div->get_input_element_type(0).is_integral()) {
         return false;
     }
 
-    std::shared_ptr<ngraph::Node> pow = std::make_shared<ov::opset1::Power>(
+    std::shared_ptr<ngraph::Node> pow = std::make_shared<ov::op::v1::Power>(
         div->input_value(1),
         ngraph::op::Constant::create(div->get_input_element_type(1), ngraph::Shape{}, {-1}));
 
@@ -41,7 +44,7 @@ bool convert_divide(std::shared_ptr<ngraph::Node> node) {
         ngraph::copy_runtime_info(div, pow);
     }
 
-    auto mul = std::make_shared<ov::opset1::Multiply>(div->input(0).get_source_output(), pow);
+    auto mul = std::make_shared<ov::op::v1::Multiply>(div->input(0).get_source_output(), pow);
     // if Divide is an inverse, then we don't need the Multiply
     if (ov::op::util::can_eliminate_eltwise_node(mul, mul->input_value(0), mul->input_value(1))) {
         pow->set_friendly_name(div->get_friendly_name());
@@ -57,7 +60,7 @@ bool convert_divide(std::shared_ptr<ngraph::Node> node) {
 
 ov::pass::ConvertDivide::ConvertDivide() {
     MATCHER_SCOPE(ConvertDivide);
-    auto div = ngraph::pattern::wrap_type<ov::opset1::Divide>();
+    auto div = ngraph::pattern::wrap_type<ov::op::v1::Divide>();
 
     matcher_pass_callback callback = [](pattern::Matcher& m) {
         return convert_divide(m.get_match_root());
@@ -70,7 +73,7 @@ ov::pass::ConvertDivide::ConvertDivide() {
 ov::pass::ConvertDivideWithConstant::ConvertDivideWithConstant() {
     MATCHER_SCOPE(ConvertDivideWithConstant);
     auto div =
-        ngraph::pattern::wrap_type<ov::opset1::Divide>({pattern::any_input(), pattern::wrap_type<opset1::Constant>()});
+        ngraph::pattern::wrap_type<ov::op::v1::Divide>({pattern::any_input(), pattern::wrap_type<ov::op::v0::Constant>()});
 
     matcher_pass_callback callback = [](pattern::Matcher& m) {
         return convert_divide(m.get_match_root());

--- a/src/common/transformations/src/transformations/op_conversions/convert_gather_0d.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_gather_0d.cpp
@@ -7,25 +7,26 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset7.hpp>
-#include <openvino/opsets/opset8.hpp>
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/constant.hpp"
 #include <vector>
 
 #include "itt.hpp"
 
 ov::pass::ConvertGather0D::ConvertGather0D() {
     MATCHER_SCOPE(ConvertGather0D);
-    auto gather = ngraph::pattern::wrap_type<opset1::Gather>();
+    auto gather = ngraph::pattern::wrap_type<ov::op::v1::Gather>();
 
     matcher_pass_callback callback = [](pattern::Matcher& m) {
-        auto gather = std::dynamic_pointer_cast<ov::opset1::Gather>(m.get_match_root());
+        auto gather = std::dynamic_pointer_cast<ov::op::v1::Gather>(m.get_match_root());
         if (!gather) {
             return false;
         }
 
         auto axes_constant =
-            std::dynamic_pointer_cast<ov::opset1::Constant>(gather->input_value(2).get_node_shared_ptr());
+            std::dynamic_pointer_cast<ov::op::v0::Constant>(gather->input_value(2).get_node_shared_ptr());
         if (!axes_constant) {
             return false;
         }
@@ -40,10 +41,10 @@ ov::pass::ConvertGather0D::ConvertGather0D() {
 
         auto axis = axes_constant->cast_vector<int64_t>()[0];
         indices =
-            std::make_shared<ov::opset1::Unsqueeze>(indices, opset1::Constant::create(element::i64, Shape{1}, {0}));
-        auto gather_new = std::make_shared<ov::opset1::Gather>(gather->input_value(0), indices, axes_constant);
+            std::make_shared<ov::op::v0::Unsqueeze>(indices, ov::op::v0::Constant::create(element::i64, Shape{1}, {0}));
+        auto gather_new = std::make_shared<ov::op::v1::Gather>(gather->input_value(0), indices, axes_constant);
         auto sq =
-            std::make_shared<ov::opset1::Squeeze>(gather_new, opset1::Constant::create(element::i64, Shape{1}, {axis}));
+            std::make_shared<ov::op::v0::Squeeze>(gather_new, ov::op::v0::Constant::create(element::i64, Shape{1}, {axis}));
         sq->set_friendly_name(gather->get_friendly_name());
 
         ngraph::copy_runtime_info(gather, {indices.get_node_shared_ptr(), gather_new, sq});

--- a/src/common/transformations/src/transformations/op_conversions/convert_gather_0d.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_gather_0d.cpp
@@ -7,13 +7,13 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/unsqueeze.hpp"
-#include "openvino/op/squeeze.hpp"
-#include "openvino/op/gather.hpp"
-#include "openvino/op/constant.hpp"
 #include <vector>
 
 #include "itt.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/unsqueeze.hpp"
 
 ov::pass::ConvertGather0D::ConvertGather0D() {
     MATCHER_SCOPE(ConvertGather0D);
@@ -43,8 +43,8 @@ ov::pass::ConvertGather0D::ConvertGather0D() {
         indices =
             std::make_shared<ov::op::v0::Unsqueeze>(indices, ov::op::v0::Constant::create(element::i64, Shape{1}, {0}));
         auto gather_new = std::make_shared<ov::op::v1::Gather>(gather->input_value(0), indices, axes_constant);
-        auto sq =
-            std::make_shared<ov::op::v0::Squeeze>(gather_new, ov::op::v0::Constant::create(element::i64, Shape{1}, {axis}));
+        auto sq = std::make_shared<ov::op::v0::Squeeze>(gather_new,
+                                                        ov::op::v0::Constant::create(element::i64, Shape{1}, {axis}));
         sq->set_friendly_name(gather->get_friendly_name());
 
         ngraph::copy_runtime_info(gather, {indices.get_node_shared_ptr(), gather_new, sq});

--- a/src/common/transformations/src/transformations/op_conversions/convert_gather_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_gather_downgrade.cpp
@@ -6,9 +6,7 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset7.hpp>
-#include <openvino/opsets/opset8.hpp>
+#include "openvino/op/gather.hpp"
 
 #include "itt.hpp"
 
@@ -18,16 +16,16 @@ using namespace ov;
 pass::ConvertGather7ToGather1::ConvertGather7ToGather1() {
     MATCHER_SCOPE(ConvertGather7ToGather1);
 
-    auto gather_v7_pattern = pattern::wrap_type<opset7::Gather>();
+    auto gather_v7_pattern = pattern::wrap_type<ov::op::v7::Gather>();
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        auto gather_v7_node = std::dynamic_pointer_cast<opset7::Gather>(m.get_match_root());
+        auto gather_v7_node = std::dynamic_pointer_cast<ov::op::v7::Gather>(m.get_match_root());
         if (!gather_v7_node)
             return false;
         if (gather_v7_node->get_batch_dims() != 0)
             return false;
 
-        auto gather_v1_node = make_shared<opset1::Gather>(gather_v7_node->input_value(0),
+        auto gather_v1_node = make_shared<ov::op::v1::Gather>(gather_v7_node->input_value(0),
                                                           gather_v7_node->input_value(1),
                                                           gather_v7_node->input_value(2));
 
@@ -44,14 +42,14 @@ pass::ConvertGather7ToGather1::ConvertGather7ToGather1() {
 pass::ConvertGather8ToGather7::ConvertGather8ToGather7() {
     MATCHER_SCOPE(ConvertGather8ToGather7);
 
-    auto gather_v8_pattern = pattern::wrap_type<opset8::Gather>();
+    auto gather_v8_pattern = pattern::wrap_type<ov::op::v8::Gather>();
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        auto gather_v8_node = std::dynamic_pointer_cast<opset8::Gather>(m.get_match_root());
+        auto gather_v8_node = std::dynamic_pointer_cast<ov::op::v8::Gather>(m.get_match_root());
         if (!gather_v8_node)
             return false;
 
-        auto gather_v7_node = make_shared<opset7::Gather>(gather_v8_node->input_value(0),
+        auto gather_v7_node = make_shared<ov::op::v7::Gather>(gather_v8_node->input_value(0),
                                                           gather_v8_node->input_value(1),
                                                           gather_v8_node->input_value(2),
                                                           gather_v8_node->get_batch_dims());

--- a/src/common/transformations/src/transformations/op_conversions/convert_gather_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_gather_downgrade.cpp
@@ -6,9 +6,9 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/gather.hpp"
 
 #include "itt.hpp"
+#include "openvino/op/gather.hpp"
 
 using namespace std;
 using namespace ov;
@@ -26,8 +26,8 @@ pass::ConvertGather7ToGather1::ConvertGather7ToGather1() {
             return false;
 
         auto gather_v1_node = make_shared<ov::op::v1::Gather>(gather_v7_node->input_value(0),
-                                                          gather_v7_node->input_value(1),
-                                                          gather_v7_node->input_value(2));
+                                                              gather_v7_node->input_value(1),
+                                                              gather_v7_node->input_value(2));
 
         gather_v1_node->set_friendly_name(gather_v7_node->get_friendly_name());
         ngraph::copy_runtime_info(gather_v7_node, gather_v1_node);
@@ -50,9 +50,9 @@ pass::ConvertGather8ToGather7::ConvertGather8ToGather7() {
             return false;
 
         auto gather_v7_node = make_shared<ov::op::v7::Gather>(gather_v8_node->input_value(0),
-                                                          gather_v8_node->input_value(1),
-                                                          gather_v8_node->input_value(2),
-                                                          gather_v8_node->get_batch_dims());
+                                                              gather_v8_node->input_value(1),
+                                                              gather_v8_node->input_value(2),
+                                                              gather_v8_node->get_batch_dims());
 
         gather_v7_node->set_friendly_name(gather_v8_node->get_friendly_name());
         ngraph::copy_runtime_info(gather_v8_node, gather_v7_node);

--- a/src/common/transformations/src/transformations/op_conversions/convert_gather_upgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_gather_upgrade.cpp
@@ -6,9 +6,7 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset7.hpp>
-#include <openvino/opsets/opset8.hpp>
+#include "openvino/op/gather.hpp"
 
 #include "itt.hpp"
 
@@ -18,14 +16,14 @@ using namespace ov;
 pass::ConvertGather1ToGather7::ConvertGather1ToGather7() {
     MATCHER_SCOPE(ConvertGather1ToGather7);
 
-    auto gather_v1_pattern = pattern::wrap_type<opset1::Gather>();
+    auto gather_v1_pattern = pattern::wrap_type<ov::op::v1::Gather>();
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        auto gather_v1_node = std::dynamic_pointer_cast<opset1::Gather>(m.get_match_root());
+        auto gather_v1_node = std::dynamic_pointer_cast<ov::op::v1::Gather>(m.get_match_root());
         if (!gather_v1_node)
             return false;
 
-        auto gather_v7_node = make_shared<opset7::Gather>(gather_v1_node->input_value(0),
+        auto gather_v7_node = make_shared<ov::op::v7::Gather>(gather_v1_node->input_value(0),
                                                           gather_v1_node->input_value(1),
                                                           gather_v1_node->input_value(2),
                                                           0);
@@ -43,14 +41,14 @@ pass::ConvertGather1ToGather7::ConvertGather1ToGather7() {
 pass::ConvertGather7ToGather8::ConvertGather7ToGather8() {
     MATCHER_SCOPE(ConvertGather7ToGather8);
 
-    auto gather_v7_pattern = pattern::wrap_type<opset7::Gather>();
+    auto gather_v7_pattern = pattern::wrap_type<ov::op::v7::Gather>();
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        auto gather_v7_node = std::dynamic_pointer_cast<opset7::Gather>(m.get_match_root());
+        auto gather_v7_node = std::dynamic_pointer_cast<ov::op::v7::Gather>(m.get_match_root());
         if (!gather_v7_node)
             return false;
 
-        auto gather_v8_node = make_shared<opset8::Gather>(gather_v7_node->input_value(0),
+        auto gather_v8_node = make_shared<ov::op::v8::Gather>(gather_v7_node->input_value(0),
                                                           gather_v7_node->input_value(1),
                                                           gather_v7_node->input_value(2),
                                                           gather_v7_node->get_batch_dims());

--- a/src/common/transformations/src/transformations/op_conversions/convert_gather_upgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_gather_upgrade.cpp
@@ -6,9 +6,9 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/gather.hpp"
 
 #include "itt.hpp"
+#include "openvino/op/gather.hpp"
 
 using namespace std;
 using namespace ov;
@@ -24,9 +24,9 @@ pass::ConvertGather1ToGather7::ConvertGather1ToGather7() {
             return false;
 
         auto gather_v7_node = make_shared<ov::op::v7::Gather>(gather_v1_node->input_value(0),
-                                                          gather_v1_node->input_value(1),
-                                                          gather_v1_node->input_value(2),
-                                                          0);
+                                                              gather_v1_node->input_value(1),
+                                                              gather_v1_node->input_value(2),
+                                                              0);
 
         gather_v7_node->set_friendly_name(gather_v1_node->get_friendly_name());
         ngraph::copy_runtime_info(gather_v1_node, gather_v7_node);
@@ -49,9 +49,9 @@ pass::ConvertGather7ToGather8::ConvertGather7ToGather8() {
             return false;
 
         auto gather_v8_node = make_shared<ov::op::v8::Gather>(gather_v7_node->input_value(0),
-                                                          gather_v7_node->input_value(1),
-                                                          gather_v7_node->input_value(2),
-                                                          gather_v7_node->get_batch_dims());
+                                                              gather_v7_node->input_value(1),
+                                                              gather_v7_node->input_value(2),
+                                                              gather_v7_node->get_batch_dims());
 
         gather_v8_node->set_friendly_name(gather_v7_node->get_friendly_name());
         ngraph::copy_runtime_info(gather_v7_node, gather_v8_node);

--- a/src/common/transformations/src/transformations/op_conversions/convert_gelu.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_gelu.cpp
@@ -6,16 +6,16 @@
 #include <ngraph/ngraph.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/gelu.hpp"
-#include "openvino/op/constant.hpp"
-#include "openvino/op/divide.hpp"
-#include "openvino/op/erf.hpp"
-#include "openvino/op/add.hpp"
-#include "openvino/op/sqrt.hpp"
-#include "openvino/op/multiply.hpp"
 #include <transformations/op_conversions/convert_gelu.hpp>
 
 #include "itt.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/erf.hpp"
+#include "openvino/op/gelu.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/sqrt.hpp"
 
 ov::pass::ConvertGELU::ConvertGELU() {
     MATCHER_SCOPE(ConvertGELU);

--- a/src/common/transformations/src/transformations/op_conversions/convert_gelu.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_gelu.cpp
@@ -6,18 +6,23 @@
 #include <ngraph/ngraph.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset2.hpp>
+#include "openvino/op/gelu.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/erf.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/sqrt.hpp"
+#include "openvino/op/multiply.hpp"
 #include <transformations/op_conversions/convert_gelu.hpp>
 
 #include "itt.hpp"
 
 ov::pass::ConvertGELU::ConvertGELU() {
     MATCHER_SCOPE(ConvertGELU);
-    auto gelu = pattern::wrap_type<ov::opset2::Gelu>();
+    auto gelu = pattern::wrap_type<ov::op::v0::Gelu>();
 
     matcher_pass_callback callback = [this](pattern::Matcher& m) {
-        auto gelu = std::dynamic_pointer_cast<ov::opset2::Gelu>(m.get_match_root());
+        auto gelu = std::dynamic_pointer_cast<ov::op::v0::Gelu>(m.get_match_root());
         if (!gelu || transformation_callback(gelu))
             return false;
         auto input = gelu->input_value(0);
@@ -25,12 +30,12 @@ ov::pass::ConvertGELU::ConvertGELU() {
 
         // f(x) = 0.5 * x * (1.0 + erf( x / sqrt(2.0) )
         auto mul =
-            std::make_shared<ov::opset1::Multiply>(input, ov::opset1::Constant::create(input_type, Shape{}, {0.5}));
-        auto sq2 = std::make_shared<ov::opset1::Sqrt>(ov::opset1::Constant::create(input_type, Shape{}, {2.0}));
-        auto div = register_new_node<ov::opset1::Divide>(input, sq2);  // can be decomposed
-        auto erf = std::make_shared<ov::opset1::Erf>(div);
-        auto add = std::make_shared<ov::opset1::Add>(erf, ov::opset1::Constant::create(input_type, Shape{}, {1.0}));
-        auto res = std::make_shared<ov::opset1::Multiply>(mul, add);
+            std::make_shared<ov::op::v1::Multiply>(input, ov::op::v0::Constant::create(input_type, Shape{}, {0.5}));
+        auto sq2 = std::make_shared<ov::op::v0::Sqrt>(ov::op::v0::Constant::create(input_type, Shape{}, {2.0}));
+        auto div = register_new_node<ov::op::v1::Divide>(input, sq2);  // can be decomposed
+        auto erf = std::make_shared<ov::op::v0::Erf>(div);
+        auto add = std::make_shared<ov::op::v1::Add>(erf, ov::op::v0::Constant::create(input_type, Shape{}, {1.0}));
+        auto res = std::make_shared<ov::op::v1::Multiply>(mul, add);
 
         res->set_friendly_name(gelu->get_friendly_name());
         ngraph::copy_runtime_info(gelu, {mul, sq2, div, erf, add, res});

--- a/src/common/transformations/src/transformations/op_conversions/convert_gp9_to_gp_ie_internal.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_gp9_to_gp_ie_internal.cpp
@@ -6,9 +6,9 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/generate_proposals.hpp"
 
 #include "itt.hpp"
+#include "openvino/op/generate_proposals.hpp"
 #include "ov_ops/generate_proposals_ie_internal.hpp"
 #include "transformations/utils/utils.hpp"
 

--- a/src/common/transformations/src/transformations/op_conversions/convert_gp9_to_gp_ie_internal.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_gp9_to_gp_ie_internal.cpp
@@ -6,8 +6,7 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset9.hpp>
+#include "openvino/op/generate_proposals.hpp"
 
 #include "itt.hpp"
 #include "ov_ops/generate_proposals_ie_internal.hpp"
@@ -16,7 +15,7 @@
 ov::pass::ConvertGP9ToGPIEInternal::ConvertGP9ToGPIEInternal() {
     matcher_pass_callback callback = [](ngraph::pattern::Matcher& m) {
         const auto root = m.get_match_root();
-        const auto old_node = std::dynamic_pointer_cast<ov::opset9::GenerateProposals>(root);
+        const auto old_node = std::dynamic_pointer_cast<ov::op::v9::GenerateProposals>(root);
         if (!old_node) {
             return false;
         }
@@ -50,7 +49,7 @@ ov::pass::ConvertGP9ToGPIEInternal::ConvertGP9ToGPIEInternal() {
         return true;
     };
 
-    const auto generate_proposals = ngraph::pattern::wrap_type<ov::opset9::GenerateProposals>();
+    const auto generate_proposals = ngraph::pattern::wrap_type<ov::op::v9::GenerateProposals>();
     const auto matcher = std::make_shared<ngraph::pattern::Matcher>(generate_proposals, "ConvertGP9ToGPIEInternal");
     register_matcher(matcher, callback);
 }

--- a/src/common/transformations/src/transformations/op_conversions/convert_interpolate11_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_interpolate11_downgrade.cpp
@@ -7,12 +7,12 @@
 #include <array>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/constant.hpp"
-#include "openvino/op/broadcast.hpp"
-#include "openvino/op/interpolate.hpp"
-#include "openvino/op/shape_of.hpp"
 
 #include "itt.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/interpolate.hpp"
+#include "openvino/op/shape_of.hpp"
 #include "utils.hpp"
 
 namespace {

--- a/src/common/transformations/src/transformations/op_conversions/convert_interpolate11_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_interpolate11_downgrade.cpp
@@ -7,8 +7,10 @@
 #include <array>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset11.hpp>
-#include <openvino/opsets/opset4.hpp>
+#include "openvino/op/constant.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/interpolate.hpp"
+#include "openvino/op/shape_of.hpp"
 
 #include "itt.hpp"
 #include "utils.hpp"
@@ -16,30 +18,30 @@
 namespace {
 // v4_sizes, v4_scales
 std::pair<ov::Output<ov::Node>, ov::Output<ov::Node>> make_v4_inputs(
-    const std::shared_ptr<ov::opset11::Interpolate>& interpolate) {
+    const std::shared_ptr<ov::op::v11::Interpolate>& interpolate) {
     ov::pass::NodeRegistry registry;
     std::pair<ov::Output<ov::Node>, ov::Output<ov::Node>> ret;
     std::shared_ptr<ov::Node> broadcast_shape;
 
     if (interpolate->get_input_size() == 3) {
         // broadcast dummy constant to the shape of axes
-        broadcast_shape = registry.make<ov::opset4::ShapeOf>(interpolate->input_value(2));
+        broadcast_shape = registry.make<ov::op::v3::ShapeOf>(interpolate->input_value(2));
     } else {
         // broadcast dummy constant to the rank of data
-        broadcast_shape = registry.make<ov::opset4::ShapeOf>(interpolate->input_value(0));
-        broadcast_shape = registry.make<ov::opset4::ShapeOf>(broadcast_shape);
+        broadcast_shape = registry.make<ov::op::v3::ShapeOf>(interpolate->input_value(0));
+        broadcast_shape = registry.make<ov::op::v3::ShapeOf>(broadcast_shape);
     }
 
     if (interpolate->get_attrs().shape_calculation_mode == ov::op::util::InterpolateBase::ShapeCalcMode::SCALES) {
         ret.second = interpolate->input_value(1);
-        std::shared_ptr<ov::Node> sizes_input = registry.make<ov::opset4::Constant>(ov::element::i32, ov::Shape{}, 1);
-        sizes_input = registry.make<ov::opset4::Broadcast>(sizes_input, broadcast_shape);
+        std::shared_ptr<ov::Node> sizes_input = registry.make<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, 1);
+        sizes_input = registry.make<ov::op::v3::Broadcast>(sizes_input, broadcast_shape);
         ret.first = sizes_input;
     } else {
         ret.first = interpolate->input_value(1);
         std::shared_ptr<ov::Node> scales_input =
-            registry.make<ov::opset4::Constant>(ov::element::f32, ov::Shape{}, 1.0f);
-        scales_input = registry.make<ov::opset4::Broadcast>(scales_input, broadcast_shape);
+            registry.make<ov::op::v0::Constant>(ov::element::f32, ov::Shape{}, 1.0f);
+        scales_input = registry.make<ov::op::v3::Broadcast>(scales_input, broadcast_shape);
         ret.second = scales_input;
     }
 
@@ -52,7 +54,7 @@ std::pair<ov::Output<ov::Node>, ov::Output<ov::Node>> make_v4_inputs(
 ov::pass::ConvertInterpolate11ToInterpolate4::ConvertInterpolate11ToInterpolate4() {
     MATCHER_SCOPE(ConvertInterpolate11ToInterpolate4);
 
-    const auto interpolate_v11_pattern = pattern::wrap_type<opset11::Interpolate>();
+    const auto interpolate_v11_pattern = pattern::wrap_type<ov::op::v11::Interpolate>();
 
     const matcher_pass_callback callback = [=](pattern::Matcher& m) {
         const auto v4_compatible_interpolation_mode = [](const op::util::InterpolateBase::InterpolateMode mode) {
@@ -65,26 +67,26 @@ ov::pass::ConvertInterpolate11ToInterpolate4::ConvertInterpolate11ToInterpolate4
             return std::find(std::begin(allowed_modes), std::end(allowed_modes), mode) != std::end(allowed_modes);
         };
 
-        const auto interpolate_v11 = std::dynamic_pointer_cast<opset11::Interpolate>(m.get_match_root());
+        const auto interpolate_v11 = std::dynamic_pointer_cast<ov::op::v11::Interpolate>(m.get_match_root());
         if (!interpolate_v11 || !v4_compatible_interpolation_mode(interpolate_v11->get_attrs().mode) ||
             transformation_callback(interpolate_v11)) {
             return false;
         }
 
         // downgrade only if the interpolation mode used to create v11 is supported by v4
-        std::shared_ptr<ov::opset4::Interpolate> interpolate_v4;
+        std::shared_ptr<ov::op::v4::Interpolate> interpolate_v4;
         ov::Output<ov::Node> v4_input_output_shape;
         ov::Output<ov::Node> v4_input_scales;
         std::tie(v4_input_output_shape, v4_input_scales) = make_v4_inputs(interpolate_v11);
 
         if (interpolate_v11->get_input_size() == 3) {  // with axes input
-            interpolate_v4 = std::make_shared<ov::opset4::Interpolate>(interpolate_v11->input_value(0),
+            interpolate_v4 = std::make_shared<ov::op::v4::Interpolate>(interpolate_v11->input_value(0),
                                                                        v4_input_output_shape,
                                                                        v4_input_scales,
                                                                        interpolate_v11->input_value(2),
                                                                        interpolate_v11->get_attrs());
         } else {
-            interpolate_v4 = std::make_shared<ov::opset4::Interpolate>(interpolate_v11->input_value(0),
+            interpolate_v4 = std::make_shared<ov::op::v4::Interpolate>(interpolate_v11->input_value(0),
                                                                        v4_input_output_shape,
                                                                        v4_input_scales,
                                                                        interpolate_v11->get_attrs());

--- a/src/common/transformations/src/transformations/op_conversions/convert_interpolate1_to_interpolate4.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_interpolate1_to_interpolate4.cpp
@@ -8,13 +8,13 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 #include <openvino/core/core.hpp>
-#include "openvino/op/convert.hpp"
-#include "openvino/op/divide.hpp"
-#include "openvino/op/interpolate.hpp"
 #include <transformations/utils/utils.hpp>
 #include <vector>
 
 #include "itt.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/interpolate.hpp"
 
 ov::pass::ConvertInterpolate1ToInterpolate4::ConvertInterpolate1ToInterpolate4() {
     MATCHER_SCOPE(ConvertInterpolate1ToInterpolate4);

--- a/src/common/transformations/src/transformations/op_conversions/convert_interpolate1_to_interpolate4.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_interpolate1_to_interpolate4.cpp
@@ -8,9 +8,9 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 #include <openvino/core/core.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset3.hpp>
-#include <openvino/opsets/opset4.hpp>
+#include "openvino/op/convert.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/interpolate.hpp"
 #include <transformations/utils/utils.hpp>
 #include <vector>
 
@@ -18,66 +18,66 @@
 
 ov::pass::ConvertInterpolate1ToInterpolate4::ConvertInterpolate1ToInterpolate4() {
     MATCHER_SCOPE(ConvertInterpolate1ToInterpolate4);
-    auto interpolate1 = ngraph::pattern::wrap_type<ov::opset1::Interpolate>(
+    auto interpolate1 = ngraph::pattern::wrap_type<ov::op::v0::Interpolate>(
         {pattern::any_input(pattern::has_static_rank()), pattern::any_input()});
     matcher_pass_callback callback = [](pattern::Matcher& m) {
-        auto interpolationV0 = std::dynamic_pointer_cast<ov::opset1::Interpolate>(m.get_match_root());
+        auto interpolationV0 = std::dynamic_pointer_cast<ov::op::v0::Interpolate>(m.get_match_root());
         if (!interpolationV0) {
             return false;
         }
 
         auto attrsV0 = interpolationV0->get_attrs();
         std::vector<size_t> axes{attrsV0.axes.begin(), attrsV0.axes.end()};
-        const auto& out_dims = std::make_shared<opset1::Convert>(interpolationV0->input_value(1), element::f32);
-        const auto& in_dims = std::make_shared<opset1::Convert>(
+        const auto& out_dims = std::make_shared<ov::op::v0::Convert>(interpolationV0->input_value(1), element::f32);
+        const auto& in_dims = std::make_shared<ov::op::v0::Convert>(
             ov::op::util::node_to_get_shape_value_of_indices_from_shape_source(interpolationV0->input_value(0), axes),
             element::f32);
 
-        std::shared_ptr<Node> scales = std::make_shared<opset1::Divide>(out_dims, in_dims);
+        std::shared_ptr<Node> scales = std::make_shared<ov::op::v1::Divide>(out_dims, in_dims);
         OPENVINO_SUPPRESS_DEPRECATED_START
         if (const auto& constant = ov::get_constant_from_source(scales)) {
             OPENVINO_SUPPRESS_DEPRECATED_END
             scales = constant;
         }
-        auto axisConstant = opset1::Constant::create(ngraph::element::i64, {axes.size()}, axes);
+        auto axisConstant = ov::op::v0::Constant::create(ngraph::element::i64, {axes.size()}, axes);
 
-        ov::opset4::Interpolate::InterpolateAttrs attrsV4;
+        ov::op::v4::Interpolate::InterpolateAttrs attrsV4;
         auto input_shape_rank = interpolationV0->get_input_partial_shape(0).rank().get_length();
         if (attrsV0.mode == "nearest") {
-            attrsV4.mode = ov::opset4::Interpolate::InterpolateMode::NEAREST;
+            attrsV4.mode = ov::op::v4::Interpolate::InterpolateMode::NEAREST;
         } else if (attrsV0.mode == "linear") {
             // If we write only
-            //    attrsV4.mode = ov::opset4::Interpolate::InterpolateMode::linear;
+            //    attrsV4.mode = ov::op::v4::Interpolate::InterpolateMode::linear;
             // instead of a conditional statements below when attrsV0.mode == "linear",
             // then we have a performance drop, because CPU have no optimized
             // version of the 'linear' mode.
             // TODO: delete this conditional statement, when CPU will have
             // optimized version of the 'linear' mode.
             if (input_shape_rank < 5) {
-                attrsV4.mode = ov::opset4::Interpolate::InterpolateMode::LINEAR_ONNX;
+                attrsV4.mode = ov::op::v4::Interpolate::InterpolateMode::LINEAR_ONNX;
             } else if (input_shape_rank == 5) {
-                attrsV4.mode = ov::opset4::Interpolate::InterpolateMode::LINEAR;
+                attrsV4.mode = ov::op::v4::Interpolate::InterpolateMode::LINEAR;
             } else {
                 return false;
             }
         } else if (attrsV0.mode == "cubic") {
-            attrsV4.mode = ov::opset4::Interpolate::InterpolateMode::CUBIC;
+            attrsV4.mode = ov::op::v4::Interpolate::InterpolateMode::CUBIC;
         } else if (attrsV0.mode == "linear_onnx") {
-            attrsV4.mode = ov::opset4::Interpolate::InterpolateMode::LINEAR_ONNX;
+            attrsV4.mode = ov::op::v4::Interpolate::InterpolateMode::LINEAR_ONNX;
         } else {
             return false;
         }
-        attrsV4.shape_calculation_mode = ov::opset4::Interpolate::ShapeCalcMode::SIZES;
-        attrsV4.nearest_mode = ov::opset4::Interpolate::NearestMode::SIMPLE;
+        attrsV4.shape_calculation_mode = ov::op::v4::Interpolate::ShapeCalcMode::SIZES;
+        attrsV4.nearest_mode = ov::op::v4::Interpolate::NearestMode::SIMPLE;
         attrsV4.pads_begin = attrsV0.pads_begin;
         attrsV4.pads_end = attrsV0.pads_end;
         attrsV4.antialias = attrsV0.antialias;
-        attrsV4.coordinate_transformation_mode = ov::opset4::Interpolate::CoordinateTransformMode::ASYMMETRIC;
+        attrsV4.coordinate_transformation_mode = ov::op::v4::Interpolate::CoordinateTransformMode::ASYMMETRIC;
         attrsV4.cube_coeff = -0.75f;
         if (attrsV0.align_corners) {
-            attrsV4.coordinate_transformation_mode = ov::opset4::Interpolate::CoordinateTransformMode::ALIGN_CORNERS;
-        } else if ((attrsV4.mode == ov::opset4::Interpolate::InterpolateMode::LINEAR_ONNX ||
-                    attrsV4.mode == ov::opset4::Interpolate::InterpolateMode::LINEAR) &&
+            attrsV4.coordinate_transformation_mode = ov::op::v4::Interpolate::CoordinateTransformMode::ALIGN_CORNERS;
+        } else if ((attrsV4.mode == ov::op::v4::Interpolate::InterpolateMode::LINEAR_ONNX ||
+                    attrsV4.mode == ov::op::v4::Interpolate::InterpolateMode::LINEAR) &&
                    std::all_of(attrsV4.pads_begin.begin(),
                                attrsV4.pads_begin.end(),
                                [](size_t i) {
@@ -89,10 +89,10 @@ ov::pass::ConvertInterpolate1ToInterpolate4::ConvertInterpolate1ToInterpolate4()
                                    return i == 0;
                                }) &&
                    !(input_shape_rank - 2 == 2 && attrsV0.axes == AxisSet{2, 3})) {
-            attrsV4.coordinate_transformation_mode = ov::opset4::Interpolate::CoordinateTransformMode::HALF_PIXEL;
+            attrsV4.coordinate_transformation_mode = ov::op::v4::Interpolate::CoordinateTransformMode::HALF_PIXEL;
         }
 
-        auto interpolateV4 = std::make_shared<ov::opset4::Interpolate>(interpolationV0->input_value(0),
+        auto interpolateV4 = std::make_shared<ov::op::v4::Interpolate>(interpolationV0->input_value(0),
                                                                        interpolationV0->input_value(1),
                                                                        scales,
                                                                        axisConstant,

--- a/src/common/transformations/src/transformations/op_conversions/convert_matrix_nms_to_matrix_nms_ie.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_matrix_nms_to_matrix_nms_ie.cpp
@@ -7,9 +7,8 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset5.hpp>
-#include <openvino/opsets/opset8.hpp>
+#include "openvino/op/matrix_nms.hpp"
+#include "openvino/op/convert.hpp"
 #include <vector>
 
 #include "itt.hpp"
@@ -18,10 +17,10 @@
 
 ov::pass::ConvertMatrixNmsToMatrixNmsIE::ConvertMatrixNmsToMatrixNmsIE(bool force_i32_output_type) {
     MATCHER_SCOPE(ConvertMatrixNmsToMatrixNmsIE);
-    auto nms = ngraph::pattern::wrap_type<ov::opset8::MatrixNms>();
+    auto nms = ngraph::pattern::wrap_type<ov::op::v8::MatrixNms>();
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        auto nms = std::dynamic_pointer_cast<ov::opset8::MatrixNms>(m.get_match_root());
+        auto nms = std::dynamic_pointer_cast<ov::op::v8::MatrixNms>(m.get_match_root());
         if (!nms || transformation_callback(nms)) {
             return false;
         }
@@ -36,7 +35,7 @@ ov::pass::ConvertMatrixNmsToMatrixNmsIE::ConvertMatrixNmsToMatrixNmsIE(bool forc
         NodeVector new_ops;
         auto attrs = nms->get_attrs();
         attrs.output_type = force_i32_output_type ? element::i32 : attrs.output_type;
-        auto nms_new = std::make_shared<op::internal::NmsStaticShapeIE<ov::opset8::MatrixNms>>(new_args.at(0),
+        auto nms_new = std::make_shared<op::internal::NmsStaticShapeIE<ov::op::v8::MatrixNms>>(new_args.at(0),
                                                                                                new_args.at(1),
                                                                                                attrs);
         new_ops.emplace_back(nms_new);
@@ -46,13 +45,13 @@ ov::pass::ConvertMatrixNmsToMatrixNmsIE::ConvertMatrixNmsToMatrixNmsIE(bool forc
         Output<Node> output_2 = nms_new->output(2);
 
         if (nms->output(1).get_element_type() != output_1.get_element_type()) {
-            output_1 = std::make_shared<opset1::Convert>(output_1, nms->output(1).get_element_type());
+            output_1 = std::make_shared<ov::op::v0::Convert>(output_1, nms->output(1).get_element_type());
             output_1.get_node_shared_ptr()->set_friendly_name(op::util::create_ie_output_name(nms->output(1)));
             new_ops.emplace_back(output_1.get_node_shared_ptr());
         }
 
         if (nms->output(2).get_element_type() != output_2.get_element_type()) {
-            output_2 = std::make_shared<opset1::Convert>(output_2, nms->output(2).get_element_type());
+            output_2 = std::make_shared<ov::op::v0::Convert>(output_2, nms->output(2).get_element_type());
             output_2.get_node_shared_ptr()->set_friendly_name(op::util::create_ie_output_name(nms->output(2)));
             new_ops.emplace_back(output_2.get_node_shared_ptr());
         }

--- a/src/common/transformations/src/transformations/op_conversions/convert_matrix_nms_to_matrix_nms_ie.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_matrix_nms_to_matrix_nms_ie.cpp
@@ -7,11 +7,11 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/matrix_nms.hpp"
-#include "openvino/op/convert.hpp"
 #include <vector>
 
 #include "itt.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/matrix_nms.hpp"
 #include "ov_ops/nms_static_shape_ie.hpp"
 #include "transformations/utils/utils.hpp"
 

--- a/src/common/transformations/src/transformations/op_conversions/convert_maxpool_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_maxpool_downgrade.cpp
@@ -6,11 +6,11 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/max_pool.hpp"
 #include <transformations/utils/utils.hpp>
 
 #include "itt.hpp"
 #include "openvino/core/descriptor/tensor.hpp"
+#include "openvino/op/max_pool.hpp"
 
 using namespace std;
 using namespace ov;

--- a/src/common/transformations/src/transformations/op_conversions/convert_maxpool_downgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_maxpool_downgrade.cpp
@@ -6,8 +6,7 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset8.hpp>
+#include "openvino/op/max_pool.hpp"
 #include <transformations/utils/utils.hpp>
 
 #include "itt.hpp"
@@ -19,10 +18,10 @@ using namespace ov;
 pass::ConvertMaxPool8ToMaxPool1::ConvertMaxPool8ToMaxPool1() {
     MATCHER_SCOPE(ConvertMaxPool8ToMaxPool1);
 
-    auto maxpool_v8_pattern = pattern::wrap_type<ov::opset8::MaxPool>();
+    auto maxpool_v8_pattern = pattern::wrap_type<ov::op::v8::MaxPool>();
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        auto maxpool_v8_node = std::dynamic_pointer_cast<ov::opset8::MaxPool>(m.get_match_root());
+        auto maxpool_v8_node = std::dynamic_pointer_cast<ov::op::v8::MaxPool>(m.get_match_root());
 
         if (!maxpool_v8_node || maxpool_v8_node->get_output_target_inputs(1).size() != 0)
             return false;
@@ -31,7 +30,7 @@ pass::ConvertMaxPool8ToMaxPool1::ConvertMaxPool8ToMaxPool1() {
             if (dilation != 1)
                 return false;
 
-        auto maxpool_v1_node = make_shared<ov::opset1::MaxPool>(maxpool_v8_node->input_value(0),
+        auto maxpool_v1_node = make_shared<ov::op::v1::MaxPool>(maxpool_v8_node->input_value(0),
                                                                 maxpool_v8_node->get_strides(),
                                                                 maxpool_v8_node->get_pads_begin(),
                                                                 maxpool_v8_node->get_pads_end(),

--- a/src/common/transformations/src/transformations/op_conversions/convert_maxpool_upgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_maxpool_upgrade.cpp
@@ -6,10 +6,10 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/max_pool.hpp"
 #include <transformations/utils/utils.hpp>
 
 #include "itt.hpp"
+#include "openvino/op/max_pool.hpp"
 
 ov::pass::ConvertMaxPool1ToMaxPool8::ConvertMaxPool1ToMaxPool8() {
     MATCHER_SCOPE(ConvertMaxPool1ToMaxPool8);

--- a/src/common/transformations/src/transformations/op_conversions/convert_maxpool_upgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_maxpool_upgrade.cpp
@@ -6,8 +6,7 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset8.hpp>
+#include "openvino/op/max_pool.hpp"
 #include <transformations/utils/utils.hpp>
 
 #include "itt.hpp"
@@ -17,10 +16,10 @@ ov::pass::ConvertMaxPool1ToMaxPool8::ConvertMaxPool1ToMaxPool8() {
     // Replaces v1::MaxPool with v8::MaxPool with default dilations, axis and index_element_type attributes
 
     auto input = pattern::any_input(pattern::has_static_rank());
-    auto maxpool_v1_pattern = ngraph::pattern::wrap_type<ov::opset1::MaxPool>({input});
+    auto maxpool_v1_pattern = ngraph::pattern::wrap_type<ov::op::v1::MaxPool>({input});
 
     matcher_pass_callback callback = [=](ngraph::pattern::Matcher& m) {
-        auto maxpool_v1_node = std::dynamic_pointer_cast<ov::opset1::MaxPool>(m.get_match_root());
+        auto maxpool_v1_node = std::dynamic_pointer_cast<ov::op::v1::MaxPool>(m.get_match_root());
 
         if (!maxpool_v1_node)
             return false;
@@ -30,7 +29,7 @@ ov::pass::ConvertMaxPool1ToMaxPool8::ConvertMaxPool1ToMaxPool8() {
             return false;
         ov::Strides dilations(spatial_dims, 1);
 
-        auto maxpool_v8_node = std::make_shared<ov::opset8::MaxPool>(maxpool_v1_node->input_value(0),
+        auto maxpool_v8_node = std::make_shared<ov::op::v8::MaxPool>(maxpool_v1_node->input_value(0),
                                                                      maxpool_v1_node->get_strides(),
                                                                      dilations,
                                                                      maxpool_v1_node->get_pads_begin(),

--- a/src/common/transformations/src/transformations/op_conversions/convert_minimum_to_power_and_max.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_minimum_to_power_and_max.cpp
@@ -7,17 +7,20 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
+#include "openvino/op/minimum.hpp"
+#include "openvino/op/maximum.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/constant.hpp"
 #include <vector>
 
 #include "itt.hpp"
 
 ov::pass::ConvertMinimum::ConvertMinimum() {
     MATCHER_SCOPE(ConvertMinimum);
-    auto minimum = ngraph::pattern::wrap_type<opset1::Minimum>();
+    auto minimum = ngraph::pattern::wrap_type<ov::op::v1::Minimum>();
 
     matcher_pass_callback callback = [this](pattern::Matcher& m) {
-        auto minimum = std::dynamic_pointer_cast<ov::opset1::Minimum>(m.get_match_root());
+        auto minimum = std::dynamic_pointer_cast<ov::op::v1::Minimum>(m.get_match_root());
         if (!minimum || transformation_callback(minimum) || !minimum->get_output_element_type(0).is_signed()) {
             return false;
         }
@@ -27,19 +30,19 @@ ov::pass::ConvertMinimum::ConvertMinimum() {
          *                                Mul(-1)--'
          */
 
-        auto neg_0 = std::make_shared<ov::opset1::Multiply>(
+        auto neg_0 = std::make_shared<ov::op::v1::Multiply>(
             minimum->input(0).get_source_output(),
-            opset1::Constant::create(minimum->get_input_element_type(0), Shape{}, {-1}));
+            ov::op::v0::Constant::create(minimum->get_input_element_type(0), Shape{}, {-1}));
 
-        auto neg_1 = std::make_shared<ov::opset1::Multiply>(
+        auto neg_1 = std::make_shared<ov::op::v1::Multiply>(
             minimum->input(1).get_source_output(),
-            opset1::Constant::create(minimum->get_input_element_type(1), Shape{}, {-1}));
+            ov::op::v0::Constant::create(minimum->get_input_element_type(1), Shape{}, {-1}));
 
-        auto max = std::make_shared<ov::opset1::Maximum>(neg_0, neg_1);
+        auto max = std::make_shared<ov::op::v1::Maximum>(neg_0, neg_1);
 
         auto neg_2 =
-            std::make_shared<ov::opset1::Multiply>(max,
-                                                   opset1::Constant::create(max->get_element_type(), Shape{}, {-1}));
+            std::make_shared<ov::op::v1::Multiply>(max,
+                                                   ov::op::v0::Constant::create(max->get_element_type(), Shape{}, {-1}));
 
         neg_2->set_friendly_name(minimum->get_friendly_name());
         ngraph::copy_runtime_info(minimum, {neg_0, neg_1, max, neg_2});

--- a/src/common/transformations/src/transformations/op_conversions/convert_minimum_to_power_and_max.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_minimum_to_power_and_max.cpp
@@ -7,13 +7,13 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/minimum.hpp"
-#include "openvino/op/maximum.hpp"
-#include "openvino/op/multiply.hpp"
-#include "openvino/op/constant.hpp"
 #include <vector>
 
 #include "itt.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/maximum.hpp"
+#include "openvino/op/minimum.hpp"
+#include "openvino/op/multiply.hpp"
 
 ov::pass::ConvertMinimum::ConvertMinimum() {
     MATCHER_SCOPE(ConvertMinimum);
@@ -40,9 +40,9 @@ ov::pass::ConvertMinimum::ConvertMinimum() {
 
         auto max = std::make_shared<ov::op::v1::Maximum>(neg_0, neg_1);
 
-        auto neg_2 =
-            std::make_shared<ov::op::v1::Multiply>(max,
-                                                   ov::op::v0::Constant::create(max->get_element_type(), Shape{}, {-1}));
+        auto neg_2 = std::make_shared<ov::op::v1::Multiply>(
+            max,
+            ov::op::v0::Constant::create(max->get_element_type(), Shape{}, {-1}));
 
         neg_2->set_friendly_name(minimum->get_friendly_name());
         ngraph::copy_runtime_info(minimum, {neg_0, neg_1, max, neg_2});

--- a/src/common/transformations/src/transformations/op_conversions/convert_mod.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_mod.cpp
@@ -7,37 +7,43 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
+#include "openvino/op/sign.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/abs.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/mod.hpp"
 #include <vector>
 
 #include "itt.hpp"
 
 ov::pass::ConvertMod::ConvertMod() {
     MATCHER_SCOPE(ConvertMod);
-    auto mod = ngraph::pattern::wrap_type<opset1::Mod>();
+    auto mod = ngraph::pattern::wrap_type<ov::op::v1::Mod>();
 
     matcher_pass_callback callback = [this](pattern::Matcher& m) {
-        auto mod = std::dynamic_pointer_cast<ov::opset1::Mod>(m.get_match_root());
+        auto mod = std::dynamic_pointer_cast<ov::op::v1::Mod>(m.get_match_root());
         if (!mod) {
             return false;
         }
 
-        const auto dividend = std::make_shared<opset1::Abs>(mod->input_value(0));
-        const auto dividend_sign = std::make_shared<opset1::Sign>(mod->input_value(0));
+        const auto dividend = std::make_shared<ov::op::v0::Abs>(mod->input_value(0));
+        const auto dividend_sign = std::make_shared<ov::op::v0::Sign>(mod->input_value(0));
         const auto dividend_et = dividend->get_element_type();
-        const auto divisor = std::make_shared<opset1::Abs>(mod->input_value(1));
+        const auto divisor = std::make_shared<ov::op::v0::Abs>(mod->input_value(1));
 
         // truncated(a / b)
-        auto div = register_new_node<opset1::Divide>(dividend, divisor);
-        auto convert_to_i64 = std::make_shared<opset1::Convert>(div, ngraph::element::i64);
-        auto convert = std::make_shared<opset1::Convert>(convert_to_i64, dividend_et);
+        auto div = register_new_node<ov::op::v1::Divide>(dividend, divisor);
+        auto convert_to_i64 = std::make_shared<ov::op::v0::Convert>(div, ngraph::element::i64);
+        auto convert = std::make_shared<ov::op::v0::Convert>(convert_to_i64, dividend_et);
         // truncated(a / b) * b
-        auto multiplication = std::make_shared<opset1::Multiply>(convert, divisor);
+        auto multiplication = std::make_shared<ov::op::v1::Multiply>(convert, divisor);
         // a mod b = a - truncated(a / b) * b
-        auto sub = register_new_node<opset1::Subtract>(dividend, multiplication);
+        auto sub = register_new_node<ov::op::v1::Subtract>(dividend, multiplication);
 
         // apply sign of dividend
-        auto mul = std::make_shared<opset1::Multiply>(dividend_sign, sub);
+        auto mul = std::make_shared<ov::op::v1::Multiply>(dividend_sign, sub);
 
         mul->set_friendly_name(mod->get_friendly_name());
         ngraph::copy_runtime_info(

--- a/src/common/transformations/src/transformations/op_conversions/convert_mod.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_mod.cpp
@@ -7,16 +7,16 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/sign.hpp"
-#include "openvino/op/divide.hpp"
-#include "openvino/op/subtract.hpp"
-#include "openvino/op/abs.hpp"
-#include "openvino/op/multiply.hpp"
-#include "openvino/op/convert.hpp"
-#include "openvino/op/mod.hpp"
 #include <vector>
 
 #include "itt.hpp"
+#include "openvino/op/abs.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/mod.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/sign.hpp"
+#include "openvino/op/subtract.hpp"
 
 ov::pass::ConvertMod::ConvertMod() {
     MATCHER_SCOPE(ConvertMod);

--- a/src/common/transformations/src/transformations/op_conversions/convert_multiclass_nms_to_multiclass_nms_ie.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_multiclass_nms_to_multiclass_nms_ie.cpp
@@ -7,10 +7,10 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/convert.hpp"
 #include <vector>
 
 #include "itt.hpp"
+#include "openvino/op/convert.hpp"
 #include "ov_ops/multiclass_nms_ie_internal.hpp"
 #include "transformations/utils/utils.hpp"
 

--- a/src/common/transformations/src/transformations/op_conversions/convert_multiclass_nms_to_multiclass_nms_ie.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_multiclass_nms_to_multiclass_nms_ie.cpp
@@ -7,8 +7,7 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset9.hpp>
+#include "openvino/op/convert.hpp"
 #include <vector>
 
 #include "itt.hpp"
@@ -60,13 +59,13 @@ pass::ConvertMulticlassNmsToMulticlassNmsIE::ConvertMulticlassNmsToMulticlassNms
         Output<Node> output_2 = nms_new->output(2);
 
         if (nms->output(1).get_element_type() != output_1.get_element_type()) {
-            output_1 = std::make_shared<opset1::Convert>(output_1, nms->output(1).get_element_type());
+            output_1 = std::make_shared<ov::op::v0::Convert>(output_1, nms->output(1).get_element_type());
             output_1.get_node_shared_ptr()->set_friendly_name(op::util::create_ie_output_name(nms->output(1)));
             new_ops.emplace_back(output_1.get_node_shared_ptr());
         }
 
         if (nms->output(2).get_element_type() != output_2.get_element_type()) {
-            output_2 = std::make_shared<opset1::Convert>(output_2, nms->output(2).get_element_type());
+            output_2 = std::make_shared<ov::op::v0::Convert>(output_2, nms->output(2).get_element_type());
             output_2.get_node_shared_ptr()->set_friendly_name(op::util::create_ie_output_name(nms->output(2)));
             new_ops.emplace_back(output_2.get_node_shared_ptr());
         }

--- a/src/common/transformations/src/transformations/op_conversions/convert_multiclass_nms_upgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_multiclass_nms_upgrade.cpp
@@ -6,9 +6,9 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/multiclass_nms.hpp"
 
 #include "itt.hpp"
+#include "openvino/op/multiclass_nms.hpp"
 
 ov::pass::ConvertMulticlassNms8ToMulticlassNms9::ConvertMulticlassNms8ToMulticlassNms9() {
     MATCHER_SCOPE(ConvertMulticlassNms8ToMulticlassNms9);

--- a/src/common/transformations/src/transformations/op_conversions/convert_multiclass_nms_upgrade.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_multiclass_nms_upgrade.cpp
@@ -6,18 +6,17 @@
 
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset8.hpp>
-#include <openvino/opsets/opset9.hpp>
+#include "openvino/op/multiclass_nms.hpp"
 
 #include "itt.hpp"
 
 ov::pass::ConvertMulticlassNms8ToMulticlassNms9::ConvertMulticlassNms8ToMulticlassNms9() {
     MATCHER_SCOPE(ConvertMulticlassNms8ToMulticlassNms9);
 
-    auto nms_v8_pattern = pattern::wrap_type<opset8::MulticlassNms>();
+    auto nms_v8_pattern = pattern::wrap_type<ov::op::v8::MulticlassNms>();
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        auto nms_v8_node = std::dynamic_pointer_cast<opset8::MulticlassNms>(m.get_match_root());
+        auto nms_v8_node = std::dynamic_pointer_cast<ov::op::v8::MulticlassNms>(m.get_match_root());
         if (!nms_v8_node)
             return false;
 
@@ -25,7 +24,7 @@ ov::pass::ConvertMulticlassNms8ToMulticlassNms9::ConvertMulticlassNms8ToMulticla
         // vector of new nGraph operations
         NodeVector new_ops;
         auto attrs = nms_v8_node->get_attrs();
-        auto nms_v9_node = std::make_shared<opset9::MulticlassNms>(new_args.at(0), new_args.at(1), attrs);
+        auto nms_v9_node = std::make_shared<ov::op::v9::MulticlassNms>(new_args.at(0), new_args.at(1), attrs);
         nms_v9_node->set_friendly_name(nms_v8_node->get_friendly_name());
         copy_runtime_info(nms_v8_node, nms_v9_node);
         replace_node(nms_v8_node, nms_v9_node);

--- a/src/common/transformations/src/transformations/op_conversions/convert_mvn1_to_mvn6.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_mvn1_to_mvn6.cpp
@@ -7,17 +7,17 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 #include <numeric>
-#include <openvino/opsets/opset2.hpp>
-#include <openvino/opsets/opset6.hpp>
+#include "openvino/op/constant.hpp"
+#include "openvino/op/mvn.hpp"
 
 #include "itt.hpp"
 
 ov::pass::ConvertMVN1ToMVN6::ConvertMVN1ToMVN6() {
     MATCHER_SCOPE(ConvertMVN1ToMVN6);
-    auto mvn = pattern::wrap_type<ov::opset2::MVN>();
+    auto mvn = pattern::wrap_type<ov::op::v0::MVN>();
 
     matcher_pass_callback callback = [](pattern::Matcher& m) {
-        auto mvn_node = std::dynamic_pointer_cast<ov::opset2::MVN>(m.get_match_root());
+        auto mvn_node = std::dynamic_pointer_cast<ov::op::v0::MVN>(m.get_match_root());
         if (!mvn_node) {
             return false;
         }
@@ -44,8 +44,8 @@ ov::pass::ConvertMVN1ToMVN6::ConvertMVN1ToMVN6() {
 
         std::vector<int64_t> axes_v(input_rank.get_length() - start_axis);
         std::iota(axes_v.begin(), axes_v.end(), start_axis);
-        auto axes = opset6::Constant::create(ngraph::element::i64, {axes_v.size()}, axes_v);
-        auto mvn6_node = std::make_shared<ov::opset6::MVN>(input,
+        auto axes = ov::op::v0::Constant::create(ngraph::element::i64, {axes_v.size()}, axes_v);
+        auto mvn6_node = std::make_shared<ov::op::v6::MVN>(input,
                                                            axes,
                                                            mvn_node->get_normalize_variance(),
                                                            eps_f,

--- a/src/common/transformations/src/transformations/op_conversions/convert_mvn1_to_mvn6.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_mvn1_to_mvn6.cpp
@@ -7,10 +7,10 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 #include <numeric>
-#include "openvino/op/constant.hpp"
-#include "openvino/op/mvn.hpp"
 
 #include "itt.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/mvn.hpp"
 
 ov::pass::ConvertMVN1ToMVN6::ConvertMVN1ToMVN6() {
     MATCHER_SCOPE(ConvertMVN1ToMVN6);

--- a/src/common/transformations/src/transformations/op_conversions/convert_negative.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_negative.cpp
@@ -7,12 +7,12 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/negative.hpp"
-#include "openvino/op/multiply.hpp"
-#include "openvino/op/constant.hpp"
 #include <vector>
 
 #include "itt.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/negative.hpp"
 
 ov::pass::ConvertNegative::ConvertNegative() {
     MATCHER_SCOPE(ConvertNegative);
@@ -24,9 +24,9 @@ ov::pass::ConvertNegative::ConvertNegative() {
             return false;
         }
 
-        auto mul =
-            std::make_shared<ov::op::v1::Multiply>(neg->input(0).get_source_output(),
-                                                   ov::op::v0::Constant::create(neg->get_element_type(), Shape{}, {-1}));
+        auto mul = std::make_shared<ov::op::v1::Multiply>(
+            neg->input(0).get_source_output(),
+            ov::op::v0::Constant::create(neg->get_element_type(), Shape{}, {-1}));
         mul->set_friendly_name(neg->get_friendly_name());
         ngraph::copy_runtime_info(neg, mul);
         ngraph::replace_node(neg, mul);

--- a/src/common/transformations/src/transformations/op_conversions/convert_negative.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_negative.cpp
@@ -7,24 +7,26 @@
 #include <memory>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
+#include "openvino/op/negative.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/constant.hpp"
 #include <vector>
 
 #include "itt.hpp"
 
 ov::pass::ConvertNegative::ConvertNegative() {
     MATCHER_SCOPE(ConvertNegative);
-    auto neg = ngraph::pattern::wrap_type<ov::opset1::Negative>();
+    auto neg = ngraph::pattern::wrap_type<ov::op::v0::Negative>();
 
     matcher_pass_callback callback = [](pattern::Matcher& m) {
-        auto neg = std::dynamic_pointer_cast<ov::opset1::Negative>(m.get_match_root());
+        auto neg = std::dynamic_pointer_cast<ov::op::v0::Negative>(m.get_match_root());
         if (!neg) {
             return false;
         }
 
         auto mul =
-            std::make_shared<ov::opset1::Multiply>(neg->input(0).get_source_output(),
-                                                   opset1::Constant::create(neg->get_element_type(), Shape{}, {-1}));
+            std::make_shared<ov::op::v1::Multiply>(neg->input(0).get_source_output(),
+                                                   ov::op::v0::Constant::create(neg->get_element_type(), Shape{}, {-1}));
         mul->set_friendly_name(neg->get_friendly_name());
         ngraph::copy_runtime_info(neg, mul);
         ngraph::replace_node(neg, mul);

--- a/src/common/transformations/src/transformations/smart_reshape/broadcast_const_range_replacement.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/broadcast_const_range_replacement.cpp
@@ -3,14 +3,6 @@
 //
 
 #include <memory>
-#include "openvino/op/broadcast.hpp"
-#include "openvino/op/equal.hpp"
-#include "openvino/op/convert.hpp"
-#include "openvino/op/constant.hpp"
-#include "openvino/op/select.hpp"
-#include "openvino/op/range.hpp"
-#include "openvino/op/gather.hpp"
-#include "openvino/op/unsqueeze.hpp"
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 #include <ngraph/validation_util.hpp>
@@ -18,6 +10,14 @@
 #include <vector>
 
 #include "itt.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/equal.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/range.hpp"
+#include "openvino/op/select.hpp"
+#include "openvino/op/unsqueeze.hpp"
 #include "transformations/utils/utils.hpp"
 
 ov::pass::BroadcastConstRangeReplacement::BroadcastConstRangeReplacement() {
@@ -37,8 +37,7 @@ ov::pass::BroadcastConstRangeReplacement::BroadcastConstRangeReplacement() {
         const auto data_const_out = broadcast->get_input_source_output(0);
         const auto target_shape_out = broadcast->get_input_source_output(1);
 
-        const auto const_node =
-            std::dynamic_pointer_cast<ov::op::v0::Constant>(data_const_out.get_node_shared_ptr());
+        const auto const_node = std::dynamic_pointer_cast<ov::op::v0::Constant>(data_const_out.get_node_shared_ptr());
         if (!const_node || !const_node->get_element_type().is_integral_number())
             return false;
 
@@ -85,8 +84,7 @@ ov::pass::BroadcastConstRangeReplacement::BroadcastConstRangeReplacement() {
         const auto original_end = node_registry.add(ov::op::v0::Constant::create(data_elem_type, {}, {elem_count}));
 
         const auto cast_gather_dim = node_registry.make<ov::op::v0::Convert>(gather_dim, data_elem_type);
-        const auto select_end =
-            node_registry.make<ov::op::v1::Select>(dim_check_one, original_end, cast_gather_dim);
+        const auto select_end = node_registry.make<ov::op::v1::Select>(dim_check_one, original_end, cast_gather_dim);
 
         const auto default_range_step = node_registry.add(ov::op::v0::Constant::create(data_elem_type, {}, {1}));
         std::shared_ptr<Node> replacement =

--- a/src/common/transformations/src/transformations/smart_reshape/broadcast_const_range_replacement.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/broadcast_const_range_replacement.cpp
@@ -3,7 +3,14 @@
 //
 
 #include <memory>
-#include <ngraph/opsets/opset8.hpp>
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/equal.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/select.hpp"
+#include "openvino/op/range.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/unsqueeze.hpp"
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 #include <ngraph/validation_util.hpp>
@@ -15,15 +22,15 @@
 
 ov::pass::BroadcastConstRangeReplacement::BroadcastConstRangeReplacement() {
     MATCHER_SCOPE(BroadcastConstRangeReplacement);
-    auto data_input = pattern::wrap_type<ngraph::opset8::Constant>();
+    auto data_input = pattern::wrap_type<ov::op::v0::Constant>();
     auto target_shape = pattern::any_input();
-    auto broadcast_pattern_node = pattern::wrap_type<ngraph::opset8::Broadcast>({data_input, target_shape});
+    auto broadcast_pattern_node = pattern::wrap_type<ov::op::v3::Broadcast>({data_input, target_shape});
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         const auto broadcast = m.get_match_root();
         // The transformation was requested only for models with BroadcastType::BIDIRECTIONAL
         // Further analysis is needed for other broadcast modes enablement
-        const auto broadcast_ptr = std::dynamic_pointer_cast<ngraph::opset8::Broadcast>(broadcast);
+        const auto broadcast_ptr = std::dynamic_pointer_cast<ov::op::v3::Broadcast>(broadcast);
         if (!broadcast_ptr || broadcast_ptr->get_broadcast_spec().m_type != ngraph::op::BroadcastType::BIDIRECTIONAL)
             return false;
 
@@ -31,7 +38,7 @@ ov::pass::BroadcastConstRangeReplacement::BroadcastConstRangeReplacement() {
         const auto target_shape_out = broadcast->get_input_source_output(1);
 
         const auto const_node =
-            std::dynamic_pointer_cast<ngraph::opset8::Constant>(data_const_out.get_node_shared_ptr());
+            std::dynamic_pointer_cast<ov::op::v0::Constant>(data_const_out.get_node_shared_ptr());
         if (!const_node || !const_node->get_element_type().is_integral_number())
             return false;
 
@@ -63,27 +70,27 @@ ov::pass::BroadcastConstRangeReplacement::BroadcastConstRangeReplacement() {
 
         NodeRegistry node_registry;
 
-        const auto axis_node = node_registry.add(ngraph::opset8::Constant::create(ngraph::element::i32, {}, {0}));
+        const auto axis_node = node_registry.add(ov::op::v0::Constant::create(ngraph::element::i32, {}, {0}));
         const auto target_dim_index_node =
-            node_registry.add(ngraph::opset8::Constant::create(ngraph::element::i64, {}, {target_dim_neg_index}));
+            node_registry.add(ov::op::v0::Constant::create(ngraph::element::i64, {}, {target_dim_neg_index}));
         const auto gather_dim =
-            node_registry.make<ngraph::opset8::Gather>(target_shape_out, target_dim_index_node, axis_node);
+            node_registry.make<ov::op::v8::Gather>(target_shape_out, target_dim_index_node, axis_node);
 
         // If the corresponding target dim is 1, use the original end of range
         const auto one_dim_const =
-            node_registry.add(ngraph::opset8::Constant::create(target_shape_out.get_element_type(), {}, {1}));
-        const auto dim_check_one = node_registry.make<ngraph::opset8::Equal>(gather_dim, one_dim_const);
+            node_registry.add(ov::op::v0::Constant::create(target_shape_out.get_element_type(), {}, {1}));
+        const auto dim_check_one = node_registry.make<ov::op::v1::Equal>(gather_dim, one_dim_const);
 
-        const auto start = node_registry.add(ngraph::opset8::Constant::create(data_elem_type, {}, {0}));
-        const auto original_end = node_registry.add(ngraph::opset8::Constant::create(data_elem_type, {}, {elem_count}));
+        const auto start = node_registry.add(ov::op::v0::Constant::create(data_elem_type, {}, {0}));
+        const auto original_end = node_registry.add(ov::op::v0::Constant::create(data_elem_type, {}, {elem_count}));
 
-        const auto cast_gather_dim = node_registry.make<ngraph::opset8::Convert>(gather_dim, data_elem_type);
+        const auto cast_gather_dim = node_registry.make<ov::op::v0::Convert>(gather_dim, data_elem_type);
         const auto select_end =
-            node_registry.make<ngraph::opset8::Select>(dim_check_one, original_end, cast_gather_dim);
+            node_registry.make<ov::op::v1::Select>(dim_check_one, original_end, cast_gather_dim);
 
-        const auto default_range_step = node_registry.add(ngraph::opset8::Constant::create(data_elem_type, {}, {1}));
+        const auto default_range_step = node_registry.add(ov::op::v0::Constant::create(data_elem_type, {}, {1}));
         std::shared_ptr<Node> replacement =
-            node_registry.make<ngraph::opset8::Range>(start, select_end, default_range_step, data_elem_type);
+            node_registry.make<ov::op::v4::Range>(start, select_end, default_range_step, data_elem_type);
 
         if (const_rank > 1) {
             // Unsqueeze the output of the Range op to the original shape of data input
@@ -91,8 +98,8 @@ ov::pass::BroadcastConstRangeReplacement::BroadcastConstRangeReplacement() {
             std::iota(final_shape_axes.begin(), final_shape_axes.end(), 0);
             final_shape_axes.erase(final_shape_axes.begin() + target_dim_index);
             const auto axes_to_unsqueeze = node_registry.add(
-                ngraph::opset8::Constant::create(ngraph::element::i64, {final_shape_axes.size()}, final_shape_axes));
-            replacement = node_registry.make<ngraph::opset8::Unsqueeze>(replacement, axes_to_unsqueeze);
+                ov::op::v0::Constant::create(ngraph::element::i64, {final_shape_axes.size()}, final_shape_axes));
+            replacement = node_registry.make<ov::op::v0::Unsqueeze>(replacement, axes_to_unsqueeze);
         }
 
         copy_runtime_info(const_node, node_registry.get());

--- a/src/common/transformations/src/transformations/smart_reshape/lstm_states_broadcast.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/lstm_states_broadcast.cpp
@@ -9,15 +9,21 @@
 #include "dimension_tracker.hpp"
 #include "itt.hpp"
 #include "openvino/op/util/sub_graph_base.hpp"
-#include "openvino/opsets/opset9.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/lstm_cell.hpp"
+#include "openvino/op/tensor_iterator.hpp"
 #include "openvino/pass/manager.hpp"
 #include "transformations/utils/utils.hpp"
 
 using namespace std;
-using namespace ov::opset9;
 
-ov::Input<ov::Node> get_outer_input_of_ti_by_parameter(const shared_ptr<Parameter>& parameter,
-                                                       const shared_ptr<TensorIterator>& ti) {
+ov::Input<ov::Node> get_outer_input_of_ti_by_parameter(const shared_ptr<ov::op::v0::Parameter>& parameter,
+                                                       const shared_ptr<ov::op::v0::TensorIterator>& ti) {
     int64_t parameter_index = ti->get_body()->get_parameter_index(parameter);
     for (const auto& input_descriptor : ti->get_input_descriptions())
         if (static_cast<int64_t>(input_descriptor->m_body_parameter_index) == parameter_index)
@@ -28,11 +34,11 @@ ov::Input<ov::Node> get_outer_input_of_ti_by_parameter(const shared_ptr<Paramete
                    parameter);
 }
 
-shared_ptr<ov::Node> deduce_outer_source_of_batch_for_inner_lstm_cell(const shared_ptr<TensorIterator>& ti,
-                                                                      const shared_ptr<LSTMCell>& lstm_cell) {
+shared_ptr<ov::Node> deduce_outer_source_of_batch_for_inner_lstm_cell(const shared_ptr<ov::op::v0::TensorIterator>& ti,
+                                                                      const shared_ptr<ov::op::v4::LSTMCell>& lstm_cell) {
     const auto& body = ti->get_body();  // body is not nullptr -- we checked earlier
 
-    map<Parameter*, ov::PartialShape> original_shapes;
+    map<ov::op::v0::Parameter*, ov::PartialShape> original_shapes;
     ov::label_t label = 1;
 
     // mark all input dimensions with labels and making them dynamic, keeping original shapes
@@ -61,7 +67,7 @@ shared_ptr<ov::Node> deduce_outer_source_of_batch_for_inner_lstm_cell(const shar
     }
 
     // batch label was tracked -- finding parameter that delivered it
-    shared_ptr<Parameter> batch_delivering_parameter;
+    shared_ptr<ov::op::v0::Parameter> batch_delivering_parameter;
     size_t index_of_batch_dim = 0;
 
     ov::label_t batch_label = ov::DimensionTracker::get_label(lstm_cell->get_input_partial_shape(0)[0]);
@@ -87,15 +93,15 @@ shared_ptr<ov::Node> deduce_outer_source_of_batch_for_inner_lstm_cell(const shar
         return nullptr;
 
     const auto& batched_source = get_outer_input_of_ti_by_parameter(batch_delivering_parameter, ti);
-    const auto& batched_shape = make_shared<ShapeOf>(batched_source.get_source_output());
-    const auto& batch = make_shared<Gather>(batched_shape,
-                                            Constant::create(ov::element::i64, ov::Shape{1}, {index_of_batch_dim}),
-                                            Constant::create(ov::element::i64, ov::Shape{}, {0}));
+    const auto& batched_shape = make_shared<ov::op::v3::ShapeOf>(batched_source.get_source_output());
+    const auto& batch = make_shared<ov::op::v8::Gather>(batched_shape,
+                                            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {index_of_batch_dim}),
+                                            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {0}));
     return batch;
 }
 
 bool broadcast_state_by_batch(ov::Input<ov::Node> input, const shared_ptr<ov::Node>& batch_delivering_node) {
-    auto constant_state = dynamic_pointer_cast<Constant>(input.get_source_output().get_node_shared_ptr());
+    auto constant_state = dynamic_pointer_cast<ov::op::v0::Constant>(input.get_source_output().get_node_shared_ptr());
     if (constant_state == nullptr)
         return false;
     const auto& constant_shape = constant_state->get_shape();
@@ -104,41 +110,41 @@ bool broadcast_state_by_batch(ov::Input<ov::Node> input, const shared_ptr<ov::No
         return false;
 
     const auto& constant_copy = constant_state->copy_with_new_inputs({});
-    const auto& broadcast_by_batch = make_shared<Broadcast>(
+    const auto& broadcast_by_batch = make_shared<ov::op::v3::Broadcast>(
         constant_copy,
-        make_shared<Concat>(ngraph::NodeVector{batch_delivering_node,
-                                               ov::op::util::make_try_fold<Gather>(
-                                                   ov::op::util::make_try_fold<ShapeOf>(constant_copy),
-                                                   Constant::create(ov::element::i64, ov::Shape{1}, {1}),
-                                                   Constant::create(ov::element::i64, ov::Shape{}, {0}))},
+        make_shared<ov::op::v0::Concat>(ngraph::NodeVector{batch_delivering_node,
+                                               ov::op::util::make_try_fold<ov::op::v8::Gather>(
+                                                   ov::op::util::make_try_fold<ov::op::v3::ShapeOf>(constant_copy),
+                                                   ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {1}),
+                                                   ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {0}))},
                             0));
     input.replace_source_output(broadcast_by_batch->output(0));
     return true;
 }
 
-bool relax_batch_for_initial_states_of_lstm_in_ti(const shared_ptr<TensorIterator>& ti,
-                                                  const shared_ptr<LSTMCell>& lstm_cell) {
+bool relax_batch_for_initial_states_of_lstm_in_ti(const shared_ptr<ov::op::v0::TensorIterator>& ti,
+                                                  const shared_ptr<ov::op::v4::LSTMCell>& lstm_cell) {
     bool rewritten = false;
     auto batch_delivering_node = deduce_outer_source_of_batch_for_inner_lstm_cell(ti, lstm_cell);
     if (batch_delivering_node == nullptr)
         return rewritten;
-    if (auto init_hidden_state = dynamic_pointer_cast<Parameter>(lstm_cell->get_input_node_shared_ptr(1))) {
+    if (auto init_hidden_state = dynamic_pointer_cast<ov::op::v0::Parameter>(lstm_cell->get_input_node_shared_ptr(1))) {
         auto outer_init_hidden_state_input = get_outer_input_of_ti_by_parameter(init_hidden_state, ti);
         rewritten |= broadcast_state_by_batch(outer_init_hidden_state_input, batch_delivering_node);
     }
-    if (auto init_cell_state = dynamic_pointer_cast<Parameter>(lstm_cell->get_input_node_shared_ptr(2))) {
+    if (auto init_cell_state = dynamic_pointer_cast<ov::op::v0::Parameter>(lstm_cell->get_input_node_shared_ptr(2))) {
         auto outer_init_cell_state_input = get_outer_input_of_ti_by_parameter(init_cell_state, ti);
         rewritten |= broadcast_state_by_batch(outer_init_cell_state_input, batch_delivering_node);
     }
     return rewritten;
 }
 
-bool relax_batch_for_initial_states_of_lstm(const shared_ptr<LSTMCell>& lstm_cell) {
+bool relax_batch_for_initial_states_of_lstm(const shared_ptr<ov::op::v4::LSTMCell>& lstm_cell) {
     bool rewritten = false;
-    const auto& batched_shape = make_shared<ShapeOf>(lstm_cell->get_input_source_output(0));
-    const auto& batch_delivering_node = make_shared<Gather>(batched_shape,
-                                                            Constant::create(ov::element::i64, ov::Shape{1}, {0}),
-                                                            Constant::create(ov::element::i64, ov::Shape{}, {0}));
+    const auto& batched_shape = make_shared<ov::op::v3::ShapeOf>(lstm_cell->get_input_source_output(0));
+    const auto& batch_delivering_node = make_shared<ov::op::v8::Gather>(batched_shape,
+                                                            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0}),
+                                                            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {0}));
     rewritten |= broadcast_state_by_batch(lstm_cell->input(1), batch_delivering_node);
     rewritten |= broadcast_state_by_batch(lstm_cell->input(2), batch_delivering_node);
     return rewritten;
@@ -154,16 +160,16 @@ bool ov::pass::LSTMStatesBroadcast::run_on_model(const shared_ptr<ov::Model>& f)
                 rewritten |= run_on_model(sub_graph);
 
         // Case without TI (LSTMCell and Constant are in the same ov::Model)
-        if (const auto& lstm_cell = dynamic_pointer_cast<LSTMCell>(node))
+        if (const auto& lstm_cell = dynamic_pointer_cast<ov::op::v4::LSTMCell>(node))
             rewritten |= relax_batch_for_initial_states_of_lstm(lstm_cell);
 
         // Case with TI (LSTMCell and Constant are in different ov::Model objects)
-        if (auto ti = dynamic_pointer_cast<TensorIterator>(node)) {
+        if (auto ti = dynamic_pointer_cast<ov::op::v0::TensorIterator>(node)) {
             auto body = ti->get_body();
             if (body == nullptr)
                 continue;
             for (const auto& body_node : body->get_ordered_ops())
-                if (const auto& lstm_cell = dynamic_pointer_cast<LSTMCell>(body_node))
+                if (const auto& lstm_cell = dynamic_pointer_cast<ov::op::v4::LSTMCell>(body_node))
                     rewritten |= relax_batch_for_initial_states_of_lstm_in_ti(ti, lstm_cell);
         }
     }

--- a/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
@@ -10,15 +10,15 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/validation_util.hpp>
 #include <numeric>
-#include "openvino/op/reshape.hpp"
-#include "openvino/op/constant.hpp"
-#include "openvino/op/transpose.hpp"
-#include "openvino/op/matmul.hpp"
-#include "openvino/op/gather.hpp"
-#include "openvino/op/shape_of.hpp"
-#include "openvino/op/concat.hpp"
 
 #include "itt.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/transpose.hpp"
 
 namespace {
 

--- a/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
@@ -10,7 +10,13 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/validation_util.hpp>
 #include <numeric>
-#include <openvino/opsets/opset4.hpp>
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/concat.hpp"
 
 #include "itt.hpp"
 
@@ -24,12 +30,12 @@ bool relax_hc_reshape_followed_by_matmul(const ngraph::pattern::PatternValueMap&
                                          bool reshape_is_A_input) {
     const auto& reshape_rank = pattern_to_output.at(reshape_label).get_partial_shape().rank();
     const auto& matmul =
-        std::dynamic_pointer_cast<ov::opset4::MatMul>(pattern_to_output.at(matmul_label).get_node_shared_ptr());
+        std::dynamic_pointer_cast<ov::op::v0::MatMul>(pattern_to_output.at(matmul_label).get_node_shared_ptr());
     if (!matmul || reshape_rank.is_dynamic() || reshape_rank.get_length() != 2)
         return false;
     const auto& shape_source = pattern_to_output.at(other_input_label);
-    if (ngraph::is_type<ov::opset4::Transpose>(shape_source.get_node_shared_ptr()) ||
-        ngraph::is_type<ov::opset4::Reshape>(shape_source.get_node_shared_ptr()))
+    if (ngraph::is_type<ov::op::v1::Transpose>(shape_source.get_node_shared_ptr()) ||
+        ngraph::is_type<ov::op::v1::Reshape>(shape_source.get_node_shared_ptr()))
         // avoiding loop creation
         return false;
 
@@ -39,14 +45,14 @@ bool relax_hc_reshape_followed_by_matmul(const ngraph::pattern::PatternValueMap&
     const auto& idx = ngraph::normalize_axes(matmul->description(), {raw_idx}, reshape_rank);
     OPENVINO_SUPPRESS_DEPRECATED_END
     const auto& C =
-        std::make_shared<ov::opset4::Gather>(std::make_shared<ov::opset4::ShapeOf>(shape_source),
-                                             ov::opset4::Constant::create(ngraph::element::i64, {idx.size()}, idx),
-                                             ov::opset4::Constant::create(ngraph::element::i64, {}, {0}));
-    const auto& N = ov::opset4::Constant::create(ngraph::element::i64, {1}, {-1});
+        std::make_shared<ov::op::v1::Gather>(std::make_shared<ov::op::v3::ShapeOf>(shape_source),
+                                             ov::op::v0::Constant::create(ngraph::element::i64, {idx.size()}, idx),
+                                             ov::op::v0::Constant::create(ngraph::element::i64, {}, {0}));
+    const auto& N = ov::op::v0::Constant::create(ngraph::element::i64, {1}, {-1});
     const auto& pattern_vector =
         reshape_is_A_input ? (matmul->get_transpose_a() ? ngraph::OutputVector({C, N}) : ngraph::OutputVector({N, C}))
                            : (matmul->get_transpose_b() ? ngraph::OutputVector({N, C}) : ngraph::OutputVector({C, N}));
-    const auto& new_reshape_pattern = std::make_shared<ov::opset4::Concat>(pattern_vector, 0);
+    const auto& new_reshape_pattern = std::make_shared<ov::op::v0::Concat>(pattern_vector, 0);
 
     auto reshape_pattern = pattern_to_output.at(reshape_pattern_label).get_node_shared_ptr();
     new_reshape_pattern->set_friendly_name(reshape_pattern->get_friendly_name());
@@ -62,8 +68,8 @@ ov::pass::ReshapeAMatMul::ReshapeAMatMul() {
     auto other_input_label = pattern::any_input();
     auto reshape_input_label = pattern::any_input();
     auto reshape_pattern_label = pattern::any_input();
-    auto reshape_label = ngraph::pattern::wrap_type<opset4::Reshape>({reshape_input_label, reshape_pattern_label});
-    auto matmul_label = ngraph::pattern::wrap_type<opset4::MatMul>({reshape_label, other_input_label});
+    auto reshape_label = ngraph::pattern::wrap_type<ov::op::v1::Reshape>({reshape_input_label, reshape_pattern_label});
+    auto matmul_label = ngraph::pattern::wrap_type<ov::op::v0::MatMul>({reshape_label, other_input_label});
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) -> bool {
         const auto& pattern_to_output = m.get_pattern_value_map();
@@ -83,8 +89,8 @@ ov::pass::ReshapeBMatMul::ReshapeBMatMul() {
     auto other_input_label = pattern::any_input();
     auto reshape_input_label = pattern::any_input();
     auto reshape_pattern_label = pattern::any_input();
-    auto reshape_label = ngraph::pattern::wrap_type<opset4::Reshape>({reshape_input_label, reshape_pattern_label});
-    auto matmul_label = ngraph::pattern::wrap_type<opset4::MatMul>({other_input_label, reshape_label});
+    auto reshape_label = ngraph::pattern::wrap_type<ov::op::v1::Reshape>({reshape_input_label, reshape_pattern_label});
+    auto matmul_label = ngraph::pattern::wrap_type<ov::op::v0::MatMul>({other_input_label, reshape_label});
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) -> bool {
         const auto& pattern_to_output = m.get_pattern_value_map();
@@ -101,21 +107,21 @@ ov::pass::ReshapeBMatMul::ReshapeBMatMul() {
 
 ov::pass::TransposeMatMul::TransposeMatMul() {
     MATCHER_SCOPE(TransposeMatMul);
-    auto matmul_label = ngraph::pattern::wrap_type<opset4::MatMul>();
+    auto matmul_label = ngraph::pattern::wrap_type<ov::op::v0::MatMul>();
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) -> bool {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto matmul =
-            std::dynamic_pointer_cast<ov::opset4::MatMul>(pattern_to_output.at(matmul_label).get_node_shared_ptr());
+            std::dynamic_pointer_cast<ov::op::v0::MatMul>(pattern_to_output.at(matmul_label).get_node_shared_ptr());
         if (!matmul)
             return false;
 
         auto transpose_is_fusable = [](const std::shared_ptr<ngraph::Node>& input) {
             const auto& input_rank = input->get_output_partial_shape(0).rank();
             if (input_rank.is_static() && input_rank.get_length() >= 2) {
-                if (auto transpose = std::dynamic_pointer_cast<ov::opset4::Transpose>(input)) {
+                if (auto transpose = std::dynamic_pointer_cast<ov::op::v1::Transpose>(input)) {
                     if (auto order =
-                            std::dynamic_pointer_cast<opset4::Constant>(transpose->get_input_node_shared_ptr(1))) {
+                            std::dynamic_pointer_cast<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1))) {
                         const auto& order_vector = order->cast_vector<int64_t>();
                         std::vector<int64_t> fusable_order(input_rank.get_length());
                         std::iota(fusable_order.begin(), fusable_order.end(), 0);
@@ -146,7 +152,7 @@ ov::pass::TransposeMatMul::TransposeMatMul() {
         }
 
         if (!fused_nodes.empty()) {
-            auto updated_matmul = std::make_shared<opset4::MatMul>(input_A, input_B, transpose_A, transpose_B);
+            auto updated_matmul = std::make_shared<ov::op::v0::MatMul>(input_A, input_B, transpose_A, transpose_B);
             fused_nodes.push_back(matmul);
             copy_runtime_info(fused_nodes, updated_matmul);
             updated_matmul->set_friendly_name(matmul->get_friendly_name());

--- a/src/common/transformations/src/transformations/smart_reshape/mimic_set_batch_size.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/mimic_set_batch_size.cpp
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <ngraph/opsets/opset5.hpp>
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/ceiling.hpp"
 #include <ngraph/pass/constant_folding.hpp>
 #include <ngraph/pass/manager.hpp>
 #include <transformations/smart_reshape/mimic_set_batch_size.hpp>
@@ -21,13 +28,13 @@ bool ov::pass::MimicSetBatchSize::run_on_model(const std::shared_ptr<ngraph::Fun
 
     std::map<std::string, float> scale;
     for (const auto& node : specialized_function->get_ops()) {
-        if (const auto& reshape = std::dynamic_pointer_cast<opset5::Reshape>(node)) {
+        if (const auto& reshape = std::dynamic_pointer_cast<ov::op::v1::Reshape>(node)) {
             const auto in_pshape = reshape->get_input_partial_shape(0),
                        out_pshape = reshape->get_output_partial_shape(0);
             if (in_pshape.rank().is_dynamic() || in_pshape.rank().get_length() <= 1 || in_pshape[0].is_dynamic() ||
                 out_pshape.rank().is_dynamic() || out_pshape.rank().get_length() <= 1 || out_pshape[0].is_dynamic())
                 continue;
-            const auto& pattern = std::dynamic_pointer_cast<opset5::Constant>(reshape->get_input_node_shared_ptr(1));
+            const auto& pattern = std::dynamic_pointer_cast<ov::op::v0::Constant>(reshape->get_input_node_shared_ptr(1));
             if (pattern && pattern->cast_vector<int64_t>()[0] > 0) {
                 scale[reshape->get_friendly_name()] =
                     static_cast<float>(out_pshape[0].get_length()) / static_cast<float>(in_pshape[0].get_length());
@@ -37,31 +44,31 @@ bool ov::pass::MimicSetBatchSize::run_on_model(const std::shared_ptr<ngraph::Fun
     // apply transformation to original function
     bool transformed = false;
     for (auto& reshape : f->get_ops()) {
-        if (!is_type<opset5::Reshape>(reshape) || !scale.count(reshape->get_friendly_name()) ||
+        if (!is_type<ov::op::v1::Reshape>(reshape) || !scale.count(reshape->get_friendly_name()) ||
             reshape->get_output_partial_shape(0).rank().is_dynamic())
             continue;
 
         const auto& shape_of =
-            std::make_shared<opset5::ShapeOf>(reshape->get_input_source_output(0), reshape->get_input_element_type(1));
-        const auto& new_input_batch = std::make_shared<ngraph::opset5::Gather>(
+            std::make_shared<ov::op::v3::ShapeOf>(reshape->get_input_source_output(0), reshape->get_input_element_type(1));
+        const auto& new_input_batch = std::make_shared<ov::op::v1::Gather>(
             shape_of,
-            ngraph::opset5::Constant::create(ngraph::element::i64, {1}, std::vector<int64_t>{0}),
-            ngraph::opset5::Constant::create(ngraph::element::i64, {}, std::vector<int64_t>{0}));
+            ov::op::v0::Constant::create(ngraph::element::i64, {1}, std::vector<int64_t>{0}),
+            ov::op::v0::Constant::create(ngraph::element::i64, {}, std::vector<int64_t>{0}));
 
-        const std::shared_ptr<Node>& new_output_batch = std::make_shared<opset5::Convert>(
-            std::make_shared<opset5::Ceiling>(std::make_shared<opset5::Multiply>(
-                std::make_shared<opset5::Convert>(new_input_batch, element::f32),
-                opset5::Constant::create(element::f32, {1}, {scale[reshape->get_friendly_name()]}))),
+        const std::shared_ptr<Node>& new_output_batch = std::make_shared<ov::op::v0::Convert>(
+            std::make_shared<ov::op::v0::Ceiling>(std::make_shared<ov::op::v1::Multiply>(
+                std::make_shared<ov::op::v0::Convert>(new_input_batch, element::f32),
+                ov::op::v0::Constant::create(element::f32, {1}, {scale[reshape->get_friendly_name()]}))),
             reshape->get_input_element_type(1));
 
         std::vector<int64_t> non_batch_dims(reshape->get_output_partial_shape(0).rank().get_length() - 1);
         std::iota(non_batch_dims.begin(), non_batch_dims.end(), 1);
-        const auto& non_batch_dims_node = std::make_shared<ngraph::opset5::Gather>(
+        const auto& non_batch_dims_node = std::make_shared<ov::op::v1::Gather>(
             reshape->input_value(1),
-            ngraph::opset5::Constant::create(ngraph::element::i64, {non_batch_dims.size()}, non_batch_dims),
-            ngraph::opset5::Constant::create(ngraph::element::i64, {}, std::vector<int64_t>{0}));
+            ov::op::v0::Constant::create(ngraph::element::i64, {non_batch_dims.size()}, non_batch_dims),
+            ov::op::v0::Constant::create(ngraph::element::i64, {}, std::vector<int64_t>{0}));
         auto new_reshape_pattern =
-            std::make_shared<opset5::Concat>(OutputVector{new_output_batch, non_batch_dims_node}, 0);
+            std::make_shared<ov::op::v0::Concat>(OutputVector{new_output_batch, non_batch_dims_node}, 0);
         reshape->input(1).replace_source_output(new_reshape_pattern->output(0));
         transformed = true;
     }

--- a/src/common/transformations/src/transformations/smart_reshape/mimic_set_batch_size.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/mimic_set_batch_size.cpp
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "openvino/op/reshape.hpp"
-#include "openvino/op/convert.hpp"
-#include "openvino/op/constant.hpp"
-#include "openvino/op/shape_of.hpp"
-#include "openvino/op/gather.hpp"
-#include "openvino/op/concat.hpp"
-#include "openvino/op/multiply.hpp"
-#include "openvino/op/ceiling.hpp"
 #include <ngraph/pass/constant_folding.hpp>
 #include <ngraph/pass/manager.hpp>
 #include <transformations/smart_reshape/mimic_set_batch_size.hpp>
 
 #include "itt.hpp"
+#include "openvino/op/ceiling.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/shape_of.hpp"
 
 using namespace ngraph;
 
@@ -34,7 +34,8 @@ bool ov::pass::MimicSetBatchSize::run_on_model(const std::shared_ptr<ngraph::Fun
             if (in_pshape.rank().is_dynamic() || in_pshape.rank().get_length() <= 1 || in_pshape[0].is_dynamic() ||
                 out_pshape.rank().is_dynamic() || out_pshape.rank().get_length() <= 1 || out_pshape[0].is_dynamic())
                 continue;
-            const auto& pattern = std::dynamic_pointer_cast<ov::op::v0::Constant>(reshape->get_input_node_shared_ptr(1));
+            const auto& pattern =
+                std::dynamic_pointer_cast<ov::op::v0::Constant>(reshape->get_input_node_shared_ptr(1));
             if (pattern && pattern->cast_vector<int64_t>()[0] > 0) {
                 scale[reshape->get_friendly_name()] =
                     static_cast<float>(out_pshape[0].get_length()) / static_cast<float>(in_pshape[0].get_length());
@@ -48,8 +49,8 @@ bool ov::pass::MimicSetBatchSize::run_on_model(const std::shared_ptr<ngraph::Fun
             reshape->get_output_partial_shape(0).rank().is_dynamic())
             continue;
 
-        const auto& shape_of =
-            std::make_shared<ov::op::v3::ShapeOf>(reshape->get_input_source_output(0), reshape->get_input_element_type(1));
+        const auto& shape_of = std::make_shared<ov::op::v3::ShapeOf>(reshape->get_input_source_output(0),
+                                                                     reshape->get_input_element_type(1));
         const auto& new_input_batch = std::make_shared<ov::op::v1::Gather>(
             shape_of,
             ov::op::v0::Constant::create(ngraph::element::i64, {1}, std::vector<int64_t>{0}),

--- a/src/common/transformations/src/transformations/smart_reshape/proposal_scales_stridedslice.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/proposal_scales_stridedslice.cpp
@@ -6,15 +6,15 @@
 #include <ngraph/pattern/op/or.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/reshape.hpp"
-#include "openvino/op/proposal.hpp"
-#include "openvino/op/convert.hpp"
-#include "openvino/op/constant.hpp"
-#include "openvino/op/parameter.hpp"
-#include "openvino/op/strided_slice.hpp"
 #include <transformations/smart_reshape/proposal_scales_stridedslice.hpp>
 
 #include "itt.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/proposal.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/strided_slice.hpp"
 
 namespace {
 

--- a/src/common/transformations/src/transformations/smart_reshape/proposal_scales_stridedslice.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/proposal_scales_stridedslice.cpp
@@ -6,9 +6,12 @@
 #include <ngraph/pattern/op/or.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset4.hpp>
-#include <openvino/opsets/opset5.hpp>
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/proposal.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/strided_slice.hpp"
 #include <transformations/smart_reshape/proposal_scales_stridedslice.hpp>
 
 #include "itt.hpp"
@@ -21,13 +24,13 @@ bool crop_scales_for_proposal(const ngraph::pattern::PatternValueMap& pattern_to
     const auto& parameter = pattern_to_output.at(parameter_label);
     const auto& proposal = pattern_to_output.at(proposal_label).get_node_shared_ptr();
 
-    auto cropped_scales = std::make_shared<ov::opset5::StridedSlice>(
+    auto cropped_scales = std::make_shared<ov::op::v1::StridedSlice>(
         proposal->input_value(2),
-        ov::opset5::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {0}),
-        ov::opset5::Constant::create(ngraph::element::i64,
+        ov::op::v0::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {0}),
+        ov::op::v0::Constant::create(ngraph::element::i64,
                                      ngraph::Shape{1},
                                      {parameter.get_partial_shape()[1].get_length()}),
-        ov::opset5::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {1}),
+        ov::op::v0::Constant::create(ngraph::element::i64, ngraph::Shape{1}, {1}),
         std::vector<int64_t>{0},
         std::vector<int64_t>{0});
 
@@ -40,21 +43,21 @@ bool crop_scales_for_proposal(const ngraph::pattern::PatternValueMap& pattern_to
 ov::pass::Proposal1Scales::Proposal1Scales() {
     // TODO: enable conditional compile
     // MATCHER_SCOPE(Proposal1Scales);
-    auto parameter_label = ngraph::pattern::wrap_type<opset5::Parameter>([](const Output<Node>& output) {
+    auto parameter_label = ngraph::pattern::wrap_type<ov::op::v0::Parameter>([](const Output<Node>& output) {
         const auto& shape = output.get_partial_shape();
         return shape.rank().is_static() && shape.rank().get_length() == 2 && shape[1].is_static() &&
                (shape[1].get_length() == 3 || shape[1].get_length() == 4);
     });
-    auto convert_label = ngraph::pattern::wrap_type<opset5::Convert>({parameter_label});
+    auto convert_label = ngraph::pattern::wrap_type<ov::op::v0::Convert>({parameter_label});
     auto param_or_convert =
         std::make_shared<ngraph::pattern::op::Or>(ngraph::OutputVector{parameter_label, convert_label});
-    auto reshape_label = ngraph::pattern::wrap_type<opset5::Reshape>(
-        {param_or_convert, ngraph::pattern::wrap_type<opset5::Constant>()},
+    auto reshape_label = ngraph::pattern::wrap_type<ov::op::v1::Reshape>(
+        {param_or_convert, ngraph::pattern::wrap_type<ov::op::v0::Constant>()},
         [](const Output<Node>& output) {
             return output.get_partial_shape().rank().is_static() && output.get_partial_shape().rank().get_length() == 1;
         });
     auto proposal_label =
-        ngraph::pattern::wrap_type<opset1::Proposal>({pattern::any_input(), pattern::any_input(), reshape_label});
+        ngraph::pattern::wrap_type<ov::op::v0::Proposal>({pattern::any_input(), pattern::any_input(), reshape_label});
 
     matcher_pass_callback callback = [parameter_label, proposal_label](pattern::Matcher& m) -> bool {
         return crop_scales_for_proposal(m.get_pattern_value_map(), parameter_label, proposal_label);
@@ -66,21 +69,21 @@ ov::pass::Proposal1Scales::Proposal1Scales() {
 ov::pass::Proposal4Scales::Proposal4Scales() {
     // TODO: enable conditional compile
     // MATCHER_SCOPE(Proposal4Scales);
-    auto parameter_label = ngraph::pattern::wrap_type<opset5::Parameter>([](const Output<Node>& output) {
+    auto parameter_label = ngraph::pattern::wrap_type<ov::op::v0::Parameter>([](const Output<Node>& output) {
         const auto& shape = output.get_partial_shape();
         return shape.rank().is_static() && shape.rank().get_length() == 2 && shape[1].is_static() &&
                (shape[1].get_length() == 3 || shape[1].get_length() == 4);
     });
-    auto convert_label = ngraph::pattern::wrap_type<opset5::Convert>({parameter_label});
+    auto convert_label = ngraph::pattern::wrap_type<ov::op::v0::Convert>({parameter_label});
     auto param_or_convert =
         std::make_shared<ngraph::pattern::op::Or>(ngraph::OutputVector{parameter_label, convert_label});
-    auto reshape_label = ngraph::pattern::wrap_type<opset5::Reshape>(
-        {param_or_convert, ngraph::pattern::wrap_type<opset5::Constant>()},
+    auto reshape_label = ngraph::pattern::wrap_type<ov::op::v1::Reshape>(
+        {param_or_convert, ngraph::pattern::wrap_type<ov::op::v0::Constant>()},
         [](const Output<Node>& output) {
             return output.get_partial_shape().rank().is_static() && output.get_partial_shape().rank().get_length() == 1;
         });
     auto proposal_label =
-        ngraph::pattern::wrap_type<opset4::Proposal>({pattern::any_input(), pattern::any_input(), reshape_label});
+        ngraph::pattern::wrap_type<ov::op::v4::Proposal>({pattern::any_input(), pattern::any_input(), reshape_label});
 
     matcher_pass_callback callback = [parameter_label, proposal_label](pattern::Matcher& m) -> bool {
         return crop_scales_for_proposal(m.get_pattern_value_map(), parameter_label, proposal_label);

--- a/src/common/transformations/src/transformations/smart_reshape/reshape_sinking.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/reshape_sinking.cpp
@@ -5,13 +5,15 @@
 #include "transformations/smart_reshape/reshape_sinking.hpp"
 
 #include "itt.hpp"
-#include "openvino/opsets/opset9.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/add.hpp"
 #include "openvino/pass/pattern/matcher.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 
 using namespace std;
-using namespace ov::opset9;
 
 ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
     MATCHER_SCOPE(ReshapeSinkingMatMul);
@@ -28,18 +30,18 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
      */
     auto any_input = pattern::any_input(pattern::has_static_rank());
     auto reshape_label =
-        ov::pass::pattern::wrap_type<Reshape>({pattern::any_input(), ov::pass::pattern::wrap_type<Constant>()},
+        ov::pass::pattern::wrap_type<ov::op::v1::Reshape>({pattern::any_input(), ov::pass::pattern::wrap_type<ov::op::v0::Constant>()},
                                               pattern::rank_equals(2));
 
-    auto matmul_label = ov::pass::pattern::wrap_type<MatMul>({reshape_label, ov::pass::pattern::wrap_type<Constant>()},
+    auto matmul_label = ov::pass::pattern::wrap_type<ov::op::v0::MatMul>({reshape_label, ov::pass::pattern::wrap_type<ov::op::v0::Constant>()},
                                                              pattern::rank_equals(2));
-    auto add_label = ov::pass::pattern::wrap_type<Add>({matmul_label, ov::pass::pattern::wrap_type<Constant>()},
+    auto add_label = ov::pass::pattern::wrap_type<ov::op::v1::Add>({matmul_label, ov::pass::pattern::wrap_type<ov::op::v0::Constant>()},
                                                        pattern::rank_equals(2));
 
     auto matmul_or_matmul_add_label = make_shared<pattern::op::Or>(OutputVector{add_label, matmul_label});
 
     auto reshape_1_label =
-        ov::pass::pattern::wrap_type<Reshape>({matmul_or_matmul_add_label, ov::pass::pattern::wrap_type<Constant>()},
+        ov::pass::pattern::wrap_type<ov::op::v1::Reshape>({matmul_or_matmul_add_label, ov::pass::pattern::wrap_type<ov::op::v0::Constant>()},
                                               pattern::has_static_rank());
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) -> bool {
@@ -48,7 +50,7 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         // check first Reshape eligibility: has a constant output pattern in a form of [-1, K]
         auto reshape = pattern_to_node.at(reshape_label);
         int64_t K = -1;
-        if (const auto& constant = dynamic_pointer_cast<Constant>(reshape->get_input_node_shared_ptr(1))) {
+        if (const auto& constant = dynamic_pointer_cast<ov::op::v0::Constant>(reshape->get_input_node_shared_ptr(1))) {
             auto output_pattern_vector = constant->cast_vector<int64_t>();
             if (output_pattern_vector.size() != 2 || output_pattern_vector[0] != -1)
                 return false;
@@ -66,11 +68,11 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
             return false;
 
         // check matmul eligibility: has constant second input in a form of [O, K]
-        auto matmul = dynamic_pointer_cast<MatMul>(pattern_to_node.at(matmul_label));
+        auto matmul = dynamic_pointer_cast<ov::op::v0::MatMul>(pattern_to_node.at(matmul_label));
         if (!matmul || matmul->get_transpose_a())
             return false;
         int64_t O = -1;
-        if (const auto& constant = dynamic_pointer_cast<Constant>(matmul->get_input_node_shared_ptr(1))) {
+        if (const auto& constant = dynamic_pointer_cast<ov::op::v0::Constant>(matmul->get_input_node_shared_ptr(1))) {
             const auto& constant_shape = constant->get_shape();
             if (constant_shape.size() != 2)
                 return false;
@@ -86,10 +88,10 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         // check add eligibility if present: has constant second input that has a form of [1, 1, ..., O] (doesn't
         // broadcast first input)
         if (pattern_to_node.count(add_label)) {
-            auto add = dynamic_pointer_cast<Add>(pattern_to_node.at(add_label));
+            auto add = dynamic_pointer_cast<ov::op::v1::Add>(pattern_to_node.at(add_label));
             if (!add || add->get_autob() != ov::op::AutoBroadcastType::NUMPY)
                 return false;
-            const auto& constant = dynamic_pointer_cast<Constant>(add->get_input_node_shared_ptr(1));
+            const auto& constant = dynamic_pointer_cast<ov::op::v0::Constant>(add->get_input_node_shared_ptr(1));
             if (!constant)
                 return false;
             const auto& constant_shape = constant->get_shape();
@@ -106,7 +108,7 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         // input_shape of the pattern except for the batch and last dimension
         auto reshape_1 = m.get_match_root();
 
-        const auto& constant = dynamic_pointer_cast<Constant>(reshape_1->get_input_node_shared_ptr(1));
+        const auto& constant = dynamic_pointer_cast<ov::op::v0::Constant>(reshape_1->get_input_node_shared_ptr(1));
         if (constant == nullptr)
             return false;
         auto output_pattern = constant->cast_vector<int64_t>();
@@ -127,8 +129,8 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
                 return false;
         }
 
-        auto first_reshape = dynamic_pointer_cast<Reshape>(reshape);
-        auto second_reshape = dynamic_pointer_cast<Reshape>(reshape_1);
+        auto first_reshape = dynamic_pointer_cast<ov::op::v1::Reshape>(reshape);
+        auto second_reshape = dynamic_pointer_cast<ov::op::v1::Reshape>(reshape_1);
         if (!first_reshape || !second_reshape)
             return false;
 
@@ -138,11 +140,11 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
 
         vector<int64_t> output_pattern_vector(input_rank - 1, 0);
         output_pattern_vector.push_back(K);
-        auto new_reshape_constant = Constant::create(ov::element::i64, Shape{input_rank}, output_pattern_vector);
+        auto new_reshape_constant = ov::op::v0::Constant::create(ov::element::i64, Shape{input_rank}, output_pattern_vector);
         reshape->input(1).replace_source_output(new_reshape_constant->output(0));
 
         output_pattern[0] = 0;
-        auto new_reshape_1_constant = Constant::create(ov::element::i64, Shape{input_rank}, output_pattern);
+        auto new_reshape_1_constant = ov::op::v0::Constant::create(ov::element::i64, Shape{input_rank}, output_pattern);
         reshape_1->input(1).replace_source_output(new_reshape_1_constant->output(0));
 
         return true;

--- a/src/common/transformations/src/transformations/smart_reshape/reshape_to_1D.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/reshape_to_1D.cpp
@@ -5,23 +5,24 @@
 #include <ngraph/pattern/matcher.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include "openvino/op/reshape.hpp"
-#include "openvino/op/constant.hpp"
 #include <transformations/smart_reshape/reshape_to_1D.hpp>
 
 #include "itt.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/reshape.hpp"
 
 ov::pass::ReshapeTo1D::ReshapeTo1D() {
     // TODO: enable conditional compile
     // MATCHER_SCOPE(ReshapeTo1D);
     auto reshape_label = ngraph::pattern::wrap_type<ov::op::v1::Reshape>(
-            {pattern::any_input(), ngraph::pattern::wrap_type<ov::op::v0::Constant>()},
-            [](const Output<Node>& output) {
-                return output.get_partial_shape().rank().is_static() && output.get_partial_shape().rank().get_length() == 1;
-            });
+        {pattern::any_input(), ngraph::pattern::wrap_type<ov::op::v0::Constant>()},
+        [](const Output<Node>& output) {
+            return output.get_partial_shape().rank().is_static() && output.get_partial_shape().rank().get_length() == 1;
+        });
 
     matcher_pass_callback callback = [](pattern::Matcher& m) -> bool {
-        m.get_match_root()->input(1).replace_source_output(ov::op::v0::Constant::create(ngraph::element::i64, {1}, {-1}));
+        m.get_match_root()->input(1).replace_source_output(
+            ov::op::v0::Constant::create(ngraph::element::i64, {1}, {-1}));
         return true;
     };
     auto m = std::make_shared<ngraph::pattern::Matcher>(reshape_label /*, matcher_name*/);

--- a/src/common/transformations/src/transformations/smart_reshape/reshape_to_1D.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/reshape_to_1D.cpp
@@ -5,7 +5,8 @@
 #include <ngraph/pattern/matcher.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
-#include <openvino/opsets/opset5.hpp>
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/constant.hpp"
 #include <transformations/smart_reshape/reshape_to_1D.hpp>
 
 #include "itt.hpp"
@@ -13,14 +14,14 @@
 ov::pass::ReshapeTo1D::ReshapeTo1D() {
     // TODO: enable conditional compile
     // MATCHER_SCOPE(ReshapeTo1D);
-    auto reshape_label = ngraph::pattern::wrap_type<opset5::Reshape>(
-        {pattern::any_input(), ngraph::pattern::wrap_type<opset5::Constant>()},
-        [](const Output<Node>& output) {
-            return output.get_partial_shape().rank().is_static() && output.get_partial_shape().rank().get_length() == 1;
-        });
+    auto reshape_label = ngraph::pattern::wrap_type<ov::op::v1::Reshape>(
+            {pattern::any_input(), ngraph::pattern::wrap_type<ov::op::v0::Constant>()},
+            [](const Output<Node>& output) {
+                return output.get_partial_shape().rank().is_static() && output.get_partial_shape().rank().get_length() == 1;
+            });
 
     matcher_pass_callback callback = [](pattern::Matcher& m) -> bool {
-        m.get_match_root()->input(1).replace_source_output(opset5::Constant::create(ngraph::element::i64, {1}, {-1}));
+        m.get_match_root()->input(1).replace_source_output(ov::op::v0::Constant::create(ngraph::element::i64, {1}, {-1}));
         return true;
     };
     auto m = std::make_shared<ngraph::pattern::Matcher>(reshape_label /*, matcher_name*/);

--- a/src/common/transformations/src/transformations/smart_reshape/shape_of_const_folding.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/shape_of_const_folding.cpp
@@ -9,13 +9,14 @@
 #include "itt.hpp"
 #include "openvino/core/validation_util.hpp"
 #include "openvino/op/shape_of.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 
 ov::pass::ShapeOfConstFolding::ShapeOfConstFolding() {
     MATCHER_SCOPE(ShapeOfConstFolding);
-    auto constant_label = pattern::wrap_type<opset10::Constant>();
-    auto shape_of_label = pattern::wrap_type<op::v0::ShapeOf, opset10::ShapeOf>({constant_label});
+    auto constant_label = pattern::wrap_type<ov::op::v0::Constant>();
+    auto shape_of_label = pattern::wrap_type<op::v0::ShapeOf, ov::op::v3::ShapeOf>({constant_label});
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) -> bool {
         auto node = m.get_match_root();

--- a/src/common/transformations/src/transformations/smart_reshape/shape_of_const_folding.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/shape_of_const_folding.cpp
@@ -8,9 +8,8 @@
 
 #include "itt.hpp"
 #include "openvino/core/validation_util.hpp"
-#include "openvino/op/shape_of.hpp"
-#include "openvino/op/shape_of.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/shape_of.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 
 ov::pass::ShapeOfConstFolding::ShapeOfConstFolding() {

--- a/src/common/transformations/src/transformations/smart_reshape/strided_slice_squeeze.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/strided_slice_squeeze.cpp
@@ -7,28 +7,31 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 #include <ngraph/validation_util.hpp>
-#include <openvino/opsets/opset5.hpp>
+#include "openvino/op/strided_slice.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/constant.hpp"
 #include <transformations/smart_reshape/strided_slice_squeeze.hpp>
 
 #include "transformations_visibility.hpp"
+#include "openvino/op/util/sub_graph_base.hpp"
 
 ov::pass::StridedSliceSqueeze::StridedSliceSqueeze() {
     // TODO: enable conditional compile
     // MATCHER_SCOPE(StridedSliceSqueeze);
-    auto ss_label = ngraph::pattern::wrap_type<opset5::StridedSlice>(pattern::consumers_count(1));
+    auto ss_label = ngraph::pattern::wrap_type<ov::op::v1::StridedSlice>(pattern::consumers_count(1));
     auto squeeze_label =
-        ngraph::pattern::wrap_type<opset5::Squeeze>({ss_label, ngraph::pattern::wrap_type<opset5::Constant>()});
+        ngraph::pattern::wrap_type<ov::op::v0::Squeeze>({ss_label, ngraph::pattern::wrap_type<ov::op::v0::Constant>()});
 
     matcher_pass_callback callback = [](pattern::Matcher& m) -> bool {
         const auto& squeeze = m.get_match_root();
-        const auto& const_axes = std::dynamic_pointer_cast<ov::opset5::Constant>(squeeze->get_input_node_shared_ptr(1));
-        auto slice = std::dynamic_pointer_cast<ov::opset5::StridedSlice>(squeeze->get_input_node_shared_ptr(0));
+        const auto& const_axes = std::dynamic_pointer_cast<ov::op::v0::Constant>(squeeze->get_input_node_shared_ptr(1));
+        auto slice = std::dynamic_pointer_cast<ov::op::v1::StridedSlice>(squeeze->get_input_node_shared_ptr(0));
         if (!const_axes || !slice)
             return false;
 
-        auto begin = std::dynamic_pointer_cast<ov::opset5::Constant>(slice->input_value(1).get_node_shared_ptr());
-        auto end = std::dynamic_pointer_cast<ov::opset5::Constant>(slice->input_value(2).get_node_shared_ptr());
-        auto strides = std::dynamic_pointer_cast<ov::opset5::Constant>(slice->input_value(3).get_node_shared_ptr());
+        auto begin = std::dynamic_pointer_cast<ov::op::v0::Constant>(slice->input_value(1).get_node_shared_ptr());
+        auto end = std::dynamic_pointer_cast<ov::op::v0::Constant>(slice->input_value(2).get_node_shared_ptr());
+        auto strides = std::dynamic_pointer_cast<ov::op::v0::Constant>(slice->input_value(3).get_node_shared_ptr());
         if (!begin || !end || !strides)
             return false;
 
@@ -96,11 +99,11 @@ ov::pass::StridedSliceSqueeze::StridedSliceSqueeze() {
             shrink_axis_mask[axis] = 1;
         }
 
-        auto new_slice = std::make_shared<opset5::StridedSlice>(
+        auto new_slice = std::make_shared<ov::op::v1::StridedSlice>(
             slice->input_value(0),
-            opset5::Constant::create(element::i64, {begin_vec.size()}, begin_vec),
-            opset5::Constant::create(element::i64, {end_vec.size()}, end_vec),
-            opset5::Constant::create(element::i64, {strides_vec.size()}, strides_vec),
+            ov::op::v0::Constant::create(element::i64, {begin_vec.size()}, begin_vec),
+            ov::op::v0::Constant::create(element::i64, {end_vec.size()}, end_vec),
+            ov::op::v0::Constant::create(element::i64, {strides_vec.size()}, strides_vec),
             begin_mask,
             end_mask,
             new_axis_mask,
@@ -115,24 +118,24 @@ ov::pass::StridedSliceSqueeze::StridedSliceSqueeze() {
 ov::pass::SqueezeStridedSlice::SqueezeStridedSlice() {
     // TODO: enable conditional compile
     // MATCHER_SCOPE(SqueezeStridedSlice);
-    auto squeeze_label = ngraph::pattern::wrap_type<opset5::Squeeze>(
-        {pattern::any_input(), ngraph::pattern::wrap_type<opset5::Constant>()},
+    auto squeeze_label = ngraph::pattern::wrap_type<ov::op::v0::Squeeze>(
+        {pattern::any_input(), ngraph::pattern::wrap_type<ov::op::v0::Constant>()},
         pattern::consumers_count(1));
-    auto ss_label = ngraph::pattern::wrap_type<opset5::StridedSlice>(
+    auto ss_label = ngraph::pattern::wrap_type<ov::op::v1::StridedSlice>(
         {squeeze_label, pattern::any_input(), pattern::any_input(), pattern::any_input()});
 
     matcher_pass_callback callback = [](pattern::Matcher& m) -> bool {
-        auto slice = std::dynamic_pointer_cast<ov::opset5::StridedSlice>(m.get_match_root());
+        auto slice = std::dynamic_pointer_cast<ov::op::v1::StridedSlice>(m.get_match_root());
         if (!slice)
             return false;
         auto squeeze = slice->get_input_node_shared_ptr(0);
-        const auto& const_axes = std::dynamic_pointer_cast<ov::opset5::Constant>(squeeze->get_input_node_shared_ptr(1));
+        const auto& const_axes = std::dynamic_pointer_cast<ov::op::v0::Constant>(squeeze->get_input_node_shared_ptr(1));
         if (!const_axes)
             return false;
 
-        auto begin = std::dynamic_pointer_cast<ov::opset5::Constant>(slice->input_value(1).get_node_shared_ptr());
-        auto end = std::dynamic_pointer_cast<ov::opset5::Constant>(slice->input_value(2).get_node_shared_ptr());
-        auto strides = std::dynamic_pointer_cast<ov::opset5::Constant>(slice->input_value(3).get_node_shared_ptr());
+        auto begin = std::dynamic_pointer_cast<ov::op::v0::Constant>(slice->input_value(1).get_node_shared_ptr());
+        auto end = std::dynamic_pointer_cast<ov::op::v0::Constant>(slice->input_value(2).get_node_shared_ptr());
+        auto strides = std::dynamic_pointer_cast<ov::op::v0::Constant>(slice->input_value(3).get_node_shared_ptr());
         if (!begin || !end || !strides)
             return false;
 
@@ -177,11 +180,11 @@ ov::pass::SqueezeStridedSlice::SqueezeStridedSlice() {
             ellipsis_mask.insert(ellipsis_mask.begin() + axis, 0);
         }
 
-        auto new_slice = std::make_shared<opset5::StridedSlice>(
+        auto new_slice = std::make_shared<ov::op::v1::StridedSlice>(
             slice->get_input_node_shared_ptr(0)->input_value(0),
-            opset5::Constant::create(element::i64, {begin_vec.size()}, begin_vec),
-            opset5::Constant::create(element::i64, {end_vec.size()}, end_vec),
-            opset5::Constant::create(element::i64, {strides_vec.size()}, strides_vec),
+            ov::op::v0::Constant::create(element::i64, {begin_vec.size()}, begin_vec),
+            ov::op::v0::Constant::create(element::i64, {end_vec.size()}, end_vec),
+            ov::op::v0::Constant::create(element::i64, {strides_vec.size()}, strides_vec),
             begin_mask,
             end_mask,
             new_axis_mask,
@@ -199,7 +202,7 @@ ov::pass::SqueezeStridedSlice::SqueezeStridedSlice() {
 
 namespace {
 
-bool squeezes_perform_the_same(std::shared_ptr<ov::opset5::Squeeze> lhs, std::shared_ptr<ov::opset5::Squeeze> rhs) {
+bool squeezes_perform_the_same(std::shared_ptr<ov::op::v0::Squeeze> lhs, std::shared_ptr<ov::op::v0::Squeeze> rhs) {
     size_t l_input_size = lhs->inputs().size(), r_input_size = rhs->inputs().size();
     if (l_input_size != r_input_size)
         return false;
@@ -208,8 +211,8 @@ bool squeezes_perform_the_same(std::shared_ptr<ov::opset5::Squeeze> lhs, std::sh
     const auto rank = lhs->get_input_partial_shape(0).rank();
     if (rank.is_dynamic())
         return false;
-    const auto l_axes = std::dynamic_pointer_cast<ov::opset5::Constant>(lhs->get_input_node_shared_ptr(1));
-    const auto r_axes = std::dynamic_pointer_cast<ov::opset5::Constant>(rhs->get_input_node_shared_ptr(1));
+    const auto l_axes = std::dynamic_pointer_cast<ov::op::v0::Constant>(lhs->get_input_node_shared_ptr(1));
+    const auto r_axes = std::dynamic_pointer_cast<ov::op::v0::Constant>(rhs->get_input_node_shared_ptr(1));
     if (l_axes && r_axes) {
         OPENVINO_SUPPRESS_DEPRECATED_START
         return ngraph::normalize_axes(lhs->description(), l_axes->cast_vector<int64_t>(), rank) ==
@@ -226,7 +229,7 @@ bool ov::pass::SharedSqueeze::run_on_model(const std::shared_ptr<ngraph::Functio
 
     bool graph_rewritten = false;
 
-    std::map<ngraph::Output<Node>, std::vector<std::shared_ptr<ov::opset5::Squeeze>>> source_to_squeeze;
+    std::map<ngraph::Output<Node>, std::vector<std::shared_ptr<ov::op::v0::Squeeze>>> source_to_squeeze;
     for (const auto& node : f->get_ordered_ops()) {
         // Recursively apply transformation for sub-graph based operations
         if (auto sub_graph_node = std::dynamic_pointer_cast<op::util::SubGraphOp>(node)) {
@@ -234,7 +237,7 @@ bool ov::pass::SharedSqueeze::run_on_model(const std::shared_ptr<ngraph::Functio
                 graph_rewritten |= run_on_model(sub_graph);
             }
         }
-        if (auto squeeze = std::dynamic_pointer_cast<ov::opset5::Squeeze>(node)) {
+        if (auto squeeze = std::dynamic_pointer_cast<ov::op::v0::Squeeze>(node)) {
             source_to_squeeze[squeeze->input_value(0)].push_back(squeeze);
         }
     }

--- a/src/common/transformations/src/transformations/smart_reshape/strided_slice_squeeze.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/strided_slice_squeeze.cpp
@@ -7,13 +7,13 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 #include <ngraph/validation_util.hpp>
-#include "openvino/op/strided_slice.hpp"
-#include "openvino/op/squeeze.hpp"
-#include "openvino/op/constant.hpp"
 #include <transformations/smart_reshape/strided_slice_squeeze.hpp>
 
-#include "transformations_visibility.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/strided_slice.hpp"
 #include "openvino/op/util/sub_graph_base.hpp"
+#include "transformations_visibility.hpp"
 
 ov::pass::StridedSliceSqueeze::StridedSliceSqueeze() {
     // TODO: enable conditional compile

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_binary.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_binary.cpp
@@ -6,14 +6,15 @@
 
 #include "itt.hpp"
 #include "openvino/op/util/op_types.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/prelu.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
 #include "transformations/transpose_sinking/ts_utils.hpp"
 
 using namespace ov;
-using namespace ov::opset10;
 using namespace ov::pass::pattern;
 using namespace ov::pass::transpose_sinking;
 using namespace ov::pass::transpose_sinking::utils;
@@ -24,7 +25,7 @@ TSBinaryForward::TSBinaryForward() {
     auto main_node_label = wrap_type<op::util::BinaryElementwiseArithmetic,
                                      op::util::BinaryElementwiseComparison,
                                      op::util::BinaryElementwiseLogical,
-                                     PRelu>([](const Output<Node>& output) -> bool {
+                                     ov::op::v0::PRelu>([](const Output<Node>& output) -> bool {
         return has_static_rank()(output) && IfNodeHasTransposeInputs(output);
     });
 
@@ -61,20 +62,20 @@ TSBinaryBackward::TSBinaryBackward() {
     auto main_node_label = wrap_type<op::util::BinaryElementwiseArithmetic,
                                      op::util::BinaryElementwiseComparison,
                                      op::util::BinaryElementwiseLogical,
-                                     PRelu>([](const Output<Node>& output) -> bool {
+                                     ov::op::v0::PRelu>([](const Output<Node>& output) -> bool {
         return has_static_rank()(output) && HasSameOutputTransposeNodes(output);
     });
 
-    auto transpose_const_label = wrap_type<Constant>();
+    auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
 
     auto transpose_label =
-        wrap_type<Transpose>({main_node_label, transpose_const_label}, [](const Output<Node>& output) -> bool {
+        wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label}, [](const Output<Node>& output) -> bool {
             return has_static_rank()(output) && is_sinking_node(output);
         });
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
-        auto transpose_const = as_type_ptr<Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
+        auto transpose_const = as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto main_node = pattern_to_output.at(main_node_label).get_node_shared_ptr();
         if (transformation_callback(main_node)) {

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_binary.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_binary.cpp
@@ -5,10 +5,10 @@
 #include "transformations/transpose_sinking/ts_binary.hpp"
 
 #include "itt.hpp"
-#include "openvino/op/util/op_types.hpp"
-#include "openvino/op/transpose.hpp"
-#include "openvino/op/prelu.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/prelu.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/util/op_types.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
@@ -69,13 +69,15 @@ TSBinaryBackward::TSBinaryBackward() {
     auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
 
     auto transpose_label =
-        wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label}, [](const Output<Node>& output) -> bool {
-            return has_static_rank()(output) && is_sinking_node(output);
-        });
+        wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label},
+                                         [](const Output<Node>& output) -> bool {
+                                             return has_static_rank()(output) && is_sinking_node(output);
+                                         });
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
-        auto transpose_const = as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
+        auto transpose_const =
+            as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto main_node = pattern_to_output.at(main_node_label).get_node_shared_ptr();
         if (transformation_callback(main_node)) {

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_concat.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_concat.cpp
@@ -6,13 +6,14 @@
 
 #include "itt.hpp"
 #include "openvino/op/util/op_types.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/transpose.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
 #include "transformations/transpose_sinking/ts_utils.hpp"
 
 using namespace ov;
-using namespace ov::opset10;
 using namespace ov::pass::pattern;
 using namespace ov::pass::transpose_sinking;
 using namespace ov::pass::transpose_sinking::utils;
@@ -20,7 +21,7 @@ using namespace ov::pass::transpose_sinking::utils;
 TSConcatForward::TSConcatForward() {
     MATCHER_SCOPE(TSConcatForward);
 
-    auto main_node_label = wrap_type<Concat>(IfNodeHasTransposeInputs);
+    auto main_node_label = wrap_type<ov::op::v0::Concat>(IfNodeHasTransposeInputs);
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
@@ -32,7 +33,7 @@ TSConcatForward::TSConcatForward() {
         }
 
         TransposeInputsInfo transpose_input_info = GetFirstTransposeInput(main_node);
-        auto concat_node = as_type_ptr<Concat>(main_node);
+        auto concat_node = as_type_ptr<ov::op::v0::Concat>(main_node);
         auto concat_axis = concat_node->get_concatenation_axis();
         if (concat_axis < 0) {
             return false;
@@ -64,27 +65,27 @@ TSConcatForward::TSConcatForward() {
 TSConcatBackward::TSConcatBackward() {
     MATCHER_SCOPE(TSConcatBackward);
 
-    auto main_node_label = wrap_type<Concat>([](const Output<Node>& output) -> bool {
+    auto main_node_label = wrap_type<ov::op::v0::Concat>([](const Output<Node>& output) -> bool {
         return has_static_rank()(output) && HasSameOutputTransposeNodes(output);
     });
 
-    auto transpose_const_label = wrap_type<Constant>();
+    auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
 
     auto transpose_label =
-        wrap_type<Transpose>({main_node_label, transpose_const_label}, [](const Output<Node>& output) -> bool {
+        wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label}, [](const Output<Node>& output) -> bool {
             return has_static_rank()(output) && is_sinking_node(output);
         });
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
-        auto transpose_const = as_type_ptr<Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
+        auto transpose_const = as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto main_node = pattern_to_output.at(main_node_label).get_node_shared_ptr();
         if (transformation_callback(main_node)) {
             return false;
         }
 
-        auto concat_node = as_type_ptr<Concat>(main_node);
+        auto concat_node = as_type_ptr<ov::op::v0::Concat>(main_node);
         auto concat_axis = concat_node->get_concatenation_axis();
         if (concat_axis < 0) {
             return false;

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_concat.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_concat.cpp
@@ -5,10 +5,10 @@
 #include "transformations/transpose_sinking/ts_concat.hpp"
 
 #include "itt.hpp"
-#include "openvino/op/util/op_types.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/transpose.hpp"
+#include "openvino/op/util/op_types.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
 #include "transformations/transpose_sinking/ts_utils.hpp"
@@ -72,13 +72,15 @@ TSConcatBackward::TSConcatBackward() {
     auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
 
     auto transpose_label =
-        wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label}, [](const Output<Node>& output) -> bool {
-            return has_static_rank()(output) && is_sinking_node(output);
-        });
+        wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label},
+                                         [](const Output<Node>& output) -> bool {
+                                             return has_static_rank()(output) && is_sinking_node(output);
+                                         });
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
-        auto transpose_const = as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
+        auto transpose_const =
+            as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto main_node = pattern_to_output.at(main_node_label).get_node_shared_ptr();
         if (transformation_callback(main_node)) {

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_data_movement.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_data_movement.cpp
@@ -6,14 +6,18 @@
 
 #include "itt.hpp"
 #include "openvino/op/util/op_types.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/batch_to_space.hpp"
+#include "openvino/op/reverse_sequence.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/space_to_batch.hpp"
+#include "openvino/op/pad.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "openvino/util/common_util.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
 #include "transformations/transpose_sinking/ts_utils.hpp"
 
 using namespace ov;
-using namespace ov::opset10;
 using namespace ov::pass::pattern;
 using namespace ov::pass::transpose_sinking;
 using namespace ov::pass::transpose_sinking::utils;
@@ -21,9 +25,9 @@ using namespace ov::pass::transpose_sinking::utils;
 namespace {
 
 std::vector<size_t> get_indices_by_op_type(const std::shared_ptr<Node>& main_node) {
-    if (as_type_ptr<Pad>(main_node)) {
+    if (as_type_ptr<ov::op::v1::Pad>(main_node)) {
         return {1, 2};
-    } else if (as_type_ptr<BatchToSpace>(main_node) || as_type_ptr<SpaceToBatch>(main_node)) {
+    } else if (as_type_ptr<ov::op::v1::BatchToSpace>(main_node) || as_type_ptr<ov::op::v1::SpaceToBatch>(main_node)) {
         return {1, 2, 3};
     } else {
         return {};
@@ -34,9 +38,9 @@ std::vector<size_t> get_indices_by_op_type(const std::shared_ptr<Node>& main_nod
 
 TSDataMovementForward::TSDataMovementForward() {
     MATCHER_SCOPE(TSDataMovementForward);
-    auto const_label = wrap_type<Constant>();
-    auto transpose_label = wrap_type<Transpose>({any_input(), const_label});
-    auto main_node_label = wrap_type<Pad, BatchToSpace, SpaceToBatch, ReverseSequence>(
+    auto const_label = wrap_type<ov::op::v0::Constant>();
+    auto transpose_label = wrap_type<ov::op::v1::Transpose>({any_input(), const_label});
+    auto main_node_label = wrap_type<ov::op::v1::Pad, ov::op::v1::BatchToSpace, ov::op::v1::SpaceToBatch, ov::op::v0::ReverseSequence>(
         {transpose_label, any_input(), any_input(), any_input()});
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
@@ -47,12 +51,12 @@ TSDataMovementForward::TSDataMovementForward() {
             return false;
         }
 
-        auto transpose = std::dynamic_pointer_cast<Transpose>(pattern_to_node.at(transpose_label));
+        auto transpose = std::dynamic_pointer_cast<ov::op::v1::Transpose>(pattern_to_node.at(transpose_label));
         if (!transpose) {
             return false;
         }
 
-        auto transpose_const = as_type_ptr<Constant>(pattern_to_node.at(const_label));
+        auto transpose_const = as_type_ptr<ov::op::v0::Constant>(pattern_to_node.at(const_label));
         if (!transpose_const) {
             return false;
         }
@@ -63,7 +67,7 @@ TSDataMovementForward::TSDataMovementForward() {
 
         const auto transpose_axis_order = transpose_const->get_axis_vector_val();
         const auto reversed_transpose_order = ReverseTransposeOrder(transpose_axis_order);
-        auto axis = std::make_shared<Constant>(element::i32, Shape{}, 0);
+        auto axis = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{}, 0);
 
         const auto& indices = get_indices_by_op_type(main_node);
         for (const auto& idx : indices) {
@@ -71,7 +75,7 @@ TSDataMovementForward::TSDataMovementForward() {
                 ChangeValuesOrder(main_node->input_value(idx), reversed_transpose_order, axis));
         }
 
-        if (auto reverse_seq = as_type_ptr<ReverseSequence>(main_node)) {
+        if (auto reverse_seq = as_type_ptr<ov::op::v0::ReverseSequence>(main_node)) {
             reverse_seq->set_batch_axis(transpose_axis_order[reverse_seq->get_batch_axis()]);
             reverse_seq->set_sequence_axis(transpose_axis_order[reverse_seq->get_sequence_axis()]);
         }
@@ -92,20 +96,20 @@ TSDataMovementBackward::TSDataMovementBackward() {
     MATCHER_SCOPE(TSDataMovementBackward);
 
     auto main_node_label =
-        wrap_type<Pad, BatchToSpace, SpaceToBatch, ReverseSequence>([](const Output<Node>& output) -> bool {
+        wrap_type<ov::op::v1::Pad, ov::op::v1::BatchToSpace, ov::op::v1::SpaceToBatch, ov::op::v0::ReverseSequence>([](const Output<Node>& output) -> bool {
             return has_static_rank()(output) && HasSameOutputTransposeNodes(output);
         });
 
-    auto transpose_const_label = wrap_type<Constant>();
+    auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
 
     auto transpose_label =
-        wrap_type<Transpose>({main_node_label, transpose_const_label}, [](const Output<Node>& output) -> bool {
+        wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label}, [](const Output<Node>& output) -> bool {
             return has_static_rank()(output) && is_sinking_node(output);
         });
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
-        auto transpose_const = as_type_ptr<Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
+        auto transpose_const = as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto main_node = pattern_to_output.at(main_node_label).get_node_shared_ptr();
         if (transformation_callback(main_node)) {
@@ -123,14 +127,14 @@ TSDataMovementBackward::TSDataMovementBackward() {
         SwapNames(main_node, transpose);
         const auto transpose_axis_order = transpose_const->get_axis_vector_val();
         const auto reversed_transpose_order = ReverseTransposeOrder(transpose_axis_order);
-        auto axis = std::make_shared<Constant>(element::i32, Shape{}, 0);
+        auto axis = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{}, 0);
         const auto& indices = get_indices_by_op_type(main_node);
         for (const auto& idx : indices) {
             main_node->input(idx).replace_source_output(
                 ChangeValuesOrder(main_node->input_value(idx), transpose_axis_order, axis));
         }
 
-        if (auto reverse_seq = as_type_ptr<ReverseSequence>(main_node)) {
+        if (auto reverse_seq = as_type_ptr<ov::op::v0::ReverseSequence>(main_node)) {
             reverse_seq->set_batch_axis(reversed_transpose_order[reverse_seq->get_batch_axis()]);
             reverse_seq->set_sequence_axis(reversed_transpose_order[reverse_seq->get_sequence_axis()]);
         }

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_fuse.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_fuse.cpp
@@ -9,8 +9,8 @@
 
 #include "itt.hpp"
 #include "openvino/core/validation_util.hpp"
-#include "openvino/op/transpose.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/transpose.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/transpose_sinking/ts_utils.hpp"
 #include "transformations/utils/utils.hpp"
@@ -21,9 +21,11 @@ using namespace ov::pass::transpose_sinking::utils;
 
 TSFuse::TSFuse() {
     MATCHER_SCOPE(TransposeFuse);
-    auto transpose_1_label = pattern::wrap_type<ov::op::v1::Transpose>({pattern::any_input(), pattern::wrap_type<ov::op::v0::Constant>()},
-                                                           HasSameOutputTransposeNodes);
-    auto transpose_2_label = pattern::wrap_type<ov::op::v1::Transpose>({transpose_1_label, pattern::wrap_type<ov::op::v0::Constant>()});
+    auto transpose_1_label =
+        pattern::wrap_type<ov::op::v1::Transpose>({pattern::any_input(), pattern::wrap_type<ov::op::v0::Constant>()},
+                                                  HasSameOutputTransposeNodes);
+    auto transpose_2_label =
+        pattern::wrap_type<ov::op::v1::Transpose>({transpose_1_label, pattern::wrap_type<ov::op::v0::Constant>()});
     ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_map();
 
@@ -31,8 +33,10 @@ TSFuse::TSFuse() {
         auto transpose2 = pattern_to_output.at(transpose_2_label);
         auto input = transpose1->input_value(0);
 
-        auto transpose1_order = std::dynamic_pointer_cast<ov::op::v0::Constant>(transpose1->get_input_node_shared_ptr(1));
-        auto transpose2_order = std::dynamic_pointer_cast<ov::op::v0::Constant>(transpose2->get_input_node_shared_ptr(1));
+        auto transpose1_order =
+            std::dynamic_pointer_cast<ov::op::v0::Constant>(transpose1->get_input_node_shared_ptr(1));
+        auto transpose2_order =
+            std::dynamic_pointer_cast<ov::op::v0::Constant>(transpose2->get_input_node_shared_ptr(1));
         if (!transpose1_order || !transpose2_order)
             return false;
 

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_fuse.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_fuse.cpp
@@ -9,21 +9,21 @@
 
 #include "itt.hpp"
 #include "openvino/core/validation_util.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/transpose_sinking/ts_utils.hpp"
 #include "transformations/utils/utils.hpp"
 
 using namespace ov;
-using namespace opset10;
 using namespace ov::pass::transpose_sinking;
 using namespace ov::pass::transpose_sinking::utils;
 
 TSFuse::TSFuse() {
     MATCHER_SCOPE(TransposeFuse);
-    auto transpose_1_label = pattern::wrap_type<Transpose>({pattern::any_input(), pattern::wrap_type<Constant>()},
+    auto transpose_1_label = pattern::wrap_type<ov::op::v1::Transpose>({pattern::any_input(), pattern::wrap_type<ov::op::v0::Constant>()},
                                                            HasSameOutputTransposeNodes);
-    auto transpose_2_label = pattern::wrap_type<Transpose>({transpose_1_label, pattern::wrap_type<Constant>()});
+    auto transpose_2_label = pattern::wrap_type<ov::op::v1::Transpose>({transpose_1_label, pattern::wrap_type<ov::op::v0::Constant>()});
     ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_map();
 
@@ -31,8 +31,8 @@ TSFuse::TSFuse() {
         auto transpose2 = pattern_to_output.at(transpose_2_label);
         auto input = transpose1->input_value(0);
 
-        auto transpose1_order = std::dynamic_pointer_cast<Constant>(transpose1->get_input_node_shared_ptr(1));
-        auto transpose2_order = std::dynamic_pointer_cast<Constant>(transpose2->get_input_node_shared_ptr(1));
+        auto transpose1_order = std::dynamic_pointer_cast<ov::op::v0::Constant>(transpose1->get_input_node_shared_ptr(1));
+        auto transpose2_order = std::dynamic_pointer_cast<ov::op::v0::Constant>(transpose2->get_input_node_shared_ptr(1));
         if (!transpose1_order || !transpose2_order)
             return false;
 
@@ -60,8 +60,8 @@ TSFuse::TSFuse() {
                 ov::replace_output_update_name(out_transpose.get_node()->output(0), input);
             }
         } else {
-            auto new_order = Constant::create(transpose_order_type, {order2.size()}, order2);
-            auto new_transpose = register_new_node<Transpose>(input, new_order);
+            auto new_order = ov::op::v0::Constant::create(transpose_order_type, {order2.size()}, order2);
+            auto new_transpose = register_new_node<ov::op::v1::Transpose>(input, new_order);
 
             new_transpose->set_friendly_name(m.get_match_root()->get_friendly_name());
             RemoveSingleOutputConsumers(transpose1);

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_gather.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_gather.cpp
@@ -6,13 +6,16 @@
 
 #include "itt.hpp"
 #include "openvino/op/util/op_types.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
 #include "transformations/transpose_sinking/ts_utils.hpp"
 
 using namespace ov;
-using namespace ov::opset10;
 using namespace ov::pass::pattern;
 using namespace ov::pass::transpose_sinking;
 using namespace ov::pass::transpose_sinking::utils;
@@ -20,20 +23,20 @@ using namespace ov::pass::transpose_sinking::utils;
 TSGatherForward::TSGatherForward() {
     MATCHER_SCOPE(TSGatherForward);
 
-    auto transpose_label = wrap_type<Transpose>({any_input(), wrap_type<Constant>()});
-    auto gather_label = wrap_type<Gather>({transpose_label, any_input(), wrap_type<Constant>()});
+    auto transpose_label = wrap_type<ov::op::v1::Transpose>({any_input(), wrap_type<ov::op::v0::Constant>()});
+    auto gather_label = wrap_type<ov::op::v8::Gather>({transpose_label, any_input(), wrap_type<ov::op::v0::Constant>()});
 
     ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_map();
 
-        auto transpose = as_type_ptr<Transpose>(pattern_to_output.at(transpose_label));
-        auto main_node = as_type_ptr<Gather>(pattern_to_output.at(gather_label));
+        auto transpose = as_type_ptr<ov::op::v1::Transpose>(pattern_to_output.at(transpose_label));
+        auto main_node = as_type_ptr<ov::op::v8::Gather>(pattern_to_output.at(gather_label));
         if (transformation_callback(main_node) || !main_node) {
             return false;
         }
 
-        auto transpose_order = as_type_ptr<Constant>(transpose->get_input_node_shared_ptr(1));
-        auto gather_axis = as_type_ptr<Constant>(main_node->get_input_node_shared_ptr(2));
+        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+        auto gather_axis = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(2));
         if (!transpose || !transpose_order || !gather_axis) {
             return false;
         }
@@ -82,14 +85,14 @@ TSGatherForward::TSGatherForward() {
         }
 
         auto new_order_const =
-            Constant::create(transpose_order->get_element_type(), {new_transpose_order.size()}, new_transpose_order);
+            ov::op::v0::Constant::create(transpose_order->get_element_type(), {new_transpose_order.size()}, new_transpose_order);
         TransposeInputsInfo transpose_input_info = {transpose, new_order_const, 0};
         // deletes Transpose from 0 input
         auto success = sink_forward::UpdateInputTransposes(main_node, transpose_input_info, {0});
         if (!success) {
             return false;
         }
-        auto new_axis = Constant::create(gather_axis->get_element_type(), gather_axis->get_shape(), {order_val[axis]});
+        auto new_axis = ov::op::v0::Constant::create(gather_axis->get_element_type(), gather_axis->get_shape(), {order_val[axis]});
         main_node->input(2).replace_source_output(new_axis);
         copy_runtime_info(gather_axis, new_axis);
         main_node->validate_and_infer_types();
@@ -109,23 +112,23 @@ TSGatherBackward::TSGatherBackward() {
     MATCHER_SCOPE(TSGatherBackward);
 
     auto gather_label =
-        wrap_type<Gather>({any_input(), any_input(), wrap_type<Constant>()}, HasSameOutputTransposeNodes);
+        wrap_type<ov::op::v8::Gather>({any_input(), any_input(), wrap_type<ov::op::v0::Constant>()}, HasSameOutputTransposeNodes);
     auto transpose_label =
-        wrap_type<Transpose>({gather_label, wrap_type<Constant>()}, [](const Output<Node>& output) -> bool {
+        wrap_type<ov::op::v1::Transpose>({gather_label, wrap_type<ov::op::v0::Constant>()}, [](const Output<Node>& output) -> bool {
             return has_static_rank()(output) && is_sinking_node(output);
         });
 
     ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_map();
 
-        auto transpose = as_type_ptr<Transpose>(pattern_to_output.at(transpose_label));
-        auto main_node = as_type_ptr<Gather>(pattern_to_output.at(gather_label));
+        auto transpose = as_type_ptr<ov::op::v1::Transpose>(pattern_to_output.at(transpose_label));
+        auto main_node = as_type_ptr<ov::op::v8::Gather>(pattern_to_output.at(gather_label));
         if (transformation_callback(main_node) || !main_node) {
             return false;
         }
 
-        auto transpose_order = as_type_ptr<Constant>(transpose->get_input_node_shared_ptr(1));
-        auto gather_axis = as_type_ptr<Constant>(main_node->get_input_node_shared_ptr(2));
+        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+        auto gather_axis = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(2));
         if (!transpose || !transpose_order || !gather_axis) {
             return false;
         }
@@ -164,7 +167,7 @@ TSGatherBackward::TSGatherBackward() {
         bool success = false;
         std::vector<size_t> axes_val;
         if (optimization) {
-            auto squeeze = std::make_shared<Squeeze>(main_node->input_value(1));
+            auto squeeze = std::make_shared<ov::op::v0::Squeeze>(main_node->input_value(1));
             main_node->input(1).replace_source_output(squeeze);
             main_node->validate_and_infer_types();
             auto new_out_pshape = main_node->get_output_partial_shape(0);
@@ -220,21 +223,21 @@ TSGatherBackward::TSGatherBackward() {
         SwapNames(main_node, transpose);
         if (success) {
             auto target_inputs = main_node->get_output_target_inputs(0);
-            auto unsqueeze_axes = Constant::create(element::i32, {axes_val.size()}, axes_val);
-            auto unsqueeze = std::make_shared<Unsqueeze>(main_node, unsqueeze_axes);
+            auto unsqueeze_axes = ov::op::v0::Constant::create(element::i32, {axes_val.size()}, axes_val);
+            auto unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(main_node, unsqueeze_axes);
             for (const auto& input : target_inputs) {
                 input.replace_source_output(unsqueeze);
             }
         }
         const auto reversed_transpose_order = ReverseTransposeOrder(order_val);
         const auto& transpose_const =
-            Constant::create(transpose_order->get_element_type(), {new_transpose_order.size()}, new_transpose_order);
+            ov::op::v0::Constant::create(transpose_order->get_element_type(), {new_transpose_order.size()}, new_transpose_order);
         for (auto& new_node : sink_backward::InsertTransposeBeforeNode(main_node,
                                                                        transpose_const,
                                                                        /* input_indexes= */ {0})) {
             register_new_node(new_node);
         }
-        auto new_axis = std::make_shared<Constant>(element::i32, Shape{1}, reversed_transpose_order[axis]);
+        auto new_axis = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{1}, reversed_transpose_order[axis]);
         copy_runtime_info(gather_axis, new_axis);
         main_node->input(2).replace_source_output(new_axis);
         main_node->validate_and_infer_types();

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_interpolate.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_interpolate.cpp
@@ -5,10 +5,10 @@
 #include "transformations/transpose_sinking/ts_interpolate.hpp"
 
 #include "itt.hpp"
-#include "openvino/op/util/op_types.hpp"
-#include "openvino/op/transpose.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/interpolate.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/util/op_types.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "openvino/util/common_util.hpp"
@@ -95,13 +95,15 @@ TSInterpolateBackward::TSInterpolateBackward() {
     auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
 
     auto transpose_label =
-        wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label}, [](const Output<Node>& output) -> bool {
-            return has_static_rank()(output) && is_sinking_node(output);
-        });
+        wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label},
+                                         [](const Output<Node>& output) -> bool {
+                                             return has_static_rank()(output) && is_sinking_node(output);
+                                         });
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
-        auto transpose_const = as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
+        auto transpose_const =
+            as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto main_node = pattern_to_output.at(main_node_label).get_node_shared_ptr();
         if (transformation_callback(main_node)) {

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_interpolate.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_interpolate.cpp
@@ -6,7 +6,9 @@
 
 #include "itt.hpp"
 #include "openvino/op/util/op_types.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/interpolate.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "openvino/util/common_util.hpp"
@@ -14,16 +16,15 @@
 #include "transformations/transpose_sinking/ts_utils.hpp"
 
 using namespace ov;
-using namespace ov::opset10;
 using namespace ov::pass::pattern;
 using namespace ov::pass::transpose_sinking;
 using namespace ov::pass::transpose_sinking::utils;
 
 TSInterpolateForward::TSInterpolateForward() {
     MATCHER_SCOPE(TSInterpolateForward);
-    auto const_label = wrap_type<Constant>();
-    auto transpose_label = wrap_type<Transpose>({any_input(), const_label});
-    auto main_node_label = wrap_type<Interpolate>({transpose_label, any_input(), any_input(), any_input()});
+    auto const_label = wrap_type<ov::op::v0::Constant>();
+    auto transpose_label = wrap_type<ov::op::v1::Transpose>({any_input(), const_label});
+    auto main_node_label = wrap_type<ov::op::v4::Interpolate>({transpose_label, any_input(), any_input(), any_input()});
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_node = m.get_pattern_map();
@@ -33,12 +34,12 @@ TSInterpolateForward::TSInterpolateForward() {
             return false;
         }
 
-        auto transpose = std::dynamic_pointer_cast<Transpose>(pattern_to_node.at(transpose_label));
+        auto transpose = std::dynamic_pointer_cast<ov::op::v1::Transpose>(pattern_to_node.at(transpose_label));
         if (!transpose) {
             return false;
         }
 
-        auto transpose_const = as_type_ptr<Constant>(pattern_to_node.at(const_label));
+        auto transpose_const = as_type_ptr<ov::op::v0::Constant>(pattern_to_node.at(const_label));
         if (!transpose_const) {
             return false;
         }
@@ -48,9 +49,9 @@ TSInterpolateForward::TSInterpolateForward() {
         main_node->input(0).replace_source_output(transpose_parent);
 
         const auto transpose_axis_order = transpose_const->get_axis_vector_val();
-        auto axis = std::make_shared<Constant>(element::i32, Shape{}, 0);
+        auto axis = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{}, 0);
 
-        const auto& interpolate = std::dynamic_pointer_cast<Interpolate>(main_node);
+        const auto& interpolate = std::dynamic_pointer_cast<ov::op::v4::Interpolate>(main_node);
         const auto& new_axes = ChangeAxes(main_node->input_value(3), transpose_axis_order, axis);
         main_node->input(3).replace_source_output(new_axes);
 
@@ -87,20 +88,20 @@ TSInterpolateForward::TSInterpolateForward() {
 TSInterpolateBackward::TSInterpolateBackward() {
     MATCHER_SCOPE(TSInterpolateBackward);
 
-    auto main_node_label = wrap_type<Interpolate>([](const Output<Node>& output) -> bool {
+    auto main_node_label = wrap_type<ov::op::v4::Interpolate>([](const Output<Node>& output) -> bool {
         return has_static_rank()(output) && HasSameOutputTransposeNodes(output);
     });
 
-    auto transpose_const_label = wrap_type<Constant>();
+    auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
 
     auto transpose_label =
-        wrap_type<Transpose>({main_node_label, transpose_const_label}, [](const Output<Node>& output) -> bool {
+        wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label}, [](const Output<Node>& output) -> bool {
             return has_static_rank()(output) && is_sinking_node(output);
         });
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
-        auto transpose_const = as_type_ptr<Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
+        auto transpose_const = as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto main_node = pattern_to_output.at(main_node_label).get_node_shared_ptr();
         if (transformation_callback(main_node)) {
@@ -118,11 +119,11 @@ TSInterpolateBackward::TSInterpolateBackward() {
         SwapNames(main_node, transpose);
         const auto transpose_axis_order = transpose_const->get_axis_vector_val();
         const auto reversed_transpose_order = ReverseTransposeOrder(transpose_axis_order);
-        auto axis = std::make_shared<Constant>(element::i32, Shape{}, 0);
+        auto axis = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{}, 0);
         auto new_axes = ChangeAxes(main_node->input_value(3), reversed_transpose_order, axis);
         main_node->input(3).replace_source_output(new_axes);
 
-        const auto& interpolate = std::dynamic_pointer_cast<Interpolate>(main_node);
+        const auto& interpolate = std::dynamic_pointer_cast<ov::op::v4::Interpolate>(main_node);
         if (interpolate) {
             op::v4::Interpolate::InterpolateAttrs attrs = interpolate->get_attrs();
             if (!attrs.pads_begin.empty() || !attrs.pads_end.empty()) {

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_reduction.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_reduction.cpp
@@ -11,14 +11,14 @@
 #include "openvino/core/validation_util.hpp"
 #include "openvino/op/util/arithmetic_reductions_keep_dims.hpp"
 #include "openvino/op/util/logical_reduction_keep_dims.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
 #include "transformations/transpose_sinking/ts_utils.hpp"
 #include "transformations/utils/utils.hpp"
 
 using namespace ov;
-using namespace opset10;
 using namespace ov::pass::pattern;
 using namespace ov::pass::transpose_sinking;
 using namespace ov::pass::transpose_sinking::utils;
@@ -42,21 +42,21 @@ bool get_keep_dims(const std::shared_ptr<Node>& main_node) {
 TSReductionForward::TSReductionForward() {
     MATCHER_SCOPE(TSReductionForward);
 
-    auto transpose_label = wrap_type<Transpose>({any_input(), wrap_type<Constant>()});
+    auto transpose_label = wrap_type<ov::op::v1::Transpose>({any_input(), wrap_type<ov::op::v0::Constant>()});
     auto reduce_label = wrap_type<op::util::ArithmeticReductionKeepDims, op::util::LogicalReductionKeepDims>(
-        {transpose_label, wrap_type<Constant>()});
+        {transpose_label, wrap_type<ov::op::v0::Constant>()});
 
     ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_map();
-        auto transpose = as_type_ptr<Transpose>(pattern_to_output.at(transpose_label));
+        auto transpose = as_type_ptr<ov::op::v1::Transpose>(pattern_to_output.at(transpose_label));
         auto main_node = pattern_to_output.at(reduce_label);
         if (!transpose || transformation_callback(main_node)) {
             return false;
         }
 
         auto keep_dims = get_keep_dims(main_node);
-        auto transpose_order = as_type_ptr<Constant>(transpose->get_input_node_shared_ptr(1));
-        auto reduction_axes = as_type_ptr<Constant>(main_node->get_input_node_shared_ptr(1));
+        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+        auto reduction_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
         if (!transpose_order || !reduction_axes)
             return false;
 
@@ -77,11 +77,11 @@ TSReductionForward::TSReductionForward() {
             transpose_order_values = GetOrderAfterReduction(non_negative_axes, transpose_order_values);
         }
 
-        auto new_transpose_order = Constant::create(transpose_order->get_element_type(),
+        auto new_transpose_order = ov::op::v0::Constant::create(transpose_order->get_element_type(),
                                                     {transpose_order_values.size()},
                                                     transpose_order_values);
 
-        auto new_const = Constant::create(reduction_axes->get_element_type(), {new_values.size()}, new_values);
+        auto new_const = ov::op::v0::Constant::create(reduction_axes->get_element_type(), {new_values.size()}, new_values);
         main_node->input(1).replace_source_output(new_const);
         TransposeInputsInfo transpose_input_info = {transpose, new_transpose_order, 0};
         // deletes Transpose from 0 input
@@ -107,10 +107,10 @@ TSReductionBackward::TSReductionBackward() {
     MATCHER_SCOPE(TSReductionBackward);
 
     auto reduce_label = wrap_type<op::util::ArithmeticReductionKeepDims, op::util::LogicalReductionKeepDims>(
-        {any_input(), wrap_type<Constant>()},
+        {any_input(), wrap_type<ov::op::v0::Constant>()},
         HasSameOutputTransposeNodes);
     auto transpose_label =
-        wrap_type<Transpose>({reduce_label, wrap_type<Constant>()}, [](const Output<Node>& output) -> bool {
+        wrap_type<ov::op::v1::Transpose>({reduce_label, wrap_type<ov::op::v0::Constant>()}, [](const Output<Node>& output) -> bool {
             return has_static_rank()(output) && is_sinking_node(output);
         });
 
@@ -124,8 +124,8 @@ TSReductionBackward::TSReductionBackward() {
 
         auto keep_dims = get_keep_dims(main_node);
 
-        auto transpose_order = as_type_ptr<Constant>(transpose->get_input_node_shared_ptr(1));
-        auto reduction_axes = as_type_ptr<Constant>(main_node->get_input_node_shared_ptr(1));
+        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+        auto reduction_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
         if (!transpose_order || !reduction_axes)
             return false;
 
@@ -140,7 +140,7 @@ TSReductionBackward::TSReductionBackward() {
             transpose_order_values = GetOrderBeforeReduction(non_negative_axes, transpose_order_values);
         }
         auto reversed_order_values = ReverseTransposeOrder(transpose_order_values);
-        auto new_transpose_order = Constant::create(transpose_order->get_element_type(),
+        auto new_transpose_order = ov::op::v0::Constant::create(transpose_order->get_element_type(),
                                                     {transpose_order_values.size()},
                                                     transpose_order_values);
 
@@ -149,7 +149,7 @@ TSReductionBackward::TSReductionBackward() {
             new_values.push_back(reversed_order_values[axis]);
         }
 
-        auto new_const = Constant::create(reduction_axes->get_element_type(), {new_values.size()}, new_values);
+        auto new_const = ov::op::v0::Constant::create(reduction_axes->get_element_type(), {new_values.size()}, new_values);
         main_node->input(1).replace_source_output(new_const);
         for (auto& new_node : sink_backward::InsertTransposeBeforeNode(main_node, new_transpose_order, {0})) {
             register_new_node(new_node);

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_slice.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_slice.cpp
@@ -6,7 +6,10 @@
 
 #include "itt.hpp"
 #include "openvino/op/util/op_types.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/slice.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "openvino/util/common_util.hpp"
@@ -14,16 +17,15 @@
 #include "transformations/transpose_sinking/ts_utils.hpp"
 
 using namespace ov;
-using namespace ov::opset10;
 using namespace ov::pass::pattern;
 using namespace ov::pass::transpose_sinking;
 using namespace ov::pass::transpose_sinking::utils;
 
 TSSliceForward::TSSliceForward() {
     MATCHER_SCOPE(TSSliceForward);
-    auto const_label = wrap_type<Constant>();
-    auto transpose_label = wrap_type<Transpose>({any_input(), const_label});
-    auto main_node_label = wrap_type<Slice>({transpose_label, any_input(), any_input(), any_input(), any_input()});
+    auto const_label = wrap_type<ov::op::v0::Constant>();
+    auto transpose_label = wrap_type<ov::op::v1::Transpose>({any_input(), const_label});
+    auto main_node_label = wrap_type<ov::op::v8::Slice>({transpose_label, any_input(), any_input(), any_input(), any_input()});
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_node = m.get_pattern_map();
@@ -33,12 +35,12 @@ TSSliceForward::TSSliceForward() {
             return false;
         }
 
-        auto transpose = std::dynamic_pointer_cast<Transpose>(pattern_to_node.at(transpose_label));
+        auto transpose = std::dynamic_pointer_cast<ov::op::v1::Transpose>(pattern_to_node.at(transpose_label));
         if (!transpose || main_node->get_input_size() < 5) {
             return false;
         }
 
-        auto transpose_const = as_type_ptr<Constant>(pattern_to_node.at(const_label));
+        auto transpose_const = as_type_ptr<ov::op::v0::Constant>(pattern_to_node.at(const_label));
         if (!transpose_const) {
             return false;
         }
@@ -48,11 +50,11 @@ TSSliceForward::TSSliceForward() {
         main_node->input(0).replace_source_output(transpose_parent);
 
         const auto transpose_axis_order = transpose_const->get_axis_vector_val();
-        auto axis = std::make_shared<Constant>(element::i32, Shape{}, std::vector<int32_t>{0});
+        auto axis = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{}, std::vector<int32_t>{0});
 
-        auto data = std::make_shared<Constant>(element::i32, Shape{transpose_axis_order.size()}, transpose_axis_order);
+        auto data = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{transpose_axis_order.size()}, transpose_axis_order);
         const auto& indices = main_node->input_value(4);
-        auto new_axis = std::make_shared<Gather>(data, indices, axis);
+        auto new_axis = std::make_shared<ov::op::v8::Gather>(data, indices, axis);
 
         main_node->input(4).replace_source_output(new_axis);
 
@@ -72,20 +74,20 @@ TSSliceForward::TSSliceForward() {
 TSSliceBackward::TSSliceBackward() {
     MATCHER_SCOPE(TSSliceBackward);
 
-    auto main_node_label = wrap_type<Slice>([](const Output<Node>& output) -> bool {
+    auto main_node_label = wrap_type<ov::op::v8::Slice>([](const Output<Node>& output) -> bool {
         return has_static_rank()(output) && HasSameOutputTransposeNodes(output);
     });
 
-    auto transpose_const_label = wrap_type<Constant>();
+    auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
 
     auto transpose_label =
-        wrap_type<Transpose>({main_node_label, transpose_const_label}, [](const Output<Node>& output) -> bool {
+        wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label}, [](const Output<Node>& output) -> bool {
             return has_static_rank()(output) && is_sinking_node(output);
         });
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
-        auto transpose_const = as_type_ptr<Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
+        auto transpose_const = as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto main_node = pattern_to_output.at(main_node_label).get_node_shared_ptr();
         if (transformation_callback(main_node)) {
@@ -107,11 +109,11 @@ TSSliceBackward::TSSliceBackward() {
         SwapNames(main_node, transpose);
         const auto transpose_axis_order = transpose_const->get_axis_vector_val();
         const auto reversed_transpose_order = ReverseTransposeOrder(transpose_axis_order);
-        auto axis = std::make_shared<Constant>(element::i32, Shape{}, std::vector<int32_t>{0});
+        auto axis = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{}, std::vector<int32_t>{0});
         auto data =
-            std::make_shared<Constant>(element::i32, Shape{reversed_transpose_order.size()}, reversed_transpose_order);
+            std::make_shared<ov::op::v0::Constant>(element::i32, Shape{reversed_transpose_order.size()}, reversed_transpose_order);
         const auto& indices = main_node->input_value(4);
-        auto new_axis = std::make_shared<Gather>(data, indices, axis);
+        auto new_axis = std::make_shared<ov::op::v8::Gather>(data, indices, axis);
         main_node->input(4).replace_source_output(new_axis);
 
         main_node->validate_and_infer_types();

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_split.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_split.cpp
@@ -5,11 +5,11 @@
 #include "transformations/transpose_sinking/ts_split.hpp"
 
 #include "itt.hpp"
-#include "openvino/op/util/op_types.hpp"
-#include "openvino/op/transpose.hpp"
 #include "openvino/op/constant.hpp"
-#include "openvino/op/variadic_split.hpp"
 #include "openvino/op/split.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/util/op_types.hpp"
+#include "openvino/op/variadic_split.hpp"
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
@@ -161,8 +161,8 @@ TSSplitBackward::TSSplitBackward() {
         {
             auto input_node = split->input_value(0);
             auto new_transpose_const = std::make_shared<ov::op::v0::Constant>(transpose_element_type,
-                                                                  Shape{transpose_axis_order.size()},
-                                                                  transpose_axis_order);
+                                                                              Shape{transpose_axis_order.size()},
+                                                                              transpose_axis_order);
             auto new_transpose = std::make_shared<ov::op::v1::Transpose>(input_node, new_transpose_const);
 
             split->input(0).replace_source_output(new_transpose->output(0));
@@ -174,8 +174,8 @@ TSSplitBackward::TSSplitBackward() {
 
         // update split axis
         auto new_split_axis_const = std::make_shared<ov::op::v0::Constant>(split_axis_constant->get_element_type(),
-                                                               Shape{},
-                                                               reversed_transposed_split_axis);
+                                                                           Shape{},
+                                                                           reversed_transposed_split_axis);
         split->input(1).replace_source_output(new_split_axis_const);
         copy_runtime_info({split_axis_constant,
                            output_transpose.transpose->shared_from_this(),
@@ -220,8 +220,9 @@ TSSplitForward::TSSplitForward() {
         sink_forward::RemoveInputNode(main_node, /* input_idx */ 0);
         const auto transpose_axis_order = transpose_input_info.transpose_const->get_axis_vector_val();
         const size_t transposed_split_axis = transpose_axis_order[split_axis];
-        auto new_split_axis_const =
-            std::make_shared<ov::op::v0::Constant>(split_axis_constant->get_element_type(), Shape{}, transposed_split_axis);
+        auto new_split_axis_const = std::make_shared<ov::op::v0::Constant>(split_axis_constant->get_element_type(),
+                                                                           Shape{},
+                                                                           transposed_split_axis);
         main_node->input(1).replace_source_output(new_split_axis_const);
         copy_runtime_info({split_axis_constant, transpose_input_info.transpose, transpose_input_info.transpose_const},
                           new_split_axis_const);

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_split.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_split.cpp
@@ -6,7 +6,10 @@
 
 #include "itt.hpp"
 #include "openvino/op/util/op_types.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/variadic_split.hpp"
+#include "openvino/op/split.hpp"
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
@@ -15,7 +18,6 @@
 
 using namespace ov::pass::pattern;
 using namespace ov;
-using namespace ov::opset10;
 using namespace ov::pass::transpose_sinking;
 using namespace ov::pass::transpose_sinking::utils;
 
@@ -25,17 +27,17 @@ using NodePtr = std::shared_ptr<Node>;
 
 struct OutputTranspose {
     OutputTranspose() : transpose(nullptr), transpose_const(nullptr) {}
-    Transpose* transpose;
-    Constant* transpose_const;
+    ov::op::v1::Transpose* transpose;
+    ov::op::v0::Constant* transpose_const;
 };
 
 OutputTranspose GetOutputTransposes(const NodePtr& node) {
     for (size_t output_idx = 0; output_idx < node->get_output_size(); ++output_idx) {
         for (auto& input : node->get_output_target_inputs(output_idx)) {
-            auto transpose_node = dynamic_cast<Transpose*>(input.get_node());
+            auto transpose_node = dynamic_cast<ov::op::v1::Transpose*>(input.get_node());
             if (!transpose_node)
                 continue;
-            auto constant_node = dynamic_cast<Constant*>(transpose_node->input_value(1).get_node());
+            auto constant_node = dynamic_cast<ov::op::v0::Constant*>(transpose_node->input_value(1).get_node());
             if (!constant_node)
                 continue;
             {
@@ -63,7 +65,7 @@ std::shared_ptr<ov::Node> FindInputNode(ov::Node* node) {
 }
 
 bool HasInputSplitAndTransposeSiblings(const Output<Node>& output) {
-    NodePtr main_node = FindInputNode<Split>(output.get_node());
+    NodePtr main_node = FindInputNode<ov::op::v1::Split>(output.get_node());
     if (!main_node) {
         return false;
     }
@@ -75,7 +77,7 @@ bool IsSplitSinked(const Output<Node>& output) {
     return HasInputSplitAndTransposeSiblings(output) && is_sinking_node(output);
 }
 
-bool GetSplitAxis(const std::shared_ptr<Constant>& split_axis, const ov::Rank& rank, int64_t& axis) {
+bool GetSplitAxis(const std::shared_ptr<ov::op::v0::Constant>& split_axis, const ov::Rank& rank, int64_t& axis) {
     auto split_axis_val = split_axis->cast_vector<int64_t>();
     if (split_axis_val.empty()) {
         return false;
@@ -122,22 +124,22 @@ bool GetSplitAxis(const std::shared_ptr<Constant>& split_axis, const ov::Rank& r
 TSSplitBackward::TSSplitBackward() {
     MATCHER_SCOPE(TSSplitBackward);
 
-    auto transpose_const_label = wrap_type<Constant>();
-    auto transpose_label = wrap_type<Transpose>({any_input(), transpose_const_label}, IsSplitSinked);
+    auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
+    auto transpose_label = wrap_type<ov::op::v1::Transpose>({any_input(), transpose_const_label}, IsSplitSinked);
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
         auto transpose_label_node = pattern_to_output.at(transpose_label).get_node();
 
-        NodePtr split = FindInputNode<Split>(transpose_label_node);
+        NodePtr split = FindInputNode<ov::op::v1::Split>(transpose_label_node);
         if (!split) {
-            split = FindInputNode<VariadicSplit>(transpose_label_node);
+            split = FindInputNode<ov::op::v1::VariadicSplit>(transpose_label_node);
         }
 
         if (!split || transformation_callback(split)) {
             return false;
         }
-        auto split_axis_constant = as_type_ptr<Constant>(split->input_value(1).get_node_shared_ptr());
+        auto split_axis_constant = as_type_ptr<ov::op::v0::Constant>(split->input_value(1).get_node_shared_ptr());
         if (!split_axis_constant) {
             return false;
         }
@@ -158,10 +160,10 @@ TSSplitBackward::TSSplitBackward() {
         // insert transpose before split
         {
             auto input_node = split->input_value(0);
-            auto new_transpose_const = std::make_shared<Constant>(transpose_element_type,
+            auto new_transpose_const = std::make_shared<ov::op::v0::Constant>(transpose_element_type,
                                                                   Shape{transpose_axis_order.size()},
                                                                   transpose_axis_order);
-            auto new_transpose = std::make_shared<Transpose>(input_node, new_transpose_const);
+            auto new_transpose = std::make_shared<ov::op::v1::Transpose>(input_node, new_transpose_const);
 
             split->input(0).replace_source_output(new_transpose->output(0));
 
@@ -171,7 +173,7 @@ TSSplitBackward::TSSplitBackward() {
         }
 
         // update split axis
-        auto new_split_axis_const = std::make_shared<Constant>(split_axis_constant->get_element_type(),
+        auto new_split_axis_const = std::make_shared<ov::op::v0::Constant>(split_axis_constant->get_element_type(),
                                                                Shape{},
                                                                reversed_transposed_split_axis);
         split->input(1).replace_source_output(new_split_axis_const);
@@ -193,7 +195,7 @@ TSSplitBackward::TSSplitBackward() {
 TSSplitForward::TSSplitForward() {
     MATCHER_SCOPE(TSSplitForward);
 
-    auto main_node_label = wrap_type<Split, VariadicSplit>(IfNodeHasTransposeInputs);
+    auto main_node_label = wrap_type<ov::op::v1::Split, ov::op::v1::VariadicSplit>(IfNodeHasTransposeInputs);
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
@@ -204,7 +206,7 @@ TSSplitForward::TSSplitForward() {
             return false;
         }
 
-        auto split_axis_constant = as_type_ptr<Constant>(main_node->input_value(1).get_node_shared_ptr());
+        auto split_axis_constant = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(1).get_node_shared_ptr());
         if (!split_axis_constant) {
             return false;
         }
@@ -219,7 +221,7 @@ TSSplitForward::TSSplitForward() {
         const auto transpose_axis_order = transpose_input_info.transpose_const->get_axis_vector_val();
         const size_t transposed_split_axis = transpose_axis_order[split_axis];
         auto new_split_axis_const =
-            std::make_shared<Constant>(split_axis_constant->get_element_type(), Shape{}, transposed_split_axis);
+            std::make_shared<ov::op::v0::Constant>(split_axis_constant->get_element_type(), Shape{}, transposed_split_axis);
         main_node->input(1).replace_source_output(new_split_axis_const);
         copy_runtime_info({split_axis_constant, transpose_input_info.transpose, transpose_input_info.transpose_const},
                           new_split_axis_const);

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_squeeze.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_squeeze.cpp
@@ -9,7 +9,10 @@
 
 #include "itt.hpp"
 #include "openvino/core/validation_util.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/reshape.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
@@ -17,7 +20,6 @@
 #include "transformations/utils/utils.hpp"
 
 using namespace ov;
-using namespace opset10;
 using namespace ov::pass::pattern;
 using namespace ov::pass::transpose_sinking;
 using namespace ov::pass::transpose_sinking::utils;
@@ -25,7 +27,7 @@ using namespace ov::pass::transpose_sinking::utils;
 namespace {
 
 /**
- * @brief Checks that Reshape operation is equal to Squeeze:
+ * @brief Checks that Reshape operation is equal to ov::op::v0::Squeeze:
  * Only 1 dims are deleted, all other dims must be the same.
  * Converts these 1 dims to axes format.
  * @arg reshape Reshape operation.
@@ -33,7 +35,7 @@ namespace {
  * @arg result_axes Contains axes which will be squeezed.
  */
 bool shape_to_squeeze_axes(const std::shared_ptr<Node>& reshape,
-                           const std::shared_ptr<Constant>& reshape_to_shape,
+                           const std::shared_ptr<ov::op::v0::Constant>& reshape_to_shape,
                            std::vector<size_t>& result_axes) {
     result_axes.clear();
     auto reduction_axes_values = reshape_to_shape->cast_vector<int64_t>();
@@ -102,15 +104,15 @@ bool squeeze_axes_to_shape(const Output<Node>& input_node,
 TSSqueezeForward::TSSqueezeForward() {
     MATCHER_SCOPE(TSSqueezeForward);
 
-    auto transpose_label = wrap_type<Transpose>({any_input(), wrap_type<Constant>()});
-    auto squeeze_with_1_input = wrap_type<Squeeze>({transpose_label});
-    auto squeeze_label = wrap_type<Squeeze, Reshape>({transpose_label, wrap_type<Constant>()});
+    auto transpose_label = wrap_type<ov::op::v1::Transpose>({any_input(), wrap_type<ov::op::v0::Constant>()});
+    auto squeeze_with_1_input = wrap_type<ov::op::v0::Squeeze>({transpose_label});
+    auto squeeze_label = wrap_type<ov::op::v0::Squeeze, ov::op::v1::Reshape>({transpose_label, wrap_type<ov::op::v0::Constant>()});
     auto pattern = std::make_shared<pattern::op::Or>(OutputVector{squeeze_with_1_input, squeeze_label});
 
     ov::matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_map();
 
-        auto transpose = as_type_ptr<Transpose>(pattern_to_output.at(transpose_label));
+        auto transpose = as_type_ptr<ov::op::v1::Transpose>(pattern_to_output.at(transpose_label));
         std::shared_ptr<Node> main_node;
         if (pattern_to_output.count(squeeze_label)) {
             main_node = pattern_to_output.at(squeeze_label);
@@ -121,20 +123,20 @@ TSSqueezeForward::TSSqueezeForward() {
             return false;
         }
 
-        auto transpose_order = as_type_ptr<Constant>(transpose->get_input_node_shared_ptr(1));
+        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
 
         if (!transpose_order) {
             return false;
         }
 
         std::vector<size_t> non_negative_axes;
-        std::shared_ptr<Constant> squeeze_axes;
+        std::shared_ptr<ov::op::v0::Constant> squeeze_axes;
         if (main_node->get_input_size() > 1) {
-            squeeze_axes = as_type_ptr<Constant>(main_node->get_input_node_shared_ptr(1));
+            squeeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
             if (!squeeze_axes) {
                 return false;
             }
-            if (as_type_ptr<Reshape>(main_node)) {
+            if (as_type_ptr<ov::op::v1::Reshape>(main_node)) {
                 auto success = shape_to_squeeze_axes(main_node, squeeze_axes, non_negative_axes);
                 if (!success) {
                     return false;
@@ -169,11 +171,11 @@ TSSqueezeForward::TSSqueezeForward() {
         }
 
         transpose_order_values = GetOrderAfterReduction(non_negative_axes, transpose_order_values);
-        auto new_transpose_order = Constant::create(transpose_order->get_element_type(),
+        auto new_transpose_order = ov::op::v0::Constant::create(transpose_order->get_element_type(),
                                                     {transpose_order_values.size()},
                                                     transpose_order_values);
 
-        if (as_type_ptr<Reshape>(main_node)) {
+        if (as_type_ptr<ov::op::v1::Reshape>(main_node)) {
             std::vector<size_t> to_shape;
             auto success = squeeze_axes_to_shape(transpose->input_value(0), new_values, to_shape);
             if (!success) {
@@ -183,7 +185,7 @@ TSSqueezeForward::TSSqueezeForward() {
         }
 
         if (squeeze_axes) {
-            auto new_const = Constant::create(squeeze_axes->get_element_type(), {new_values.size()}, new_values);
+            auto new_const = ov::op::v0::Constant::create(squeeze_axes->get_element_type(), {new_values.size()}, new_values);
             main_node->input(1).replace_source_output(new_const);
             copy_runtime_info(squeeze_axes, new_const);
         }
@@ -210,11 +212,11 @@ TSSqueezeForward::TSSqueezeForward() {
 
 TSSqueezeBackward::TSSqueezeBackward() {
     MATCHER_SCOPE(TSSqueezeBackward);
-    auto squeeze_with_1_input = wrap_type<Squeeze>({any_input()}, HasSameOutputTransposeNodes);
-    auto squeeze_label = wrap_type<Squeeze, Reshape>({any_input(), wrap_type<Constant>()}, HasSameOutputTransposeNodes);
+    auto squeeze_with_1_input = wrap_type<ov::op::v0::Squeeze>({any_input()}, HasSameOutputTransposeNodes);
+    auto squeeze_label = wrap_type<ov::op::v0::Squeeze, ov::op::v1::Reshape>({any_input(), wrap_type<ov::op::v0::Constant>()}, HasSameOutputTransposeNodes);
     auto pattern = std::make_shared<pattern::op::Or>(OutputVector{squeeze_with_1_input, squeeze_label});
     auto transpose_label =
-        wrap_type<Transpose>({pattern, wrap_type<Constant>()}, [](const Output<Node>& output) -> bool {
+        wrap_type<ov::op::v1::Transpose>({pattern, wrap_type<ov::op::v0::Constant>()}, [](const Output<Node>& output) -> bool {
             return has_static_rank()(output) && is_sinking_node(output);
         });
 
@@ -233,20 +235,20 @@ TSSqueezeBackward::TSSqueezeBackward() {
             return false;
         }
 
-        auto transpose_order = as_type_ptr<Constant>(transpose->get_input_node_shared_ptr(1));
+        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
 
         if (!transpose_order) {
             return false;
         }
 
         std::vector<size_t> non_negative_axes;
-        std::shared_ptr<Constant> squeeze_axes;
+        std::shared_ptr<ov::op::v0::Constant> squeeze_axes;
         if (main_node->get_input_size() > 1) {
-            squeeze_axes = as_type_ptr<Constant>(main_node->get_input_node_shared_ptr(1));
+            squeeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
             if (!squeeze_axes) {
                 return false;
             }
-            if (as_type_ptr<Reshape>(main_node)) {
+            if (as_type_ptr<ov::op::v1::Reshape>(main_node)) {
                 auto success = shape_to_squeeze_axes(main_node, squeeze_axes, non_negative_axes);
                 if (!success) {
                     return false;
@@ -283,11 +285,11 @@ TSSqueezeBackward::TSSqueezeBackward() {
             new_values.push_back(reversed_order_values[axis]);
         }
 
-        auto new_transpose_order = Constant::create(transpose_order->get_element_type(),
+        auto new_transpose_order = ov::op::v0::Constant::create(transpose_order->get_element_type(),
                                                     {transpose_order_values.size()},
                                                     transpose_order_values);
         auto new_transpose = transpose->clone_with_new_inputs({main_node->input_value(0), new_transpose_order});
-        if (as_type_ptr<Reshape>(main_node)) {
+        if (as_type_ptr<ov::op::v1::Reshape>(main_node)) {
             std::vector<size_t> to_shape;
             auto success = squeeze_axes_to_shape(new_transpose->output(0), new_values, to_shape);
             if (!success) {
@@ -298,7 +300,7 @@ TSSqueezeBackward::TSSqueezeBackward() {
 
         std::shared_ptr<Node> new_squeeze;
         if (!squeeze_all_dims) {
-            auto new_const = Constant::create(squeeze_axes->get_element_type(), {new_values.size()}, new_values);
+            auto new_const = ov::op::v0::Constant::create(squeeze_axes->get_element_type(), {new_values.size()}, new_values);
             main_node->input(1).replace_source_output(new_const);
             copy_runtime_info(squeeze_axes, new_const);
         }

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_unary.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_unary.cpp
@@ -7,14 +7,21 @@
 #include <utility>
 
 #include "itt.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/softplus.hpp"
+#include "openvino/op/is_inf.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/is_finite.hpp"
+#include "openvino/op/clamp.hpp"
+#include "openvino/op/elu.hpp"
+#include "openvino/op/logical_not.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
 #include "transformations/transpose_sinking/ts_utils.hpp"
 #include "transformations/utils/utils.hpp"
 
 using namespace ov;
-using namespace ov::opset10;
 using namespace ov::pass::pattern;
 using namespace ov::op::util;
 using namespace ov::pass::transpose_sinking;
@@ -55,9 +62,9 @@ NodePair SwapNodes(const NodePtr& first_node, const NodePtr& second_node) {
 TSUnaryForward::TSUnaryForward() {
     MATCHER_SCOPE(TSUnaryForward);
 
-    auto transpose_label = wrap_type<Transpose>({any_input(), any_input()});
+    auto transpose_label = wrap_type<ov::op::v1::Transpose>({any_input(), any_input()});
     auto unary_label =
-        wrap_type<UnaryElementwiseArithmetic, Clamp, Elu, SoftPlus, LogicalNot, Convert, IsInf, IsNaN, IsFinite>(
+        wrap_type<UnaryElementwiseArithmetic, ov::op::v0::Clamp, ov::op::v0::Elu, ov::op::v4::SoftPlus, ov::op::v1::LogicalNot, ov::op::v0::Convert, ov::op::v10::IsInf, ov::op::v10::IsNaN, ov::op::v10::IsFinite>(
             {transpose_label});
 
     ov::matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
@@ -95,17 +102,17 @@ TSUnaryBackward::TSUnaryBackward() {
     };
 
     auto unary_label =
-        wrap_type<UnaryElementwiseArithmetic, Clamp, Elu, SoftPlus, LogicalNot, Convert, IsInf, IsNaN, IsFinite>(
+        wrap_type<UnaryElementwiseArithmetic, ov::op::v0::Clamp, ov::op::v0::Elu, ov::op::v4::SoftPlus, ov::op::v1::LogicalNot, ov::op::v0::Convert, ov::op::v10::IsInf, ov::op::v10::IsNaN, ov::op::v10::IsFinite>(
             {any_input()},
             unary_restrictions);
 
-    auto transpose_const_label = wrap_type<Constant>();
+    auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
 
-    auto transpose_label = wrap_type<Transpose>({unary_label, transpose_const_label}, IfSinkingEnabled);
+    auto transpose_label = wrap_type<ov::op::v1::Transpose>({unary_label, transpose_const_label}, IfSinkingEnabled);
 
     ov::matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
-        auto transpose_const = as_type_ptr<Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
+        auto transpose_const = as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto unary = pattern_to_output.at(unary_label).get_node_shared_ptr();
         if (transformation_callback(unary)) {

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_unary.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_unary.cpp
@@ -7,15 +7,15 @@
 #include <utility>
 
 #include "itt.hpp"
-#include "openvino/op/softplus.hpp"
-#include "openvino/op/is_inf.hpp"
-#include "openvino/op/transpose.hpp"
-#include "openvino/op/is_finite.hpp"
 #include "openvino/op/clamp.hpp"
-#include "openvino/op/elu.hpp"
-#include "openvino/op/logical_not.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
+#include "openvino/op/elu.hpp"
+#include "openvino/op/is_finite.hpp"
+#include "openvino/op/is_inf.hpp"
+#include "openvino/op/logical_not.hpp"
+#include "openvino/op/softplus.hpp"
+#include "openvino/op/transpose.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
 #include "transformations/transpose_sinking/ts_utils.hpp"
@@ -63,9 +63,15 @@ TSUnaryForward::TSUnaryForward() {
     MATCHER_SCOPE(TSUnaryForward);
 
     auto transpose_label = wrap_type<ov::op::v1::Transpose>({any_input(), any_input()});
-    auto unary_label =
-        wrap_type<UnaryElementwiseArithmetic, ov::op::v0::Clamp, ov::op::v0::Elu, ov::op::v4::SoftPlus, ov::op::v1::LogicalNot, ov::op::v0::Convert, ov::op::v10::IsInf, ov::op::v10::IsNaN, ov::op::v10::IsFinite>(
-            {transpose_label});
+    auto unary_label = wrap_type<UnaryElementwiseArithmetic,
+                                 ov::op::v0::Clamp,
+                                 ov::op::v0::Elu,
+                                 ov::op::v4::SoftPlus,
+                                 ov::op::v1::LogicalNot,
+                                 ov::op::v0::Convert,
+                                 ov::op::v10::IsInf,
+                                 ov::op::v10::IsNaN,
+                                 ov::op::v10::IsFinite>({transpose_label});
 
     ov::matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
@@ -101,10 +107,15 @@ TSUnaryBackward::TSUnaryBackward() {
         return HasSameOutputTransposeNodes(output);
     };
 
-    auto unary_label =
-        wrap_type<UnaryElementwiseArithmetic, ov::op::v0::Clamp, ov::op::v0::Elu, ov::op::v4::SoftPlus, ov::op::v1::LogicalNot, ov::op::v0::Convert, ov::op::v10::IsInf, ov::op::v10::IsNaN, ov::op::v10::IsFinite>(
-            {any_input()},
-            unary_restrictions);
+    auto unary_label = wrap_type<UnaryElementwiseArithmetic,
+                                 ov::op::v0::Clamp,
+                                 ov::op::v0::Elu,
+                                 ov::op::v4::SoftPlus,
+                                 ov::op::v1::LogicalNot,
+                                 ov::op::v0::Convert,
+                                 ov::op::v10::IsInf,
+                                 ov::op::v10::IsNaN,
+                                 ov::op::v10::IsFinite>({any_input()}, unary_restrictions);
 
     auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
 
@@ -112,7 +123,8 @@ TSUnaryBackward::TSUnaryBackward() {
 
     ov::matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
-        auto transpose_const = as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
+        auto transpose_const =
+            as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto unary = pattern_to_output.at(unary_label).get_node_shared_ptr();
         if (transformation_callback(unary)) {

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_unsqueeze.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_unsqueeze.cpp
@@ -9,14 +9,16 @@
 
 #include "itt.hpp"
 #include "openvino/core/validation_util.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/unsqueeze.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
 #include "transformations/transpose_sinking/ts_utils.hpp"
 #include "transformations/utils/utils.hpp"
 
 using namespace ov;
-using namespace opset10;
 using namespace ov::pass::pattern;
 using namespace ov::pass::transpose_sinking;
 using namespace ov::pass::transpose_sinking::utils;
@@ -24,7 +26,7 @@ using namespace ov::pass::transpose_sinking::utils;
 namespace {
 
 /**
- * @brief Checks that Reshape operation is equal to Unsqueeze:
+ * @brief Checks that Reshape operation is equal to ov::op::v0::Unsqueeze:
  * Only 1 dims are inserted, all other dims must be the same.
  * Converts these 1 dims to axes format.
  * @arg reshape Reshape operation.
@@ -32,7 +34,7 @@ namespace {
  * @arg result_axes contains axes which will be unsqueezed.
  */
 bool shape_to_unsqueeze_axes(const std::shared_ptr<Node>& reshape,
-                             const std::shared_ptr<Constant>& reshape_to_shape,
+                             const std::shared_ptr<ov::op::v0::Constant>& reshape_to_shape,
                              std::vector<size_t>& result_axes) {
     result_axes.clear();
     auto reduction_axes_values = reshape_to_shape->cast_vector<int64_t>();
@@ -72,7 +74,7 @@ bool shape_to_unsqueeze_axes(const std::shared_ptr<Node>& reshape,
  * @brief Converts unsqueeze_axes to actual shape (2nd input) for Reshape operation
  * using the shape of the 1st input to Reshape.
  * @arg input_node 1st input to Reshape op.
- * @arg unsqueeze_axes In case of Reshape op is equal to Unsqueeze, these axes indicate the places where 1 dims have
+ * @arg unsqueeze_axes In case of Reshape op is equal to ov::op::v0::Unsqueeze, these axes indicate the places where 1 dims have
  * to be inserted.
  */
 bool unsqueeze_axes_to_shape(const Output<Node>& input_node,
@@ -102,26 +104,26 @@ bool unsqueeze_axes_to_shape(const Output<Node>& input_node,
 TSUnsqueezeForward::TSUnsqueezeForward() {
     MATCHER_SCOPE(TSUnsqueezeForward);
 
-    auto transpose_label = wrap_type<Transpose>({any_input(), wrap_type<Constant>()});
-    auto unsqueeze_label = wrap_type<Unsqueeze, Reshape>({transpose_label, wrap_type<Constant>()});
+    auto transpose_label = wrap_type<ov::op::v1::Transpose>({any_input(), wrap_type<ov::op::v0::Constant>()});
+    auto unsqueeze_label = wrap_type<ov::op::v0::Unsqueeze, ov::op::v1::Reshape>({transpose_label, wrap_type<ov::op::v0::Constant>()});
 
     ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_map();
 
-        auto transpose = as_type_ptr<Transpose>(pattern_to_output.at(transpose_label));
+        auto transpose = as_type_ptr<ov::op::v1::Transpose>(pattern_to_output.at(transpose_label));
         auto main_node = pattern_to_output.at(unsqueeze_label);
         if (!transpose || transformation_callback(main_node)) {
             return false;
         }
 
-        auto transpose_order = as_type_ptr<Constant>(transpose->get_input_node_shared_ptr(1));
-        auto unsqueeze_axes = as_type_ptr<Constant>(main_node->get_input_node_shared_ptr(1));
+        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+        auto unsqueeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
         if (!transpose_order || !unsqueeze_axes) {
             return false;
         }
 
         std::vector<size_t> non_negative_axes;
-        if (as_type_ptr<Reshape>(main_node)) {
+        if (as_type_ptr<ov::op::v1::Reshape>(main_node)) {
             auto success = shape_to_unsqueeze_axes(main_node, unsqueeze_axes, non_negative_axes);
             if (!success) {
                 return false;
@@ -137,16 +139,16 @@ TSUnsqueezeForward::TSUnsqueezeForward() {
 
         ts_order_values = GetOrderBeforeReduction(non_negative_axes, ts_order_values);
         auto new_transpose_order =
-            Constant::create(transpose_order->get_element_type(), {ts_order_values.size()}, ts_order_values);
+            ov::op::v0::Constant::create(transpose_order->get_element_type(), {ts_order_values.size()}, ts_order_values);
 
         std::shared_ptr<Node> new_unsqueeze;
-        if (as_type_ptr<Reshape>(main_node)) {
+        if (as_type_ptr<ov::op::v1::Reshape>(main_node)) {
             std::vector<size_t> new_values;
             auto success = unsqueeze_axes_to_shape(transpose->input_value(0), non_negative_axes, new_values);
             if (!success) {
                 return false;
             }
-            auto new_const = Constant::create(unsqueeze_axes->get_element_type(), {new_values.size()}, new_values);
+            auto new_const = ov::op::v0::Constant::create(unsqueeze_axes->get_element_type(), {new_values.size()}, new_values);
             main_node->input(1).replace_source_output(new_const);
             copy_runtime_info(unsqueeze_axes, new_const);
         }
@@ -175,9 +177,9 @@ TSUnsqueezeBackward::TSUnsqueezeBackward() {
     MATCHER_SCOPE(TSUnsqueezeBackward);
 
     auto unsqueeze_label =
-        wrap_type<Unsqueeze, Reshape>({any_input(), wrap_type<Constant>()}, HasSameOutputTransposeNodes);
+        wrap_type<ov::op::v0::Unsqueeze, ov::op::v1::Reshape>({any_input(), wrap_type<ov::op::v0::Constant>()}, HasSameOutputTransposeNodes);
     auto transpose_label =
-        wrap_type<Transpose>({unsqueeze_label, wrap_type<Constant>()}, [](const Output<Node>& output) -> bool {
+        wrap_type<ov::op::v1::Transpose>({unsqueeze_label, wrap_type<ov::op::v0::Constant>()}, [](const Output<Node>& output) -> bool {
             return has_static_rank()(output) && is_sinking_node(output);
         });
 
@@ -190,13 +192,13 @@ TSUnsqueezeBackward::TSUnsqueezeBackward() {
             return false;
         }
 
-        auto transpose_order = std::dynamic_pointer_cast<Constant>(transpose->get_input_node_shared_ptr(1));
-        auto unsqueeze_axes = std::dynamic_pointer_cast<Constant>(main_node->get_input_node_shared_ptr(1));
+        auto transpose_order = std::dynamic_pointer_cast<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+        auto unsqueeze_axes = std::dynamic_pointer_cast<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
         if (!transpose_order || !unsqueeze_axes)
             return false;
 
         std::vector<size_t> non_negative_axes;
-        if (as_type_ptr<Reshape>(main_node)) {
+        if (as_type_ptr<ov::op::v1::Reshape>(main_node)) {
             auto success = shape_to_unsqueeze_axes(main_node, unsqueeze_axes, non_negative_axes);
             if (!success) {
                 return false;
@@ -228,14 +230,14 @@ TSUnsqueezeBackward::TSUnsqueezeBackward() {
         }
 
         transpose_order_values = GetOrderAfterReduction(new_values, transpose_order_values);
-        auto new_transpose_order = std::make_shared<Constant>(transpose_order->get_element_type(),
+        auto new_transpose_order = std::make_shared<ov::op::v0::Constant>(transpose_order->get_element_type(),
                                                               Shape{transpose_order_values.size()},
                                                               transpose_order_values);
 
         for (auto& new_node : sink_backward::InsertTransposeBeforeNode(main_node, new_transpose_order, {0})) {
             register_new_node(new_node);
         }
-        if (as_type_ptr<Reshape>(main_node)) {
+        if (as_type_ptr<ov::op::v1::Reshape>(main_node)) {
             std::vector<size_t> to_shape;
             auto success = unsqueeze_axes_to_shape(main_node->input_value(0), new_values, to_shape);
             if (!success) {
@@ -243,7 +245,7 @@ TSUnsqueezeBackward::TSUnsqueezeBackward() {
             }
             new_values = to_shape;
         }
-        auto new_const = Constant::create(unsqueeze_axes->get_element_type(), {new_values.size()}, new_values);
+        auto new_const = ov::op::v0::Constant::create(unsqueeze_axes->get_element_type(), {new_values.size()}, new_values);
         main_node->input(1).replace_source_output(new_const);
 
         main_node->validate_and_infer_types();

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_utils.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_utils.cpp
@@ -6,7 +6,28 @@
 
 #include "itt.hpp"
 #include "openvino/op/util/op_types.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/softplus.hpp"
+#include "openvino/op/reverse_sequence.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/space_to_batch.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/is_inf.hpp"
+#include "openvino/op/batch_to_space.hpp"
+#include "openvino/op/variadic_split.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/logical_not.hpp"
+#include "openvino/op/pad.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/prelu.hpp"
+#include "openvino/op/elu.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/clamp.hpp"
+#include "openvino/op/interpolate.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/split.hpp"
+#include "openvino/op/slice.hpp"
+#include "openvino/op/is_finite.hpp"
 #include "openvino/util/common_util.hpp"
 #include "transformations/rt_info/transpose_sinking_attr.hpp"
 #include "transformations/utils/utils.hpp"
@@ -17,40 +38,39 @@ namespace transpose_sinking {
 namespace utils {
 
 using namespace ov;
-using namespace ov::opset10;
 
 using NodePtr = std::shared_ptr<Node>;
 
 Output<Node> ChangeValuesOrder(const Output<Node>& input,
                                const AxisVector& transpose_axis_order,
-                               const std::shared_ptr<Constant>& axis) {
-    auto indices = std::make_shared<Constant>(element::i32, Shape{transpose_axis_order.size()}, transpose_axis_order);
-    auto gather = std::make_shared<Gather>(input, indices, axis);
+                               const std::shared_ptr<ov::op::v0::Constant>& axis) {
+    auto indices = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{transpose_axis_order.size()}, transpose_axis_order);
+    auto gather = std::make_shared<ov::op::v8::Gather>(input, indices, axis);
     copy_runtime_info(input.get_node_shared_ptr(), gather);
     return gather;
 }
 
 Output<Node> ChangeAxes(const Output<Node>& indices,
-                        const std::shared_ptr<Constant>& data,
-                        const std::shared_ptr<Constant>& axis) {
-    auto gather = std::make_shared<Gather>(data, indices, axis);
+                        const std::shared_ptr<ov::op::v0::Constant>& data,
+                        const std::shared_ptr<ov::op::v0::Constant>& axis) {
+    auto gather = std::make_shared<ov::op::v8::Gather>(data, indices, axis);
     copy_runtime_info(indices.get_node_shared_ptr(), gather);
     return gather;
 }
 Output<Node> ChangeAxes(const Output<Node>& indices,
                         const AxisVector& transpose_axis_order,
-                        const std::shared_ptr<Constant>& axis) {
-    auto data = std::make_shared<Constant>(element::i32, Shape{transpose_axis_order.size()}, transpose_axis_order);
+                        const std::shared_ptr<ov::op::v0::Constant>& axis) {
+    auto data = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{transpose_axis_order.size()}, transpose_axis_order);
     return ChangeAxes(indices, data, axis);
 }
 
 TransposeInputsInfo GetFirstTransposeInput(const NodePtr& node) {
     for (size_t input_idx = 0; input_idx < node->get_input_size(); ++input_idx) {
         NodePtr input_node = node->get_input_node_shared_ptr(input_idx);
-        auto transpose_node = as_type_ptr<Transpose>(input_node);
+        auto transpose_node = as_type_ptr<ov::op::v1::Transpose>(input_node);
         if (!transpose_node)
             continue;
-        auto constant_node = as_type_ptr<Constant>(transpose_node->input_value(1).get_node_shared_ptr());
+        auto constant_node = as_type_ptr<ov::op::v0::Constant>(transpose_node->input_value(1).get_node_shared_ptr());
         if (!constant_node)
             continue;
         {
@@ -122,8 +142,8 @@ ov::Rank::value_type GetMaxInputRank(const NodePtr& node) {
 NodePtr InsertUnsqueeze(const Output<Node>& node, size_t n_dims) {
     std::vector<size_t> dims(n_dims);
     std::iota(dims.begin(), dims.end(), 0);
-    auto unsqueeze_const = std::make_shared<Constant>(ov::element::i64, Shape{dims.size()}, dims);
-    auto unsqueeze = std::make_shared<Unsqueeze>(node, unsqueeze_const);
+    auto unsqueeze_const = std::make_shared<ov::op::v0::Constant>(ov::element::i64, Shape{dims.size()}, dims);
+    auto unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(node, unsqueeze_const);
     copy_runtime_info(node.get_node_shared_ptr(), {unsqueeze, unsqueeze_const});
     return unsqueeze;
 }
@@ -193,10 +213,10 @@ bool UpdateInputTransposes(const NodePtr& main_node,
                 return false;
             }
             const auto reversed_transpose_axis_order = ReverseTransposeOrder(transpose_order);
-            auto new_transpose_const = std::make_shared<Constant>(transpose_element_type,
+            auto new_transpose_const = std::make_shared<ov::op::v0::Constant>(transpose_element_type,
                                                                   Shape{reversed_transpose_axis_order.size()},
                                                                   reversed_transpose_axis_order);
-            auto new_transpose = std::make_shared<Transpose>(input_node, new_transpose_const);
+            auto new_transpose = std::make_shared<ov::op::v1::Transpose>(input_node, new_transpose_const);
 
             main_node->input(i).replace_source_output(new_transpose->output(0));
 
@@ -223,11 +243,11 @@ NodeVector InsertOutputTransposes(const NodePtr& main_node, const TransposeInput
     NodeVector new_nodes;
 
     for (size_t i = 0; i < main_node->get_output_size(); ++i) {
-        auto new_transpose_const = std::make_shared<Constant>(transpose_element_type,
+        auto new_transpose_const = std::make_shared<ov::op::v0::Constant>(transpose_element_type,
                                                               Shape{transpose_axis_order.size()},
                                                               transpose_axis_order);
         auto main_node_consumers = main_node->output(i).get_target_inputs();
-        auto new_transpose = std::make_shared<Transpose>(main_node->output(i), new_transpose_const);
+        auto new_transpose = std::make_shared<ov::op::v1::Transpose>(main_node->output(i), new_transpose_const);
         for (auto& consumer : main_node_consumers) {
             consumer.replace_source_output(new_transpose);
         }
@@ -249,7 +269,7 @@ NodeVector InsertOutputTransposes(const NodePtr& main_node, const TransposeInput
 namespace sink_backward {
 
 NodeVector InsertTransposeBeforeNode(const NodePtr& main_node,
-                                     const std::shared_ptr<Constant>& transpose_const,
+                                     const std::shared_ptr<ov::op::v0::Constant>& transpose_const,
                                      std::vector<size_t> input_indexes) {
     if (input_indexes.empty()) {
         input_indexes.resize(main_node->get_input_size());
@@ -270,10 +290,10 @@ NodeVector InsertTransposeBeforeNode(const NodePtr& main_node,
     for (const auto& i : input_indexes) {
         auto input_node = FixInputNodeRank(main_node->input_value(i), max_input_rank);
 
-        auto new_transpose_const = std::make_shared<Constant>(transpose_element_type,
+        auto new_transpose_const = std::make_shared<ov::op::v0::Constant>(transpose_element_type,
                                                               Shape{transpose_axis_order.size()},
                                                               transpose_axis_order);
-        auto new_transpose = std::make_shared<Transpose>(input_node, new_transpose_const);
+        auto new_transpose = std::make_shared<ov::op::v1::Transpose>(input_node, new_transpose_const);
 
         main_node->input(i).replace_source_output(new_transpose->output(0));
 
@@ -296,33 +316,33 @@ namespace {
 bool CanPropagateForwardThrough(Node* node) {
     // todo: collect this info automatically
     CHECK_TRANSPOSE_SINKING_SUPPORTED(op::util::UnaryElementwiseArithmetic, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(Clamp, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(Elu, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(SoftPlus, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(LogicalNot, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(Convert, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(IsInf, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(IsNaN, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(IsFinite, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v0::Clamp, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v0::Elu, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v4::SoftPlus, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v1::LogicalNot, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v0::Convert, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v10::IsInf, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v10::IsNaN, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v10::IsFinite, node)
     CHECK_TRANSPOSE_SINKING_SUPPORTED(op::util::BinaryElementwiseArithmetic, node)
     CHECK_TRANSPOSE_SINKING_SUPPORTED(op::util::BinaryElementwiseComparison, node)
     CHECK_TRANSPOSE_SINKING_SUPPORTED(op::util::BinaryElementwiseLogical, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(PRelu, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(Pad, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(BatchToSpace, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(SpaceToBatch, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(ReverseSequence, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(Gather, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(Interpolate, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v0::PRelu, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v1::Pad, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v1::BatchToSpace, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v1::SpaceToBatch, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v0::ReverseSequence, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v8::Gather, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v4::Interpolate, node)
     CHECK_TRANSPOSE_SINKING_SUPPORTED(op::util::ArithmeticReductionKeepDims, node)
     CHECK_TRANSPOSE_SINKING_SUPPORTED(op::util::LogicalReductionKeepDims, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(Slice, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(Split, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(VariadicSplit, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(Squeeze, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(Reshape, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(Unsqueeze, node)
-    CHECK_TRANSPOSE_SINKING_SUPPORTED(Transpose, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v8::Slice, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v1::Split, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v1::VariadicSplit, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v0::Squeeze, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v1::Reshape, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v0::Unsqueeze, node)
+    CHECK_TRANSPOSE_SINKING_SUPPORTED(ov::op::v1::Transpose, node)
 
     return false;
 }
@@ -347,12 +367,12 @@ void UpdateForwardSinkingAbility(const NodePtr& node) {
 
 namespace {
 
-std::shared_ptr<Constant> GetTransposeConstant(Node* node) {
-    auto transpose_node = dynamic_cast<Transpose*>(node);
+std::shared_ptr<ov::op::v0::Constant> GetTransposeConstant(Node* node) {
+    auto transpose_node = dynamic_cast<ov::op::v1::Transpose*>(node);
     if (!transpose_node)
         return {};
 
-    auto constant_node = as_type_ptr<Constant>(transpose_node->input_value(1).get_node_shared_ptr());
+    auto constant_node = as_type_ptr<ov::op::v0::Constant>(transpose_node->input_value(1).get_node_shared_ptr());
     if (!constant_node)
         return {};
 


### PR DESCRIPTION
### Details:
each transformation adds ~ 20mb to the inference_engine_transformations_obj.lib. Z7 -> Zi flag decreases the lib size by~40mb only.

In total we have over 200 transformations. Size of the lib ~ sum of each transformation .obj (200 * 20mb = 4gb+, that exceeds the limit). We didn't find the way how we can increase this limit.
Another finding is if we delete the transformation body and even class declaration and definition and leave the empty file with opset and graph_rewrite includes, e.g.

#include <openvino/pass/graph_rewrite.hpp> (+11mb)

#include <openvino/opsets/opset5.hpp> (+ 6mb)

the .obj file takes 17mb+. 

So the current solution is to use the concreate op versions (ov::op::v1:: ) instead of opset5:: and delete the opset5 (6, 7, n) includes.
In this PR the approach (op versions ov::op::vN instead of opsetN:: ) was applied only for the part of transformations to reduce the risks for this Release. 

### Tickets:
 - *91401*
