### PR TITLE
AUTO select device based on RemoteContext input

### DIFF
--- a/src/inference/include/openvino/runtime/auto/properties.hpp
+++ b/src/inference/include/openvino/runtime/auto/properties.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <openvino/runtime/properties.hpp>
+#include "ie_remote_context.hpp"
 #include <string>
 
 namespace ov {
@@ -28,5 +29,10 @@ static constexpr Property<bool> enable_startup_fallback{"ENABLE_STARTUP_FALLBACK
  * selected device
  */
 static constexpr Property<bool> enable_runtime_fallback{"ENABLE_RUNTIME_FALLBACK"};
+
+/**
+ * @brief the RemoteContext input for auto
+ */
+static constexpr Property<ov::RemoteContext> remote_context{"REMOTE_CONTEXT"};
 }  // namespace intel_auto
 }  // namespace ov

--- a/src/plugins/auto/src/common.hpp
+++ b/src/plugins/auto/src/common.hpp
@@ -211,6 +211,8 @@ public:
     std::mutex                                     _fallbackMutex;
     MultiDeviceInferencePlugin*                    _plugin;
     SoExecNetwork                                  _hwExecutableNetwork;
+    bool                                           _useRemoteContext = {false};
+    ov::RemoteContext                              _remoteContext;
     virtual ~AutoScheduleContext() = default;
 };
 }  // namespace MultiDevicePlugin

--- a/src/plugins/auto/src/plugin.hpp
+++ b/src/plugins/auto/src/plugin.hpp
@@ -53,7 +53,8 @@ public:
 
     MOCKTESTMACRO DeviceInformation SelectDevice(const std::vector<DeviceInformation>& metaDevices,
                                                  const std::string& networkPrecision = METRIC_VALUE(FP32),
-                                                 unsigned int priority = 0);
+                                                 unsigned int priority = 0,
+                                                 const std::string& remoteContextDevice = "");
     void UnregisterPriority(const unsigned int& priority, const std::string& deviceName);
     void RegisterPriority(const unsigned int& priority, const std::string& deviceName);
 

--- a/src/plugins/auto/src/plugin_config.cpp
+++ b/src/plugins/auto/src/plugin_config.cpp
@@ -25,6 +25,7 @@ void PluginConfig::set_default() {
         std::make_tuple(ov::hint::num_requests, 0, UnsignedTypeValidator()),
         std::make_tuple(ov::intel_auto::enable_startup_fallback, true),
         std::make_tuple(ov::intel_auto::enable_runtime_fallback, true),
+        std::make_tuple(ov::intel_auto::remote_context, ov::RemoteContext{}),
         // RO for register only
         std::make_tuple(ov::device::full_name),
         std::make_tuple(ov::device::capabilities),
@@ -65,6 +66,13 @@ ov::Any PluginConfig::get_property(const std::string& name) const {
 bool PluginConfig::is_batching_disabled() const {
     if (user_properties.find(ov::hint::allow_auto_batching.name()) != user_properties.end()) {
         return !user_properties.at(ov::hint::allow_auto_batching.name()).as<bool>();
+    }
+    return false;
+}
+
+bool PluginConfig::is_set_remote_context() const {
+    if (user_properties.find(ov::intel_auto::remote_context.name()) != user_properties.end()) {
+        return !user_properties.at(ov::intel_auto::remote_context.name()).as<bool>();
     }
     return false;
 }

--- a/src/plugins/auto/src/plugin_config.hpp
+++ b/src/plugins/auto/src/plugin_config.hpp
@@ -65,6 +65,7 @@ public:
     void set_user_property(const ov::AnyMap& properties);
     ov::Any get_property(const std::string& name) const;
     bool is_batching_disabled() const;
+    bool is_set_remote_context() const;
     bool is_set_by_user(const std::string& name) const;
     bool is_supported(const std::string& name) const;
 
@@ -153,6 +154,9 @@ public:
         multi_supported_configKeys.erase(std::remove(
                                 multi_supported_configKeys.begin(), multi_supported_configKeys.end(), ov::intel_auto::enable_runtime_fallback.name()),
                                 multi_supported_configKeys.end());
+        multi_supported_configKeys.erase(std::remove(
+                                multi_supported_configKeys.begin(), multi_supported_configKeys.end(), ov::intel_auto::remote_context.name()),
+                                multi_supported_configKeys.end());
         return pluginName == "AUTO" ? supported_configKeys : multi_supported_configKeys;
     }
 
@@ -167,6 +171,9 @@ public:
                                 multi_supported_properties.end());
         multi_supported_properties.erase(std::remove(
                                 multi_supported_properties.begin(), multi_supported_properties.end(), ov::intel_auto::enable_runtime_fallback),
+                                multi_supported_properties.end());
+        multi_supported_properties.erase(std::remove(
+                                multi_supported_properties.begin(), multi_supported_properties.end(), ov::intel_auto::remote_context),
                                 multi_supported_properties.end());
         return pluginName == "AUTO" ? supported_properties : multi_supported_properties;
     }

