### PR TITLE
Normalize_L2 relax constant input restriction

### DIFF
--- a/src/core/src/op/normalize_l2.cpp
+++ b/src/core/src/op/normalize_l2.cpp
@@ -38,8 +38,6 @@ void op::v0::NormalizeL2::validate_and_infer_types() {
     const auto& input_rank = input_pshape.rank();
     const auto& axes_rank = axes_pshape.rank();
 
-    NODE_VALIDATION_CHECK(this, has_and_set_equal_bounds(input_value(1)), "Input axes must be Constant type");
-
     if (axes_rank.is_static()) {
         NODE_VALIDATION_CHECK(this,
                               axes_rank.get_length() <= 1,

--- a/src/core/tests/type_prop/normalize_l2.cpp
+++ b/src/core/tests/type_prop/normalize_l2.cpp
@@ -39,7 +39,7 @@ TEST(type_prop, normalize_l2_axes_input_not_constant) {
     auto axes = make_shared<op::Parameter>(element::u64, Shape{1});
     float eps{1e-6f};
     auto eps_mode = op::EpsMode::ADD;
-    ASSERT_NO_THROW(make_shared<op::v0::NormalizeL2>(data, axes, eps, eps_mode));
+    ASSERT_NO_THROW(auto op = make_shared<op::v0::NormalizeL2>(data, axes, eps, eps_mode));
 }
 
 TEST(type_prop, normalize_l2_invalid_axes_rank) {

--- a/src/core/tests/type_prop/normalize_l2.cpp
+++ b/src/core/tests/type_prop/normalize_l2.cpp
@@ -39,16 +39,7 @@ TEST(type_prop, normalize_l2_axes_input_not_constant) {
     auto axes = make_shared<op::Parameter>(element::u64, Shape{1});
     float eps{1e-6f};
     auto eps_mode = op::EpsMode::ADD;
-
-    try {
-        auto normalize = make_shared<op::v0::NormalizeL2>(data, axes, eps, eps_mode);
-        // Should have thrown, so fail if it didn't
-        FAIL() << "Invalid input tensor rank.";
-    } catch (const NodeValidationFailure& error) {
-        EXPECT_HAS_SUBSTRING(error.what(), std::string("Input axes must be Constant type"));
-    } catch (...) {
-        FAIL() << "Deduced type check failed for unexpected reason";
-    }
+    ASSERT_NO_THROW(make_shared<op::v0::NormalizeL2>(data, axes, eps, eps_mode));
 }
 
 TEST(type_prop, normalize_l2_invalid_axes_rank) {


### PR DESCRIPTION
### Details:
 - After the changes (https://github.com/openvinotoolkit/openvino/commit/b452dab8f08055cefac5d8d1eec79455563961f9) in TypeRelaxed::clone_with_new_inputs -- relaxed NormalizeL2 operation cannot be cloned

### Tickets:
 - *110999*

PR to master: https://github.com/openvinotoolkit/openvino/pull/17568
