### PR TITLE
[PyOV] Add upper bound to flake version

### DIFF
--- a/src/bindings/python/requirements_test.txt
+++ b/src/bindings/python/requirements_test.txt
@@ -4,7 +4,7 @@ numpy
 onnx
 bandit
 black
-flake8
+flake8<=5.0.4
 flake8-annotations-complexity
 flake8-broken-line
 flake8-bugbear


### PR DESCRIPTION
### Details:
 - Limit linter version to avoid release branch CI breaking
