### PR TITLE
[GPU] Use BFS processing order for out_of_order queue

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -628,6 +628,11 @@ void program::post_optimize_graph(bool is_internal) {
 
     // update loop input/output primitive mappings
     apply_opt_pass<update_loop_primitive_map>();
+
+    // Recalculate processing order after all graph transformation to keep optimal primitives ordering
+    // for OOO queue
+    if (_config.get_property(ov::intel_gpu::queue_type) == QueueTypes::out_of_order)
+        get_processing_order().calculate_BFS_processing_order();
 }
 
 // mark if the node is constant assuming that all dependencies are marked properly


### PR DESCRIPTION
### Details:
 - This PR fixes performance issue caused by changing processing order from DFS to BFS during remove redundant reorder pass, which leads to less efficient kernels execution in case of out_of_order queue and higher host overheads in case of barriers usage for kernels synchronization
 - PR to master https://github.com/openvinotoolkit/openvino/pull/17250 

### Tickets:
 - 108347
