### PR TITLE
[Snippets] Refactored work with Loop ID

### DIFF
--- a/src/common/snippets/include/snippets/lowered/expression.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression.hpp
@@ -24,8 +24,6 @@ class Expression : public std::enable_shared_from_this<Expression> {
     friend class ExpressionPort;
 
 public:
-    static size_t LOOP_NULL_ID;
-
     Expression() = default;
     virtual ~Expression() = default;
 
@@ -48,16 +46,25 @@ public:
     size_t get_input_count() const { return m_input_port_connectors.size(); }
     size_t get_output_count() const { return m_output_port_connectors.size(); }
 
-    std::vector<size_t> get_loop_ids() const { return m_loop_ids; }
-    void set_loop_ids(const std::vector<size_t>& loops) { m_loop_ids = loops; }
-    void set_loop_id(size_t id, size_t idx);
-    void remove_loop_id(size_t id);
-
     void validate() const;
     void init_emitter(const std::shared_ptr<const TargetMachine>& target);
 
     ExpressionPort get_input_port(size_t i);
     ExpressionPort get_output_port(size_t i);
+
+    std::vector<size_t> get_loop_ids() const;
+    void set_loop_ids(const std::vector<size_t>& loops);
+    // Insert loop ID before inner ID in vector of identifiers so loop with inner ID is inside new Loop
+    //   loop_ids: [.., id, inner, ..]
+    // Default value of inner ID - SIZE_MAX - it means, that the new Loop is the most outer Loop
+    void add_outer_loop_id(size_t id, size_t inner = SIZE_MAX);
+    void add_outer_loop_ids(const std::vector<size_t>& ids, size_t inner);
+    // Insert loop ID after outer ID in vector of identifiers so new Loop is inside Loop with outer ID
+    //   loop_ids: [.., outer, id, ..]
+    // Default value of outer ID - SIZE_MAX - it means, that the new Loop is the most inner Loop
+    void add_inner_loop_id(size_t id, size_t outer = SIZE_MAX);
+    void replace_loop_id(size_t prev_id, size_t new_id);
+    void remove_loop_id(size_t id);
 
 protected:
     // Note: The constructor initialization is private since an expression can be created only by Linear IR.

--- a/src/common/snippets/include/snippets/lowered/expression.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression.hpp
@@ -54,17 +54,6 @@ public:
 
     std::vector<size_t> get_loop_ids() const;
     void set_loop_ids(const std::vector<size_t>& loops);
-    // Insert loop ID before inner ID in vector of identifiers so loop with inner ID is inside new Loop
-    //   loop_ids: [.., id, inner, ..]
-    // Default value of inner ID - SIZE_MAX - it means, that the new Loop is the most outer Loop
-    void add_outer_loop_id(size_t id, size_t inner = SIZE_MAX);
-    void add_outer_loop_ids(const std::vector<size_t>& ids, size_t inner);
-    // Insert loop ID after outer ID in vector of identifiers so new Loop is inside Loop with outer ID
-    //   loop_ids: [.., outer, id, ..]
-    // Default value of outer ID - SIZE_MAX - it means, that the new Loop is the most inner Loop
-    void add_inner_loop_id(size_t id, size_t outer = SIZE_MAX);
-    void replace_loop_id(size_t prev_id, size_t new_id);
-    void remove_loop_id(size_t id);
 
 protected:
     // Note: The constructor initialization is private since an expression can be created only by Linear IR.
@@ -80,6 +69,7 @@ protected:
     std::vector<PortDescriptorPtr> m_input_port_descriptors{};
     std::vector<PortDescriptorPtr> m_output_port_descriptors{};
     // The order Loops identifies: Outer ---> Inner
+    // Note: The loops with the same dimension index (splitted dimension) should be successively nested
     std::vector<size_t> m_loop_ids;
 };
 using ExpressionPtr = std::shared_ptr<Expression>;

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -86,15 +86,19 @@ public:
                                 size_t loop_id);
 
     /* ===== The methods for work with Loop IDs of Expression ===== */
-    static void replace_loop_id(const ExpressionPtr& expr, size_t prev_id, size_t new_id);
-    static void remove_loop_id(const ExpressionPtr& expr, size_t id);
+    // Notes:
+    //  - These methods don't update the corresponding LoopInfo
+    //  - These methods should be private
+    // TODO [112195] : fix these notes
+    void replace_loop_id(const ExpressionPtr& expr, size_t prev_id, size_t new_id);
+    void remove_loop_id(const ExpressionPtr& expr, size_t id);
     // Insert loop ID before (as outer Loop) or after (as inner Loop) target ID in vector of identifiers
     // Before:                                 | After:
     //   loop_ids: [.., new_id, target_id, ..] |    loop_ids: [.., target_id, new_id, ..]
     // Default value of target ID - SIZE_MAX - for `after` the new Loop is the most inner Loop
     //                                         for `before` the new Loop is the most outer Loop
-    static void insert_loop_id(const ExpressionPtr& expr, size_t new_id, bool before = true, size_t target_id = SIZE_MAX);
-    static void insert_loop_ids(const ExpressionPtr& expr, const std::vector<size_t>& new_ids, bool before = true, size_t target_id = SIZE_MAX);
+    void insert_loop_id(const ExpressionPtr& expr, size_t new_id, bool before = true, size_t target_id = SIZE_MAX);
+    void insert_loop_ids(const ExpressionPtr& expr, const std::vector<size_t>& new_ids, bool before = true, size_t target_id = SIZE_MAX);
 
 private:
     static void get_io_loop_ports(LinearIR::constExprIt loop_begin_pos,

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -22,12 +22,13 @@ public:
     class LoopInfo {
     public:
         LoopInfo() = default;
-        LoopInfo(size_t work_amount, size_t increment,
+        LoopInfo(size_t work_amount, size_t increment, size_t dim_idx,
                  const std::vector<ExpressionPort>& entries,
                  const std::vector<ExpressionPort>& exits)
-            : work_amount(work_amount), increment(increment), entry_exprs(entries), exit_exprs(exits) {}
+            : work_amount(work_amount), increment(increment), dim_idx(dim_idx), entry_exprs(entries), exit_exprs(exits) {}
         size_t work_amount = 0;
         size_t increment = 0;
+        size_t dim_idx = 0;  // The numeration begins from the end (dim_idx = 0 -> is the most inner dimension)
         // The order of entry and exit expressions is important:
         //     - The position before first entry expr is Loop Begin position
         //     - The position after last exit expr is Loop End position
@@ -48,9 +49,9 @@ public:
                    size_t loop_depth, size_t vector_size);
     void mark_loop(LinearIR::constExprIt loop_begin_pos,
                    LinearIR::constExprIt loop_end_pos,
-                   size_t idx,
                    size_t work_amount,
                    size_t work_amount_increment,
+                   size_t dim_idx,
                    const std::vector<ExpressionPort>& entries,
                    const std::vector<ExpressionPort>& exits);
 
@@ -63,12 +64,9 @@ public:
                                 const std::vector<ExpressionPort>& exits,
                                 LinearIR::constExprIt& loop_begin_pos,
                                 LinearIR::constExprIt& loop_end_pos,
-                                size_t loop_id = Expression::LOOP_NULL_ID);
+                                size_t loop_id);
 
 private:
