### PR TITLE
Fixed Python API build for Ubuntu 22.04 with python3.11

### DIFF
--- a/.ci/openvino-onnx/Dockerfile
+++ b/.ci/openvino-onnx/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:23.04
 
 LABEL version=2021.03.30.1
 
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
         python3 \
         python3-pip \
         python3-dev \
+        pybind11-dev \
         python3-virtualenv \
         cython3 \
         tox && \
@@ -71,5 +72,5 @@ RUN ninja install
 WORKDIR /openvino/src/bindings/python
 ENV OpenVINO_DIR=/openvino/dist/runtime/cmake
 ENV LD_LIBRARY_PATH=/openvino/dist/runtime/lib/intel64:/openvino/dist/runtime/3rdparty/tbb/lib
-ENV PYTHONPATH=/openvino/bin/intel64/${BUILD_TYPE}/python_api/python3.10:${PYTHONPATH}
+ENV PYTHONPATH=/openvino/bin/intel64/${BUILD_TYPE}/python_api/python3.11:${PYTHONPATH}
 CMD tox

--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -62,6 +62,7 @@ if [ -f /etc/lsb-release ] || [ -f /etc/debian_version ] ; then
         python3-venv \
         python3-setuptools \
         libpython3-dev \
+        pybind11-dev \
         libffi-dev \
         `# spell checking for MO sources` \
         python3-enchant \

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -36,12 +36,18 @@ function(ov_check_python_build_conditions)
     # Try to find python3 and its libs
     find_host_package(PythonInterp 3 ${find_package_mode})
     if(PYTHONINTERP_FOUND)
+        if(PYTHON_VERSION_MINOR GREATER_EQUAL 11)
+            set(pybind11_min_version 2.9.2)
+        else()
+            set(pybind11_min_version 2.8.0)
+        endif()
+
         function(_ov_find_python_libs_new)
             set(pybind11_tools_dir "${OpenVINOPython_SOURCE_DIR}/thirdparty/pybind11/tools")
             if(EXISTS ${pybind11_tools_dir})
                 list(APPEND CMAKE_MODULE_PATH ${pybind11_tools_dir})
             else()
-                find_package(pybind11 2.8.0 QUIET)
+                find_package(pybind11 ${pybind11_min_version} QUIET)
                 list(APPEND CMAKE_MODULE_PATH "${pybind11_DIR}")
             endif()
             # use libraries with the same version as python itself
@@ -106,6 +112,8 @@ function(ov_check_python_build_conditions)
 
     # to disable API 1.0
     set(ie_python_req_FOUND ${ie_python_req_FOUND} PARENT_SCOPE)
+    # set pybind11 minimal version
+    set(pybind11_min_version ${pybind11_min_version} PARENT_SCOPE)
 endfunction()
 
 ov_check_python_build_conditions()
@@ -161,7 +169,7 @@ endif()
 # Build the code
 #
 
-find_package(pybind11 2.8.0 QUIET)
+find_package(pybind11 ${pybind11_min_version} QUIET)
 
 if(NOT pybind11_FOUND)
     add_subdirectory(thirdparty/pybind11 EXCLUDE_FROM_ALL)

--- a/tools/mo/unit_tests/mock_mo_frontend/mock_mo_python_api/CMakeLists.txt
+++ b/tools/mo/unit_tests/mock_mo_frontend/mock_mo_python_api/CMakeLists.txt
@@ -28,7 +28,13 @@ set(PYBIND_FE_SRC ${CMAKE_CURRENT_SOURCE_DIR}/mock_mo_python_api.cpp)
 
 source_group("src" FILES ${PYBIND_FE_SRC})
 
-find_package(pybind11 2.8.0 QUIET)
+if(PYTHON_VERSION_MINOR GREATER_EQUAL 11)
+    set(pybind11_min_version 2.9.2)
+else()
+    set(pybind11_min_version 2.8.0)
+endif()
+
+find_package(pybind11 ${pybind11_min_version} QUIET)
 
 if(NOT pybind11_FOUND)
     add_subdirectory(${OpenVINO_SOURCE_DIR}/src/bindings/python/thirdparty/pybind11


### PR DESCRIPTION
### Details:
 - Increase minimal pybind11 version for python 3.11

### Tickets:
 - CVS-109469
