### PR TITLE
Support sizes input as list to upsample ops

### DIFF
--- a/src/frontends/pytorch/src/op/upsample.cpp
+++ b/src/frontends/pytorch/src/op/upsample.cpp
@@ -54,6 +54,9 @@ OutputVector base_translate_upsample(const NodeContext& context,
         scales = context.mark_node(std::make_shared<v1::Multiply>(spatial_scales, scales));
     } else {
         auto out_sizes = context.get_input(1);
+        if (context.get_input_type(1).is<type::List>()) {
+            out_sizes = concat_list_construct(out_sizes.get_node_shared_ptr());
+        }
         output_sizes = context.mark_node(std::make_shared<v1::Multiply>(out_sizes, output_sizes));
     }
     auto attrs = v4::Interpolate::InterpolateAttrs(interpolate_mode, size_mode, pad, pad);

--- a/tests/layer_tests/pytorch_tests/test_upsample.py
+++ b/tests/layer_tests/pytorch_tests/test_upsample.py
@@ -138,3 +138,31 @@ class TestUpsample3D(PytorchLayerTest):
     def test_upsample3d(self, mode, size, scale, ie_device, precision, ir_version):
         self._test(*self.create_model(size, scale, mode), ie_device,
                    precision, ir_version, trace_model=True, **{"custom_eps": 1e-3})
+
+
+class TestUpsample2DListSizes(PytorchLayerTest):
+    def _prepare_input(self):
+        import numpy as np
+        return (np.random.randn(1, 3, 200, 200).astype(np.float32),)
+
+    def create_model(self, mode):
+        import torch
+        import torch.nn.functional as F
+
+        class aten_upsample(torch.nn.Module):
+            def __init__(self, mode):
+                super().__init__()
+                self.mode = mode
+
+            def forward(self, x):
+                return F.interpolate(x, size=x.shape[-2:], mode=self.mode)
+
+        ref_net = None
+
+        return aten_upsample(mode), ref_net, F"aten::upsample_{mode}2d"
+
+    @pytest.mark.parametrize("mode", ['nearest', 'bilinear', 'bicubic'])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_upsample2d_list_sizes(self, mode, ie_device, precision, ir_version):
+        self._test(*self.create_model(mode), ie_device, precision, ir_version, trace_model=True)


### PR DESCRIPTION
### Details:
 - *Support sizes input as list to upsample ops*
 - _This enables deeplabv3*, fcn_resnet* and lraspp_mobilenet_v3_large models from torchvision_

### Tickets:
 - *ticket-id*
