### PR TITLE
HOT FIX: fix binding wrong core with latency mode in i9-13900

### DIFF
--- a/src/inference/src/dev/threading/cpu_streams_executor.cpp
+++ b/src/inference/src/dev/threading/cpu_streams_executor.cpp
@@ -157,9 +157,13 @@ struct CPUStreamsExecutor::Impl {
                     _taskArena.reset(new custom::task_arena{concurrency});
 #    endif
                 } else {
-                    _taskArena.reset(new custom::task_arena{custom::task_arena::constraints{}
-                                                                .set_core_type(selected_core_type)
-                                                                .set_max_concurrency(concurrency)});
+                    if (cpu_core_type == ALL_PROC) {
+                        _taskArena.reset(new custom::task_arena{concurrency});
+                    } else {
+                        _taskArena.reset(new custom::task_arena{custom::task_arena::constraints{}
+                                                                    .set_core_type(selected_core_type)
+                                                                    .set_max_concurrency(concurrency)});
+                    }
                 }
             } else if (_impl->_config._proc_type_table.size() > 1 && !_impl->_config._cpu_pinning) {
                 _taskArena.reset(new custom::task_arena{custom::task_arena::constraints{_numaNodeId, concurrency}});


### PR DESCRIPTION
### Details:
 - *fix binding wrong core with latency mode in i9-13900 which is 8Pcore + 16Ecore*

### Tickets:
 - *ticket-id*
