### PR TITLE
Fix enable_plugins_xml

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -96,7 +96,7 @@ ie_option (ENABLE_HETERO "Enables Hetero Device Plugin" ON)
 
 ie_option (ENABLE_TEMPLATE "Enable template plugin" ON)
 
-ie_dependent_option (ENABLE_PLUGINS_XML "Generate plugins.xml configuration file or not" OFF "NOT BUILD_SHARED_LIBS" OFF)
+ie_dependent_option (ENABLE_PLUGINS_XML "Generate plugins.xml configuration file or not" OFF "BUILD_SHARED_LIBS" OFF)
 
 ie_dependent_option (GAPI_TEST_PERF "if GAPI unit tests should examine performance" OFF "ENABLE_TESTS;ENABLE_GAPI_PREPROCESSING" OFF)
 


### PR DESCRIPTION
### Details:
`cmake_dependent_option(<option> "<help_text>" <value> <depends> <force>)`
Makes `<option>` available to the user if the [semicolon-separated list](https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#cmake-language-lists) of conditions in `<depends>` are all true. Otherwise, a local variable named `<option>` is set to `<force>`.

https://cmake.org/cmake/help/latest/module/CMakeDependentOption.html

### Tickets:
 - E78176
 - E78327

### Release cherry-pick
https://github.com/openvinotoolkit/openvino/pull/17293 