### PR TITLE
[DOCS] Added a missing import keyword

### DIFF
--- a/tools/pot/docs/AccuracyAwareQuantizationUsage.md
+++ b/tools/pot/docs/AccuracyAwareQuantizationUsage.md
@@ -133,7 +133,7 @@ The example code below shows a basic quantization workflow with accuracy control
 .. code-block:: python
    
    from openvino.tools.pot import IEEngine
-   from openvino.tools.pot load_model, save_model
+   from openvino.tools.pot import load_model, save_model
    from openvino.tools.pot import compress_model_weights
    from openvino.tools.pot import create_pipeline
    

--- a/tools/pot/docs/DefaultQuantizationUsage.md
+++ b/tools/pot/docs/DefaultQuantizationUsage.md
@@ -108,7 +108,7 @@ An example code below shows a basic quantization workflow:
 .. code-block:: python
 
    from openvino.tools.pot import IEEngine
-   from openvino.tools.pot load_model, save_model
+   from openvino.tools.pot import load_model, save_model
    from openvino.tools.pot import compress_model_weights
    from openvino.tools.pot import create_pipeline
 


### PR DESCRIPTION
### Details:
 - Couple of code blocks were missing an `import` keyword

