### PR TITLE
Add us/ms convertion for performance counters to Core

### DIFF
--- a/samples/cpp/benchmark_app/statistics_report.cpp
+++ b/samples/cpp/benchmark_app/statistics_report.cpp
@@ -88,7 +88,7 @@ void StatisticsReport::dump_performance_counters_request(CsvDumper& dumper, cons
                        ? status_names[(int)layer.status]
                        : "INVALID_STATUS");
         dumper << layer.node_type << layer.exec_type;
-        dumper << layer.real_time.count() / 1000.0 << layer.cpu_time.count() / 1000.0;
+        dumper << layer.real_time.count() << layer.cpu_time.count();
         total += layer.real_time;
         total_cpu += layer.cpu_time;
         dumper.endLine();
@@ -98,7 +98,7 @@ void StatisticsReport::dump_performance_counters_request(CsvDumper& dumper, cons
            << ""
            << ""
            << "";
-    dumper << total.count() / 1000.0 << total_cpu.count() / 1000.0;
+    dumper << total.count() << total_cpu.count();
     dumper.endLine();
     dumper.endLine();
 }
@@ -134,7 +134,7 @@ void StatisticsReport::dump_sort_performance_counters_request(CsvDumper& dumper,
                            ? status_names[(int)layer.status]
                            : "INVALID_STATUS");
             dumper << layer.node_type << layer.exec_type;
-            dumper << layer.real_time.count() / 1000.0 << layer.cpu_time.count() / 1000.0;
+            dumper << layer.real_time.count() << layer.cpu_time.count();
             dumper << (layer.real_time * 1.0 / total) * 100;
             dumper.endLine();
         }
@@ -144,7 +144,7 @@ void StatisticsReport::dump_sort_performance_counters_request(CsvDumper& dumper,
            << ""
            << ""
            << "";
-    dumper << total.count() / 1000.0 << total_cpu.count() / 1000.0 << 100.0;
+    dumper << total.count() << total_cpu.count() << 100.0;
     dumper.endLine();
     dumper.endLine();
 }
@@ -286,14 +286,14 @@ const nlohmann::json StatisticsReportJSON::perf_counters_to_json(
                                                                                      : "INVALID_STATUS");
         item["node_type"] = layer.node_type;
         item["exec_type"] = layer.exec_type;
-        item["real_time"] = layer.real_time.count() / 1000.0;
-        item["cpu_time"] = layer.cpu_time.count() / 1000.0;
+        item["real_time"] = layer.real_time.count();
+        item["cpu_time"] = layer.cpu_time.count();
         total += layer.real_time;
         total_cpu += layer.cpu_time;
         js["nodes"].push_back(item);
     }
-    js["total_real_time"] = total.count() / 1000.0;
-    js["total_cpu_time"] = total_cpu.count() / 1000.0;
+    js["total_real_time"] = total.count();
+    js["total_cpu_time"] = total_cpu.count();
     return js;
 }
 
@@ -322,14 +322,14 @@ const nlohmann::json StatisticsReportJSON::sort_perf_counters_to_json(
                                                                                      : "INVALID_STATUS");
         item["node_type"] = layer.node_type;
         item["exec_type"] = layer.exec_type;
-        item["real_time"] = layer.real_time.count() / 1000.0;
-        item["cpu_time"] = layer.cpu_time.count() / 1000.0;
+        item["real_time"] = layer.real_time.count();
+        item["cpu_time"] = layer.cpu_time.count();
         item["%"] = std::round(layer.real_time * 10000.0 / total) / 100;
         js["nodes"].push_back(item);
     }
 
-    js["total_real_time"] = total.count() / 1000.0;
-    js["total_cpu_time"] = total_cpu.count() / 1000.0;
+    js["total_real_time"] = total.count();
+    js["total_cpu_time"] = total_cpu.count();
     return js;
 }
 

--- a/samples/cpp/common/utils/include/samples/common.hpp
+++ b/samples/cpp/common/utils/include/samples/common.hpp
@@ -413,15 +413,15 @@ static UNUSED void printPerformanceCounts(std::vector<ov::ProfilingInfo> perform
 
         stream << std::setw(30) << std::left << "execType: " + std::string(it.exec_type) << " ";
         stream << "realTime (ms): " << std::setw(10) << std::left << std::fixed << std::setprecision(3)
-               << it.real_time.count() / 1000.0 << " ";
+               << it.real_time.count() << " ";
         stream << "cpuTime (ms): " << std::setw(10) << std::left << std::fixed << std::setprecision(3)
-               << it.cpu_time.count() / 1000.0 << " ";
+               << it.cpu_time.count() << " ";
         stream << std::endl;
     }
     stream << std::setw(25) << std::left << "Total time: " << std::fixed << std::setprecision(3)
-           << totalTime.count() / 1000.0 << " milliseconds" << std::endl;
+           << totalTime.count() << " milliseconds" << std::endl;
     stream << std::setw(25) << std::left << "Total CPU time: " << std::fixed << std::setprecision(3)
-           << totalTimeCpu.count() / 1000.0 << " milliseconds" << std::endl;
+           << totalTimeCpu.count() << " milliseconds" << std::endl;
     stream << std::endl;
     stream << "Full device name: " << deviceName << std::endl;
     stream << std::endl;
