### PR TITLE
[PT FE] Align datatype precision mismatch in frozen layer tests

### DIFF
--- a/src/frontends/pytorch/src/op/add.cpp
+++ b/src/frontends/pytorch/src/op/add.cpp
@@ -26,7 +26,7 @@ OutputVector translate_add(const NodeContext& context) {
         // Case when two lists gets concatenated
         FRONT_END_OP_CONVERSION_CHECK(false, "aten::add is used for concatenation of lists, not possible to convert");
     }
-    align_eltwise_input_types(context, lhs, rhs, true);
+    align_eltwise_input_types(context, lhs, rhs, false);
     if (!context.input_is_none(2)) {
         auto converted_alpha = context.mark_node(std::make_shared<ov::op::v1::ConvertLike>(context.get_input(2), rhs));
         rhs = context.mark_node(std::make_shared<ov::op::v1::Multiply>(converted_alpha, rhs));

--- a/src/frontends/pytorch/src/utils.cpp
+++ b/src/frontends/pytorch/src/utils.cpp
@@ -351,13 +351,13 @@ void align_eltwise_input_types(const NodeContext& context, Output<Node>& lhs, Ou
     auto rhs_dst_type = rhs_type;
     if (is_lhs_scalar && lhs_type.is_real() && !rhs_type.is_real()) {
         // if div we need to also align float types to highest bitness regardless of scalar
-        if (!align_scalars)
+        if (!align_scalars && lhs.get_node_shared_ptr()->inputs().empty()) // Checking empty is quick workaround to check whether input is prim::Constant in layer tests, not suitable for production
             lhs_dst_type = element::f32;
         rhs_dst_type = element::f32;
     } else if (is_rhs_scalar && !lhs_type.is_real() && rhs_type.is_real()) {
         lhs_dst_type = element::f32;
         // if div we need to also align float types to highest bitness regardless of scalar
-        if (!align_scalars)
+        if (!align_scalars && rhs.get_node_shared_ptr()->inputs().empty()) // Checking empty is quick workaround to check whether input is prim::Constant in layer tests, not suitable for production
             rhs_dst_type = element::f32;
     } else if (is_lhs_scalar) {
         lhs = context.mark_node(std::make_shared<opset10::ConvertLike>(lhs, rhs));

--- a/src/frontends/pytorch/src/utils.hpp
+++ b/src/frontends/pytorch/src/utils.hpp
@@ -101,7 +101,7 @@ OutputVector translate_1to1_match_2_inputs_align_types(const NodeContext& contex
     FRONT_END_OP_CONVERSION_CHECK(!context.input_is_none(0) && !context.input_is_none(1), "Inputs should not be None.");
     auto lhs = context.get_input(0);
     auto rhs = context.get_input(1);
-    align_eltwise_input_types(context, lhs, rhs, true);
+    align_eltwise_input_types(context, lhs, rhs, false);
     return {context.mark_node(std::make_shared<T>(lhs, rhs))};
 }
 


### PR DESCRIPTION
### Details:
 - *Fix bug found in pytorch layer_tests that datatype precision of model might change when one of inputs to `align_eltwise_input_types` is folded to constant after freezing torch model.*
 - *...*

### Tickets:
 - *111838*