--- a/src/plugins/auto/tests/unit/auto_ctput_call_multi.cpp
+++ b/src/plugins/auto/tests/unit/auto_ctput_call_multi.cpp
@@ -132,8 +132,12 @@ public:
         ON_CALL(*plugin, SelectDevice)
             .WillByDefault([this](const std::vector<DeviceInformation>& metaDevices,
                                   const std::string& netPrecision,
-                                  unsigned int priority) {
-                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices, netPrecision, priority);
+                                  unsigned int priority,
+                                  const std::string& remoteContextDevice) {
+                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices,
+                                                                        netPrecision,
+                                                                        priority,
+                                                                        remoteContextDevice);
             });
 
         ON_CALL(*plugin, GetValidDevice)
@@ -156,12 +160,6 @@ public:
         ON_CALL(*plugin, GetDeviceList).WillByDefault([this](const std::map<std::string, std::string>& config) {
             return plugin->MultiDeviceInferencePlugin::GetDeviceList(config);
         });
-        ON_CALL(*plugin, SelectDevice)
-            .WillByDefault([this](const std::vector<DeviceInformation>& metaDevices,
-                                  const std::string& netPrecision,
-                                  unsigned int Priority) {
-                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices, netPrecision, Priority);
-            });
         std::vector<std::string> cpuCability{"FP32", "FP16", "INT8", "BIN"};
         std::vector<std::string> gpuCability{"FP32", "FP16", "BATCHED_BLOB", "BIN", "INT8"};
         ON_CALL(*core, GetMetric(StrEq(CommonTestUtils::DEVICE_CPU), StrEq(METRIC_KEY(OPTIMIZATION_CAPABILITIES)), _))

--- a/src/plugins/auto/tests/unit/auto_ctput_test.cpp
+++ b/src/plugins/auto/tests/unit/auto_ctput_test.cpp
@@ -128,8 +128,12 @@ public:
         ON_CALL(*plugin, SelectDevice)
             .WillByDefault([this](const std::vector<DeviceInformation>& metaDevices,
                                   const std::string& netPrecision,
-                                  unsigned int priority) {
-                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices, netPrecision, priority);
+                                  unsigned int priority,
+                                  const std::string& remoteContextDevice) {
+                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices,
+                                                                        netPrecision,
+                                                                        priority,
+                                                                        remoteContextDevice);
             });
 
         ON_CALL(*plugin, GetValidDevice)
@@ -152,12 +156,6 @@ public:
         ON_CALL(*plugin, GetDeviceList).WillByDefault([this](const std::map<std::string, std::string>& config) {
             return plugin->MultiDeviceInferencePlugin::GetDeviceList(config);
         });
-        ON_CALL(*plugin, SelectDevice)
-            .WillByDefault([this](const std::vector<DeviceInformation>& metaDevices,
-                                  const std::string& netPrecision,
-                                  unsigned int Priority) {
-                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices, netPrecision, Priority);
-            });
         std::vector<std::string> cpuCability{"FP32", "FP16", "INT8", "BIN"};
         std::vector<std::string> gpuCability{"FP32", "FP16", "BATCHED_BLOB", "BIN", "INT8"};
         ON_CALL(*core, GetMetric(StrEq(CommonTestUtils::DEVICE_CPU), StrEq(METRIC_KEY(OPTIMIZATION_CAPABILITIES)), _))

