### PR TITLE
LPT cmake warning flag was removed

### DIFF
--- a/src/common/low_precision_transformations/CMakeLists.txt
+++ b/src/common/low_precision_transformations/CMakeLists.txt
@@ -4,10 +4,6 @@
 
 set (TARGET_NAME "inference_engine_lp_transformations")
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    ie_add_compiler_flags(/wd4267)
-endif()
-
 set(PUBLIC_HEADERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 file(GLOB_RECURSE LIBRARY_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)


### PR DESCRIPTION
### Details:
 - *CMake warning ignore compiler flag was removed*

### Tickets:
 - *95169*