@@ -567,9 +567,9 @@ static UNUSED void printPerformanceCountsSort(std::vector<ov::ProfilingInfo> per
 
                 stream << std::setw(30) << std::left << "execType: " + std::string(it.exec_type) << " ";
                 stream << "realTime (ms): " << std::setw(10) << std::left << std::fixed << std::setprecision(3)
-                       << it.real_time.count() / 1000.0 << " ";
+                       << it.real_time.count() << " ";
                 stream << "cpuTime (ms): " << std::setw(10) << std::left << std::fixed << std::setprecision(3)
-                       << it.cpu_time.count() / 1000.0 << " ";
+                       << it.cpu_time.count()  << " ";
 
                 double opt_proportion = it.real_time.count() * 100.0 / totalTime.count();
                 std::stringstream opt_proportion_ss;
@@ -583,7 +583,7 @@ static UNUSED void printPerformanceCountsSort(std::vector<ov::ProfilingInfo> per
             }
         }
     }
-    stream << std::setw(25) << std::left << "Total time: " + std::to_string(totalTime.count() / 1000.0)
+    stream << std::setw(25) << std::left << "Total time: " + std::to_string(totalTime.count())
            << " milliseconds" << std::endl;
     stream << std::endl;
     stream << "Full device name: " << deviceName << std::endl;

--- a/samples/cpp/speech_sample/utils.hpp
+++ b/samples/cpp/speech_sample/utils.hpp
@@ -244,19 +244,19 @@ void print_performance_counters(std::map<std::string, ov::ProfilingInfo> const& 
     // if GNA HW counters
     for (const auto& it : utterancePerfMap) {
         std::string const& counter_name = it.first;
-        float current_units_us = static_cast<float>(it.second.real_time.count());
+        float current_units_ms = static_cast<float>(it.second.real_time.count());
         float call_units_us = 0;
         if (numberOfFrames == 0) {
             throw std::logic_error("Number off frames = 0,  division by zero.");
         } else {
-            call_units_us = current_units_us / numberOfFrames;
+            call_units_us = 1000.0 * current_units_ms / numberOfFrames;
         }
         if (FLAGS_d.find("GNA") != std::string::npos) {
             stream << std::setw(30) << std::left << counter_name.substr(4, counter_name.size() - 1);
         } else {
             stream << std::setw(30) << std::left << counter_name;
         }
-        stream << std::setw(16) << std::right << current_units_us / 1000;
+        stream << std::setw(16) << std::right << current_units_ms;
         stream << std::setw(21) << std::right << call_units_us;
         stream << std::endl;
     }

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/utils.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/utils.py
@@ -414,8 +414,8 @@ def print_perf_counters_sort(perf_counts_list,sort_flag="sort"):
             total_detail_data = sorted(total_detail_data,key=lambda tmp_data:tmp_data[-4],reverse=True)
             total_detail_data = [tmp_data for tmp_data in total_detail_data if str(tmp_data[1])!="Status.NOT_RUN"]
         print_detail_result(total_detail_data)
-        print(f'Total time:       {total_time / 1000:.3f} milliseconds')
-        print(f'Total CPU time:   {total_time_cpu / 1000:.3f} milliseconds')
+        print(f'Total time:       {total_time} milliseconds')
+        print(f'Total CPU time:   {total_time_cpu} milliseconds')
         print(f'Total proportion: {"%.2f"%(round(total_real_time_proportion)*100)} % \n')
     return total_detail_data
 
@@ -437,8 +437,8 @@ def print_detail_result(result_list):
                 f"{str(layerStatus):<20} "
                 f"layerType: {layerType[:max_print_length - 4] + '...' if (len(layerType) >= max_print_length) else layerType:<20} "
                 f"execType: {execType:<20} "
-                f"realTime (ms): {real_time / 1000:<10.3f} "
-                f"cpuTime (ms): {cpu_time / 1000:<10.3f}"
+                f"realTime (ms): {real_time :<10} "
+                f"cpuTime (ms): {cpu_time :<10}"
                 f"proportion: {str(real_proportion +'%'):<8}")
 
 def print_perf_counters(perf_counts_list):
@@ -453,13 +453,13 @@ def print_perf_counters(perf_counts_list):
                 f"{str(pi.status):<20} "
                 f"layerType: {pi.node_type[:max_print_length - 4] + '...' if (len(pi.node_type) >= max_print_length) else pi.node_type:<20} "
                 f"execType: {pi.exec_type:<20} "
-                f"realTime (ms): {pi.real_time / timedelta(milliseconds=1):<10.3f} "
-                f"cpuTime (ms): {pi.cpu_time / timedelta(milliseconds=1):<10.3f}")
+                f"realTime (ms): {pi.real_time.microseconds:<10} "
+                f"cpuTime (ms): {pi.cpu_time.microseconds:<10}")
 
             total_time += pi.real_time
             total_time_cpu += pi.cpu_time
-        print(f'Total time:     {total_time / timedelta(milliseconds=1)} milliseconds')
-        print(f'Total CPU time: {total_time_cpu / timedelta(milliseconds=1)} milliseconds\n')
+        print(f'Total time:     {total_time.microseconds} milliseconds')
+        print(f'Total CPU time: {total_time_cpu.microseconds} milliseconds\n')
 
 
 def get_command_line_arguments(argv):


### PR DESCRIPTION
### Details:
 - *Legacy API report performance counters in us, new API reports them in ms. Add unit convertion in legacy convert utils.*
 - *Remove unit convertion from samples.*

### Tickets:
 - *ticket-id*
