### PR TITLE
Fixed to use rank of input_partial_shape

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/ops/shape_of.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/shape_of.cpp
@@ -19,7 +19,7 @@ static void CreateShapeOfOpCommon(Program& p, const std::shared_ptr<ngraph::Node
 
     auto primitive = cldnn::shape_of(layerName,
                                      inputs[0],
-                                     op->get_output_partial_shape(0).rank().get_length(),
+                                     op->get_input_partial_shape(0).rank().get_length(),
                                      cldnn::element_type_to_data_type(op->get_output_element_type(0)));
 
     p.add_primitive(*op, primitive);


### PR DESCRIPTION
### Details:
 - *When creating ShapeOfOp, use rank of input_partial_shape not output_partial_shape*

### Tickets:
 - *110900*
