### PR TITLE
[GPU] Fix accuracy issue for assign and fully_connected_mmad

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
@@ -8,6 +8,7 @@
 #include "program_node.h"
 #include "mutable_data_inst.h"
 #include "convert_color_inst.h"
+#include "assign_inst.h"
 #include "tensor_type.h"
 #include <memory>
 #include <vector>
@@ -56,6 +57,21 @@ void add_required_reorders::run(program& p) {
             continue;  // only nodes with dependencies
         if (usr->is_type<data>())
             continue;
+
+        // If usr is assign and input and output data types are different
+        // add reorder with usr's output data type between dep and usr
+        if (usr->is_type<assign>()) {
+            auto& dep = usr->get_dependency(0);
+            auto dep_layout = dep.get_output_layout();
+            auto out_layout = usr->get_output_layout();
+            bool required_reorder = out_layout.data_type != dep_layout.data_type;
+            if (required_reorder) {
+                auto new_reorder = std::make_shared<reorder>(dep.id() + "_reorder_" + usr->id(), dep.id(), out_layout.format, out_layout.data_type);
+                auto& new_reorder_node = p.get_or_create(new_reorder);
+                p.add_intermediate(new_reorder_node, *usr, dep);
+                new_reorder_node.recalc_output_layout(false);
+            }
+        }
 
         if (optimize_data) {
             auto fused_ops = usr->get_fused_primitives();

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_MMAD.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_MMAD.cl
@@ -204,9 +204,9 @@ KERNEL(fully_connected_gpu_MMAD)(
 #endif  // SPATIAL_MAJOR
 
 #if !SPLIT_SPATIAL
-            uint input_idx = input_offset + spatial * MMAD_INPUT_SPATIAL_PITCH + FEATURE_BLOCKS_COUNT * FEATURE_PITCH;
+            uint input_idx = input_offset + spatial * MMAD_INPUT_SPATIAL_PITCH + FEATURE_BLOCKS_COUNT * MMAD_INPUT_FBLOCK_PITCH;
 #else
-            uint input_idx = input_offset + FEATURE_BLOCKS_COUNT * FEATURE_PITCH +
+            uint input_idx = input_offset + FEATURE_BLOCKS_COUNT * MMAD_INPUT_FBLOCK_PITCH +
                              zi * MMAD_INPUT_Z_PITCH + yi * MMAD_INPUT_Y_PITCH + xi * MMAD_INPUT_X_PITCH;
 #endif // !SPLIT_SPATIAL
             uint filter_idx = filter_offset + spatial * MMAD_FILTER_SPATIAL_PITCH + FEATURE_BLOCKS_COUNT * MMAD_FILTER_FBLOCK_PITCH;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -1589,6 +1589,20 @@ INSTANTIATE_TEST_SUITE_P(
 );
 
 INSTANTIATE_TEST_SUITE_P(
+    mmad,
+    fully_connected_i8_i8_test,
+    testing::Combine(
+        testing::Values(1),
+        testing::Values(16, 43, 64),
+        testing::Values(1),
+        testing::Values(1),
+        testing::Values(16, 32, 64),
+        testing::Values(format::bfyx, format::b_fs_yx_fsv32)
+    ),
+    fully_connected_i8_i8_test::PrintToStringParamName
+);
+
+INSTANTIATE_TEST_SUITE_P(
     basic,
     fully_connected_i8_u8_test,
     testing::Combine(


### PR DESCRIPTION
### Details:
 - Add reorder with output data type between dep and `assign` if input and output data types are different during `add_required_reorders` pass
 - Fix incorrect input index to handle leftovers for `fullyconnected_mmad` kernel

### Tickets:
 - 98010