### PR TITLE
Check model file isn't empty before reading via FEs

### DIFF
--- a/src/frontends/tensorflow/src/frontend.cpp
+++ b/src/frontends/tensorflow/src/frontend.cpp
@@ -97,6 +97,11 @@ bool FrontEnd::supported_impl(const std::vector<ov::Any>& variants) const {
 
     if (variants[0].is<std::string>()) {
         std::string model_path = variants[0].as<std::string>();
+
+        std::ifstream model_file(model_path);
+        if (model_file.peek() == std::ifstream::traits_type::eof()) // file is empty
+            return false;
+
         if (ov::util::ends_with(model_path, ".pb") && GraphIteratorProto::is_supported(model_path)) {
             // handle binary protobuf format
             // for automatic deduction of the frontend to convert the model
@@ -148,6 +153,11 @@ ov::frontend::InputModel::Ptr FrontEnd::load_impl(const std::vector<ov::Any>& va
 
     if (variants[0].is<std::string>()) {
         auto model_path = variants[0].as<std::string>();
+
+        std::ifstream model_file(model_path);
+        FRONT_END_GENERAL_CHECK(model_file.peek() != std::ifstream::traits_type::eof(),
+                                "[TensorFlow Frontend] Model ", model_path, " is empty");
+
         if (GraphIteratorProto::is_supported(model_path)) {
             // handle binary protobuf format
             return std::make_shared<InputModel>(std::make_shared<GraphIteratorProto>(model_path), m_telemetry);

--- a/src/inference/src/ie_network_reader.cpp
+++ b/src/inference/src/ie_network_reader.cpp
@@ -443,6 +443,10 @@ CNNNetwork details::ReadNetwork(const std::string& modelPath,
     std::string model_path = modelPath;
 #endif
 
+    std::ifstream model_file(model_path);
+    if (model_file.peek() == std::ifstream::traits_type::eof())
+        IE_THROW(NetworkNotRead) << "Unable to read the model: " << modelPath << " File is empty";
+
     // Try to load with FrontEndManager
     ov::frontend::FrontEndManager manager;
     ov::frontend::FrontEnd::Ptr FE;


### PR DESCRIPTION
### Details:
 - TF FE `GraphIteratorProtoTxt::is_supported(model_path)` check may be passed if `model_path` is empty file or contains space character

### Tickets:
 - CVS-109938