-    static void exprs_marking(LinearIR::constExprIt loop_begin_pos,
-                              LinearIR::constExprIt loop_end_pos,
-                              size_t loop_id, size_t idx);
     static void get_io_loop_ports(LinearIR::constExprIt loop_begin_pos,
                                   LinearIR::constExprIt loop_end_pos,
                                   std::vector<ExpressionPort>& entries,

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -22,13 +22,13 @@ public:
     struct LoopPort {
         LoopPort() = default;
         LoopPort(const ExpressionPort& port, bool is_scheduled = true)
-            : port(port), is_incremented(is_scheduled) {}
+            : port(std::make_shared<ExpressionPort>(port)), is_incremented(is_scheduled) {}
 
         friend bool operator==(const LoopPort& lhs, const LoopPort& rhs);
         friend bool operator!=(const LoopPort& lhs, const LoopPort& rhs);
         friend bool operator<(const LoopPort& lhs, const LoopPort& rhs);
 
-        ExpressionPort port = {};
+        std::shared_ptr<ExpressionPort> port = {};
         // True if after each Loop iteration the corresponding data pointer should be incremented.
         // Otherwise, the data pointer shift is skipped
         bool is_incremented = true;
@@ -44,9 +44,6 @@ public:
         LoopInfo(size_t work_amount, size_t increment, size_t dim_idx,
                  const std::vector<ExpressionPort>& entries,
                  const std::vector<ExpressionPort>& exits);
-
-        std::vector<ExpressionPort> get_entry_ports() const;
-        std::vector<ExpressionPort> get_exit_ports() const;
 
         size_t work_amount = 0;
         size_t increment = 0;

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -22,13 +22,13 @@ public:
     struct LoopPort {
         LoopPort() = default;
         LoopPort(const ExpressionPort& port, bool is_scheduled = true)
-            : port(std::make_shared<ExpressionPort>(port)), is_incremented(is_scheduled) {}
+            : expr_port(std::make_shared<ExpressionPort>(port)), is_incremented(is_scheduled) {}
 
         friend bool operator==(const LoopPort& lhs, const LoopPort& rhs);
         friend bool operator!=(const LoopPort& lhs, const LoopPort& rhs);
         friend bool operator<(const LoopPort& lhs, const LoopPort& rhs);
 
-        std::shared_ptr<ExpressionPort> port = {};
+        std::shared_ptr<ExpressionPort> expr_port = {};
         // True if after each Loop iteration the corresponding data pointer should be incremented.
         // Otherwise, the data pointer shift is skipped
         bool is_incremented = true;

--- a/src/common/snippets/include/snippets/lowered/pass/fuse_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/fuse_loops.hpp
@@ -45,10 +45,12 @@ public:
 private:
     static bool can_be_fused(const LinearIR::LoopManager::LoopInfoPtr& loop_current,
                              const LinearIR::LoopManager::LoopInfoPtr& loop_target);
-    static bool fuse_upper_into_current(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, const ExpressionPort& current_entry_point,
+    static bool fuse_upper_into_current(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager,
+                                        const std::shared_ptr<ExpressionPort>& current_entry_point,
                                         size_t current_loop_id, size_t target_loop_id,
                                         LinearIR::constExprIt& current_loop_begin_pos, LinearIR::constExprIt& current_loop_end_pos);
-    static bool fuse_lower_into_current(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, const ExpressionPort& current_entry_point,
+    static bool fuse_lower_into_current(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager,
+                                        const std::shared_ptr<ExpressionPort>& current_entry_point,
                                         size_t current_loop_id, size_t target_loop_id,
                                         LinearIR::constExprIt& current_loop_begin_pos, LinearIR::constExprIt& current_loop_end_pos);
     static void fuse_points(std::vector<LinearIR::LoopManager::LoopPort>& exit_points, std::vector<LinearIR::LoopManager::LoopPort>& entry_points,

--- a/src/common/snippets/include/snippets/lowered/pass/fuse_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/fuse_loops.hpp
@@ -46,10 +46,10 @@ private:
     static bool can_be_fused(const LinearIR::LoopManager::LoopInfoPtr& loop_current,
                              const LinearIR::LoopManager::LoopInfoPtr& loop_target);
     static bool fuse_upper_into_current(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, const ExpressionPort& current_entry_point,
-                                        size_t current_loop_id, size_t target_loop_id, size_t dim_idx,
+                                        size_t current_loop_id, size_t target_loop_id,
                                         LinearIR::constExprIt& current_loop_begin_pos, LinearIR::constExprIt& current_loop_end_pos);
     static bool fuse_lower_into_current(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, const ExpressionPort& current_entry_point,
-                                        size_t current_loop_id, size_t target_loop_id, size_t dim_idx,
+                                        size_t current_loop_id, size_t target_loop_id,
                                         LinearIR::constExprIt& current_loop_begin_pos, LinearIR::constExprIt& current_loop_end_pos);
     static void fuse_points(std::vector<ExpressionPort>& exit_points, std::vector<ExpressionPort>& entry_points,
                             LinearIR::constExprIt loop_begin_pos, LinearIR::constExprIt loop_end_pos);

--- a/src/common/snippets/include/snippets/lowered/pass/fuse_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/fuse_loops.hpp
@@ -51,7 +51,7 @@ private:
     static bool fuse_lower_into_current(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, const ExpressionPort& current_entry_point,
                                         size_t current_loop_id, size_t target_loop_id,
                                         LinearIR::constExprIt& current_loop_begin_pos, LinearIR::constExprIt& current_loop_end_pos);
-    static void fuse_points(std::vector<ExpressionPort>& exit_points, std::vector<ExpressionPort>& entry_points,
+    static void fuse_points(std::vector<LinearIR::LoopManager::LoopPoint>& exit_points, std::vector<LinearIR::LoopManager::LoopPoint>& entry_points,
                             LinearIR::constExprIt loop_begin_pos, LinearIR::constExprIt loop_end_pos);
 };
 

--- a/src/common/snippets/include/snippets/lowered/pass/fuse_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/fuse_loops.hpp
@@ -51,7 +51,7 @@ private:
     static bool fuse_lower_into_current(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, const ExpressionPort& current_entry_point,
                                         size_t current_loop_id, size_t target_loop_id,
                                         LinearIR::constExprIt& current_loop_begin_pos, LinearIR::constExprIt& current_loop_end_pos);
-    static void fuse_points(std::vector<LinearIR::LoopManager::LoopPoint>& exit_points, std::vector<LinearIR::LoopManager::LoopPoint>& entry_points,
+    static void fuse_points(std::vector<LinearIR::LoopManager::LoopPort>& exit_points, std::vector<LinearIR::LoopManager::LoopPort>& entry_points,
                             LinearIR::constExprIt loop_begin_pos, LinearIR::constExprIt loop_end_pos);
 };
 

--- a/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
@@ -20,22 +20,20 @@ namespace pass {
  */
 class InitLoops : public Pass {
 public:
-    OPENVINO_RTTI("InsertLoops", "Pass")
+    OPENVINO_RTTI("InitLoops", "Pass")
     InitLoops();
     bool run(LinearIR& linear_ir) override;
 
 private:
     static void insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, size_t loop_id, bool has_outer_loop);
 
-    static std::vector<int64_t> init_ptr_increments(std::vector<LinearIR::LoopManager::LoopPoint>& loop_inputs,
-                                                    std::vector<LinearIR::LoopManager::LoopPoint>& loop_outputs,
+    static std::vector<int64_t> init_ptr_increments(std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
+                                                    std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs,
                                                     const LinearIR::LoopManagerPtr& loop_manager,
                                                     size_t loop_id, size_t work_amount, size_t dim_idx);
-    static std::vector<int64_t> init_finalization_offsets(std::vector<LinearIR::LoopManager::LoopPoint>& loop_inputs,
-                                                          std::vector<LinearIR::LoopManager::LoopPoint>& loop_outputs,
-                                                          size_t work_amount);
-    static std::vector<int64_t> init_element_type_sizes(const std::vector<LinearIR::LoopManager::LoopPoint>& loop_inputs,
-                                                        const std::vector<LinearIR::LoopManager::LoopPoint>& loop_outputs);
+    static std::vector<int64_t> init_finalization_offsets(const std::vector<int64_t>& ptr_increments, size_t work_amount);
+    static std::vector<int64_t> init_element_type_sizes(const std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
+                                                        const std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
@@ -27,13 +27,15 @@ public:
 private:
     static void insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, size_t loop_id, bool has_outer_loop);
 
-    static std::vector<int64_t> init_ptr_increments(const std::vector<ExpressionPort>& loop_inputs,
-                                                    const std::vector<ExpressionPort>& loop_outputs,
+    static std::vector<int64_t> init_ptr_increments(std::vector<LinearIR::LoopManager::LoopPoint>& loop_inputs,
+                                                    std::vector<LinearIR::LoopManager::LoopPoint>& loop_outputs,
                                                     const LinearIR::LoopManagerPtr& loop_manager,
                                                     size_t loop_id, size_t work_amount, size_t dim_idx);
-    static std::vector<int64_t> init_finalization_offsets(const std::vector<int64_t>& finalization_offsets, size_t work_amount);
-    static std::vector<int64_t> init_element_type_sizes(const std::vector<ExpressionPort>& loop_inputs,
-                                                        const std::vector<ExpressionPort>& loop_outputs);
+    static std::vector<int64_t> init_finalization_offsets(std::vector<LinearIR::LoopManager::LoopPoint>& loop_inputs,
+                                                          std::vector<LinearIR::LoopManager::LoopPoint>& loop_outputs,
+                                                          size_t work_amount);
+    static std::vector<int64_t> init_element_type_sizes(const std::vector<LinearIR::LoopManager::LoopPoint>& loop_inputs,
+                                                        const std::vector<LinearIR::LoopManager::LoopPoint>& loop_outputs);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
@@ -25,10 +25,12 @@ public:
     bool run(LinearIR& linear_ir) override;
 
 private:
-    static void insertion(LinearIR& linear_ir, const LinearIR::LoopManager::LoopInfoPtr& loop_info, size_t loop_id, bool has_outer_loop);
+    static void insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, size_t loop_id, bool has_outer_loop);
+
     static std::vector<int64_t> init_ptr_increments(const std::vector<ExpressionPort>& loop_inputs,
                                                     const std::vector<ExpressionPort>& loop_outputs,
-                                                    size_t work_amount, size_t dim_idx);
+                                                    const LinearIR::LoopManagerPtr& loop_manager,
+                                                    size_t loop_id, size_t work_amount, size_t dim_idx);
     static std::vector<int64_t> init_finalization_offsets(const std::vector<int64_t>& finalization_offsets, size_t work_amount);
     static std::vector<int64_t> init_element_type_sizes(const std::vector<ExpressionPort>& loop_inputs,
                                                         const std::vector<ExpressionPort>& loop_outputs);

--- a/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
@@ -25,11 +25,10 @@ public:
     bool run(LinearIR& linear_ir) override;
 
 private:
-    static void insertion(LinearIR& linear_ir, const LinearIR::LoopManager::LoopInfoPtr& loop_info,
-                          size_t loop_id, size_t dim_idx, bool has_outer_loop);
+    static void insertion(LinearIR& linear_ir, const LinearIR::LoopManager::LoopInfoPtr& loop_info, size_t loop_id, bool has_outer_loop);
     static std::vector<int64_t> init_ptr_increments(const std::vector<ExpressionPort>& loop_inputs,
                                                     const std::vector<ExpressionPort>& loop_outputs,
-                                                    size_t dim_idx);
+                                                    size_t work_amount, size_t dim_idx);
     static std::vector<int64_t> init_finalization_offsets(const std::vector<int64_t>& finalization_offsets, size_t work_amount);
     static std::vector<int64_t> init_element_type_sizes(const std::vector<ExpressionPort>& loop_inputs,
                                                         const std::vector<ExpressionPort>& loop_outputs);

--- a/src/common/snippets/include/snippets/lowered/pass/insert_buffers.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_buffers.hpp
@@ -29,7 +29,8 @@ public:
 
 private:
     void insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager,
-                   const std::vector<ExpressionPort>& loop_entries, const std::vector<ExpressionPort>& loop_exits);
+                   const std::vector<LinearIR::LoopManager::LoopPort>& loop_entries,
+                   const std::vector<LinearIR::LoopManager::LoopPort>& loop_exits);
 
     LinearIR::constExprIt insertion_position(const LinearIR& linear_ir,
                                              const LinearIR::LoopManagerPtr& loop_manager,

--- a/src/common/snippets/include/snippets/lowered/pass/insert_buffers.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_buffers.hpp
@@ -6,6 +6,8 @@
 
 #include "pass.hpp"
 
+#include "snippets/lowered/loop_manager.hpp"
+
 namespace ov {
 namespace snippets {
 namespace lowered {

--- a/src/common/snippets/include/snippets/lowered/pass/insert_buffers.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_buffers.hpp
@@ -26,12 +26,12 @@ public:
     bool run(LinearIR& linear_ir) override;
 
 private:
-    void insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, size_t loop_id,
+    void insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager,
                    const std::vector<ExpressionPort>& loop_entries, const std::vector<ExpressionPort>& loop_exits);
 
     LinearIR::constExprIt insertion_position(const LinearIR& linear_ir,
                                              const LinearIR::LoopManagerPtr& loop_manager,
-                                             const ExpressionPtr& up_expr,
+                                             const ExpressionPtr& expr,
                                              const ExpressionPtr& down_expr);
 
     int32_t m_buffer_allocation_rank;

--- a/src/common/snippets/include/snippets/lowered/pass/validate_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/validate_loops.hpp
@@ -18,8 +18,10 @@ namespace pass {
  * @brief The pass validates LoopInfo that describes Loops:
  *          - Verifies the correctness of nested Loops.
  *            The loops with the same dimension index (splitted dimension) should be successively nested
- *          - The upper Loop, the upper the corresponding dim_idx
- *        Note: should be called before explicit Loop insertion in LinearIR (InitLoop pass call).
+ *          - dim_idx are sorted in accordance with loop nesting
+ *        Notes:
+ *          - should be called before explicit Loop insertion in LinearIR (InitLoop pass call).
+ *          - TODO [112196] : probably, it's a temporary design. Need to investigate it and remove these limitations
  * @ingroup snippets
  */
 class ValidateLoops : public Pass {

--- a/src/common/snippets/include/snippets/lowered/pass/validate_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/validate_loops.hpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "pass.hpp"
+
+#include "snippets/lowered/loop_manager.hpp"
+
+namespace ov {
+namespace snippets {
+namespace lowered {
+namespace pass {
+
+/**
+ * @interface ValidateLoops
+ * @brief The pass validates LoopInfo that describes Loops:
+ *          - Verifies the correctness of nested Loops.
+ *            The loops with the same dimension index (splitted dimension) should be successively nested
+ *          - The upper Loop, the upper the corresponding dim_idx
+ *        Note: should be called before explicit Loop insertion in LinearIR (InitLoop pass call).
+ * @ingroup snippets
+ */
+class ValidateLoops : public Pass {
+public:
+    OPENVINO_RTTI("ValidateLoops", "Pass")
+    ValidateLoops();
+    bool run(LinearIR& linear_ir) override;
+};
+
+} // namespace pass
+} // namespace lowered
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/src/lowered/expression.cpp
+++ b/src/common/snippets/src/lowered/expression.cpp
@@ -106,52 +106,6 @@ void Expression::set_loop_ids(const std::vector<size_t>& loops) {
     m_loop_ids = loops;
 }
 
-void Expression::add_outer_loop_id(size_t id, size_t inner) {
-    OPENVINO_ASSERT(std::find(m_loop_ids.cbegin(), m_loop_ids.cend(), id) == m_loop_ids.cend(),
-                    "Expression cannot have several the same Loop IDs");
-    auto insert_it = m_loop_ids.cbegin();
-    if (inner != SIZE_MAX) {
-        insert_it = std::find(m_loop_ids.cbegin(), m_loop_ids.cend(), inner);
-        OPENVINO_ASSERT(insert_it != m_loop_ids.cend(), "Failed add outer loop ID: Inner ID hasn't been found");
-    }
-    m_loop_ids.insert(insert_it, id);
-}
-
-void Expression::add_outer_loop_ids(const std::vector<size_t>& ids, size_t inner) {
-    const auto insert_it = std::find(m_loop_ids.cbegin(), m_loop_ids.cend(), inner);
-    OPENVINO_ASSERT(insert_it != m_loop_ids.cend(), "Failed add outer loop IDs: Inner ID hasn't been found");
-    m_loop_ids.insert(insert_it, ids.cbegin(), ids.cend());
-    std::unordered_set<size_t> s(m_loop_ids.cbegin(), m_loop_ids.cend());
-    OPENVINO_ASSERT(s.size() == m_loop_ids.size(), "Loop IDs must be unique");
-}
-
-void Expression::add_inner_loop_id(size_t id, size_t outer) {
-    OPENVINO_ASSERT(std::find(m_loop_ids.cbegin(), m_loop_ids.cend(), id) == m_loop_ids.cend(),
-                    "Expression cannot have several the same Loop IDs");
-    auto insert_it = m_loop_ids.cend();
-    if (outer != SIZE_MAX) {
-        insert_it = std::find(m_loop_ids.cbegin(), m_loop_ids.cend(), outer);
-        OPENVINO_ASSERT(insert_it != m_loop_ids.cend(), "Failed add outer loop ID: Inner ID hasn't been found");
-        insert_it = std::next(insert_it);
-    }
-    m_loop_ids.insert(insert_it, id);
-}
-
-void Expression::replace_loop_id(size_t prev_id, size_t new_id) {
-    OPENVINO_ASSERT(std::find(m_loop_ids.cbegin(), m_loop_ids.cend(), new_id) == m_loop_ids.cend(),
-                    "Expression already has the Loop with ID " + std::to_string(new_id));
-    auto it = std::find(m_loop_ids.begin(), m_loop_ids.end(), prev_id);
-    OPENVINO_ASSERT(it != m_loop_ids.end(),
-                    "Expression doesn't have the Loop with ID " + std::to_string(prev_id));
-    (*it) = new_id;
-}
-
-void Expression::remove_loop_id(size_t id) {
-    const auto it = std::find(m_loop_ids.cbegin(), m_loop_ids.cend(), id);
-    OPENVINO_ASSERT(it != m_loop_ids.cend(), "Expression doesn't have the Loop with ID " + std::to_string(id));
-    m_loop_ids.erase(it);
-}
-
 ExpressionPort Expression::get_input_port(size_t i) {
     return ExpressionPort(this->shared_from_this(), ExpressionPort::Type::Input, i);
 }

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -210,6 +210,7 @@ void LinearIR::LoopManager::mark_loop(LinearIR::constExprIt loop_begin_pos,
 
 
 void LinearIR::LoopManager::insert_loop_id(const ExpressionPtr& expr, size_t new_id, bool before, size_t target_id) {
+    OPENVINO_ASSERT(m_map.count(new_id) == 1, "Failed marking expression by Loop ID: the Loop with this ID hasn't registered");
     auto& loop_ids = expr->m_loop_ids;
     OPENVINO_ASSERT(std::find(loop_ids.cbegin(), loop_ids.cend(), new_id) == loop_ids.cend(),
                     "Expression cannot have several the same Loop IDs");
@@ -222,6 +223,8 @@ void LinearIR::LoopManager::insert_loop_id(const ExpressionPtr& expr, size_t new
 }
 
 void LinearIR::LoopManager::insert_loop_ids(const ExpressionPtr& expr, const std::vector<size_t>& new_ids, bool before, size_t target_id) {
+    OPENVINO_ASSERT(std::all_of(new_ids.cbegin(), new_ids.cend(), [this](const size_t& id) { return m_map.count(id) == 1; }),
+                    "Failed marking expression by Loop ID: the Loop with this ID hasn't registered");
     auto& loop_ids = expr->m_loop_ids;
     auto insert_it = before ? loop_ids.cbegin() : loop_ids.cend();
     if (target_id != SIZE_MAX) {
@@ -234,6 +237,7 @@ void LinearIR::LoopManager::insert_loop_ids(const ExpressionPtr& expr, const std
 }
 
 void LinearIR::LoopManager::replace_loop_id(const ExpressionPtr& expr, size_t prev_id, size_t new_id) {
+    OPENVINO_ASSERT(m_map.count(new_id), "Failed marking expression by Loop ID: the Loop with this ID hasn't registered");
     auto& loop_ids = expr->m_loop_ids;
     OPENVINO_ASSERT(std::find(loop_ids.cbegin(), loop_ids.cend(), new_id) == loop_ids.cend(),
                     "Expression already has the Loop with ID " + std::to_string(new_id));

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -30,13 +30,13 @@ LinearIR::LoopManager::LoopInfo::LoopInfo(size_t work_amount, size_t increment, 
 bool operator==(const LinearIR::LoopManager::LoopPort& lhs, const LinearIR::LoopManager::LoopPort& rhs) {
     if (&lhs == &rhs)
         return true;
-    return lhs.port == rhs.port && lhs.is_incremented == rhs.is_incremented;
+    return lhs.expr_port == rhs.expr_port && lhs.is_incremented == rhs.is_incremented;
 }
 bool operator!=(const LinearIR::LoopManager::LoopPort& lhs, const LinearIR::LoopManager::LoopPort& rhs) {
     return !(lhs == rhs);
 }
 bool operator<(const LinearIR::LoopManager::LoopPort& lhs, const LinearIR::LoopManager::LoopPort& rhs) {
-    return (lhs.port < rhs.port) || (lhs.port == rhs.port && (lhs.is_incremented < rhs.is_incremented));
+    return (lhs.expr_port < rhs.expr_port) || (lhs.expr_port == rhs.expr_port && (lhs.is_incremented < rhs.is_incremented));
 }
 
 size_t LinearIR::LoopManager::add_loop_info(const LoopInfoPtr &loop) {
@@ -78,7 +78,7 @@ void LinearIR::LoopManager::get_loop_bounds(const LinearIR &linear_ir,
                                             size_t loop_id) {
     OPENVINO_ASSERT(!entries.empty(), "Loop must have entry points");
     OPENVINO_ASSERT(!exits.empty(), "Loop must have entry points");
-    const auto& entry_expr = entries.front().port->get_expr();
+    const auto& entry_expr = entries.front().expr_port->get_expr();
     loop_begin_pos = std::find(linear_ir.begin(), linear_ir.end(), entry_expr);
     OPENVINO_ASSERT(loop_begin_pos != linear_ir.end(), "Loop begin hasn't been found!");
 
@@ -91,7 +91,7 @@ void LinearIR::LoopManager::get_loop_bounds(const LinearIR &linear_ir,
     }
 
     // At the moment all Loops must have exit points
-    const auto& exit_expr = exits.back().port->get_expr();
+    const auto& exit_expr = exits.back().expr_port->get_expr();
     loop_end_pos = std::next(std::find(loop_begin_pos, linear_ir.end(), exit_expr));
     OPENVINO_ASSERT(loop_end_pos != linear_ir.end(), "Loop end hasn't been found!");
 }

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -27,17 +27,6 @@ LinearIR::LoopManager::LoopInfo::LoopInfo(size_t work_amount, size_t increment, 
         exit_points.emplace_back(port);
 }
 
-std::vector<ExpressionPort> LinearIR::LoopManager::LoopInfo::get_entry_ports() const {
-    std::vector<ExpressionPort> ports;
-    std::transform(entry_points.cbegin(), entry_points.cend(), std::back_inserter(ports), [](const LoopPort& point) { return point.port; });
-    return ports;
-}
-std::vector<ExpressionPort> LinearIR::LoopManager::LoopInfo::get_exit_ports() const {
-    std::vector<ExpressionPort> ports;
-    std::transform(exit_points.cbegin(), exit_points.cend(), std::back_inserter(ports), [](const LoopPort& point) { return point.port; });
-    return ports;
-}
-
 bool operator==(const LinearIR::LoopManager::LoopPort& lhs, const LinearIR::LoopManager::LoopPort& rhs) {
     if (&lhs == &rhs)
         return true;
@@ -89,7 +78,7 @@ void LinearIR::LoopManager::get_loop_bounds(const LinearIR &linear_ir,
                                             size_t loop_id) {
     OPENVINO_ASSERT(!entries.empty(), "Loop must have entry points");
     OPENVINO_ASSERT(!exits.empty(), "Loop must have entry points");
-    const auto& entry_expr = entries.front().port.get_expr();
+    const auto& entry_expr = entries.front().port->get_expr();
     loop_begin_pos = std::find(linear_ir.begin(), linear_ir.end(), entry_expr);
     OPENVINO_ASSERT(loop_begin_pos != linear_ir.end(), "Loop begin hasn't been found!");
 
@@ -102,7 +91,7 @@ void LinearIR::LoopManager::get_loop_bounds(const LinearIR &linear_ir,
     }
 
     // At the moment all Loops must have exit points
-    const auto& exit_expr = exits.back().port.get_expr();
+    const auto& exit_expr = exits.back().port->get_expr();
     loop_end_pos = std::next(std::find(loop_begin_pos, linear_ir.end(), exit_expr));
     OPENVINO_ASSERT(loop_end_pos != linear_ir.end(), "Loop end hasn't been found!");
 }
@@ -210,8 +199,8 @@ void LinearIR::LoopManager::mark_loop(LinearIR::constExprIt loop_begin_pos,
                                       size_t work_amount,
                                       size_t work_amount_increment,
                                       size_t dim_idx,
-                                      const std::vector<ExpressionPort> &entries,
-                                      const std::vector<ExpressionPort> &exits) {
+                                      const std::vector<ExpressionPort>& entries,
+                                      const std::vector<ExpressionPort>& exits) {
     const auto loop_info = std::make_shared<LoopManager::LoopInfo>(work_amount, work_amount_increment, dim_idx, entries, exits);
     const auto loop_id = this->add_loop_info(loop_info);
     for (auto expr_it = loop_begin_pos; expr_it != loop_end_pos; ++expr_it) {

--- a/src/common/snippets/src/lowered/pass/allocate_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/allocate_buffers.cpp
@@ -58,8 +58,17 @@ void AllocateBuffers::propagate_offset(const LinearIR& linear_ir, const Expressi
 bool AllocateBuffers::run(LinearIR& linear_ir) {
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::AllocateBuffers");
 
-    bool modified = false;
     size_t offset = 0;
+    std::set<ExpressionPtr> allocated_buffers;
+
+    auto allocate = [&](const std::shared_ptr<op::Buffer>& buffer, const ExpressionPtr& expr, size_t buffer_size) {
+        offset = m_buffer_scratchpad_size;
+        buffer->set_offset(static_cast<int64_t>(offset));
+        propagate_offset(linear_ir, expr, offset);
+        m_buffer_scratchpad_size += buffer_size;
+        allocated_buffers.insert(expr);
+    };
+
     for (auto expr_it = linear_ir.begin(); expr_it != linear_ir.end(); expr_it++) {
         const auto& expr = *expr_it;
         if (auto buffer = as_type_ptr<op::Buffer>(expr->get_node())) {
@@ -67,6 +76,7 @@ bool AllocateBuffers::run(LinearIR& linear_ir) {
             // If it's the first buffer, offsets are zero => nothing to propagate, can continue
             if (m_buffer_scratchpad_size == 0) {
                 m_buffer_scratchpad_size += buffer_size;
+                allocated_buffers.insert(expr);
                 continue;
             }
 
@@ -77,29 +87,55 @@ bool AllocateBuffers::run(LinearIR& linear_ir) {
                 // TODO: It should be unified in MemoryManager with memory reuse in the near future
                 const auto ma = ov::as_type_ptr<op::MemoryAccess>(parent_node);
                 if (ma && ma->is_full_memory_access_op()) {
-                    offset = m_buffer_scratchpad_size;
-                    buffer->set_offset(static_cast<int64_t>(offset));
-                    propagate_offset(linear_ir, *expr_it, offset);
-                    m_buffer_scratchpad_size += buffer_size;
+                    allocate(buffer, *expr_it, buffer_size);
                     continue;
                 }
+
+                // Loop       Full_MA
+                //  |           |
+                // Buffer_1  Buffer_0
+                //   \         /
+                //     Full_MA
+                // At the moment the pass support only sequentially implicit InPlace.
+                // If Buffer_0 is allocated firstly as Buffer after full memory access op,
+                // we cannot reuse this allocated memory for Buffer_1 - we must allocate new memory for it.
+                // TODO: It should be unified in MemoryManager with memory reuse in the near future
+                bool need_allocate = false;
+                const auto consumers = expr->get_output_port_connector(0)->get_consumers();
+                for (const auto& consumer : consumers) {
+                    const auto& consumer_expr = consumer.get_expr();
+                    const auto& child_node = consumer_expr->get_node();
+                    const auto ma = ov::as_type_ptr<op::MemoryAccess>(child_node);
+                    if (ma && ma->is_full_memory_access_op()) {
+                        for (size_t i = 0; i < consumer_expr->get_input_count() && !need_allocate; ++i) {
+                            if (i == consumer.get_index())
+                                continue;
+                            const auto buffer_sibling = consumer_expr->get_input_port_connector(i)->get_source().get_expr();
+                            need_allocate = ov::is_type<op::Buffer>(buffer_sibling->get_node()) && allocated_buffers.count(buffer_sibling) != 0;
+                        }
+                    }
+                    if (need_allocate)
+                        break;
+                }
+                if (need_allocate) {
+                    allocate(buffer, *expr_it, buffer_size);
+                    continue;
+                }
+
                 const auto current_allocated_memory_size = m_buffer_scratchpad_size - offset;
                 if (buffer_size > current_allocated_memory_size) {
                     m_buffer_scratchpad_size += (buffer_size - current_allocated_memory_size);
                     // Note: we don't update offset because we just add memory to needed size
                 }
                 propagate_offset(linear_ir, *expr_it, offset);
+                allocated_buffers.insert(expr);
             } else {
                 // Single Buffer without input should allocate new memory
-                offset = m_buffer_scratchpad_size;
-                buffer->set_offset(static_cast<int64_t>(offset));
-                propagate_offset(linear_ir, *expr_it, offset);
-                m_buffer_scratchpad_size += buffer_size;
+                allocate(buffer, *expr_it, buffer_size);
             }
-            modified = true;
         }
     }
-    return modified;
+    return !allocated_buffers.empty();
 }
 
 } // namespace pass

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -24,17 +24,17 @@ void filter_ports(std::vector<LoopPort>& loop_entries, std::vector<LoopPort>& lo
     new_loop_exits.reserve(loop_exits.size());
 
     for (const auto& loop_entry_point : loop_entries) {
-        const auto& expr = loop_entry_point.port->get_expr();
+        const auto& expr = loop_entry_point.expr_port->get_expr();
         const auto ma = ov::as_type_ptr<op::MemoryAccess>(expr->get_node());
-        if (ma && ma->is_memory_access_input_port(loop_entry_point.port->get_index())) {
+        if (ma && ma->is_memory_access_input_port(loop_entry_point.expr_port->get_index())) {
             new_loop_entries.push_back(loop_entry_point);
         }
     }
 
     for (const auto& loop_exit_point : loop_exits) {
-        const auto& expr = loop_exit_point.port->get_expr();
+        const auto& expr = loop_exit_point.expr_port->get_expr();
         const auto ma = ov::as_type_ptr<op::MemoryAccess>(expr->get_node());
-        if (ma && ma->is_memory_access_output_port(loop_exit_point.port->get_index())) {
+        if (ma && ma->is_memory_access_output_port(loop_exit_point.expr_port->get_index())) {
             new_loop_exits.push_back(loop_exit_point);
         }
     }
@@ -90,7 +90,7 @@ std::vector<int64_t> InitLoops::init_ptr_increments(std::vector<LoopPort>& loop_
     ptr_increments.reserve(loop_inputs.size() + loop_outputs.size());
 
     for (auto& loop_input : loop_inputs) {
-        const auto& port = loop_input.port;
+        const auto& port = loop_input.expr_port;
         // For strides we have to use layout from source since source writes data by special rules
         const auto source = *port->get_connected_ports().begin();
         const auto loop_ids = port->get_expr()->get_loop_ids();
@@ -106,7 +106,7 @@ std::vector<int64_t> InitLoops::init_ptr_increments(std::vector<LoopPort>& loop_
     }
 
     for (auto& loop_output : loop_outputs) {
-        const auto& port = loop_output.port;
+        const auto& port = loop_output.expr_port;
         const auto loop_ids = port->get_expr()->get_loop_ids();
         const auto& layout = port->get_descriptor_ptr()->get_layout();
         const auto& shape = port->get_descriptor_ptr()->get_shape();
@@ -135,11 +135,11 @@ std::vector<int64_t> InitLoops::init_element_type_sizes(const std::vector<LoopPo
     std::vector<int64_t> element_types;
     element_types.reserve(loop_inputs.size() + loop_outputs.size());
     for (const auto& in : loop_inputs) {
-        const auto& port = in.port;
+        const auto& port = in.expr_port;
         element_types.push_back(port->get_expr()->get_node()->get_input_element_type(port->get_index()).size());
     }
     for (const auto& out : loop_outputs) {
-        const auto& port = out.port;
+        const auto& port = out.expr_port;
         element_types.push_back(port->get_expr()->get_node()->get_output_element_type(port->get_index()).size());
     }
     return element_types;
@@ -174,9 +174,9 @@ void InitLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& l
 
     std::vector<PortConnectorPtr> loop_end_inputs;
     for (const auto& expr_point : loop_entries)
-        loop_end_inputs.push_back(expr_point.port->get_port_connector_ptr());
+        loop_end_inputs.push_back(expr_point.expr_port->get_port_connector_ptr());
     for (const auto& expr_port : loop_exits)
-        loop_end_inputs.push_back(expr_port.port->get_port_connector_ptr());
+        loop_end_inputs.push_back(expr_port.expr_port->get_port_connector_ptr());
     loop_end_inputs.push_back(loop_begin_expr->get_output_port_connector(0));
 
     const auto& loop_end_expr = linear_ir.create_expression(loop_end, loop_end_inputs);

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -24,17 +24,17 @@ void filter_ports(std::vector<LoopPort>& loop_entries, std::vector<LoopPort>& lo
     new_loop_exits.reserve(loop_exits.size());
 
     for (const auto& loop_entry_point : loop_entries) {
-        const auto& expr = loop_entry_point.port.get_expr();
+        const auto& expr = loop_entry_point.port->get_expr();
         const auto ma = ov::as_type_ptr<op::MemoryAccess>(expr->get_node());
-        if (ma && ma->is_memory_access_input_port(loop_entry_point.port.get_index())) {
+        if (ma && ma->is_memory_access_input_port(loop_entry_point.port->get_index())) {
             new_loop_entries.push_back(loop_entry_point);
         }
     }
 
     for (const auto& loop_exit_point : loop_exits) {
-        const auto& expr = loop_exit_point.port.get_expr();
+        const auto& expr = loop_exit_point.port->get_expr();
         const auto ma = ov::as_type_ptr<op::MemoryAccess>(expr->get_node());
-        if (ma && ma->is_memory_access_output_port(loop_exit_point.port.get_index())) {
+        if (ma && ma->is_memory_access_output_port(loop_exit_point.port->get_index())) {
             new_loop_exits.push_back(loop_exit_point);
         }
     }
@@ -92,10 +92,10 @@ std::vector<int64_t> InitLoops::init_ptr_increments(std::vector<LoopPort>& loop_
     for (auto& loop_input : loop_inputs) {
         const auto& port = loop_input.port;
         // For strides we have to use layout from source since source writes data by special rules
-        const auto source = *port.get_connected_ports().begin();
-        const auto loop_ids = port.get_expr()->get_loop_ids();
-        const auto& layout = port.get_descriptor_ptr()->get_layout();
-        const auto& shape = port.get_descriptor_ptr()->get_shape();
+        const auto source = *port->get_connected_ports().begin();
+        const auto loop_ids = port->get_expr()->get_loop_ids();
+        const auto& layout = port->get_descriptor_ptr()->get_layout();
+        const auto& shape = port->get_descriptor_ptr()->get_shape();
         const auto& dim = *(layout.rbegin() + dim_idx);
         int64_t ptr_increment = 0;
         // If relevant dim is not broadcasted, then ptr_increment is the dim stride in the new layout
@@ -107,9 +107,9 @@ std::vector<int64_t> InitLoops::init_ptr_increments(std::vector<LoopPort>& loop_
 
     for (auto& loop_output : loop_outputs) {
         const auto& port = loop_output.port;
-        const auto loop_ids = port.get_expr()->get_loop_ids();
-        const auto& layout = port.get_descriptor_ptr()->get_layout();
-        const auto& shape = port.get_descriptor_ptr()->get_shape();
+        const auto loop_ids = port->get_expr()->get_loop_ids();
+        const auto& layout = port->get_descriptor_ptr()->get_layout();
+        const auto& shape = port->get_descriptor_ptr()->get_shape();
         const auto& dim = *(layout.rbegin() + dim_idx);
         int64_t ptr_increment = 0;
         // If relevant dim is not broadcasted, then ptr_increment is the dim stride in the new layout
@@ -136,11 +136,11 @@ std::vector<int64_t> InitLoops::init_element_type_sizes(const std::vector<LoopPo
     element_types.reserve(loop_inputs.size() + loop_outputs.size());
     for (const auto& in : loop_inputs) {
         const auto& port = in.port;
-        element_types.push_back(port.get_expr()->get_node()->get_input_element_type(port.get_index()).size());
+        element_types.push_back(port->get_expr()->get_node()->get_input_element_type(port->get_index()).size());
     }
     for (const auto& out : loop_outputs) {
         const auto& port = out.port;
-        element_types.push_back(port.get_expr()->get_node()->get_output_element_type(port.get_index()).size());
+        element_types.push_back(port->get_expr()->get_node()->get_output_element_type(port->get_index()).size());
     }
     return element_types;
 }
@@ -174,9 +174,9 @@ void InitLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& l
 
     std::vector<PortConnectorPtr> loop_end_inputs;
     for (const auto& expr_point : loop_entries)
-        loop_end_inputs.push_back(expr_point.port.get_port_connector_ptr());
+        loop_end_inputs.push_back(expr_point.port->get_port_connector_ptr());
     for (const auto& expr_port : loop_exits)
-        loop_end_inputs.push_back(expr_port.port.get_port_connector_ptr());
+        loop_end_inputs.push_back(expr_port.port->get_port_connector_ptr());
     loop_end_inputs.push_back(loop_begin_expr->get_output_port_connector(0));
 
     const auto& loop_end_expr = linear_ir.create_expression(loop_end, loop_end_inputs);

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -46,11 +46,11 @@ void filter_ports(std::vector<LoopPort>& loop_entries, std::vector<LoopPort>& lo
 int64_t get_dim_stride(const LinearIR::LoopManagerPtr& loop_manager, const std::vector<size_t>& loop_ids,
                        size_t loop_id, size_t dim, size_t dim_idx,
                        const std::vector<size_t>& layout, const std::vector<size_t>& shape) {
-    // Example, shape = [3, 384, 64], loop_ids = [0, 1, 2]
+    // Example, shape = [3, 384, 64], loop_ids = [2, 1, 0], layout = [0, 1, 2]
     // Loop Info:                            | Pointer increments:
-    // - 0: work_amount = 12, dim_idx = 1    | 1 x 64 x 32 - 32 is work_amount of inner splitted Loop
-    // - 1: work_amount = 32, dim_idx = 1    | 1 x 64
-    // - 2: work_amount = 64, dim_idx = 0    | 1
+    // - 2: work_amount = 12, dim_idx = 1    | 1 x 64 x 32 - (1 * shape[layout[2]] * 32) where 32 is work_amount of inner splitted Loop
+    // - 1: work_amount = 32, dim_idx = 1    | 1 x 64 - (1 * shape[layout[2]])
+    // - 0: work_amount = 64, dim_idx = 0    | 1
     // Note that dim_idx enumerates dimensions from the end: 64, 384, 3
     // Firstly, we find all Loop IDs with the same dimension index.
     // The Loop Info's with the same dimension index mean that these Loops split this dimension together.

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -16,24 +16,24 @@ namespace pass {
 
 namespace {
 void filter_ports(LinearIR& linear_ir,
-                  std::vector<ExpressionPort>& loop_entries, std::vector<ExpressionPort>& loop_exits) {
-    std::vector<ExpressionPort> new_loop_entries;
-    std::vector<ExpressionPort> new_loop_exits;
+                  std::vector<LinearIR::LoopManager::LoopPoint>& loop_entries, std::vector<LinearIR::LoopManager::LoopPoint>& loop_exits) {
+    std::vector<LinearIR::LoopManager::LoopPoint> new_loop_entries;
+    std::vector<LinearIR::LoopManager::LoopPoint> new_loop_exits;
     new_loop_entries.reserve(loop_entries.size());
     new_loop_exits.reserve(loop_exits.size());
 
     for (const auto& loop_entry_point : loop_entries) {
-        const auto& expr = loop_entry_point.get_expr();
+        const auto& expr = loop_entry_point.port.get_expr();
         const auto ma = ov::as_type_ptr<op::MemoryAccess>(expr->get_node());
-        if (ma && ma->is_memory_access_input_port(loop_entry_point.get_index())) {
+        if (ma && ma->is_memory_access_input_port(loop_entry_point.port.get_index())) {
             new_loop_entries.push_back(loop_entry_point);
         }
     }
 
     for (const auto& loop_exit_point : loop_exits) {
-        const auto& expr = loop_exit_point.get_expr();
+        const auto& expr = loop_exit_point.port.get_expr();
         const auto ma = ov::as_type_ptr<op::MemoryAccess>(expr->get_node());
-        if (ma && ma->is_memory_access_output_port(loop_exit_point.get_index())) {
+        if (ma && ma->is_memory_access_output_port(loop_exit_point.port.get_index())) {
             new_loop_exits.push_back(loop_exit_point);
         }
     }
@@ -79,70 +79,95 @@ void add_stride_from_splitted_loops(int64_t& increment, const LinearIR::LoopMana
 
 InitLoops::InitLoops() : Pass() {}
 
-std::vector<int64_t> InitLoops::init_ptr_increments(const std::vector<ExpressionPort>& loop_inputs,
-                                                    const std::vector<ExpressionPort>& loop_outputs,
+std::vector<int64_t> InitLoops::init_ptr_increments(std::vector<LinearIR::LoopManager::LoopPoint>& loop_inputs,
+                                                    std::vector<LinearIR::LoopManager::LoopPoint>& loop_outputs,
                                                     const LinearIR::LoopManagerPtr& loop_manager,
                                                     size_t loop_id, size_t work_amount, size_t dim_idx) {
-     std::vector<int64_t> ptr_increments;
-    for (const auto& loop_input : loop_inputs) {
+    std::vector<int64_t> ptr_increments;
+    ptr_increments.reserve(loop_inputs.size() + loop_outputs.size());
+
+    for (auto& loop_input : loop_inputs) {
+        const auto& port = loop_input.port;
         // For strides we have to use layout from source since source writes data by special rules
-        const auto source = *loop_input.get_connected_ports().begin();
-        const auto loop_ids = loop_input.get_expr()->get_loop_ids();
-        const auto& layout = loop_input.get_descriptor_ptr()->get_layout();
-        const auto& shape = loop_input.get_descriptor_ptr()->get_shape();
+        const auto source = *port.get_connected_ports().begin();
+        const auto loop_ids = port.get_expr()->get_loop_ids();
+        const auto& layout = port.get_descriptor_ptr()->get_layout();
+        const auto& shape = port.get_descriptor_ptr()->get_shape();
         const auto& dim = *(layout.rbegin() + dim_idx);
-        int64_t ptr_increment = 0;
-        // If relevant dim is not broadcasted, then ptr_increment is the dim stride in the new layout
-        if (!(shape[dim] == 1 && work_amount != 1)) {
-            ptr_increment = get_dim_stride(dim, source.get_descriptor_ptr()->get_layout(), shape);
-            add_stride_from_splitted_loops(ptr_increment, loop_manager, loop_ids, loop_id, dim_idx);
+        // If ptr increment has not been manually set
+        if (loop_input.ptr_increment == LinearIR::LoopManager::LoopPoint::UNDEFINED) {
+            loop_input.ptr_increment = 0;
+            // If relevant dim is not broadcasted, then ptr_increment is the dim stride in the new layout
+            if (!(shape[dim] == 1 && work_amount != 1)) {
+                loop_input.ptr_increment = get_dim_stride(dim, source.get_descriptor_ptr()->get_layout(), shape);
+                add_stride_from_splitted_loops(loop_input.ptr_increment, loop_manager, loop_ids, loop_id, dim_idx);
+            }
         }
-        ptr_increments.push_back(ptr_increment);
+        ptr_increments.push_back(loop_input.ptr_increment);
     }
 
-    for (const auto& loop_output : loop_outputs) {
-        const auto loop_ids = loop_output.get_expr()->get_loop_ids();
-        const auto& layout = loop_output.get_descriptor_ptr()->get_layout();
-        const auto& shape = loop_output.get_descriptor_ptr()->get_shape();
+    for (auto& loop_output : loop_outputs) {
+        const auto& port = loop_output.port;
+        const auto loop_ids = port.get_expr()->get_loop_ids();
+        const auto& layout = port.get_descriptor_ptr()->get_layout();
+        const auto& shape = port.get_descriptor_ptr()->get_shape();
         const auto& dim = *(layout.rbegin() + dim_idx);
-        int64_t ptr_increment = 0;
-        // If relevant dim is not broadcasted, then ptr_increment is the dim stride in the new layout
-        if (!(shape[dim] == 1 && work_amount != 1)) {
-            ptr_increment = get_dim_stride(dim, layout, shape);
-            add_stride_from_splitted_loops(ptr_increment, loop_manager, loop_ids, loop_id, dim_idx);
+        // If ptr increment has not been manually set
+        if (loop_output.ptr_increment == LinearIR::LoopManager::LoopPoint::UNDEFINED) {
+            loop_output.ptr_increment = 0;
+            // If relevant dim is not broadcasted, then ptr_increment is the dim stride in the new layout
+            if (!(shape[dim] == 1 && work_amount != 1)) {
+                loop_output.ptr_increment = get_dim_stride(dim, layout, shape);
+                add_stride_from_splitted_loops(loop_output.ptr_increment, loop_manager, loop_ids, loop_id, dim_idx);
+            }
         }
-        ptr_increments.push_back(ptr_increment);
+        ptr_increments.push_back(loop_output.ptr_increment);
     }
-
     return ptr_increments;
 }
 
-std::vector<int64_t> InitLoops::init_finalization_offsets(const std::vector<int64_t>& ptr_increments, size_t work_amount) {
+std::vector<int64_t> InitLoops::init_finalization_offsets(std::vector<LinearIR::LoopManager::LoopPoint>& loop_inputs,
+                                                          std::vector<LinearIR::LoopManager::LoopPoint>& loop_outputs,
+                                                          size_t work_amount) {
     std::vector<int64_t> finalization_offsets;
-    for (const auto& ptr_incr : ptr_increments) {
-        int64_t offset = -1 * ptr_incr * work_amount;
-        finalization_offsets.push_back(offset);
+    finalization_offsets.reserve(loop_inputs.size() + loop_outputs.size());
+
+    for (auto& loop_input : loop_inputs) {
+        // If finalization offset has not been manually set
+        if (loop_input.finalization_offset == LinearIR::LoopManager::LoopPoint::UNDEFINED) {
+            loop_input.finalization_offset = -1 * loop_input.ptr_increment * work_amount;
+        }
+        finalization_offsets.push_back(loop_input.finalization_offset);
+    }
+    for (auto& loop_output : loop_outputs) {
+        // If finalization offset has not been manually set
+        if (loop_output.finalization_offset == LinearIR::LoopManager::LoopPoint::UNDEFINED) {
+            loop_output.finalization_offset = -1 * loop_output.ptr_increment * work_amount;
+        }
+        finalization_offsets.push_back(loop_output.finalization_offset);
     }
     return finalization_offsets;
 }
 
-std::vector<int64_t> InitLoops::init_element_type_sizes(const std::vector<ExpressionPort>& loop_inputs,
-                                                        const std::vector<ExpressionPort>& loop_outputs) {
+std::vector<int64_t> InitLoops::init_element_type_sizes(const std::vector<LinearIR::LoopManager::LoopPoint>& loop_inputs,
+                                                        const std::vector<LinearIR::LoopManager::LoopPoint>& loop_outputs) {
     std::vector<int64_t> element_types;
     element_types.reserve(loop_inputs.size() + loop_outputs.size());
     for (const auto& in : loop_inputs) {
-        element_types.push_back(in.get_expr()->get_node()->get_input_element_type(in.get_index()).size());
+        const auto& port = in.port;
+        element_types.push_back(port.get_expr()->get_node()->get_input_element_type(port.get_index()).size());
     }
     for (const auto& out : loop_outputs) {
-        element_types.push_back(out.get_expr()->get_node()->get_output_element_type(out.get_index()).size());
+        const auto& port = out.port;
+        element_types.push_back(port.get_expr()->get_node()->get_output_element_type(port.get_index()).size());
     }
     return element_types;
 }
 
 void InitLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, size_t loop_id, bool has_outer_loop) {
     const auto loop_info = loop_manager->get_loop_info(loop_id);
-    auto loop_entries = loop_info->entry_exprs;
-    auto loop_exits = loop_info->exit_exprs;
+    auto loop_entries = loop_info->entry_points;
+    auto loop_exits = loop_info->exit_points;
     const auto work_amount = loop_info->work_amount;
     const auto work_amount_increment = loop_info->increment;
     const auto dim_idx = loop_info->dim_idx;
@@ -153,7 +178,7 @@ void InitLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& l
     filter_ports(linear_ir, loop_entries, loop_exits);
 
     const auto ptr_increments = init_ptr_increments(loop_entries, loop_exits, loop_manager, loop_id, work_amount, dim_idx);
-    const auto finalization_offsets = init_finalization_offsets(ptr_increments, work_amount);
+    const auto finalization_offsets = init_finalization_offsets(loop_entries, loop_exits, work_amount);
     const auto io_data_sizes = init_element_type_sizes(loop_entries, loop_exits);
 
     const auto& loop_begin = std::make_shared<op::LoopBegin>();
@@ -166,10 +191,10 @@ void InitLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& l
     loop_end->has_outer_loop = has_outer_loop;
 
     std::vector<PortConnectorPtr> loop_end_inputs;
-    for (const auto& expr_port : loop_entries)
-        loop_end_inputs.push_back(expr_port.get_expr()->get_input_port_connector(expr_port.get_index()));
+    for (const auto& expr_point : loop_entries)
+        loop_end_inputs.push_back(expr_point.port.get_port_connector_ptr());
     for (const auto& expr_port : loop_exits)
-        loop_end_inputs.push_back(expr_port.get_expr()->get_output_port_connector(expr_port.get_index()));
+        loop_end_inputs.push_back(expr_port.port.get_port_connector_ptr());
     loop_end_inputs.push_back(loop_begin_expr->get_output_port_connector(0));
 
     const auto& loop_end_expr = linear_ir.create_expression(loop_end, loop_end_inputs);

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -62,11 +62,12 @@ void add_stride_from_splitted_loops(int64_t& increment, const LinearIR::LoopMana
     // Firstly, we find all Loop IDs with the same dimension index.
     // The Loop Info's with the same dimension index mean that these Loops split this dimension together.
     // It's possible in Brgemm Blocking by M, for example
-    std::unordered_set<size_t> splitted_loops;
+    std::vector<size_t> splitted_loops;
+    // Inner -> Outer
     for (auto it = loop_ids.rbegin(); it != loop_ids.rend(); ++it) {
         const auto id = *it;
         if (loop_manager->get_loop_info(id)->dim_idx == dim_idx)
-            splitted_loops.insert(id);
+            splitted_loops.push_back(id);
     }
     // Secondly, we added work amount of inner splitted Loops
     for (auto id : splitted_loops) {

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -57,23 +57,8 @@ InitLoops::InitLoops() : Pass() {}
 
 std::vector<int64_t> InitLoops::init_ptr_increments(const std::vector<ExpressionPort>& loop_inputs,
                                                     const std::vector<ExpressionPort>& loop_outputs,
-                                                    size_t dim_idx) {
+                                                    size_t work_amount, size_t dim_idx) {
      std::vector<int64_t> ptr_increments;
-    // Note: Need to find max relevant dim expr to account for broadcasting, collect relevant_dims as well
-    size_t max_relevant_dim_size = 1;
-    for (const auto& loop_input : loop_inputs) {
-        const auto& layout = loop_input.get_descriptor_ptr()->get_layout();
-        const auto& shape = loop_input.get_descriptor_ptr()->get_shape();
-        const auto& dim = *(layout.rbegin() + dim_idx);
-        max_relevant_dim_size = std::max(shape[dim], max_relevant_dim_size);
-    }
-    for (const auto& loop_output : loop_outputs) {
-        const auto& layout = loop_output.get_descriptor_ptr()->get_layout();
-        const auto& shape = loop_output.get_descriptor_ptr()->get_shape();
-        const auto& dim = *(layout.rbegin() + dim_idx);
-        max_relevant_dim_size = std::max(shape[dim], max_relevant_dim_size);
-    }
-
     for (const auto& loop_input : loop_inputs) {
         // For strides we have to use layout from source since source writes data by special rules
         const auto source = *loop_input.get_connected_ports().begin();
@@ -82,7 +67,7 @@ std::vector<int64_t> InitLoops::init_ptr_increments(const std::vector<Expression
         const auto& dim = *(layout.rbegin() + dim_idx);
         int64_t ptr_increment = 0;
         // If relevant dim is not broadcasted, then ptr_increment is the dim stride in the new layout
-        if (!(shape[dim] == 1 && max_relevant_dim_size != 1))
+        if (!(shape[dim] == 1 && work_amount != 1))
             ptr_increment = get_dim_stride(dim, source.get_descriptor_ptr()->get_layout(), shape);
         ptr_increments.push_back(ptr_increment);
     }
@@ -93,7 +78,7 @@ std::vector<int64_t> InitLoops::init_ptr_increments(const std::vector<Expression
         const auto& dim = *(layout.rbegin() + dim_idx);
         int64_t ptr_increment = 0;
         // If relevant dim is not broadcasted, then ptr_increment is the dim stride in the new layout
-        if (!(shape[dim] == 1 && max_relevant_dim_size != 1))
+        if (!(shape[dim] == 1 && work_amount != 1))
             ptr_increment = get_dim_stride(dim, layout, shape);
         ptr_increments.push_back(ptr_increment);
     }
@@ -123,19 +108,19 @@ std::vector<int64_t> InitLoops::init_element_type_sizes(const std::vector<Expres
     return element_types;
 }
 
-void InitLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManager::LoopInfoPtr& loop_info,
-                          size_t loop_id, size_t dim_idx, bool has_outer_loop) {
+void InitLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManager::LoopInfoPtr& loop_info, size_t loop_id, bool has_outer_loop) {
     auto loop_entries = loop_info->entry_exprs;
     auto loop_exits = loop_info->exit_exprs;
     const auto work_amount = loop_info->work_amount;
     const auto work_amount_increment = loop_info->increment;
+    const auto dim_idx = loop_info->dim_idx;
 
     LinearIR::constExprIt loop_begin_pos, loop_end_pos;
     LinearIR::LoopManager::get_loop_bounds(linear_ir, loop_entries, loop_exits, loop_begin_pos, loop_end_pos, loop_id);
 
     filter_ports(linear_ir, loop_entries, loop_exits);
 
-    auto ptr_increments = init_ptr_increments(loop_entries, loop_exits, dim_idx);
+    auto ptr_increments = init_ptr_increments(loop_entries, loop_exits, work_amount, dim_idx);
     auto finalization_offsets = init_finalization_offsets(ptr_increments, work_amount);
     const auto io_data_sizes = init_element_type_sizes(loop_entries, loop_exits);
 
@@ -181,13 +166,10 @@ bool InitLoops::run(LinearIR& linear_ir) {
         const auto loop_depth = expr_loops.size();
         for (size_t i = 0; i < loop_depth; ++i) {
             const auto loop_id = expr_loops[i];
-            if (loop_id == Expression::LOOP_NULL_ID)
-                continue;
-            bool need_to_insert = inserted_loops.find(loop_id) == inserted_loops.end();
-            if (need_to_insert) {
+            if (inserted_loops.count(loop_id) == 0) {
                 const auto loop_info = loop_manager->get_loop_info(loop_id);
                 const bool has_outer_loop = i > 0 && inserted_loops.find(expr_loops[i - 1]) != inserted_loops.end();
-                insertion(linear_ir, loop_info, loop_id, loop_depth - i - 1, has_outer_loop);
+                insertion(linear_ir, loop_info, loop_id, has_outer_loop);
                 inserted_loops.insert(loop_id);  // save Loop ID
             }
         }

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -22,7 +22,6 @@ LinearIR::constExprIt InsertBuffers::insertion_position(const LinearIR& linear_i
                                                         const ExpressionPtr& up_expr, const ExpressionPtr& down_expr) {
     const auto up_loops = up_expr->get_loop_ids();
     const auto down_loops = down_expr->get_loop_ids();
-    OPENVINO_ASSERT(up_loops != down_loops, "Buffer isn't supported in Inner Loop at the moment!");
     // If upper expression is out of Loop, we can insert Buffer implicitly after him
     if (up_loops.empty()) {
         const auto it = std::find(linear_ir.cbegin(), linear_ir.cend(), up_expr);

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -64,7 +64,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPt
                               const std::vector<LinearIR::LoopManager::LoopPort>& loop_entries,
                               const std::vector<LinearIR::LoopManager::LoopPort>& loop_exits) {
     for (const auto& entry_point : loop_entries) {
-        const auto& entry_port = entry_point.port;
+        const auto& entry_port = entry_point.expr_port;
         const auto& expr = entry_port->get_expr();
         const auto port = entry_port->get_index();
         const auto node = expr->get_node();
@@ -113,7 +113,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPt
     }
 
     for (const auto& exit_point : loop_exits) {
-        const auto& exit_port = exit_point.port;
+        const auto& exit_port = exit_point.expr_port;
         const auto& expr = exit_port->get_expr();
         const auto port = exit_port->get_index();
         const auto node = expr->get_node();

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -200,8 +200,8 @@ bool InsertBuffers::run(LinearIR& linear_ir) {
     const auto loop_data_map = loop_manager->get_map();
     for (const auto& loop_data : loop_data_map) {
         const auto loop_info = loop_data.second;
-        const auto loop_entries = loop_info->entry_exprs;
-        const auto loop_exits = loop_info->exit_exprs;
+        const auto loop_entries = loop_info->get_entry_ports();
+        const auto loop_exits = loop_info->get_exit_ports();
         insertion(linear_ir, loop_manager, loop_entries, loop_exits);
     }
 

--- a/src/common/snippets/src/lowered/pass/insert_load_store.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_load_store.cpp
@@ -28,8 +28,9 @@ void InsertLoadStore::update_loops(const LinearIR::LoopManagerPtr& loop_manager,
 
 void InsertLoadStore::update_loop(const LinearIR::LoopManager::LoopInfoPtr& loop_info,
                                   const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports, bool is_entry) {
-    auto& ports = is_entry ? loop_info->entry_exprs : loop_info->exit_exprs;
-    auto port_it = std::find(ports.begin(), ports.end(), actual_port);
+    auto& ports = is_entry ? loop_info->entry_points : loop_info->exit_points;
+    auto port_it = std::find_if(ports.begin(), ports.end(),
+                                [&actual_port](const LoopManager::LoopPoint& point) { return point.port == actual_port; });
     if (port_it == ports.end())
         return;
     port_it = ports.erase(port_it);

--- a/src/common/snippets/src/lowered/pass/insert_load_store.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_load_store.cpp
@@ -30,7 +30,7 @@ void InsertLoadStore::update_loop(const LinearIR::LoopManager::LoopInfoPtr& loop
                                   const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports, bool is_entry) {
     auto& ports = is_entry ? loop_info->entry_points : loop_info->exit_points;
     auto port_it = std::find_if(ports.begin(), ports.end(),
-                                [&actual_port](const LoopManager::LoopPort& point) { return point.port == actual_port; });
+                                [&actual_port](const LoopManager::LoopPort& point) { return *point.port.get() == actual_port; });
     if (port_it == ports.end())
         return;
     port_it = ports.erase(port_it);

--- a/src/common/snippets/src/lowered/pass/insert_load_store.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_load_store.cpp
@@ -30,7 +30,7 @@ void InsertLoadStore::update_loop(const LinearIR::LoopManager::LoopInfoPtr& loop
                                   const ExpressionPort& actual_port, const std::vector<ExpressionPort>& target_ports, bool is_entry) {
     auto& ports = is_entry ? loop_info->entry_points : loop_info->exit_points;
     auto port_it = std::find_if(ports.begin(), ports.end(),
-                                [&actual_port](const LoopManager::LoopPort& point) { return *point.port.get() == actual_port; });
+                                [&actual_port](const LoopManager::LoopPort& point) { return *point.expr_port.get() == actual_port; });
     if (port_it == ports.end())
         return;
     port_it = ports.erase(port_it);

--- a/src/common/snippets/src/lowered/pass/move_result_out_of_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/move_result_out_of_loop.cpp
@@ -34,15 +34,9 @@ bool MoveResultOutOfLoop::run(LinearIR& linear_ir) {
         const auto& input_connector = expr->get_input_port_connector(0);
         const auto& parent_expr = input_connector->get_source().get_expr();
         const auto parent_loop_ids = parent_expr->get_loop_ids();
-        int outer_loop_id = static_cast<int>(parent_loop_ids.size()) - 1;
-        for (; outer_loop_id >= 0; --outer_loop_id) {
-            if (parent_loop_ids[outer_loop_id] != Expression::LOOP_NULL_ID) {
-                break;
-            }
-        }
 
         // Parent is out of Loop: just verify that Result is after Parent
-        if (outer_loop_id < 0) {
+        if (parent_loop_ids.empty()) {
             const auto parent_it = std::find(forward_it, linear_ir.cend(), parent_expr);
             // If Parent is found after Result, we should move Result
             if (parent_it != linear_ir.cend()) {
@@ -56,7 +50,7 @@ bool MoveResultOutOfLoop::run(LinearIR& linear_ir) {
         }
 
         LinearIR::constExprIt loop_begin_pos, loop_end_pos;
-        loop_manager->get_loop_bounds(linear_ir, parent_loop_ids[outer_loop_id], loop_begin_pos, loop_end_pos);
+        loop_manager->get_loop_bounds(linear_ir, *(parent_loop_ids.cbegin()), loop_begin_pos, loop_end_pos);
         // If the Result isn't found after Outer LoopEnd, need to move it to there
         if (std::find(loop_end_pos, linear_ir.cend(), expr) == linear_ir.cend()) {
             expr_it = std::prev(expr_it);  // save iterator before moving

--- a/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
+++ b/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
@@ -111,11 +111,11 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
                 expr->add_outer_loop_ids(softmax_loop_ids, expr->get_loop_ids().back());
             }
 
-            auto update_loop_bounds = [&softmax_expr](std::vector<ExpressionPort>& points,
+            auto update_loop_bounds = [&softmax_expr](std::vector<LinearIR::LoopManager::LoopPoint>& points,
                                                      const std::vector<ExpressionPort>& new_points,
                                                      const LinearIR::LoopManager::LoopInfoPtr& loop_info) {
-                auto entry_found = std::find_if(points.begin(), points.end(), [&softmax_expr](const ExpressionPort& desc) {
-                    return desc.get_expr() == softmax_expr;
+                auto entry_found = std::find_if(points.begin(), points.end(), [&softmax_expr](const LinearIR::LoopManager::LoopPoint& point) {
+                    return point.port.get_expr() == softmax_expr;
                 });
                 if (entry_found != points.end()) {
                     entry_found = points.erase(entry_found);
@@ -126,9 +126,9 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
             // Update Loop info for outer loops
             for (auto loop_id : softmax_loop_ids) {
                 const auto loop_info = loop_manager->get_loop_info(loop_id);
-                update_loop_bounds(loop_info->entry_exprs, std::vector<ExpressionPort>{(*max.first)->get_input_port(0),
+                update_loop_bounds(loop_info->entry_points, std::vector<ExpressionPort>{(*max.first)->get_input_port(0),
                                                                                        (*sub.first)->get_input_port(0)}, loop_info);
-                update_loop_bounds(loop_info->exit_exprs, std::vector<ExpressionPort>{(*mul.first)->get_output_port(0)}, loop_info);
+                update_loop_bounds(loop_info->exit_points, std::vector<ExpressionPort>{(*mul.first)->get_output_port(0)}, loop_info);
             }
 
             /* =========================================== */

--- a/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
+++ b/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
@@ -108,13 +108,13 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
                     expr->set_loop_ids(softmax_loop_ids);
                     continue;
                 }
-                expr->add_outer_loop_ids(softmax_loop_ids, expr->get_loop_ids().back());
+                loop_manager->insert_loop_ids(expr, softmax_loop_ids, true, expr->get_loop_ids().back());
             }
 
-            auto update_loop_bounds = [&softmax_expr](std::vector<LinearIR::LoopManager::LoopPoint>& points,
+            auto update_loop_bounds = [&softmax_expr](std::vector<LinearIR::LoopManager::LoopPort>& points,
                                                      const std::vector<ExpressionPort>& new_points,
                                                      const LinearIR::LoopManager::LoopInfoPtr& loop_info) {
-                auto entry_found = std::find_if(points.begin(), points.end(), [&softmax_expr](const LinearIR::LoopManager::LoopPoint& point) {
+                auto entry_found = std::find_if(points.begin(), points.end(), [&softmax_expr](const LinearIR::LoopManager::LoopPort& point) {
                     return point.port.get_expr() == softmax_expr;
                 });
                 if (entry_found != points.end()) {

--- a/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
+++ b/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
@@ -43,26 +43,24 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
 
             expr_it = linear_ir.erase(expr_it);   // Remove Softmax
 
-            std::vector<ExpressionPtr> outer_exprs;
+            std::vector<ExpressionPtr> new_exprs;
 
             // We need an iterator to the inserted element
-            auto push_node = [&linear_ir, &expr_it, &softmax_loop_ids](const std::shared_ptr<Node>& n) {
+            auto push_node = [&linear_ir, &expr_it, &new_exprs](const std::shared_ptr<Node>& n) {
                 const auto expr = linear_ir.insert(expr_it, n);
-                (*expr)->set_loop_ids(softmax_loop_ids);
+                new_exprs.push_back(*expr);
                 return std::make_pair(expr, n);
             };
 
             // Note: VectorBuffer is a special case, since it should go before the initial Load. So we handle it separately
             const auto& vector_buffer_max = push_node(std::make_shared<op::VectorBuffer>());
-            outer_exprs.push_back(*vector_buffer_max.first);
             // ReduceMax loop
             const auto& max = push_node(std::make_shared<ov::op::v1::Maximum>(softmax->get_input_source_output(0), vector_buffer_max.second));
 
             const auto horizon_max = push_node(std::make_shared<op::HorizonMax>(max.second));
-            outer_exprs.push_back(*horizon_max.first);
 
             // Markup of ReduceMax Loop
-            loop_manager->mark_loop(max.first, horizon_max.first, 1, inner_work_amount, m_vector_size,
+            loop_manager->mark_loop(max.first, horizon_max.first, inner_work_amount, m_vector_size, 0,
                                     std::vector<ExpressionPort>{(*max.first)->get_input_port(0),
                                                                 (*max.first)->get_input_port(1)},
                                     std::vector<ExpressionPort>{(*max.first)->get_output_port(0)});
@@ -70,8 +68,6 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
             const auto broadcast_horizon_max = push_node(
                     std::make_shared<op::BroadcastMove>(horizon_max.second, horizon_max.second->get_input_partial_shape(0)));
             const auto vector_buffer_sum = push_node(std::make_shared<op::VectorBuffer>());
-            outer_exprs.push_back(*broadcast_horizon_max.first);
-            outer_exprs.push_back(*vector_buffer_sum.first);
 
             // Sub + Exp + ReduceSum Loop
             const auto sub = push_node(std::make_shared<ov::op::v1::Subtract>(softmax->get_input_source_output(0), broadcast_horizon_max.second));
@@ -79,10 +75,9 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
             const auto sum = push_node(std::make_shared<ov::op::v1::Add>(exp.second, vector_buffer_sum.second));
 
             const auto horizon_sum = push_node(std::make_shared<op::HorizonSum>(sum.second));
-            outer_exprs.push_back(*horizon_sum.first);
 
             // Markup of ReduceMax Loop
-            loop_manager->mark_loop(sub.first, horizon_sum.first, 1, inner_work_amount, m_vector_size,
+            loop_manager->mark_loop(sub.first, horizon_sum.first, inner_work_amount, m_vector_size, 0,
                                     std::vector<ExpressionPort>{(*sub.first)->get_input_port(0),
                                                                 (*sub.first)->get_input_port(1),
                                                                 (*sum.first)->get_input_port(1)},
@@ -92,8 +87,6 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
             // Divide is expensive operation, so we decompose it into 1 / x * y, where 1 / x is executed outside loop
             const auto pow = push_node(std::make_shared<op::PowerStatic>(horizon_sum.second, -1.f));
             const auto broadcast_pow = push_node(std::make_shared<op::BroadcastMove>(pow.second, horizon_sum.second->get_input_partial_shape(0)));
-            outer_exprs.push_back(*pow.first);
-            outer_exprs.push_back(*broadcast_pow.first);
 
             // Mul (pseudo-Divide loop)
             const auto mul = push_node(std::make_shared<ov::op::v1::Multiply>(exp.second, broadcast_pow.second));
@@ -104,14 +97,18 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
             linear_ir.replace_input(output_connector->get_consumers(), (*mul.first)->get_output_port_connector(0));
 
             // Markup of Mul Loop
-            loop_manager->mark_loop(mul.first, expr_it, 1, inner_work_amount, m_vector_size,
+            loop_manager->mark_loop(mul.first, expr_it, inner_work_amount, m_vector_size, 0,
                                     std::vector<ExpressionPort>{(*mul.first)->get_input_port(0),
                                                                 (*mul.first)->get_input_port(1)},
                                     std::vector<ExpressionPort>{(*mul.first)->get_output_port(0)});
 
-            // Markup inner loop for outside expression with null loop id
-            for (const auto& expr : outer_exprs) {
-                expr->set_loop_id(Expression::LOOP_NULL_ID, 1);
+            // Moved other Loop IDs from Softmax
+            for (const auto& expr : new_exprs) {
+                if (expr->get_loop_ids().empty()) {
+                    expr->set_loop_ids(softmax_loop_ids);
+                    continue;
+                }
+                expr->add_outer_loop_ids(softmax_loop_ids, expr->get_loop_ids().back());
             }
 
             auto update_loop_bounds = [&softmax_expr](std::vector<ExpressionPort>& points,
@@ -128,8 +125,6 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
 
             // Update Loop info for outer loops
             for (auto loop_id : softmax_loop_ids) {
-                if (loop_id == Expression::LOOP_NULL_ID)
-                    continue;
                 const auto loop_info = loop_manager->get_loop_info(loop_id);
                 update_loop_bounds(loop_info->entry_exprs, std::vector<ExpressionPort>{(*max.first)->get_input_port(0),
                                                                                        (*sub.first)->get_input_port(0)}, loop_info);

--- a/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
+++ b/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
@@ -115,7 +115,7 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
                                                      const std::vector<ExpressionPort>& new_points,
                                                      const LinearIR::LoopManager::LoopInfoPtr& loop_info) {
                 auto entry_found = std::find_if(points.begin(), points.end(), [&softmax_expr](const LinearIR::LoopManager::LoopPort& point) {
-                    return point.port->get_expr() == softmax_expr;
+                    return point.expr_port->get_expr() == softmax_expr;
                 });
                 if (entry_found != points.end()) {
                     entry_found = points.erase(entry_found);

--- a/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
+++ b/src/common/snippets/src/lowered/pass/softmax_decomposition.cpp
@@ -115,7 +115,7 @@ bool SoftmaxDecomposition::run(LinearIR& linear_ir) {
                                                      const std::vector<ExpressionPort>& new_points,
                                                      const LinearIR::LoopManager::LoopInfoPtr& loop_info) {
                 auto entry_found = std::find_if(points.begin(), points.end(), [&softmax_expr](const LinearIR::LoopManager::LoopPort& point) {
-                    return point.port.get_expr() == softmax_expr;
+                    return point.port->get_expr() == softmax_expr;
                 });
                 if (entry_found != points.end()) {
                     entry_found = points.erase(entry_found);

--- a/src/common/snippets/src/lowered/pass/validate_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_loops.cpp
@@ -1,0 +1,85 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/lowered/pass/validate_loops.hpp"
+
+#include "snippets/lowered/linear_ir.hpp"
+#include "snippets/lowered/loop_manager.hpp"
+#include "snippets/itt.hpp"
+
+namespace ov {
+namespace snippets {
+namespace lowered {
+namespace pass {
+
+using LoopPort = LinearIR::LoopManager::LoopPort;
+
+ValidateLoops::ValidateLoops() {}
+
+bool ValidateLoops::run(LinearIR& linear_ir) {
+    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::ValidateLoops")
+    if (linear_ir.empty())
+        return false;
+
+    const auto& loop_manager = linear_ir.get_loop_manager();
+    const auto& loops = loop_manager->get_map();
+
+    // Already validated vectors of Loop IDs
+    std::set<std::vector<size_t>> validated_nested_loops;
+    auto is_already_verified = [&validated_nested_loops](const std::vector<size_t>& ids) {
+        // If `ids` is subsequence of one of loop_ids in `validated_nested_loops` set,
+        // it means that `ids` is already validated too
+        for (const auto& loop : validated_nested_loops) {
+            if (std::search(ids.cbegin(), ids.cend(), loop.cbegin(), loop.cend()) != ids.cend()) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    std::vector<size_t> dim_indexes;
+
+    auto validate_loop_points = [&loop_manager, &dim_indexes, &validated_nested_loops, &is_already_verified](std::vector<LoopPort>& points) {
+        for (auto& point : points) {
+            const auto& port = point.port;
+            const auto expr = port.get_expr();
+            const auto loop_ids = expr->get_loop_ids();
+            // If loop_ids of the current port is subsequence of already validated IDs, skip
+            if (is_already_verified(loop_ids))
+                continue;
+
+            dim_indexes.clear();
+            dim_indexes.reserve(loop_ids.size());
+            // Outer Loop -> Inner Loop
+            for (size_t i = 0; i < loop_ids.size(); ++i) {
+                const auto id = loop_ids[i];
+                const auto dim_idx = loop_manager->get_loop_info(id)->dim_idx;
+                if (std::find(dim_indexes.cbegin(), dim_indexes.cend(), dim_idx) == dim_indexes.cend()) {
+                    dim_indexes.push_back(dim_idx);
+                } else {
+                    OPENVINO_ASSERT(*dim_indexes.rbegin() == dim_idx,
+                                    "Incorrect Loop ID configuration: the Loops with splitted dimension should be successively nested");
+                }
+                if (i > 0) {
+                    OPENVINO_ASSERT(loop_manager->get_loop_info(loop_ids[i - 1])->dim_idx >= dim_idx,
+                                    "Incorrect Loop ID configuration: The upper Loop, the upper the corresponding dim_idx");
+                }
+            }
+            validated_nested_loops.insert(loop_ids);
+        }
+    };
+
+    for (const auto& pair : loops) {
+        const auto& loop_info = pair.second;
+        validate_loop_points(loop_info->entry_points);
+        validate_loop_points(loop_info->exit_points);
+    }
+
+    return true;
+}
+
+} // namespace pass
+} // namespace lowered
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/src/lowered/pass/validate_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_loops.cpp
@@ -42,8 +42,7 @@ bool ValidateLoops::run(LinearIR& linear_ir) {
 
     auto validate_loop_points = [&loop_manager, &dim_indexes, &validated_nested_loops, &is_already_verified](std::vector<LoopPort>& points) {
         for (auto& point : points) {
-            const auto& port = point.port;
-            const auto expr = port.get_expr();
+            const auto expr = point.port->get_expr();
             const auto loop_ids = expr->get_loop_ids();
             // If loop_ids of the current port is subsequence of already validated IDs, skip
             if (is_already_verified(loop_ids))

--- a/src/common/snippets/src/lowered/pass/validate_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_loops.cpp
@@ -40,9 +40,9 @@ bool ValidateLoops::run(LinearIR& linear_ir) {
 
     std::vector<size_t> dim_indexes;
 
-    auto validate_loop_points = [&loop_manager, &dim_indexes, &validated_nested_loops, &is_already_verified](std::vector<LoopPort>& points) {
-        for (auto& point : points) {
-            const auto expr = point.port->get_expr();
+    auto validate_loop_ports = [&loop_manager, &dim_indexes, &validated_nested_loops, &is_already_verified](std::vector<LoopPort>& loop_ports) {
+        for (auto& loop_port : loop_ports) {
+            const auto expr = loop_port.expr_port->get_expr();
             const auto loop_ids = expr->get_loop_ids();
             // If loop_ids of the current port is subsequence of already validated IDs, skip
             if (is_already_verified(loop_ids))
@@ -62,7 +62,7 @@ bool ValidateLoops::run(LinearIR& linear_ir) {
                 }
                 if (i > 0) {
                     OPENVINO_ASSERT(loop_manager->get_loop_info(loop_ids[i - 1])->dim_idx >= dim_idx,
-                                    "Incorrect Loop ID configuration: The upper Loop, the upper the corresponding dim_idx");
+                                    "Incorrect Loop ID configuration: dim_idx should be sorted in accordance with loop nesting");
                 }
             }
             validated_nested_loops.insert(loop_ids);
@@ -71,8 +71,8 @@ bool ValidateLoops::run(LinearIR& linear_ir) {
 
     for (const auto& pair : loops) {
         const auto& loop_info = pair.second;
-        validate_loop_points(loop_info->entry_points);
-        validate_loop_points(loop_info->exit_points);
+        validate_loop_ports(loop_info->entry_points);
+        validate_loop_ports(loop_info->exit_points);
     }
 
     return true;

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -547,8 +547,6 @@ void snippets::op::Subgraph::control_flow_transformations(lowered::LinearIR& lin
     final_pipeline.register_pass<lowered::pass::CleanupLoopOffsets>();
     final_pipeline.run(linear_ir);
 
-    linear_ir.serialize("debug.xml", "debug.bin");
-
     m_buffer_scratchpad = buffer_allocation_pass->get_scratchpad_size();
 }
 

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -547,6 +547,8 @@ void snippets::op::Subgraph::control_flow_transformations(lowered::LinearIR& lin
     final_pipeline.register_pass<lowered::pass::CleanupLoopOffsets>();
     final_pipeline.run(linear_ir);
 
+    linear_ir.serialize("debug.xml", "debug.bin");
+
     m_buffer_scratchpad = buffer_allocation_pass->get_scratchpad_size();
 }
 

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -38,6 +38,7 @@
 #include "snippets/lowered/pass/move_result_out_of_loop.hpp"
 #include "snippets/lowered/pass/clean_repeated_ptr_shifts.hpp"
 #include "snippets/lowered/pass/identify_buffers.hpp"
+#include "snippets/lowered/pass/validate_loops.hpp"
 
 #include "transformations/utils/utils.hpp"
 
@@ -528,6 +529,7 @@ void snippets::op::Subgraph::control_flow_transformations(lowered::LinearIR& lin
     common_pipeline.register_pass<lowered::pass::MoveResultOutOfLoop>();
     common_pipeline.register_pass<lowered::pass::InsertBuffers>(buffer_allocation_rank);
     common_pipeline.register_pass<lowered::pass::InsertLoadStore>(vector_size);
+    //common_pipeline.register_pass<lowered::pass::ValidateLoops>();
     common_pipeline.register_pass<lowered::pass::InitLoops>();
     common_pipeline.register_pass<lowered::pass::MoveScalarToConsumer>();
     common_pipeline.register_pass<lowered::pass::LoadMoveBroadcastToBroadcastLoad>();

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -529,7 +529,7 @@ void snippets::op::Subgraph::control_flow_transformations(lowered::LinearIR& lin
     common_pipeline.register_pass<lowered::pass::MoveResultOutOfLoop>();
     common_pipeline.register_pass<lowered::pass::InsertBuffers>(buffer_allocation_rank);
     common_pipeline.register_pass<lowered::pass::InsertLoadStore>(vector_size);
-    //common_pipeline.register_pass<lowered::pass::ValidateLoops>();
+    common_pipeline.register_pass<lowered::pass::ValidateLoops>();
     common_pipeline.register_pass<lowered::pass::InitLoops>();
     common_pipeline.register_pass<lowered::pass::MoveScalarToConsumer>();
     common_pipeline.register_pass<lowered::pass::LoadMoveBroadcastToBroadcastLoad>();


### PR DESCRIPTION
### Details:
 - *Removed limitation for Loop IDs normalization. Now we don't need to normalize the count of nested Loops. It'd be different for expressions.*
 - *Allowed to disable incrementing of `LoopPort` in `LoopInfo`*

### Tickets:
 - *111497*
 
 
 ### Demo:
 We don't have tests for LinearIR infrastructure but anyway I've tried to emulate blocking for simple eltwise test `Add` with input shapes `[1x16x32x25],[1x16x32x25]` and `block_size = 4`.
 
 
![add_splitted_loops_comparison](https://github.com/openvinotoolkit/openvino/assets/43129309/4a66d59d-52dd-439d-a1fe-6961a1ba62c9)

