### PR TITLE
HOT FIX: use hyper threading for Pcore only in latency mode

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -63,6 +63,15 @@ std::vector<std::vector<int>> get_streams_info_table(const int input_streams,
                     }
                 }
             }
+        } else if ((proc_type_table[0][EFFICIENT_CORE_PROC] > 0) &&
+                   (limit_threads = proc_type_table[0][MAIN_CORE_PROC])) {
+            stream_info[PROC_TYPE] = MAIN_CORE_PROC;
+            stream_info[THREADS_PER_STREAM] =
+                (input_threads == 0)
+                    ? proc_type_table[0][MAIN_CORE_PROC] + proc_type_table[0][HYPER_THREADING_PROC]
+                    : std::min(proc_type_table[0][MAIN_CORE_PROC] + proc_type_table[0][HYPER_THREADING_PROC],
+                               input_threads);
+            streams_info_table.push_back(stream_info);
         } else {
             stream_info[PROC_TYPE] = MAIN_CORE_PROC;
             stream_info[THREADS_PER_STREAM] = (limit_threads == 0)

--- a/src/plugins/intel_cpu/tests/unit/streams_info_table_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/streams_info_table_test.cpp
@@ -400,7 +400,7 @@ StreamsCalculationTestCase _1sockets_14cores_latency_3 = {
     0,
     6,
     {{20, 6, 8, 6}},
-    {{1, MAIN_CORE_PROC, 6}},
+    {{1, MAIN_CORE_PROC, 12}},
 };
 
 StreamsCalculationTestCase _1sockets_14cores_latency_4 = {
@@ -590,7 +590,7 @@ StreamsCalculationTestCase _1sockets_10cores_latency_3 = {
     0,
     2,
     {{12, 2, 8, 2}},
-    {{1, MAIN_CORE_PROC, 2}},
+    {{1, MAIN_CORE_PROC, 4}},
 };
 
 StreamsCalculationTestCase _1sockets_10cores_latency_4 = {
@@ -680,7 +680,7 @@ StreamsCalculationTestCase _1sockets_8cores_latency_3 = {
     0,
     4,
     {{12, 4, 4, 4}},
-    {{1, MAIN_CORE_PROC, 4}},
+    {{1, MAIN_CORE_PROC, 8}},
 };
 
 StreamsCalculationTestCase _1sockets_8cores_latency_4 = {


### PR DESCRIPTION
### Details:
 - *use hyper threading for Pcore only to solve latency regression on  i9-12900K *


### Tickets:
 - *ticket-id*
