### PR TITLE
[CPU][ARM] Enable oneDNN acl fullyconnected (inner_product)

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -508,6 +508,7 @@ bool FullyConnected::created() const {
 const std::vector<impl_desc_type>& FullyConnected::getPrimitivesPriority() {
     std::vector<impl_desc_type> priorities = {
             impl_desc_type::unknown,
+            impl_desc_type::acl,
             impl_desc_type::brgemm_sparse_avx512_amx,
             impl_desc_type::brgemm_avx512_amx,
             impl_desc_type::brgemm_avx512,


### PR DESCRIPTION
### Details:
 - The reason why at the moment a oneDNN acl implementation is picked for fullyconnected node is the fallback logic we have for selecting optimal primitive descriptor. So acl implementation was not in the list and we picked the first supported primitive descriptor (which is acl implementation).
With the fix the node will actually find acl implementation in the priority list.
There is no impact on overall logic, but the fallback should be avoided in general.