### PR TITLE
[GPU] Minor fix for shape inference of dynamic reshape

### DIFF
--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -74,6 +74,11 @@ std::vector<layout> reshape_inst::calc_output_layouts(reshape_node const& /*node
 
     ShapeType pattern_shape = impl_param.input_layouts.size() == 2 ? impl_param.get_input_layout(1).get<ShapeType>()
                                                                    : ShapeType(ov::Shape{ prim->output_pattern.size() });
+    // Since reshape does not support 0D tensor(scalar) for shape input
+    // the case propagated to 0D tensor should be handled manually with 1D tensor
+    if (pattern_shape.size() == 0) {
+        pattern_shape = ShapeType{1};
+    }
     std::vector<ShapeType> output_shapes = {ShapeType()};
     std::vector<ShapeType> input_shapes = {
         input_layout.get<ShapeType>(),

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/reshape_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/reshape_si_test.cpp
@@ -82,6 +82,11 @@ INSTANTIATE_TEST_SUITE_P(smoke, reshape_test_two_inputs,
             layout{ov::PartialShape{1, 384, 16, 64}, data_types::f32, format::bfyx}
         },
         {
+            layout{ov::PartialShape{1, 128, 1024}, data_types::f32, format::bfyx},
+            layout{ov::PartialShape{}, data_types::i64, format::bfyx}, {131072}, ov::PartialShape::dynamic(1), true,
+            layout{ov::PartialShape{131072}, data_types::f32, format::bfyx}
+        },
+        {
             layout{ov::PartialShape::dynamic(2), data_types::f32, format::bfyx},
             layout{ov::PartialShape{4}, data_types::i64, format::bfyx}, {0, 1, 2, 3}, ov::PartialShape::dynamic(4), true,
             layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx}


### PR DESCRIPTION
### Details:
 - Reshape does not support 0D tensor(scalar) for `shape` input
 - If the preceding reshape node which converts from 0D tensor to 1D tensor is removed during `handle_reshape` opt pass, the next reshape node should handle 0D tensor with 1D tensor manually

### Tickets:
 - 110534