--- a/src/plugins/auto/tests/unit/auto_default_perf_hint_test.cpp
+++ b/src/plugins/auto/tests/unit/auto_default_perf_hint_test.cpp
@@ -296,8 +296,12 @@ public:
         ON_CALL(*plugin, SelectDevice)
             .WillByDefault([this](const std::vector<DeviceInformation>& metaDevices,
                                   const std::string& netPrecision,
-                                  unsigned int priority) {
-                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices, netPrecision, priority);
+                                  unsigned int priority,
+                                  const std::string& remoteContextDevice) {
+                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices,
+                                                                        netPrecision,
+                                                                        priority,
+                                                                        remoteContextDevice);
             });
 
         ON_CALL(*plugin, GetValidDevice)
@@ -320,12 +324,6 @@ public:
         ON_CALL(*plugin, GetDeviceList).WillByDefault([this](const std::map<std::string, std::string>& config) {
             return plugin->MultiDeviceInferencePlugin::GetDeviceList(config);
         });
-        ON_CALL(*plugin, SelectDevice)
-            .WillByDefault([this](const std::vector<DeviceInformation>& metaDevices,
-                                  const std::string& netPrecision,
-                                  unsigned int Priority) {
-                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices, netPrecision, Priority);
-            });
         std::vector<std::string> cpuCability{"FP32", "FP16", "INT8", "BIN"};
         std::vector<std::string> gpuCability{"FP32", "FP16", "BATCHED_BLOB", "BIN", "INT8"};
         ON_CALL(*core, GetMetric(StrEq(CommonTestUtils::DEVICE_CPU), StrEq(METRIC_KEY(OPTIMIZATION_CAPABILITIES)), _))

--- a/src/plugins/auto/tests/unit/auto_load_network_properties_test.cpp
+++ b/src/plugins/auto/tests/unit/auto_load_network_properties_test.cpp
@@ -192,8 +192,12 @@ public:
         ON_CALL(*plugin, SelectDevice)
             .WillByDefault([this](const std::vector<DeviceInformation>& metaDevices,
                                   const std::string& netPrecision,
-                                  unsigned int priority) {
-                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices, netPrecision, priority);
+                                  unsigned int priority,
+                                  const std::string& remoteContextDevice) {
+                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices,
+                                                                        netPrecision,
+                                                                        priority,
+                                                                        remoteContextDevice);
             });
 
         ON_CALL(*plugin, GetValidDevice)
@@ -216,12 +220,6 @@ public:
         ON_CALL(*plugin, GetDeviceList).WillByDefault([this](const std::map<std::string, std::string>& config) {
             return plugin->MultiDeviceInferencePlugin::GetDeviceList(config);
         });
-        ON_CALL(*plugin, SelectDevice)
-            .WillByDefault([this](const std::vector<DeviceInformation>& metaDevices,
-                                  const std::string& netPrecision,
-                                  unsigned int Priority) {
-                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices, netPrecision, Priority);
-            });
         std::vector<std::string> cpuCability{"FP32", "FP16", "INT8", "BIN"};
         std::vector<std::string> gpuCability{"FP32", "FP16", "BATCHED_BLOB", "BIN", "INT8"};
         ON_CALL(*core, GetMetric(StrEq(CommonTestUtils::DEVICE_CPU), StrEq(METRIC_KEY(OPTIMIZATION_CAPABILITIES)), _))

--- a/src/plugins/auto/tests/unit/auto_release_helper_test.cpp
+++ b/src/plugins/auto/tests/unit/auto_release_helper_test.cpp
@@ -167,9 +167,9 @@ TEST_P(AutoReleaseHelperTest, releaseResource) {
             std::list<DeviceInformation> devices(metaDevices.begin(), metaDevices.end());
             return devices;
         });
