### PR TITLE
[CPU] Skip PriorBox-8 tests.

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/priorbox.h
+++ b/src/plugins/intel_cpu/src/nodes/priorbox.h
@@ -4,10 +4,6 @@
 
 #pragma once
 
-#include <memory>
-#include <vector>
-
-#include <ie_common.h>
 #include <node.h>
 
 namespace ov {
@@ -16,7 +12,7 @@ namespace node {
 
 class PriorBox : public Node {
 public:
-    PriorBox(const std::shared_ptr<ngraph::Node>& op, const GraphContext::CPtr context);
+    PriorBox(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context);
 
     void getSupportedDescriptors() override {};
     void initSupportedPrimitiveDescriptors() override;
@@ -29,7 +25,7 @@ public:
 
     void executeDynamicImpl(dnnl::stream strm) override { execute(strm); }
 
-    static bool isSupportedOperation(const std::shared_ptr<const ngraph::Node>& op, std::string& errorMessage) noexcept;
+    static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
 private:
     float offset;

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -120,6 +120,8 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*smoke_FakeQuantizeLayerCPUTest.*bin.*)",
         // Issue: 69222
         R"(.*smoke_PriorBoxClustered.*PriorBoxClusteredLayerCPUTest.*_netPRC=f16_.*)",
+        // Skip the PriorBox from opset8 due to this is not supported by plugin and executed on reference.
+        R"(.*smoke_PriorBox_Basic/PriorBoxLayerTest.*)",
         // Issue: 72005
         // there are some inconsistency between cpu plugin and ng ref
         // for ctcMergeRepeated is true when legal randomized inputs value.

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/prior_box.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/prior_box.cpp
@@ -8,7 +8,6 @@
 
 #include <openvino/core/partial_shape.hpp>
 #include "ngraph_functions/builders.hpp"
-#include "shared_test_classes/base/layer_test_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "test_utils/cpu_test_utils.hpp"
 
@@ -61,7 +60,7 @@ public:
                  imageShapes,
                  targetDevice) = obj.param;
 
-        ngraph::op::PriorBoxAttrs attributes;
+        ov::op::v0::PriorBox::Attributes attributes;
         std::tie(
             attributes.min_size,
             attributes.max_size,
@@ -122,7 +121,7 @@ protected:
 
         init_input_shapes({ inputShapes, imageShapes });
 
-        ngraph::op::PriorBoxAttrs attributes;
+        ov::op::v0::PriorBox::Attributes attributes;
         std::tie(
             attributes.min_size,
             attributes.max_size,
@@ -139,15 +138,15 @@ protected:
 
         auto params = ngraph::builder::makeDynamicParams(netPrecision, inputDynamicShapes);
 
-        auto shape_of_1 = std::make_shared<ngraph::opset3::ShapeOf>(params[0]);
-        auto shape_of_2 = std::make_shared<ngraph::opset3::ShapeOf>(params[1]);
-        auto priorBox = std::make_shared<ngraph::op::PriorBox>(
+        auto shape_of_1 = std::make_shared<ov::op::v3::ShapeOf>(params[0]);
+        auto shape_of_2 = std::make_shared<ov::op::v3::ShapeOf>(params[1]);
+        auto priorBox = std::make_shared<ov::op::v0::PriorBox>(
                 shape_of_1,
                 shape_of_2,
                 attributes);
 
-        ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(priorBox)};
-        function = std::make_shared <ngraph::Function>(results, params, "priorBox");
+        ov::ResultVector results{std::make_shared<ov::op::v0::Result>(priorBox)};
+        function = std::make_shared <ov::Model>(results, params, "priorBox");
     }
 };
 


### PR DESCRIPTION
### Details:
 - *Shared tests for PriorBox are based on the opset8 version which is not supported by CPU plugin now. Actually they are executed on the ref implementation.*

### Tickets:
 - *98677*
