### PR TITLE
[GPU] Fix bug in reorder_redundant_reorder

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -637,7 +637,7 @@ void remove_redundant_reorders::run(program& p) {
                           !reshape_input_node.has_fused_primitives();
         bool remove_current = remove_dep && !reshape_input_node.get_dependencies().empty() &&
                               reshape_input_node.get_dependency(0).get_output_layout() == reshape_node.get_output_layout() &&
-                              reshape_node.has_fused_primitives();
+                              !reshape_node.has_fused_primitives();
 
         if (remove_dep) {
             LOG_NODE_REMOVAL(reshape_input_node.id());

--- a/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
@@ -124,7 +124,7 @@ struct loop_impl : typed_primitive_impl<loop> {
 
             // Set sliced output memory
             for (const auto& concat_output_mem_mapping : concatenated_output_mem_mappings) {
-                concat_output_mem_mapping.setup_concatenated_output_memory(current_iteration_idx);
+                concat_output_mem_mapping.setup_sliced_output_memory(current_iteration_idx);
             }
 
             // execute body network

--- a/src/plugins/intel_gpu/src/graph/include/loop_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/loop_inst.h
@@ -470,9 +470,9 @@ private:
             }
         }
 
-        void setup_concatenated_output_memory(uint64_t iteration) const {
+        void setup_sliced_output_memory(uint64_t iteration) const {
             const auto& sliced_output_mem = sliced_mems.at(iteration);
-            concat_data_prim->set_output_memory(sliced_output_mem);
+            sliced_data_prim->set_output_memory(sliced_output_mem);
         }
 
         memory::ptr get_sliced_mem(int64_t iteration) const {

--- a/src/plugins/intel_gpu/src/graph/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/loop.cpp
@@ -232,7 +232,7 @@ void loop_inst::update_mapped_memory() {
             body_network->get_primitive(internal_id)->set_output_memory(to_mem);
         } else {
             for (auto& mem_mapping : concatenated_output_mem_mappings) {
-                if (mem_mapping.concat_data_prim->id() == internal_id) {
+                if (mem_mapping.sliced_data_prim->id() == internal_id) {
                     mem_mapping.concatenated_mem = to_mem;
                     break;
                 }
@@ -339,7 +339,7 @@ void loop_inst::preprocess_output_memory() {
             const int64_t max_iteration = _max_iteration;
             std::vector<memory::ptr> sliced_mems;
             sliced_mems.reserve(max_iteration);
-            for (int j=0; j < max_iteration; ++j) {
+            for (int32_t j = 0; j < max_iteration; ++j) {
                 memory::ptr sliced_mem = engine.allocate_memory(sliced_layout, 0);
                 sliced_mems.push_back(sliced_mem);
             }
@@ -351,7 +351,8 @@ void loop_inst::preprocess_output_memory() {
             concatenated_memory_mapping memory_mapping_info(
                 output_mapping.axis, to_mem, sliced_mems, _network.get_stream(),
                 num_elements_iteration, output_mapping.stride, start);
-            memory_mapping_info.concat_data_prim = body_network->get_primitive(internal_id);
+            memory_mapping_info.sliced_data_prim = body_network->get_primitive(internal_id);
+            memory_mapping_info.concat_data_prim = get_network().get_primitive(external_id);
             concatenated_output_mem_mappings.push_back(memory_mapping_info);
         }
     }
@@ -467,7 +468,7 @@ std::vector<memory::ptr> loop_inst::get_sliced_mem(const primitive_id& internal_
         }
     }
     for (const auto& mem_mapping : concatenated_output_mem_mappings) {
-        if (mem_mapping.concat_data_prim->id() == internal_id) {
+        if (mem_mapping.sliced_data_prim->id() == internal_id) {
             return mem_mapping.sliced_mems;
         }
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_elt_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_elt_kernel_base.cpp
@@ -81,6 +81,7 @@ KernelsData LSTMEltKernelBase::GetCommonKernelsData(const Params& params, const 
     auto jit = CreateJit(kernelName, cldnnJit, entryPoint);
 
     kernel.params.workGroups.global = {out.X().v, out.Batch().v, 1};
+    kernel.params.workGroups.local = GetOptimalLocalWorkGroupSizes(kernel.params.workGroups.global, params.engineInfo);
     kernel.code.kernelString = GetKernelString(kernelName, jit, entryPoint, params.engineInfo);
     kernel.params.arguments.push_back({ArgumentDescriptor::Types::INPUT, 0});
     kernel.params.arguments.push_back({ArgumentDescriptor::Types::OUTPUT, 0});


### PR DESCRIPTION
### Details:
 - 1) reshape w/ fused primiitive should not be optimized out 
 - 2) Wrong usage of slice mem / concat mem in loop
 - 3) LWS not set in lstm_elt


### Tickets:
 - 109657
