### PR TITLE
[GPU] Don't throw exception if no devices are found

### DIFF
--- a/src/bindings/c/tests/ov_remote_context_test.cpp
+++ b/src/bindings/c/tests/ov_remote_context_test.cpp
@@ -26,7 +26,11 @@ protected:
 
         char* info = nullptr;
         const char* key = ov_property_key_available_devices;
-        if (ov_core_get_property(core, "GPU", key, &info) != ov_status_e::OK) {
+        EXPECT_EQ(ov_core_get_property(core, "GPU", key, &info), ov_status_e::OK);
+        EXPECT_STRNE(info, nullptr);
+
+        if (strlen(info) == 0) {
+            ov_free(info);
             GTEST_SKIP();
         }
         ov_free(info);

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/engine_configuration.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/engine_configuration.hpp
@@ -18,7 +18,7 @@ enum class engine_types : int32_t {
     ocl,
 };
 
-inline std::ostream& operator<<(std::ostream& os, engine_types type) {
+inline std::ostream& operator<<(std::ostream& os, const engine_types& type) {
     switch (type) {
     case engine_types::ocl: os << "ocl"; break;
     default: os << "unknown"; break;
@@ -31,5 +31,14 @@ inline std::ostream& operator<<(std::ostream& os, engine_types type) {
 enum class runtime_types : int32_t {
     ocl,
 };
+
+inline std::ostream& operator<<(std::ostream& os, const runtime_types& type) {
+    switch (type) {
+    case runtime_types::ocl: os << "ocl"; break;
+    default: os << "unknown"; break;
+    }
+
+    return os;
+}
 
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -536,7 +536,8 @@ InferenceEngine::IExecutableNetworkInternal::Ptr Plugin::ImportNetwork(std::istr
 
 Parameter Plugin::GetConfig(const std::string& name, const std::map<std::string, Parameter>& options) const {
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "Plugin::GetConfig");
-
+    OPENVINO_ASSERT(!device_map.empty(), "[GPU] Can't get ", name, " property as no supported devices found or an error happened during devices query.\n"
+                                         "[GPU] Please check OpenVINO documentation for GPU drivers setup guide.\n");
     std::string device_id = default_device_id;
     if (options.find(ov::device::id.name()) != options.end()) {
         device_id = options.find(ov::device::id.name())->second.as<std::string>();
@@ -578,6 +579,32 @@ auto StringRightTrim = [](std::string string, std::string substring, bool case_s
 Parameter Plugin::GetMetric(const std::string& name, const std::map<std::string, Parameter>& options) const {
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "Plugin::GetMetric");
     GPU_DEBUG_GET_INSTANCE(debug_config);
+
+    // The metrics below don't depend on the device ID, so we should handle those
+    // earler than querying actual ID to avoid exceptions when no devices are found
+    if (name == ov::supported_properties) {
+        return decltype(ov::supported_properties)::value_type {get_supported_properties()};
+    } else if (name == METRIC_KEY(SUPPORTED_METRICS)) {
+        IE_SET_METRIC_RETURN(SUPPORTED_METRICS, LegacyAPIHelper::get_supported_metrics());
+    } else if (name == METRIC_KEY(SUPPORTED_CONFIG_KEYS)) {
+        IE_SET_METRIC_RETURN(SUPPORTED_CONFIG_KEYS, LegacyAPIHelper::get_supported_configs());
+    } else if (name == METRIC_KEY(AVAILABLE_DEVICES)) {
+        std::vector<std::string> availableDevices = { };
+        for (auto const& dev : device_map)
+            availableDevices.push_back(dev.first);
+        return decltype(ov::available_devices)::value_type {availableDevices};
+    } else if (name == ov::caching_properties) {
+        std::vector<ov::PropertyName> cachingProperties;
+        cachingProperties.push_back(ov::PropertyName(ov::device::architecture.name(), PropertyMutability::RO));
+        cachingProperties.push_back(ov::PropertyName(ov::intel_gpu::execution_units_count.name(), PropertyMutability::RO));
+        cachingProperties.push_back(ov::PropertyName(ov::intel_gpu::driver_version.name(), PropertyMutability::RO));
+        cachingProperties.push_back(ov::PropertyName(ov::hint::inference_precision.name(), PropertyMutability::RW));
+        cachingProperties.push_back(ov::PropertyName(ov::hint::execution_mode.name(), PropertyMutability::RW));
+        return decltype(ov::caching_properties)::value_type(cachingProperties);
+    } else if (name == METRIC_KEY(IMPORT_EXPORT_SUPPORT)) {
+        IE_SET_METRIC_RETURN(IMPORT_EXPORT_SUPPORT, true);
+    }
+
     auto device_id = GetConfig(ov::device::id.name(), options).as<std::string>();
 
     auto iter = device_map.find(std::to_string(cldnn::device_query::device_id));
@@ -589,16 +616,7 @@ Parameter Plugin::GetMetric(const std::string& name, const std::map<std::string,
     auto device_info = device->get_info();
     bool is_new_api = IsNewAPI();
 
-    if (name == ov::supported_properties) {
-        return decltype(ov::supported_properties)::value_type {get_supported_properties()};
-    } else if (name == METRIC_KEY(SUPPORTED_METRICS)) {
-        IE_SET_METRIC_RETURN(SUPPORTED_METRICS, LegacyAPIHelper::get_supported_metrics());
-    } else if (name == METRIC_KEY(AVAILABLE_DEVICES)) {
-        std::vector<std::string> availableDevices = { };
-        for (auto const& dev : device_map)
-            availableDevices.push_back(dev.first);
-        return decltype(ov::available_devices)::value_type {availableDevices};
-    } else if (name == ov::intel_gpu::device_total_mem_size) {
+    if (name == ov::intel_gpu::device_total_mem_size) {
         return decltype(ov::intel_gpu::device_total_mem_size)::value_type {device_info.max_global_mem_size};
     } else if (name == ov::device::type) {
         if (is_new_api) {
@@ -647,8 +665,6 @@ Parameter Plugin::GetMetric(const std::string& name, const std::map<std::string,
         auto deviceName = StringRightTrim(device_info.dev_name, "NEO", false);
         deviceName += std::string(" (") + (device_info.dev_type == cldnn::device_type::discrete_gpu ? "dGPU" : "iGPU") + ")";
         return decltype(ov::device::full_name)::value_type {deviceName};
-    } else if (name == METRIC_KEY(SUPPORTED_CONFIG_KEYS)) {
-        IE_SET_METRIC_RETURN(SUPPORTED_CONFIG_KEYS, LegacyAPIHelper::get_supported_configs());
     } else if (name == ov::device::capabilities) {
         return decltype(ov::device::capabilities)::value_type {get_device_capabilities(device_info)};
     } else if (name == ov::range_for_async_infer_requests) {
@@ -664,16 +680,6 @@ Parameter Plugin::GetMetric(const std::string& name, const std::map<std::string,
     } else if (name == METRIC_KEY(MAX_BATCH_SIZE) ||
                name == ov::max_batch_size) {
         return decltype(ov::max_batch_size)::value_type {static_cast<uint32_t>(get_max_batch_size(options))};
-    } else if (name == METRIC_KEY(IMPORT_EXPORT_SUPPORT)) {
-        IE_SET_METRIC_RETURN(IMPORT_EXPORT_SUPPORT, true);
-    } else if (name == ov::caching_properties) {
-        std::vector<ov::PropertyName> cachingProperties;
-        cachingProperties.push_back(ov::PropertyName(ov::device::architecture.name(), PropertyMutability::RO));
-        cachingProperties.push_back(ov::PropertyName(ov::intel_gpu::execution_units_count.name(), PropertyMutability::RO));
-        cachingProperties.push_back(ov::PropertyName(ov::intel_gpu::driver_version.name(), PropertyMutability::RO));
-        cachingProperties.push_back(ov::PropertyName(ov::hint::inference_precision.name(), PropertyMutability::RW));
-        cachingProperties.push_back(ov::PropertyName(ov::hint::execution_mode.name(), PropertyMutability::RW));
-        return decltype(ov::caching_properties)::value_type(cachingProperties);
     } else if (name == ov::intel_gpu::driver_version) {
         return decltype(ov::intel_gpu::driver_version)::value_type {device_info.driver_version};
     } else if (name == ov::intel_gpu::device_id) {

--- a/src/plugins/intel_gpu/src/plugin/remote_blob.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_blob.cpp
@@ -8,7 +8,6 @@
 #include "intel_gpu/plugin/remote_allocators.hpp"
 #include "intel_gpu/plugin/plugin.hpp"
 #include "intel_gpu/runtime/itt.hpp"
-#include "intel_gpu/runtime/device_query.hpp"
 
 using namespace InferenceEngine;
 using namespace InferenceEngine::gpu;

--- a/src/plugins/intel_gpu/src/runtime/device_query.cpp
+++ b/src/plugins/intel_gpu/src/runtime/device_query.cpp
@@ -27,9 +27,5 @@ device_query::device_query(engine_types engine_type,
     }
     default: throw std::runtime_error("Unsupported engine type in device_query");
     }
-
-    if (_available_devices.empty()) {
-        throw std::runtime_error("No suitable devices found for requested engine and runtime types");
-    }
 }
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/runtime/engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/engine.cpp
@@ -265,6 +265,9 @@ std::shared_ptr<cldnn::engine> engine::create(engine_types engine_type, runtime_
     device_query query(engine_type, runtime_type);
     auto devices = query.get_available_devices();
 
+    OPENVINO_ASSERT(!devices.empty(), "[GPU] Can't create ", engine_type, " engine for ", runtime_type, " runtime as no suitable devices are found\n"
+                                      "[GPU] Please check OpenVINO documentation for GPU drivers setup guide.\n");
+
     auto iter = devices.find(std::to_string(device_query::device_id));
     auto& device = iter != devices.end() ? iter->second : devices.begin()->second;
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.cpp
@@ -187,6 +187,10 @@ std::vector<device::ptr> ocl_device_detector::create_device_list() const {
     cl_uint num_platforms = 0;
     // Get number of platforms availible
     cl_int error_code = clGetPlatformIDs(0, NULL, &num_platforms);
+    if (num_platforms == 0 || error_code == CL_PLATFORM_NOT_FOUND_KHR) {
+        return {};
+    }
+
     OPENVINO_ASSERT(error_code == CL_SUCCESS, create_device_error_msg, "[GPU] clGetPlatformIDs error code: ", std::to_string(error_code));
     // Get platform list
     std::vector<cl_platform_id> platform_ids(num_platforms);
@@ -211,7 +215,6 @@ std::vector<device::ptr> ocl_device_detector::create_device_list() const {
             continue;
         }
     }
-    OPENVINO_ASSERT(!supported_devices.empty(), create_device_error_msg);
     return supported_devices;
 }
 

--- a/src/plugins/intel_gpu/tests/gtest_main_gpu.cpp
+++ b/src/plugins/intel_gpu/tests/gtest_main_gpu.cpp
@@ -30,7 +30,7 @@
 #include <cstdio>
 #include <string>
 
-#include "../../intel_gpu/include/intel_gpu/runtime/device_query.hpp"
+#include "intel_gpu/runtime/device_query.hpp"
 #include "gtest/gtest.h"
 #include "test_utils/test_utils.h"
 #include "gflags/gflags.h"

--- a/src/plugins/intel_gpu/tests/test_cases/cl_mem_input_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/cl_mem_input_test.cpp
@@ -75,6 +75,8 @@ template <typename T>
 void start_cl_mem_check_2_inputs(bool is_caching_test) {
     device_query query(engine_types::ocl, runtime_types::ocl);
     auto devices = query.get_available_devices();
+    ASSERT_TRUE(!devices.empty());
+
     auto iter = devices.find(std::to_string(device_query::device_id));
     auto& device = iter != devices.end() ? iter->second : devices.begin()->second;
     auto engine = engine::create(engine_types::ocl, runtime_types::ocl, device);
@@ -156,6 +158,7 @@ TEST(export_import_cl_mem_check, check_2_inputs) {
 TEST(cl_mem_check, check_input) {
     device_query query(engine_types::ocl, runtime_types::ocl);
     auto devices = query.get_available_devices();
+    ASSERT_TRUE(!devices.empty());
     auto iter = devices.find(std::to_string(device_query::device_id));
     auto& device = iter != devices.end() ? iter->second : devices.begin()->second;
     auto engine = engine::create(engine_types::ocl, runtime_types::ocl, device);
@@ -267,6 +270,7 @@ TEST(cl_mem_check, check_input) {
 TEST(cl_mem_check, check_write_access_type) {
     device_query query(engine_types::ocl, runtime_types::ocl);
     auto devices = query.get_available_devices();
+    ASSERT_TRUE(!devices.empty());
     cldnn::device::ptr device = devices.begin()->second;
     for (auto& dev : devices) {
         if (dev.second->get_info().dev_type == device_type::discrete_gpu)
@@ -301,6 +305,7 @@ TEST(cl_mem_check, check_write_access_type) {
 TEST(cl_mem_check, check_read_access_type) {
     device_query query(engine_types::ocl, runtime_types::ocl);
     auto devices = query.get_available_devices();
+    ASSERT_TRUE(!devices.empty());
     cldnn::device::ptr device = devices.begin()->second;
     for (auto& dev : devices) {
         if (dev.second->get_info().dev_type == device_type::discrete_gpu)

--- a/src/plugins/intel_gpu/tests/test_cases/convert_color_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/convert_color_gpu_test.cpp
@@ -296,6 +296,7 @@ TEST(convert_color, nv12_to_rgb_two_planes_surface_u8) {
 
     device_query query(engine_types::ocl, runtime_types::ocl);
     auto devices = query.get_available_devices();
+    ASSERT_TRUE(!devices.empty());
     auto iter = devices.find(std::to_string(device_query::device_id));
     auto& device = iter != devices.end() ? iter->second : devices.begin()->second;
     auto engine = engine::create(engine_types::ocl, runtime_types::ocl, device);
@@ -376,6 +377,7 @@ TEST(convert_color, nv12_to_rgb_single_plane_surface_u8) {
 
     device_query query(engine_types::ocl, runtime_types::ocl);
     auto devices = query.get_available_devices();
+    ASSERT_TRUE(!devices.empty());
     auto iter = devices.find(std::to_string(device_query::device_id));
     auto& device = iter != devices.end() ? iter->second : devices.begin()->second;
     auto engine = engine::create(engine_types::ocl, runtime_types::ocl, device);
@@ -532,6 +534,7 @@ void test_convert_color_i420_to_rgb_three_planes_surface_u8(bool is_caching_test
 
     device_query query(engine_types::ocl, runtime_types::ocl);
     auto devices = query.get_available_devices();
+    ASSERT_TRUE(!devices.empty());
     auto iter = devices.find(std::to_string(device_query::device_id));
     auto& device = iter != devices.end() ? iter->second : devices.begin()->second;
     auto engine = engine::create(engine_types::ocl, runtime_types::ocl, device);

--- a/src/plugins/intel_gpu/tests/test_cases/mem_perf_test.cpp
+++ b/src/plugins/intel_gpu/tests/test_cases/mem_perf_test.cpp
@@ -8,7 +8,6 @@
 #include <intel_gpu/primitives/input_layout.hpp>
 #include <intel_gpu/primitives/activation.hpp>
 #include <intel_gpu/primitives/data.hpp>
-#include <intel_gpu/runtime/device_query.hpp>
 
 static size_t img_size = 800;
 static std::string kernel_code =


### PR DESCRIPTION
### Details:
 - Currently GPU plugin may throw exception in Plugin c-tor if no available devices are found. In case if user just query the devices via core.get_property("GPU", ov::available_devices); he'll get an exception for such hw configuration. This patch allows empty result of the devices query
Also changed GetMetric impl to handle several properties before trying to determine current device
 - PR to master: #17288
