### PR TITLE
[CPU] Get rid of shouldTryBrgconv flag

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -116,7 +116,6 @@ private:
     VectorDims outputStaticShape() const;
     void appendLegacyZeroPointsArgs();
     void appendZeroPointsArgs();
-    void initTryBrgconvFlag();
 
     bool withBiases;
     bool withSum;
@@ -156,7 +155,7 @@ private:
     const size_t Y_AXIS = 1;
 
     bool isWino = false;
-    bool shouldTryBrgconv = false;
+    static const bool isBrgConvAvailable;
     std::vector<dnnl::primitive_attr> attrs;
     AttrPtr pAttr;
     bool autoPadding = false;


### PR DESCRIPTION
### Details:
 - No code logic changed overall
 
 At the moment shouldTryBrgConv is essentially just a check for avx512 isa.

- [ ] Run xeon benchmark just in case