### PR TITLE
[GPU] Added print batch_hash and entry_hash of corresponding opencl kernel

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
@@ -35,6 +35,9 @@ struct typed_primitive_impl_ocl : public typed_primitive_impl<PType> {
     std::vector<std::string> _cached_kernel_ids;
     std::vector<kernel::ptr> _kernels;
 
+    // a pair of batch program hash and kernel entry hash of each ocl impl.
+    std::pair<std::string, std::string> kernel_dump_info;
+
     typed_primitive_impl_ocl() :  _kernel_data({}), _cached_kernel_ids({}), _kernels({}) {
         _kernel_data.weightsReorderParams.engine = kernel_selector::generic_kernel_params::Engine::NONE;
         _kernel_data.weightsReorderParams.cpuKernel = nullptr;
@@ -142,8 +145,11 @@ protected:
         if (!_kernel_data.kernels.empty()) {
             auto compiled_kernels = kernels_cache.get_kernels(params);
             _kernels.insert(_kernels.begin(), compiled_kernels.begin(), compiled_kernels.end());
+            // batch program hash and kernel entry point to find corresponding cl source code
+            kernel_dump_info = std::make_pair(std::to_string(kernels_cache.get_kernel_batch_hash(params)),
+                                          _kernel_data.kernels[0].code.kernelString->entry_point);
         }
-    }
+   }
 
     void init_by_cached_kernels(const kernels_cache& kernels_cache) override {
         if (is_cpu()) {
@@ -305,6 +311,10 @@ protected:
 
     std::vector<kernel::ptr> get_kernels() override {
         return _kernels;
+    }
+
+    std::pair<std::string, std::string> get_kernels_dump_info() const override {
+        return kernel_dump_info;
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -69,6 +69,10 @@ struct primitive_impl {
     virtual std::vector<kernel::ptr> get_kernels() const { return {}; }
     virtual void save(cldnn::BinaryOutputBuffer& ob) const {}
     virtual void load(cldnn::BinaryInputBuffer& ib) {}
+    // returns a pair of batch program hash and kernel entry of each ocl impl. Returns "" for other impl types.
+    virtual std::pair<std::string, std::string> get_kernels_dump_info() const {
+        return std::make_pair("", "");
+    }
 
     // If this flag is set as false, the memory allocated for this primitive is not allowed to be reused
     bool can_reuse_memory = true;

--- a/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
@@ -207,8 +207,16 @@ void dump_graph_init(std::ofstream& graph,
         if (!node->is_type<data>()) {
             graph << "\\n Selected kernel: "
                   << (node->get_selected_impl() == nullptr ? "none"
-                                                           : node->get_selected_impl()->get_kernel_name()) + " / "
+                        : (node->get_preferred_impl_type() == impl_types::ocl && node->get_selected_impl()->get_kernels_dump_info().second.size())
+                        ?  node->get_selected_impl()->get_kernels_dump_info().second
+                        : node->get_selected_impl()->get_kernel_name()) + " / "
                   << node->get_preferred_impl_type();
+            if (node->get_selected_impl()) {
+                auto dump_info = node->get_selected_impl()->get_kernels_dump_info();
+                if (dump_info.first.size()) {
+                    graph << "\\n batch_hash : " << dump_info.first;
+                }
+            }
         }
         graph << "\n" + dump_mem_info(node);
         graph << "\"";

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -190,6 +190,13 @@ std::unique_ptr<json_composite> program_node::desc_to_json() const {
 #pragma clang diagnostic ignored "-Wpotentially-evaluated-expression"
 #endif
         impls.push_back(selected_impl->get_kernel_name());
+
+        if (get_preferred_impl_type() == impl_types::ocl) {
+            json_composite cl_dump_info;
+            cl_dump_info.add("batch_hash", selected_impl->get_kernels_dump_info().first);
+            cl_dump_info.add("kernel_entry", selected_impl->get_kernels_dump_info().second);
+            node_info->add("cl dump_ info", cl_dump_info);
+        }
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/runtime/kernels_cache.cpp
@@ -291,6 +291,9 @@ void kernels_cache::build_batch(const engine& build_engine, const batch_program&
                     } else {
                         compiled_kernels[params] = { std::make_pair(kernel, kernel_part_idx) };
                     }
+                    if (_kernel_batch_hash.find(params) == _kernel_batch_hash.end()) {
+                       _kernel_batch_hash[params] = batch.hash_value;
+                    }
                 } else {
                     throw std::runtime_error("Could not find entry point");
                 }
@@ -447,6 +450,7 @@ void kernels_cache::build_all() {
 void kernels_cache::reset() {
     _kernels.clear();
     _kernels_code.clear();
+    _kernel_batch_hash.clear();
     _pending_compilation = false;
 }
 

--- a/src/plugins/intel_gpu/src/runtime/kernels_cache.hpp
+++ b/src/plugins/intel_gpu/src/runtime/kernels_cache.hpp
@@ -84,7 +84,7 @@ private:
     std::map<std::vector<unsigned char>, uint32_t> _cached_binaries;
     std::unordered_map<std::string, kernel::ptr> _cached_kernels;
     std::vector<std::string> batch_header_str;
-
+    std::unordered_map<kernel_impl_params, size_t, impl_hasher> _kernel_batch_hash;
     void get_program_source(const kernels_code& kernels_source_code, std::vector<batch_program>*) const;
     void build_batch(const engine& build_engine, const batch_program& batch, compiled_kernels& compiled_kernels);
 
@@ -120,6 +120,12 @@ public:
     std::string get_cached_kernel_id(kernel::ptr kernel) const;
     std::vector<std::string> get_cached_kernel_ids(const std::vector<kernel::ptr>& kernels) const;
     void add_to_cached_kernels(const std::vector<kernel::ptr>& kernels);
+
+    size_t get_kernel_batch_hash(const kernel_impl_params params) const {
+        if (_kernel_batch_hash.find(params) != _kernel_batch_hash.end())
+            return _kernel_batch_hash.at(params);
+        return 0;
+    }
 
     void save(BinaryOutputBuffer& ob) const;
     void load(BinaryInputBuffer& ib);


### PR DESCRIPTION
### Details:
 - ocl nodes in  OV_GPU_DumpGraph will show corresponding batch hash and kernel entry name in the dumped cl codes by OV_GPU_DumpSources

