### PR TITLE
[CPU] Fix kernel precision mismatch in Reduce node

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -1820,8 +1820,9 @@ void Reduce::initSupportedPrimitiveDescriptors() {
     }
 
     support_split = algorithm != Algorithm::ReduceL2 && algorithm != Algorithm::ReduceLogSumExp &&
-                    algorithm != Algorithm::ReduceSumSquare;
-    precision_change = input_prec == Precision::BF16 && output_prec == Precision::FP32;
+                    algorithm != Algorithm::ReduceSumSquare &&
+                    (input_prec == output_prec || (input_prec == Precision::BF16 && output_prec == Precision::FP32));
+    precision_change = input_prec != output_prec;
 
     src_data_size = input_prec.size();
     dst_data_size = output_prec.size();

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -1819,10 +1819,10 @@ void Reduce::initSupportedPrimitiveDescriptors() {
         }
     }
 
+    precision_change = input_prec != output_prec;
     support_split = algorithm != Algorithm::ReduceL2 && algorithm != Algorithm::ReduceLogSumExp &&
                     algorithm != Algorithm::ReduceSumSquare &&
-                    (input_prec == output_prec || (input_prec == Precision::BF16 && output_prec == Precision::FP32));
-    precision_change = input_prec != output_prec;
+                    (!precision_change || (input_prec == Precision::BF16 && output_prec == Precision::FP32));
 
     src_data_size = input_prec.size();
     dst_data_size = output_prec.size();


### PR DESCRIPTION
### Details:
 - *The bug is introduced in by the last commit 44b7e448c3037a599fd321cdb6cb0936f9055796 of https://github.com/openvinotoolkit/openvino/pull/16829. The precision constraints imposed on the usage of auxiliary kernel (use_aux_kernel), should also be imposed on the optimization entrance (ReduceAll_opt).*

### Tickets:
 - *[CVS-110021](https://jira.devtools.intel.com/browse/CVS-110021)*
