### PR TITLE
[apiConformance] Fix rebalance missing changes

### DIFF
--- a/src/plugins/intel_gna/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
+++ b/src/plugins/intel_gna/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
@@ -25,6 +25,7 @@ INSTANTIATE_TEST_SUITE_P(nightly_OVClassBasicPropsTestP,
 
 // TODO
 INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_OVClassModelTestP, OVClassModelTestP, ::testing::Values("GNA"));
+INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_OVClassModelOptionalTestP, OVClassModelOptionalTestP, ::testing::Values("GNA"));
 
 //
 // IE Class GetMetric

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
@@ -13,6 +13,7 @@ namespace {
 // IE Class Common tests with <pluginName, target_device params>
 //
 INSTANTIATE_TEST_SUITE_P(nightly_OVClassModelTestP, OVClassModelTestP, ::testing::Values("GPU"));
+INSTANTIATE_TEST_SUITE_P(nightly_OVClassModelOptionalTestP, OVClassModelOptionalTestP, ::testing::Values("GPU"));
 
 // Several devices case
 INSTANTIATE_TEST_SUITE_P(nightly_OVClassSeveralDevicesTest,

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -126,6 +126,6 @@ std::vector<std::string> disabledTestPatterns() {
             // TODO: move auto/multi cases to dedicated unit tests
             R"(.*(Auto|Multi).*SetPropLoadNetWorkGetPropTests.*)",
             // unsupported metrics
-            R"(.*nightly_MultiHeteroAutoBatchOVGetMetricPropsTest.*OVGetMetricPropsTest.*(AVAILABLE_DEVICES|DEVICE_UUID|OPTIMIZATION_CAPABILITIES|MAX_BATCH_SIZE|DEVICE_GOPS|DEVICE_GOPS|RANGE_FOR_ASYNC_INFER_REQUESTS|RANGE_FOR_STREAMS).*)",
+            R"(.*nightly_MultiHeteroAutoBatchOVGetMetricPropsTest.*OVGetMetricPropsTest.*(FULL_DEVICE_NAME_with_DEVICE_ID AVAILABLE|DEVICES|DEVICE_UUID|OPTIMIZATION_CAPABILITIES|MAX_BATCH_SIZE|DEVICE_GOPS|DEVICE_TYPE|RANGE_FOR_ASYNC_INFER_REQUESTS|RANGE_FOR_STREAMS).*)",
     };
 }

--- a/src/plugins/template/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
+++ b/src/plugins/template/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
@@ -21,6 +21,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_OVClassModelTestP,
                          OVClassModelTestP,
                          ::testing::Values(CommonTestUtils::DEVICE_TEMPLATE));
 