-    ON_CALL(*plugin, SelectDevice(Property(&std::vector<DeviceInformation>::size, Eq(2)), _, _))
+    ON_CALL(*plugin, SelectDevice(Property(&std::vector<DeviceInformation>::size, Eq(2)), _, _, _))
             .WillByDefault(Return(metaDevices[1]));
-    ON_CALL(*plugin, SelectDevice(Property(&std::vector<DeviceInformation>::size, Eq(1)), _, _))
+    ON_CALL(*plugin, SelectDevice(Property(&std::vector<DeviceInformation>::size, Eq(1)), _, _, _))
             .WillByDefault(Return(metaDevices[0]));
     config.insert({InferenceEngine::MultiDeviceConfigParams::KEY_MULTI_DEVICE_PRIORITIES,
                   CommonTestUtils::DEVICE_CPU + std::string(",") + CommonTestUtils::DEVICE_GPU});

--- a/src/plugins/auto/tests/unit/auto_runtime_fallback_test.cpp
+++ b/src/plugins/auto/tests/unit/auto_runtime_fallback_test.cpp
@@ -188,8 +188,12 @@ public:
         ON_CALL(*plugin, SelectDevice)
             .WillByDefault([this](const std::vector<DeviceInformation>& metaDevices,
                                   const std::string& netPrecision,
-                                  unsigned int priority) {
-                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices, netPrecision, priority);
+                                  unsigned int priority,
+                                  const std::string& remoteContextDevice) {
+                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices,
+                                                                        netPrecision,
+                                                                        priority,
+                                                                        remoteContextDevice);
             });
 
         ON_CALL(*plugin, GetValidDevice)
@@ -201,12 +205,6 @@ public:
         ON_CALL(*plugin, GetDeviceList).WillByDefault([this](const std::map<std::string, std::string>& config) {
             return plugin->MultiDeviceInferencePlugin::GetDeviceList(config);
         });
-        ON_CALL(*plugin, SelectDevice)
-            .WillByDefault([this](const std::vector<DeviceInformation>& metaDevices,
-                                  const std::string& netPrecision,
-                                  unsigned int Priority) {
-                return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices, netPrecision, Priority);
-            });
 
         inferReqInternal = std::make_shared<NiceMock<MockIInferRequestInternal>>();
         mockExecutor = std::make_shared<ImmediateExecutor>();

