### PR TITLE
Fix the names copying in TransposeSinking backward transformations

### DIFF
--- a/src/common/transformations/include/transformations/transpose_sinking/ts_utils.hpp
+++ b/src/common/transformations/include/transformations/transpose_sinking/ts_utils.hpp
@@ -54,11 +54,6 @@ void SwapOutputNames(ov::Output<ov::Node>, ov::Output<ov::Node>);
  */
 void SwapFriendlyNames(const std::shared_ptr<ov::Node>&, const std::shared_ptr<ov::Node>&);
 
-/**
- * @brief Swaps @args output tensor names and friendly names
- */
-void SwapNames(const std::shared_ptr<ov::Node>&, const std::shared_ptr<ov::Node>&);
-
 namespace sink_forward {
 /**
  * @brief Inserts reversed transposed on @args main_node inputs. Removes input transpose specified in @arg
@@ -94,15 +89,16 @@ ov::NodeVector InsertTransposeBeforeNode(const std::shared_ptr<ov::Node>& main_n
 void UpdateForwardSinkingAbility(const std::shared_ptr<ov::Node>&);
 
 /**
- *  @brief Checks if @arg has consumers that all are the same transpose operation. If no consumers at all
- *  returns false.
+ *  @brief Checks if @arg has consumers that are all the same Transpose operation
+ *  and that sinking is enabled for all these Transpose ops. Otherwise returns false.
+ *  If no consumers at all returns false.
  */
-bool HasSameOutputTransposeNodes(const ov::Output<ov::Node>&);
+bool CheckTransposeConsumers(const ov::Output<ov::Node>&);
 
 /**
- * @brief Removes all direct node consumers that have one output
+ * @brief Removes all Transpose consumers for given node
  */
-void RemoveSingleOutputConsumers(const std::shared_ptr<ov::Node>&);
+bool RemoveTransposeConsumers(const std::shared_ptr<ov::Node>& node);
 
 /**
  * @brief Inserts Gather operation which changes the order of values in @arg input

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_binary.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_binary.cpp
@@ -66,16 +66,15 @@ TSBinaryBackward::TSBinaryBackward() {
                                      op::util::BinaryElementwiseLogical,
                                      ov::op::v0::PRelu,
                                      ov::op::v0::FakeQuantize>([](const Output<Node>& output) -> bool {
-        return has_static_rank()(output) && HasSameOutputTransposeNodes(output);
+        return has_static_rank()(output) && CheckTransposeConsumers(output);
     });
 
     auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
 
-    auto transpose_label =
-        wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label},
-                                         [](const Output<Node>& output) -> bool {
-                                             return has_static_rank()(output) && is_sinking_node(output);
-                                         });
+    auto transpose_label = wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label},
+                                                            [](const Output<Node>& output) -> bool {
+                                                                return has_static_rank()(output);
+                                                            });
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
@@ -91,10 +90,7 @@ TSBinaryBackward::TSBinaryBackward() {
             register_new_node(new_node);
         }
         main_node->validate_and_infer_types();
-        // remove output transposes
-        RemoveSingleOutputConsumers(main_node);
-
-        SwapNames(transpose, main_node);
+        RemoveTransposeConsumers(main_node);
         return true;
     };
 

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_fuse.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_fuse.cpp
@@ -23,7 +23,7 @@ TSFuse::TSFuse() {
     MATCHER_SCOPE(TransposeFuse);
     auto transpose_1_label =
         pattern::wrap_type<ov::op::v1::Transpose>({pattern::any_input(), pattern::wrap_type<ov::op::v0::Constant>()},
-                                                  HasSameOutputTransposeNodes);
+                                                  CheckTransposeConsumers);
     auto transpose_2_label =
         pattern::wrap_type<ov::op::v1::Transpose>({transpose_1_label, pattern::wrap_type<ov::op::v0::Constant>()});
     ov::matcher_pass_callback matcher_pass_callback = [=](pattern::Matcher& m) {
@@ -68,7 +68,7 @@ TSFuse::TSFuse() {
             auto new_transpose = register_new_node<ov::op::v1::Transpose>(input, new_order);
 
             new_transpose->set_friendly_name(m.get_match_root()->get_friendly_name());
-            RemoveSingleOutputConsumers(transpose1);
+            RemoveTransposeConsumers(transpose1);
             copy_runtime_info(transpose1, new_transpose);
             ov::replace_node(transpose1, new_transpose);
 

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_interpolate.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_interpolate.cpp
@@ -89,16 +89,15 @@ TSInterpolateBackward::TSInterpolateBackward() {
     MATCHER_SCOPE(TSInterpolateBackward);
 
     auto main_node_label = wrap_type<ov::op::v4::Interpolate>([](const Output<Node>& output) -> bool {
-        return has_static_rank()(output) && HasSameOutputTransposeNodes(output);
+        return has_static_rank()(output) && CheckTransposeConsumers(output);
     });
 
     auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
 
-    auto transpose_label =
-        wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label},
-                                         [](const Output<Node>& output) -> bool {
-                                             return has_static_rank()(output) && is_sinking_node(output);
-                                         });
+    auto transpose_label = wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label},
+                                                            [](const Output<Node>& output) -> bool {
+                                                                return has_static_rank()(output);
+                                                            });
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
@@ -116,9 +115,7 @@ TSInterpolateBackward::TSInterpolateBackward() {
             register_new_node(new_node);
         }
 
-        // remove output transposes
-        RemoveSingleOutputConsumers(main_node);
-        SwapNames(main_node, transpose);
+        RemoveTransposeConsumers(main_node);
         const auto transpose_axis_order = transpose_const->get_axis_vector_val();
         const auto reversed_transpose_order = ReverseTransposeOrder(transpose_axis_order);
         auto axis = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{}, 0);

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_slice.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_slice.cpp
@@ -78,16 +78,15 @@ TSSliceBackward::TSSliceBackward() {
     MATCHER_SCOPE(TSSliceBackward);
 
     auto main_node_label = wrap_type<ov::op::v8::Slice>([](const Output<Node>& output) -> bool {
-        return has_static_rank()(output) && HasSameOutputTransposeNodes(output);
+        return has_static_rank()(output) && CheckTransposeConsumers(output);
     });
 
     auto transpose_const_label = wrap_type<ov::op::v0::Constant>();
 
-    auto transpose_label =
-        wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label},
-                                         [](const Output<Node>& output) -> bool {
-                                             return has_static_rank()(output) && is_sinking_node(output);
-                                         });
+    auto transpose_label = wrap_type<ov::op::v1::Transpose>({main_node_label, transpose_const_label},
+                                                            [](const Output<Node>& output) -> bool {
+                                                                return has_static_rank()(output);
+                                                            });
 
     matcher_pass_callback matcher_pass_callback = [=](Matcher& m) {
         const auto& pattern_to_output = m.get_pattern_value_map();
@@ -109,9 +108,7 @@ TSSliceBackward::TSSliceBackward() {
             register_new_node(new_node);
         }
 
-        // remove output transposes
-        RemoveSingleOutputConsumers(main_node);
-        SwapNames(main_node, transpose);
+        RemoveTransposeConsumers(main_node);
         const auto transpose_axis_order = transpose_const->get_axis_vector_val();
         const auto reversed_transpose_order = ReverseTransposeOrder(transpose_axis_order);
         auto axis = std::make_shared<ov::op::v0::Constant>(element::i32, Shape{}, std::vector<int32_t>{0});

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_split.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_split.cpp
@@ -70,11 +70,11 @@ bool HasInputSplitAndTransposeSiblings(const Output<Node>& output) {
         return false;
     }
 
-    return HasSameOutputTransposeNodes(main_node);
+    return CheckTransposeConsumers(main_node);
 }
 
 bool IsSplitSinked(const Output<Node>& output) {
-    return HasInputSplitAndTransposeSiblings(output) && is_sinking_node(output);
+    return HasInputSplitAndTransposeSiblings(output);
 }
 
 bool GetSplitAxis(const std::shared_ptr<ov::op::v0::Constant>& split_axis, const ov::Rank& rank, int64_t& axis) {
@@ -184,7 +184,7 @@ TSSplitBackward::TSSplitBackward() {
 
         // remove split output transposes
         split->validate_and_infer_types();
-        RemoveSingleOutputConsumers(split);
+        RemoveTransposeConsumers(split);
         return true;
     };
 

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_utils.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_utils.cpp
@@ -112,11 +112,6 @@ void SwapFriendlyNames(const NodePtr& node1, const NodePtr& node2) {
     node1->set_friendly_name(node2_name);
 }
 
-void SwapNames(const NodePtr& node1, const NodePtr& node2) {
-    SwapFriendlyNames(node1, node2);
-    SwapOutputNames(node1->output(0), node2->output(0));
-}
-
 namespace {
 
 bool HasDynamicRankInput(const NodePtr& node) {
@@ -393,7 +388,7 @@ Node* FindFirstConsumer(const NodePtr& node) {
     return nullptr;
 }
 
-bool HasSameOutputTransposeNodes(const NodePtr& main_node) {
+bool CheckTransposeConsumers(const NodePtr& main_node) {
     AxisVector first_transpose_axis_order;
     {
         Node* first_consumer = FindFirstConsumer(main_node);
@@ -418,6 +413,9 @@ bool HasSameOutputTransposeNodes(const NodePtr& main_node) {
                             transpose_axis_order.end(),
                             first_transpose_axis_order.begin()))
                 return false;
+            if (!is_sinking_node(input.get_node())) {
+                return false;
+            }
         }
     }
 
@@ -426,19 +424,52 @@ bool HasSameOutputTransposeNodes(const NodePtr& main_node) {
 
 }  // namespace
 
-bool HasSameOutputTransposeNodes(const Output<Node>& output) {
-    return HasSameOutputTransposeNodes(output.get_node_shared_ptr());
+bool CheckTransposeConsumers(const Output<Node>& output) {
+    return CheckTransposeConsumers(output.get_node_shared_ptr());
 }
 
-void RemoveSingleOutputConsumers(const NodePtr& node) {
+bool RemoveTransposeConsumers(const NodePtr& node) {
+    std::unordered_map<size_t, std::vector<ov::op::v1::Transpose*>> out_idx_to_redundant_transposes;
+
+    // in case of multiple Transposes connected directly to Result ops,
+    // we can't guarantee that friendly names are copied correctly,
+    // we preserve only one of possible variants.
+    // This note related to friendly names only, not to tensor names.
+    ov::op::v1::Transpose* transpose_connected_to_result = nullptr;
     for (size_t output_idx = 0; output_idx < node->get_output_size(); ++output_idx) {
-        for (auto& input : node->get_output_target_inputs(output_idx)) {
-            Node* consumer = input.get_node();
-            if (consumer->get_output_size() != 1)
-                continue;
-            consumer->output(0).replace(node->output(output_idx));
+        for (auto& consumer_input : node->get_output_target_inputs(output_idx)) {
+            auto transpose = dynamic_cast<ov::op::v1::Transpose*>(consumer_input.get_node());
+            if (!transpose) {
+                // should never happen
+                // the check that all consumers of the main node are Transposes is added
+                // to the pattern of the transformations
+                OPENVINO_ASSERT(false, "TransposeSinking error: attempted to remove not Transpose consumer.");
+            }
+            out_idx_to_redundant_transposes[output_idx].push_back(transpose);
+
+            for (const auto& transpose_consumer_input : transpose->output(0).get_target_inputs()) {
+                if (dynamic_cast<ov::op::v0::Result*>(transpose_consumer_input.get_node())) {
+                    transpose_connected_to_result = transpose;
+                }
+            }
         }
     }
+
+    if (transpose_connected_to_result) {
+        node->set_friendly_name(transpose_connected_to_result->get_friendly_name());
+    } else if (out_idx_to_redundant_transposes.count(0) && !out_idx_to_redundant_transposes[0].empty()) {
+        // if no transpose connected to result op found
+        // we save any friendly name
+        node->set_friendly_name((*out_idx_to_redundant_transposes[0].begin())->get_friendly_name());
+    }
+
+    for (const auto& key_value : out_idx_to_redundant_transposes) {
+        for (const auto& transpose : key_value.second) {
+            transpose->output(0).replace(node->output(key_value.first));
+        }
+    }
+
+    return true;
 }
 
 std::vector<size_t> GetOrderAfterReduction(const std::vector<size_t>& axes_values,

--- a/src/common/transformations/tests/transpose_sinking/ts_general_test.cpp
+++ b/src/common/transformations/tests/transpose_sinking/ts_general_test.cpp
@@ -12,6 +12,7 @@
 #include "openvino/opsets/opset10.hpp"
 #include "openvino/pass/manager.hpp"
 #include "transformations/init_node_info.hpp"
+#include "transformations/rt_info/transpose_sinking_attr.hpp"
 
 using namespace testing;
 using namespace ov::opset10;
@@ -435,6 +436,71 @@ TEST_F(TransformationTestsF, TSGeneralCheckShapeOfConstFoldingDisabled) {
     manager.register_pass<TSGeneral>();
 }
 
+TEST_F(TransformationTestsF, TSGeneralBackwardSinkingNotAvailableForOneOfMultipleTransposes) {
+    using namespace transpose_sinking::testing::general;
+    ov::Shape input_shape = {96, 40, 55};
+    ov::element::Type input_type = ov::element::f32;
+    {
+        auto X = std::make_shared<Parameter>(input_type, input_shape);
+        auto relu = std::make_shared<Relu>(X);
+
+        auto order = std::make_shared<Constant>(ov::element::u64, ov::Shape{3}, ov::Shape{0, 2, 1});
+        auto transpose = std::make_shared<Transpose>(relu, order);
+        mark_as_no_sinking_node(transpose);
+
+        auto order2 = std::make_shared<Constant>(ov::element::u64, ov::Shape{3}, ov::Shape{0, 2, 1});
+        auto transpose2 = std::make_shared<Transpose>(relu, order2);
+
+        auto relu2 = std::make_shared<Relu>(transpose);
+        auto res = std::make_shared<Result>(relu2);
+        auto res2 = std::make_shared<Result>(transpose2);
+
+        function = std::make_shared<ov::Model>(ov::ResultVector{res, res2}, ov::ParameterVector{X});
+    }
+    manager.register_pass<TSGeneralBackward>();
+}
+
+TEST(TransformationTests, TSGeneralBackwardCheckFriendlyAndTensorNamesForMultipleTransposes) {
+    using namespace transpose_sinking::testing::general;
+    ov::Shape input_shape = {96, 40, 55};
+    ov::element::Type input_type = ov::element::f32;
+
+    auto X = std::make_shared<Parameter>(input_type, input_shape);
+    auto relu = std::make_shared<Relu>(X);
+    relu->set_friendly_name("relu");
+    relu->output(0).set_names({"relu:0"});
+
+    auto order = std::make_shared<Constant>(ov::element::u64, ov::Shape{3}, ov::Shape{0, 2, 1});
+    auto transpose = std::make_shared<Transpose>(relu, order);
+    transpose->set_friendly_name("transpose_1");
+    transpose->output(0).set_names({"transpose_1:0"});
+
+    auto order2 = std::make_shared<Constant>(ov::element::u64, ov::Shape{3}, ov::Shape{0, 2, 1});
+    auto transpose2 = std::make_shared<Transpose>(relu, order2);
+    transpose2->set_friendly_name("transpose_2");
+    transpose2->output(0).set_names({"transpose_2:0"});
+
+    auto res = std::make_shared<Result>(transpose);
+    auto res2 = std::make_shared<Result>(transpose2);
+
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{res, res2}, ov::ParameterVector{X});
+
+    ov::pass::Manager manager;
+    manager.register_pass<TSGeneralBackward>();
+    manager.run_passes(model);
+
+    EXPECT_EQ(count_ops_of_type<Transpose>(model), 1);
+    // both options are possible, it depends on consumers order (set<Input<Node>)
+    // the order in the set can be different, it depends on Node*
+    std::vector<std::string> possible_relu_names = {"transpose_1", "transpose_2"};
+    EXPECT_NE(std::find(possible_relu_names.begin(), possible_relu_names.end(), relu->get_friendly_name()),
+              possible_relu_names.end());
+    std::vector<std::string> expected_tensor_names = {"relu:0", "transpose_1:0", "transpose_2:0"};
+    auto actual_names = relu->output(0).get_names();
+    for (const auto& name : expected_tensor_names) {
+        EXPECT_NE(actual_names.find(name), actual_names.end());
+    }
+}
 }  // namespace general
 }  // namespace testing
 }  // namespace transpose_sinking


### PR DESCRIPTION
PR to the master branch: https://github.com/openvinotoolkit/openvino/pull/17283 

### Details:

- Fix copying of `tensor names` in TS sinking transformations in multi consumers cases. The new logic:
![image](https://user-images.githubusercontent.com/21181928/235377674-9d775f48-452e-4ad3-9115-cbb3af281ab7.png)

- Fix `friendly names` copying in TS transformation in multi consumers cases.
The new logic: We detect Transpose directly connected to Result operation and copy its name.
If there are multiple such Transposes, TS will work anyway and copy one of available names.
 ![image](https://user-images.githubusercontent.com/21181928/235377985-a82bdf89-c4a4-4ee9-a23e-8e1dbaaaa981.png)

- Fix `sinking is available` check in TS transformations.

- Added `sorting by tensor names` option to GraphComparator 

Performance runs showed no significant degradation.

### Tickets:
 - *108928*
