### PR TITLE
Ability to build universal2 wheel packages

### DIFF
--- a/src/bindings/python/wheel/CMakeLists.txt
+++ b/src/bindings/python/wheel/CMakeLists.txt
@@ -90,18 +90,22 @@ endmacro()
 
 # For macOS and Linux `PLATFORM_TAG` is not always correctly detected
 # So, we need to add our-own post-processing
-if(APPLE AND DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
+if(APPLE)
     _ov_platform_arch()
 
-    set(_macos_min_version "${CMAKE_OSX_DEPLOYMENT_TARGET}")
-    if(_macos_min_version MATCHES "^1[0-9]$")
-        set(_macos_min_version "${CMAKE_OSX_DEPLOYMENT_TARGET}.0")
+    if(CMAKE_OSX_DEPLOYMENT_TARGET)
+        set(_macos_target_version "${CMAKE_OSX_DEPLOYMENT_TARGET}")
+        if(_macos_target_version MATCHES "^1[0-9]$")
+            set(_macos_target_version "${CMAKE_OSX_DEPLOYMENT_TARGET}.0")
+        endif()
+        string(REPLACE "." "_" _macos_target_version "${_macos_target_version}")
+    else()
+        string(REGEX MATCH "1[0-9]_[0-9]+" _macos_target_version ${PLATFORM_TAG})
     endif()
-    string(REPLACE "." "_" _macos_min_version "${_macos_min_version}")
 
     # common platform tag looks like macosx_<macos major>_<macos minor>_<arch>
-    if(_arch AND _macos_min_version)
-        set(PLATFORM_TAG "macosx_${_macos_min_version}_${_arch}")
+    if(_arch AND _macos_target_version)
+        set(PLATFORM_TAG "macosx_${_macos_target_version}_${_arch}")
     endif()
 elseif(LINUX)
     _ov_platform_arch()


### PR DESCRIPTION
### Details:
 - Ability to build `openvino-2023.1.0-11090-cp39-cp39-macosx_13_0_universal2.whl`
 wheel