### PR TITLE
Multiple fixes to get list of ops from torchvision detection models

### DIFF
--- a/src/bindings/python/src/openvino/frontend/pytorch/decoder.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/decoder.py
@@ -28,6 +28,9 @@ def get_type_from_py_type(value):
 
 def ivalue_to_constant(ivalue):
     ov_type = get_type_from_py_type(ivalue)
+    if ov_type == OVType.i64:
+        # TODO: Figure out better way to handle this
+        return op.Constant(OVType.i32, Shape([]), [np.clip(ivalue, np.iinfo(np.int32).min, np.iinfo(np.int32).max)]).outputs()
     if ov_type.is_static():
         return op.Constant(ov_type, Shape([]), [ivalue]).outputs()
 

--- a/src/core/shape_inference/include/gather_shape_inference.hpp
+++ b/src/core/shape_inference/include/gather_shape_inference.hpp
@@ -71,6 +71,7 @@ void shape_infer(const GatherBase* op,
 
     if (data_rank.is_static() && indices_rank.is_static()) {
         auto out_rank = data_rank.get_length() + indices_rank.get_length() - 1 - batch_dims;
+        NODE_VALIDATION_CHECK(op, out_rank >= 0, "Calculated out rank is negative: ", out_rank);
         // scalar has one
         output_pshape.resize(out_rank);
 

--- a/src/core/src/op/util/multi_subgraph_base.cpp
+++ b/src/core/src/op/util/multi_subgraph_base.cpp
@@ -6,6 +6,7 @@
 
 #include "ngraph/graph_util.hpp"
 #include "ngraph/opsets/opset5.hpp"
+#include "openvino/util/log.hpp"
 
 ov::op::util::MultiSubGraphOp::InputDescription::InputDescription(uint64_t input_index, uint64_t body_parameter_index)
     : m_input_index(input_index),
@@ -160,7 +161,17 @@ void ov::op::util::MultiSubGraphOp::validate_and_infer_type_body(
         body_parameter->set_partial_shape(input_partial_shape);
         body_parameter->set_element_type(dtype);
     }
-    body->validate_nodes_and_infer_types();
+    try {
+        body->validate_nodes_and_infer_types();
+    } catch (std::exception& e) {
+        if (m_bodies.size() > 1) {
+            // If one body cannot be validated it may mean that it is not needed and will be removed on future stages
+            OPENVINO_DEBUG << "Exception happened during validation of one of the body of MultiSubGraphOp: " << e.what()
+                           << '\n';
+        } else {
+            throw e;
+        }
+    }
 }
 
 ov::op::util::MultiSubGraphOp::OutputMap ov::op::util::MultiSubGraphOp::get_mapping_outputs_on_body_description(

--- a/src/frontends/pytorch/src/op/getitem.cpp
+++ b/src/frontends/pytorch/src/op/getitem.cpp
@@ -33,6 +33,8 @@ OutputVector translate_getitem(const NodeContext& context) {
                                       list_elems.size());
         return {list_elems.at(getitem_idx)};
     }
+    FRONT_END_OP_CONVERSION_CHECK(!std::dynamic_pointer_cast<ov::op::v0::Parameter>(input.get_node_shared_ptr()),
+                                  "aten::__getitem__ is inside the body, this is not supported.");
     auto getitem_idx = context.get_input(1);
     auto zero = context.mark_node(ov::op::v0::Constant::create(element::i32, Shape{}, {0}));
     return {context.mark_node(std::make_shared<ov::op::v8::Gather>(input, getitem_idx, zero))};

--- a/src/frontends/pytorch/src/op/reshape.cpp
+++ b/src/frontends/pytorch/src/op/reshape.cpp
@@ -18,7 +18,7 @@ OutputVector translate_reshape(const NodeContext& context) {
     // Schema: aten::reshape(Tensor input, int[] shape) -> Tensor
     // For shape parameter, int[] is converted into single dimensional Tensor.
     num_inputs_check(context, 2, 2);
-    auto reshape = std::make_shared<ov::op::v1::Reshape>(context.get_input(0), context.get_input(1), false);
+    auto reshape = std::make_shared<ov::op::v1::Reshape>(context.get_input(0), context.get_input(1), true);
     return {context.mark_node(reshape)};
 };
 

--- a/src/frontends/pytorch/src/transforms/aten_cat_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/aten_cat_replacer.cpp
@@ -97,6 +97,12 @@ AtenCatToConcat::AtenCatToConcat() {
         }
 
         const auto&& tmp_inputs = get_list_as_outputs(cat->get_input_source_output(0));
+        if (tmp_inputs.size() == 1 &&
+            std::dynamic_pointer_cast<ov::op::v0::Parameter>(tmp_inputs.front().get_node_shared_ptr())) {
+            // aten::cat is located inside body while inputs are located outside of the body. This case is not
+            // supported.
+            return false;
+        }
         auto result = std::make_shared<ov::op::v0::Concat>(OutputVector(tmp_inputs.begin(), tmp_inputs.end()), axis);
         copy_runtime_info(cat, result);
         replace_node(cat, result);

--- a/src/frontends/pytorch/src/transforms/listconstruct_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/listconstruct_replacer.cpp
@@ -87,6 +87,10 @@ ListConstructReplacer::ListConstructReplacer() {
             auto reshape = std::make_shared<v1::Reshape>(input, neg_1, false);
             inputs.push_back(reshape);
         }
+        if (inputs.size() == 0) {
+            // Concat for empty list is not supported.
+            return false;
+        }
         auto concat = std::make_shared<v0::Concat>(inputs, 0);
         copy_runtime_info({list_node}, concat);
         replace_node(list_node, concat);

--- a/src/frontends/pytorch/src/translate_session.cpp
+++ b/src/frontends/pytorch/src/translate_session.cpp
@@ -220,8 +220,15 @@ OutputVector TranslateSession::convert_node(const NodeContext& context) {
         OPENVINO_DEBUG << "Some exception happened during conversion of node of type: " << context.get_op_type()
                        << '\n';
     }
-    // Create PtFrameworkNode for everything that wasn't able to be converted normally
-    return make_framework_node(context);
+    try {
+        // Create PtFrameworkNode for everything that wasn't able to be converted normally
+        return make_framework_node(context);
+    } catch (std::exception& e) {
+        std::stringstream err;
+        err << "Exception happened during construction of FrameworkNode of type " << context.get_op_type() << ": "
+            << e.what() << ". Not possible to recover.";
+        throw std::runtime_error(err.str());
+    }
 }
 
 void TranslateSession::encode_tensor_name(Output<Node> output,


### PR DESCRIPTION
### Details:
 - *These changes allow to see list of unconverted operations in detection models from `torchvision`*
 - *This PR shouldn't be merged as is*

### Tickets:
 - *None*
