### PR TITLE
[TF FE] Use original input types for SavedModel

### DIFF
--- a/src/frontends/tensorflow/src/input_model.cpp
+++ b/src/frontends/tensorflow/src/input_model.cpp
@@ -175,7 +175,15 @@ void InputModel::InputModelTFImpl::load_places() {
             }
             std::vector<std::string> names = {op_name};
             auto tensor_place = std::make_shared<TensorPlace>(m_input_model, pshape, type, names);
+
+            // In Model Optimizer user can refer to model inputs by a name of Placeholder
+            // and its output port, for example, using `input_name` and `input_name:0`
+            // Also, SavedModel format contains a signature that maps external input names to internal ones with port
+            // index like `input_name` maps to `serving_default_input_name:0`.
+            // So we have to store with `:0` as well to get its tensor by `get_place_by_tensor_name` method
             m_tensor_places[op_name] = tensor_place;
+            m_tensor_places[op_name + ":0"] = tensor_place;
+
             if (op_type == "Placeholder") {
                 // by default, PlaceholderWithDefault is NOT used as input
                 m_inputs.push_back(tensor_place);
@@ -462,12 +470,16 @@ std::vector<ov::frontend::Place::Ptr> InputModel::InputModelTFImpl::get_outputs(
 }
 
 ov::frontend::Place::Ptr InputModel::InputModelTFImpl::get_place_by_tensor_name(const std::string& tensorName) const {
-    std::string internalTensorName = tensorName;
+    std::string internal_tensor_name = tensorName;
 
-    if (m_saved_model_input_names.get()) {
+    // For SavedModel format, an user can work with external input names, namely, without `serving_default_` prefix
+    // so we have to map it into the internal name to find the tensor in the tensor pool m_tensor_places.
+    // m_saved_model_input_names contains a map from external name to the internal name with port ':0'
+    // for example, `input_mask` maps to `serving_default_input_mask:0`
+    if (m_saved_model_input_names) {
         for (const auto& alt_name : *m_saved_model_input_names) {
             if (alt_name.second == tensorName) {
-                internalTensorName = alt_name.first;
+                internal_tensor_name = alt_name.first;
                 break;
             }
         }
@@ -476,28 +488,28 @@ ov::frontend::Place::Ptr InputModel::InputModelTFImpl::get_place_by_tensor_name(
     if (m_saved_model_output_names.get()) {
         for (const auto& alt_name : *m_saved_model_output_names) {
             if (alt_name.second == tensorName) {
-                internalTensorName = alt_name.first;
+                internal_tensor_name = alt_name.first;
                 break;
             }
         }
     }
 
-    if (m_tensor_places.find(internalTensorName) != m_tensor_places.end()) {
-        return m_tensor_places.at(internalTensorName);
+    if (m_tensor_places.find(internal_tensor_name) != m_tensor_places.end()) {
+        return m_tensor_places.at(internal_tensor_name);
     }
 
     // check that operation node exists for which this place is specified
     std::string operation_name;
     size_t port_idx;
     std::string port_type;
-    tensorflow::extract_operation_name_and_port(internalTensorName, operation_name, port_idx, port_type);
+    tensorflow::extract_operation_name_and_port(internal_tensor_name, operation_name, port_idx, port_type);
 
     if (m_op_places_map.find(operation_name) != m_op_places_map.end()) {
         // new Tensor places must be constructed of dynamic rank and type
-        std::vector<std::string> names = {internalTensorName};
+        std::vector<std::string> names = {internal_tensor_name};
         auto m_var_place =
             std::make_shared<TensorPlace>(m_input_model, ov::PartialShape::dynamic(), ov::element::dynamic, names);
-        m_tensor_places[internalTensorName] = m_var_place;
+        m_tensor_places[internal_tensor_name] = m_var_place;
         return m_var_place;
     }
 

--- a/src/frontends/tensorflow/tests/basic_api.cpp
+++ b/src/frontends/tensorflow/tests/basic_api.cpp
@@ -8,6 +8,7 @@
 
 using namespace ngraph;
 using namespace ov::frontend;
+using namespace ov::frontend::tensorflow::tests;
 
 using TFBasicTest = FrontEndBasicTest;
 

--- a/src/frontends/tensorflow/tests/compilation.cpp
+++ b/src/frontends/tensorflow/tests/compilation.cpp
@@ -10,26 +10,7 @@
 #include "tf_utils.hpp"
 #include "utils.hpp"
 
-namespace {
-std::shared_ptr<ov::Model> convert_model(const std::string& model_path) {
-    ov::frontend::FrontEndManager fem;
-    auto front_end = fem.load_by_framework(TF_FE);
-    if (!front_end) {
-        throw "TensorFlow Frontend is not initialized";
-    }
-    auto model_filename = FrontEndTestUtils::make_model_path(std::string(TEST_TENSORFLOW_MODELS_DIRNAME) + model_path);
-    auto input_model = front_end->load(model_filename);
-    if (!input_model) {
-        throw "Input model is not read";
-    }
-    auto model = front_end->convert(input_model);
-    if (!model) {
-        throw "Model is not converted";
-    }
-
-    return model;
-}
-}  // namespace
+using namespace ov::frontend::tensorflow::tests;
 
 class CompileModelsTests : public ::testing::Test {};
 

--- a/src/frontends/tensorflow/tests/conversion.cpp
+++ b/src/frontends/tensorflow/tests/conversion.cpp
@@ -9,6 +9,7 @@
 #include "tf_utils.hpp"
 
 using namespace ov::frontend;
+using namespace ov::frontend::tensorflow::tests;
 
 using TFConversionExtensionTest = FrontEndConversionExtensionTest;
 

--- a/src/frontends/tensorflow/tests/convert_model.cpp
+++ b/src/frontends/tensorflow/tests/convert_model.cpp
@@ -8,6 +8,7 @@
 
 using namespace ngraph;
 using namespace ov::frontend;
+using namespace ov::frontend::tensorflow::tests;
 
 using TFConvertModelTest = FrontEndConvertModelTest;
 

--- a/src/frontends/tensorflow/tests/convert_saved_model.cpp
+++ b/src/frontends/tensorflow/tests/convert_saved_model.cpp
@@ -1,0 +1,61 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <openvino/opsets/opset10.hpp>
+
+#include "common_test_utils/ngraph_test_utils.hpp"
+#include "gtest/gtest.h"
+#include "test_common.hpp"
+#include "tf_utils.hpp"
+
+using namespace std;
+using namespace ov;
+using namespace ov::opset10;
+using namespace ov::frontend::tensorflow::tests;
+
+TEST_F(TransformationTestsF, SavedModelProgramOnly) {
+    { model = convert_model("saved_model_program-only"); }
+    {
+        // create a reference graph
+        auto x = make_shared<Constant>(element::f32, Shape{2, 3}, vector<float>{1, 2, 3, 3, 2, 1});
+        auto y = make_shared<Parameter>(element::f32, Shape{1});
+        auto add = make_shared<Add>(x, y);
+
+        model_ref = make_shared<Model>(OutputVector{add}, ParameterVector{y});
+    }
+}
+
+TEST_F(TransformationTestsF, SavedModelVariables) {
+    { model = convert_model("saved_model_variables"); }
+    {
+        // create a reference graph
+        auto x = make_shared<Parameter>(element::f32, Shape{1});
+        auto y = make_shared<Constant>(element::f32, Shape{}, vector<float>{123});
+        auto multiply = make_shared<Multiply>(x, y);
+
+        model_ref = make_shared<Model>(OutputVector{multiply}, ParameterVector{x});
+    }
+}
+
+TEST_F(TransformationTestsF, SavedModelWithInputIntegerType) {
+    {
+        model = convert_model("saved_model_with_gather",
+                              nullptr,
+                              {"params", "indices"},
+                              {},
+                              {PartialShape{10, 5}, PartialShape{3}});
+    }
+    {
+        // create a reference graph
+        auto params = make_shared<Parameter>(element::f32, Shape{10, 5});
+        auto indices = make_shared<Parameter>(element::i32, Shape{3});
+        auto gather_axis = make_shared<Constant>(element::i32, Shape{}, 0);
+        auto gather = make_shared<Gather>(params, indices, gather_axis);
+
+        auto const_mul = make_shared<Constant>(element::f32, Shape{}, 5);
+        auto mul = make_shared<Multiply>(gather, const_mul);
+
+        model_ref = make_shared<Model>(OutputVector{mul}, ParameterVector{params, indices});
+    }
+}

--- a/src/frontends/tensorflow/tests/convert_unsupported.cpp
+++ b/src/frontends/tensorflow/tests/convert_unsupported.cpp
@@ -21,6 +21,7 @@ using namespace ov;
 using namespace ov::element;
 using namespace ov::opset10;
 using namespace ov::frontend;
+using namespace ov::frontend::tensorflow::tests;
 
 namespace {
 class TestDecoder : public ov::frontend::DecoderBase {
@@ -70,25 +71,6 @@ shared_ptr<Model> convert_model_partially(const string& model_path) {
         throw "Model is not converted partially";
     }
 
-    return model;
-}
-
-shared_ptr<Model> convert_model(const string& model_path, const ConversionExtension::Ptr& conv_ext = nullptr) {
-    FrontEndManager fem;
-    auto front_end = fem.load_by_framework(TF_FE);
-    if (!front_end) {
-        throw "TensorFlow Frontend is not initialized";
-    }
-    if (conv_ext) {
-        front_end->add_extension(conv_ext);
-    }
-    auto model_filename = FrontEndTestUtils::make_model_path(string(TEST_TENSORFLOW_MODELS_DIRNAME) + model_path);
-    auto input_model = front_end->load(model_filename);
-    if (!input_model) {
-        throw "Input model is not read";
-    }
-
-    auto model = front_end->convert(input_model);
     return model;
 }
 

--- a/src/frontends/tensorflow/tests/library_extension.cpp
+++ b/src/frontends/tensorflow/tests/library_extension.cpp
@@ -7,6 +7,7 @@
 #include "tf_utils.hpp"
 
 using namespace ov::frontend;
+using namespace ov::frontend::tensorflow::tests;
 
 using TFLibraryExtensionTest = FrontendLibraryExtensionTest;
 

--- a/src/frontends/tensorflow/tests/op_extension.cpp
+++ b/src/frontends/tensorflow/tests/op_extension.cpp
@@ -11,6 +11,7 @@
 #include "tf_utils.hpp"
 
 using namespace ov::frontend;
+using namespace ov::frontend::tensorflow::tests;
 
 using TFOpExtensionTest = FrontEndOpExtensionTest;
 

--- a/src/frontends/tensorflow/tests/telemetry.cpp
+++ b/src/frontends/tensorflow/tests/telemetry.cpp
@@ -11,6 +11,7 @@
 #include "utils.hpp"
 
 using namespace ov::frontend;
+using namespace ov::frontend::tensorflow::tests;
 using namespace std;
 using namespace std::placeholders;
 

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_with_gather.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_saved_model_with_gather.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+import tensorflow as tf
+
+
+# This test model aims to cover conversion of SavedModel with integer input types
+class ModelWithGather(tf.Module):
+    def __init__(self):
+        super(ModelWithGather, self).__init__()
+        self.var1 = tf.Variable(5.0)
+
+    @tf.function(input_signature=[tf.TensorSpec([20, 5], tf.float32), tf.TensorSpec([4], tf.int32)])
+    def __call__(self, params, indices):
+        gather = tf.raw_ops.GatherV2(params=params, indices=indices, axis=0)
+        return {'test_output_name': gather * self.var1}
+
+
+module = ModelWithGather()
+tf.saved_model.save(module, os.path.join(sys.argv[1], "saved_model_with_gather"))

--- a/src/frontends/tensorflow/tests/tf_utils.cpp
+++ b/src/frontends/tensorflow/tests/tf_utils.cpp
@@ -1,0 +1,78 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "tf_utils.hpp"
+
+#include "utils.hpp"
+
+using namespace std;
+using namespace ov;
+using namespace ov::element;
+using namespace ov::frontend;
+
+namespace ov {
+namespace frontend {
+namespace tensorflow {
+namespace tests {
+
+shared_ptr<Model> convert_model(const string& model_path,
+                                const ConversionExtension::Ptr& conv_ext,
+                                const vector<string>& input_names,
+                                const vector<element::Type>& input_types,
+                                const vector<PartialShape>& input_shapes) {
+    FrontEndManager fem;
+    auto front_end = fem.load_by_framework(TF_FE);
+    if (!front_end) {
+        throw "TensorFlow Frontend is not initialized";
+    }
+    if (conv_ext) {
+        front_end->add_extension(conv_ext);
+    }
+    auto model_filename = FrontEndTestUtils::make_model_path(string(TEST_TENSORFLOW_MODELS_DIRNAME) + model_path);
+    auto input_model = front_end->load(model_filename);
+    if (!input_model) {
+        throw "Input model is not read";
+    }
+
+    // set custom inputs, input shapes and types
+    vector<Place::Ptr> input_places;
+    for (const auto& input_name : input_names) {
+        auto input_place = input_model->get_place_by_tensor_name(input_name);
+        if (!input_place) {
+            throw "Input place with name " + input_name + " is not found ";
+        }
+        input_places.push_back(input_place);
+    }
+    if (input_places.size() < input_types.size()) {
+        throw "The number of input places is less than the number of types";
+    }
+    for (size_t ind = 0; ind < input_types.size(); ++ind) {
+        auto input_type = input_types[ind];
+        auto input_place = input_places[ind];
+        input_model->set_element_type(input_place, input_type);
+    }
+    if (input_places.size() < input_shapes.size()) {
+        throw "The number of input places is less than the number of shapes";
+    }
+    for (size_t ind = 0; ind < input_shapes.size(); ++ind) {
+        auto input_shape = input_shapes[ind];
+        auto input_place = input_places[ind];
+        input_model->set_partial_shape(input_place, input_shape);
+    }
+    if (!input_places.empty()) {
+        input_model->override_all_inputs(input_places);
+    }
+
+    auto model = front_end->convert(input_model);
+    if (!model) {
+        throw "Model is not converted";
+    }
+
+    return model;
+}
+
+}  // namespace tests
+}  // namespace tensorflow
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/tensorflow/tests/tf_utils.hpp
+++ b/src/frontends/tensorflow/tests/tf_utils.hpp
@@ -4,6 +4,27 @@
 
 #pragma once
 
+#include <openvino/core/partial_shape.hpp>
+#include <openvino/core/type/element_type.hpp>
+#include <openvino/frontend/extension.hpp>
 #include <string>
+#include <vector>
 
+namespace ov {
+namespace frontend {
+namespace tensorflow {
+namespace tests {
 static const std::string TF_FE = "tf";
+
+// a wrapper to create TensorFlow Frontend and configure the conversion pipeline
+// by registering new translator via extension, specifying (new) inputs, their shapes and types
+std::shared_ptr<Model> convert_model(const std::string& model_path,
+                                     const ov::frontend::ConversionExtension::Ptr& conv_ext = nullptr,
+                                     const std::vector<std::string>& input_names = {},
+                                     const std::vector<ov::element::Type>& input_types = {},
+                                     const std::vector<ov::PartialShape>& input_shapes = {});
+
+}  // namespace tests
+}  // namespace tensorflow
+}  // namespace frontend
+}  // namespace ov


### PR DESCRIPTION
**Details:** The problem is that if user tries to convert a model with specified shapes `"--input input1[2,3],input2[4,5]"`, TF FE creates a new tensor place with dynamic type. Though, it should use the original type for `input1` and `input2`. That is a reason to get inconsistent type during conversion of SM format.

Also, refactor TF FE unit-tests. 

**Ticket:** 109544


