### PR TITLE
[PT FE] Improve exception when decoder cannot trace or script the model

### DIFF
--- a/src/bindings/python/src/openvino/frontend/pytorch/decoder.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/decoder.py
@@ -97,7 +97,21 @@ class TorchScriptPythonDecoder (Decoder):
         self.m_decoders = []
         self._input_signature = None
         if graph_element is None:
-            pt_module = self._get_scripted_model(pt_module, example_input, freeze)
+            try:
+                pt_module = self._get_scripted_model(pt_module, example_input, freeze)
+            except Exception as e:
+                if example_input is not None:
+                    msg = "tracing or scripting"
+                    help_msg = ""
+                else:
+                    msg = "scripting"
+                    help_msg = "Tracing sometimes provide better results, "
+                    "please provide valid 'example_input' argument. "
+                raise RuntimeError(
+                    f"Couldn't get TorchScript module by {msg}. {help_msg}"
+                    "You can also provide TorchScript module that you obtained"
+                    " yourself, please refer to PyTorch documentation: "
+                    "https://pytorch.org/tutorials/beginner/Intro_to_TorchScript_tutorial.html.")
             self.graph_element = pt_module.inlined_graph
         else:
             self.graph_element = graph_element

--- a/tests/layer_tests/mo_python_api_tests/test_mo_convert_pytorch.py
+++ b/tests/layer_tests/mo_python_api_tests/test_mo_convert_pytorch.py
@@ -844,3 +844,13 @@ class ConvertONNXFallthroughTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, ".*OpenVINO does not support the following ONNX operations: MyTorchOp.*"):
             convert_model(pytorch_model, input_shape=[
                           1, 2, 3], use_legacy_frontend=True)
+
+
+class ConvertRaisesExampleInputs(unittest.TestCase):
+    def test_example_inputs(self):
+        from openvino.tools.mo import convert_model
+        pytorch_model = create_pt_model_with_custom_op()
+
+        # Check that mo raises error message of wrong argument.
+        with self.assertRaisesRegex(AssertionError, ".*argument is not recognized.*"):
+            convert_model(pytorch_model, example_inputs=(torch.tensor(1),))

--- a/tools/mo/openvino/tools/mo/convert_impl.py
+++ b/tools/mo/openvino/tools/mo/convert_impl.py
@@ -878,7 +878,9 @@ def _convert(cli_parser: argparse.ArgumentParser, framework, args, python_api_us
                 example_inputs = None
                 if 'example_input' in args and args['example_input'] is not None:
                     example_inputs = args['example_input']
-                   
+                elif 'example_inputs' in args:
+                    raise AssertionError("'example_inputs' argument is not recognized, maybe you meant to provide 'example_input'?")
+
                 if 'use_legacy_frontend' in args and args['use_legacy_frontend']:
                     # TO DO: remove this path, when pytorch frontend productization is finished, CVS-103726
                     # prevent invoking legacy mo python onnx frontend for models converted on the fly


### PR DESCRIPTION
### Details:
 - *If user do not provide "example_input" or incorrectly provide "example_inputs" instead Decoder and convert_model was printing tracing or scripting stacktrace, which could confuse user. Print better exception.*

### Tickets:
 - *109831*
