### PR TITLE
Don't print check in case of throwing ov::Exception

### DIFF
--- a/src/core/src/except.cpp
+++ b/src/core/src/except.cpp
@@ -12,7 +12,11 @@ void ov::Exception::create(const CheckLocInfo& check_loc_info,
                            const std::string& context_info,
                            const std::string& explanation) {
     OPENVINO_SUPPRESS_DEPRECATED_START
-    throw ov::Exception(make_what(check_loc_info, context_info, explanation));
+    CheckLocInfo loc_info;
+    loc_info.file = check_loc_info.file;
+    loc_info.line = check_loc_info.line;
+    loc_info.check_string = nullptr;
+    throw ov::Exception(make_what(loc_info, context_info, explanation));
     OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
@@ -30,8 +34,12 @@ std::string ov::Exception::make_what(const CheckLocInfo& check_loc_info,
         return path.substr(project_root.length() + 1);
     };
     std::stringstream ss;
-    ss << "Check '" << check_loc_info.check_string << "' failed at " << getRelativePath(check_loc_info.file) << ":"
-       << check_loc_info.line;
+    if (check_loc_info.check_string) {
+        ss << "Check '" << check_loc_info.check_string << "' failed at " << getRelativePath(check_loc_info.file) << ":"
+            << check_loc_info.line;
+    } else {
+        ss << "Exception from " << getRelativePath(check_loc_info.file) << ":" << check_loc_info.line;
+    }
     if (!context_info.empty()) {
         ss << ":" << std::endl << context_info;
     }

--- a/src/core/src/except.cpp
+++ b/src/core/src/except.cpp
@@ -36,7 +36,7 @@ std::string ov::Exception::make_what(const CheckLocInfo& check_loc_info,
     std::stringstream ss;
     if (check_loc_info.check_string) {
         ss << "Check '" << check_loc_info.check_string << "' failed at " << getRelativePath(check_loc_info.file) << ":"
-            << check_loc_info.line;
+           << check_loc_info.line;
     } else {
         ss << "Exception from " << getRelativePath(check_loc_info.file) << ":" << check_loc_info.line;
     }


### PR DESCRIPTION
### Details:
 - Don't print `Check: 'false' at`

### Tickets:
 - *ticket-id*
