### PR TITLE
MultiSubGraphOp ops optimization for common Constants

### DIFF
--- a/src/frontends/onnx/frontend/src/core/graph.cpp
+++ b/src/frontends/onnx/frontend/src/core/graph.cpp
@@ -477,8 +477,15 @@ Output<ngraph::Node> Subgraph::get_ng_node_from_cache(const std::string& name) {
         return m_cache->get_node(name);
     }
     const auto from_parent_node = m_parent_graph->get_ng_node_from_cache(name);
-    if (op::is_constant(from_parent_node.get_node()))
-        return from_parent_node;
+    const auto param_it =
+        std::find_if(std::begin(m_parameter_to_parent_node_map),
+                     std::end(m_parameter_to_parent_node_map),
+                     [&name](const std::pair<std::shared_ptr<ngraph::op::Parameter>, std::string>& it) {
+                         return it.second == name;
+                     });
+    if (param_it != std::end(m_parameter_to_parent_node_map)) {
+        return param_it->first;
+    }
     auto new_param = std::make_shared<ngraph::op::Parameter>(from_parent_node.get_element_type(),
                                                              from_parent_node.get_partial_shape());
     m_parameter_to_parent_node_map.insert({new_param, name});

--- a/src/frontends/onnx/frontend/src/op/if.cpp
+++ b/src/frontends/onnx/frontend/src/op/if.cpp
@@ -65,8 +65,8 @@ OutputVector if_op(const Node& node) {
                        std::end(then_branch_inputs_from_parent),
                        from_parent) == 0) {
             if_node->set_input(from_parent, nullptr, *else_param);
-            else_param++;
         }
+        else_param++;
     }
 
     NGRAPH_CHECK(then_branch->get_results().size() == else_branch->get_results().size(),

--- a/src/frontends/onnx/tests/onnx_import_controlflow.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_controlflow.in.cpp
@@ -773,7 +773,7 @@ NGRAPH_TEST(${BACKEND_NAME}, onnx_if_with_only_indentity_in_else_branch) {
                                 14.f,      16.f, 18.f,      20.f,      22.f,       24.f,     26.f,
                                 28.f,      30.f, 25.33333f, 27.f,      28.666667f, 30.33333f};
     test_case.add_input<float>(x);
-    test_case.add_expected_output<float>(expected);
+    test_case.add_expected_output<float>(Shape{1, 5, 2, 2}, expected);
     test_case.run();
 }
 


### PR DESCRIPTION
Ticket: 109208

The current state:
We can have a big Constant in the main `ov::Model` scope which is consumed inside `else` and `then` subgraphs of If. In the current state we have two copies of such `Costant` (inside subgraphs) in IR path.
The proposed solution: skip `PushConstantToSubgraph` for such a case, changing ONNX FE to use one `set_input` call for single `Constant` used in both branches.
Option 1 to consider: Changing deserialization (+ probably serialization) to avoid duplication of Constants allocation from the same memory of *.bin
Option 2 to consider: Marking such common Constants with some `RtInfo` during `set_input`  (not sure how to deal with subgraphs that can be const-folded in such a case)