### PR TITLE
Fix issue with Pow when both inputs are scalars

### DIFF
--- a/src/frontends/pytorch/src/utils.cpp
+++ b/src/frontends/pytorch/src/utils.cpp
@@ -347,33 +347,24 @@ void align_eltwise_input_types(const NodeContext& context, Output<Node>& lhs, Ou
     // consider dynamic rank as non scalar
     const auto is_lhs_scalar = lhs_rank.is_static() && lhs_rank.get_length() == 0;
     const auto is_rhs_scalar = rhs_rank.is_static() && rhs_rank.get_length() == 0;
-    if (is_lhs_scalar && is_rhs_scalar) {
-        // if both scalar, align to lhs
-        rhs = context.mark_node(std::make_shared<opset10::ConvertLike>(rhs, lhs));
-        return;
-    }
     auto lhs_dst_type = lhs_type;
     auto rhs_dst_type = rhs_type;
-    if (is_lhs_scalar) {
-        if (lhs_type.is_real() && !rhs_type.is_real()) {
+    if (is_lhs_scalar && lhs_type.is_real() && !rhs_type.is_real()) {
             // if div we need to also align float types to highest bitness regardless of scalar
             if (!align_scalars)
                 lhs_dst_type = element::f32;
             rhs_dst_type = element::f32;
-        } else {
-            lhs = context.mark_node(std::make_shared<opset10::ConvertLike>(lhs, rhs));
-            return;
-        }
-    } else if (is_rhs_scalar) {
-        if (!lhs_type.is_real() && rhs_type.is_real()) {
+    } else if (is_rhs_scalar && !lhs_type.is_real() && rhs_type.is_real()) {
             lhs_dst_type = element::f32;
             // if div we need to also align float types to highest bitness regardless of scalar
             if (!align_scalars)
                 rhs_dst_type = element::f32;
-        } else {
-            rhs = context.mark_node(std::make_shared<opset10::ConvertLike>(rhs, lhs));
-            return;
-        }
+    } else if (is_lhs_scalar) {
+        lhs = context.mark_node(std::make_shared<opset10::ConvertLike>(lhs, rhs));
+        return;
+    } else if (is_rhs_scalar) {
+        rhs = context.mark_node(std::make_shared<opset10::ConvertLike>(rhs, lhs));
+        return;
     }
 
     if (lhs_dst_type == element::boolean || rhs_dst_type == element::boolean) {

--- a/tests/layer_tests/pytorch_tests/test_pow.py
+++ b/tests/layer_tests/pytorch_tests/test_pow.py
@@ -104,3 +104,22 @@ class TestPowMixedTypes(PytorchLayerTest):
         self.rhs_shape = rhs_shape
         self._test(*self.create_model(lhs_type, lhs_shape, rhs_type, rhs_shape),
                    ie_device, precision, ir_version)
+
+class TestPowMixedTypesScalars(PytorchLayerTest):
+    def _prepare_input(self):
+        return (torch.randn([1,2,3,4]).numpy(),)
+
+    def create_model(self):
+
+        class aten_pow(torch.nn.Module):
+            def forward(self, x):
+                return torch.pow(x.size(2), -0.5)
+
+        ref_net = None
+
+        return aten_pow(), ref_net, "aten::pow"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_pow_mixed_types(self, ie_device, precision, ir_version):
+        self._test(*self.create_model(), ie_device, precision, ir_version)


### PR DESCRIPTION
### Details:
 - *When both inputs to Pow or any other eltwise op we need to pay attention to float type, if one is int other is float we need to make both types as float32*

### Tickets:
 - *TBD*
