### PR TITLE
[PyOV] Bump `fastjsonschema` for dependabot

### DIFF
--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -9,7 +9,7 @@ PyYAML>=5.4.1
 scipy>=1.7
 wheel>=0.38.1
 defusedxml>=0.7.1
-fastjsonschema~=2.16.3
+fastjsonschema~=2.17.1
 test-generator==0.1.2
 requests>=2.25.1
 opencv-python>=4.5

--- a/tools/constraints.txt
+++ b/tools/constraints.txt
@@ -10,7 +10,7 @@ pytest>=5.0,<7.3
 protobuf>=3.18.1,<4.0.0
 defusedxml>=0.7.1
 requests>=2.25.1
-fastjsonschema>=2.15.1,<2.17
+fastjsonschema>=2.15.1,<2.18
 coverage>=4.4.2,<=7.0.5
 astroid>=2.9.0
 pylint>=2.7.0


### PR DESCRIPTION
### Details:
 - Dependabot failed the upgrade at https://github.com/openvinotoolkit/openvino/pull/17648 because of pip conflicts. An update to tools constraints was also needed.

### Tickets:
 - N/A
