### PR TITLE
[IE_TESTS] Correct random data generation

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -172,7 +172,19 @@ std::vector<std::string> disabledTestPatterns() {
         // AUTO does not support import / export
         R"(.*smoke_Auto_BehaviorTests/OVCompiledGraphImportExportTest.*(mportExport|readFromV10IR).*/targetDevice=(AUTO).*)",
         // AdaptiveAvgPool is converted into Reduce op for suitable parameters. CPU Reduce impl doesn't support non planar layout for 3D case
-        R"(.*StaticAdaPoolAvg3DLayoutTest.*OS=\(1\).*_inFmts=(nwc|nCw16c|nCw8c).*)"
+        R"(.*StaticAdaPoolAvg3DLayoutTest.*OS=\(1\).*_inFmts=(nwc|nCw16c|nCw8c).*)",
+        // Issue: 111404
+        R"(.*smoke_set1/GatherElementsCPUTest.*)",
+        // Issue: 111405
+        R"(.*smoke_(static|dynamic)/GridSampleLayerTestCPU.CompareWithRefs.*_padMode=ZEROS.*)",
+        // Issue: 111406
+        R"(.*smoke_InterpolateLinearOnnx_Layout_Test/InterpolateLayerCPUTest.*)",
+        R"(.*smoke_InterpolateLinear_Layout_Test/InterpolateLayerCPUTest.*)",
+        R"(.*smoke_InterpolateCubic_Layout_Test/InterpolateLayerCPUTest.*)",
+        // Issue: 111412
+        R"(.*smoke_Proposal_(Static|Dynamic)_Test_Case1/ProposalLayerCPUTest.*)",
+        // Issue: 111418
+        R"(.*smoke_Snippets_ConvertStub/ConvertStub\.CompareWithRefImpl/IS=.*_OT=\(bf16\)_#N=2_#S=2_targetDevice=CPU.*)",
     };
 
 #if defined(OPENVINO_ARCH_X86)

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/classes/activation.cpp
@@ -52,13 +52,19 @@ void ActivationLayerCPUTest::generate_inputs(const std::vector<ngraph::Shape>& t
     uint32_t range = 0;
     int32_t resolution = 0;
 
-    if (activationType == ngraph::helpers::ActivationTypes::Exp &&
-        netPrecision == InferenceEngine::Precision::BF16) {
+    if (activationType == ActivationTypes::Exp && netPrecision == Precision::BF16) {
         startFrom = 0;
         range = 2;
         resolution = 32768;
-    } else if (activationType == ngraph::helpers::ActivationTypes::Acosh) {
+    } else if (activationType == ActivationTypes::Acosh) {
         startFrom = 2;
+        range = 2;
+        resolution = 128;
+    } else if (activationType == ActivationTypes::Acos ||
+               activationType == ActivationTypes::Asin ||
+               activationType == ActivationTypes::Atanh) {
+        // range [-1. 1] is required
+        startFrom = -1;
         range = 2;
         resolution = 128;
     } else {

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -116,14 +116,17 @@ std::vector<std::string> disabledTestPatterns() {
             R"(.*CachingSupportCase.*GPU.*CompileModelCacheTestBase.*CompareWithRefImpl.*)",
             // Currently 1D convolution has an issue
             R"(.*smoke_ConvolutionLayerGPUTest_dynamic1DSymPad.*)",
-
             // Looks like the test is targeting CPU plugin and doesn't respect that execution graph may vary from plugin to plugin
             R"(.*ExecGraphSerializationTest.*)",
-
             // TODO: support getconfig in auto/multi CVS-104942
             // TODO: move auto/multi cases to dedicated unit tests
             R"(.*(Auto|Multi).*SetPropLoadNetWorkGetPropTests.*)",
             // unsupported metrics
             R"(.*nightly_MultiHeteroAutoBatchOVGetMetricPropsTest.*OVGetMetricPropsTest.*(FULL_DEVICE_NAME_with_DEVICE_ID|AVAILABLE_DEVICES|DEVICE_UUID|OPTIMIZATION_CAPABILITIES|MAX_BATCH_SIZE|DEVICE_GOPS|DEVICE_TYPE|RANGE_FOR_ASYNC_INFER_REQUESTS|RANGE_FOR_STREAMS).*)",
+            // Issue: 111437
+            R"(.*smoke_Deconv_2D_Dynamic_.*FP32/DeconvolutionLayerGPUTest.CompareWithRefs.*)",
+            R"(.*smoke_GroupDeconv_2D_Dynamic_.*FP32/GroupDeconvolutionLayerGPUTest.CompareWithRefs.*)",
+            // Issue: 111440
+            R"(.*smoke_set1/GatherElementsGPUTest.CompareWithRefs.*)",
     };
 }

--- a/src/plugins/template/tests/functional/skip_tests_config.cpp
+++ b/src/plugins/template/tests/functional/skip_tests_config.cpp
@@ -117,6 +117,8 @@ std::vector<std::string> disabledTestPatterns() {
         // CVS-110345
         R"(.*ReferenceInterpolate_v11.*data_type=f16.*)",
         R"(.*LSTMSequence_With_Hardcoded_Refs.*ReferenceLSTMSequenceTest.*iType=f16.*)",
+        // CVS-111443
+        R"(.*eltwiseOpType=Mod_secondaryInputType=PARAMETER_opType=VECTOR_NetType=(f16|f32).*)"
     };
 
 #ifdef _WIN32

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/base/utils/ranges.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/base/utils/ranges.hpp
@@ -12,6 +12,13 @@
 #include "ngraph/op/divide.hpp"
 #include "ngraph/op/erf.hpp"
 #include "ngraph/op/non_max_suppression.hpp"
+#include "ngraph/op/reduce_l1.hpp"
+#include "ngraph/op/reduce_l2.hpp"
+#include "ngraph/op/reduce_sum.hpp"
+#include "ngraph/op/reduce_prod.hpp"
+#include "ngraph/op/reduce_mean.hpp"
+#include "ngraph/op/max.hpp"
+#include "ngraph/op/min.hpp"
 
 namespace ov {
 namespace test {

--- a/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
@@ -26,7 +26,7 @@ ov::runtime::Tensor generate(const std::shared_ptr<ov::Node>& node,
     size_t inNodeCnt = node->get_input_size();
     InputGenerateData inGenData;
     if (elemType.is_real()) {
-        inGenData.range = 2560;
+        inGenData.range = 10;
         inGenData.resolution = 256;
     }
     auto it = inputRanges.find(node->get_type_info());
@@ -39,18 +39,13 @@ ov::runtime::Tensor generate(const std::shared_ptr<ov::Node>& node,
         inGenData = range.size() < inNodeCnt ? range.front() : range.at(port);
     }
     return ov::test::utils::create_and_fill_tensor(elemType, targetShape, inGenData.range,
-                                          inGenData.start_from, inGenData.resolution, inGenData.seed);
+                                                   inGenData.start_from, inGenData.resolution, inGenData.seed);
 }
 
 namespace Activation {
-// todo: this is a bug fixed! Merge it separately.
-//  Default parameters InputGenerateData(10, 20, 32768, 1) lead to input generation according to 10 + x/32768,
-//  where x {0, 20}, so all generated values are in the range [10, 10 + 6.1e-4].
-//  Thus all the interval more-or-less fall within the uncertainty validation interval
-//  Fix let the range be at least 20x of resolution
 ov::runtime::Tensor generate(const ov::element::Type& elemType,
                              const ov::Shape& targetShape,
-                             InputGenerateData inGenData = InputGenerateData(-1, 2*32768, 32768, 1)) {
+                             InputGenerateData inGenData = InputGenerateData(-1, 2, 32768, 1)) {
     if (!elemType.is_signed()) {
         inGenData.range = 15;
         inGenData.start_from = 0;

--- a/src/tests/ie_test_utils/common_test_utils/data_utils.hpp
+++ b/src/tests/ie_test_utils/common_test_utils/data_utils.hpp
@@ -195,14 +195,15 @@ void inline
 fill_data_random(T *pointer, std::size_t size, const uint32_t range = 10, int32_t start_from = 0, const int32_t k = 1,
                  const int seed = 1) {
     testing::internal::Random random(seed);
-    random.Generate(range);
+    const uint32_t k_range = k * range; // range with respect to k
+    random.Generate(k_range);
 
     if (start_from < 0 && !std::is_signed<T>::value) {
         start_from = 0;
     }
 
     for (std::size_t i = 0; i < size; i++) {
-        pointer[i] = static_cast<T>(start_from + static_cast<T>(random.Generate(range)) / k);
+        pointer[i] = static_cast<T>(start_from + static_cast<T>(random.Generate(k_range)) / k);
     }
 }
 


### PR DESCRIPTION
### Details:
 - In current implementation k (resolution) parameter of generation function affect the range of the generated data. Change the behavior so k parameter only affects granularity.
 Example:
 - Before: start_from -1, range 2, resolution 100 generates numbers in range: [-1, 0.01] with resolution 100
 - After: start_from -1, range 2, resolution 100 generates numbers in range: [-1, 1] with resolution 100
 - [x] Many tests failed, should be fixed / adopted to the corrected behavior.
 - [x] Create tickets for skipped tests
 
 ### Ticket:
 - 110384

Multiple test instances started to fail after correction of random data generation.
Failing instances were skipped for now and follow-up tickets were created for future investigation.
### Follow up plugin tickets:
### GPU:
- 111440 - GatherElements
- 111437 - Deconv, GroupDeconv
### Template:
- 111443 - Eltwise Mod
### CPU:
- 111418 - Snippets Convert
- 111412 - Proposal
- 111406 - Interpolate
- 111405 - GridSample
- 111404 - GatherElements