### PR TITLE
Review prior box and clustered class for shape inference aspects

### DIFF
--- a/src/common/transformations/tests/op_conversions/convert_prior_box_v8_to_v0_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_prior_box_v8_to_v0_test.cpp
@@ -20,8 +20,8 @@ using namespace ngraph;
 
 TEST_F(TransformationTestsF, ConvertPriorBox8To0) {
     {
-        const Shape input_shape{2, 2};
-        const Shape image_Shape{10, 10};
+        const Shape input_shape{2};
+        const Shape image_Shape{2};
         op::v8::PriorBox::Attributes attrs;
         attrs.min_size = {2.0f};
         attrs.max_size = {5.0f};
@@ -38,8 +38,8 @@ TEST_F(TransformationTestsF, ConvertPriorBox8To0) {
     }
 
     {
-        const Shape input_shape{2, 2};
-        const Shape image_Shape{10, 10};
+        const Shape input_shape{2};
+        const Shape image_Shape{2};
         op::v0::PriorBox::Attributes attrs;
         attrs.min_size = {2.0f};
         attrs.max_size = {5.0f};
@@ -57,8 +57,8 @@ TEST_F(TransformationTestsF, ConvertPriorBox8To0) {
 
 TEST_F(TransformationTestsF, ConvertPriorBox8To0_min_max_aspect_ratios_order) {
     {
-        const Shape input_shape{2, 2};
-        const Shape image_Shape{10, 10};
+        const Shape input_shape{2};
+        const Shape image_Shape{2};
         op::v8::PriorBox::Attributes attrs;
         attrs.min_size = {2.0f};
         attrs.max_size = {5.0f};

--- a/src/core/include/openvino/op/prior_box.hpp
+++ b/src/core/include/openvino/op/prior_box.hpp
@@ -59,9 +59,7 @@ public:
     void set_attrs(Attributes attrs);
 
     bool visit_attributes(AttributeVisitor& visitor) override;
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;
 
 private:
@@ -122,9 +120,7 @@ public:
     void set_attrs(Attributes attrs);
 
     bool visit_attributes(AttributeVisitor& visitor) override;
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;
 
 private:

--- a/src/core/include/openvino/op/prior_box.hpp
+++ b/src/core/include/openvino/op/prior_box.hpp
@@ -56,6 +56,8 @@ public:
     const Attributes& get_attrs() const {
         return m_attrs;
     }
+    void set_attrs(Attributes attrs);
+
     bool visit_attributes(AttributeVisitor& visitor) override;
     OPENVINO_SUPPRESS_DEPRECATED_START
     bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
@@ -117,6 +119,8 @@ public:
     const Attributes& get_attrs() const {
         return m_attrs;
     }
+    void set_attrs(Attributes attrs);
+
     bool visit_attributes(AttributeVisitor& visitor) override;
     OPENVINO_SUPPRESS_DEPRECATED_START
     bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;

--- a/src/core/include/openvino/op/prior_box_clustered.hpp
+++ b/src/core/include/openvino/op/prior_box_clustered.hpp
@@ -48,6 +48,8 @@ public:
     const Attributes& get_attrs() const {
         return m_attrs;
     }
+    void set_attrs(Attributes attrs);
+
     bool visit_attributes(AttributeVisitor& visitor) override;
     OPENVINO_SUPPRESS_DEPRECATED_START
     bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;

--- a/src/core/include/openvino/op/prior_box_clustered.hpp
+++ b/src/core/include/openvino/op/prior_box_clustered.hpp
@@ -51,9 +51,7 @@ public:
     void set_attrs(Attributes attrs);
 
     bool visit_attributes(AttributeVisitor& visitor) override;
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    bool evaluate(const HostTensorVector& outputs, const HostTensorVector& inputs) const override;
-    OPENVINO_SUPPRESS_DEPRECATED_END
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
     bool has_evaluate() const override;
 
 private:

--- a/src/core/shape_inference/include/prior_box_clustered_shape_inference.hpp
+++ b/src/core/shape_inference/include/prior_box_clustered_shape_inference.hpp
@@ -10,29 +10,19 @@ namespace ov {
 namespace op {
 namespace v0 {
 template <class TShape>
-std::vector<TShape> shape_infer(const PriorBox* const op,
-                                const std::vector<TShape>& input_shapes,
-                                const std::map<size_t, HostTensorPtr>& constant_data = {}) {
-    return prior_box::shape_infer(op, input_shapes, constant_data);
-}
-}  // namespace v0
-
-namespace v8 {
-template <class TShape>
-std::vector<TShape> shape_infer(const PriorBox* const op,
+std::vector<TShape> shape_infer(const PriorBoxClustered* const op,
                                 const std::vector<TShape>& input_shapes,
                                 const std::map<size_t, HostTensorPtr>& constant_data = {}) {
     return prior_box::shape_infer(op, input_shapes, constant_data);
 }
 
 template <class TShape>
-void shape_infer(const PriorBox* op,
+void shape_infer(const PriorBoxClustered* op,
                  const std::vector<TShape>& input_shapes,
                  std::vector<TShape>& output_shapes,
                  const std::map<size_t, HostTensorPtr>& constant_data = {}) {
     output_shapes = prior_box::shape_infer(op, input_shapes, constant_data);
 }
-}  // namespace v8
-
+}  // namespace v0
 }  // namespace op
 }  // namespace ov

--- a/src/core/shape_inference/include/prior_box_shape_inference.hpp
+++ b/src/core/shape_inference/include/prior_box_shape_inference.hpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "dimension_util.hpp"
+#include "openvino/op/prior_box.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace op {
+namespace prior_box {
+
+template <class TOp, class TShape>
+std::vector<TShape> shape_infer(const TOp* const op,
+                                const std::vector<TShape>& input_shapes,
+                                const std::map<size_t, HostTensorPtr>& constant_data) {
+    NODE_VALIDATION_CHECK(op, input_shapes.size() == 2);
+
+    auto out_size_rank = input_shapes[0].rank();
+    auto img_size_rank = input_shapes[1].rank();
+    NODE_VALIDATION_CHECK(op,
+                          out_size_rank.compatible(img_size_rank) && out_size_rank.compatible(1),
+                          "output size input rank ",
+                          out_size_rank,
+                          " must match image shape input rank ",
+                          img_size_rank,
+                          " and both must be 1-D");
+
+    auto output_shapes = std::vector<TShape>(1, TShape{2});
+
+    if (auto out_size = get_input_const_data_as_shape<TShape>(op, 0, constant_data)) {
+        NODE_VALIDATION_CHECK(op, out_size->size() == 2, "Output size must have two elements. Got: ", out_size->size());
+
+        using TDim = typename TShape::value_type;
+        const auto num_of_priors = TOp::number_of_priors(op->get_attrs());
+        output_shapes.front().push_back((*out_size)[0] * (*out_size)[1] * TDim(num_of_priors) * 4);
+    } else {
+        output_shapes.front().emplace_back(ov::util::dim::inf_bound);
+    }
+
+    return output_shapes;
+}
+}  // namespace prior_box
+
+namespace v0 {
+template <class TShape>
+std::vector<TShape> shape_infer(const PriorBox* const op,
+                                const std::vector<TShape>& input_shapes,
+                                const std::map<size_t, HostTensorPtr>& constant_data = {}) {
+    return prior_box::shape_infer(op, input_shapes, constant_data);
+}
+}  // namespace v0
+
+namespace v8 {
+template <class TShape>
+std::vector<TShape> shape_infer(const PriorBox* const op,
+                                const std::vector<TShape>& input_shapes,
+                                const std::map<size_t, HostTensorPtr>& constant_data = {}) {
+    return prior_box::shape_infer(op, input_shapes, constant_data);
+}
+
+template <class TShape>
+void shape_infer(const PriorBox* op,
+                 const std::vector<TShape>& input_shapes,
+                 std::vector<TShape>& output_shapes,
+                 const std::map<size_t, HostTensorPtr>& constant_data = {}) {
+    output_shapes = prior_box::shape_infer(op, input_shapes, constant_data);
+}
+}  // namespace v8
+
+}  // namespace op
+}  // namespace ov

--- a/src/core/shape_inference/include/prior_box_shape_inference_util.hpp
+++ b/src/core/shape_inference/include/prior_box_shape_inference_util.hpp
@@ -4,16 +4,18 @@
 
 #pragma once
 
+#include <array>
+
 #include "dimension_util.hpp"
 #include "utils.hpp"
 
 namespace ov {
 namespace op {
 namespace prior_box {
-namespace validate {
-std::vector<PartialShape> inputs_et(const Node* const op) {
-    static constexpr auto input_names = std::array<const char*, 2>{"output size", "image"};
+constexpr std::array<char const*, 2> input_names{"output size", "image"};
 
+namespace validate {
+inline std::vector<PartialShape> inputs_et(const Node* const op) {
     const auto inputs_size = op->get_input_size();
     auto input_shapes = std::vector<PartialShape>();
     input_shapes.reserve(inputs_size);
@@ -22,7 +24,7 @@ std::vector<PartialShape> inputs_et(const Node* const op) {
         const auto& et = op->get_input_element_type(i);
         NODE_VALIDATION_CHECK(op,
                               et.is_integral_number(),
-                              input_names[i],
+                              prior_box::input_names[i],
                               " input must be an integral number, but is: ",
                               et);
         input_shapes.push_back(op->get_input_partial_shape(i));

--- a/src/core/shape_inference/include/prior_box_shape_inference_util.hpp
+++ b/src/core/shape_inference/include/prior_box_shape_inference_util.hpp
@@ -1,0 +1,79 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "dimension_util.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace op {
+namespace prior_box {
+namespace validate {
+std::vector<PartialShape> inputs_et(const Node* const op) {
+    static constexpr auto input_names = std::array<const char*, 2>{"output size", "image"};
+
+    const auto inputs_size = op->get_input_size();
+    auto input_shapes = std::vector<PartialShape>();
+    input_shapes.reserve(inputs_size);
+
+    for (size_t i = 0; i < inputs_size; ++i) {
+        const auto& et = op->get_input_element_type(i);
+        NODE_VALIDATION_CHECK(op,
+                              et.is_integral_number(),
+                              input_names[i],
+                              " input must be an integral number, but is: ",
+                              et);
+        input_shapes.push_back(op->get_input_partial_shape(i));
+    }
+    return input_shapes;
+}
+}  // namespace validate
+
+template <class TDim,
+          class TOp,
+          typename std::enable_if<std::is_same<v0::PriorBox, TOp>::value ||
+                                  std::is_same<v8::PriorBox, TOp>::value>::type* = nullptr>
+TDim number_of_priors(const TOp* const op) {
+    return {static_cast<typename TDim::value_type>(TOp::number_of_priors(op->get_attrs()))};
+}
+
+template <class TDim>
+TDim number_of_priors(const v0::PriorBoxClustered* const op) {
+    return {static_cast<typename TDim::value_type>(op->get_attrs().widths.size())};
+}
+
+template <class TOp, class TShape>
+std::vector<TShape> shape_infer(const TOp* const op,
+                                const std::vector<TShape>& input_shapes,
+                                const std::map<size_t, HostTensorPtr>& constant_data) {
+    NODE_VALIDATION_CHECK(op, input_shapes.size() == 2);
+
+    auto out_size_rank = input_shapes[0].rank();
+    auto img_size_rank = input_shapes[1].rank();
+    NODE_VALIDATION_CHECK(op,
+                          out_size_rank.compatible(img_size_rank) && out_size_rank.compatible(1),
+                          "output size input rank ",
+                          out_size_rank,
+                          " must match image shape input rank ",
+                          img_size_rank,
+                          " and both must be 1-D");
+
+    auto output_shapes = std::vector<TShape>(1, TShape{2});
+
+    if (auto out_size = get_input_const_data_as_shape<TShape>(op, 0, constant_data)) {
+        NODE_VALIDATION_CHECK(op, out_size->size() == 2, "Output size must have two elements. Got: ", out_size->size());
+
+        using TDim = typename TShape::value_type;
+        const auto num_of_priors = prior_box::number_of_priors<TDim>(op);
+        output_shapes.front().push_back((*out_size)[0] * (*out_size)[1] * num_of_priors * 4);
+    } else {
+        output_shapes.front().emplace_back(ov::util::dim::inf_bound);
+    }
+
+    return output_shapes;
+}
+}  // namespace prior_box
+}  // namespace op
+}  // namespace ov

--- a/src/core/src/op/prior_box.cpp
+++ b/src/core/src/op/prior_box.cpp
@@ -14,29 +14,6 @@
 
 namespace ov {
 namespace op {
-namespace prior_box {
-static constexpr auto input_names = std::array<const char*, 2>{"output size", "image"};
-
-namespace validate {
-std::vector<PartialShape> inputs_et(const Node* const op) {
-    const auto inputs_size = op->get_input_size();
-    auto input_shapes = std::vector<PartialShape>();
-    input_shapes.reserve(inputs_size);
-
-    for (size_t i = 0; i < inputs_size; ++i) {
-        const auto& et = op->get_input_element_type(i);
-        NODE_VALIDATION_CHECK(op,
-                              et.is_integral_number(),
-                              prior_box::input_names[i],
-                              " input must be an integral number, but is: ",
-                              et);
-        input_shapes.push_back(op->get_input_partial_shape(i));
-    }
-    return input_shapes;
-}
-}  // namespace validate
-}  // namespace prior_box
-
 // ------------------------------ V0 ------------------------------
 namespace v0 {
 namespace {

--- a/src/core/src/op/prior_box_clustered.cpp
+++ b/src/core/src/op/prior_box_clustered.cpp
@@ -10,6 +10,7 @@
 #include "ngraph/op/constant.hpp"
 #include "ngraph/runtime/host_tensor.hpp"
 #include "ngraph/runtime/reference/prior_box_clustered.hpp"
+#include "prior_box_clustered_shape_inference.hpp"
 
 using namespace std;
 using namespace ngraph;
@@ -24,27 +25,8 @@ ov::op::v0::PriorBoxClustered::PriorBoxClustered(const Output<Node>& layer_shape
 
 void ov::op::v0::PriorBoxClustered::validate_and_infer_types() {
     OV_OP_SCOPE(v0_PriorBoxClustered_validate_and_infer_types);
-    // shape node should have integer data type. For now we only allow i64
-    auto layer_shape_et = get_input_element_type(0);
-    NODE_VALIDATION_CHECK(this,
-                          layer_shape_et.is_integral_number(),
-                          "layer shape input must be an integral number, but is: ",
-                          layer_shape_et);
 
-    auto image_shape_et = get_input_element_type(1);
-    NODE_VALIDATION_CHECK(this,
-                          image_shape_et.is_integral_number(),
-                          "image shape input must be an integral number, but is: ",
-                          image_shape_et);
-
-    auto layer_shape_rank = get_input_partial_shape(0).rank();
-    auto image_shape_rank = get_input_partial_shape(1).rank();
-    NODE_VALIDATION_CHECK(this,
-                          layer_shape_rank.compatible(image_shape_rank),
-                          "layer shape input rank ",
-                          layer_shape_rank,
-                          " must match image shape input rank ",
-                          image_shape_rank);
+    const auto input_shapes = prior_box::validate::inputs_et(this);
 
     NODE_VALIDATION_CHECK(this,
                           m_attrs.widths.size() == m_attrs.heights.size(),
@@ -53,23 +35,10 @@ void ov::op::v0::PriorBoxClustered::validate_and_infer_types() {
                           " doesn't match size of widths vector: ",
                           m_attrs.widths.size());
 
+    const auto output_shapes = shape_infer(this, input_shapes);
+
+    set_output_type(0, element::f32, output_shapes.front());
     set_input_is_relevant_to_shape(0);
-
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    if (auto const_shape = get_constant_from_source(input_value(0).get_node_shared_ptr())) {
-        OPENVINO_SUPPRESS_DEPRECATED_END
-        NODE_VALIDATION_CHECK(this,
-                              shape_size(const_shape->get_shape()) == 2,
-                              "Layer shape must have rank 2",
-                              const_shape->get_shape());
-
-        auto layer_shape = const_shape->get_shape_val();
-        // {Prior boxes, variances-adjusted prior boxes}
-        const auto num_priors = m_attrs.widths.size();
-        set_output_type(0, element::f32, ov::Shape{2, 4 * layer_shape[0] * layer_shape[1] * num_priors});
-    } else {
-        set_output_type(0, element::f32, ov::PartialShape{2, Dimension::dynamic()});
-    }
 }
 
 shared_ptr<Node> ov::op::v0::PriorBoxClustered::clone_with_new_inputs(const OutputVector& new_args) const {
@@ -151,4 +120,8 @@ bool op::v0::PriorBoxClustered::has_evaluate() const {
         break;
     }
     return false;
+}
+
+void op::v0::PriorBoxClustered::set_attrs(Attributes attrs) {
+    m_attrs = std::move(attrs);
 }

--- a/src/core/tests/type_prop/prior_box.cpp
+++ b/src/core/tests/type_prop/prior_box.cpp
@@ -4,7 +4,6 @@
 
 #include "openvino/op/prior_box.hpp"
 
-#include "bound_evaluate.hpp"
 #include "common_test_utils/test_assertions.hpp"
 #include "gmock/gmock.h"
 #include "openvino/opsets/opset11.hpp"

--- a/src/core/tests/type_prop/prior_box.cpp
+++ b/src/core/tests/type_prop/prior_box.cpp
@@ -2,74 +2,296 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ngraph/op/prior_box.hpp"
+#include "openvino/op/prior_box.hpp"
 
-#include "gtest/gtest.h"
-#include "ngraph/ngraph.hpp"
+#include "bound_evaluate.hpp"
+#include "common_test_utils/test_assertions.hpp"
+#include "gmock/gmock.h"
+#include "openvino/opsets/opset11.hpp"
+#include "type_prop.hpp"
 
-using namespace ngraph;
+using namespace ov;
+using namespace ov::opset11;
+using namespace testing;
 
-TEST(type_prop, prior_box1) {
-    op::v0::PriorBox::Attributes attrs;
-    attrs.min_size = {2.0f, 3.0f};
-    attrs.aspect_ratio = {1.5f, 2.0f, 2.5f};
-    attrs.scale_all_sizes = false;
+template <class TOp>
+class PriorBoxTest : public TypePropOpTest<TOp> {
+protected:
+    using Attrs = typename TOp::Attributes;
 
-    auto layer_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {32, 32});
-    auto image_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
-    auto pb = std::make_shared<op::v0::PriorBox>(layer_shape, image_shape, attrs);
-    ASSERT_EQ(pb->get_shape(), (Shape{2, 20480}));
+    void SetUp() override {
+        this->attrs.min_size = {2.0f, 3.0f};
+        this->attrs.aspect_ratio = {1.5f, 2.0f, 2.5f};
+        this->attrs.scale_all_sizes = false;
+    }
+
+    template <class T = TOp, typename std::enable_if<std::is_same<T, op::v0::PriorBox>::value>::type* = nullptr>
+    static void check_def_attrs(const TOp* const op) {
+        const auto& attrs = op->get_attrs();
+
+        EXPECT_EQ(attrs.min_size, std::vector<float>());
+        EXPECT_EQ(attrs.max_size, std::vector<float>());
+        EXPECT_EQ(attrs.aspect_ratio, std::vector<float>());
+        EXPECT_EQ(attrs.density, std::vector<float>());
+        EXPECT_EQ(attrs.fixed_ratio, std::vector<float>());
+        EXPECT_EQ(attrs.fixed_size, std::vector<float>());
+        EXPECT_EQ(attrs.variance, std::vector<float>());
+        EXPECT_FALSE(attrs.clip);
+        EXPECT_FALSE(attrs.flip);
+        EXPECT_TRUE(attrs.scale_all_sizes);
+        EXPECT_FLOAT_EQ(attrs.step, 0.0f);
+        EXPECT_FLOAT_EQ(attrs.offset, 0.0f);
+    }
+
+    template <class T = TOp, typename std::enable_if<std::is_same<T, op::v8::PriorBox>::value>::type* = nullptr>
+    static void check_def_attrs(const TOp* const op) {
+        const auto& attrs = op->get_attrs();
+
+        EXPECT_EQ(attrs.min_size, std::vector<float>());
+        EXPECT_EQ(attrs.max_size, std::vector<float>());
+        EXPECT_EQ(attrs.aspect_ratio, std::vector<float>());
+        EXPECT_EQ(attrs.density, std::vector<float>());
+        EXPECT_EQ(attrs.fixed_ratio, std::vector<float>());
+        EXPECT_EQ(attrs.fixed_size, std::vector<float>());
+        EXPECT_EQ(attrs.variance, std::vector<float>());
+        EXPECT_FALSE(attrs.clip);
+        EXPECT_FALSE(attrs.flip);
+        EXPECT_TRUE(attrs.scale_all_sizes);
+        EXPECT_TRUE(attrs.min_max_aspect_ratios_order);
+        EXPECT_FLOAT_EQ(attrs.step, 0.0f);
+        EXPECT_FLOAT_EQ(attrs.offset, 0.0f);
+    }
+
+    Attrs attrs;
+};
+
+TYPED_TEST_SUITE_P(PriorBoxTest);
+
+TYPED_TEST_P(PriorBoxTest, default_ctor) {
+    const auto output_size = std::make_shared<Parameter>(element::i32, PartialShape{2});
+    const auto image_size = std::make_shared<Parameter>(element::i32, Shape{2});
+
+    const auto op = this->make_op();
+    op->set_arguments(OutputVector{output_size, image_size});
+    op->set_attrs({});
+    op->validate_and_infer_types();
+
+    this->check_def_attrs(op.get());
+    EXPECT_EQ(op->get_input_size(), 2);
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, -1}));
 }
 
-TEST(type_prop, prior_box2) {
-    op::v0::PriorBox::Attributes attrs;
-    attrs.min_size = {2.0f, 3.0f};
-    attrs.aspect_ratio = {1.5f, 2.0f, 2.5f};
-    attrs.flip = true;
-    attrs.scale_all_sizes = false;
+TYPED_TEST_P(PriorBoxTest, simple_inference) {
+    const auto output_size = Constant::create(element::i8, Shape{2}, {2, 5});
+    const auto image_size = Constant::create(element::i8, Shape{2}, {300, 300});
 
-    auto layer_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {32, 32});
-    auto image_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
-    auto pb = std::make_shared<op::v0::PriorBox>(layer_shape, image_shape, attrs);
-    ASSERT_EQ(pb->get_shape(), (Shape{2, 32768}));
+    const auto op = this->make_op(output_size, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_input_size(), 2);
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, 200}));
 }
 
-TEST(type_prop, prior_box3) {
-    op::v0::PriorBox::Attributes attrs;
-    attrs.min_size = {256.0f};
-    attrs.max_size = {315.0f};
-    attrs.aspect_ratio = {2.0f};
-    attrs.flip = true;
+TYPED_TEST_P(PriorBoxTest, inputs_dynamic_rank) {
+    const auto output_size = std::make_shared<Parameter>(element::i64, PartialShape::dynamic());
+    const auto image_size = std::make_shared<Parameter>(element::i64, PartialShape::dynamic());
 
-    auto layer_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {1, 1});
-    auto image_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
-    auto pb = std::make_shared<op::v0::PriorBox>(layer_shape, image_shape, attrs);
-    ASSERT_EQ(pb->get_shape(), (Shape{2, 16}));
+    const auto op = this->make_op(output_size, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_input_size(), 2);
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, -1}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
 }
 
-TEST(type_prop, prior_box_v8_1) {
-    op::v8::PriorBox::Attributes attrs;
-    attrs.min_size = {2.0f, 3.0f};
-    attrs.aspect_ratio = {1.5f, 2.0f, 2.5f};
-    attrs.scale_all_sizes = false;
-    attrs.min_max_aspect_ratios_order = true;
+TYPED_TEST_P(PriorBoxTest, input_output_size_is_dynamic_rank) {
+    const auto output_size = std::make_shared<Parameter>(element::u64, PartialShape::dynamic());
+    const auto image_size = Constant::create(element::u64, Shape{2}, {300, 300});
 
-    auto layer_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {32, 32});
-    auto image_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
-    auto pb = std::make_shared<op::v8::PriorBox>(layer_shape, image_shape, attrs);
-    ASSERT_EQ(pb->get_shape(), (Shape{2, 20480}));
+    const auto op = this->make_op(output_size, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, -1}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
 }
 
-TEST(type_prop, prior_box_v8_2) {
-    op::v8::PriorBox::Attributes attrs;
-    attrs.min_size = {2.0f, 3.0f};
-    attrs.aspect_ratio = {1.5f, 2.0f, 2.5f};
-    attrs.flip = true;
-    attrs.scale_all_sizes = false;
-    attrs.min_max_aspect_ratios_order = false;
+TYPED_TEST_P(PriorBoxTest, input_output_size_is_static_rank_with_dynamic_dims) {
+    auto out_size_shape = PartialShape::dynamic(1);
+    set_shape_labels(out_size_shape, 10);
 
-    auto layer_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {32, 32});
-    auto image_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
-    auto pb = std::make_shared<op::v8::PriorBox>(layer_shape, image_shape, attrs);
-    ASSERT_EQ(pb->get_shape(), (Shape{2, 32768}));
+    const auto output_size = std::make_shared<Parameter>(element::u32, out_size_shape);
+    const auto image_size = Constant::create(element::u32, Shape{2}, {300, 300});
+
+    const auto op = this->make_op(output_size, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, -1}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
 }
+
+TYPED_TEST_P(PriorBoxTest, input_image_size_is_dynamic_rank) {
+    const auto output_size = Constant::create(element::u8, Shape{2}, {32, 32});
+    const auto image_size = std::make_shared<Parameter>(element::u8, PartialShape::dynamic());
+
+    const auto op = this->make_op(output_size, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, 20480}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
+}
+
+TYPED_TEST_P(PriorBoxTest, input_image_size_is_static_rank_dynamic_dim) {
+    this->attrs.flip = true;
+
+    auto img_size_shape = PartialShape::dynamic(1);
+    set_shape_labels(img_size_shape, 20);
+
+    const auto output_size = Constant::create(element::u16, Shape{2}, {32, 32});
+    const auto image_size = std::make_shared<Parameter>(element::u16, img_size_shape);
+
+    const auto op = this->make_op(output_size, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, 32768}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
+}
+
+TYPED_TEST_P(PriorBoxTest, inputs_are_interval_shapes) {
+    auto out_size_shape = PartialShape{{0, 10}};
+    auto img_size_shape = PartialShape{{1, 5}};
+    set_shape_labels(out_size_shape, 20);
+    set_shape_labels(img_size_shape, 20);
+
+    const auto output_size = std::make_shared<Parameter>(element::u64, out_size_shape);
+    const auto image_size = std::make_shared<Parameter>(element::u64, img_size_shape);
+
+    const auto op = this->make_op(output_size, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, -1}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
+}
+
+TYPED_TEST_P(PriorBoxTest, preseve_values_and_labels_on_inputs) {
+    auto out_size_shape = PartialShape{6, 8};
+    DimensionTracker::set_label(out_size_shape[0], 10);
+
+    const auto output_size = std::make_shared<Parameter>(element::i16, out_size_shape);
+    const auto image_size = Constant::create(element::i16, Shape{2}, {300, 300});
+    const auto out_shape_of = std::make_shared<ShapeOf>(output_size);
+
+    const auto op = this->make_op(out_shape_of, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, 960}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
+}
+
+TYPED_TEST_P(PriorBoxTest, preseve_partial_values_and_labels_on_inputs) {
+    auto out_size_shape = PartialShape{{1, 4}, {5, 10}};
+    set_shape_labels(out_size_shape, 10);
+
+    const auto output_size = std::make_shared<Parameter>(element::u64, out_size_shape);
+    const auto image_size = Constant::create(element::u64, Shape{2}, {300, 300});
+    const auto out_shape_of = std::make_shared<ShapeOf>(output_size);
+
+    const auto op = this->make_op(out_shape_of, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, {100, 800}}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
+}
+
+TYPED_TEST_P(PriorBoxTest, preseve_partial_values_inf_bound) {
+    auto out_size_shape = PartialShape{{1, 4}, {5, -1}};  // ShapeOf make 2nd Dim {0, -1}
+    set_shape_labels(out_size_shape, 10);
+
+    const auto output_size = std::make_shared<Parameter>(element::u64, out_size_shape);
+    const auto image_size = Constant::create(element::u64, Shape{2}, {300, 300});
+    const auto out_shape_of = std::make_shared<ShapeOf>(output_size);
+
+    const auto op = this->make_op(out_shape_of, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, {0, -1}}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
+}
+
+TYPED_TEST_P(PriorBoxTest, out_size_input_not_integer) {
+    const auto output_size = Constant::create(element::f16, Shape{2}, {5, 5});
+    const auto image_size = Constant::create(element::i16, Shape{2}, {300, 300});
+
+    OV_EXPECT_THROW(std::ignore = this->make_op(output_size, image_size, this->attrs),
+                    NodeValidationFailure,
+                    HasSubstr("output size input must be an integral number"));
+}
+
+TYPED_TEST_P(PriorBoxTest, img_size_input_not_integer) {
+    const auto output_size = Constant::create(element::i16, Shape{2}, {5, 5});
+    const auto image_size = Constant::create(element::bf16, Shape{2}, {300, 300});
+
+    OV_EXPECT_THROW(std::ignore = this->make_op(output_size, image_size, this->attrs),
+                    NodeValidationFailure,
+                    HasSubstr("image input must be an integral number"));
+}
+
+TYPED_TEST_P(PriorBoxTest, out_and_img_size_inputs_ranks_not_compatible) {
+    const auto output_size = std::make_shared<Parameter>(element::u64, PartialShape{2});
+    const auto image_size = std::make_shared<Parameter>(element::u64, PartialShape{2, 1});
+
+    OV_EXPECT_THROW(std::ignore = this->make_op(output_size, image_size, this->attrs),
+                    NodeValidationFailure,
+                    HasSubstr("output size input rank 1 must match image shape input rank 2"));
+}
+
+TYPED_TEST_P(PriorBoxTest, out_and_img_size_same_rank_not_1d) {
+    const auto output_size = std::make_shared<Parameter>(element::u64, PartialShape{2, 1});
+    const auto image_size = std::make_shared<Parameter>(element::u64, PartialShape{2, 1});
+
+    OV_EXPECT_THROW(std::ignore = this->make_op(output_size, image_size, this->attrs),
+                    NodeValidationFailure,
+                    HasSubstr("output size input rank 2 must match image shape input rank 2 and both must be 1-D"));
+}
+
+TYPED_TEST_P(PriorBoxTest, out_size_input_not_two_elements_tensor) {
+    const auto output_size = std::make_shared<Parameter>(element::u64, PartialShape{5, 5, 5});
+    const auto out_shape_of = std::make_shared<ShapeOf>(output_size);
+    const auto image_size = std::make_shared<Parameter>(element::u64, PartialShape::dynamic());
+
+    OV_EXPECT_THROW(std::ignore = this->make_op(out_shape_of, image_size, this->attrs),
+                    NodeValidationFailure,
+                    HasSubstr("Output size must have two elements"));
+}
+
+REGISTER_TYPED_TEST_SUITE_P(PriorBoxTest,
+                            default_ctor,
+                            simple_inference,
+                            inputs_dynamic_rank,
+                            input_output_size_is_dynamic_rank,
+                            input_output_size_is_static_rank_with_dynamic_dims,
+                            input_image_size_is_dynamic_rank,
+                            input_image_size_is_static_rank_dynamic_dim,
+                            inputs_are_interval_shapes,
+                            preseve_values_and_labels_on_inputs,
+                            preseve_partial_values_and_labels_on_inputs,
+                            preseve_partial_values_inf_bound,
+                            out_size_input_not_integer,
+                            img_size_input_not_integer,
+                            out_and_img_size_inputs_ranks_not_compatible,
+                            out_and_img_size_same_rank_not_1d,
+                            out_size_input_not_two_elements_tensor);
+
+using PriorBoxTypes = Types<op::v0::PriorBox, op::v8::PriorBox>;
+INSTANTIATE_TYPED_TEST_SUITE_P(type_prop, PriorBoxTest, PriorBoxTypes);

--- a/src/core/tests/type_prop/prior_box_clustered.cpp
+++ b/src/core/tests/type_prop/prior_box_clustered.cpp
@@ -2,98 +2,282 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ngraph/op/prior_box_clustered.hpp"
+#include "openvino/op/prior_box_clustered.hpp"
 
-#include "gtest/gtest.h"
-#include "ngraph/ngraph.hpp"
-#include "util/type_prop.hpp"
+#include "common_test_utils/test_assertions.hpp"
+#include "gmock/gmock.h"
+#include "openvino/opsets/opset11.hpp"
+#include "type_prop.hpp"
 
-using namespace ngraph;
+using namespace ov;
+using namespace ov::opset11;
+using namespace testing;
 
-TEST(type_prop, prior_box_clustered) {
-    op::PriorBoxClusteredAttrs attrs;
-    attrs.widths = {4.0f, 2.0f, 3.2f};
-    attrs.heights = {1.0f, 2.0f, 1.1f};
+template <class TOp>
+class PriorBoxClusteredTest : public TypePropOpTest<TOp> {
+protected:
+    using Attrs = typename TOp::Attributes;
 
-    auto layer_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {19, 19});
-    auto image_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
-    auto pbc = std::make_shared<op::PriorBoxClustered>(layer_shape, image_shape, attrs);
-    // Output shape - 4 * 19 * 19 * 3 (attrs.widths.size())
-    ASSERT_EQ(pbc->get_shape(), (Shape{2, 4332}));
-}
-
-TEST(type_prop, prior_box_clustered_float_layer_shape) {
-    op::PriorBoxClusteredAttrs attrs;
-    attrs.widths = {4.0f, 2.0f, 3.2f};
-    attrs.heights = {1.0f, 2.0f, 1.1f};
-
-    auto layer_shape = op::Constant::create<float>(element::f32, Shape{2}, {19, 19});
-    auto image_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
-
-    try {
-        auto pbc = std::make_shared<op::PriorBoxClustered>(layer_shape, image_shape, attrs);
-        // Should have thrown, so fail if it didn't
-        FAIL() << "Incorrect prior_box_clustered value type exception not handled";
-    } catch (const NodeValidationFailure& error) {
-        EXPECT_HAS_SUBSTRING(error.what(), std::string("layer shape input must be an integral number"));
-    } catch (...) {
-        FAIL() << "Deduced type check failed for unexpected reason";
+    void SetUp() override {
+        this->attrs.widths = {4.0f, 2.0f, 3.2f};
+        this->attrs.heights = {1.0f, 2.0f, 1.1f};
     }
-}
 
-TEST(type_prop, prior_box_clustered_float_image_shape) {
-    op::PriorBoxClusteredAttrs attrs;
-    attrs.widths = {4.0f, 2.0f, 3.2f};
-    attrs.heights = {1.0f, 2.0f, 1.1f};
+    template <class T = TOp>
+    static void check_def_attrs(const TOp* const op) {
+        const auto& attrs = op->get_attrs();
 
-    auto layer_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {19, 19});
-    auto image_shape = op::Constant::create<float>(element::f32, Shape{2}, {300, 300});
-
-    try {
-        auto pbc = std::make_shared<op::PriorBoxClustered>(layer_shape, image_shape, attrs);
-        // Should have thrown, so fail if it didn't
-        FAIL() << "Incorrect prior_box_clustered value type exception not handled";
-    } catch (const NodeValidationFailure& error) {
-        EXPECT_HAS_SUBSTRING(error.what(), std::string("image shape input must be an integral number"));
-    } catch (...) {
-        FAIL() << "Deduced type check failed for unexpected reason";
+        EXPECT_EQ(attrs.widths, std::vector<float>());
+        EXPECT_EQ(attrs.heights, std::vector<float>());
+        EXPECT_EQ(attrs.variances, std::vector<float>());
+        EXPECT_TRUE(attrs.clip);
+        EXPECT_FLOAT_EQ(attrs.step_widths, 0.0f);
+        EXPECT_FLOAT_EQ(attrs.step_heights, 0.0f);
+        EXPECT_FLOAT_EQ(attrs.step, 0.0f);
+        EXPECT_FLOAT_EQ(attrs.offset, 0.0f);
     }
+
+    Attrs attrs;
+};
+
+TYPED_TEST_SUITE_P(PriorBoxClusteredTest);
+
+TYPED_TEST_P(PriorBoxClusteredTest, default_ctor) {
+    const auto output_size = Constant::create(element::i32, Shape{2}, {2, 5});
+    const auto image_size = std::make_shared<Parameter>(element::i32, Shape{2});
+
+    const auto op = this->make_op();
+    op->set_arguments(OutputVector{output_size, image_size});
+    op->set_attrs({});
+    op->validate_and_infer_types();
+
+    this->check_def_attrs(op.get());
+    EXPECT_EQ(op->get_input_size(), 2);
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, 0}));
 }
 
-TEST(type_prop, prior_box_clustered_widths_heights_different) {
-    op::PriorBoxClusteredAttrs attrs;
-    attrs.widths = {4.0f, 2.0f, 3.2f};
-    attrs.heights = {1.0f, 2.0f};
+TYPED_TEST_P(PriorBoxClusteredTest, simple_inference) {
+    const auto output_size = Constant::create(element::i8, Shape{2}, {2, 5});
+    const auto image_size = Constant::create(element::i8, Shape{2}, {300, 300});
 
-    auto layer_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {19, 19});
-    auto image_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
+    const auto op = this->make_op(output_size, image_size, this->attrs);
 
-    try {
-        auto pbc = std::make_shared<op::PriorBoxClustered>(layer_shape, image_shape, attrs);
-        // Should have thrown, so fail if it didn't
-        FAIL() << "Incorrect prior_box_clustered value type exception not handled";
-    } catch (const NodeValidationFailure& error) {
-        EXPECT_HAS_SUBSTRING(error.what(), std::string("Size of heights vector:"));
-    } catch (...) {
-        FAIL() << "Deduced type check failed for unexpected reason";
-    }
+    EXPECT_EQ(op->get_input_size(), 2);
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, 120}));
 }
 
-TEST(type_prop, prior_box_clustered_not_rank_2) {
-    op::PriorBoxClusteredAttrs attrs;
-    attrs.widths = {4.0f, 2.0f, 3.2f};
-    attrs.heights = {1.0f, 2.0f, 1.1f};
+TYPED_TEST_P(PriorBoxClusteredTest, inputs_dynamic_rank) {
+    const auto output_size = std::make_shared<Parameter>(element::i64, PartialShape::dynamic());
+    const auto image_size = std::make_shared<Parameter>(element::i64, PartialShape::dynamic());
 
-    auto layer_shape = op::Constant::create<int64_t>(element::i64, Shape{3}, {19, 19, 19});
-    auto image_shape = op::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
+    const auto op = this->make_op(output_size, image_size, this->attrs);
 
-    try {
-        auto pbc = std::make_shared<op::PriorBoxClustered>(layer_shape, image_shape, attrs);
-        // Should have thrown, so fail if it didn't
-        FAIL() << "Incorrect prior_box_clustered value type exception not handled";
-    } catch (const NodeValidationFailure& error) {
-        EXPECT_HAS_SUBSTRING(error.what(), std::string("Layer shape must have rank 2"));
-    } catch (...) {
-        FAIL() << "Deduced type check failed for unexpected reason";
-    }
+    EXPECT_EQ(op->get_input_size(), 2);
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, -1}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
 }
+
+TYPED_TEST_P(PriorBoxClusteredTest, input_output_size_is_dynamic_rank) {
+    const auto output_size = std::make_shared<Parameter>(element::u64, PartialShape::dynamic());
+    const auto image_size = Constant::create(element::u64, Shape{2}, {300, 300});
+
+    const auto op = this->make_op(output_size, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, -1}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
+}
+
+TYPED_TEST_P(PriorBoxClusteredTest, input_output_size_is_static_rank_with_dynamic_dims) {
+    auto out_size_shape = PartialShape::dynamic(1);
+    set_shape_labels(out_size_shape, 10);
+
+    const auto output_size = std::make_shared<Parameter>(element::u32, out_size_shape);
+    const auto image_size = Constant::create(element::u32, Shape{2}, {300, 300});
+
+    const auto op = this->make_op(output_size, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, -1}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
+}
+
+TYPED_TEST_P(PriorBoxClusteredTest, input_image_size_is_dynamic_rank) {
+    const auto output_size = Constant::create(element::u8, Shape{2}, {32, 32});
+    const auto image_size = std::make_shared<Parameter>(element::u8, PartialShape::dynamic());
+
+    const auto op = this->make_op(output_size, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, 12288}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
+}
+
+TYPED_TEST_P(PriorBoxClusteredTest, input_image_size_is_static_rank_dynamic_dim) {
+    auto img_size_shape = PartialShape::dynamic(1);
+    set_shape_labels(img_size_shape, 20);
+
+    const auto output_size = Constant::create(element::u16, Shape{2}, {32, 32});
+    const auto image_size = std::make_shared<Parameter>(element::u16, img_size_shape);
+
+    const auto op = this->make_op(output_size, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, 12288}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
+}
+
+TYPED_TEST_P(PriorBoxClusteredTest, inputs_are_interval_shapes) {
+    auto out_size_shape = PartialShape{{0, 10}};
+    auto img_size_shape = PartialShape{{1, 5}};
+    set_shape_labels(out_size_shape, 20);
+    set_shape_labels(img_size_shape, 20);
+
+    const auto output_size = std::make_shared<Parameter>(element::u64, out_size_shape);
+    const auto image_size = std::make_shared<Parameter>(element::u64, img_size_shape);
+
+    const auto op = this->make_op(output_size, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, -1}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
+}
+
+TYPED_TEST_P(PriorBoxClusteredTest, preseve_values_and_labels_on_inputs) {
+    auto out_size_shape = PartialShape{6, 8};
+    DimensionTracker::set_label(out_size_shape[0], 10);
+
+    const auto output_size = std::make_shared<Parameter>(element::i16, out_size_shape);
+    const auto image_size = Constant::create(element::i16, Shape{2}, {300, 300});
+    const auto out_shape_of = std::make_shared<ShapeOf>(output_size);
+
+    const auto op = this->make_op(out_shape_of, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, 576}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
+}
+
+TYPED_TEST_P(PriorBoxClusteredTest, preseve_partial_values_and_labels_on_inputs) {
+    auto out_size_shape = PartialShape{{1, 4}, {5, 10}};
+    set_shape_labels(out_size_shape, 10);
+
+    const auto output_size = std::make_shared<Parameter>(element::u64, out_size_shape);
+    const auto image_size = Constant::create(element::u64, Shape{2}, {300, 300});
+    const auto out_shape_of = std::make_shared<ShapeOf>(output_size);
+
+    const auto op = this->make_op(out_shape_of, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, {60, 480}}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
+}
+
+TYPED_TEST_P(PriorBoxClusteredTest, preseve_partial_values_inf_bound) {
+    auto out_size_shape = PartialShape{{1, 4}, {5, -1}};  // ShapeOf make 2nd Dim {0, -1}
+    set_shape_labels(out_size_shape, 10);
+
+    const auto output_size = std::make_shared<Parameter>(element::u64, out_size_shape);
+    const auto image_size = Constant::create(element::u64, Shape{2}, {300, 300});
+    const auto out_shape_of = std::make_shared<ShapeOf>(output_size);
+
+    const auto op = this->make_op(out_shape_of, image_size, this->attrs);
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape({2, {0, -1}}));
+    EXPECT_THAT(get_shape_labels(op->get_output_partial_shape(0)), Each(no_label));
+}
+
+TYPED_TEST_P(PriorBoxClusteredTest, out_size_input_not_integer) {
+    const auto output_size = Constant::create(element::f16, Shape{2}, {5, 5});
+    const auto image_size = Constant::create(element::i16, Shape{2}, {300, 300});
+
+    OV_EXPECT_THROW(std::ignore = this->make_op(output_size, image_size, this->attrs),
+                    NodeValidationFailure,
+                    HasSubstr("output size input must be an integral number"));
+}
+
+TYPED_TEST_P(PriorBoxClusteredTest, img_size_input_not_integer) {
+    const auto output_size = Constant::create(element::i16, Shape{2}, {5, 5});
+    const auto image_size = Constant::create(element::bf16, Shape{2}, {300, 300});
+
+    OV_EXPECT_THROW(std::ignore = this->make_op(output_size, image_size, this->attrs),
+                    NodeValidationFailure,
+                    HasSubstr("image input must be an integral number"));
+}
+
+TYPED_TEST_P(PriorBoxClusteredTest, out_and_img_size_inputs_ranks_not_compatible) {
+    const auto output_size = std::make_shared<Parameter>(element::u64, PartialShape{2});
+    const auto image_size = std::make_shared<Parameter>(element::u64, PartialShape{2, 1});
+
+    OV_EXPECT_THROW(std::ignore = this->make_op(output_size, image_size, this->attrs),
+                    NodeValidationFailure,
+                    HasSubstr("output size input rank 1 must match image shape input rank 2"));
+}
+
+TYPED_TEST_P(PriorBoxClusteredTest, out_and_img_size_same_rank_not_1d) {
+    const auto output_size = std::make_shared<Parameter>(element::u64, PartialShape{2, 1});
+    const auto image_size = std::make_shared<Parameter>(element::u64, PartialShape{2, 1});
+
+    OV_EXPECT_THROW(std::ignore = this->make_op(output_size, image_size, this->attrs),
+                    NodeValidationFailure,
+                    HasSubstr("output size input rank 2 must match image shape input rank 2 and both must be 1-D"));
+}
+
+TYPED_TEST_P(PriorBoxClusteredTest, out_size_input_not_two_elements_tensor) {
+    const auto output_size = std::make_shared<Parameter>(element::u64, PartialShape{5, 5, 5});
+    const auto out_shape_of = std::make_shared<ShapeOf>(output_size);
+    const auto image_size = std::make_shared<Parameter>(element::u64, PartialShape::dynamic());
+
+    OV_EXPECT_THROW(std::ignore = this->make_op(out_shape_of, image_size, this->attrs),
+                    NodeValidationFailure,
+                    HasSubstr("Output size must have two elements"));
+}
+
+TYPED_TEST_P(PriorBoxClusteredTest, widths_heights_different) {
+    this->attrs.widths = {4.0f, 2.0f, 3.2f};
+    this->attrs.heights = {1.0f, 2.0f};
+
+    const auto output_size = Constant::create(element::i16, Shape{2}, {5, 5});
+    const auto image_size = Constant::create(element::i16, Shape{2}, {300, 300});
+
+    OV_EXPECT_THROW(std::ignore = this->make_op(output_size, image_size, this->attrs),
+                    NodeValidationFailure,
+                    HasSubstr("Size of heights vector: 2 doesn't match size of widths vector: 3"));
+}
+
+REGISTER_TYPED_TEST_SUITE_P(PriorBoxClusteredTest,
+                            default_ctor,
+                            simple_inference,
+                            inputs_dynamic_rank,
+                            input_output_size_is_dynamic_rank,
+                            input_output_size_is_static_rank_with_dynamic_dims,
+                            input_image_size_is_dynamic_rank,
+                            input_image_size_is_static_rank_dynamic_dim,
+                            inputs_are_interval_shapes,
+                            preseve_values_and_labels_on_inputs,
+                            preseve_partial_values_and_labels_on_inputs,
+                            preseve_partial_values_inf_bound,
+                            out_size_input_not_integer,
+                            img_size_input_not_integer,
+                            out_and_img_size_inputs_ranks_not_compatible,
+                            out_and_img_size_same_rank_not_1d,
+                            out_size_input_not_two_elements_tensor,
+                            widths_heights_different);
+
+using PriorBoxClusteredTypes = Types<op::v0::PriorBoxClustered>;
+INSTANTIATE_TYPED_TEST_SUITE_P(type_prop, PriorBoxClusteredTest, PriorBoxClusteredTypes);

--- a/src/core/tests/visitors/op/prior_box.cpp
+++ b/src/core/tests/visitors/op/prior_box.cpp
@@ -20,8 +20,8 @@ using ngraph::test::ValueMap;
 
 TEST(attributes, prior_box_op) {
     NodeBuilder::get_ops().register_factory<opset1::PriorBox>();
-    const auto layer_shape = make_shared<op::Parameter>(element::i64, Shape{128, 128});
-    const auto image_shape = make_shared<op::Parameter>(element::i64, Shape{32, 32});
+    const auto layer_shape = make_shared<op::Parameter>(element::i64, Shape{2});
+    const auto image_shape = make_shared<op::Parameter>(element::i64, Shape{2});
 
     op::v0::PriorBox::Attributes attrs;
     attrs.min_size = vector<float>{16.f, 32.f};
@@ -106,8 +106,8 @@ TEST(attributes, prior_box_op2) {
 
 TEST(attributes, prior_box_v8_op) {
     NodeBuilder::get_ops().register_factory<opset8::PriorBox>();
-    const auto layer_shape = make_shared<op::Parameter>(element::i64, Shape{128, 128});
-    const auto image_shape = make_shared<op::Parameter>(element::i64, Shape{32, 32});
+    const auto layer_shape = make_shared<op::Parameter>(element::i64, Shape{2});
+    const auto image_shape = make_shared<op::Parameter>(element::i64, Shape{2});
 
     op::v8::PriorBox::Attributes attrs;
     attrs.min_size = vector<float>{16.f, 32.f};

--- a/src/core/tests/visitors/op/prior_box_clustered.cpp
+++ b/src/core/tests/visitors/op/prior_box_clustered.cpp
@@ -14,8 +14,8 @@ using ngraph::test::ValueMap;
 
 TEST(attributes, prior_box_clustered_op) {
     NodeBuilder::get_ops().register_factory<opset1::PriorBoxClustered>();
-    const auto layer_shape = make_shared<op::Parameter>(element::i64, Shape{32, 32});
-    const auto image_shape = make_shared<op::Parameter>(element::i64, Shape{300, 300});
+    const auto layer_shape = make_shared<op::Parameter>(element::i64, Shape{2});
+    const auto image_shape = make_shared<op::Parameter>(element::i64, Shape{2});
 
     op::PriorBoxClusteredAttrs attrs;
     attrs.heights = {2.0f, 3.0f};
@@ -48,8 +48,8 @@ TEST(attributes, prior_box_clustered_op) {
 
 TEST(attributes, prior_box_clustered_op2) {
     NodeBuilder::get_ops().register_factory<opset1::PriorBoxClustered>();
-    const auto layer_shape = make_shared<op::Parameter>(element::i64, Shape{32, 32});
-    const auto image_shape = make_shared<op::Parameter>(element::i64, Shape{300, 300});
+    const auto layer_shape = make_shared<op::Parameter>(element::i64, Shape{2});
+    const auto image_shape = make_shared<op::Parameter>(element::i64, Shape{2});
 
     op::PriorBoxClusteredAttrs attrs;
     attrs.heights = {44.0f, 10.0f, 30.0f, 19.0f, 94.0f, 32.0f, 61.0f, 53.0f, 17.0f};

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.cpp
@@ -57,6 +57,7 @@
 #include "max_pool_shape_inference.hpp"
 #include "one_hot_shape_inference.hpp"
 #include "pad_shape_inference.hpp"
+#include "prior_box_shape_inference.hpp"
 #include "proposal_shape_inference.hpp"
 #include "psroi_pooling_shape_inference.hpp"
 #include "range_shape_inference.hpp"
@@ -501,6 +502,7 @@ const IShapeInferCommonFactory::TRegistry IShapeInferCommonFactory::registry{
     _OV_OP_SHAPE_INFER_REG(ov::op::internal::AUGRUCell, entryIO),
     _OV_OP_SHAPE_INFER_REG(ov::op::internal::AUGRUSequence, entryIO),
     _OV_OP_SHAPE_INFER_REG(Pad, entryIOC),
+    _OV_OP_SHAPE_INFER_REG(PriorBox, entryIOC),
     _OV_OP_SHAPE_INFER_REG(Proposal, entryIO),
     _OV_OP_SHAPE_INFER_REG(PSROIPooling, entryIO),
     _OV_OP_SHAPE_INFER_REG(Range, entryIOC),

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference.cpp
@@ -57,6 +57,7 @@
 #include "max_pool_shape_inference.hpp"
 #include "one_hot_shape_inference.hpp"
 #include "pad_shape_inference.hpp"
+#include "prior_box_clustered_shape_inference.hpp"
 #include "prior_box_shape_inference.hpp"
 #include "proposal_shape_inference.hpp"
 #include "psroi_pooling_shape_inference.hpp"
@@ -503,6 +504,7 @@ const IShapeInferCommonFactory::TRegistry IShapeInferCommonFactory::registry{
     _OV_OP_SHAPE_INFER_REG(ov::op::internal::AUGRUSequence, entryIO),
     _OV_OP_SHAPE_INFER_REG(Pad, entryIOC),
     _OV_OP_SHAPE_INFER_REG(PriorBox, entryIOC),
+    _OV_OP_SHAPE_INFER_REG(PriorBoxClustered, entryIOC),
     _OV_OP_SHAPE_INFER_REG(Proposal, entryIO),
     _OV_OP_SHAPE_INFER_REG(PSROIPooling, entryIO),
     _OV_OP_SHAPE_INFER_REG(Range, entryIOC),

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/prior_box_clustered_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/prior_box_clustered_shape_inference_test.cpp
@@ -1,0 +1,137 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gmock/gmock.h>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "openvino/opsets/opset11.hpp"
+#include "utils.hpp"
+
+using namespace ov;
+using namespace ov::intel_cpu;
+using namespace testing;
+
+class PriorBoxClusteredV0StaticShapeInferenceTest : public OpStaticShapeInferenceTest<op::v0::PriorBoxClustered> {
+protected:
+    void SetUp() override {
+        output_shapes.resize(1);
+
+        attrs.widths = {2.0f, 3.0f};
+        attrs.heights = {1.5f, 2.0f};
+    }
+
+    typename op_type::Attributes attrs;
+};
+
+TEST_F(PriorBoxClusteredV0StaticShapeInferenceTest, default_ctor_no_args) {
+    op = make_op();
+    op->set_attrs(attrs);
+
+    int32_t out_size[] = {2, 5};
+    input_shapes = ShapeVector{{2}, {2}};
+
+    shape_inference(op.get(),
+                    input_shapes,
+                    output_shapes,
+                    {{0, std::make_shared<HostTensor>(element::i32, ov::Shape{2}, out_size)}});
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({2, 80}));
+}
+
+TEST_F(PriorBoxClusteredV0StaticShapeInferenceTest, all_inputs_dynamic_rank) {
+    const auto out_size = std::make_shared<op::v0::Parameter>(element::i32, PartialShape::dynamic());
+    const auto img_size = std::make_shared<op::v0::Parameter>(element::i32, PartialShape::dynamic());
+
+    op = make_op(out_size, img_size, attrs);
+
+    int32_t output_size[] = {2, 5};
+
+    input_shapes = ShapeVector{{2}, {2}};
+    shape_inference(op.get(),
+                    input_shapes,
+                    output_shapes,
+                    {{0, std::make_shared<HostTensor>(element::i32, ov::Shape{2}, output_size)}});
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes[0], (StaticShape{2, 4 * 2 * 5 * 2}));
+}
+
+TEST_F(PriorBoxClusteredV0StaticShapeInferenceTest, all_inputs_static_rank) {
+    const auto out_size = std::make_shared<op::v0::Parameter>(element::i32, PartialShape::dynamic(1));
+    const auto img_size = std::make_shared<op::v0::Parameter>(element::i32, PartialShape::dynamic(1));
+
+    op = make_op(out_size, img_size, attrs);
+
+    int32_t output_size[] = {5, 2};
+
+    input_shapes = ShapeVector{{2}, {2}};
+    shape_inference(op.get(),
+                    input_shapes,
+                    output_shapes,
+                    {{0, std::make_shared<HostTensor>(element::i32, ov::Shape{2}, output_size)}});
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes[0], (StaticShape{2, 4 * 5 * 2 * 2}));
+}
+
+TEST_F(PriorBoxClusteredV0StaticShapeInferenceTest, out_size_constant) {
+    const auto out_size = op::v0::Constant::create(element::i32, Shape{2}, {4, 6});
+    const auto img_size = std::make_shared<op::v0::Parameter>(element::i32, PartialShape::dynamic(1));
+
+    op = make_op(out_size, img_size, attrs);
+
+    input_shapes = ShapeVector{{2}, {2}};
+    shape_inference(op.get(), input_shapes, output_shapes);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes[0], (StaticShape{2, 4 * 4 * 6 * 2}));
+}
+
+TEST_F(PriorBoxClusteredV0StaticShapeInferenceTest, all_inputs_constants) {
+    const auto out_size = op::v0::Constant::create(element::i32, Shape{2}, {12, 16});
+    const auto img_size = op::v0::Constant::create(element::i32, Shape{2}, {50, 50});
+
+    op = make_op(out_size, img_size, attrs);
+
+    input_shapes = ShapeVector{{2}, {2}};
+    shape_inference(op.get(), input_shapes, output_shapes);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes[0], (StaticShape{2, 4 * 12 * 16 * 2}));
+}
+
+TEST_F(PriorBoxClusteredV0StaticShapeInferenceTest, invalid_number_of_elements_in_out_size) {
+    const auto out_size = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
+    const auto img_size = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
+
+    op = make_op(out_size, img_size, attrs);
+
+    int64_t output_size[] = {5, 2, 1};
+    input_shapes = ShapeVector{{2}, {2}};
+
+    OV_EXPECT_THROW(shape_inference(op.get(),
+                                    input_shapes,
+                                    output_shapes,
+                                    {{0, std::make_shared<HostTensor>(element::i64, ov::Shape{3}, output_size)}}),
+                    NodeValidationFailure,
+                    HasSubstr("Output size must have two elements"));
+}
+
+TEST_F(PriorBoxClusteredV0StaticShapeInferenceTest, invalid_input_ranks) {
+    const auto out_size = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
+    const auto img_size = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
+
+    op = make_op(out_size, img_size, attrs);
+
+    int64_t output_size[] = {5, 2, 1};
+    input_shapes = ShapeVector{{2, 1}, {2}};
+
+    OV_EXPECT_THROW(shape_inference(op.get(),
+                                    input_shapes,
+                                    output_shapes,
+                                    {{0, std::make_shared<HostTensor>(element::i64, ov::Shape{3}, output_size)}}),
+                    NodeValidationFailure,
+                    HasSubstr("output size input rank 2 must match image shape input rank 1"));
+}

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/prior_box_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/prior_box_shape_inference_test.cpp
@@ -1,0 +1,138 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gmock/gmock.h>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "openvino/opsets/opset11.hpp"
+#include "utils.hpp"
+
+using namespace ov;
+using namespace ov::intel_cpu;
+using namespace testing;
+
+class PriorBoxV8StaticShapeInferenceTest : public OpStaticShapeInferenceTest<op::v8::PriorBox> {
+protected:
+    void SetUp() override {
+        output_shapes.resize(1);
+
+        attrs.min_size = {2.0f, 3.0f};
+        attrs.aspect_ratio = {1.5f, 2.0f, 2.5f};
+        attrs.scale_all_sizes = false;
+    }
+
+    typename op_type::Attributes attrs;
+};
+
+TEST_F(PriorBoxV8StaticShapeInferenceTest, default_ctor_no_args) {
+    op = make_op();
+    op->set_attrs(attrs);
+
+    int32_t out_size[] = {2, 5};
+    input_shapes = ShapeVector{{2}, {2}};
+
+    shape_inference(op.get(),
+                    input_shapes,
+                    output_shapes,
+                    {{0, std::make_shared<HostTensor>(element::i32, ov::Shape{2}, out_size)}});
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes.front(), StaticShape({2, 200}));
+}
+
+TEST_F(PriorBoxV8StaticShapeInferenceTest, all_inputs_dynamic_rank) {
+    const auto out_size = std::make_shared<op::v0::Parameter>(element::i32, PartialShape::dynamic());
+    const auto img_size = std::make_shared<op::v0::Parameter>(element::i32, PartialShape::dynamic());
+
+    op = make_op(out_size, img_size, attrs);
+
+    int32_t output_size[] = {2, 5};
+
+    input_shapes = ShapeVector{{2}, {2}};
+    shape_inference(op.get(),
+                    input_shapes,
+                    output_shapes,
+                    {{0, std::make_shared<HostTensor>(element::i32, ov::Shape{2}, output_size)}});
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes[0], (StaticShape{2, 200}));
+}
+
+TEST_F(PriorBoxV8StaticShapeInferenceTest, all_inputs_static_rank) {
+    const auto out_size = std::make_shared<op::v0::Parameter>(element::i32, PartialShape::dynamic(1));
+    const auto img_size = std::make_shared<op::v0::Parameter>(element::i32, PartialShape::dynamic(1));
+
+    op = make_op(out_size, img_size, attrs);
+
+    int32_t output_size[] = {5, 2};
+
+    input_shapes = ShapeVector{{2}, {2}};
+    shape_inference(op.get(),
+                    input_shapes,
+                    output_shapes,
+                    {{0, std::make_shared<HostTensor>(element::i32, ov::Shape{2}, output_size)}});
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes[0], (StaticShape{2, 200}));
+}
+
+TEST_F(PriorBoxV8StaticShapeInferenceTest, out_size_constant) {
+    const auto out_size = op::v0::Constant::create(element::i32, Shape{2}, {4, 6});
+    const auto img_size = std::make_shared<op::v0::Parameter>(element::i32, PartialShape::dynamic(1));
+
+    op = make_op(out_size, img_size, attrs);
+
+    input_shapes = ShapeVector{{2}, {2}};
+    shape_inference(op.get(), input_shapes, output_shapes);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes[0], (StaticShape{2, 480}));
+}
+
+TEST_F(PriorBoxV8StaticShapeInferenceTest, all_inputs_constants) {
+    const auto out_size = op::v0::Constant::create(element::i32, Shape{2}, {12, 16});
+    const auto img_size = op::v0::Constant::create(element::i32, Shape{2}, {50, 50});
+
+    op = make_op(out_size, img_size, attrs);
+
+    input_shapes = ShapeVector{{2}, {2}};
+    shape_inference(op.get(), input_shapes, output_shapes);
+
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes[0], (StaticShape{2, 3840}));
+}
+
+TEST_F(PriorBoxV8StaticShapeInferenceTest, invalid_number_of_elements_in_out_size) {
+    const auto out_size = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
+    const auto img_size = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
+
+    op = make_op(out_size, img_size, attrs);
+
+    int64_t output_size[] = {5, 2, 1};
+    input_shapes = ShapeVector{{2}, {2}};
+
+    OV_EXPECT_THROW(shape_inference(op.get(),
+                                    input_shapes,
+                                    output_shapes,
+                                    {{0, std::make_shared<HostTensor>(element::i64, ov::Shape{3}, output_size)}}),
+                    NodeValidationFailure,
+                    HasSubstr("Output size must have two elements"));
+}
+
+TEST_F(PriorBoxV8StaticShapeInferenceTest, invalid_input_ranks) {
+    const auto out_size = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
+    const auto img_size = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
+
+    op = make_op(out_size, img_size, attrs);
+
+    int64_t output_size[] = {5, 2, 1};
+    input_shapes = ShapeVector{{2, 1}, {2}};
+
+    OV_EXPECT_THROW(shape_inference(op.get(),
+                                    input_shapes,
+                                    output_shapes,
+                                    {{0, std::make_shared<HostTensor>(element::i64, ov::Shape{3}, output_size)}}),
+                    NodeValidationFailure,
+                    HasSubstr("output size input rank 2 must match image shape input rank 1"));
+}


### PR DESCRIPTION
### Details:
 - Review for partial shape and label propagation.
 - Add template implementation of shape inference.
 - Add/update unit test for static and dynamic shapes.
 - Review partial values and labels are preserved on inputs.
 - Update `evaluate` member functions to use `Tensor` instead `HostTensor`.
 - Remove `ngraph` namespace from reviewed operators where possible.

### Tickets:
 - 97242
 - 97296
 - 97345
 - 97394
 - 97497
 - 97546