--- a/src/plugins/auto/tests/unit/auto_select_device_failed_test.cpp
+++ b/src/plugins/auto/tests/unit/auto_select_device_failed_test.cpp
@@ -219,7 +219,7 @@ TEST_P(AutoLoadFailedTest, LoadCNNetWork) {
         // set the return value of SelectDevice
         // for example if there are three device, if will return GPU on the first call, and then MYRIAD
         // at last CPU
-        ON_CALL(*plugin, SelectDevice(Property(&std::vector<DeviceInformation>::size, Eq(selDevsSize)), _, _))
+        ON_CALL(*plugin, SelectDevice(Property(&std::vector<DeviceInformation>::size, Eq(selDevsSize)), _, _, _))
             .WillByDefault(Return(metaDevices[deviceConfigs.size() - selDevsSize]));
         devicesStr += deviceName;
         devicesStr += ((++iter) == deviceConfigs.end()) ? "" : ",";
@@ -236,16 +236,16 @@ TEST_P(AutoLoadFailedTest, LoadCNNetWork) {
     if (thrExcWheSelect) {
         selDevsSize = deviceConfigs.size();
         if (selDevsSize > 1) {
-            ON_CALL(*plugin, SelectDevice(Property(&std::vector<DeviceInformation>::size, Eq(selDevsSize - 1)), _, _))
+            ON_CALL(*plugin, SelectDevice(Property(&std::vector<DeviceInformation>::size, Eq(selDevsSize - 1)), _, _, _))
                 .WillByDefault(Throw(InferenceEngine::GeneralError{""}));
         } else {
-            ON_CALL(*plugin, SelectDevice(Property(&std::vector<DeviceInformation>::size, Eq(1)), _, _))
+            ON_CALL(*plugin, SelectDevice(Property(&std::vector<DeviceInformation>::size, Eq(1)), _, _, _))
                 .WillByDefault(Throw(InferenceEngine::GeneralError{""}));
         }
     }
 
     EXPECT_CALL(*plugin, ParseMetaDevices(_, _)).Times(AtLeast(1));
-    EXPECT_CALL(*plugin, SelectDevice(_, _, _)).Times(selectCount);
+    EXPECT_CALL(*plugin, SelectDevice(_, _, _, _)).Times(selectCount);
     EXPECT_CALL(*core, LoadNetwork(::testing::Matcher<const InferenceEngine::CNNNetwork&>(_),
                 ::testing::Matcher<const std::string&>(_),
                 ::testing::Matcher<const Config&>(_))).Times(loadCount);

--- a/src/plugins/auto/tests/unit/auto_startup_fallback_properties_test.cpp
+++ b/src/plugins/auto/tests/unit/auto_startup_fallback_properties_test.cpp
@@ -117,7 +117,7 @@ TEST_P(AutoStartupFallback, releaseResource) {
             std::list<DeviceInformation> devices(metaDevices.begin(), metaDevices.end());
             return devices;
         });
-    ON_CALL(*plugin, SelectDevice(_, _, _)).WillByDefault(Return(metaDevices[1]));
+    ON_CALL(*plugin, SelectDevice(_, _, _, _)).WillByDefault(Return(metaDevices[1]));
 
     EXPECT_CALL(
         *core,

--- a/src/plugins/auto/tests/unit/exec_network_get_metrics.cpp
+++ b/src/plugins/auto/tests/unit/exec_network_get_metrics.cpp
@@ -276,7 +276,7 @@ TEST_P(ExecNetworkGetMetricOptimalNumInferReq, OPTIMAL_NUMBER_OF_INFER_REQUESTS)
         metaDevices.push_back({actualDeviceName, {}, actualCustomerNum, ""});
         ON_CALL(*core, GetConfig(_, StrEq(ov::compilation_num_threads.name()))).WillByDefault(Return(8));
     }
-    ON_CALL(*plugin, SelectDevice(_, _, _)).WillByDefault(Return(metaDevices[1]));
+    ON_CALL(*plugin, SelectDevice(_, _, _, _)).WillByDefault(Return(metaDevices[1]));
     ON_CALL(*plugin, ParseMetaDevices(_, _)).WillByDefault(Return(metaDevices));
     ON_CALL(*plugin, GetValidDevice)
         .WillByDefault([](const std::vector<DeviceInformation>& metaDevices, const std::string& netPrecision) {
@@ -284,7 +284,7 @@ TEST_P(ExecNetworkGetMetricOptimalNumInferReq, OPTIMAL_NUMBER_OF_INFER_REQUESTS)
             return devices;
         });
     EXPECT_CALL(*plugin, ParseMetaDevices(_, _)).Times(1);
-    EXPECT_CALL(*plugin, SelectDevice(_, _, _)).Times(1);
+    EXPECT_CALL(*plugin, SelectDevice(_, _, _, _)).Times(1);
 
     if (cpuSleep) {
         ON_CALL(*core, LoadNetwork(::testing::Matcher<const InferenceEngine::CNNNetwork&>(_),
@@ -411,7 +411,7 @@ TEST_P(ExecNetworkGetMetricOtherTest, modelPriority_perfHint_exclusiveAsyncReq_t
         {CommonTestUtils::DEVICE_CPU, {{CONFIG_KEY(PERFORMANCE_HINT), performanceHint}}, 3, ""});
     metaDevices.push_back({actualDeviceName, {{CONFIG_KEY(PERFORMANCE_HINT), performanceHint}}, 2, ""});
 
-    ON_CALL(*plugin, SelectDevice(_, _, _)).WillByDefault(Return(metaDevices[1]));
+    ON_CALL(*plugin, SelectDevice(_, _, _, _)).WillByDefault(Return(metaDevices[1]));
     ON_CALL(*plugin, ParseMetaDevices(_, _)).WillByDefault(Return(metaDevices));
     ON_CALL(*plugin, GetValidDevice)
         .WillByDefault([](const std::vector<DeviceInformation>& metaDevices, const std::string& netPrecision) {
@@ -419,7 +419,7 @@ TEST_P(ExecNetworkGetMetricOtherTest, modelPriority_perfHint_exclusiveAsyncReq_t
             return devices;
         });
     EXPECT_CALL(*plugin, ParseMetaDevices(_, _)).Times(1);
-    EXPECT_CALL(*plugin, SelectDevice(_, _, _)).Times(1);
+    EXPECT_CALL(*plugin, SelectDevice(_, _, _, _)).Times(1);
 
     ON_CALL(*core, GetConfig(_, StrEq(ov::compilation_num_threads.name()))).WillByDefault(Return(8));
     ON_CALL(*core,

--- a/src/plugins/auto/tests/unit/include/mock_auto_device_plugin.hpp
+++ b/src/plugins/auto/tests/unit/include/mock_auto_device_plugin.hpp
@@ -19,7 +19,7 @@ public:
                 ((const std::vector<DeviceInformation>&), const std::string&),
                 (override));
     MOCK_METHOD(DeviceInformation, SelectDevice, ((const std::vector<DeviceInformation>&),
-                const std::string&, unsigned int), (override));
+                const std::string&, unsigned int, const std::string&), (override));
     MOCK_METHOD((std::vector<DeviceInformation>), ParseMetaDevices,
                 (const std::string&, (const std::map<std::string, std::string>&)), (const, override));
 };

--- a/src/plugins/auto/tests/unit/select_device_test.cpp
+++ b/src/plugins/auto/tests/unit/select_device_test.cpp
@@ -260,8 +260,8 @@ public:
        ON_CALL(*core, GetMetric(StrEq("GPU.1"),
                     StrEq(METRIC_KEY(DEVICE_TYPE)), _)).WillByDefault(RETURN_MOCK_VALUE(dGpuType));
        ON_CALL(*plugin, SelectDevice).WillByDefault([this](const std::vector<DeviceInformation>& metaDevices,
-                   const std::string& netPrecision, unsigned int priority) {
-               return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices, netPrecision, priority);
+                   const std::string& netPrecision, unsigned int priority, const std::string& remoteContextDevice) {
+               return plugin->MultiDeviceInferencePlugin::SelectDevice(metaDevices, netPrecision, priority, remoteContextDevice);
                });
        ON_CALL(*plugin, GetValidDevice)
            .WillByDefault([this](const std::vector<DeviceInformation>& metaDevices, const std::string& netPrecision) {
@@ -280,7 +280,7 @@ TEST_P(SelectDeviceTest, SelectDevice) {
     bool reverse;
     std::tie(netPrecision, devices, expect, throwExcept, enableDevicePriority, reverse) = this->GetParam();
 
-    EXPECT_CALL(*plugin, SelectDevice(_, _, _)).Times(1);
+    EXPECT_CALL(*plugin, SelectDevice(_, _, _, _)).Times(1);
     if (devices.size() >= 1) {
         EXPECT_CALL(*core, GetMetric(_, _, _)).Times(AtLeast(static_cast<int>(devices.size()) - 1));
     } else {
@@ -288,9 +288,9 @@ TEST_P(SelectDeviceTest, SelectDevice) {
     }
 
     if (throwExcept) {
-        ASSERT_THROW(plugin->SelectDevice(devices, netPrecision, 0), InferenceEngine::Exception);
+        ASSERT_THROW(plugin->SelectDevice(devices, netPrecision, 0, ""), InferenceEngine::Exception);
     } else {
-        auto result =  plugin->SelectDevice(devices, netPrecision, 0);
+        auto result =  plugin->SelectDevice(devices, netPrecision, 0, "");
         compare(result, expect);
     }
 }


### PR DESCRIPTION
### Details:
- App create RemoteContext based on data location
- App use AUTO device and run compile_mode() with RemoteContext.
- AUTO identify the data location and load network to corresponding HW plugin

### Tickets:
 - *CVS-95311*
