### PR TITLE
[Core] StridedSlice improvements of bound evaluation and constant folding

### DIFF
--- a/src/core/include/openvino/op/strided_slice.hpp
+++ b/src/core/include/openvino/op/strided_slice.hpp
@@ -112,14 +112,14 @@ public:
     bool evaluate(const HostTensorVector& output_values, const HostTensorVector& input_values) const override;
     OPENVINO_SUPPRESS_DEPRECATED_END
     bool has_evaluate() const override;
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    OPENVINO_SUPPRESS_DEPRECATED_END
     bool evaluate_lower(TensorVector& outputs) const override;
     bool evaluate_upper(TensorVector& outputs) const override;
     bool evaluate_label(TensorLabelVector& output_labels) const override;
+    bool constant_fold(OutputVector& output_values, const OutputVector& inputs_values) override;
 
 private:
     AxisSet convert_mask_to_axis_set(const std::vector<int64_t>& mask) const;
+    bool indicies_input_has_and_set_bounds(const size_t port, const std::vector<int64_t>& masks) const;
 
     std::vector<int64_t> m_begin_mask;
     std::vector<int64_t> m_end_mask;

--- a/src/core/src/bound_evaluate.cpp
+++ b/src/core/src/bound_evaluate.cpp
@@ -49,7 +49,7 @@ bool are_same_tensor(const ov::Tensor& lhs, const ov::Tensor& rhs) {
            (lhs.data() == rhs.data());
 }
 
