### PR TITLE
[Backport] OMZ submodule bump for Python 3.11

### DIFF
--- a/docs/OV_Runtime_UG/supported_plugins/CPU.md
+++ b/docs/OV_Runtime_UG/supported_plugins/CPU.md
@@ -444,7 +444,6 @@ Currently, the ``sparse weights decompression feature`` is supported with the fo
 2. Feature is only supported for Matrix Multiplication operations.
 3. HW target must have Intel AMX extension support (e.g., Intel® 4th Generation Xeon® processors (code name Sapphire Rapids)).
 4. The number of input and output channels of the weights must be a multiple of 64.
-5. Current feature implementation supports only sparse rate higher than 0.5.
 
 Additional Resources
 ###########################################################

--- a/samples/python/benchmark/bert_benchmark/requirements.txt
+++ b/samples/python/benchmark/bert_benchmark/requirements.txt
@@ -1,4 +1,4 @@
 datasets
-transformers[onnx]
+transformers[onnx]; python_version < "3.11"
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch


### PR DESCRIPTION
### Details:
 - backport of https://github.com/openvinotoolkit/openvino/pull/17117
