### PR TITLE
Remove `funcTestUtils` from `ov_conditional_compilation_tests`

### DIFF
--- a/src/common/conditional_compilation/tests/CMakeLists.txt
+++ b/src/common/conditional_compilation/tests/CMakeLists.txt
@@ -9,8 +9,10 @@ ov_add_test_target(
         ROOT ${CMAKE_CURRENT_SOURCE_DIR}
         DEPENDENCIES
         LINK_LIBRARIES
+            gtest
+            gtest_main
             gmock
-            funcTestUtils
+            openvino::conditional_compilation
         INCLUDES
             "${CMAKE_CURRENT_SOURCE_DIR}/../include"
         ADD_CLANG_FORMAT


### PR DESCRIPTION
### Details:
 - Because `ov_conditional_compilation_tests` is enabled via `ENABLE_TESTS`, so with `ENABLE_FUNCTIONAL_TESTS=OFF` build fails with "fatal error: openvino/itt.hpp: No such file or directory" due `funcTestUtils` dependency