-bool are_equal(const ov::Tensor& lhs, const ov::Tensor& rhs, size_t element_limit = 10) {
+bool are_equal(const ov::Tensor& lhs, const ov::Tensor& rhs) {
     if (!lhs || !rhs) {
         return false;
     }
@@ -59,7 +59,7 @@ bool are_equal(const ov::Tensor& lhs, const ov::Tensor& rhs, size_t element_limi
     const auto& lhs_et = lhs.get_element_type();
     const auto& rhs_et = rhs.get_element_type();
 
-    auto are_eq = (lhs_et == rhs_et) && (lhs_shape == rhs_shape) && shape_size(lhs_shape) <= element_limit;
+    auto are_eq = (lhs_et == rhs_et) && (lhs_shape == rhs_shape);
 
     if (are_eq) {
         are_eq = memcmp(lhs.data(), rhs.data(), lhs.get_byte_size()) == 0;
@@ -317,10 +317,14 @@ std::pair<ov::Tensor, ov::Tensor> ov::evaluate_both_bounds(const Output<Node>& o
             bool labels_evaluated = node->evaluate_label(output_labels);
             for (size_t i = 0; i < node->get_output_size(); ++i) {
                 auto& out_tensor = node->get_output_tensor(i);
+
                 out_tensor.set_lower_value(outputs_lower[i]);
-                out_tensor.set_upper_value(outputs_upper[i]);
-                if (same_inputs || are_equal(outputs_lower[i], outputs_upper[i]))
+                if (same_inputs || are_equal(outputs_lower[i], outputs_upper[i])) {
                     out_tensor.set_upper_value(outputs_lower[i]);
+                } else {
+                    out_tensor.set_upper_value(outputs_upper[i]);
+                }
+
                 if (labels_evaluated)
                     node->get_output_tensor(i).set_value_label(output_labels[i]);
             }

--- a/src/core/tests/constant_folding.cpp
+++ b/src/core/tests/constant_folding.cpp
@@ -2268,6 +2268,126 @@ TEST(constant_folding, strided_slice_ignored_dynamic_begin_end_values_from_shape
     ASSERT_EQ(sliced_values, values_out);
 }
 
+TEST(constant_folding, strided_slice_all_ignore_mask_set_for_non_parameter_begin_end) {
+    const auto constant =
+        make_shared<op::Constant>(element::i32,
+                                  Shape{1, 1, 2, 4, 2},
+                                  std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
+    constant->set_friendly_name("constant");
+
+    const auto begin_shape = PartialShape{{2, 5}, -1, 10, 1, {0, 200}};
+    const auto p_begin = std::make_shared<op::Parameter>(element::i64, begin_shape);
+    const auto shape_of_begin = std::make_shared<op::ShapeOf>(p_begin);
+    shape_of_begin->set_friendly_name("begin");
+
+    const auto end_shape = PartialShape{-1, 1, {2, 3}, 0, 0};
+    const auto p_end = std::make_shared<op::Parameter>(element::i64, end_shape);
+    const auto shape_of_end = std::make_shared<op::ShapeOf>(p_end);
+    shape_of_end->set_friendly_name("end");
+
+    const auto stride = op::Constant::create(element::i64, {5}, {1, 1, 1, 2, 2});
+    stride->set_friendly_name("stride");
+
+    const auto slice = make_shared<op::v1::StridedSlice>(constant,
+                                                         shape_of_begin,
+                                                         shape_of_end,
+                                                         stride,
+                                                         std::vector<int64_t>{1, 1, 1, 1, 1},
+                                                         std::vector<int64_t>{1, 1, 1, 1, 1});
+    slice->set_friendly_name("test");
+
+    auto model = make_shared<ov::Model>(slice, ParameterVector{p_begin, p_end});
+
+    run_constant_folding(model);
+
+    ASSERT_EQ(count_ops_of_type<op::v1::StridedSlice>(model), 0);
+    ASSERT_EQ(count_ops_of_type<op::Constant>(model), 1);
+
+    const auto new_const = get_result_constant(model);
+    ASSERT_TRUE(new_const);
+    check_names(new_const, {"constant", "begin", "end", "stride", "test"});
+    const auto values_out = new_const->get_vector<int>();
+
+    vector<int> sliced_values{1, 5, 9, 13};
+    ASSERT_EQ(sliced_values, values_out);
+}
+
+TEST(constant_folding, strided_slice_all_ignore_mask_set_for_parameter_begin_end) {
+    const auto constant =
+        make_shared<op::Constant>(element::i32,
+                                  Shape{1, 1, 2, 4, 2},
+                                  std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
+    constant->set_friendly_name("constant");
+
+    const auto begin_shape = PartialShape{{1, 5}};
+    const auto p_begin = std::make_shared<op::Parameter>(element::i64, begin_shape);
+    p_begin->set_friendly_name("begin");
+
+    const auto end_shape = PartialShape{5};
+    const auto p_end = std::make_shared<op::Parameter>(element::i64, end_shape);
+    p_end->set_friendly_name("end");
+
+    const auto stride = op::Constant::create(element::i64, {5}, {1, 1, 1, 2, 2});
+    stride->set_friendly_name("stride");
+
+    const auto slice = make_shared<op::v1::StridedSlice>(constant,
+                                                         p_begin,
+                                                         p_end,
+                                                         stride,
+                                                         std::vector<int64_t>{1, 1, 1, 1, 1},
+                                                         std::vector<int64_t>{1, 1, 1, 1, 1});
+    slice->set_friendly_name("test");
+
+    auto model = make_shared<ov::Model>(slice, ParameterVector{p_begin, p_end});
+
+    run_constant_folding(model);
+
+    ASSERT_EQ(count_ops_of_type<op::v1::StridedSlice>(model), 0);
+    ASSERT_EQ(count_ops_of_type<op::Constant>(model), 1);
+
+    const auto new_const = get_result_constant(model);
+    ASSERT_TRUE(new_const);
+    check_names(new_const, {"constant", "begin", "end", "stride", "test"});
+    const auto values_out = new_const->get_vector<int>();
+
+    vector<int> sliced_values{1, 5, 9, 13};
+    ASSERT_EQ(sliced_values, values_out);
+}
+
+TEST(constant_folding, strided_slice_not_all_ignore_mask_set_for_parameter_begin_end) {
+    const auto constant =
+        make_shared<op::Constant>(element::i32,
+                                  Shape{1, 1, 2, 4, 2},
+                                  std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
+    constant->set_friendly_name("constant");
+
+    const auto begin_shape = PartialShape::dynamic();
+    const auto p_begin = std::make_shared<op::Parameter>(element::i64, begin_shape);
+    p_begin->set_friendly_name("begin");
+
+    const auto end_shape = PartialShape{5};
+    const auto p_end = std::make_shared<op::Parameter>(element::i64, end_shape);
+    p_end->set_friendly_name("end");
+
+    const auto stride = op::Constant::create(element::i64, {5}, {1, 1, 1, 2, 2});
+    stride->set_friendly_name("stride");
+
+    const auto slice = make_shared<op::v1::StridedSlice>(constant,
+                                                         p_begin,
+                                                         p_end,
+                                                         stride,
+                                                         std::vector<int64_t>{1, 1, 1, 1},
+                                                         std::vector<int64_t>{1, 1, 1, 1});
+    slice->set_friendly_name("test");
+
+    auto model = make_shared<ov::Model>(slice, ParameterVector{p_begin, p_end});
+
+    run_constant_folding(model);
+
+    ASSERT_EQ(count_ops_of_type<op::v1::StridedSlice>(model), 1);
+    ASSERT_EQ(count_ops_of_type<op::Constant>(model), 2);
+}
+
 TEST(constant_folding, strided_slice_not_ignored_dynamic_begin_from_shape_of) {
     const auto constant =
         make_shared<op::Constant>(element::i32,

--- a/src/core/tests/constant_folding.cpp
+++ b/src/core/tests/constant_folding.cpp
@@ -2224,6 +2224,86 @@ TEST(constant_folding, const_strided_slice) {
     ASSERT_EQ(sliced_values, values_out);
 }
 
+TEST(constant_folding, strided_slice_ignored_dynamic_begin_end_values_from_shape_of) {
+    const auto constant =
+        make_shared<op::Constant>(element::i32,
+                                  Shape{1, 1, 2, 4, 2},
+                                  std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
+    constant->set_friendly_name("constant");
+
+    const auto begin_shape = PartialShape{0, -1, 0, 0, 0};
+    const auto p_begin = std::make_shared<op::Parameter>(element::i64, begin_shape);
+    const auto shape_of_begin = std::make_shared<op::ShapeOf>(p_begin);
+    shape_of_begin->set_friendly_name("begin");
+
+    const auto end_shape = PartialShape{-1, 512, 2, 2, 16};
+    const auto p_end = std::make_shared<op::Parameter>(element::i64, end_shape);
+    const auto shape_of_end = std::make_shared<op::ShapeOf>(p_end);
+    shape_of_end->set_friendly_name("end");
+
+    const auto stride = op::Constant::create(element::i64, {5}, {1, 1, 1, 1, 1});
+    stride->set_friendly_name("stride");
+
+    const auto slice = make_shared<op::v1::StridedSlice>(constant,
+                                                         shape_of_begin,
+                                                         shape_of_end,
+                                                         stride,
+                                                         std::vector<int64_t>{0, 1, 0, 0, 0},
+                                                         std::vector<int64_t>{1, 1, 0, 0, 1});
+    slice->set_friendly_name("test");
+
+    auto model = make_shared<ov::Model>(slice, ParameterVector{p_begin, p_end});
+
+    run_constant_folding(model);
+
+    ASSERT_EQ(count_ops_of_type<op::v1::StridedSlice>(model), 0);
+    ASSERT_EQ(count_ops_of_type<op::Constant>(model), 1);
+
+    const auto new_const = get_result_constant(model);
+    ASSERT_TRUE(new_const);
+    check_names(new_const, {"constant", "begin", "end", "stride", "test"});
+    const auto values_out = new_const->get_vector<int>();
+
+    vector<int> sliced_values{1, 2, 3, 4, 9, 10, 11, 12};
+    ASSERT_EQ(sliced_values, values_out);
+}
+
+TEST(constant_folding, strided_slice_not_ignored_dynamic_begin_from_shape_of) {
+    const auto constant =
+        make_shared<op::Constant>(element::i32,
+                                  Shape{1, 1, 2, 4, 2},
+                                  std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
+    constant->set_friendly_name("constant");
+
+    const auto begin_shape = PartialShape{0, -1, 0, 0, 0};
+    const auto p_begin = std::make_shared<op::Parameter>(element::i64, begin_shape);
+    const auto shape_of_begin = std::make_shared<op::ShapeOf>(p_begin);
+    shape_of_begin->set_friendly_name("begin");
+
+    const auto end_shape = PartialShape{-1, 512, 2, 2, 16};
+    const auto p_end = std::make_shared<op::Parameter>(element::i64, end_shape);
+    const auto shape_of_end = std::make_shared<op::ShapeOf>(p_end);
+    shape_of_end->set_friendly_name("end");
+
+    const auto stride = op::Constant::create(element::i64, {5}, {1, 1, 1, 1, 1});
+    stride->set_friendly_name("stride");
+
+    const auto slice = make_shared<op::v1::StridedSlice>(constant,
+                                                         shape_of_begin,
+                                                         shape_of_end,
+                                                         stride,
+                                                         std::vector<int64_t>{0, 0, 0, 0, 0},
+                                                         std::vector<int64_t>{1, 1, 0, 0, 1});
+    slice->set_friendly_name("test");
+
+    auto model = make_shared<ov::Model>(slice, ParameterVector{p_begin, p_end});
+
+    run_constant_folding(model);
+
+    ASSERT_EQ(count_ops_of_type<op::v1::StridedSlice>(model), 1);
+    ASSERT_EQ(count_ops_of_type<op::Constant>(model), 2);
+}
+
 TEST(constant_folding, constant_dyn_reshape) {
     Shape shape_in{2, 4};
     vector<float> values_in{0, 1, 2, 3, 4, 5, 6, 7};


### PR DESCRIPTION
### Details:
- Perform bound evaluation when begin, end inputs got partial value but mask for corresponding input is set and this value is ignored.
- Implement custom fold if default not work to check `StridedSlice` special case where begin and end values are ignored but mask but they are not constants.

### Tickets:
 -  101315