+INSTANTIATE_TEST_SUITE_P(smoke_OVClassModelOptionalTestP,
+                         OVClassModelOptionalTestP,
+                         ::testing::Values(CommonTestUtils::DEVICE_TEMPLATE));
+
 TEST(OVClassBasicPropsTest, smoke_TEMPLATEGetSetConfigNoThrow) {
     ov::Core core = createCoreWithTemplate();
 

--- a/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/behavior/ov_infer_request/io_tensor.cpp
@@ -12,7 +12,7 @@ using namespace ov::test::behavior;
 using namespace ov::test::conformance;
 
 namespace {
-INSTANTIATE_TEST_SUITE_P(ov_infer_request, OVInferRequestIOTensorTest,
+INSTANTIATE_TEST_SUITE_P(ov_infer_request_mandatory, OVInferRequestIOTensorTest,
                         ::testing::Combine(
                                 ::testing::ValuesIn(return_all_possible_device_combination()),
                                 ::testing::Values(pluginConfig)),
@@ -24,27 +24,24 @@ std::vector<ov::element::Type> ovIOTensorElemTypes = {
     ov::element::f16,
     ov::element::f32,
     ov::element::f64,
-    ov::element::i4,
     ov::element::i8,
     ov::element::i16,
     ov::element::i32,
     ov::element::i64,
-    ov::element::u1,
-    ov::element::u4,
     ov::element::u8,
     ov::element::u16,
     ov::element::u32,
     ov::element::u64,
 };
 
-INSTANTIATE_TEST_SUITE_P(ov_infer_request, OVInferRequestIOTensorSetPrecisionTest,
+INSTANTIATE_TEST_SUITE_P(ov_infer_request_mandatory, OVInferRequestIOTensorSetPrecisionTest,
                          ::testing::Combine(
                                  ::testing::ValuesIn(ovIOTensorElemTypes),
                                  ::testing::ValuesIn(return_all_possible_device_combination()),
                                  ::testing::Values(pluginConfig)),
                          OVInferRequestIOTensorSetPrecisionTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(ov_infer_request, OVInferRequestCheckTensorPrecision,
+INSTANTIATE_TEST_SUITE_P(ov_infer_request_mandatory, OVInferRequestCheckTensorPrecision,
                          ::testing::Combine(
                                  ::testing::ValuesIn(ovIOTensorElemTypes),
                                  ::testing::ValuesIn(return_all_possible_device_combination()),

--- a/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/behavior/ov_plugin/core_integration.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/behavior/ov_plugin/core_integration.cpp
@@ -20,6 +20,10 @@ INSTANTIATE_TEST_SUITE_P(ov_plugin_mandatory,
                          OVClassModelTestP,
                          ::testing::ValuesIn(return_all_possible_device_combination()));
 
+INSTANTIATE_TEST_SUITE_P(ov_plugin,
+                         OVClassModelOptionalTestP,
+                         ::testing::ValuesIn(return_all_possible_device_combination()));
+
 // IE Class Query network
 
 INSTANTIATE_TEST_SUITE_P(ov_plugin_mandatory,

--- a/src/tests/functional/plugin/shared/include/base/ov_behavior_test_utils.hpp
+++ b/src/tests/functional/plugin/shared/include/base/ov_behavior_test_utils.hpp
@@ -209,6 +209,7 @@ public:
     }
 };
 using OVClassModelTestP = OVClassBaseTestP;
+using OVClassModelOptionalTestP = OVClassBaseTestP;
 
 class OVCompiledModelClassBaseTestP : public OVClassNetworkTest,
                                       public ::testing::WithParamInterface<std::string>,

--- a/src/tests/functional/plugin/shared/include/behavior/compiled_model/compiled_model_base.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/compiled_model/compiled_model_base.hpp
@@ -166,12 +166,12 @@ TEST(OVCompiledModelBaseTest, canCompileModelToDefaultDevice) {
     EXPECT_NO_THROW(auto execNet = core->compile_model(function));
 }
 
-TEST_P(OVCompiledModelBaseTestOptional, canCompileModelAndCreateInferRequest) {
+TEST_P(OVCompiledModelBaseTest, canCompileModelAndCreateInferRequest) {
     auto execNet = core->compile_model(function, target_device, configuration);
     EXPECT_NO_THROW(auto req = execNet.create_infer_request());
 }
 
-TEST_P(OVCompiledModelBaseTest, checkGetExecGraphInfoIsNotNullptr) {
+TEST_P(OVCompiledModelBaseTestOptional, checkGetExecGraphInfoIsNotNullptr) {
     auto execNet = core->compile_model(function, target_device, configuration);
     auto execGraph = execNet.get_runtime_model();
     EXPECT_NE(execGraph, nullptr);

--- a/src/tests/functional/plugin/shared/include/behavior/ov_plugin/query_model.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_plugin/query_model.hpp
@@ -29,7 +29,7 @@ TEST_P(OVClassModelTestP, QueryModelWithKSO) {
     }
 }
 
-TEST_P(OVClassModelTestP, QueryModelWithMatMul) {
+TEST_P(OVClassQueryModelTest, QueryModelWithMatMul) {
     ov::Core ie = createCoreWithTemplate();
 
     std::shared_ptr<ngraph::Function> func;
@@ -76,11 +76,6 @@ TEST_P(OVClassQueryModelTest, QueryModelHETEROWithDeviceIDNoThrow) {
                                       ov::device::priorities(target_device + "." + deviceIDs[0], target_device)));
 }
 
-TEST_P(OVClassQueryModelTest, QueryModelWithDeviceID) {
-    ov::Core ie = createCoreWithTemplate();
-    ie.query_model(simpleNetwork, target_device + ".0");
-}
-
 TEST_P(OVClassQueryModelTest, QueryModelWithBigDeviceIDThrows) {
     ov::Core ie = createCoreWithTemplate();
     ASSERT_THROW(ie.query_model(actualNetwork, target_device + ".110"), ov::Exception);
@@ -91,14 +86,6 @@ TEST_P(OVClassQueryModelTest, QueryModelWithInvalidDeviceIDThrows) {
     ASSERT_THROW(ie.query_model(actualNetwork, target_device + ".l0"), ov::Exception);
 }
 
-TEST_P(OVClassQueryModelTest, QueryModelHETEROWithBigDeviceIDThrows) {
-    ov::Core ie = createCoreWithTemplate();
-
-    ASSERT_THROW(ie.query_model(actualNetwork,
-                                CommonTestUtils::DEVICE_HETERO,
-                                ov::device::priorities(target_device + ".100", target_device)),
-                 ov::Exception);
-}
 }  // namespace behavior
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - *API: remove u1 u4 i4 for OVInferRequestIOTensorSetPrecisionTest and OVInferRequestCheckTensorPrecision*
- *API: OVInferRequestIOTensorTest , OVInferRequestIOTensorSetPrecisionTest , OVInferRequestCheckTensorPrecision set us mandatory*
 - *GPU: add missing OVGetMetricPropsTest tests to skip_tests_config*
 - *API: split OVClassModelTestP tests to mandatory and optional, optional tests is named OVClassModelOptionalTestP*
 - *remove some OVClassQueryModelTest*

### Tickets:
 - *CVS-103950*
