### PR TITLE
[Benchmark_app] - Update comments and help text

### DIFF
--- a/samples/cpp/benchmark_app/README.md
+++ b/samples/cpp/benchmark_app/README.md
@@ -193,7 +193,7 @@ Running the application with the ``-h`` or ``--help`` option yields the followin
           -ip   <value>           Optional. Specifies precision for all input layers of the model.
           -op   <value>           Optional. Specifies precision for all output layers of the model.
           -iop  <value>           Optional. Specifies precision for input and output layers by name.
-                                                   Example: -iop "input:FP16, output:FP16".
+                                                   Example: -iop "input:f16, output:f16".
                                                    Notice that quotes are required.
                                                    Overwrites precision from ip and op options for specified layers.
           -mean_values   [R,G,B]  Optional. Mean values to be used for the input image per channel. Values to be provided in the [R,G,B] format. Can be defined for desired input of the    model, for example: "--mean_values data[255,255,255],info[255,255,255]". The exact meaning and order of channels depend on how the original model was trained. Applying the    values affects performance and may cause type conversion

--- a/samples/cpp/benchmark_app/benchmark_app.hpp
+++ b/samples/cpp/benchmark_app/benchmark_app.hpp
@@ -149,7 +149,7 @@ static constexpr char outputs_precision_message[] = "Optional. Specifies precisi
 
 static constexpr char iop_message[] =
     "Optional. Specifies precision for input and output layers by name.\n"
-    "                                             Example: -iop \"input:FP16, output:FP16\".\n"
+    "                                             Example: -iop \"input:f16, output:f16\".\n"
     "                                             Notice that quotes are required.\n"
     "                                             Overwrites precision from ip and op options for "
     "specified layers.";
@@ -329,7 +329,7 @@ DEFINE_string(ip, "", inputs_precision_message);
 DEFINE_string(op, "", outputs_precision_message);
 
 /// @brief Specify precision for input and output layers by name.\n"
-///        Example: -iop \"input:FP16, output:FP16\".\n"
+///        Example: -iop \"input:f16, output:f16\".\n"
 ///        Notice that quotes are required.\n"
 ///        Overwrites layout from ip and op options for specified layers.";
 DEFINE_string(iop, "", iop_message);


### PR DESCRIPTION
The issue is for the benchmark_app.exe, the -ip and -op params used to take the value “FP16”.  Now you must enter “F16”.  According to the help text, it still says ”FP16”

<img width="402" alt="image" src="https://github.com/openvinotoolkit/openvino/assets/52502732/9acde608-4aa5-4f6b-922d-f1897f86b998">

Copy of: https://github.com/openvinotoolkit/openvino/pull/17707