### PR TITLE
Calculate TensorView strides on demand not in ctor

### DIFF
--- a/src/inference/src/dev/make_tensor.cpp
+++ b/src/inference/src/dev/make_tensor.cpp
@@ -26,6 +26,7 @@ public:
           m_shape{shape},
           m_capacity{shape},
           m_strides{},
+          m_strides_once{},
           m_ptr{ptr} {
         OPENVINO_ASSERT(m_ptr != nullptr);
         OPENVINO_ASSERT(m_element_type != element::undefined && m_element_type.is_static());
@@ -61,7 +62,7 @@ public:
         OPENVINO_ASSERT(m_element_type.bitwidth() >= 8,
                         "Could not get strides for types with bitwidths less then 8 bit. Tensor type: ",
                         m_element_type);
-        update_strides();
+        std::call_once(m_strides_once, &ViewTensor::update_strides, this);
         return m_strides;
     }
 
@@ -86,6 +87,7 @@ protected:
     Shape m_shape;
     Shape m_capacity;
     mutable Strides m_strides;
+    mutable std::once_flag m_strides_once;
     void* m_ptr;
 };
 

--- a/src/inference/src/dev/make_tensor.cpp
+++ b/src/inference/src/dev/make_tensor.cpp
@@ -72,8 +72,11 @@ protected:
         if (!shape.empty()) {
             m_strides.resize(shape.size());
             m_strides.back() = m_element_type.size();
-            std::copy(shape.rbegin(), shape.rend() - 1, m_strides.rbegin() + 1);
-            std::partial_sum(m_strides.rbegin(), m_strides.rend(), m_strides.rbegin(), std::multiplies<size_t>());
+            std::transform(shape.crbegin(),
+                           shape.crend() - 1,
+                           m_strides.rbegin(),
+                           m_strides.rbegin() + 1,
+                           std::multiplies<size_t>());
         }
     }
 


### PR DESCRIPTION
### Details:
 - Improve the strides calculation performance by reduce number of loops (2 ->1). 
 - Move strides calculation from `TensorView` constructor to `get_strides` and `set_shape` member functions. Strides are calculated only once until (on demand) or when new shape is set. This change improve speed of tensor creation from `TensorView` as this type  of tensor is wrapper for existing memory and use default strides which not always is used.

### Tickets:
 - 111776
