### PR TITLE
[CPU] In place memory for dynamic shapes

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -135,11 +135,11 @@ void Memory::update() {
     }
 }
 
-void Memory::Create(const MemoryDesc &desc, DnnlMemoryMngrPtr memMgr) {
+void Memory::Create(const MemoryDesc &desc, MemoryMngrPtr memMgr) {
     Create(desc.clone(), memMgr);
 }
 
-void Memory::Create(MemoryDescPtr desc, DnnlMemoryMngrPtr memMgr) {
+void Memory::Create(MemoryDescPtr desc, MemoryMngrPtr memMgr) {
     mgrHandle = DnnlMemMngrHandle(memMgr, this);
     bool memAllocated = mgrHandle->getRawPtr();
 

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -35,10 +35,10 @@ namespace {
 }   // namespace
 
 Memory::Memory(const dnnl::engine& eng, MemoryDescPtr desc, const void* data, bool pads_zeroing) :
+    pMemDesc(desc),
     eng(eng),
     mgrHandle(std::make_shared<DnnlMemoryMngr>(std::unique_ptr<MemoryMngrWithReuse>(new MemoryMngrWithReuse())), this),
-    dnnlMemHandle(this),
-    pMemDesc(desc) {
+    dnnlMemHandle(this) {
         Create(pMemDesc, data, pads_zeroing);
     }
 
@@ -46,7 +46,7 @@ Memory::Memory(const dnnl::engine& eng, const MemoryDesc& desc, const void* data
     Memory::Memory(eng, desc.clone(), data, pads_zeroing) {}
 
 Memory::Memory(const dnnl::engine& eng, MemoryDescPtr desc, MemoryMngrPtr mngr) :
-    eng(eng), pMemDesc(desc), mgrHandle(mngr, this), dnnlMemHandle(this) {
+    pMemDesc(desc), eng(eng), mgrHandle(mngr, this), dnnlMemHandle(this) {
         bool memAllocated = mgrHandle->getRawPtr();
 
         Create(desc, nullptr, !memAllocated);

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -286,7 +286,7 @@ void LockBasedMemoryMngr::setExtBuff(void* ptr, size_t size) {
 }
 bool LockBasedMemoryMngr::resize(size_t size) {
     std::lock_guard<std::mutex> guard(m_lock);
-    m_pMemMngr->resize(size);
+    return m_pMemMngr->resize(size);
 }
 bool LockBasedMemoryMngr::hasExtBuffer() const noexcept {
     std::lock_guard<std::mutex> guard(m_lock);

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -275,5 +275,30 @@ void DnnlMemoryMngr::notifyUpdate() {
         }
     }
 }
+
+void* LockBasedMemoryMngr::getRawPtr() const noexcept {
+    std::lock_guard<std::mutex> guard(m_lock);
+    return m_pMemMngr->getRawPtr();
+}
+void LockBasedMemoryMngr::setExtBuff(void* ptr, size_t size) {
+    std::lock_guard<std::mutex> guard(m_lock);
+    m_pMemMngr->setExtBuff(ptr, size);
+}
+bool LockBasedMemoryMngr::resize(size_t size) {
+    std::lock_guard<std::mutex> guard(m_lock);
+    m_pMemMngr->resize(size);
+}
+bool LockBasedMemoryMngr::hasExtBuffer() const noexcept {
+    std::lock_guard<std::mutex> guard(m_lock);
+    return m_pMemMngr->hasExtBuffer();
+}
+void LockBasedMemoryMngr::registerMemory(Memory* memPtr) {
+    std::lock_guard<std::mutex> guard(m_lock);
+    m_pMemMngr->registerMemory(memPtr);
+}
+void LockBasedMemoryMngr::unregisterMemory(Memory* memPtr) {
+    std::lock_guard<std::mutex> guard(m_lock);
+    m_pMemMngr->unregisterMemory(memPtr);
+}
 }   // namespace intel_cpu
 }   // namespace ov

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -93,13 +93,14 @@ void Memory::create(MemoryDescPtr desc, const void* data, bool pads_zeroing) {
     m_padsZeroing = pads_zeroing;
     dnnlMemHandle.resetDnnlPrim();
 
-    if (m_pMemDesc->isDefined()) {
-        auto memSize = m_pMemDesc->getCurrentMemSize();
-        if (nullptr != data) {
-            m_mgrHandle->setExtBuff(const_cast<void*>(data), memSize);
-        } else {
-            m_mgrHandle->resize(memSize);
-        }
+    if (!m_pMemDesc->isDefined()) {
+        return;
+    }
+    auto memSize = m_pMemDesc->getCurrentMemSize();
+    if (nullptr != data) {
+        m_mgrHandle->setExtBuff(const_cast<void*>(data), memSize);
+    } else {
+        m_mgrHandle->resize(memSize);
     }
 }
 

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -37,7 +37,7 @@ namespace {
 Memory::Memory(const dnnl::engine& eng, MemoryDescPtr desc, const void* data, bool pads_zeroing) :
     m_pMemDesc(desc),
     m_eng(eng),
-    m_mgrHandle(std::make_shared<DnnlMemoryMngr>(std::unique_ptr<MemoryMngrWithReuse>(new MemoryMngrWithReuse())), this),
+    m_mgrHandle(std::make_shared<DnnlMemoryMngr>(make_unique<MemoryMngrWithReuse>()), this),
     dnnlMemHandle(this) {
         create(m_pMemDesc, data, pads_zeroing);
     }

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -72,15 +72,13 @@ void Memory::create(MemoryDescPtr desc, const void* data, bool pads_zeroing) {
     m_padsZeroing = pads_zeroing;
     dnnlMemHandle.resetDnnlPrim();
 
-    size_t memSize = 0;
     if (m_pMemDesc->isDefined()) {
-        memSize = m_pMemDesc->getCurrentMemSize();
-    }
-
-    if (nullptr != data) {
-        m_mgrHandle->setExtBuff(const_cast<void*>(data), memSize);
-    } else {
-        m_mgrHandle->resize(memSize);
+        auto memSize = m_pMemDesc->getCurrentMemSize();
+        if (nullptr != data) {
+            m_mgrHandle->setExtBuff(const_cast<void*>(data), memSize);
+        } else {
+            m_mgrHandle->resize(memSize);
+        }
     }
 }
 

--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -116,6 +116,21 @@ private:
     std::unique_ptr<IMemoryMngr> _pMemMngr;
 };
 
+class LockBasedMemoryMngr : public IMemoryMngrObserver {
+public:
+    explicit LockBasedMemoryMngr(std::unique_ptr<IMemoryMngrObserver> mngr) : m_pMemMngr(std::move(mngr)) {}
+    void* getRawPtr() const noexcept override;
+    void setExtBuff(void* ptr, size_t size) override;
+    bool resize(size_t size) override;
+    bool hasExtBuffer() const noexcept override;
+    void registerMemory(Memory* memPtr) override;
+    void unregisterMemory(Memory* memPtr) override;
+
+private:
+    std::unique_ptr<IMemoryMngrObserver> m_pMemMngr;
+    mutable std::mutex m_lock;
+};
+
 using MemoryMngrPtr = std::shared_ptr<IMemoryMngrObserver>;
 using MemoryMngrCPtr = std::shared_ptr<const IMemoryMngrObserver>;
 

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
@@ -60,7 +60,6 @@ void DnnlPostOpsComposer::updateWeiScales() {
 
     DnnlBlockedMemoryDesc memoryDesc(InferenceEngine::Precision::FP32, Shape({wei_scale_values.size()}));
     auto mem = std::make_shared<Memory>(engine, memoryDesc);
-    // mem->Create(memoryDesc);
     memcpy(mem->GetData(), wei_scale_values.data(), wei_scale_values.size() * sizeof(float));
     args[DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS] = mem;
 }
@@ -74,7 +73,6 @@ void DnnlPostOpsComposer::updateDestScales() {
 
     DnnlBlockedMemoryDesc memoryDesc(InferenceEngine::Precision::FP32, Shape({1}));
     auto mem = std::make_shared<Memory>(engine, memoryDesc);
-    // mem->Create(memoryDesc);
     memcpy(mem->GetData(), &dst_scale_val, sizeof(float));
     args[DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST] = mem;
 }
@@ -93,7 +91,6 @@ void DnnlPostOpsComposer::appendBinary(const dnnl::algorithm alg, const std::vec
 
     // copy the data as args
     auto mem = std::make_shared<Memory>(engine, memoryDesc);
-    // mem->Create(memoryDesc);
     memcpy(mem->GetData(), data.data(), data.size() * sizeof(float));
     args[DNNL_ARG_ATTR_MULTIPLE_POST_OP(ops.len() - 1) | DNNL_ARG_SRC_1] = mem;
 }

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
@@ -59,9 +59,9 @@ void DnnlPostOpsComposer::updateWeiScales() {
     attr.set_scales_mask(DNNL_ARG_WEIGHTS, wei_scale_mask);
 
     DnnlBlockedMemoryDesc memoryDesc(InferenceEngine::Precision::FP32, Shape({wei_scale_values.size()}));
-    auto mem = std::make_shared<Memory>(engine);
-    mem->Create(memoryDesc);
-    memcpy(mem->GetPtr(), wei_scale_values.data(), wei_scale_values.size() * sizeof(float));
+    auto mem = std::make_shared<Memory>(engine, memoryDesc);
+    // mem->Create(memoryDesc);
+    memcpy(mem->GetData(), wei_scale_values.data(), wei_scale_values.size() * sizeof(float));
     args[DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS] = mem;
 }
 
@@ -73,9 +73,9 @@ void DnnlPostOpsComposer::updateDestScales() {
     attr.set_scales_mask(DNNL_ARG_DST, 0);
 
     DnnlBlockedMemoryDesc memoryDesc(InferenceEngine::Precision::FP32, Shape({1}));
-    auto mem = std::make_shared<Memory>(engine);
-    mem->Create(memoryDesc);
-    memcpy(mem->GetPtr(), &dst_scale_val, sizeof(float));
+    auto mem = std::make_shared<Memory>(engine, memoryDesc);
+    // mem->Create(memoryDesc);
+    memcpy(mem->GetData(), &dst_scale_val, sizeof(float));
     args[DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST] = mem;
 }
 
@@ -92,9 +92,9 @@ void DnnlPostOpsComposer::appendBinary(const dnnl::algorithm alg, const std::vec
     ops.append_binary(alg, memoryDesc.getDnnlDesc());
 
     // copy the data as args
-    auto mem = std::make_shared<Memory>(engine);
-    mem->Create(memoryDesc);
-    memcpy(mem->GetPtr(), data.data(), data.size() * sizeof(float));
+    auto mem = std::make_shared<Memory>(engine, memoryDesc);
+    // mem->Create(memoryDesc);
+    memcpy(mem->GetData(), data.data(), data.size() * sizeof(float));
     args[DNNL_ARG_ATTR_MULTIPLE_POST_OP(ops.len() - 1) | DNNL_ARG_SRC_1] = mem;
 }
 

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
@@ -60,7 +60,7 @@ void DnnlPostOpsComposer::updateWeiScales() {
 
     DnnlBlockedMemoryDesc memoryDesc(InferenceEngine::Precision::FP32, Shape({wei_scale_values.size()}));
     auto mem = std::make_shared<Memory>(engine, memoryDesc);
-    memcpy(mem->GetData(), wei_scale_values.data(), wei_scale_values.size() * sizeof(float));
+    memcpy(mem->getData(), wei_scale_values.data(), wei_scale_values.size() * sizeof(float));
     args[DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS] = mem;
 }
 
@@ -73,7 +73,7 @@ void DnnlPostOpsComposer::updateDestScales() {
 
     DnnlBlockedMemoryDesc memoryDesc(InferenceEngine::Precision::FP32, Shape({1}));
     auto mem = std::make_shared<Memory>(engine, memoryDesc);
-    memcpy(mem->GetData(), &dst_scale_val, sizeof(float));
+    memcpy(mem->getData(), &dst_scale_val, sizeof(float));
     args[DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST] = mem;
 }
 
@@ -91,7 +91,7 @@ void DnnlPostOpsComposer::appendBinary(const dnnl::algorithm alg, const std::vec
 
     // copy the data as args
     auto mem = std::make_shared<Memory>(engine, memoryDesc);
-    memcpy(mem->GetData(), data.data(), data.size() * sizeof(float));
+    memcpy(mem->getData(), data.data(), data.size() * sizeof(float));
     args[DNNL_ARG_ATTR_MULTIPLE_POST_OP(ops.len() - 1) | DNNL_ARG_SRC_1] = mem;
 }
 

--- a/src/plugins/intel_cpu/src/dnnl_scratch_pad.h
+++ b/src/plugins/intel_cpu/src/dnnl_scratch_pad.h
@@ -23,8 +23,8 @@ public:
     }
 
     MemoryPtr createScratchPadMem(const MemoryDescPtr& md) {
-        auto mem = std::make_shared<Memory>(eng);
-        mem->Create(md, mgrPtr);
+        auto mem = std::make_shared<Memory>(eng, std::unique_ptr<IMemoryMngr>(mgrPtr.get()), md);
+        // mem->Create(md, mgrPtr);
         return mem;
     }
 };

--- a/src/plugins/intel_cpu/src/dnnl_scratch_pad.h
+++ b/src/plugins/intel_cpu/src/dnnl_scratch_pad.h
@@ -23,8 +23,7 @@ public:
     }
 
     MemoryPtr createScratchPadMem(const MemoryDescPtr& md) {
-        auto mem = std::make_shared<Memory>(eng, std::unique_ptr<IMemoryMngr>(mgrPtr.get()), md);
-        // mem->Create(md, mgrPtr);
+        auto mem = std::make_shared<Memory>(eng, md, mgrPtr);
         return mem;
     }
 };

--- a/src/plugins/intel_cpu/src/dnnl_scratch_pad.h
+++ b/src/plugins/intel_cpu/src/dnnl_scratch_pad.h
@@ -14,7 +14,7 @@ namespace ov {
 namespace intel_cpu {
 
 class DnnlScratchPad {
-    DnnlMemoryMngrPtr mgrPtr;
+    MemoryMngrPtr mgrPtr;
     dnnl::engine eng;
 
 public:

--- a/src/plugins/intel_cpu/src/dnnl_scratch_pad.h
+++ b/src/plugins/intel_cpu/src/dnnl_scratch_pad.h
@@ -19,7 +19,7 @@ class DnnlScratchPad {
 
 public:
     DnnlScratchPad(dnnl::engine eng) : eng(eng) {
-        mgrPtr = std::make_shared<DnnlMemoryMngr>(std::unique_ptr<MemoryMngrWithReuse>(new MemoryMngrWithReuse()));
+        mgrPtr = std::make_shared<DnnlMemoryMngr>(make_unique<MemoryMngrWithReuse>());
     }
 
     MemoryPtr createScratchPadMem(const MemoryDescPtr& md) {

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -253,9 +253,6 @@ int Edge::getOutputNum() const {
 }
 
 void Edge::allocateCommon(const std::function<void(const MemoryPtr&, const MemoryDesc&)>& allocate) {
-    if (status != Status::NeedAllocation)
-        return;
-
     if (memoryPtr)
         IE_THROW() << "Unexpected behaviour: status == NeedAllocation but memory is already allocated.";
 

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -119,7 +119,7 @@ bool Edge::enforceReorder() {
         Type::Input == parentNode->getType() &&
         parentNode->isConstant()) {
         if (auto pInputNode = std::dynamic_pointer_cast<node::Input>(parentNode)) {
-            auto rawMemPtr = pInputNode->getMemoryPtr()->GetData();
+            auto rawMemPtr = pInputNode->getMemoryPtr()->getData();
             bool isAligned = (reinterpret_cast<uintptr_t>(rawMemPtr) & 15) == 0;
             if (!isAligned) {
                 return true;

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -304,9 +304,12 @@ void Edge::externalAllocate(WeightsSharing::Ptr weightsCache) {
 
     if (weightsCache) {
         auto alloc = [this] () {
-            auto threadSafeMngr =
-                std::make_shared<LockBasedMemoryMngr>(make_unique<DnnlMemoryMngr>(make_unique<MemoryMngrWithReuse>()));
-            allocate(threadSafeMngr);
+            auto allocateFunc = [this](const MemoryDesc& inputDesc) -> MemoryPtr {
+                auto parentPtr = getParent();
+                return std::make_shared<StaticMemory>(parentPtr->getEngine(), inputDesc, nullptr, false);  // no pads zeroing
+            };
+
+            allocateCommon(allocateFunc);
             return memoryPtr;
         };
 

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -303,7 +303,9 @@ void Edge::externalAllocate(WeightsSharing::Ptr weightsCache) {
 
     if (weightsCache) {
         auto alloc = [this] () {
-            allocate();
+            auto threadSafeMngr =
+                std::make_shared<LockBasedMemoryMngr>(make_unique<DnnlMemoryMngr>(make_unique<MemoryMngrWithReuse>()));
+            allocate(threadSafeMngr);
             return memoryPtr;
         };
 

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -413,7 +413,9 @@ const MemoryDesc& Edge::getDesc() const {
 }
 
 const IMemory &Edge::getMemory() {
-    return *getMemoryPtr();
+    auto memPtr = getMemoryPtr();
+    IE_ASSERT(memPtr != nullptr) << " Dereferencing NULL memory in edge: " << name();
+    return *memPtr;
 }
 
 MemoryPtr Edge::getMemoryPtr() const {

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -236,6 +236,7 @@ Edge::ReorderStatus Edge::needReorder() {
 }
 
 void Edge::reuse(MemoryPtr ptr) {
+    OPENVINO_ASSERT(ptr != nullptr, "Attempt to reuse initialized memory in " + name());
     memoryPtr = ptr;
     changeStatus(Status::Allocated);
 

--- a/src/plugins/intel_cpu/src/edge.h
+++ b/src/plugins/intel_cpu/src/edge.h
@@ -64,7 +64,8 @@ public:
     const std::shared_ptr<Node> getChild() const;
 
     const Memory& getMemory();
-    MemoryPtr& getMemoryPtr();
+    MemoryPtr getMemoryPtr() const;
+    void resetMemoryPtr(MemoryPtr mem);
 
     ReorderStatus needReorder();
     bool isDropped() const;

--- a/src/plugins/intel_cpu/src/edge.h
+++ b/src/plugins/intel_cpu/src/edge.h
@@ -51,7 +51,7 @@ public:
 
     void init();
     void allocate(const void* mem_ptr = nullptr);
-    void allocate(DnnlMemoryMngrPtr memMngr);
+    void allocate(MemoryMngrPtr memMngr);
     void externalAllocate(WeightsSharing::Ptr weightsCache);
     void reuse(MemoryPtr ptr);
     void validate();

--- a/src/plugins/intel_cpu/src/edge.h
+++ b/src/plugins/intel_cpu/src/edge.h
@@ -67,7 +67,7 @@ public:
     MemoryPtr getMemoryPtr() const;
 
     ReorderStatus needReorder();
-    NodePtr modifiedInPlace() const;
+    std::shared_ptr<Node> modifiedInPlace() const;
     bool isDropped() const;
     bool isUseExternalMemory() const;
 

--- a/src/plugins/intel_cpu/src/edge.h
+++ b/src/plugins/intel_cpu/src/edge.h
@@ -63,7 +63,7 @@ public:
     const std::shared_ptr<Node> getParent() const;
     const std::shared_ptr<Node> getChild() const;
 
-    const Memory& getMemory();
+    const IMemory& getMemory();
     MemoryPtr getMemoryPtr() const;
     void resetMemoryPtr(MemoryPtr mem);
 
@@ -108,7 +108,7 @@ private:
     void collectConsumers(std::vector<std::shared_ptr<Node>>& result) const;
 
     EdgePtr getBaseEdge(int look = LOOK_BOTH);
-    void allocateCommon(const std::function<void(const MemoryPtr&, const MemoryDesc&)>& allocate);
+    void allocateCommon(const std::function<void(MemoryPtr, const MemoryDesc&)>& allocate);
 
     friend class Graph;
 };

--- a/src/plugins/intel_cpu/src/edge.h
+++ b/src/plugins/intel_cpu/src/edge.h
@@ -67,6 +67,7 @@ public:
     MemoryPtr getMemoryPtr() const;
 
     ReorderStatus needReorder();
+    NodePtr modifiedInPlace() const;
     bool isDropped() const;
     bool isUseExternalMemory() const;
 

--- a/src/plugins/intel_cpu/src/edge.h
+++ b/src/plugins/intel_cpu/src/edge.h
@@ -43,11 +43,14 @@ public:
         No = 2
     };
 
+    enum LOOK { LOOK_UP = 1, LOOK_DOWN = 2, LOOK_BOTH = LOOK_UP | LOOK_DOWN };
+
     inline Status getStatus() const noexcept {
         return status;
     }
 
     void changeStatus(Status state);
+    bool inPlace(LOOK look = LOOK_BOTH) const;
 
     void init();
     void allocate(const void* mem_ptr = nullptr);
@@ -103,10 +106,7 @@ private:
 
     void collectConsumers(std::vector<std::shared_ptr<Node>>& result) const;
 
-    enum LOOK { LOOK_UP = 1, LOOK_DOWN = 2, LOOK_BOTH = LOOK_UP | LOOK_DOWN };
-
     EdgePtr getBaseEdge(int look = LOOK_BOTH);
-    bool inPlace(LOOK look = LOOK_BOTH) const;
     void allocateCommon(const std::function<void(const MemoryPtr&, const MemoryDesc&)>& allocate);
 
     friend class Graph;

--- a/src/plugins/intel_cpu/src/edge.h
+++ b/src/plugins/intel_cpu/src/edge.h
@@ -103,7 +103,7 @@ private:
 
     void collectConsumers(std::vector<std::shared_ptr<Node>>& result) const;
 
-    enum LOOK { LOOK_UP = 1, LOOK_DOWN = 2, LOOK_BOTH = LOOK_UP | LOOK_DOWN, LOOK_NO_RECURRENT = 4 };
+    enum LOOK { LOOK_UP = 1, LOOK_DOWN = 2, LOOK_BOTH = LOOK_UP | LOOK_DOWN };
 
     EdgePtr getBaseEdge(int look = LOOK_BOTH);
     bool inPlace(LOOK look = LOOK_BOTH) const;

--- a/src/plugins/intel_cpu/src/edge.h
+++ b/src/plugins/intel_cpu/src/edge.h
@@ -65,7 +65,6 @@ public:
 
     const IMemory& getMemory();
     MemoryPtr getMemoryPtr() const;
-    void resetMemoryPtr(MemoryPtr mem);
 
     ReorderStatus needReorder();
     bool isDropped() const;
@@ -108,7 +107,7 @@ private:
     void collectConsumers(std::vector<std::shared_ptr<Node>>& result) const;
 
     EdgePtr getBaseEdge(int look = LOOK_BOTH);
-    void allocateCommon(const std::function<void(MemoryPtr, const MemoryDesc&)>& allocate);
+    void allocateCommon(const std::function<MemoryPtr(const MemoryDesc&)>& allocate);
 
     friend class Graph;
 };

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -702,7 +702,7 @@ void Graph::InitEdges() {
 
     numberOfEdges = graphEdges.size(); //update the total number
 
-    for (auto i = 0; i < numberOfEdges; i++) {
+    for (ptrdiff_t i = 0; i < numberOfEdges; i++) {
         auto edge = graphEdges[i];
         if (needReorder(edge)) {
             constexpr bool optimizedReorder = false;
@@ -794,7 +794,7 @@ void Graph::AllocateWithReuse() {
 
     std::vector<MemorySolver::Box> definedBoxes;
     std::vector<MemorySolver::Box> undefinedBoxes;
-    for (int i = 0; i < remaining_edge_clusters_count; i++) {
+    for (size_t i = 0; i < remaining_edge_clusters_count; i++) {
         MemorySolver::Box box = { std::numeric_limits<int>::max(), 0, 0, static_cast<int64_t>(i) };
         int64_t boxSize = 0;
         for (auto &edge : edge_clusters[i]) {

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -354,12 +354,7 @@ void Graph::InitGraph() {
 
     InitDescriptors();
 
-    //TODO: move in a separate method
-    {
-        for (auto& node : graphNodes) {
-            resolveInPlaceDirection(node);
-        }
-    }
+    ResolveInplaceDirections();
 
     InitOptimalPrimitiveDescriptors();
 
@@ -460,6 +455,15 @@ void Graph::InitDescriptors() {
         node->selectOptimalPrimitiveDescriptor();
     }
 }
+
+void Graph::ResolveInplaceDirections() {
+     OV_ITT_SCOPED_TASK(itt::domains::intel_cpu, "Graph::ResolveInplaceDirections");
+
+    for (auto& node : graphNodes) {
+        resolveInPlaceDirection(node);
+    }
+}
+
 
 void Graph::InitOptimalPrimitiveDescriptors() {
     OV_ITT_SCOPED_TASK(itt::domains::intel_cpu, "Graph::InitOptimalPrimitiveDescriptors");

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -914,13 +914,8 @@ void Graph::AllocateWithReuse() {
                         } else {
                             auto sharedEdge = edge->getSharedEdge();
                             auto sharedEdgeParent = sharedEdge->getParent();
-                            if (sharedEdgeParent->isConstant()) {
-                                edge->allocate(sharedEdge->getMemoryPtr()->GetData());
-                                DEBUG_LOG(*edge, " const sharedEdge with ", *sharedEdge);
-                            } else {
-                                edge->allocate(sharedEdge->getMemoryPtr()->getMemoryMngr());
-                                DEBUG_LOG(*edge, " sharedEdge with ", *sharedEdge);
-                            }
+                            edge->allocate(sharedEdge->getMemoryPtr()->getMemoryMngr());
+                            DEBUG_LOG(*edge, " sharedEdge with ", *sharedEdge);
                         }
                     }
                 });

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -956,7 +956,15 @@ void Graph::AllocateWithReuse() {
                         } else if (edge->inPlace(Edge::LOOK_UP)) {
                             edge->getParent()->resolveInPlaceEdges(Edge::LOOK_UP);
                         } else {
-                            edge->getMemory();
+                            auto sharedEdge = edge->getSharedEdge();
+                            auto sharedEdgeParent = sharedEdge->getParent();
+                            if (sharedEdgeParent->isConstant()) {
+                                edge->allocate(sharedEdge->getMemoryPtr()->GetData());
+                                DEBUG_LOG(*edge, " const sharedEdge with ", *sharedEdge);
+                            } else {
+                                edge->allocate(sharedEdge->getMemoryPtr()->getMemoryMngr());
+                                DEBUG_LOG(*edge, " sharedEdge with ", *sharedEdge);
+                            }
                         }
                     }
                 });

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -354,6 +354,13 @@ void Graph::InitGraph() {
 
     InitDescriptors();
 
+    //TODO: move in a separate method
+    {
+        for (auto& node : graphNodes) {
+            resolveInPlaceDirection(node);
+        }
+    }
+
     InitOptimalPrimitiveDescriptors();
 
     InitEdges();
@@ -1562,6 +1569,7 @@ bool Graph::InsertNode(NodePtr parent, NodePtr child, NodePtr node, int parentPo
         node->initSupportedPrimitiveDescriptors();
         node->filterSupportedPrimitiveDescriptors();
         node->selectOptimalPrimitiveDescriptor();
+        resolveInPlaceDirection(node);
         node->initOptimalPrimitiveDescriptor();
     }
 
@@ -1673,6 +1681,105 @@ void Graph::EnforceInferencePrecision() {
 
 std::shared_ptr<ngraph::Function> Graph::dump() const {
     return dump_graph_as_ie_ngraph_net(*this);
+}
+
+void Graph::resolveInPlaceDirection(const NodePtr& node) const {
+    enum InplaceDirectionType {UP, DOWN, CYCLIC, NONE};
+    enum PortType {INPUT, OUTPUT};
+
+    auto inPlaceDirection = [](const NodePtr& node, PortType portType, int portNum) -> InplaceDirectionType {
+        if (PortType::INPUT == portType) {
+            auto inPlaceInpPort = node->inPlaceInputPort(portNum);
+            if (inPlaceInpPort >= 0) {
+                auto inPlaceOutPort = node->inPlaceOutPort(inPlaceInpPort);
+                if (inPlaceOutPort == inPlaceInpPort) {
+                    return InplaceDirectionType::CYCLIC;
+                } else if (inPlaceOutPort < 0) {
+                    return InplaceDirectionType::DOWN;
+                } else {
+                    IE_THROW() << "Non trivial inPlace memory dependency has been detected";
+                }
+            }
+            // the requested port has a negative inPlace tag, let's check whether it is referenced from the output
+            auto& config = node->getSelectedPrimitiveDescriptor()->getConfig();
+            for (auto& portConf : config.outConfs) {
+                if (portConf.inPlace() == portNum) {
+                    return InplaceDirectionType::UP;
+                }
+            }
+        } else if (PortType::OUTPUT == portType) {
+            auto inPlaceOutPort = node->inPlaceOutPort(portNum);
+            if (inPlaceOutPort >= 0) {
+                auto inPlaceInpPort = node->inPlaceInputPort(inPlaceOutPort);
+                if (inPlaceOutPort == inPlaceInpPort) {
+                    return InplaceDirectionType::CYCLIC;
+                } else if (inPlaceInpPort < 0) {
+                    return InplaceDirectionType::UP;
+                } else {
+                    IE_THROW() << "Non trivial inPlace memory dependency has been detected";
+                }
+            }
+            // the requested port has a negative inPlace tag, let's check whether it is referenced from the input
+            auto& config = node->getSelectedPrimitiveDescriptor()->getConfig();
+            for (auto& portConf : config.inConfs) {
+                if (portConf.inPlace() == portNum) {
+                    return InplaceDirectionType::DOWN;
+                }
+            }
+        }
+        return InplaceDirectionType::NONE;
+    };
+
+    auto& inpEdges = node->getParentEdges();
+    for (auto& wEdge : inpEdges) {
+        if (auto pEdge = wEdge.lock()) {
+            auto inpPort = pEdge->getOutputNum();
+            auto inPlaceInpPort = node->inPlaceInputPort(inpPort);
+            if (inPlaceInpPort >= 0 && inPlaceDirection(node, PortType::INPUT, inpPort) == InplaceDirectionType::CYCLIC) {
+                // inPlace memory cyclic dependency detected, need to resolve
+                // let's check the parent node first
+                auto pParent = pEdge->getParent();
+                auto parentInPlaceDirection = inPlaceDirection(pParent, PortType::OUTPUT, pEdge->getInputNum());
+                if (parentInPlaceDirection == InplaceDirectionType::UP) {
+                    auto config = node->getSelectedPrimitiveDescriptor()->getConfig();
+                    config.inConfs[inpPort].inPlace(-1);
+                    node->initDescriptor(config);
+                } else if (parentInPlaceDirection == InplaceDirectionType::DOWN) {
+                    auto config = node->getSelectedPrimitiveDescriptor()->getConfig();
+                    config.outConfs[inPlaceInpPort].inPlace(-1);
+                    node->initDescriptor(config);
+                } else {
+                    // the parent node does not use inPlace memory, let's check children
+                    std::function<InplaceDirectionType(const NodePtr& node, int portIdx)> searchNonCyclicDirection;
+                    searchNonCyclicDirection = [&](const NodePtr& node, int portIdx) -> InplaceDirectionType {
+                        auto& childEdges = node->getChildEdgesAtPort(portIdx);
+                        for (auto& edge : childEdges) {
+                            auto pChild = edge->getChild();
+                            auto result = inPlaceDirection(pChild, PortType::INPUT, edge->getOutputNum());
+                            if (InplaceDirectionType::UP == result || InplaceDirectionType::DOWN == result) {
+                                return result;
+                            } else if (InplaceDirectionType::CYCLIC == result) {
+                                return searchNonCyclicDirection(pChild, pChild->inPlaceInputPort(edge->getOutputNum()));
+                            }
+                        }
+                        return InplaceDirectionType::NONE;
+                    };
+                    auto result = searchNonCyclicDirection(node, inPlaceInpPort);
+                    if (one_of(result, InplaceDirectionType::UP, InplaceDirectionType::NONE)) {
+                        auto config = node->getSelectedPrimitiveDescriptor()->getConfig();
+                        config.inConfs[inpPort].inPlace(-1);
+                        node->initDescriptor(config);
+                    } else if (InplaceDirectionType::DOWN == result) {
+                        auto config = node->getSelectedPrimitiveDescriptor()->getConfig();
+                        config.outConfs[inPlaceInpPort].inPlace(-1);
+                        node->initDescriptor(config);
+                    } else {
+                        IE_THROW() << "A node without an inPlace memory cyclic dependency has not been found";
+                    }
+                }
+            }
+        }
+    }
 }
 
 }   // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -883,7 +883,7 @@ void Graph::AllocateWithReuse() {
         }
         for (auto& group : groups) {
             auto grpMemMngr =
-                std::make_shared<DnnlMemoryMngr>(std::unique_ptr<MemoryMngrWithReuse>(new MemoryMngrWithReuse()));
+                std::make_shared<DnnlMemoryMngr>(make_unique<MemoryMngrWithReuse>());
             for (auto& box : group) {
                 for (auto& edge : edge_clusters[box.id]) {
                     if (edge->getStatus() == Edge::Status::NeedAllocation) {

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -632,6 +632,84 @@ void Graph::InitEdges() {
             updateEdge(i);
         }
     }
+
+    // secondary pass to eliminate complex implace conflicts
+    std::function<NodePtr(const EdgePtr& edge)> findNodeModifyingMemory;
+    findNodeModifyingMemory = [&findNodeModifyingMemory](const EdgePtr& edge) -> NodePtr {
+        auto childNode = edge->getChild();
+        if (childNode && childNode->isInPlace()) {
+            // check if the children nodes are able to modify the memory
+            auto childPort = edge->getOutputNum();
+            auto inPlaceInputPort = childNode->inPlaceInputPort(childPort);
+            if (inPlaceInputPort >= 0) {
+                if (childNode->isExecutable()) {
+                    // Node can modify the memory
+                    return childNode;
+                }
+                for (auto&& edge : childNode->getChildEdgesAtPort(inPlaceInputPort)) {
+                    // continue searching
+                    if (auto result = findNodeModifyingMemory(edge)) {
+                        return result;
+                    }
+                }
+            }
+            // check backward dependency
+            if (auto childSPD = childNode->getSelectedPrimitiveDescriptor()) {
+                auto& outConfs = childSPD->getConfig().outConfs;
+                for (size_t i = 0; i < outConfs.size(); ++i) {
+                    const auto& conf = outConfs[i];
+                    if (childPort >= 0 && conf.inPlace() == childPort) {
+                        if (childNode->isExecutable()) {
+                            // Node can modify the memory
+                            return childNode;
+                        }
+                        for (auto&& edge : childNode->getChildEdgesAtPort(i)) {
+                            // continue searching
+                            if (auto result = findNodeModifyingMemory(edge)) {
+                                return result;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // nothing has been found
+        return nullptr;
+    };
+
+    auto needReorder = [&findNodeModifyingMemory](const EdgePtr& edge) -> bool {
+        int inNumber = edge->getInputNum();
+        const auto portChildEdges = edge->getParent()->getChildEdgesAtPort(inNumber);
+        if (portChildEdges.size() > 1) {
+            if (auto modifyingNode = findNodeModifyingMemory(edge)) {
+                auto execIndex = modifyingNode->getExecIndex();
+                for (auto pEdgePeer : portChildEdges) {
+                    if (pEdgePeer == edge)
+                        continue;
+                    std::vector<NodePtr> vecConsumers;
+                    pEdgePeer->collectConsumers(vecConsumers);
+
+                    for (auto node : vecConsumers) {
+                        if (node->getExecIndex() >= execIndex) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    };
+
+    numberOfEdges = graphEdges.size(); //update the total number
+
+    for (auto i = 0; i < numberOfEdges; i++) {
+        auto edge = graphEdges[i];
+        if (needReorder(edge)) {
+            constexpr bool optimizedReorder = false;
+            insertReorder(edge, optimizedReorder);
+            updateEdge(i);
+        }
+    }
 }
 
 static inline bool isConstOutput(EdgePtr edge) {

--- a/src/plugins/intel_cpu/src/graph.h
+++ b/src/plugins/intel_cpu/src/graph.h
@@ -229,6 +229,7 @@ protected:
     void ResolveInplaceDirections();
     void InitOptimalPrimitiveDescriptors();
     void InitEdges();
+    bool ProcessDynNodes();
     void Allocate();
     void AllocateWithReuse();
     void ExtractExecutableNodes();

--- a/src/plugins/intel_cpu/src/graph.h
+++ b/src/plugins/intel_cpu/src/graph.h
@@ -256,6 +256,8 @@ private:
     GraphContext::CPtr context;
 
     void EnforceInferencePrecision();
+    void EnforceBF16();
+    void resolveInPlaceDirection(const NodePtr& node) const;
 };
 
 }   // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/graph.h
+++ b/src/plugins/intel_cpu/src/graph.h
@@ -226,6 +226,7 @@ protected:
     void InitGraph();
     void InitNodes();
     void InitDescriptors();
+    void ResolveInplaceDirections();
     void InitOptimalPrimitiveDescriptors();
     void InitEdges();
     void Allocate();

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -242,7 +242,7 @@ void GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales(Graph &graph) {
         if (scalesBlob == nullptr)
             IE_THROW() << "Cannot cast to TBlob internal scales blob";
 
-        auto scalesData = static_cast<const float*>(scalesBlob->GetPtr());
+        auto scalesData = static_cast<const float*>(scalesBlob->GetData());
         if (scalesData == nullptr)
             IE_THROW() << "scalesBlob has not allocated buffer";
         auto scalesDims = getNormalizedDimsBySize(scales->getOutputShapeAtPort(0).getDims(),
@@ -768,7 +768,7 @@ void GraphOptimizer::FuseConvolutionAndZeroPoints(Graph &graph) {
         if (zeroPointsBlob == nullptr)
             IE_THROW() << "Cannot cast to TBlob internal zero points blob";
 
-        auto zeroPointsData = static_cast<const uint8_t*>(zeroPointsBlob->GetPtr());
+        auto zeroPointsData = static_cast<const uint8_t*>(zeroPointsBlob->GetData());
         if (zeroPointsData == nullptr)
             IE_THROW() << "zeroPointsBlob has not allocated buffer";
 
@@ -798,7 +798,7 @@ void GraphOptimizer::FuseConvolutionAndZeroPoints(Graph &graph) {
         if (weightsBlob == nullptr)
             IE_THROW() << "Cannot cast to TBlob internal weights blob";
 
-        auto weightsPtr = static_cast<const int8_t*>(weightsBlob->GetPtr());
+        auto weightsPtr = static_cast<const int8_t*>(weightsBlob->GetData());
         if (weightsPtr == nullptr)
             IE_THROW() << "weightsBlob has not allocated buffer";
 

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -242,7 +242,7 @@ void GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales(Graph &graph) {
         if (scalesBlob == nullptr)
             IE_THROW() << "Cannot cast to TBlob internal scales blob";
 
-        auto scalesData = static_cast<const float*>(scalesBlob->GetData());
+        auto scalesData = static_cast<const float*>(scalesBlob->getData());
         if (scalesData == nullptr)
             IE_THROW() << "scalesBlob has not allocated buffer";
         auto scalesDims = getNormalizedDimsBySize(scales->getOutputShapeAtPort(0).getDims(),
@@ -768,7 +768,7 @@ void GraphOptimizer::FuseConvolutionAndZeroPoints(Graph &graph) {
         if (zeroPointsBlob == nullptr)
             IE_THROW() << "Cannot cast to TBlob internal zero points blob";
 
-        auto zeroPointsData = static_cast<const uint8_t*>(zeroPointsBlob->GetData());
+        auto zeroPointsData = static_cast<const uint8_t*>(zeroPointsBlob->getData());
         if (zeroPointsData == nullptr)
             IE_THROW() << "zeroPointsBlob has not allocated buffer";
 
@@ -798,7 +798,7 @@ void GraphOptimizer::FuseConvolutionAndZeroPoints(Graph &graph) {
         if (weightsBlob == nullptr)
             IE_THROW() << "Cannot cast to TBlob internal weights blob";
 
-        auto weightsPtr = static_cast<const int8_t*>(weightsBlob->GetData());
+        auto weightsPtr = static_cast<const int8_t*>(weightsBlob->getData());
         if (weightsPtr == nullptr)
             IE_THROW() << "weightsBlob has not allocated buffer";
 

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -207,7 +207,7 @@ void InferRequestBase::changeDefaultPtr() {
         auto input = inputNodesMap.find(it.first);
         if (input != inputNodesMap.end()) {
             NodePtr inputNodePtr = input->second;
-            if (inputNodePtr->getChildEdgeAt(0)->getMemory().GetData() == it.second->buffer())
+            if (inputNodePtr->getChildEdgeAt(0)->getMemory().GetData() == static_cast<void*>(it.second->buffer()))
                 continue;
             auto& childEdges = inputNodePtr->getChildEdges();
             // Input cannot be in-place with other primitives

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -105,7 +105,7 @@ void InferRequestBase::PushStates() {
                     auto cur_state_mem = cur_node->getStore();
                     auto data_ptr = state->GetState()->cbuffer().as<void*>();
                     auto data_size = state->GetState()->byteSize();
-                    auto cur_state_mem_buf = static_cast<uint8_t*>(cur_state_mem->GetPtr());
+                    auto cur_state_mem_buf = static_cast<uint8_t*>(cur_state_mem->GetData());
 
                     cpu_memcpy(cur_state_mem_buf, data_ptr, data_size);
                 }
@@ -127,7 +127,7 @@ void InferRequestBase::PullStates() {
                     auto cur_state_mem = cur_node->getStore();
                     auto data_ptr = state->GetState()->cbuffer().as<void*>();
                     auto data_size = state->GetState()->byteSize();
-                    auto cur_state_mem_buf = static_cast<uint8_t*>(cur_state_mem->GetPtr());
+                    auto cur_state_mem_buf = static_cast<uint8_t*>(cur_state_mem->GetData());
 
                     cpu_memcpy(data_ptr, cur_state_mem_buf, data_size);
                 }

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -220,12 +220,9 @@ void InferRequestBase::changeDefaultPtr() {
                     break;
                 }
 
-                if (child->getType() == Type::Concatenation) {
-                    auto concat = dynamic_cast<node::Concat*>(child.get());
-                    if (concat && concat->isOptimized()) {
-                        canBeInPlace = false;
-                        break;
-                    }
+                if (child->getType() == Type::Concatenation && child->isInPlace()) {
+                    canBeInPlace = false;
+                    break;
                 }
 
                 // Cannot be in-place before split because split is using different ptrs without offsets

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -225,7 +225,7 @@ void InferRequestBase::changeDefaultPtr() {
                 }
 
                 // the input memory should be referenced by the children, otherwise it should be written to a
-                // specific location 
+                // specific location
                 if (ce->inPlace(Edge::LOOK_DOWN)) {
                     canBeInPlace = false;
                     break;

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -193,8 +193,12 @@ std::map<std::string, InferenceEngine::InferenceEngineProfileInfo> InferRequestB
     return perfMap;
 }
 
-static inline void changeEdgePtr(const EdgePtr &edge, void *newPtr) {
-    edge->getMemoryPtr()->setDataHandle(newPtr);
+static inline void changeEdgePtr(const EdgePtr &edge, InferenceEngine::Blob::Ptr blob) {
+    auto size = blob->byteSize();
+    auto& mem = edge->getMemory();
+    auto memMngr = mem.getMemoryMngr();
+    IE_ASSERT(memMngr);
+    memMngr->setExtBuff(blob->buffer(), size);
 }
 
 void InferRequestBase::changeDefaultPtr() {
@@ -203,7 +207,7 @@ void InferRequestBase::changeDefaultPtr() {
         auto input = inputNodesMap.find(it.first);
         if (input != inputNodesMap.end()) {
             NodePtr inputNodePtr = input->second;
-            if (inputNodePtr->getChildEdgeAt(0)->getMemory().GetData() == it.second)
+            if (inputNodePtr->getChildEdgeAt(0)->getMemory().GetData() == it.second->buffer())
                 continue;
             auto& childEdges = inputNodePtr->getChildEdges();
             // Input cannot be in-place with other primitives
@@ -225,28 +229,28 @@ void InferRequestBase::changeDefaultPtr() {
                     break;
                 }
 
-                // Cannot be in-place before split because split is using different ptrs without offsets
-                if (child->getType() == Type::Split) {
+                // // Cannot be in-place before split because split is using different ptrs without offsets
+                // if (child->getType() == Type::Split) {
+                //     canBeInPlace = false;
+                //     break;
+                // }
+
+                if (child->isInPlace() && child->getType() != Type::Split) {
                     canBeInPlace = false;
                     break;
                 }
 
-                if (child->isInPlace()) {
-                    canBeInPlace = false;
-                    break;
-                }
+                // auto& edges = child->getChildEdges();
+                // for (auto& edge : edges) {
+                //     auto e = edge.lock();
+                //     if (!e)
+                //         IE_THROW() << "Node " << child->getName() << " contains empty child edge";
 
-                auto& edges = child->getChildEdges();
-                for (auto& edge : edges) {
-                    auto e = edge.lock();
-                    if (!e)
-                        IE_THROW() << "Node " << child->getName() << " contains empty child edge";
-
-                    if (e->getMemory().GetData() == ce->getMemory().GetData()) {
-                        canBeInPlace = false;
-                        break;
-                    }
-                }
+                //     if (e->getMemory().GetData() == ce->getMemory().GetData()) {
+                //         canBeInPlace = false;
+                //         break;
+                //     }
+                // }
 
                 if (!canBeInPlace)
                     break;
@@ -268,7 +272,7 @@ void InferRequestBase::changeDefaultPtr() {
         auto output = outputNodesMap.find(it.first);
         if (output != outputNodesMap.end()) {
             auto parentEdge = output->second->getParentEdgeAt(0);
-            if (parentEdge->getMemory().GetData() == it.second)
+            if (parentEdge->getMemory().GetData() == static_cast<void*>(it.second->buffer()))
                 continue;
 
             bool canBeInPlace = true;
@@ -357,16 +361,16 @@ void LegacyInferRequest::changeDefaultPtr() {
     for (auto &it : inMap) {
         const auto &name = it.first;
         auto itr = externalPtr.find(name);
-        if (itr != externalPtr.end() && itr->second != _inputs[name]->buffer()) {
-            itr->second = _inputs[name]->buffer();
+        if (itr != externalPtr.end() && !(itr->second->buffer() == _inputs[name]->buffer())) {
+            itr->second = _inputs[name];
         }
     }
     const auto &outMap = graph->outputNodesMap;
     for (auto &it : outMap) {
         const auto &name = it.first;
         auto itr = externalPtr.find(name);
-        if (itr != externalPtr.end() && itr->second != _outputs[name]->buffer()) {
-            itr->second = _outputs[name]->buffer();
+        if (itr != externalPtr.end() && !(itr->second->buffer() == _outputs[name]->buffer())) {
+            itr->second = _outputs[name];
         }
     }
     InferRequestBase::changeDefaultPtr();
@@ -433,7 +437,7 @@ void LegacyInferRequest::SetBlob(const std::string& name, const InferenceEngine:
             auto pBlobDesc = MemoryDescUtils::interpretAsBlobDesc(graph->getInputNodeByName(name)->getChildEdgesAtPort(0)[0]->getMemory());
             if (data->getTensorDesc() == pBlobDesc &&
                 graph->_normalizePreprocMap.find(name) == graph->_normalizePreprocMap.end()) {
-                externalPtr[name] = data->buffer();
+                externalPtr[name] = data;
             } else if (externalPtr.find(name) != externalPtr.end()) {
                 externalPtr.erase(name);
             }
@@ -466,7 +470,7 @@ void LegacyInferRequest::SetBlob(const std::string& name, const InferenceEngine:
 
         auto pBlobDesc = MemoryDescUtils::interpretAsBlobDesc(graph->getOutputNodeByName(name)->getParentEdgesAtPort(0)[0]->getMemory());
         if (data->getTensorDesc() == pBlobDesc) {
-            externalPtr[name] = data->buffer();
+            externalPtr[name] = data;
         } else if (externalPtr.find(name) != externalPtr.end()) {
             externalPtr.erase(name);
         }
@@ -511,7 +515,7 @@ InferenceEngine::Blob::Ptr LegacyInferRequest::GetBlob(const std::string& name) 
             _inputs[name]->allocate();
             if (pBlob->getTensorDesc() == desc &&
                 graph->_normalizePreprocMap.find(name) == graph->_normalizePreprocMap.end()) {
-                externalPtr[name] = _inputs[name]->buffer();
+                externalPtr[name] = _inputs[name];
             }
         }
         data = _inputs[name];
@@ -573,7 +577,7 @@ InferenceEngine::Blob::Ptr LegacyInferRequest::GetBlob(const std::string& name) 
 
             _outputs[name] = data;
             if (!externalPtr.count(name) && data->getTensorDesc() == pBlobDesc) {
-                externalPtr[name] = data->buffer();
+                externalPtr[name] = data;
             }
         }
         data = _outputs[name];
@@ -689,8 +693,8 @@ void InferRequest::SetBlob(const std::string& name, const InferenceEngine::Blob:
                                                                                                                 blobDesc.getDims());
         }
         if (actualDesc->isCompatible(MemoryDescUtils::convertToCpuBlockedMemoryDesc(blobDesc)) &&
-                graph->_normalizePreprocMap.find(name) == graph->_normalizePreprocMap.end()) {
-            externalPtr[name] = data->buffer();
+            graph->_normalizePreprocMap.find(name) == graph->_normalizePreprocMap.end()) {
+            externalPtr[name] = data;
         } else if (externalPtr.find(name) != externalPtr.end()) {
             externalPtr.erase(name);
         }
@@ -722,7 +726,7 @@ void InferRequest::SetBlob(const std::string& name, const InferenceEngine::Blob:
 
         const auto &desc = graph->getOutputNodeByName(name)->getParentEdgesAtPort(0)[0]->getMemory().getDesc();
         if (!isDynamic && blobDesc == MemoryDescUtils::convertToTensorDesc(desc)) {
-            externalPtr[name] = data->buffer();
+            externalPtr[name] = data;
         } else if (externalPtr.find(name) != externalPtr.end()) {
             externalPtr.erase(name);
         }
@@ -769,8 +773,8 @@ InferenceEngine::Blob::Ptr InferRequest::GetBlob(const std::string& name) {
 
                 if (!isDynamic &&
                     desc == MemoryDescUtils::convertToTensorDesc(graph->getInputNodeByName(name)->getChildEdgesAtPort(0)[0]->getMemory().getDesc()) &&
-                        graph->_normalizePreprocMap.find(name) == graph->_normalizePreprocMap.end()) {
-                    externalPtr[name] = _inputs[name]->buffer();
+                    graph->_normalizePreprocMap.find(name) == graph->_normalizePreprocMap.end()) {
+                    externalPtr[name] = _inputs[name];
                 }
             } else {
                 IE_THROW() << "Blob with name: " << name << " exists in CPU plugin graph, but absents in network inputs";
@@ -829,7 +833,7 @@ InferenceEngine::Blob::Ptr InferRequest::GetBlob(const std::string& name) {
                 _outputs[name] = data;
                 if (!isDynamic && !externalPtr.count(name) &&
                     data->getTensorDesc() == MemoryDescUtils::convertToTensorDesc(output->second->getParentEdgesAtPort(0)[0]->getMemory().getDesc())) {
-                    externalPtr[name] = data->buffer();
+                    externalPtr[name] = data;
                 }
             } else {
                 IE_THROW() << "Blob with name: " << name << " exists in CPU plugin graph, but absents in network outputs";

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -105,7 +105,7 @@ void InferRequestBase::PushStates() {
                     auto cur_state_mem = cur_node->getStore();
                     auto data_ptr = state->GetState()->cbuffer().as<void*>();
                     auto data_size = state->GetState()->byteSize();
-                    auto cur_state_mem_buf = static_cast<uint8_t*>(cur_state_mem->GetData());
+                    auto cur_state_mem_buf = static_cast<uint8_t*>(cur_state_mem->getData());
 
                     cpu_memcpy(cur_state_mem_buf, data_ptr, data_size);
                 }
@@ -127,7 +127,7 @@ void InferRequestBase::PullStates() {
                     auto cur_state_mem = cur_node->getStore();
                     auto data_ptr = state->GetState()->cbuffer().as<void*>();
                     auto data_size = state->GetState()->byteSize();
-                    auto cur_state_mem_buf = static_cast<uint8_t*>(cur_state_mem->GetData());
+                    auto cur_state_mem_buf = static_cast<uint8_t*>(cur_state_mem->getData());
 
                     cpu_memcpy(data_ptr, cur_state_mem_buf, data_size);
                 }
@@ -207,7 +207,7 @@ void InferRequestBase::changeDefaultPtr() {
         auto input = inputNodesMap.find(it.first);
         if (input != inputNodesMap.end()) {
             NodePtr inputNodePtr = input->second;
-            if (inputNodePtr->getChildEdgeAt(0)->getMemory().GetData() == static_cast<void*>(it.second->buffer()))
+            if (inputNodePtr->getChildEdgeAt(0)->getMemory().getData() == static_cast<void*>(it.second->buffer()))
                 continue;
             auto& childEdges = inputNodePtr->getChildEdges();
             // Perform checks that the user's memory will not be modified
@@ -257,11 +257,11 @@ void InferRequestBase::changeDefaultPtr() {
         auto output = outputNodesMap.find(it.first);
         if (output != outputNodesMap.end()) {
             auto parentEdge = output->second->getParentEdgeAt(0);
-            if (parentEdge->getMemory().GetData() == static_cast<void*>(it.second->buffer()))
+            if (parentEdge->getMemory().getData() == static_cast<void*>(it.second->buffer()))
                 continue;
 
             bool canBeInPlace = true;
-            void* defaultPtr = parentEdge->getMemory().GetData();
+            void* defaultPtr = parentEdge->getMemory().getData();
             // Cannot be in-place after concat because concat is using different ptrs without offsets
             auto parent = parentEdge->getParent();
             NodePtr previousParent;
@@ -278,7 +278,7 @@ void InferRequestBase::changeDefaultPtr() {
                     if (!e)
                         IE_THROW() << "Node " << parent->getName() << " contains empty parent edge";
 
-                    if (e->getMemory().GetData() == defaultPtr) {
+                    if (e->getMemory().getData() == defaultPtr) {
                         parent = e->getParent();
                         break;
                     }

--- a/src/plugins/intel_cpu/src/infer_request.h
+++ b/src/plugins/intel_cpu/src/infer_request.h
@@ -56,7 +56,7 @@ protected:
     virtual void PushInputData() = 0;
 
     Graph* graph = nullptr;
-    std::unordered_map<std::string, void*> externalPtr;
+    std::unordered_map<std::string, InferenceEngine::Blob::Ptr> externalPtr;
 
 private:
     void PushStates();

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.cpp
@@ -89,7 +89,7 @@ BlockedMemoryDescPtr MemoryDescUtils::convertToBlockedMemoryDesc(const MemoryDes
     }
 }
 
-InferenceEngine::Blob::Ptr MemoryDescUtils::interpretAsBlob(const Memory &mem) {
+InferenceEngine::Blob::Ptr MemoryDescUtils::interpretAsBlob(const IMemory &mem) {
     // TODO [DS]: Rewrite when IE is moved to the new TensorDescriptor
     auto& memDesc = mem.getDesc();
     InferenceEngine::TensorDesc desc = convertToTensorDesc(memDesc);
@@ -98,7 +98,7 @@ InferenceEngine::Blob::Ptr MemoryDescUtils::interpretAsBlob(const Memory &mem) {
     return make_blob_with_precision(desc, mem.GetData());
 }
 
-InferenceEngine::TensorDesc MemoryDescUtils::interpretAsBlobDesc(const Memory &mem) {
+InferenceEngine::TensorDesc MemoryDescUtils::interpretAsBlobDesc(const IMemory &mem) {
     auto& memDesc = mem.getDesc();
     InferenceEngine::TensorDesc desc = convertToTensorDesc(memDesc);
 

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.cpp
@@ -95,7 +95,7 @@ InferenceEngine::Blob::Ptr MemoryDescUtils::interpretAsBlob(const IMemory &mem) 
     InferenceEngine::TensorDesc desc = convertToTensorDesc(memDesc);
 
     desc = InferenceEngine::TensorDesc(desc.getPrecision(), memDesc.getShape().getStaticDims(), desc.getBlockingDesc());
-    return make_blob_with_precision(desc, mem.GetData());
+    return make_blob_with_precision(desc, mem.getData());
 }
 
 InferenceEngine::TensorDesc MemoryDescUtils::interpretAsBlobDesc(const IMemory &mem) {

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.h
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.h
@@ -19,7 +19,7 @@ class DnnlMemoryDesc;
 class BlockedMemoryDesc;
 class DnnlBlockedMemoryDesc;
 class CpuBlockedMemoryDesc;
-class Memory;
+class IMemory;
 
 class MemoryDescUtils {
 public:
@@ -65,14 +65,14 @@ public:
      * @param desc Memory from which will be created InferenceEngine::Blob
      * @return pointer to InferenceEngine::Blob
      */
-    static InferenceEngine::Blob::Ptr interpretAsBlob(const Memory& mem);
+    static InferenceEngine::Blob::Ptr interpretAsBlob(const IMemory& mem);
 
     /**
      * @brief Creates InferenceEngine::TensorDesc from Memory with the memory reuse
      * @param desc Memory from which will be created InferenceEngine::Blob
      * @return InferenceEngine::TensorDesc
      */
-    static InferenceEngine::TensorDesc interpretAsBlobDesc(const Memory& mem);
+    static InferenceEngine::TensorDesc interpretAsBlobDesc(const IMemory& mem);
 
     /**
      * @brief Converts MemoryDesc to InferenceEngine::TensorDesc

--- a/src/plugins/intel_cpu/src/memory_state.h
+++ b/src/plugins/intel_cpu/src/memory_state.h
@@ -21,7 +21,7 @@ public:
         : InferenceEngine::IVariableStateInternal{name} {
         state = make_blob_with_precision(MemoryDescUtils::convertToTensorDesc(storage->getDesc()));
         state->allocate();
-        cpu_memcpy(state->buffer(), storage->GetData(), storage->GetSize());
+        cpu_memcpy(state->buffer(), storage->getData(), storage->getSize());
     }
 
     void Reset() override;

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -1471,12 +1471,15 @@ bool Node::isInputTensorAtPortEmpty(size_t port) const {
         IE_THROW() << "Incorrect input port number for node " << getName();
     }
 
-    if (inputShapes[port].isStatic()) {
-        return inputShapes[port].hasZeroDims();
+    if (inputShapes[port].hasZeroDims()) {
+        return true;
     } else {
-        auto& mem = getParentEdgesAtPort(port)[0]->getMemory();
-        if (mem.isAllocated()) {
-            return mem.getShape().hasZeroDims();
+        auto edge = getParentEdgesAtPort(port)[0];
+        if (one_of(edge->getStatus(), Edge::Status::Allocated, Edge::Status::Validated)) {
+            auto&& mem = edge->getMemory();
+            if (mem.isAllocated()) {
+                return mem.getShape().hasZeroDims();
+            }
         }
     }
     return false;

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -377,7 +377,7 @@ void Node::resolveInPlaceEdges(Edge::LOOK look) {
         for (size_t i = 0; i < getParentEdges().size() && i < selected_pd->getConfig().inConfs.size(); i++) {
             auto inplaceOutIndx = selected_pd->getConfig().inConfs[i].inPlace();
 
-            if (inplaceOutIndx < 0) //parentEdge->getStatus() != Edge::Status::NotAllocated ||
+            if (inplaceOutIndx < 0)
                 continue;
 
             auto parentEdge = getParentEdgeAt(i);
@@ -398,7 +398,7 @@ void Node::resolveInPlaceEdges(Edge::LOOK look) {
         for (size_t i = 0; i < getChildEdges().size() && i < selected_pd->getConfig().outConfs.size(); i++) {
             auto inplaceInpIndx = selected_pd->getConfig().outConfs[i].inPlace();
 
-            if (inplaceInpIndx < 0) //childEdge->getStatus() != Edge::Status::NotAllocated ||
+            if (inplaceInpIndx < 0)
                 continue;
 
             auto baseMemMngr = getParentEdgesAtPort(inplaceInpIndx).front()->getMemory().getMemoryMngr();
@@ -1473,13 +1473,12 @@ bool Node::isInputTensorAtPortEmpty(size_t port) const {
 
     if (inputShapes[port].hasZeroDims()) {
         return true;
-    } else {
-        auto edge = getParentEdgesAtPort(port)[0];
-        if (one_of(edge->getStatus(), Edge::Status::Allocated, Edge::Status::Validated)) {
-            auto&& mem = edge->getMemory();
-            if (mem.isAllocated()) {
-                return mem.getShape().hasZeroDims();
-            }
+    }
+    auto edge = getParentEdgesAtPort(port)[0];
+    if (one_of(edge->getStatus(), Edge::Status::Allocated, Edge::Status::Validated)) {
+        auto&& mem = edge->getMemory();
+        if (mem.isAllocated()) {
+            return mem.getShape().hasZeroDims();
         }
     }
     return false;
@@ -1491,11 +1490,10 @@ bool Node::isOutputTensorAtPortEmpty(size_t port) const {
     }
     if (outputShapes[port].isStatic()) {
         return outputShapes[port].hasZeroDims();
-    } else {
-        auto& mem = getChildEdgesAtPort(port)[0]->getMemory();
-        if (mem.isAllocated()) {
-            return mem.getShape().hasZeroDims();
-        }
+    }
+    auto&& mem = getChildEdgesAtPort(port)[0]->getMemory();
+    if (mem.isAllocated()) {
+        return mem.getShape().hasZeroDims();
     }
     return false;
 }

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -385,8 +385,8 @@ void Node::resolveInPlaceEdges(Edge::LOOK look) {
 
             auto baseMemMngr = getChildEdgesAtPort(inplaceOutIndx)[0]->getMemory().getMemoryMngr();
             auto memMngr = std::make_shared<PartitionedMemoryMngr>(baseMemMngr);
-            auto newMem = std::make_shared<Memory>(getEngine(), std::unique_ptr<IMemoryMngr>(memMngr.get()), selected_pd->getConfig().inConfs[i].getMemDesc());
-            parentEdge->resetMemoryPtr(newMem);
+            auto newMem = std::make_shared<Memory>(getEngine(), selected_pd->getConfig().inConfs[i].getMemDesc(), memMngr);
+            parentEdge->reuse(newMem);
         }
     }
     if (look & Edge::LOOK_UP) {
@@ -403,8 +403,8 @@ void Node::resolveInPlaceEdges(Edge::LOOK look) {
             for (auto& childEdge : childEdges) {
                 IE_ASSERT(childEdge->getStatus() == Edge::Status::NotAllocated) <<
                     " Unexpected inplace resolve call to an allocated edge: " << childEdge->name();
-                auto newMem = std::make_shared<Memory>(getEngine(), std::unique_ptr<IMemoryMngr>(memMngr.get()), selected_pd->getConfig().outConfs[i].getMemDesc());
-                childEdge->resetMemoryPtr(newMem);
+                auto newMem = std::make_shared<Memory>(getEngine(), selected_pd->getConfig().outConfs[i].getMemDesc(), memMngr);
+                childEdge->reuse(newMem);
             }
         }
     }

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -818,7 +818,7 @@ void Node::prepareMemory(const DnnlMemoryDescPtr& intDesc, size_t indx) {
         // TODO [DS]: internal blobs should be removed or rewritten using Memory object
         auto newDesc = MemoryDescUtils::convertToDnnlBlockedMemoryDesc(internalBlob->getTensorDesc());
 
-        Memory memory(engine, newDesc, internalBlob->buffer());
+        Memory memory{engine, newDesc, internalBlob->buffer()};
 
         MemoryPtr _ptr = std::make_shared<Memory>(engine, intDesc);
         node::Reorder::reorderData(memory, *_ptr, context->getParamsCache());

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -872,13 +872,13 @@ MemoryPtr Node::prepareWeightMemory(DnnlMemoryDescPtr weightDesc) {
     if (!edgeMem)
         IE_THROW() << "Cannot get const weights edgeMem for node " << getName() << ".";
 
-    auto constDnnlMemOutDesc = edgeMem->GetDescWithType<DnnlMemoryDesc>();
+    auto constDnnlMemOutDesc = edgeMem->getDescWithType<DnnlMemoryDesc>();
     auto weightSrcDesc = constDnnlMemOutDesc->getDnnlDesc();
     weightSrcDesc = weightSrcDesc.reshape(weightDesc->getDnnlDesc().get_dims());
     auto create = [&] () {
         auto newSrcDesc = DnnlExtensionUtils::makeDescriptor(weightSrcDesc);
 
-        Memory srcMemory{ getEngine(), newSrcDesc, edgeMem->GetData() };
+        Memory srcMemory{ getEngine(), newSrcDesc, edgeMem->getData() };
         MemoryPtr _ptr = std::make_shared<Memory>(getEngine(), weightDesc);
         node::Reorder::reorderData(srcMemory, *_ptr, context->getParamsCache());
 
@@ -894,8 +894,8 @@ MemoryPtr Node::prepareWeightMemory(DnnlMemoryDescPtr weightDesc) {
         auto weightCache = context->getWeightsCache();
         if (weightCache != nullptr) {
             const std::string string_hash = getName() + "_" + format
-                                            + "_" + std::to_string(edgeMem->GetSize())
-                                            + "_" + std::to_string(reinterpret_cast<uint64_t>(edgeMem->GetData()));
+                                            + "_" + std::to_string(edgeMem->getSize())
+                                            + "_" + std::to_string(reinterpret_cast<uint64_t>(edgeMem->getData()));
 
             ptr = *weightCache->findOrCreate(string_hash, create);
         } else {
@@ -1193,7 +1193,7 @@ void Node::appendPostOpArgs(const dnnl::primitive_attr& attr,
                             std::unordered_map<int, dnnl::memory>& primArgs,
                             const std::unordered_map<int, MemoryPtr>& postOpsArgs) {
     for (auto & entry : postOpsArgs) {
-        primArgs[entry.first] = entry.second->GetPrimitive();
+        primArgs[entry.first] = entry.second->getPrimitive();
     }
 }
 
@@ -1240,7 +1240,7 @@ std::vector<InferenceEngine::Precision> Node::getInputPrecisions() const {
     for (size_t i = 0; i < getParentEdges().size(); i++) {
         auto parentEdge = getParentEdgeAt(i);
         if (parentEdge && parentEdge->getStatus() == Edge::Status::Validated) {
-            inputPrecisions.emplace_back(DnnlExtensionUtils::DataTypeToIEPrecision((parentEdge->getMemoryPtr()->GetDataType())));
+            inputPrecisions.emplace_back(DnnlExtensionUtils::DataTypeToIEPrecision((parentEdge->getMemoryPtr()->getDataType())));
         }
     }
     return inputPrecisions;
@@ -1251,7 +1251,7 @@ std::vector<InferenceEngine::Precision> Node::getOutputPrecisions() const {
     for (size_t i = 0; i < getChildEdges().size(); i++) {
         auto childEdge = getChildEdgeAt(i);
         if (childEdge && childEdge->getStatus() == Edge::Status::Validated) {
-            outputPrecisions.emplace_back(DnnlExtensionUtils::DataTypeToIEPrecision((childEdge->getMemoryPtr()->GetDataType())));
+            outputPrecisions.emplace_back(DnnlExtensionUtils::DataTypeToIEPrecision((childEdge->getMemoryPtr()->getDataType())));
         }
     }
     return outputPrecisions;
@@ -1412,11 +1412,11 @@ std::pair<std::vector<float>, std::vector<float>> Node::getScalesAndShifts(const
             IE_THROW() << "Cannot cast " << constInput->getName() << " to Input";
         }
         auto constBlob = constInputNode->getMemoryPtr();
-        const auto elementsCount = constBlob->GetDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
+        const auto elementsCount = constBlob->getDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
         buffer.resize(elementsCount);
-        cpu_convert(constBlob->GetData(),
+        cpu_convert(constBlob->getData(),
                     &buffer[0],
-                    DnnlExtensionUtils::DataTypeToIEPrecision(constBlob->GetDataType()),
+                    DnnlExtensionUtils::DataTypeToIEPrecision(constBlob->getDataType()),
                     Precision::FP32,
                     elementsCount);
     };
@@ -1476,7 +1476,7 @@ bool Node::isInputTensorAtPortEmpty(size_t port) const {
     } else {
         auto& mem = getParentEdgesAtPort(port)[0]->getMemory();
         if (mem.isAllocated()) {
-            return mem.GetShape().hasZeroDims();
+            return mem.getShape().hasZeroDims();
         }
     }
     return false;
@@ -1491,7 +1491,7 @@ bool Node::isOutputTensorAtPortEmpty(size_t port) const {
     } else {
         auto& mem = getChildEdgesAtPort(port)[0]->getMemory();
         if (mem.isAllocated()) {
-            return mem.GetShape().hasZeroDims();
+            return mem.getShape().hasZeroDims();
         }
     }
     return false;

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -188,6 +188,9 @@ public:
     const std::vector<EdgePtr> getParentEdgesAtPort(size_t idx) const;
     const std::vector<EdgePtr> getChildEdgesAtPort(size_t idx) const;
 
+    int inPlaceInputPort(int portIdx) const;
+    int inPlaceOutPort(int portIdx) const;
+
     bool isDropped() {
         return (isEdgesEmpty(childEdges) && isEdgesEmpty(parentEdges));
     }
@@ -354,7 +357,7 @@ public:
 
     PerfCount &PerfCounter() { return perfCounter; }
 
-    void resolveInPlaceEdges();
+    virtual void resolveInPlaceEdges();
 
     virtual void execute(dnnl::stream strm) = 0;
     void updateShapes();

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -357,7 +357,7 @@ public:
 
     PerfCount &PerfCounter() { return perfCounter; }
 
-    virtual void resolveInPlaceEdges();
+    virtual void resolveInPlaceEdges(Edge::LOOK look = Edge::LOOK_BOTH);
 
     virtual void execute(dnnl::stream strm) = 0;
     void updateShapes();

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -199,7 +199,7 @@ public:
         return engine;
     }
 
-    bool isInPlace();
+    bool isInPlace() const;
 
     // must be called only after Graph::InitEdges()
     virtual bool isExecutable() const {
@@ -601,7 +601,7 @@ protected:
         Const,
         NoConst
     };
-    InPlaceType inplace = InPlaceType::Unknown;
+    mutable InPlaceType inplace = InPlaceType::Unknown;
     ConstantType constant = ConstantType::Unknown;
     std::vector<InferenceEngine::Blob::Ptr> internalBlobs;
     std::vector<MemoryPtr> internalBlobMemory;

--- a/src/plugins/intel_cpu/src/nodes/adaptive_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/adaptive_pooling.cpp
@@ -43,7 +43,7 @@ public:
         VectorDims outputDims(inputRank);
         outputDims[0] = inputDims[0];
         outputDims[1] = inputDims[1];
-        auto newSpatialDimsPtr = reinterpret_cast<int32_t *>(data_dependency.at(1)->GetData());
+        auto newSpatialDimsPtr = reinterpret_cast<int32_t *>(data_dependency.at(1)->getData());
         for (size_t i = 0; i < spatialDimsSize; i++) {
             outputDims[i + 2] = newSpatialDimsPtr[i];
         }
@@ -136,7 +136,7 @@ void AdaptivePooling::getSupportedDescriptors() {
 }
 
 bool AdaptivePooling::needShapeInfer() const {
-    const auto newSpatialDimsPtr = reinterpret_cast<int32_t *>(getParentEdgesAtPort(1)[0]->getMemoryPtr()->GetData());
+    const auto newSpatialDimsPtr = reinterpret_cast<int32_t *>(getParentEdgesAtPort(1)[0]->getMemoryPtr()->getData());
     for (int i = 0; i < spatialDimsCount; i++) {
         if (static_cast<int32_t>(spatialDimsValue[i]) != newSpatialDimsPtr[i]) {
             for (size_t j = 0; j < spatialDimsValue.size(); j++) {
@@ -184,8 +184,8 @@ void AdaptivePooling::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void AdaptivePooling::execute(dnnl::stream strm) {
-    auto inputPrec = getParentEdgeAt(0)->getMemory().GetDataType();
-    auto outputPrec = getChildEdgeAt(0)->getMemory().GetDataType();
+    auto inputPrec = getParentEdgeAt(0)->getMemory().getDataType();
+    auto outputPrec = getChildEdgeAt(0)->getMemory().getDataType();
     if (!(inputPrec == dnnl_f32 && outputPrec == dnnl_f32))
         IE_THROW() << errorPrefix << "doesn't support demanded precisions";
 
@@ -194,22 +194,22 @@ void AdaptivePooling::execute(dnnl::stream strm) {
     int *indexDst = nullptr;
 
     if (algorithm == Algorithm::AdaptivePoolingMax) {
-        indexDst = reinterpret_cast<int *>(getChildEdgeAt(1)->getMemoryPtr()->GetData());
+        indexDst = reinterpret_cast<int *>(getChildEdgeAt(1)->getMemoryPtr()->getData());
     }
 
     auto isPlainFmt = srcMemory0.getDesc().hasLayoutType(LayoutType::ncsp);
     auto isTailCFmt = srcMemory0.getDesc().hasLayoutType(LayoutType::nspc);
     auto isBlkFmt = srcMemory0.getDesc().hasLayoutType(LayoutType::nCsp16c) || srcMemory0.getDesc().hasLayoutType(LayoutType::nCsp8c);
 
-    auto srcBlockDesc = srcMemory0.GetDescWithType<BlockedMemoryDesc>();
+    auto srcBlockDesc = srcMemory0.getDescWithType<BlockedMemoryDesc>();
     int blockSize = isBlkFmt ? srcBlockDesc->getBlockDims().back() : 1;
 
-    const auto *src = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    const auto *srcPooledSpatialShapes = reinterpret_cast<const int *>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
-    auto *dst = reinterpret_cast<float *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *src = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    const auto *srcPooledSpatialShapes = reinterpret_cast<const int *>(getParentEdgeAt(1)->getMemoryPtr()->getData());
+    auto *dst = reinterpret_cast<float *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
-    if (static_cast<int>(srcMemory1.GetShape().getElementsCount()) != spatialDimsCount)
-        IE_THROW() << errorPrefix << "has input spatial dimension (" << srcMemory1.GetShape().getElementsCount()
+    if (static_cast<int>(srcMemory1.getShape().getElementsCount()) != spatialDimsCount)
+        IE_THROW() << errorPrefix << "has input spatial dimension (" << srcMemory1.getShape().getElementsCount()
                    << ") inconsistent with pooling vector size (" << spatialDimsCount << ")";
 
     auto inputDimVector = srcMemory0.getStaticDims();
@@ -226,14 +226,14 @@ void AdaptivePooling::execute(dnnl::stream strm) {
     const int iHW = IH * IW;
     const int oDHW = OD * OH * OW, oHW = OH * OW;
 
-    const int chPadding = blockSize * (isBlkFmt ? srcBlockDesc->getBlockDims()[1] : srcMemory0.GetShape().getStaticDims()[1]);
+    const int chPadding = blockSize * (isBlkFmt ? srcBlockDesc->getBlockDims()[1] : srcMemory0.getShape().getStaticDims()[1]);
     const int blockCount = (isTailCFmt ? 1 :  chPadding / blockSize);
     auto selectedPrimitiveDescriptor = getSelectedPrimitiveDescriptor();
     if (!selectedPrimitiveDescriptor)
         IE_THROW() << errorPrefix << "doesn't have primitive descriptors.";
     auto config = selectedPrimitiveDescriptor->getConfig();
     auto srcStrides = srcBlockDesc->getStrides();
-    auto dstStrides = getChildEdgesAtPort(0)[0]->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
+    auto dstStrides = getChildEdgesAtPort(0)[0]->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
 
     // unified strides array
     const size_t tailDimsOffset = (isTailCFmt ? -1 : 0);

--- a/src/plugins/intel_cpu/src/nodes/adaptive_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/adaptive_pooling.cpp
@@ -43,7 +43,7 @@ public:
         VectorDims outputDims(inputRank);
         outputDims[0] = inputDims[0];
         outputDims[1] = inputDims[1];
-        auto newSpatialDimsPtr = reinterpret_cast<int32_t *>(data_dependency.at(1)->GetPtr());
+        auto newSpatialDimsPtr = reinterpret_cast<int32_t *>(data_dependency.at(1)->GetData());
         for (size_t i = 0; i < spatialDimsSize; i++) {
             outputDims[i + 2] = newSpatialDimsPtr[i];
         }
@@ -136,7 +136,7 @@ void AdaptivePooling::getSupportedDescriptors() {
 }
 
 bool AdaptivePooling::needShapeInfer() const {
-    const auto newSpatialDimsPtr = reinterpret_cast<int32_t *>(getParentEdgesAtPort(1)[0]->getMemoryPtr()->GetPtr());
+    const auto newSpatialDimsPtr = reinterpret_cast<int32_t *>(getParentEdgesAtPort(1)[0]->getMemoryPtr()->GetData());
     for (int i = 0; i < spatialDimsCount; i++) {
         if (static_cast<int32_t>(spatialDimsValue[i]) != newSpatialDimsPtr[i]) {
             for (size_t j = 0; j < spatialDimsValue.size(); j++) {
@@ -194,7 +194,7 @@ void AdaptivePooling::execute(dnnl::stream strm) {
     int *indexDst = nullptr;
 
     if (algorithm == Algorithm::AdaptivePoolingMax) {
-        indexDst = reinterpret_cast<int *>(getChildEdgeAt(1)->getMemoryPtr()->GetPtr());
+        indexDst = reinterpret_cast<int *>(getChildEdgeAt(1)->getMemoryPtr()->GetData());
     }
 
     auto isPlainFmt = srcMemory0.getDesc().hasLayoutType(LayoutType::ncsp);
@@ -204,9 +204,9 @@ void AdaptivePooling::execute(dnnl::stream strm) {
     auto srcBlockDesc = srcMemory0.GetDescWithType<BlockedMemoryDesc>();
     int blockSize = isBlkFmt ? srcBlockDesc->getBlockDims().back() : 1;
 
-    const auto *src = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    const auto *srcPooledSpatialShapes = reinterpret_cast<const int *>(getParentEdgeAt(1)->getMemoryPtr()->GetPtr());
-    auto *dst = reinterpret_cast<float *>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const auto *src = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *srcPooledSpatialShapes = reinterpret_cast<const int *>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
+    auto *dst = reinterpret_cast<float *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
 
     if (static_cast<int>(srcMemory1.GetShape().getElementsCount()) != spatialDimsCount)
         IE_THROW() << errorPrefix << "has input spatial dimension (" << srcMemory1.GetShape().getElementsCount()

--- a/src/plugins/intel_cpu/src/nodes/batch_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/batch_to_space.cpp
@@ -102,21 +102,21 @@ static std::vector<size_t> getShape5D(const SizeVector &shape) {
 
 template<typename T>
 void BatchToSpace::batchToSpaceKernel() {
-    const auto *srcData = reinterpret_cast<const T *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    const auto *blockShapesPtr = reinterpret_cast<int *>(getParentEdgeAt(1)->getMemoryPtr()->GetPtr());
+    const auto *srcData = reinterpret_cast<const T *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *blockShapesPtr = reinterpret_cast<int *>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
     size_t dataRank = getParentEdgesAtPort(0)[0]->getMemoryPtr()->GetShape().getRank();
     blockShapeIn.clear();
     for (size_t i = 0; i < dataRank; i++) {
         blockShapeIn.push_back(*(blockShapesPtr + i));
     }
 
-    const auto *padsBeginPtr = reinterpret_cast<int *>(getParentEdgeAt(2)->getMemoryPtr()->GetPtr());
+    const auto *padsBeginPtr = reinterpret_cast<int *>(getParentEdgeAt(2)->getMemoryPtr()->GetData());
     cropsBeginIn.clear();
     for (size_t i = 0; i < dataRank; i++) {
         cropsBeginIn.push_back(*(padsBeginPtr + i));
     }
 
-    auto *dstData = reinterpret_cast<T *>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    auto *dstData = reinterpret_cast<T *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
 
     const auto &inDims = getParentEdgesAtPort(0)[0]->getMemory().getStaticDims();
     const auto &outDims = getChildEdgesAtPort(0)[0]->getMemory().getStaticDims();

--- a/src/plugins/intel_cpu/src/nodes/batch_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/batch_to_space.cpp
@@ -102,26 +102,26 @@ static std::vector<size_t> getShape5D(const SizeVector &shape) {
 
 template<typename T>
 void BatchToSpace::batchToSpaceKernel() {
-    const auto *srcData = reinterpret_cast<const T *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    const auto *blockShapesPtr = reinterpret_cast<int *>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
-    size_t dataRank = getParentEdgesAtPort(0)[0]->getMemoryPtr()->GetShape().getRank();
+    const auto *srcData = reinterpret_cast<const T *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    const auto *blockShapesPtr = reinterpret_cast<int *>(getParentEdgeAt(1)->getMemoryPtr()->getData());
+    size_t dataRank = getParentEdgesAtPort(0)[0]->getMemoryPtr()->getShape().getRank();
     blockShapeIn.clear();
     for (size_t i = 0; i < dataRank; i++) {
         blockShapeIn.push_back(*(blockShapesPtr + i));
     }
 
-    const auto *padsBeginPtr = reinterpret_cast<int *>(getParentEdgeAt(2)->getMemoryPtr()->GetData());
+    const auto *padsBeginPtr = reinterpret_cast<int *>(getParentEdgeAt(2)->getMemoryPtr()->getData());
     cropsBeginIn.clear();
     for (size_t i = 0; i < dataRank; i++) {
         cropsBeginIn.push_back(*(padsBeginPtr + i));
     }
 
-    auto *dstData = reinterpret_cast<T *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    auto *dstData = reinterpret_cast<T *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
     const auto &inDims = getParentEdgesAtPort(0)[0]->getMemory().getStaticDims();
     const auto &outDims = getChildEdgesAtPort(0)[0]->getMemory().getStaticDims();
 
-    auto srcDesc = getParentEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>();
+    auto srcDesc = getParentEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>();
 
     const bool blocked = srcDesc->hasLayoutType(LayoutType::nCsp8c) || srcDesc->hasLayoutType(LayoutType::nCsp16c);
     const auto dimsSize = inDims.size();
@@ -139,7 +139,7 @@ void BatchToSpace::batchToSpaceKernel() {
         blockShape.erase(blockShape.begin() + 1);
     }
 
-    auto dstDesc = getChildEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>();
+    auto dstDesc = getChildEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>();
 
     const size_t blockSize = blocked ? dstDesc->getBlockDims().back() : 1lu;
     const size_t blockCountInput = srcDesc->getBlockDims()[1];

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
@@ -1297,9 +1297,9 @@ void BinaryConvolution::executeReference(const uint8_t* src, const uint8_t* weig
 }
 
 void BinaryConvolution::execute(dnnl::stream strm) {
-    auto &srcMemory = getParentEdgeAt(0)->getMemoryPtr();
-    auto &weightsMemory = getParentEdgeAt(1)->getMemoryPtr();
-    auto &dstMemory = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemory = getParentEdgeAt(0)->getMemoryPtr();
+    auto weightsMemory = getParentEdgeAt(1)->getMemoryPtr();
+    auto dstMemory = getChildEdgeAt(0)->getMemoryPtr();
 
     auto src = reinterpret_cast<const uint8_t*>(srcMemory->GetPtr());
     auto weights = reinterpret_cast<const uint8_t*>(weightsMemory->GetPtr());

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
@@ -1301,23 +1301,23 @@ void BinaryConvolution::execute(dnnl::stream strm) {
     auto weightsMemory = getParentEdgeAt(1)->getMemoryPtr();
     auto dstMemory = getChildEdgeAt(0)->getMemoryPtr();
 
-    auto src = reinterpret_cast<const uint8_t*>(srcMemory->GetData());
-    auto weights = reinterpret_cast<const uint8_t*>(weightsMemory->GetData());
-    auto dst = reinterpret_cast<uint8_t*>(dstMemory->GetData());
+    auto src = reinterpret_cast<const uint8_t*>(srcMemory->getData());
+    auto weights = reinterpret_cast<const uint8_t*>(weightsMemory->getData());
+    auto dst = reinterpret_cast<uint8_t*>(dstMemory->getData());
 
-    auto srcDesc = getParentEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>();
+    auto srcDesc = getParentEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>();
     std::vector<size_t> srcStride(srcDesc->getStrides().size());
     for (size_t i = 0; i < srcStride.size(); i++) {
         srcStride[srcDesc->getOrder()[i]] = srcDesc->getStrides()[i];
     }
 
-    auto weiDesc = getParentEdgeAt(1)->getMemory().GetDescWithType<BlockedMemoryDesc>();
+    auto weiDesc = getParentEdgeAt(1)->getMemory().getDescWithType<BlockedMemoryDesc>();
     std::vector<size_t> weightsStride(weiDesc->getShape().getRank());
     for (size_t i = 0; i < weightsStride.size(); i++) {
         weightsStride[weiDesc->getOrder()[i]] = weiDesc->getStrides()[i];
     }
 
-    auto dstDesc = getChildEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>();
+    auto dstDesc = getChildEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>();
     std::vector<size_t> dstStride(dstDesc->getStrides().size());
     for (size_t i = 0; i < dstStride.size(); i++) {
         dstStride[dstDesc->getOrder()[i]] = dstDesc->getStrides()[i];

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
@@ -1301,9 +1301,9 @@ void BinaryConvolution::execute(dnnl::stream strm) {
     auto weightsMemory = getParentEdgeAt(1)->getMemoryPtr();
     auto dstMemory = getChildEdgeAt(0)->getMemoryPtr();
 
-    auto src = reinterpret_cast<const uint8_t*>(srcMemory->GetPtr());
-    auto weights = reinterpret_cast<const uint8_t*>(weightsMemory->GetPtr());
-    auto dst = reinterpret_cast<uint8_t*>(dstMemory->GetPtr());
+    auto src = reinterpret_cast<const uint8_t*>(srcMemory->GetData());
+    auto weights = reinterpret_cast<const uint8_t*>(weightsMemory->GetData());
+    auto dst = reinterpret_cast<uint8_t*>(dstMemory->GetData());
 
     auto srcDesc = getParentEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>();
     std::vector<size_t> srcStride(srcDesc->getStrides().size());

--- a/src/plugins/intel_cpu/src/nodes/broadcast.cpp
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.cpp
@@ -117,12 +117,12 @@ bool Broadcast::needPrepareParams() const {
 void Broadcast::prepareParams() {
     if (!constMap[TARGET_SHAPE_IDX]) {
         const auto& targetShapeMem = getParentEdgesAtPort(TARGET_SHAPE_IDX)[0]->getMemory();
-        const int32_t* targetShapeData = reinterpret_cast<const int32_t *>(targetShapeMem.GetPtr());
+        const int32_t* targetShapeData = reinterpret_cast<const int32_t *>(targetShapeMem.GetData());
         targetShape.assign(targetShapeData, targetShapeData + targetShapeMem.getStaticDims()[0]);
     }
     if (broadcastType == EXPLICIT && !constMap[AXES_MAPPING_IDX]) {
         const auto& axesMapMem = getParentEdgesAtPort(AXES_MAPPING_IDX)[0]->getMemory();
-        const int32_t* axesMapData = reinterpret_cast<const int32_t *>(axesMapMem.GetPtr());
+        const int32_t* axesMapData = reinterpret_cast<const int32_t *>(axesMapMem.GetData());
         axesMapping.assign(axesMapData, axesMapData + axesMapMem.getStaticDims()[0]);
     }
 
@@ -162,7 +162,7 @@ bool Broadcast::needShapeInfer() const {
         if (targetShape.empty()) {
             return true;
         }
-        const int32_t* targetShapeData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(TARGET_SHAPE_IDX)[0]->getMemory().GetPtr());
+        const int32_t* targetShapeData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(TARGET_SHAPE_IDX)[0]->getMemory().GetData());
         for (size_t i = 0lu; i < targetShape.size(); i++) {
             if (targetShape[i] != targetShapeData[i]) {
                 return true;
@@ -173,7 +173,7 @@ bool Broadcast::needShapeInfer() const {
         if (axesMapping.empty()) {
             return true;
         }
-        const int32_t* axesMappingData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(AXES_MAPPING_IDX)[0]->getMemory().GetPtr());
+        const int32_t* axesMappingData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(AXES_MAPPING_IDX)[0]->getMemory().GetData());
         for (size_t i = 0lu; i < axesMapping.size(); i++) {
             if (axesMapping[i] != axesMappingData[i]) {
                 return true;
@@ -231,8 +231,8 @@ void Broadcast::plainExecute(dnnl::stream strm) {
     }
 
     const size_t workAmountDst = dstStrides[0] * dstDims[0];
-    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr()->GetPtr());
-    auto *dstData = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr()->GetData());
+    auto *dstData = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
 
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t i = 0lu, srcIdx = 0lu, start = 0lu, end = 0lu;

--- a/src/plugins/intel_cpu/src/nodes/broadcast.cpp
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.cpp
@@ -117,21 +117,21 @@ bool Broadcast::needPrepareParams() const {
 void Broadcast::prepareParams() {
     if (!constMap[TARGET_SHAPE_IDX]) {
         const auto& targetShapeMem = getParentEdgesAtPort(TARGET_SHAPE_IDX)[0]->getMemory();
-        const int32_t* targetShapeData = reinterpret_cast<const int32_t *>(targetShapeMem.GetData());
+        const int32_t* targetShapeData = reinterpret_cast<const int32_t *>(targetShapeMem.getData());
         targetShape.assign(targetShapeData, targetShapeData + targetShapeMem.getStaticDims()[0]);
     }
     if (broadcastType == EXPLICIT && !constMap[AXES_MAPPING_IDX]) {
         const auto& axesMapMem = getParentEdgesAtPort(AXES_MAPPING_IDX)[0]->getMemory();
-        const int32_t* axesMapData = reinterpret_cast<const int32_t *>(axesMapMem.GetData());
+        const int32_t* axesMapData = reinterpret_cast<const int32_t *>(axesMapMem.getData());
         axesMapping.assign(axesMapData, axesMapData + axesMapMem.getStaticDims()[0]);
     }
 
-    const auto& srcDims = getParentEdgesAtPort(INPUT_DATA_IDX)[0]->getMemory().GetShape().getStaticDims();
+    const auto& srcDims = getParentEdgesAtPort(INPUT_DATA_IDX)[0]->getMemory().getShape().getStaticDims();
     repeats.assign(targetShape.begin(), targetShape.end());
     const auto ndims = repeats.size();
 
-    auto srcBlockedDims = getParentEdgeAt(INPUT_DATA_IDX)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getBlockDims();
-    auto dstBlockedDims = getChildEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getBlockDims();
+    auto srcBlockedDims = getParentEdgeAt(INPUT_DATA_IDX)->getMemory().getDescWithType<BlockedMemoryDesc>()->getBlockDims();
+    auto dstBlockedDims = getChildEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>()->getBlockDims();
 
     if (broadcastType == NUMPY) {
         for (size_t i = 0lu; i < srcDims.size(); i++) {
@@ -162,7 +162,7 @@ bool Broadcast::needShapeInfer() const {
         if (targetShape.empty()) {
             return true;
         }
-        const int32_t* targetShapeData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(TARGET_SHAPE_IDX)[0]->getMemory().GetData());
+        const int32_t* targetShapeData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(TARGET_SHAPE_IDX)[0]->getMemory().getData());
         for (size_t i = 0lu; i < targetShape.size(); i++) {
             if (targetShape[i] != targetShapeData[i]) {
                 return true;
@@ -173,7 +173,7 @@ bool Broadcast::needShapeInfer() const {
         if (axesMapping.empty()) {
             return true;
         }
-        const int32_t* axesMappingData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(AXES_MAPPING_IDX)[0]->getMemory().GetData());
+        const int32_t* axesMappingData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(AXES_MAPPING_IDX)[0]->getMemory().getData());
         for (size_t i = 0lu; i < axesMapping.size(); i++) {
             if (axesMapping[i] != axesMappingData[i]) {
                 return true;
@@ -203,10 +203,10 @@ void Broadcast::execute(dnnl::stream strm) {
 void Broadcast::plainExecute(dnnl::stream strm) {
     VectorDims srcDims = getParentEdgeAt(INPUT_DATA_IDX)->getMemory().getStaticDims();
     const auto& dstDims = getChildEdgeAt(0)->getMemory().getStaticDims();
-    const auto& dataSrcRank = getParentEdgeAt(INPUT_DATA_IDX)->getMemory().GetShape().getRank();
-    const auto& dataDstRank = getChildEdgeAt(0)->getMemory().GetShape().getRank();
+    const auto& dataSrcRank = getParentEdgeAt(INPUT_DATA_IDX)->getMemory().getShape().getRank();
+    const auto& dataDstRank = getChildEdgeAt(0)->getMemory().getShape().getRank();
 
-    auto srcDesc = getParentEdgeAt(INPUT_DATA_IDX)->getMemory().GetDescWithType<BlockedMemoryDesc>();
+    auto srcDesc = getParentEdgeAt(INPUT_DATA_IDX)->getMemory().getDescWithType<BlockedMemoryDesc>();
     VectorDims srcStrides = srcDesc->getStrides();
     const size_t dataSize = srcDesc->getPrecision().size();
 
@@ -215,7 +215,7 @@ void Broadcast::plainExecute(dnnl::stream strm) {
     if (!srcStrides.size())
         srcStrides = VectorDims(1, 1);
 
-    auto dstDesc = getChildEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>();
+    auto dstDesc = getChildEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>();
     VectorDims dstStrides = dstDesc->getStrides();
     VectorDims srcAligned(dataDstRank);
     VectorDims srcStridesAligned(dataDstRank);
@@ -231,8 +231,8 @@ void Broadcast::plainExecute(dnnl::stream strm) {
     }
 
     const size_t workAmountDst = dstStrides[0] * dstDims[0];
-    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr()->GetData());
-    auto *dstData = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr()->getData());
+    auto *dstData = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t i = 0lu, srcIdx = 0lu, start = 0lu, end = 0lu;

--- a/src/plugins/intel_cpu/src/nodes/bucketize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.cpp
@@ -177,9 +177,9 @@ void Bucketize::execute(dnnl::stream strm) {
 }
 
 void Bucketize::prepareParams() {
-    auto& inputTensorMemPtr = getParentEdgeAt(INPUT_TENSOR_PORT)->getMemoryPtr();
-    auto& inputBinsMemPtr = getParentEdgeAt(INPUT_BINS_PORT)->getMemoryPtr();
-    auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto inputTensorMemPtr = getParentEdgeAt(INPUT_TENSOR_PORT)->getMemoryPtr();
+    auto inputBinsMemPtr = getParentEdgeAt(INPUT_BINS_PORT)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         IE_THROW() << "Destination memory didn't allocate.";
     if (!inputTensorMemPtr || !inputTensorMemPtr->isAllocated())

--- a/src/plugins/intel_cpu/src/nodes/bucketize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.cpp
@@ -213,9 +213,9 @@ bool Bucketize::isExecutable() const {
 
 template <typename T, typename T_BOUNDARIES, typename T_IND>
 void Bucketize::bucketize() {
-    const auto *input_data = reinterpret_cast<const T *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    const auto *boundaries_data = reinterpret_cast<const T_BOUNDARIES *>(getParentEdgeAt(1)->getMemoryPtr()->GetPtr());
-    auto *output_data = reinterpret_cast<T_IND *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetPtr());
+    const auto *input_data = reinterpret_cast<const T *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *boundaries_data = reinterpret_cast<const T_BOUNDARIES *>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
+    auto *output_data = reinterpret_cast<T_IND *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
 
     if (!with_bins) {
         memset(output_data, 0, num_values * sizeof(T_IND));

--- a/src/plugins/intel_cpu/src/nodes/bucketize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.cpp
@@ -213,9 +213,9 @@ bool Bucketize::isExecutable() const {
 
 template <typename T, typename T_BOUNDARIES, typename T_IND>
 void Bucketize::bucketize() {
-    const auto *input_data = reinterpret_cast<const T *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    const auto *boundaries_data = reinterpret_cast<const T_BOUNDARIES *>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
-    auto *output_data = reinterpret_cast<T_IND *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
+    const auto *input_data = reinterpret_cast<const T *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    const auto *boundaries_data = reinterpret_cast<const T_BOUNDARIES *>(getParentEdgeAt(1)->getMemoryPtr()->getData());
+    auto *output_data = reinterpret_cast<T_IND *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
 
     if (!with_bins) {
         memset(output_data, 0, num_values * sizeof(T_IND));

--- a/src/plugins/intel_cpu/src/nodes/color_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/color_convert.cpp
@@ -1026,11 +1026,11 @@ InferenceEngine::Precision ColorConvert::Converter::outputPrecision(size_t idx) 
 }
 
 const void * ColorConvert::Converter::input(size_t idx) const {
-    return _node->getParentEdgeAt(idx)->getMemoryPtr()->GetPtr();
+    return _node->getParentEdgeAt(idx)->getMemoryPtr()->GetData();
 }
 
 void * ColorConvert::Converter::output(size_t idx) const {
-    return _node->getChildEdgeAt(idx)->getMemoryPtr()->GetPtr();
+    return _node->getChildEdgeAt(idx)->getMemoryPtr()->GetData();
 }
 
 const VectorDims & ColorConvert::Converter::inputDims(size_t idx) const {

--- a/src/plugins/intel_cpu/src/nodes/color_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/color_convert.cpp
@@ -1026,11 +1026,11 @@ InferenceEngine::Precision ColorConvert::Converter::outputPrecision(size_t idx) 
 }
 
 const void * ColorConvert::Converter::input(size_t idx) const {
-    return _node->getParentEdgeAt(idx)->getMemoryPtr()->GetData();
+    return _node->getParentEdgeAt(idx)->getMemoryPtr()->getData();
 }
 
 void * ColorConvert::Converter::output(size_t idx) const {
-    return _node->getChildEdgeAt(idx)->getMemoryPtr()->GetData();
+    return _node->getChildEdgeAt(idx)->getMemoryPtr()->getData();
 }
 
 const VectorDims & ColorConvert::Converter::inputDims(size_t idx) const {

--- a/src/plugins/intel_cpu/src/nodes/common/tile_broadcast_utils.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/tile_broadcast_utils.cpp
@@ -247,8 +247,8 @@ void TileBroadcastCommon::broadcastScalar(const char *srcData, char *dstData, si
 }
 
 void TileBroadcastCommon::optimizedExecute(const MemoryPtr& srcMemory, const MemoryPtr& dstMemory) {
-    auto srcData = reinterpret_cast<const char *>(srcMemory->GetPtr());
-    auto dstData = reinterpret_cast<char *>(dstMemory->GetPtr());
+    auto srcData = reinterpret_cast<const char *>(srcMemory->GetData());
+    auto dstData = reinterpret_cast<char *>(dstMemory->GetData());
 
     if (srcMemory->getStaticDims() == dstMemory->getStaticDims()) {
         const auto prc = dstMemory->getDesc().getPrecision();
@@ -260,7 +260,7 @@ void TileBroadcastCommon::optimizedExecute(const MemoryPtr& srcMemory, const Mem
         if (optimizedParams.dstStrides[0] == optimizedParams.dims[5] * optimizedParams.dstStrides[5]) {
             size_t data_size = optimizedParams.dstStrides[5];
             size_t elt_cnt = optimizedParams.dims[5];
-            auto srcData_i32 = reinterpret_cast<const int *>(srcMemory->GetPtr());
+            auto srcData_i32 = reinterpret_cast<const int *>(srcMemory->GetData());
             if (data_size == 1) {
                 memset(dstData, srcData[0], elt_cnt);
             } else if (data_size == 4 && srcData_i32[0] == 0) {

--- a/src/plugins/intel_cpu/src/nodes/common/tile_broadcast_utils.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/tile_broadcast_utils.cpp
@@ -247,8 +247,8 @@ void TileBroadcastCommon::broadcastScalar(const char *srcData, char *dstData, si
 }
 
 void TileBroadcastCommon::optimizedExecute(const MemoryPtr& srcMemory, const MemoryPtr& dstMemory) {
-    auto srcData = reinterpret_cast<const char *>(srcMemory->GetData());
-    auto dstData = reinterpret_cast<char *>(dstMemory->GetData());
+    auto srcData = reinterpret_cast<const char *>(srcMemory->getData());
+    auto dstData = reinterpret_cast<char *>(dstMemory->getData());
 
     if (srcMemory->getStaticDims() == dstMemory->getStaticDims()) {
         const auto prc = dstMemory->getDesc().getPrecision();
@@ -260,7 +260,7 @@ void TileBroadcastCommon::optimizedExecute(const MemoryPtr& srcMemory, const Mem
         if (optimizedParams.dstStrides[0] == optimizedParams.dims[5] * optimizedParams.dstStrides[5]) {
             size_t data_size = optimizedParams.dstStrides[5];
             size_t elt_cnt = optimizedParams.dims[5];
-            auto srcData_i32 = reinterpret_cast<const int *>(srcMemory->GetData());
+            auto srcData_i32 = reinterpret_cast<const int *>(srcMemory->getData());
             if (data_size == 1) {
                 memset(dstData, srcData[0], elt_cnt);
             } else if (data_size == 4 && srcData_i32[0] == 0) {

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -640,9 +640,9 @@ void Concat::resolveInPlaceEdges(Edge::LOOK look) {
             IE_ASSERT(parentEdge->getStatus() == Edge::Status::NotAllocated) << "Unexpected inplace resolve call to an allocated edge: " << parentEdge->name();
 
             auto memMngr = std::make_shared<PartitionedMemoryMngr>(baseMemMngr, numberOfInputs, i);
-            auto newMem = std::make_shared<Memory>(getEngine(), std::unique_ptr<IMemoryMngr>(memMngr.get()), selected_pd->getConfig().inConfs[i].getMemDesc());
+            auto newMem = std::make_shared<Memory>(getEngine(), selected_pd->getConfig().inConfs[i].getMemDesc(), memMngr);
 
-            parentEdge->resetMemoryPtr(newMem);
+            parentEdge->reuse(newMem);
         }
     } else {
         Node::resolveInPlaceEdges(look);

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -640,10 +640,10 @@ void Concat::resolveInPlaceEdges(Edge::LOOK look) {
             IE_ASSERT(parentEdge->getStatus() == Edge::Status::NotAllocated) << "Unexpected inplace resolve call to an allocated edge: " << parentEdge->name();
 
             auto memMngr = std::make_shared<PartitionedMemoryMngr>(baseMemMngr, numberOfInputs, i);
-            parentEdge->getMemoryPtr().reset(new Memory(getEngine()));
-            parentEdge->getMemoryPtr()->Create(selected_pd->getConfig().inConfs[i].getMemDesc(), memMngr);
+            auto newMem = std::make_shared<Memory>(getEngine());
+            newMem->Create(selected_pd->getConfig().inConfs[i].getMemDesc(), memMngr);
 
-            parentEdge->changeStatus(Edge::Status::Allocated);
+            parentEdge->resetMemoryPtr(newMem);
         }
     } else {
         Node::resolveInPlaceEdges(look);

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -649,7 +649,7 @@ void Concat::resolveInPlaceEdges(Edge::LOOK look) {
             MemoryPtr newMem;
             if (partDim != 0) {
                 auto memMngr = std::make_shared<PartitionedMemoryMngr>(baseMemMngr, baseDim, offset, partDim);
-                auto newMem = std::make_shared<Memory>(getEngine(), memDesc, memMngr);
+                newMem = std::make_shared<Memory>(getEngine(), memDesc, memMngr);
             } else {
                 // empty tensor, no need to reference a part, default memory is enough
                 newMem = std::make_shared<Memory>(getEngine(), memDesc);

--- a/src/plugins/intel_cpu/src/nodes/concat.h
+++ b/src/plugins/intel_cpu/src/nodes/concat.h
@@ -26,6 +26,7 @@ public:
     bool created() const override;
     void execute(dnnl::stream strm) override;
     void executeDynamicImpl(dnnl::stream strm) override { execute(strm); }
+    void resolveInPlaceEdges() override;
 
     bool isOptimized() const;
 

--- a/src/plugins/intel_cpu/src/nodes/concat.h
+++ b/src/plugins/intel_cpu/src/nodes/concat.h
@@ -28,8 +28,6 @@ public:
     void executeDynamicImpl(dnnl::stream strm) override { execute(strm); }
     void resolveInPlaceEdges() override;
 
-    bool isOptimized() const;
-
     InferenceEngine::Precision getRuntimePrecision() const override;
 
     bool isExecutable() const override;

--- a/src/plugins/intel_cpu/src/nodes/concat.h
+++ b/src/plugins/intel_cpu/src/nodes/concat.h
@@ -26,7 +26,7 @@ public:
     bool created() const override;
     void execute(dnnl::stream strm) override;
     void executeDynamicImpl(dnnl::stream strm) override { execute(strm); }
-    void resolveInPlaceEdges() override;
+    void resolveInPlaceEdges(Edge::LOOK look) override;
 
     InferenceEngine::Precision getRuntimePrecision() const override;
 

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -905,7 +905,7 @@ void Convolution::addZeroPoints(dnnl::primitive_attr& attr) {
 
     if (!stockInputZeroPointsMemPtr) {
         DnnlBlockedMemoryDesc memoryDesc(Precision::I32, {inputZeroPoints.size()});
-        stockInputZeroPointsMemPtr.reset(new Memory(getEngine(), memoryDesc, inputZeroPoints.data()));
+        stockInputZeroPointsMemPtr = std::make_shared<Memory>(getEngine(), memoryDesc, inputZeroPoints.data());
     }
 }
 
@@ -925,7 +925,7 @@ void Convolution::addLegacyZeroPoints(dnnl::primitive_attr& attr) {
 
         if (!legacyWeightsZeroPointsMemPtr) {
             DnnlBlockedMemoryDesc memoryDesc(Precision::FP32, {legacyWeightsZeroPoints.size()});
-            legacyWeightsZeroPointsMemPtr.reset(new Memory(getEngine(), memoryDesc, legacyWeightsZeroPoints.data()));
+            legacyWeightsZeroPointsMemPtr = std::make_shared<Memory>(getEngine(), memoryDesc, legacyWeightsZeroPoints.data());
         }
     }
 
@@ -935,7 +935,7 @@ void Convolution::addLegacyZeroPoints(dnnl::primitive_attr& attr) {
 
         if (!legacyOutputCompensationMemPtr) {
             DnnlBlockedMemoryDesc memoryDesc(Precision::I32, {legacyOutputCompensation.size()});
-            legacyOutputCompensationMemPtr.reset(new Memory(getEngine(), memoryDesc, legacyOutputCompensation.data()));
+            legacyOutputCompensationMemPtr = std::make_shared<Memory>(getEngine(), memoryDesc, legacyOutputCompensation.data());
         }
     }
 }
@@ -1450,7 +1450,8 @@ void Convolution::executeDynamicImpl(dnnl::stream strm) {
         const size_t sumPortNum = getParentEdges().size() - 1;
         const auto& sumInpMem = getParentEdgesAtPort(sumPortNum).front()->getMemory();
         auto inp1 = subgraph->getInput(1);
-        // inp1->getChildEdgesAtPort(0).front()->getMemoryPtr()->setDataHandle(sumInpMem.GetData());
+        auto inp1Mem = inp1->getChildEdgesAtPort(0).front()->getMemoryPtr();
+        inp1Mem->getMemoryMngr()->setExtBuff(sumInpMem.GetData(), sumInpMem.GetSize());
 
         subgraph->infer();
 

--- a/src/plugins/intel_cpu/src/nodes/convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/convert.cpp
@@ -144,8 +144,8 @@ void Convert::execute(dnnl::stream strm) {
     if (parentPaddElemCount != childPaddElemCount)
         IE_THROW() << errorPrefix << " has different elements number in input and output buffers";
 
-    void* srcPtr = parentMem.GetPtr();
-    void* dstPtr = childMem.GetPtr();
+    void* srcPtr = parentMem.GetData();
+    void* dstPtr = childMem.GetData();
 
     cpu_convert(srcPtr,
                 dstPtr,

--- a/src/plugins/intel_cpu/src/nodes/convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/convert.cpp
@@ -138,14 +138,14 @@ void Convert::execute(dnnl::stream strm) {
     auto& parentMem = getParentEdgeAt(0)->getMemory();
     auto& childMem = getChildEdgeAt(0)->getMemory();
 
-    const auto parentPaddElemCount = parentMem.GetDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
-    const auto childPaddElemCount = childMem.GetDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
+    const auto parentPaddElemCount = parentMem.getDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
+    const auto childPaddElemCount = childMem.getDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
 
     if (parentPaddElemCount != childPaddElemCount)
         IE_THROW() << errorPrefix << " has different elements number in input and output buffers";
 
-    void* srcPtr = parentMem.GetData();
-    void* dstPtr = childMem.GetData();
+    void* srcPtr = parentMem.getData();
+    void* dstPtr = childMem.getData();
 
     cpu_convert(srcPtr,
                 dstPtr,

--- a/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.cpp
@@ -70,9 +70,9 @@ void CTCGreedyDecoder::initSupportedPrimitiveDescriptors() {
 }
 
 void CTCGreedyDecoder::execute(dnnl::stream strm) {
-    const float* probabilities = reinterpret_cast<const float *>(getParentEdgeAt(DATA_INDEX)->getMemoryPtr()->GetPtr());
-    const float* sequenceMask = reinterpret_cast<const float *>(getParentEdgeAt(SEQUENCE_LENGTH_INDEX)->getMemoryPtr()->GetPtr());
-    float* outputSequences = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetPtr());
+    const float* probabilities = reinterpret_cast<const float *>(getParentEdgeAt(DATA_INDEX)->getMemoryPtr()->GetData());
+    const float* sequenceMask = reinterpret_cast<const float *>(getParentEdgeAt(SEQUENCE_LENGTH_INDEX)->getMemoryPtr()->GetData());
+    float* outputSequences = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
 
     const size_t T = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[0];
     const size_t B = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[1];

--- a/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.cpp
@@ -70,9 +70,9 @@ void CTCGreedyDecoder::initSupportedPrimitiveDescriptors() {
 }
 
 void CTCGreedyDecoder::execute(dnnl::stream strm) {
-    const float* probabilities = reinterpret_cast<const float *>(getParentEdgeAt(DATA_INDEX)->getMemoryPtr()->GetData());
-    const float* sequenceMask = reinterpret_cast<const float *>(getParentEdgeAt(SEQUENCE_LENGTH_INDEX)->getMemoryPtr()->GetData());
-    float* outputSequences = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
+    const float* probabilities = reinterpret_cast<const float *>(getParentEdgeAt(DATA_INDEX)->getMemoryPtr()->getData());
+    const float* sequenceMask = reinterpret_cast<const float *>(getParentEdgeAt(SEQUENCE_LENGTH_INDEX)->getMemoryPtr()->getData());
+    float* outputSequences = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
 
     const size_t T = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[0];
     const size_t B = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[1];

--- a/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder_seq_len.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder_seq_len.cpp
@@ -75,10 +75,10 @@ void CTCGreedyDecoderSeqLen::initSupportedPrimitiveDescriptors() {
 }
 
 void CTCGreedyDecoderSeqLen::execute(dnnl::stream strm) {
-    const float* probabilities = reinterpret_cast<const float *>(getParentEdgeAt(DATA_INDEX)->getMemoryPtr()->GetPtr());
-    const int* sequenceLengths = reinterpret_cast<const int *>(getParentEdgeAt(SEQUENCE_LENGTH_INDEX)->getMemoryPtr()->GetPtr());
-    int* decodedClasses =  reinterpret_cast<int *>(getChildEdgesAtPort(DECODED_CLASSES_INDEX)[0]->getMemoryPtr()->GetPtr());
-    int* decodedClassesLength = reinterpret_cast<int *>(getChildEdgesAtPort(DECODED_CLASSES_LENGTH_INDEX)[0]->getMemoryPtr()->GetPtr());
+    const float* probabilities = reinterpret_cast<const float *>(getParentEdgeAt(DATA_INDEX)->getMemoryPtr()->GetData());
+    const int* sequenceLengths = reinterpret_cast<const int *>(getParentEdgeAt(SEQUENCE_LENGTH_INDEX)->getMemoryPtr()->GetData());
+    int* decodedClasses =  reinterpret_cast<int *>(getChildEdgesAtPort(DECODED_CLASSES_INDEX)[0]->getMemoryPtr()->GetData());
+    int* decodedClassesLength = reinterpret_cast<int *>(getChildEdgesAtPort(DECODED_CLASSES_LENGTH_INDEX)[0]->getMemoryPtr()->GetData());
 
     const size_t B = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[0];;
     const size_t T = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[1];;
@@ -87,7 +87,7 @@ void CTCGreedyDecoderSeqLen::execute(dnnl::stream strm) {
 
     int blankIndex = C - 1;
     if (inputShapes.size() > BLANK_INDEX)
-        blankIndex = (reinterpret_cast<const int  *>(getParentEdgeAt(BLANK_INDEX)->getMemoryPtr()->GetPtr()))[0];
+        blankIndex = (reinterpret_cast<const int  *>(getParentEdgeAt(BLANK_INDEX)->getMemoryPtr()->GetData()))[0];
 
     size_t workAmount = 0;
     for (size_t b = 0; b < B; b++) {

--- a/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder_seq_len.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder_seq_len.cpp
@@ -75,10 +75,10 @@ void CTCGreedyDecoderSeqLen::initSupportedPrimitiveDescriptors() {
 }
 
 void CTCGreedyDecoderSeqLen::execute(dnnl::stream strm) {
-    const float* probabilities = reinterpret_cast<const float *>(getParentEdgeAt(DATA_INDEX)->getMemoryPtr()->GetData());
-    const int* sequenceLengths = reinterpret_cast<const int *>(getParentEdgeAt(SEQUENCE_LENGTH_INDEX)->getMemoryPtr()->GetData());
-    int* decodedClasses =  reinterpret_cast<int *>(getChildEdgesAtPort(DECODED_CLASSES_INDEX)[0]->getMemoryPtr()->GetData());
-    int* decodedClassesLength = reinterpret_cast<int *>(getChildEdgesAtPort(DECODED_CLASSES_LENGTH_INDEX)[0]->getMemoryPtr()->GetData());
+    const float* probabilities = reinterpret_cast<const float *>(getParentEdgeAt(DATA_INDEX)->getMemoryPtr()->getData());
+    const int* sequenceLengths = reinterpret_cast<const int *>(getParentEdgeAt(SEQUENCE_LENGTH_INDEX)->getMemoryPtr()->getData());
+    int* decodedClasses =  reinterpret_cast<int *>(getChildEdgesAtPort(DECODED_CLASSES_INDEX)[0]->getMemoryPtr()->getData());
+    int* decodedClassesLength = reinterpret_cast<int *>(getChildEdgesAtPort(DECODED_CLASSES_LENGTH_INDEX)[0]->getMemoryPtr()->getData());
 
     const size_t B = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[0];;
     const size_t T = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[1];;
@@ -87,7 +87,7 @@ void CTCGreedyDecoderSeqLen::execute(dnnl::stream strm) {
 
     int blankIndex = C - 1;
     if (inputShapes.size() > BLANK_INDEX)
-        blankIndex = (reinterpret_cast<const int  *>(getParentEdgeAt(BLANK_INDEX)->getMemoryPtr()->GetData()))[0];
+        blankIndex = (reinterpret_cast<const int  *>(getParentEdgeAt(BLANK_INDEX)->getMemoryPtr()->getData()))[0];
 
     size_t workAmount = 0;
     for (size_t b = 0; b < B; b++) {

--- a/src/plugins/intel_cpu/src/nodes/ctc_loss.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_loss.cpp
@@ -67,11 +67,11 @@ void CTCLoss::executeDynamicImpl(dnnl::stream strm) {
 void CTCLoss::execute(dnnl::stream strm) {
     StatusCode returnCode = OK;
 
-    const float* logits = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    const int* logitsLength = reinterpret_cast<const int *>(getParentEdgeAt(1)->getMemoryPtr()->GetPtr());
-    const int* labels = reinterpret_cast<const int *>(getParentEdgeAt(2)->getMemoryPtr()->GetPtr());
-    const int* labelsLength = reinterpret_cast<const int *>(getParentEdgeAt(3)->getMemoryPtr()->GetPtr());
-    float* dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetPtr());
+    const float* logits = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    const int* logitsLength = reinterpret_cast<const int *>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
+    const int* labels = reinterpret_cast<const int *>(getParentEdgeAt(2)->getMemoryPtr()->GetData());
+    const int* labelsLength = reinterpret_cast<const int *>(getParentEdgeAt(3)->getMemoryPtr()->GetData());
+    float* dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
 
     const auto &inDims = getParentEdgeAt(0)->getMemory().getStaticDims();
     const size_t batchNum = inDims[0];
@@ -80,7 +80,7 @@ void CTCLoss::execute(dnnl::stream strm) {
 
     int blankIndex = classesNum - 1;
     if (inputShapes.size() > 4) {
-        blankIndex = reinterpret_cast<const int *>(getParentEdgeAt(4)->getMemoryPtr()->GetPtr())[0];
+        blankIndex = reinterpret_cast<const int *>(getParentEdgeAt(4)->getMemoryPtr()->GetData())[0];
     }
 
     std::vector<int> decodedTargetLenB(batchNum, 0);

--- a/src/plugins/intel_cpu/src/nodes/ctc_loss.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_loss.cpp
@@ -67,11 +67,11 @@ void CTCLoss::executeDynamicImpl(dnnl::stream strm) {
 void CTCLoss::execute(dnnl::stream strm) {
     StatusCode returnCode = OK;
 
-    const float* logits = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    const int* logitsLength = reinterpret_cast<const int *>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
-    const int* labels = reinterpret_cast<const int *>(getParentEdgeAt(2)->getMemoryPtr()->GetData());
-    const int* labelsLength = reinterpret_cast<const int *>(getParentEdgeAt(3)->getMemoryPtr()->GetData());
-    float* dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
+    const float* logits = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    const int* logitsLength = reinterpret_cast<const int *>(getParentEdgeAt(1)->getMemoryPtr()->getData());
+    const int* labels = reinterpret_cast<const int *>(getParentEdgeAt(2)->getMemoryPtr()->getData());
+    const int* labelsLength = reinterpret_cast<const int *>(getParentEdgeAt(3)->getMemoryPtr()->getData());
+    float* dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
 
     const auto &inDims = getParentEdgeAt(0)->getMemory().getStaticDims();
     const size_t batchNum = inDims[0];
@@ -80,7 +80,7 @@ void CTCLoss::execute(dnnl::stream strm) {
 
     int blankIndex = classesNum - 1;
     if (inputShapes.size() > 4) {
-        blankIndex = reinterpret_cast<const int *>(getParentEdgeAt(4)->getMemoryPtr()->GetData())[0];
+        blankIndex = reinterpret_cast<const int *>(getParentEdgeAt(4)->getMemoryPtr()->getData())[0];
     }
 
     std::vector<int> decodedTargetLenB(batchNum, 0);

--- a/src/plugins/intel_cpu/src/nodes/cum_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/cum_sum.cpp
@@ -109,8 +109,8 @@ void CumSum::execute(dnnl::stream strm) {
 
 template <typename dataType>
 void CumSum::exec() {
-    const auto *input = reinterpret_cast<const dataType *>(getParentEdgeAt(CUM_SUM_DATA)->getMemoryPtr()->GetPtr());
-    auto *output = reinterpret_cast<dataType *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetPtr());
+    const auto *input = reinterpret_cast<const dataType *>(getParentEdgeAt(CUM_SUM_DATA)->getMemoryPtr()->GetData());
+    auto *output = reinterpret_cast<dataType *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
     const VectorDims strides = getParentEdgeAt(CUM_SUM_DATA)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
 
     if (reverse) {
@@ -226,18 +226,18 @@ inline size_t CumSum::getStartOffset(const std::vector<size_t> &forStartOffset, 
     return startOffset;
 }
 
-size_t CumSum::getAxis(const Memory& _axis, const Memory& _data) const {
+size_t CumSum::getAxis(const IMemory& _axis, const IMemory& _data) const {
     const auto& axisPrecision = _axis.getDesc().getPrecision();
     const int64_t dataShapeSize = static_cast<int64_t>(_data.GetShape().getRank());
     int64_t axisValueFromBlob = 0;
     switch (axisPrecision) {
         case Precision::I32 : {
-            const auto *axisPtr = reinterpret_cast<const int32_t *>(_axis.GetPtr());
+            const auto *axisPtr = reinterpret_cast<const int32_t *>(_axis.GetData());
             axisValueFromBlob = static_cast<int64_t>(axisPtr[0]);
             break;
         }
         case Precision::I64 : {
-            const auto *axisPtr = reinterpret_cast<const int64_t *>(_axis.GetPtr());
+            const auto *axisPtr = reinterpret_cast<const int64_t *>(_axis.GetData());
             axisValueFromBlob = axisPtr[0];
             break;
         }

--- a/src/plugins/intel_cpu/src/nodes/cum_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/cum_sum.cpp
@@ -109,9 +109,9 @@ void CumSum::execute(dnnl::stream strm) {
 
 template <typename dataType>
 void CumSum::exec() {
-    const auto *input = reinterpret_cast<const dataType *>(getParentEdgeAt(CUM_SUM_DATA)->getMemoryPtr()->GetData());
-    auto *output = reinterpret_cast<dataType *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
-    const VectorDims strides = getParentEdgeAt(CUM_SUM_DATA)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
+    const auto *input = reinterpret_cast<const dataType *>(getParentEdgeAt(CUM_SUM_DATA)->getMemoryPtr()->getData());
+    auto *output = reinterpret_cast<dataType *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
+    const VectorDims strides = getParentEdgeAt(CUM_SUM_DATA)->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
 
     if (reverse) {
         if (exclusive) {
@@ -228,16 +228,16 @@ inline size_t CumSum::getStartOffset(const std::vector<size_t> &forStartOffset, 
 
 size_t CumSum::getAxis(const IMemory& _axis, const IMemory& _data) const {
     const auto& axisPrecision = _axis.getDesc().getPrecision();
-    const int64_t dataShapeSize = static_cast<int64_t>(_data.GetShape().getRank());
+    const int64_t dataShapeSize = static_cast<int64_t>(_data.getShape().getRank());
     int64_t axisValueFromBlob = 0;
     switch (axisPrecision) {
         case Precision::I32 : {
-            const auto *axisPtr = reinterpret_cast<const int32_t *>(_axis.GetData());
+            const auto *axisPtr = reinterpret_cast<const int32_t *>(_axis.getData());
             axisValueFromBlob = static_cast<int64_t>(axisPtr[0]);
             break;
         }
         case Precision::I64 : {
-            const auto *axisPtr = reinterpret_cast<const int64_t *>(_axis.GetData());
+            const auto *axisPtr = reinterpret_cast<const int64_t *>(_axis.getData());
             axisValueFromBlob = axisPtr[0];
             break;
         }

--- a/src/plugins/intel_cpu/src/nodes/cum_sum.h
+++ b/src/plugins/intel_cpu/src/nodes/cum_sum.h
@@ -38,7 +38,7 @@ private:
 
     inline size_t getStartOffset(const std::vector<size_t> &forStartOffset, const std::vector<size_t>& strides) const;
 
-    size_t getAxis(const Memory& _axis, const Memory& _data) const;
+    size_t getAxis(const IMemory& _axis, const IMemory& _data) const;
 
     enum { CUM_SUM_DATA, AXIS, numOfInputs };
     bool exclusive;

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -264,7 +264,7 @@ InferenceEngine::Blob::Ptr Deconvolution::createWeiBlobAsIO(InferenceEngine::Siz
     if (intBuffSize < offset) {
         IE_THROW() << "Cannot create internal buffer. Buffer can be overrun.";
     }
-    cpu_memcpy_s(data, intBuffSize, blb->GetPtr(), blbSize);
+    cpu_memcpy_s(data, intBuffSize, blb->GetData(), blbSize);
 
     return internalBlob;
 }
@@ -579,8 +579,7 @@ VectorDims Deconvolution::shapeInferInternal(const VectorDims &inDims, std::vect
                 outSpDimsVecShape = {outSpDims.size()};
                 inputShapesRefs.push_back(std::cref(outSpDimsVecShape));
                 CpuBlockedMemoryDesc desc(Precision::I32, Shape(outSpDimsVecShape));
-                auto mem = std::make_shared<Memory>(getEngine());
-                mem->Create(desc, outSpDims.data());
+                auto mem = std::make_shared<Memory>(getEngine(), desc, outSpDims.data());
                 inputValues[i] = mem;
                 break;
             }
@@ -1107,7 +1106,7 @@ std::vector<int32_t> Deconvolution::readOutputSpatialDims() const {
     if (shapeMemPtr->getStaticDims()[0] != spDimsNum) {
         IE_THROW() << "Can't read output spatial dims, beause 'output_shape' input has incorrect number of elements";
     }
-    const int32_t *outShapePtr = reinterpret_cast<const int32_t *>(shapeMemPtr->GetPtr());
+    const int32_t *outShapePtr = reinterpret_cast<const int32_t *>(shapeMemPtr->GetData());
     std::vector<int32_t> outSpDims(outShapePtr, outShapePtr + shapeMemPtr->getStaticDims()[0]);
     return outSpDims;
 }

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -235,7 +235,7 @@ InferenceEngine::Blob::Ptr Deconvolution::createWeiBlobAsIO(InferenceEngine::Siz
     if (!blb)
         IE_THROW() << "Cannot get const weights blob for node " << getName() << ".";
 
-    auto const blbSize = blb->GetSize();
+    auto const blbSize = blb->getSize();
 
     // WA: In int8 case, we are processing weights using internal blob.
     InferenceEngine::SizeVector dimsForBlockedDesc{dims};
@@ -251,7 +251,7 @@ InferenceEngine::Blob::Ptr Deconvolution::createWeiBlobAsIO(InferenceEngine::Siz
         orderForBlockedDesc.push_back(i);
 
     BlockingDesc blkDesc(dimsForBlockedDesc, orderForBlockedDesc);
-    InferenceEngine::TensorDesc tensorDesc(DnnlExtensionUtils::DataTypeToIEPrecision(blb->GetDataType()), dims, blkDesc);
+    InferenceEngine::TensorDesc tensorDesc(DnnlExtensionUtils::DataTypeToIEPrecision(blb->getDataType()), dims, blkDesc);
 
     Blob::Ptr internalBlob = InferenceEngine::make_shared_blob<int8_t>(tensorDesc);
     internalBlob->allocate();
@@ -264,7 +264,7 @@ InferenceEngine::Blob::Ptr Deconvolution::createWeiBlobAsIO(InferenceEngine::Siz
     if (intBuffSize < offset) {
         IE_THROW() << "Cannot create internal buffer. Buffer can be overrun.";
     }
-    cpu_memcpy_s(data, intBuffSize, blb->GetData(), blbSize);
+    cpu_memcpy_s(data, intBuffSize, blb->getData(), blbSize);
 
     return internalBlob;
 }
@@ -761,13 +761,14 @@ void Deconvolution::createPrimitive() {
         } else {
             inDims = getInputShapeAtPort(0).getStaticDims();
             outDims = getOutputShapeAtPort(0).getStaticDims();
-            inDesc = getParentEdgesAtPort(0).front()->getMemory().GetDescWithType<DnnlMemoryDesc>();
-            outDesc = getChildEdgesAtPort(0).front()->getMemory().GetDescWithType<DnnlMemoryDesc>();
+
+            inDesc = getParentEdgesAtPort(0).front()->getMemory().getDescWithType<DnnlMemoryDesc>();
+            outDesc = getChildEdgesAtPort(0).front()->getMemory().getDescWithType<DnnlMemoryDesc>();
         }
 
         dnnl::memory::desc dnnlBiasDesc;
         if (withBiases) {
-            DnnlMemoryDescPtr biasDesc = getParentEdgesAtPort(biasPort).front()->getMemory().GetDescWithType<DnnlMemoryDesc>();
+            DnnlMemoryDescPtr biasDesc = getParentEdgesAtPort(biasPort).front()->getMemory().getDescWithType<DnnlMemoryDesc>();
             dnnlBiasDesc = biasDesc->getDnnlDesc();
         }
 
@@ -806,8 +807,8 @@ void Deconvolution::prepareParams() {
     if (selected_pd == nullptr)
         IE_THROW() << "Preferable primitive descriptor is not set for node " << getName() << ".";
 
-    auto inMemoryDesc = getParentEdgesAtPort(0).front()->getMemory().GetDescWithType<DnnlMemoryDesc>();
-    auto outMemoryDesc = getChildEdgesAtPort(0).front()->getMemory().GetDescWithType<DnnlMemoryDesc>();
+    auto inMemoryDesc = getParentEdgesAtPort(0).front()->getMemory().getDescWithType<DnnlMemoryDesc>();
+    auto outMemoryDesc = getChildEdgesAtPort(0).front()->getMemory().getDescWithType<DnnlMemoryDesc>();
 
     AttrPtr pAttrLocal;
     if (isDynamicNode()) {
@@ -830,15 +831,15 @@ void Deconvolution::prepareParams() {
     DnnlMemoryDescCPtr biasDesc;
 
     if (isInt8) {
-        wghDesc = internalBlobMemory.front()->GetDescWithType<DnnlMemoryDesc>();
+        wghDesc = internalBlobMemory.front()->getDescWithType<DnnlMemoryDesc>();
         if (withBiases) {
             biasMemPtr = getParentEdgesAtPort(biasPort)[0]->getMemoryPtr();
             if (!biasMemPtr || !biasMemPtr->isAllocated())
                 IE_THROW() << "Bias memory  memory didn't allocate.";
-            biasDesc = biasMemPtr->GetDescWithType<DnnlMemoryDesc>();
+            biasDesc = biasMemPtr->getDescWithType<DnnlMemoryDesc>();
         }
     } else {
-        wghDesc = getParentEdgesAtPort(1).front()->getMemory().GetDescWithType<DnnlMemoryDesc>();
+        wghDesc = getParentEdgesAtPort(1).front()->getMemory().getDescWithType<DnnlMemoryDesc>();
     }
 
     DeconvKey key = {inMemoryDesc,
@@ -953,20 +954,20 @@ void Deconvolution::prepareParams() {
 
     if (execPtr) {
         if (key.isInt8) {
-            primArgs[DNNL_ARG_SRC] = srcMemPtr->GetPrimitive();
-            primArgs[DNNL_ARG_WEIGHTS] = internalBlobMemory.front()->GetPrimitive();
-            primArgs[DNNL_ARG_DST]=  dstMemPtr->GetPrimitive();
+            primArgs[DNNL_ARG_SRC] = srcMemPtr->getPrimitive();
+            primArgs[DNNL_ARG_WEIGHTS] = internalBlobMemory.front()->getPrimitive();
+            primArgs[DNNL_ARG_DST]=  dstMemPtr->getPrimitive();
             if (withBiases)
-                primArgs[DNNL_ARG_BIAS] = biasMemPtr->GetPrimitive();
+                primArgs[DNNL_ARG_BIAS] = biasMemPtr->getPrimitive();
         } else {
-            primArgs[DNNL_ARG_DIFF_DST] = srcMemPtr->GetPrimitive();
-            primArgs[DNNL_ARG_WEIGHTS] = wghMemPtr->GetPrimitive();
-            primArgs[DNNL_ARG_DIFF_SRC] = dstMemPtr->GetPrimitive();
+            primArgs[DNNL_ARG_DIFF_DST] = srcMemPtr->getPrimitive();
+            primArgs[DNNL_ARG_WEIGHTS] = wghMemPtr->getPrimitive();
+            primArgs[DNNL_ARG_DIFF_SRC] = dstMemPtr->getPrimitive();
         }
         Node::appendPostOpArgs(*pAttrLocal, primArgs, postOpsArgs);
 
         auto scratchpadMem = getScratchPadMem(execPtr->getScratchPadDesc());
-        primArgs[DNNL_ARG_SCRATCHPAD] = scratchpadMem->GetPrimitive();
+        primArgs[DNNL_ARG_SCRATCHPAD] = scratchpadMem->getPrimitive();
 #ifdef CPU_DEBUG_CAPS
         if (result.second == CacheEntryBase::LookUpStatus::Miss) {
             auto pd = execPtr->getPrimitiveDesc();
@@ -1051,7 +1052,7 @@ InferenceEngine::Precision Deconvolution::getRuntimePrecision() const {
     for (size_t i = 0; i < std::min(getParentEdges().size(), inputsNumLimit); i++) {
         auto parentEdge = getParentEdgeAt(i);
         if (parentEdge && parentEdge->getStatus() == Edge::Status::Validated) {
-            inputPrecisions.emplace_back(DnnlExtensionUtils::DataTypeToIEPrecision((parentEdge->getMemoryPtr()->GetDataType())));
+            inputPrecisions.emplace_back(DnnlExtensionUtils::DataTypeToIEPrecision((parentEdge->getMemoryPtr()->getDataType())));
         }
     }
 
@@ -1106,7 +1107,7 @@ std::vector<int32_t> Deconvolution::readOutputSpatialDims() const {
     if (shapeMemPtr->getStaticDims()[0] != spDimsNum) {
         IE_THROW() << "Can't read output spatial dims, beause 'output_shape' input has incorrect number of elements";
     }
-    const int32_t *outShapePtr = reinterpret_cast<const int32_t *>(shapeMemPtr->GetData());
+    const int32_t *outShapePtr = reinterpret_cast<const int32_t *>(shapeMemPtr->getData());
     std::vector<int32_t> outSpDims(outShapePtr, outShapePtr + shapeMemPtr->getStaticDims()[0]);
     return outSpDims;
 }

--- a/src/plugins/intel_cpu/src/nodes/def_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/def_conv.cpp
@@ -1160,10 +1160,10 @@ void DeformableConvolution::DefConvRefExecutor::exec(const float* src, const flo
 }
 
 void DeformableConvolution::prepareParams() {
-    auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto& srcMemPtr = getParentEdgeAt(DATA_ID)->getMemoryPtr();
-    auto& offMemPtr = getParentEdgeAt(OFF_ID)->getMemoryPtr();
-    auto& weiMemPtr = getParentEdgeAt(WEI_ID)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(DATA_ID)->getMemoryPtr();
+    auto offMemPtr = getParentEdgeAt(OFF_ID)->getMemoryPtr();
+    auto weiMemPtr = getParentEdgeAt(WEI_ID)->getMemoryPtr();
 
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         IE_THROW() << errorPrefix << " did not allocate destination memory";
@@ -1175,7 +1175,7 @@ void DeformableConvolution::prepareParams() {
         IE_THROW() << errorPrefix << " did not allocate weights memory";
 
     if (getOriginalInputsNumber() > 3) {
-        auto& modMemPtr = getParentEdgeAt(MOD_ID)->getMemoryPtr();
+        auto modMemPtr = getParentEdgeAt(MOD_ID)->getMemoryPtr();
         if (!modMemPtr || !modMemPtr->isAllocated())
             IE_THROW() << errorPrefix << " did not allocate modulations memory";
     }

--- a/src/plugins/intel_cpu/src/nodes/def_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/def_conv.cpp
@@ -1190,15 +1190,15 @@ void DeformableConvolution::prepareParams() {
     updatePadding();
 
     std::vector<std::shared_ptr<BlockedMemoryDesc>> descVector {
-        getParentEdgeAt(DATA_ID)->getMemory().GetDescWithType<BlockedMemoryDesc>(),
-        getParentEdgeAt(OFF_ID)->getMemory().GetDescWithType<BlockedMemoryDesc>(),
-        getParentEdgeAt(WEI_ID)->getMemory().GetDescWithType<BlockedMemoryDesc>()
+        getParentEdgeAt(DATA_ID)->getMemory().getDescWithType<BlockedMemoryDesc>(),
+        getParentEdgeAt(OFF_ID)->getMemory().getDescWithType<BlockedMemoryDesc>(),
+        getParentEdgeAt(WEI_ID)->getMemory().getDescWithType<BlockedMemoryDesc>()
     };
 
     if (withModulation) {
-        descVector.push_back(getParentEdgeAt(MOD_ID)->getMemory().GetDescWithType<BlockedMemoryDesc>());
+        descVector.push_back(getParentEdgeAt(MOD_ID)->getMemory().getDescWithType<BlockedMemoryDesc>());
     }
-    descVector.push_back(getChildEdgesAtPort(0)[0]->getMemory().GetDescWithType<BlockedMemoryDesc>());
+    descVector.push_back(getChildEdgesAtPort(0)[0]->getMemory().getDescWithType<BlockedMemoryDesc>());
 
     DefConvKey key = {
         descVector,
@@ -1278,15 +1278,15 @@ void DeformableConvolution::execute(dnnl::stream strm) {
     auto &srcMemory2 = getParentEdgeAt(2)->getMemory();
     auto &dstMemory = getChildEdgeAt(0)->getMemory();
 
-    const auto *src = reinterpret_cast<const float *>(srcMemory0.GetData());
-    const auto *offsets = reinterpret_cast<const float *>(srcMemory1.GetData());
-    const auto *weights = reinterpret_cast<const float *>(srcMemory2.GetData());
+    const auto *src = reinterpret_cast<const float *>(srcMemory0.getData());
+    const auto *offsets = reinterpret_cast<const float *>(srcMemory1.getData());
+    const auto *weights = reinterpret_cast<const float *>(srcMemory2.getData());
     float* modulation = nullptr;
     if (inputsNumber > 3) {
-        modulation = reinterpret_cast<float *>(getParentEdgeAt(3)->getMemory().GetData());
+        modulation = reinterpret_cast<float *>(getParentEdgeAt(3)->getMemory().getData());
     }
 
-    float *dst = reinterpret_cast<float *>(dstMemory.GetData());
+    float *dst = reinterpret_cast<float *>(dstMemory.getData());
 
     auto selectedPrimitiveDescriptor = getSelectedPrimitiveDescriptor();
     if (!selectedPrimitiveDescriptor)

--- a/src/plugins/intel_cpu/src/nodes/def_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/def_conv.cpp
@@ -1278,15 +1278,15 @@ void DeformableConvolution::execute(dnnl::stream strm) {
     auto &srcMemory2 = getParentEdgeAt(2)->getMemory();
     auto &dstMemory = getChildEdgeAt(0)->getMemory();
 
-    const auto *src = reinterpret_cast<const float *>(srcMemory0.GetPtr());
-    const auto *offsets = reinterpret_cast<const float *>(srcMemory1.GetPtr());
-    const auto *weights = reinterpret_cast<const float *>(srcMemory2.GetPtr());
+    const auto *src = reinterpret_cast<const float *>(srcMemory0.GetData());
+    const auto *offsets = reinterpret_cast<const float *>(srcMemory1.GetData());
+    const auto *weights = reinterpret_cast<const float *>(srcMemory2.GetData());
     float* modulation = nullptr;
     if (inputsNumber > 3) {
-        modulation = reinterpret_cast<float *>(getParentEdgeAt(3)->getMemory().GetPtr());
+        modulation = reinterpret_cast<float *>(getParentEdgeAt(3)->getMemory().GetData());
     }
 
-    float *dst = reinterpret_cast<float *>(dstMemory.GetPtr());
+    float *dst = reinterpret_cast<float *>(dstMemory.GetData());
 
     auto selectedPrimitiveDescriptor = getSelectedPrimitiveDescriptor();
     if (!selectedPrimitiveDescriptor)

--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
@@ -292,8 +292,8 @@ void DepthToSpace::DepthToSpaceExecutor::exec(const MemoryPtr& srcMemPtr, const 
     if (!permuteKernel)
         IE_THROW() << "Could not execute. Kernel for Transpose node was not compiled.";
 
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetPtr());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
 
     permuteKernel->execute(srcData, dstData, MB);
 }

--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
@@ -161,8 +161,8 @@ void DepthToSpace::initSupportedPrimitiveDescriptors() {
 }
 
 void DepthToSpace::createPrimitive() {
-    auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto& srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         THROW_ERROR << "has not allocated destination memory";
     if (!srcMemPtr || !srcMemPtr->isAllocated())
@@ -288,7 +288,7 @@ DepthToSpace::DepthToSpaceExecutor::DepthToSpaceExecutor(const DepthToSpaceAttrs
     permuteKernel = std::unique_ptr<PermuteKernel>(new PermuteKernel(params));
 }
 
-void DepthToSpace::DepthToSpaceExecutor::exec(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr, const int MB) {
+void DepthToSpace::DepthToSpaceExecutor::exec(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr, const int MB) {
     if (!permuteKernel)
         IE_THROW() << "Could not execute. Kernel for Transpose node was not compiled.";
 

--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
@@ -185,7 +185,7 @@ void DepthToSpace::createPrimitive() {
 }
 
 void DepthToSpace::prepareParams() {
-    attrs.srcBlockedDims = getParentEdgeAt(0)->getMemoryPtr()->GetDescWithType<BlockedMemoryDesc>()->getBlockDims();
+    attrs.srcBlockedDims = getParentEdgeAt(0)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>()->getBlockDims();
     auto builder = [](const DepthToSpaceAttrs& key) -> std::shared_ptr<DepthToSpaceExecutor> {
         return std::make_shared<DepthToSpaceExecutor>(key);
     };
@@ -292,8 +292,8 @@ void DepthToSpace::DepthToSpaceExecutor::exec(const MemoryPtr& srcMemPtr, const 
     if (!permuteKernel)
         IE_THROW() << "Could not execute. Kernel for Transpose node was not compiled.";
 
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetData());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->getData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->getData());
 
     permuteKernel->execute(srcData, dstData, MB);
 }

--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.h
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.h
@@ -46,7 +46,7 @@ private:
     DepthToSpaceAttrs attrs;
     struct DepthToSpaceExecutor {
         DepthToSpaceExecutor(const DepthToSpaceAttrs& attrs);
-        void exec(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr, const int MB);
+        void exec(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr, const int MB);
         ~DepthToSpaceExecutor() = default;
 
     private:

--- a/src/plugins/intel_cpu/src/nodes/detection_output.cpp
+++ b/src/plugins/intel_cpu/src/nodes/detection_output.cpp
@@ -169,15 +169,15 @@ void DetectionOutput::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void DetectionOutput::execute(dnnl::stream strm) {
-    float *dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetPtr());
+    float *dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
 
-    const float *locData     = reinterpret_cast<const float *>(getParentEdgeAt(ID_LOC)->getMemoryPtr()->GetPtr());
-    const float *confData    = reinterpret_cast<const float *>(getParentEdgeAt(ID_CONF)->getMemoryPtr()->GetPtr());
-    const float *priorData   = reinterpret_cast<const float *>(getParentEdgeAt(ID_PRIOR)->getMemoryPtr()->GetPtr());
+    const float *locData     = reinterpret_cast<const float *>(getParentEdgeAt(ID_LOC)->getMemoryPtr()->GetData());
+    const float *confData    = reinterpret_cast<const float *>(getParentEdgeAt(ID_CONF)->getMemoryPtr()->GetData());
+    const float *priorData   = reinterpret_cast<const float *>(getParentEdgeAt(ID_PRIOR)->getMemoryPtr()->GetData());
     const float *ARMConfData = inputShapes.size() > 3 ?
-            reinterpret_cast<const float *>(getParentEdgeAt(ID_ARM_CONF)->getMemoryPtr()->GetPtr()) : nullptr;
+            reinterpret_cast<const float *>(getParentEdgeAt(ID_ARM_CONF)->getMemoryPtr()->GetData()) : nullptr;
     const float *ARMLocData = inputShapes.size() > 4 ?
-            reinterpret_cast<const float *>(getParentEdgeAt(ID_ARM_LOC)->getMemoryPtr()->GetPtr()) : nullptr;
+            reinterpret_cast<const float *>(getParentEdgeAt(ID_ARM_LOC)->getMemoryPtr()->GetData()) : nullptr;
 
     float *reorderedConfData = reorderedConf.data();
     int *reorderedConfDataIndices = reinterpret_cast<int*>(reorderedConf.data());

--- a/src/plugins/intel_cpu/src/nodes/detection_output.cpp
+++ b/src/plugins/intel_cpu/src/nodes/detection_output.cpp
@@ -93,14 +93,14 @@ DetectionOutput::DetectionOutput(const std::shared_ptr<ngraph::Node>& op, const 
 }
 
 void DetectionOutput::prepareParams() {
-    const auto& idPriorDims = getParentEdgeAt(ID_PRIOR)->getMemory().GetShape().getStaticDims();
-    const auto &idConfDims = getParentEdgeAt(ID_CONF)->getMemory().GetShape().getStaticDims();
+    const auto& idPriorDims = getParentEdgeAt(ID_PRIOR)->getMemory().getShape().getStaticDims();
+    const auto &idConfDims = getParentEdgeAt(ID_CONF)->getMemory().getShape().getStaticDims();
     priorsNum = static_cast<int>(idPriorDims.back() / priorSize);
     isPriorsPerImg = idPriorDims.front() != 1;
     classesNum = static_cast<int>(idConfDims.back() / priorsNum);
     locNumForClasses = isShareLoc ? 1 : classesNum;
 
-    const auto& idLocDims = getParentEdgeAt(ID_LOC)->getMemory().GetShape().getStaticDims();
+    const auto& idLocDims = getParentEdgeAt(ID_LOC)->getMemory().getShape().getStaticDims();
     if (priorsNum * locNumForClasses * 4 != static_cast<int>(idLocDims[1]))
         IE_THROW() << errorPrefix << "has incorrect number of priors, which must match number of location predictions ("
         << priorsNum * locNumForClasses * 4 << " vs "
@@ -169,15 +169,15 @@ void DetectionOutput::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void DetectionOutput::execute(dnnl::stream strm) {
-    float *dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
+    float *dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
 
-    const float *locData     = reinterpret_cast<const float *>(getParentEdgeAt(ID_LOC)->getMemoryPtr()->GetData());
-    const float *confData    = reinterpret_cast<const float *>(getParentEdgeAt(ID_CONF)->getMemoryPtr()->GetData());
-    const float *priorData   = reinterpret_cast<const float *>(getParentEdgeAt(ID_PRIOR)->getMemoryPtr()->GetData());
+    const float *locData     = reinterpret_cast<const float *>(getParentEdgeAt(ID_LOC)->getMemoryPtr()->getData());
+    const float *confData    = reinterpret_cast<const float *>(getParentEdgeAt(ID_CONF)->getMemoryPtr()->getData());
+    const float *priorData   = reinterpret_cast<const float *>(getParentEdgeAt(ID_PRIOR)->getMemoryPtr()->getData());
     const float *ARMConfData = inputShapes.size() > 3 ?
-            reinterpret_cast<const float *>(getParentEdgeAt(ID_ARM_CONF)->getMemoryPtr()->GetData()) : nullptr;
+            reinterpret_cast<const float *>(getParentEdgeAt(ID_ARM_CONF)->getMemoryPtr()->getData()) : nullptr;
     const float *ARMLocData = inputShapes.size() > 4 ?
-            reinterpret_cast<const float *>(getParentEdgeAt(ID_ARM_LOC)->getMemoryPtr()->GetData()) : nullptr;
+            reinterpret_cast<const float *>(getParentEdgeAt(ID_ARM_LOC)->getMemoryPtr()->getData()) : nullptr;
 
     float *reorderedConfData = reorderedConf.data();
     int *reorderedConfDataIndices = reinterpret_cast<int*>(reorderedConf.data());
@@ -845,7 +845,7 @@ inline void DetectionOutput::generateOutput(float* reorderedConfData, int* indic
     else
         dstDataSize = imgNum * classesNum * priorsNum * DETECTION_SIZE * sizeof(float);
 
-    if (static_cast<size_t>(dstDataSize) > getChildEdgesAtPort(0)[0]->getMemory().GetSize()) {
+    if (static_cast<size_t>(dstDataSize) > getChildEdgesAtPort(0)[0]->getMemory().getSize()) {
         IE_THROW() << errorPrefix << OUT_OF_BOUNDS;
     }
     memset(dstData, 0, dstDataSize);

--- a/src/plugins/intel_cpu/src/nodes/dft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/dft.cpp
@@ -239,8 +239,8 @@ void DFT::execute(dnnl::stream strm) {
     const auto inputDataEdge = getParentEdgeAt(DATA_INDEX);
     const auto outputDataEdge = getChildEdgeAt(0);
 
-    const auto src = reinterpret_cast<const float*>(inputDataEdge->getMemoryPtr()->GetPtr());
-    auto dst = reinterpret_cast<float*>(outputDataEdge->getMemoryPtr()->GetPtr());
+    const auto src = reinterpret_cast<const float*>(inputDataEdge->getMemoryPtr()->GetData());
+    auto dst = reinterpret_cast<float*>(outputDataEdge->getMemoryPtr()->GetData());
 
     const auto inputRank = inputDataEdge->getMemory().GetShape().getRank();
 
@@ -542,7 +542,7 @@ void DFT::prepareParams() {
 
 std::vector<int32_t> DFT::getAxes() const {
     auto axesEdge = getParentEdgeAt(AXES_INDEX);
-    const auto* axesStartPtr = reinterpret_cast<const int32_t*>(axesEdge->getMemoryPtr()->GetPtr());
+    const auto* axesStartPtr = reinterpret_cast<const int32_t*>(axesEdge->getMemoryPtr()->GetData());
     auto axes = std::vector<int32_t>(axesStartPtr, axesStartPtr + axesEdge->getMemory().getStaticDims()[0]);
     for (auto& axis : axes) {
         if (axis < 0) {

--- a/src/plugins/intel_cpu/src/nodes/dft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/dft.cpp
@@ -239,13 +239,13 @@ void DFT::execute(dnnl::stream strm) {
     const auto inputDataEdge = getParentEdgeAt(DATA_INDEX);
     const auto outputDataEdge = getChildEdgeAt(0);
 
-    const auto src = reinterpret_cast<const float*>(inputDataEdge->getMemoryPtr()->GetData());
-    auto dst = reinterpret_cast<float*>(outputDataEdge->getMemoryPtr()->GetData());
+    const auto src = reinterpret_cast<const float*>(inputDataEdge->getMemoryPtr()->getData());
+    auto dst = reinterpret_cast<float*>(outputDataEdge->getMemoryPtr()->getData());
 
-    const auto inputRank = inputDataEdge->getMemory().GetShape().getRank();
+    const auto inputRank = inputDataEdge->getMemory().getShape().getRank();
 
-    const auto& inputStrides = inputDataEdge->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
-    const auto& outputStrides = outputDataEdge->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
+    const auto& inputStrides = inputDataEdge->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
+    const auto& outputStrides = outputDataEdge->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
 
     size_t nComplexMaxFFT = 0;
     for (size_t axis : axes) {
@@ -542,7 +542,7 @@ void DFT::prepareParams() {
 
 std::vector<int32_t> DFT::getAxes() const {
     auto axesEdge = getParentEdgeAt(AXES_INDEX);
-    const auto* axesStartPtr = reinterpret_cast<const int32_t*>(axesEdge->getMemoryPtr()->GetData());
+    const auto* axesStartPtr = reinterpret_cast<const int32_t*>(axesEdge->getMemoryPtr()->getData());
     auto axes = std::vector<int32_t>(axesStartPtr, axesStartPtr + axesEdge->getMemory().getStaticDims()[0]);
     for (auto& axis : axes) {
         if (axis < 0) {

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -2472,7 +2472,7 @@ void Eltwise::fuseInto(NodePtr& parentNode) {
 void Eltwise::appendMemory(const std::vector<float> &data, MemoryPtr &memPtr, std::vector<MemoryPtr>& postOpsMem) {
     if (!memPtr) {
         DnnlBlockedMemoryDesc memoryDesc(Precision::FP32, {data.size()});
-        memPtr.reset(new Memory(getEngine(), memoryDesc, data.data()));
+        memPtr = std::make_shared<Memory>(getEngine(), memoryDesc, data.data());
         postOpsMem.push_back(memPtr);
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -2219,10 +2219,10 @@ void Eltwise::createPrimitive() {
 
     start_offset_in.resize(inputNum);
     for (size_t i = 0; i < inputNum; i++) {
-        const auto desc = getParentEdgeAt(i)->getMemory().GetDescWithType<BlockedMemoryDesc>();
+        const auto desc = getParentEdgeAt(i)->getMemory().getDescWithType<BlockedMemoryDesc>();
         start_offset_in[i] = desc->getOffsetPadding() * desc->getPrecision().size();
     }
-    const auto desc = getChildEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>();
+    const auto desc = getChildEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>();
     start_offset_out = desc->getOffsetPadding() * desc->getPrecision().size();
 
     for (size_t i = 0; i < inputNum; ++i) {
@@ -2249,7 +2249,7 @@ void Eltwise::prepareParams() {
         return;
     }
 
-    auto outBlockingDesc = getChildEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>();
+    auto outBlockingDesc = getChildEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>();
     const auto &outOrder = outBlockingDesc->getOrder();
     const auto &currentOutBlkDims = outBlockingDesc->getBlockDims();
 
@@ -2265,7 +2265,7 @@ void Eltwise::prepareParams() {
     size_t outRank = currentOutBlkDims.size();
 
     for (size_t i = 0; i < inputNum; i++) {
-        auto inBlockingDesc = getParentEdgeAt(i)->getMemory().GetDescWithType<BlockedMemoryDesc>();
+        auto inBlockingDesc = getParentEdgeAt(i)->getMemory().getDescWithType<BlockedMemoryDesc>();
         currentInBlkDims[i] = inBlockingDesc->getBlockDims();
         size_t inRank = currentInBlkDims[i].size();
 
@@ -2379,7 +2379,7 @@ void Eltwise::prepareParams() {
 
 bool Eltwise::needPrepareParams() const {
     for (size_t i = 0; i < getParentEdges().size(); i++) {
-        if (getParentEdgesAtPort(i)[0]->getMemory().GetDescWithType<BlockedMemoryDesc>()->getBlockDims() != currentInBlkDims[i])
+        if (getParentEdgesAtPort(i)[0]->getMemory().getDescWithType<BlockedMemoryDesc>()->getBlockDims() != currentInBlkDims[i])
             return true;
     }
     return false;
@@ -2394,8 +2394,8 @@ void Eltwise::execute(dnnl::stream strm) {
         jit_eltwise_call_args_ptrs args_ptrs = {};
         VectorDims dims_out = implType == EltwiseImplType::optimizedShapeAgnostic ? execParams.outDims : execPtr->getOutDims();
         for (size_t i = 0; i < memPtrs.size() - 1; i++)
-            args_ptrs.src_ptr[i] = reinterpret_cast<const uint8_t*>(memPtrs[i]->GetData()) + start_offset_in[i];
-        args_ptrs.dst_ptr = reinterpret_cast<uint8_t*>(memPtrs.back()->GetData()) + start_offset_out;
+            args_ptrs.src_ptr[i] = reinterpret_cast<const uint8_t*>(memPtrs[i]->getData()) + start_offset_in[i];
+        args_ptrs.dst_ptr = reinterpret_cast<uint8_t*>(memPtrs.back()->getData()) + start_offset_out;
 
         args_ptrs.post_op_data = fqDataPtrs.data();
 
@@ -2752,7 +2752,7 @@ InferenceEngine::Precision Eltwise::getRuntimePrecision() const {
     for (size_t i = 0; i < getParentEdges().size(); i++) {
         auto parentEdge = getParentEdgeAt(i);
         if (parentEdge && parentEdge->getStatus() == Edge::Status::Validated && !parentEdge->getParent()->isConstant()) {
-            inputPrecisions.emplace_back(DnnlExtensionUtils::DataTypeToIEPrecision((parentEdge->getMemoryPtr()->GetDataType())));
+            inputPrecisions.emplace_back(DnnlExtensionUtils::DataTypeToIEPrecision((parentEdge->getMemoryPtr()->getDataType())));
         }
     }
 

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -2471,10 +2471,8 @@ void Eltwise::fuseInto(NodePtr& parentNode) {
 
 void Eltwise::appendMemory(const std::vector<float> &data, MemoryPtr &memPtr, std::vector<MemoryPtr>& postOpsMem) {
     if (!memPtr) {
-        memPtr.reset(new Memory(getEngine()));
         DnnlBlockedMemoryDesc memoryDesc(Precision::FP32, {data.size()});
-        memPtr->Create(memoryDesc, data.data());
-
+        memPtr.reset(new Memory(getEngine(), memoryDesc, data.data()));
         postOpsMem.push_back(memPtr);
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_offset_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_offset_sum.cpp
@@ -81,11 +81,11 @@ void EmbeddingBagOffsetSum::prepareParams() {
 }
 
 void EmbeddingBagOffsetSum::initFromInputs() {
-    indicesData_ = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->GetPtr());
-    offsetsData_ = reinterpret_cast<const int *>(getParentEdgeAt(OFFSETS_IDX)->getMemoryPtr()->GetPtr());
+    indicesData_ = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->GetData());
+    offsetsData_ = reinterpret_cast<const int *>(getParentEdgeAt(OFFSETS_IDX)->getMemoryPtr()->GetData());
 
     if (getParentEdges().size() > DEFAULT_INDEX_IDX) {
-        defaultIndices_ = reinterpret_cast<const int *>(getParentEdgeAt(DEFAULT_INDEX_IDX)->getMemoryPtr()->GetPtr());
+        defaultIndices_ = reinterpret_cast<const int *>(getParentEdgeAt(DEFAULT_INDEX_IDX)->getMemoryPtr()->GetData());
     }
 }
 
@@ -131,10 +131,10 @@ bool EmbeddingBagOffsetSum::isExecutable() const {
 }
 
 void EmbeddingBagOffsetSum::execute(dnnl::stream strm) {
-    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
     const uint8_t* weightsData = nullptr;
     if (_withWeights)
-        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->GetPtr());
+        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->GetData());
 
     const auto &inputMem  = getParentEdgeAt(0)->getMemory();
     EmbeddingBagSum::execute(srcData, weightsData, inputMem.getDesc().getPrecision(),

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_offset_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_offset_sum.cpp
@@ -81,11 +81,11 @@ void EmbeddingBagOffsetSum::prepareParams() {
 }
 
 void EmbeddingBagOffsetSum::initFromInputs() {
-    indicesData_ = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->GetData());
-    offsetsData_ = reinterpret_cast<const int *>(getParentEdgeAt(OFFSETS_IDX)->getMemoryPtr()->GetData());
+    indicesData_ = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->getData());
+    offsetsData_ = reinterpret_cast<const int *>(getParentEdgeAt(OFFSETS_IDX)->getMemoryPtr()->getData());
 
     if (getParentEdges().size() > DEFAULT_INDEX_IDX) {
-        defaultIndices_ = reinterpret_cast<const int *>(getParentEdgeAt(DEFAULT_INDEX_IDX)->getMemoryPtr()->GetData());
+        defaultIndices_ = reinterpret_cast<const int *>(getParentEdgeAt(DEFAULT_INDEX_IDX)->getMemoryPtr()->getData());
     }
 }
 
@@ -131,10 +131,10 @@ bool EmbeddingBagOffsetSum::isExecutable() const {
 }
 
 void EmbeddingBagOffsetSum::execute(dnnl::stream strm) {
-    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
     const uint8_t* weightsData = nullptr;
     if (_withWeights)
-        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->GetData());
+        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->getData());
 
     const auto &inputMem  = getParentEdgeAt(0)->getMemory();
     EmbeddingBagSum::execute(srcData, weightsData, inputMem.getDesc().getPrecision(),

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_packed_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_packed_sum.cpp
@@ -75,7 +75,7 @@ void EmbeddingBagPackedSum::prepareParams() {
 }
 
 void EmbeddingBagPackedSum::initFromInputs() {
-    _indices = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->GetPtr());
+    _indices = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->GetData());
 }
 
 void EmbeddingBagPackedSum::getIndices(size_t embIndex, const int*& indices, size_t& size, int& weightsIdx, bool& withWeight) {
@@ -99,10 +99,10 @@ bool EmbeddingBagPackedSum::isExecutable() const {
 }
 
 void EmbeddingBagPackedSum::execute(dnnl::stream strm) {
-    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
     const uint8_t* weightsData = nullptr;
     if (_withWeights)
-        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->GetPtr());
+        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->GetData());
 
     const auto &inputMem  = getParentEdgeAt(0)->getMemory();
     EmbeddingBagSum::execute(srcData, weightsData, inputMem.getDesc().getPrecision(),

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_packed_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_packed_sum.cpp
@@ -75,7 +75,7 @@ void EmbeddingBagPackedSum::prepareParams() {
 }
 
 void EmbeddingBagPackedSum::initFromInputs() {
-    _indices = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->GetData());
+    _indices = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->getData());
 }
 
 void EmbeddingBagPackedSum::getIndices(size_t embIndex, const int*& indices, size_t& size, int& weightsIdx, bool& withWeight) {
@@ -99,10 +99,10 @@ bool EmbeddingBagPackedSum::isExecutable() const {
 }
 
 void EmbeddingBagPackedSum::execute(dnnl::stream strm) {
-    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
     const uint8_t* weightsData = nullptr;
     if (_withWeights)
-        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->GetData());
+        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->getData());
 
     const auto &inputMem  = getParentEdgeAt(0)->getMemory();
     EmbeddingBagSum::execute(srcData, weightsData, inputMem.getDesc().getPrecision(),

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_sum.cpp
@@ -54,7 +54,7 @@ void EmbeddingBagSum::processData(const T* srcData, const T* weightsData,
     initFromInputs();
 
     const size_t outputBagsNum = outMemory->GetShape().getStaticDims()[0];
-    auto *dstData = reinterpret_cast<T *>(outMemory->GetPtr());
+    auto *dstData = reinterpret_cast<T *>(outMemory->GetData());
 
     auto threadBody = [&](const int ithr, const int nthr) {
         size_t start(0lu), end(0lu);

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_sum.cpp
@@ -53,8 +53,8 @@ void EmbeddingBagSum::processData(const T* srcData, const T* weightsData,
 
     initFromInputs();
 
-    const size_t outputBagsNum = outMemory->GetShape().getStaticDims()[0];
-    auto *dstData = reinterpret_cast<T *>(outMemory->GetData());
+    const size_t outputBagsNum = outMemory->getShape().getStaticDims()[0];
+    auto *dstData = reinterpret_cast<T *>(outMemory->getData());
 
     auto threadBody = [&](const int ithr, const int nthr) {
         size_t start(0lu), end(0lu);

--- a/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.cpp
@@ -83,14 +83,14 @@ void EmbeddingSegmentsSum::prepareParams() {
 }
 
 void EmbeddingSegmentsSum::initFromInputs() {
-    indices_ = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->GetPtr());
+    indices_ = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->GetData());
     indicesSize_ = getParentEdgeAt(INDICES_IDX)->getMemory().GetShape().getElementsCount();
 
-    segmentIds_ = reinterpret_cast<const int *>(getParentEdgeAt(SEGMENT_ID_IDX)->getMemoryPtr()->GetPtr());
+    segmentIds_ = reinterpret_cast<const int *>(getParentEdgeAt(SEGMENT_ID_IDX)->getMemoryPtr()->GetData());
     lastNumSegments_ = getNumSegments();
 
     if (getParentEdges().size() > DEFAULT_INDEX_IDX) {
-        defaultIndices_ = reinterpret_cast<const int *>(getParentEdgeAt(DEFAULT_INDEX_IDX)->getMemoryPtr()->GetPtr());
+        defaultIndices_ = reinterpret_cast<const int *>(getParentEdgeAt(DEFAULT_INDEX_IDX)->getMemoryPtr()->GetData());
     }
 }
 
@@ -123,7 +123,7 @@ void EmbeddingSegmentsSum::getIndices(size_t embIndex, const int*& indices, size
 }
 
 int32_t EmbeddingSegmentsSum::getNumSegments() const {
-    return reinterpret_cast<const int32_t *>(getParentEdgesAtPort(NUM_SEGMENTS_IDX)[0]->getMemory().GetPtr())[0];
+    return reinterpret_cast<const int32_t *>(getParentEdgesAtPort(NUM_SEGMENTS_IDX)[0]->getMemory().GetData())[0];
 }
 
 bool EmbeddingSegmentsSum::needShapeInfer() const {
@@ -147,10 +147,10 @@ bool EmbeddingSegmentsSum::isExecutable() const {
 }
 
 void EmbeddingSegmentsSum::execute(dnnl::stream strm) {
-    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
     const uint8_t* weightsData = nullptr;
     if (_withWeights)
-        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->GetPtr());
+        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->GetData());
 
     const auto &inputMem  = getParentEdgeAt(0)->getMemory();
     EmbeddingBagSum::execute(srcData, weightsData, inputMem.getDesc().getPrecision(),

--- a/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.cpp
@@ -83,14 +83,14 @@ void EmbeddingSegmentsSum::prepareParams() {
 }
 
 void EmbeddingSegmentsSum::initFromInputs() {
-    indices_ = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->GetData());
-    indicesSize_ = getParentEdgeAt(INDICES_IDX)->getMemory().GetShape().getElementsCount();
+    indices_ = reinterpret_cast<const int *>(getParentEdgeAt(INDICES_IDX)->getMemoryPtr()->getData());
+    indicesSize_ = getParentEdgeAt(INDICES_IDX)->getMemory().getShape().getElementsCount();
 
-    segmentIds_ = reinterpret_cast<const int *>(getParentEdgeAt(SEGMENT_ID_IDX)->getMemoryPtr()->GetData());
+    segmentIds_ = reinterpret_cast<const int *>(getParentEdgeAt(SEGMENT_ID_IDX)->getMemoryPtr()->getData());
     lastNumSegments_ = getNumSegments();
 
     if (getParentEdges().size() > DEFAULT_INDEX_IDX) {
-        defaultIndices_ = reinterpret_cast<const int *>(getParentEdgeAt(DEFAULT_INDEX_IDX)->getMemoryPtr()->GetData());
+        defaultIndices_ = reinterpret_cast<const int *>(getParentEdgeAt(DEFAULT_INDEX_IDX)->getMemoryPtr()->getData());
     }
 }
 
@@ -123,7 +123,7 @@ void EmbeddingSegmentsSum::getIndices(size_t embIndex, const int*& indices, size
 }
 
 int32_t EmbeddingSegmentsSum::getNumSegments() const {
-    return reinterpret_cast<const int32_t *>(getParentEdgesAtPort(NUM_SEGMENTS_IDX)[0]->getMemory().GetData())[0];
+    return reinterpret_cast<const int32_t *>(getParentEdgesAtPort(NUM_SEGMENTS_IDX)[0]->getMemory().getData())[0];
 }
 
 bool EmbeddingSegmentsSum::needShapeInfer() const {
@@ -147,10 +147,10 @@ bool EmbeddingSegmentsSum::isExecutable() const {
 }
 
 void EmbeddingSegmentsSum::execute(dnnl::stream strm) {
-    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
     const uint8_t* weightsData = nullptr;
     if (_withWeights)
-        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->GetData());
+        weightsData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(PER_SAMPLE_WEIGHTS_IDX)->getMemoryPtr()->getData());
 
     const auto &inputMem  = getParentEdgeAt(0)->getMemory();
     EmbeddingBagSum::execute(srcData, weightsData, inputMem.getDesc().getPrecision(),

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
@@ -465,10 +465,10 @@ bool AclEltwiseExecutor::init(const EltwiseAttrs &eltwiseAttrs, const std::vecto
 void AclEltwiseExecutor::exec(const std::vector<MemoryCPtr> &src, const std::vector<MemoryPtr> &dst,
                               const void *post_ops_data_) {
     for (size_t i = 0; i < src.size(); i++) {
-        srcTensors[i].allocator()->import_memory(src[i]->GetData());
+        srcTensors[i].allocator()->import_memory(src[i]->getData());
     }
     for (size_t i = 0; i < dst.size(); i++) {
-        dstTensors[i].allocator()->import_memory(dst[i]->GetData());
+        dstTensors[i].allocator()->import_memory(dst[i]->getData());
     }
 
     exec_func();

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.cpp
@@ -465,10 +465,10 @@ bool AclEltwiseExecutor::init(const EltwiseAttrs &eltwiseAttrs, const std::vecto
 void AclEltwiseExecutor::exec(const std::vector<MemoryCPtr> &src, const std::vector<MemoryPtr> &dst,
                               const void *post_ops_data_) {
     for (size_t i = 0; i < src.size(); i++) {
-        srcTensors[i].allocator()->import_memory(src[i]->GetPtr());
+        srcTensors[i].allocator()->import_memory(src[i]->GetData());
     }
     for (size_t i = 0; i < dst.size(); i++) {
-        dstTensors[i].allocator()->import_memory(dst[i]->GetPtr());
+        dstTensors[i].allocator()->import_memory(dst[i]->GetData());
     }
 
     exec_func();

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
@@ -93,7 +93,7 @@ bool ov::intel_cpu::ACLInterpolateExecutor::init(const InterpolateAttrs &interpo
 void ov::intel_cpu::ACLInterpolateExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst, const void *post_ops_data_) {
     auto in_ptr_ = padPreprocess(src, dst);
     srcTensor.allocator()->import_memory(const_cast<void *>(reinterpret_cast<const void *>(in_ptr_)));
-    dstTensor.allocator()->import_memory(dst[0]->GetPtr());
+    dstTensor.allocator()->import_memory(dst[0]->GetData());
 
     acl_scale->run();
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.cpp
@@ -93,7 +93,7 @@ bool ov::intel_cpu::ACLInterpolateExecutor::init(const InterpolateAttrs &interpo
 void ov::intel_cpu::ACLInterpolateExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst, const void *post_ops_data_) {
     auto in_ptr_ = padPreprocess(src, dst);
     srcTensor.allocator()->import_memory(const_cast<void *>(reinterpret_cast<const void *>(in_ptr_)));
-    dstTensor.allocator()->import_memory(dst[0]->GetData());
+    dstTensor.allocator()->import_memory(dst[0]->getData());
 
     acl_scale->run();
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
@@ -63,8 +63,8 @@ bool AclMVNExecutor::init(const MVNAttrs& mvnAttrs,
 }
 
 void AclMVNExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst, const void *post_ops_data_) {
-    srcTensor.allocator()->import_memory(src[0]->GetPtr());
-    dstTensor.allocator()->import_memory(dst[0]->GetPtr());
+    srcTensor.allocator()->import_memory(src[0]->GetData());
+    dstTensor.allocator()->import_memory(dst[0]->GetData());
 
     mvn->run();
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
@@ -63,8 +63,8 @@ bool AclMVNExecutor::init(const MVNAttrs& mvnAttrs,
 }
 
 void AclMVNExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst, const void *post_ops_data_) {
-    srcTensor.allocator()->import_memory(src[0]->GetData());
-    dstTensor.allocator()->import_memory(dst[0]->GetData());
+    srcTensor.allocator()->import_memory(src[0]->getData());
+    dstTensor.allocator()->import_memory(dst[0]->getData());
 
     mvn->run();
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.cpp
@@ -173,9 +173,9 @@ bool AclPoolingExecutor::init(const PoolingAttrs& poolingAttrs,
 }
 
 void AclPoolingExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst, std::unordered_map<int, MemoryPtr> postOpsArgs) {
-    srcTensor.allocator()->import_memory(src[0]->GetPtr());
-    dstTensor.allocator()->import_memory(dst[0]->GetPtr());
-    if (dst.size() > 1u) indTensor.allocator()->import_memory(dst[1]->GetPtr());
+    srcTensor.allocator()->import_memory(src[0]->GetData());
+    dstTensor.allocator()->import_memory(dst[0]->GetData());
+    if (dst.size() > 1u) indTensor.allocator()->import_memory(dst[1]->GetData());
 
     exec_func();
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.cpp
@@ -173,9 +173,9 @@ bool AclPoolingExecutor::init(const PoolingAttrs& poolingAttrs,
 }
 
 void AclPoolingExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst, std::unordered_map<int, MemoryPtr> postOpsArgs) {
-    srcTensor.allocator()->import_memory(src[0]->GetData());
-    dstTensor.allocator()->import_memory(dst[0]->GetData());
-    if (dst.size() > 1u) indTensor.allocator()->import_memory(dst[1]->GetData());
+    srcTensor.allocator()->import_memory(src[0]->getData());
+    dstTensor.allocator()->import_memory(dst[0]->getData());
+    if (dst.size() > 1u) indTensor.allocator()->import_memory(dst[1]->getData());
 
     exec_func();
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.cpp
@@ -92,8 +92,8 @@ bool AclReduceExecutor::init(const ReduceAttrs& reduceAttrs,
 }
 
 void AclReduceExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst, const void *post_ops_data_) {
-    srcTensor.allocator()->import_memory(src[0]->GetPtr());
-    dstTensor.allocator()->import_memory(dst[0]->GetPtr());
+    srcTensor.allocator()->import_memory(src[0]->GetData());
+    dstTensor.allocator()->import_memory(dst[0]->GetData());
 
     exec_func();
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.cpp
@@ -92,8 +92,8 @@ bool AclReduceExecutor::init(const ReduceAttrs& reduceAttrs,
 }
 
 void AclReduceExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst, const void *post_ops_data_) {
-    srcTensor.allocator()->import_memory(src[0]->GetData());
-    dstTensor.allocator()->import_memory(dst[0]->GetData());
+    srcTensor.allocator()->import_memory(src[0]->getData());
+    dstTensor.allocator()->import_memory(dst[0]->getData());
 
     exec_func();
 

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
@@ -451,7 +451,7 @@ inline SizeVector getBlockND(const SizeVector& shape) {
 }
 
 const uint8_t* ov::intel_cpu::InterpolateExecutor::padPreprocess(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst) {
-    const uint8_t *src_data_origin = reinterpret_cast<uint8_t*>(src[0]->GetData());
+    const uint8_t *src_data_origin = reinterpret_cast<uint8_t*>(src[0]->getData());
 
     const auto &srcDim = src[0]->getStaticDims();
     const auto &dstDim = dst[0]->getStaticDims();

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_detection_output.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_detection_output.cpp
@@ -277,14 +277,14 @@ void ExperimentalDetectronDetectionOutput::execute(dnnl::stream strm) {
     assert(classes_num_ == static_cast<int>(getParentEdgeAt(INPUT_SCORES)->getMemory().getStaticDims()[1]));
     assert(4 * classes_num_ == static_cast<int>(getParentEdgeAt(INPUT_DELTAS)->getMemory().getStaticDims()[1]));
 
-    const auto* boxes = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->GetPtr());
-    const auto* deltas = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->GetPtr());
-    const auto* scores = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->GetPtr());
-    const auto* im_info = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->GetPtr());
+    const auto* boxes = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->GetData());
+    const auto* deltas = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->GetData());
+    const auto* scores = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->GetData());
+    const auto* im_info = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->GetData());
 
-    auto* output_boxes = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_BOXES)[0]->getMemoryPtr()->GetPtr());
-    auto* output_scores = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->GetPtr());
-    auto* output_classes = reinterpret_cast<int32_t *>(getChildEdgesAtPort(OUTPUT_CLASSES)[0]->getMemoryPtr()->GetPtr());
+    auto* output_boxes = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_BOXES)[0]->getMemoryPtr()->GetData());
+    auto* output_scores = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->GetData());
+    auto* output_classes = reinterpret_cast<int32_t *>(getChildEdgesAtPort(OUTPUT_CLASSES)[0]->getMemoryPtr()->GetData());
 
     const float img_H = im_info[0];
     const float img_W = im_info[1];

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_detection_output.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_detection_output.cpp
@@ -277,14 +277,14 @@ void ExperimentalDetectronDetectionOutput::execute(dnnl::stream strm) {
     assert(classes_num_ == static_cast<int>(getParentEdgeAt(INPUT_SCORES)->getMemory().getStaticDims()[1]));
     assert(4 * classes_num_ == static_cast<int>(getParentEdgeAt(INPUT_DELTAS)->getMemory().getStaticDims()[1]));
 
-    const auto* boxes = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->GetData());
-    const auto* deltas = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->GetData());
-    const auto* scores = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->GetData());
-    const auto* im_info = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->GetData());
+    const auto* boxes = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->getData());
+    const auto* deltas = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->getData());
+    const auto* scores = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->getData());
+    const auto* im_info = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->getData());
 
-    auto* output_boxes = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_BOXES)[0]->getMemoryPtr()->GetData());
-    auto* output_scores = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->GetData());
-    auto* output_classes = reinterpret_cast<int32_t *>(getChildEdgesAtPort(OUTPUT_CLASSES)[0]->getMemoryPtr()->GetData());
+    auto* output_boxes = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_BOXES)[0]->getMemoryPtr()->getData());
+    auto* output_scores = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->getData());
+    auto* output_classes = reinterpret_cast<int32_t *>(getChildEdgesAtPort(OUTPUT_CLASSES)[0]->getMemoryPtr()->getData());
 
     const float img_H = im_info[0];
     const float img_W = im_info[1];

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_generate_proposals_single_image.cpp
@@ -349,13 +349,13 @@ void ExperimentalDetectronGenerateProposalsSingleImage::execute(dnnl::stream str
             IE_THROW() << "'Deltas' blob size for ONNXProposal is incompatible with 'scores' blob size!";
 
         // Prepare memory
-        const float *p_deltas_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->GetPtr());
-        const float *p_scores_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->GetPtr());
-        const float *p_anchors_item = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ANCHORS)->getMemoryPtr()->GetPtr());
-        const float *p_img_info_cpu = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->GetPtr());
+        const float *p_deltas_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->GetData());
+        const float *p_scores_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->GetData());
+        const float *p_anchors_item = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ANCHORS)->getMemoryPtr()->GetData());
+        const float *p_img_info_cpu = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->GetData());
 
-        float *p_roi_item       = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetPtr());
-        float *p_roi_score_item = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->GetPtr());
+        float *p_roi_item       = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetData());
+        float *p_roi_score_item = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->GetData());
 
         const int anchors_num = scoreDims[0];
 

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_generate_proposals_single_image.cpp
@@ -349,13 +349,13 @@ void ExperimentalDetectronGenerateProposalsSingleImage::execute(dnnl::stream str
             IE_THROW() << "'Deltas' blob size for ONNXProposal is incompatible with 'scores' blob size!";
 
         // Prepare memory
-        const float *p_deltas_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->GetData());
-        const float *p_scores_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->GetData());
-        const float *p_anchors_item = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ANCHORS)->getMemoryPtr()->GetData());
-        const float *p_img_info_cpu = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->GetData());
+        const float *p_deltas_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->getData());
+        const float *p_scores_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->getData());
+        const float *p_anchors_item = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ANCHORS)->getMemoryPtr()->getData());
+        const float *p_img_info_cpu = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->getData());
 
-        float *p_roi_item       = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetData());
-        float *p_roi_score_item = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->GetData());
+        float *p_roi_item       = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->getData());
+        float *p_roi_score_item = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->getData());
 
         const int anchors_num = scoreDims[0];
 

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.cpp
@@ -70,8 +70,8 @@ void ExperimentalDetectronPriorGridGenerator::execute(dnnl::stream strm) {
     const float step_w = stride_w_ ? stride_w_ : static_cast<float>(getParentEdgeAt(INPUT_IMAGE)->getMemory().getStaticDims()[3]) / layer_width;
     const float step_h = stride_h_ ? stride_h_ : static_cast<float>(getParentEdgeAt(INPUT_IMAGE)->getMemory().getStaticDims()[2]) / layer_height;
 
-    const auto *bottom_data_0 = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    auto *top_data_0 = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetPtr());
+    const auto *bottom_data_0 = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    auto *top_data_0 = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetData());
 
     for (int h = 0; h < layer_height; ++h) {
         for (int w = 0; w < layer_width; ++w) {

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.cpp
@@ -70,8 +70,8 @@ void ExperimentalDetectronPriorGridGenerator::execute(dnnl::stream strm) {
     const float step_w = stride_w_ ? stride_w_ : static_cast<float>(getParentEdgeAt(INPUT_IMAGE)->getMemory().getStaticDims()[3]) / layer_width;
     const float step_h = stride_h_ ? stride_h_ : static_cast<float>(getParentEdgeAt(INPUT_IMAGE)->getMemory().getStaticDims()[2]) / layer_height;
 
-    const auto *bottom_data_0 = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    auto *top_data_0 = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetData());
+    const auto *bottom_data_0 = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    auto *top_data_0 = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->getData());
 
     for (int h = 0; h < layer_height; ++h) {
         for (int w = 0; w < layer_width; ++w) {

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_roifeatureextractor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_roifeatureextractor.cpp
@@ -335,11 +335,11 @@ void ExperimentalDetectronROIFeatureExtractor::execute(dnnl::stream strm) {
     const int channels_num = getParentEdgeAt(INPUT_FEATURES_START)->getMemory().getStaticDims()[1];
     const int feaxels_per_roi = pooled_height_ * pooled_width_ * channels_num;
 
-    auto *input_rois = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->GetPtr());
-    auto *output_rois_features = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROI_FEATURES)[0]->getMemoryPtr()->GetPtr());
+    auto *input_rois = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->GetData());
+    auto *output_rois_features = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROI_FEATURES)[0]->getMemoryPtr()->GetData());
     float *output_rois = nullptr;
     if (OUTPUT_ROIS < outputShapes.size()) {
-        output_rois = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetPtr());
+        output_rois = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetData());
     }
 
     std::vector<int> level_ids(num_rois, 0);
@@ -357,7 +357,7 @@ void ExperimentalDetectronROIFeatureExtractor::execute(dnnl::stream strm) {
         const int level_rois_offset = rois_per_level[i];
         const int level_rois_num = rois_per_level[i + 1] - level_rois_offset;
         if (level_rois_num > 0) {
-            auto *featuremap = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_FEATURES_START + i)->getMemoryPtr()->GetPtr());
+            auto *featuremap = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_FEATURES_START + i)->getMemoryPtr()->GetData());
             const int featuremap_height = getParentEdgeAt(INPUT_FEATURES_START + i)->getMemory().getStaticDims()[2];
             const int featuremap_width = getParentEdgeAt(INPUT_FEATURES_START + i)->getMemory().getStaticDims()[3];
             ROIAlignForward_cpu_kernel<float>(feaxels_per_roi * level_rois_num,

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_roifeatureextractor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_roifeatureextractor.cpp
@@ -335,11 +335,11 @@ void ExperimentalDetectronROIFeatureExtractor::execute(dnnl::stream strm) {
     const int channels_num = getParentEdgeAt(INPUT_FEATURES_START)->getMemory().getStaticDims()[1];
     const int feaxels_per_roi = pooled_height_ * pooled_width_ * channels_num;
 
-    auto *input_rois = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->GetData());
-    auto *output_rois_features = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROI_FEATURES)[0]->getMemoryPtr()->GetData());
+    auto *input_rois = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->getData());
+    auto *output_rois_features = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROI_FEATURES)[0]->getMemoryPtr()->getData());
     float *output_rois = nullptr;
     if (OUTPUT_ROIS < outputShapes.size()) {
-        output_rois = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetData());
+        output_rois = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->getData());
     }
 
     std::vector<int> level_ids(num_rois, 0);
@@ -357,7 +357,7 @@ void ExperimentalDetectronROIFeatureExtractor::execute(dnnl::stream strm) {
         const int level_rois_offset = rois_per_level[i];
         const int level_rois_num = rois_per_level[i + 1] - level_rois_offset;
         if (level_rois_num > 0) {
-            auto *featuremap = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_FEATURES_START + i)->getMemoryPtr()->GetData());
+            auto *featuremap = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_FEATURES_START + i)->getMemoryPtr()->getData());
             const int featuremap_height = getParentEdgeAt(INPUT_FEATURES_START + i)->getMemory().getStaticDims()[2];
             const int featuremap_width = getParentEdgeAt(INPUT_FEATURES_START + i)->getMemory().getStaticDims()[3];
             ROIAlignForward_cpu_kernel<float>(feaxels_per_roi * level_rois_num,

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_topkrois.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_topkrois.cpp
@@ -67,9 +67,9 @@ void ExperimentalDetectronTopKROIs::execute(dnnl::stream strm) {
     const int input_rois_num = getParentEdgeAt(INPUT_ROIS)->getMemory().getStaticDims()[0];
     const int top_rois_num = (std::min)(max_rois_num_, input_rois_num);
 
-    auto *input_rois = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->GetPtr());
-    auto *input_probs = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_PROBS)->getMemoryPtr()->GetPtr());
-    auto *output_rois = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetPtr());
+    auto *input_rois = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->GetData());
+    auto *input_probs = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_PROBS)->getMemoryPtr()->GetData());
+    auto *output_rois = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetData());
 
     std::vector<size_t> idx(input_rois_num);
     iota(idx.begin(), idx.end(), 0);

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_topkrois.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_topkrois.cpp
@@ -67,9 +67,9 @@ void ExperimentalDetectronTopKROIs::execute(dnnl::stream strm) {
     const int input_rois_num = getParentEdgeAt(INPUT_ROIS)->getMemory().getStaticDims()[0];
     const int top_rois_num = (std::min)(max_rois_num_, input_rois_num);
 
-    auto *input_rois = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->GetData());
-    auto *input_probs = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_PROBS)->getMemoryPtr()->GetData());
-    auto *output_rois = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetData());
+    auto *input_rois = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ROIS)->getMemoryPtr()->getData());
+    auto *input_probs = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_PROBS)->getMemoryPtr()->getData());
+    auto *output_rois = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->getData());
 
     std::vector<size_t> idx(input_rois_num);
     iota(idx.begin(), idx.end(), 0);

--- a/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
+++ b/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
@@ -419,8 +419,8 @@ void ExtractImagePatches::initSupportedPrimitiveDescriptors() {
 
 void ExtractImagePatches::execute(dnnl::stream strm) {
     if (execPtr) {
-        auto src = getParentEdgeAt(0)->getMemoryPtr()->GetPtr();
-        auto dst = getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetPtr();
+        auto src = getParentEdgeAt(0)->getMemoryPtr()->GetData();
+        auto dst = getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData();
         const auto inStrides = getParentEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
         const auto outStrides = getChildEdgesAtPort(0)[0]->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
         execPtr->exec(src, dst, inStrides, outStrides);

--- a/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
+++ b/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
@@ -419,10 +419,10 @@ void ExtractImagePatches::initSupportedPrimitiveDescriptors() {
 
 void ExtractImagePatches::execute(dnnl::stream strm) {
     if (execPtr) {
-        auto src = getParentEdgeAt(0)->getMemoryPtr()->GetData();
-        auto dst = getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData();
-        const auto inStrides = getParentEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
-        const auto outStrides = getChildEdgesAtPort(0)[0]->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
+        auto src = getParentEdgeAt(0)->getMemoryPtr()->getData();
+        auto dst = getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData();
+        const auto inStrides = getParentEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
+        const auto outStrides = getChildEdgesAtPort(0)[0]->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
         execPtr->exec(src, dst, inStrides, outStrides);
     } else {
         IE_THROW() << "Can't execute extract image patches node. Primitive wasn't created";

--- a/src/plugins/intel_cpu/src/nodes/eye.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eye.cpp
@@ -108,7 +108,7 @@ void Eye::executeSpecified() {
     auto outPtr = getChildEdgeAt(0)->getMemoryPtr();
     if (!outPtr || !outPtr ->isAllocated())
             THROW_ERROR << errorPrefix << "Destination memory didn't allocate.";
-    T *dst = reinterpret_cast<T *>(outPtr->GetPtr());
+    T *dst = reinterpret_cast<T *>(outPtr->GetData());
 
     const size_t batchVolume = getBatchVolume(getBatchShape());
     const size_t spatialCount = colNum * rowNum;

--- a/src/plugins/intel_cpu/src/nodes/eye.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eye.cpp
@@ -108,7 +108,7 @@ void Eye::executeSpecified() {
     auto outPtr = getChildEdgeAt(0)->getMemoryPtr();
     if (!outPtr || !outPtr ->isAllocated())
             THROW_ERROR << errorPrefix << "Destination memory didn't allocate.";
-    T *dst = reinterpret_cast<T *>(outPtr->GetData());
+    T *dst = reinterpret_cast<T *>(outPtr->getData());
 
     const size_t batchVolume = getBatchVolume(getBatchShape());
     const size_t spatialCount = colNum * rowNum;

--- a/src/plugins/intel_cpu/src/nodes/eye.h
+++ b/src/plugins/intel_cpu/src/nodes/eye.h
@@ -45,7 +45,7 @@ private:
         auto rowMem = getParentEdgeAt(ROWS_NUM)->getMemoryPtr();
         if (rowMem == nullptr)
             IE_THROW() << errorPrefix << " doesn't contain row_count data";
-        const int *rowPtr = reinterpret_cast<const int *>(rowMem->GetPtr());
+        const int *rowPtr = reinterpret_cast<const int *>(rowMem->GetData());
 
         return rowPtr[0];
     }
@@ -53,7 +53,7 @@ private:
         auto colMem = getParentEdgeAt(COLS_NUM)->getMemoryPtr();
         if (colMem == nullptr)
             IE_THROW() << errorPrefix << " doesn't contain col_count data";
-        const int *colPtr =  reinterpret_cast<const int *>(colMem->GetPtr());
+        const int *colPtr =  reinterpret_cast<const int *>(colMem->GetData());
 
         return colPtr[0];
     }
@@ -61,7 +61,7 @@ private:
         auto diagIndMem = getParentEdgeAt(DIAGONAL_INDEX)->getMemoryPtr();
         if (diagIndMem == nullptr)
             IE_THROW() << errorPrefix << " doesn't contain diag_index data";
-        const int *diagIndexPtr = reinterpret_cast<const int *>(diagIndMem->GetPtr());
+        const int *diagIndexPtr = reinterpret_cast<const int *>(diagIndMem->GetData());
 
         return diagIndexPtr[0];
     }
@@ -69,7 +69,7 @@ private:
         if (withBatchShape) {
             const int batchShapeSize = static_cast<const int>(getParentEdgeAt(BATCH_SHAPE)->getMemoryPtr()->GetShape().getElementsCount());
             std::vector<int> batchShape(batchShapeSize);
-            const int *batchShapePtr = reinterpret_cast<const int *>(getParentEdgeAt(BATCH_SHAPE)->getMemoryPtr()->GetPtr());
+            const int *batchShapePtr = reinterpret_cast<const int *>(getParentEdgeAt(BATCH_SHAPE)->getMemoryPtr()->GetData());
             batchShape.assign(batchShapePtr, batchShapePtr + batchShapeSize);
             return batchShape;
         } else {

--- a/src/plugins/intel_cpu/src/nodes/eye.h
+++ b/src/plugins/intel_cpu/src/nodes/eye.h
@@ -45,7 +45,7 @@ private:
         auto rowMem = getParentEdgeAt(ROWS_NUM)->getMemoryPtr();
         if (rowMem == nullptr)
             IE_THROW() << errorPrefix << " doesn't contain row_count data";
-        const int *rowPtr = reinterpret_cast<const int *>(rowMem->GetData());
+        const int *rowPtr = reinterpret_cast<const int *>(rowMem->getData());
 
         return rowPtr[0];
     }
@@ -53,7 +53,7 @@ private:
         auto colMem = getParentEdgeAt(COLS_NUM)->getMemoryPtr();
         if (colMem == nullptr)
             IE_THROW() << errorPrefix << " doesn't contain col_count data";
-        const int *colPtr =  reinterpret_cast<const int *>(colMem->GetData());
+        const int *colPtr =  reinterpret_cast<const int *>(colMem->getData());
 
         return colPtr[0];
     }
@@ -61,15 +61,15 @@ private:
         auto diagIndMem = getParentEdgeAt(DIAGONAL_INDEX)->getMemoryPtr();
         if (diagIndMem == nullptr)
             IE_THROW() << errorPrefix << " doesn't contain diag_index data";
-        const int *diagIndexPtr = reinterpret_cast<const int *>(diagIndMem->GetData());
+        const int *diagIndexPtr = reinterpret_cast<const int *>(diagIndMem->getData());
 
         return diagIndexPtr[0];
     }
     inline const std::vector<int> getBatchShape() const {
         if (withBatchShape) {
-            const int batchShapeSize = static_cast<const int>(getParentEdgeAt(BATCH_SHAPE)->getMemoryPtr()->GetShape().getElementsCount());
+            const int batchShapeSize = static_cast<const int>(getParentEdgeAt(BATCH_SHAPE)->getMemoryPtr()->getShape().getElementsCount());
             std::vector<int> batchShape(batchShapeSize);
-            const int *batchShapePtr = reinterpret_cast<const int *>(getParentEdgeAt(BATCH_SHAPE)->getMemoryPtr()->GetData());
+            const int *batchShapePtr = reinterpret_cast<const int *>(getParentEdgeAt(BATCH_SHAPE)->getMemoryPtr()->getData());
             batchShape.assign(batchShapePtr, batchShapePtr + batchShapeSize);
             return batchShape;
         } else {

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -1837,7 +1837,7 @@ void FakeQuantize::initializePostOpDataLegacy(const VectorDims &dims, const size
 void FakeQuantize::appendMemory(const size_t dataSize, const void *data, MemoryPtr &memPtr, std::vector<MemoryPtr>& postOpsMem) {
     if (!memPtr) {
         DnnlBlockedMemoryDesc memoryDesc(Precision::FP32, {dataSize});
-        memPtr.reset(new Memory(getEngine(), memoryDesc, data));
+        memPtr = std::make_shared<Memory>(getEngine(), memoryDesc, data);
 
         postOpsMem.push_back(memPtr);
     }

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -1486,8 +1486,8 @@ void FakeQuantize::createPrimitive() {
 }
 
 void FakeQuantize::executeReference() {
-    auto &srcMemory = getParentEdgeAt(0)->getMemoryPtr();
-    auto &dstMemory = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemory = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemory = getChildEdgeAt(0)->getMemoryPtr();
 
     auto src = reinterpret_cast<const float *>(srcMemory->GetPtr());
 
@@ -1596,8 +1596,8 @@ void FakeQuantize::executeReference() {
 }
 void FakeQuantize::executeBinarization(const std::unique_ptr<jit_uni_quantize_kernel> &pKernel) const {
 #if defined(OPENVINO_ARCH_X86_64)
-    const auto &srcMemory = getParentEdgeAt(0)->getMemoryPtr();
-    auto &dstMemory = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemory = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemory = getChildEdgeAt(0)->getMemoryPtr();
 
     auto src = reinterpret_cast<const uint8_t *>(srcMemory->GetPtr());
     auto dst = reinterpret_cast<uint8_t *>(dstMemory->GetPtr());
@@ -1638,8 +1638,8 @@ void FakeQuantize::executeBinarization(const std::unique_ptr<jit_uni_quantize_ke
 
 void FakeQuantize::executeQuantization(const std::unique_ptr<jit_uni_quantize_kernel> &pKernel) const {
 #if defined(OPENVINO_ARCH_X86_64)
-    auto &srcMemory = getParentEdgeAt(0)->getMemoryPtr();
-    auto &dstMemory = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemory = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemory = getChildEdgeAt(0)->getMemoryPtr();
 
     auto src = reinterpret_cast<const uint8_t *>(srcMemory->GetPtr());
     auto dst = reinterpret_cast<uint8_t *>(dstMemory->GetPtr());

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -1391,7 +1391,7 @@ bool FakeQuantize::needPrepareParams() const {
 
 void FakeQuantize::prepareParams() {
     if (isBinarization()) {
-        const size_t axisSize = getParentEdgeAt(0)->getMemory().GetShape().getStaticDims()[getAxis()];
+        const size_t axisSize = getParentEdgeAt(0)->getMemory().getShape().getStaticDims()[getAxis()];
         const size_t newPaddedSize = rnd_up(axisSize, 16);
         IE_ASSERT(newPaddedSize != 0);
 
@@ -1487,13 +1487,13 @@ void FakeQuantize::executeReference() {
     auto srcMemory = getParentEdgeAt(0)->getMemoryPtr();
     auto dstMemory = getChildEdgeAt(0)->getMemoryPtr();
 
-    auto src = reinterpret_cast<const float *>(srcMemory->GetData());
+    auto src = reinterpret_cast<const float *>(srcMemory->getData());
 
     auto srcDims = srcMemory->getStaticDims();
     auto dstDims = dstMemory->getStaticDims();
 
-    auto s_str = srcMemory->GetDescWithType<BlockedMemoryDesc>()->getStrides();
-    auto d_str = dstMemory->GetDescWithType<BlockedMemoryDesc>()->getStrides();
+    auto s_str = srcMemory->getDescWithType<BlockedMemoryDesc>()->getStrides();
+    auto d_str = dstMemory->getDescWithType<BlockedMemoryDesc>()->getStrides();
 
     const int N = srcDims[0];
     const int C = srcDims.size() > 1 ? srcDims[1] : 1;
@@ -1514,13 +1514,13 @@ void FakeQuantize::executeReference() {
         }
         d_str[1] = tmp;
 
-        auto dst = reinterpret_cast<uint8_t *>(dstMemory->GetData());
+        auto dst = reinterpret_cast<uint8_t *>(dstMemory->getData());
 
         const int nbits = 8;
         const int CB = impl::utils::div_up(C, nbits);
 
-        auto thresholds = reinterpret_cast<const float*>(internalBlobMemory[0]->GetData());
-        auto output_mask = reinterpret_cast<const uint32_t*>(internalBlobMemory[1]->GetData());
+        auto thresholds = reinterpret_cast<const float*>(internalBlobMemory[0]->getData());
+        auto output_mask = reinterpret_cast<const uint32_t*>(internalBlobMemory[1]->getData());
 
         parallel_nd(N, CB, D, H, W, [&](dim_t n, dim_t cb, dim_t d, dim_t h, dim_t w) {
             uint8_t bin_val = 0x00;
@@ -1550,7 +1550,7 @@ void FakeQuantize::executeReference() {
             dst[dst_off / nbits] = bin_val;
         });
     } else {
-        auto dst = reinterpret_cast<float *>(dstMemory->GetData());
+        auto dst = reinterpret_cast<float *>(dstMemory->getData());
 
         parallel_nd(N, C, D, H, W, [&](dim_t n, dim_t c, dim_t d, dim_t h, dim_t w) {
             size_t src_off = srcDims.size() == 5 ?
@@ -1597,15 +1597,15 @@ void FakeQuantize::executeBinarization(const std::unique_ptr<jit_uni_quantize_ke
     auto srcMemory = getParentEdgeAt(0)->getMemoryPtr();
     auto dstMemory = getChildEdgeAt(0)->getMemoryPtr();
 
-    auto src = reinterpret_cast<const uint8_t *>(srcMemory->GetData());
-    auto dst = reinterpret_cast<uint8_t *>(dstMemory->GetData());
+    auto src = reinterpret_cast<const uint8_t *>(srcMemory->getData());
+    auto dst = reinterpret_cast<uint8_t *>(dstMemory->getData());
 
-    auto thresholds = reinterpret_cast<const float*>(internalBlobMemory[0]->GetData());
-    auto output_mask = reinterpret_cast<const float*>(internalBlobMemory[1]->GetData());
+    auto thresholds = reinterpret_cast<const float*>(internalBlobMemory[0]->getData());
+    auto output_mask = reinterpret_cast<const float*>(internalBlobMemory[1]->getData());
 
     auto src_dims = srcMemory->getStaticDims();
 
-    auto srcMemDesc = srcMemory->GetDescWithType<BlockedMemoryDesc>();
+    auto srcMemDesc = srcMemory->getDescWithType<BlockedMemoryDesc>();
     std::vector<size_t> s_str = srcMemDesc->getStrides();
     size_t tmp = s_str[s_str.size() - 1];
     for (int i = s_str.size() - 1; i > 1; i--) {
@@ -1639,8 +1639,8 @@ void FakeQuantize::executeQuantization(const std::unique_ptr<jit_uni_quantize_ke
     auto srcMemory = getParentEdgeAt(0)->getMemoryPtr();
     auto dstMemory = getChildEdgeAt(0)->getMemoryPtr();
 
-    auto src = reinterpret_cast<const uint8_t *>(srcMemory->GetData());
-    auto dst = reinterpret_cast<uint8_t *>(dstMemory->GetData());
+    auto src = reinterpret_cast<const uint8_t *>(srcMemory->getData());
+    auto dst = reinterpret_cast<uint8_t *>(dstMemory->getData());
 
     auto& srcDesc = srcMemory->getDesc();
     auto srcDims = srcDesc.getShape().getStaticDims();
@@ -1653,7 +1653,7 @@ void FakeQuantize::executeQuantization(const std::unique_ptr<jit_uni_quantize_ke
     auto src_type_size = jqp.src_prc.size();
     auto dst_type_size = jqp.dst_prc.size();
 
-    auto srcMemDesc = srcMemory->GetDescWithType<BlockedMemoryDesc>();
+    auto srcMemDesc = srcMemory->getDescWithType<BlockedMemoryDesc>();
     auto s_str = srcMemDesc->getStrides();
 
     if (is_blk_format) {

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -312,11 +312,11 @@ void FullyConnected::prepareParams() {
     DnnlMemoryDescPtr weightDesc = MemoryDescUtils::convertToDnnlMemoryDesc(weightDescIP);
     DnnlMemoryDescCPtr biasDesc = nullptr;
     if (biasMemPtr) {
-        biasDesc = biasMemPtr->GetDescWithType<DnnlMemoryDesc>();
+        biasDesc = biasMemPtr->getDescWithType<DnnlMemoryDesc>();
     }
 
-    DnnlMemoryDescCPtr inDesc = srcMemPtr->GetDescWithType<DnnlMemoryDesc>();
-    DnnlMemoryDescCPtr outDesc = dstMemPtr->GetDescWithType<DnnlMemoryDesc>();
+    DnnlMemoryDescCPtr inDesc = srcMemPtr->getDescWithType<DnnlMemoryDesc>();
+    DnnlMemoryDescCPtr outDesc = dstMemPtr->getDescWithType<DnnlMemoryDesc>();
 
     useConv1x1 = canBeExecutedInConv1x1();
     FCKey key = {inDesc,
@@ -398,19 +398,19 @@ void FullyConnected::prepareParams() {
 
     if (execPtr) {
         if (execPtr->getSrcDesc()->isCompatible(*inDesc)) {
-            primArgs[DNNL_ARG_SRC] = srcMemPtr->GetPrimitive();
+            primArgs[DNNL_ARG_SRC] = srcMemPtr->getPrimitive();
         } else {
-            primArgs[DNNL_ARG_SRC] = dnnl::memory(execPtr->getDnnlSrcDesc(), engine, srcMemPtr->GetData());
+            primArgs[DNNL_ARG_SRC] = dnnl::memory(execPtr->getDnnlSrcDesc(), engine, srcMemPtr->getData());
         }
 
         if (execPtr->getDstDesc()->isCompatible(*outDesc)) {
-            primArgs[DNNL_ARG_DST] = dstMemPtr->GetPrimitive();
+            primArgs[DNNL_ARG_DST] = dstMemPtr->getPrimitive();
         } else {
-            primArgs[DNNL_ARG_DST] = dnnl::memory(execPtr->getDnnlDstDesc(), engine, dstMemPtr->GetData());
+            primArgs[DNNL_ARG_DST] = dnnl::memory(execPtr->getDnnlDstDesc(), engine, dstMemPtr->getData());
         }
 
         if (!prevExecPtr || !execPtr->getWeightDesc()->isCompatible(*(prevExecPtr->getWeightDesc()))) {
-            primArgs[DNNL_ARG_WEIGHTS] = prepareWeightMemory(execPtr->getWeightDesc())->GetPrimitive();
+            primArgs[DNNL_ARG_WEIGHTS] = prepareWeightMemory(execPtr->getWeightDesc())->getPrimitive();
         }
         // changed shapes may also cause the kernel type changed
         selected_pd->setImplementationType(execPtr->getImplementationType());
@@ -422,11 +422,11 @@ void FullyConnected::prepareParams() {
         useConv1x1 = execPtr->getImplementationType() == brgconv_avx512_1x1;
 
         if (withBiases) {
-            primArgs[DNNL_ARG_BIAS] = biasMemPtr->GetPrimitive();
+            primArgs[DNNL_ARG_BIAS] = biasMemPtr->getPrimitive();
         }
 
         auto schratchpadMem = getScratchPadMem(execPtr->getScratchPadDesc());
-        primArgs[DNNL_ARG_SCRATCHPAD] = schratchpadMem->GetPrimitive();
+        primArgs[DNNL_ARG_SCRATCHPAD] = schratchpadMem->getPrimitive();
 #ifdef CPU_DEBUG_CAPS
         if (result.second == CacheEntryBase::LookUpStatus::Miss) {
             auto pd = execPtr->getPrimitiveDesc();
@@ -449,10 +449,10 @@ void FullyConnected::execute(dnnl::stream strm) {
         auto param = primArgs.find(argType);
         if (param != primArgs.end()) {
             if (argType == DNNL_ARG_SRC && (getInputShapeAtPort(DATA_ID).getRank() == 3 || useConv1x1)) {
-                primArgs.at(argType).set_data_handle(getParentEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
+                primArgs.at(argType).set_data_handle(getParentEdgesAtPort(0)[0]->getMemoryPtr()->getData());
             }
             if (argType == DNNL_ARG_DST && (getOutputShapeAtPort(0).getRank() == 3 || useConv1x1)) {
-                primArgs.at(argType).set_data_handle(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
+                primArgs.at(argType).set_data_handle(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
             }
         }
     };
@@ -744,7 +744,7 @@ InferenceEngine::Precision FullyConnected::getRuntimePrecision() const {
     for (size_t i = 0; i < std::min(getParentEdges().size(), inputsNumLimit); i++) {
         auto parentEdge = getParentEdgeAt(i);
         if (parentEdge && parentEdge->getStatus() == Edge::Status::Validated) {
-            inputPrecisions.emplace_back(DnnlExtensionUtils::DataTypeToIEPrecision((parentEdge->getMemoryPtr()->GetDataType())));
+            inputPrecisions.emplace_back(DnnlExtensionUtils::DataTypeToIEPrecision((parentEdge->getMemoryPtr()->getDataType())));
         }
     }
 
@@ -840,7 +840,7 @@ bool FullyConnected::canBeExecutedInConv1x1() const {
         getOriginalInputPrecisionAtPort(DATA_ID) == InferenceEngine::Precision::FP32 &&
         one_of(inRank, 2u, 3u) && weightRank == 2) {
         auto dstMemPtr = getChildEdgesAtPort(0)[0]->getMemoryPtr();
-        DnnlMemoryDescCPtr outDesc = dstMemPtr->GetDescWithType<DnnlMemoryDesc>();
+        DnnlMemoryDescCPtr outDesc = dstMemPtr->getDescWithType<DnnlMemoryDesc>();
         // brg convolution does not support stride
         dnnl::impl::memory_desc_wrapper wrapped(outDesc->getDnnlDesc().get());
         if (wrapped.offset0() == 0)
@@ -905,8 +905,8 @@ bool FullyConnected::useSparseWeightsDecompression() {
     if (blb == nullptr)
         IE_THROW() << "Cannot get const blob for node " << getName() << ".";
 
-    auto weightsData = reinterpret_cast<const int8_t*>(blb->GetData());
-    auto elementsCount = blb->GetDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
+    auto weightsData = reinterpret_cast<const int8_t*>(blb->getData());
+    auto elementsCount = blb->getDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
     size_t zerosCounts = 0;
     for (size_t i = 0; i < elementsCount; i++) {
         if (weightsData[i] == 0) {

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -905,7 +905,7 @@ bool FullyConnected::useSparseWeightsDecompression() {
     if (blb == nullptr)
         IE_THROW() << "Cannot get const blob for node " << getName() << ".";
 
-    auto weightsData = reinterpret_cast<const int8_t*>(blb->GetPtr());
+    auto weightsData = reinterpret_cast<const int8_t*>(blb->GetData());
     auto elementsCount = blb->GetDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
     size_t zerosCounts = 0;
     for (size_t i = 0; i < elementsCount; i++) {

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -308,10 +308,10 @@ bool Gather::needPrepareParams() const {
 }
 
 void Gather::prepareParams() {
-    auto& dataMemPtr = getParentEdgeAt(GATHER_DATA)->getMemoryPtr();
+    auto dataMemPtr = getParentEdgeAt(GATHER_DATA)->getMemoryPtr();
     if (!dataMemPtr || !dataMemPtr->isAllocated())
         THROW_ERROR << " has not allocated input data memory.";
-    auto& idxMemPtr = getParentEdgeAt(GATHER_INDICES)->getMemoryPtr();
+    auto idxMemPtr = getParentEdgeAt(GATHER_INDICES)->getMemoryPtr();
     if (!idxMemPtr || !idxMemPtr->isAllocated())
         THROW_ERROR << " has not allocated input indices memory.";
     if (getSelectedPrimitiveDescriptor() == nullptr)
@@ -607,10 +607,10 @@ void Gather::resolveInPlaceEdges(Edge::LOOK look) {
             //     getName() << " with type " << getTypeStr();
 
             auto memMngr = std::make_shared<PartitionedMemoryMngr>(baseMemMngr, baseDim, offset);
-            childEdge->getMemoryPtr().reset(new Memory(getEngine()));
-            childEdge->getMemoryPtr()->Create(config.outConfs[outputPort].getMemDesc(), memMngr);
+            auto newMem = std::make_shared<Memory>(getEngine());
+            newMem->Create(config.outConfs[outputPort].getMemDesc(), memMngr);
 
-            childEdge->changeStatus(Edge::Status::Allocated);
+            childEdge->resetMemoryPtr(newMem);
         }
     } else {
         Node::resolveInPlaceEdges(look);

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -607,9 +607,9 @@ void Gather::resolveInPlaceEdges(Edge::LOOK look) {
             //     getName() << " with type " << getTypeStr();
 
             auto memMngr = std::make_shared<PartitionedMemoryMngr>(baseMemMngr, baseDim, offset);
-            auto newMem = std::make_shared<Memory>(getEngine(), std::unique_ptr<IMemoryMngr>(memMngr.get()), config.outConfs[outputPort].getMemDesc());
+            auto newMem = std::make_shared<Memory>(getEngine(), config.outConfs[outputPort].getMemDesc(), memMngr);
 
-            childEdge->resetMemoryPtr(newMem);
+            childEdge->reuse(newMem);
         }
     } else {
         Node::resolveInPlaceEdges(look);

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -603,8 +603,8 @@ void Gather::resolveInPlaceEdges(Edge::LOOK look) {
         ptrdiff_t offset = index < 0 ? baseDim + index : index;
         const auto& childEdges = getChildEdgesAtPort(outputPort);
         for (auto& childEdge : childEdges) {
-            // IE_ASSERT(parentEdge->getStatus() == Edge::Status::NotAllocated) << "Unexpected edge status in node: " <<
-            //     getName() << " with type " << getTypeStr();
+            IE_ASSERT(childEdge->getStatus() == Edge::Status::NotAllocated) << " Unexpected edge status in node: " <<
+                getName() << " with type " << getTypeStr();
 
             auto memMngr = std::make_shared<PartitionedMemoryMngr>(baseMemMngr, baseDim, offset);
             auto newMem = std::make_shared<Memory>(getEngine(), config.outConfs[outputPort].getMemDesc(), memMngr);

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -62,7 +62,7 @@ public:
                 IE_THROW() << "Unsupported precision " << data_dependency.at(GATHER_AXIS)->getDesc().getPrecision()
                            << " for axis tensor.";
             }
-            m_axis = reinterpret_cast<const int32_t *>(data_dependency.at(GATHER_AXIS)->GetData())[0];
+            m_axis = reinterpret_cast<const int32_t *>(data_dependency.at(GATHER_AXIS)->getData())[0];
         }
 
         if (m_axis < 0)
@@ -303,7 +303,7 @@ bool Gather::needPrepareParams() const {
     }
     bool result = inputShapesModified();
     if (!isAxisInputConst)
-        result = result || axis != (reinterpret_cast<const int32_t*>(getParentEdgeAt(GATHER_AXIS)->getMemoryPtr()->GetData()))[0];
+        result = result || axis != (reinterpret_cast<const int32_t*>(getParentEdgeAt(GATHER_AXIS)->getMemoryPtr()->getData()))[0];
     return result;
 }
 
@@ -318,7 +318,7 @@ void Gather::prepareParams() {
         THROW_ERROR << " has unidentified preferable primitive descriptor.";
 
     if (!isAxisInputConst) {
-        axis = (reinterpret_cast<const int32_t*>(getParentEdgeAt(GATHER_AXIS)->getMemoryPtr()->GetData()))[0];
+        axis = (reinterpret_cast<const int32_t*>(getParentEdgeAt(GATHER_AXIS)->getMemoryPtr()->getData()))[0];
         if (axis < 0)
             axis += dataSrcRank;
         if (axis < 0 || axis >= dataSrcRank || batchDims > axis)
@@ -365,9 +365,9 @@ void Gather::prepareParams() {
 void Gather::execute(dnnl::stream strm) {
 #if defined(OPENVINO_ARCH_X86_64)
     if (jitKernel && jitKernel->isSupportedConfiguration(afterAxisSize)) {
-        const void* srcIndices = getParentEdgeAt(GATHER_INDICES)->getMemoryPtr()->GetData();
-        const void* srcData = getParentEdgeAt(GATHER_DATA)->getMemoryPtr()->GetData();
-        uint8_t* dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+        const void* srcIndices = getParentEdgeAt(GATHER_INDICES)->getMemoryPtr()->getData();
+        const void* srcData = getParentEdgeAt(GATHER_DATA)->getMemoryPtr()->getData();
+        uint8_t* dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
         const uint64_t dataElPerVec = jitKernel->getDataElPerVec();
 
@@ -421,9 +421,9 @@ void Gather::execute(dnnl::stream strm) {
 void Gather::executeDynamicImpl(dnnl::stream strm) {
 #if defined(OPENVINO_ARCH_X86_64)
     if (jitKernel && jitKernel->isSupportedConfiguration(afterAxisSize)) {
-        const void* srcIndices = getParentEdgeAt(GATHER_INDICES)->getMemoryPtr()->GetData();
-        const void* srcData = getParentEdgeAt(GATHER_DATA)->getMemoryPtr()->GetData();
-        uint8_t* dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+        const void* srcIndices = getParentEdgeAt(GATHER_INDICES)->getMemoryPtr()->getData();
+        const void* srcData = getParentEdgeAt(GATHER_DATA)->getMemoryPtr()->getData();
+        uint8_t* dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
         const uint64_t dataElPerVec = jitKernel->getDataElPerVec();
 
@@ -548,9 +548,9 @@ void Gather::initShortParams(threadExecParams& p, const uint64_t start) {
 }
 
 void Gather::execReference() {
-    const int32_t* srcIndices = reinterpret_cast<const int32_t*>(getParentEdgeAt(GATHER_INDICES)->getMemoryPtr()->GetData());
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(getParentEdgeAt(GATHER_DATA)->getMemoryPtr()->GetData());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    const int32_t* srcIndices = reinterpret_cast<const int32_t*>(getParentEdgeAt(GATHER_INDICES)->getMemoryPtr()->getData());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(getParentEdgeAt(GATHER_DATA)->getMemoryPtr()->getData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
     const size_t dstAfterBatchSize = betweenBatchAndAxisSize * specIdxAndAfterAxSizeB;
     parallel_for2d(beforeBatchSize, specIndicesSize, [&](const size_t b, const size_t j) {

--- a/src/plugins/intel_cpu/src/nodes/gather.h
+++ b/src/plugins/intel_cpu/src/nodes/gather.h
@@ -24,6 +24,8 @@ public:
     void createPrimitive() override;
     void execute(dnnl::stream strm) override;
     bool created() const override;
+    bool isExecutable() const override;
+    void resolveInPlaceEdges() override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ngraph::Node>& op, std::string& errorMessage) noexcept;
 
@@ -79,6 +81,7 @@ private:
     uint64_t totalWork = 0lu;
 
     std::vector<threadExecParams> execParamsPerThread;
+    std::vector<int> constIndices;
 
     static constexpr size_t GATHER_DATA = 0;
     static constexpr size_t GATHER_INDICES = 1;

--- a/src/plugins/intel_cpu/src/nodes/gather.h
+++ b/src/plugins/intel_cpu/src/nodes/gather.h
@@ -25,7 +25,7 @@ public:
     void execute(dnnl::stream strm) override;
     bool created() const override;
     bool isExecutable() const override;
-    void resolveInPlaceEdges() override;
+    void resolveInPlaceEdges(Edge::LOOK look) override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ngraph::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/gather_elements.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_elements.cpp
@@ -103,9 +103,9 @@ void GatherElements::executeDynamicImpl(dnnl::stream strm) {
 
 template <typename dataType>
 void GatherElements::directExecution() {
-    const auto *srcData = reinterpret_cast<const dataType *>(getParentEdgeAt(dataIndex_)->getMemoryPtr()->GetPtr());
-    const auto *indices = reinterpret_cast<const int *>(getParentEdgeAt(indicesIndex_)->getMemoryPtr()->GetPtr());
-    auto *dstData = reinterpret_cast<dataType *>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const auto *srcData = reinterpret_cast<const dataType *>(getParentEdgeAt(dataIndex_)->getMemoryPtr()->GetData());
+    const auto *indices = reinterpret_cast<const int *>(getParentEdgeAt(indicesIndex_)->getMemoryPtr()->GetData());
+    auto *dstData = reinterpret_cast<dataType *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
 
     const int outSize = getChildEdgesAtPort(0)[0]->getMemory().GetShape().getElementsCount();
     auto threadBody = [&](const int ithr, const int nthr) {

--- a/src/plugins/intel_cpu/src/nodes/gather_elements.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_elements.cpp
@@ -103,11 +103,11 @@ void GatherElements::executeDynamicImpl(dnnl::stream strm) {
 
 template <typename dataType>
 void GatherElements::directExecution() {
-    const auto *srcData = reinterpret_cast<const dataType *>(getParentEdgeAt(dataIndex_)->getMemoryPtr()->GetData());
-    const auto *indices = reinterpret_cast<const int *>(getParentEdgeAt(indicesIndex_)->getMemoryPtr()->GetData());
-    auto *dstData = reinterpret_cast<dataType *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *srcData = reinterpret_cast<const dataType *>(getParentEdgeAt(dataIndex_)->getMemoryPtr()->getData());
+    const auto *indices = reinterpret_cast<const int *>(getParentEdgeAt(indicesIndex_)->getMemoryPtr()->getData());
+    auto *dstData = reinterpret_cast<dataType *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
-    const int outSize = getChildEdgesAtPort(0)[0]->getMemory().GetShape().getElementsCount();
+    const int outSize = getChildEdgesAtPort(0)[0]->getMemory().getShape().getElementsCount();
     auto threadBody = [&](const int ithr, const int nthr) {
         int start(0lu), end(0lu);
         splitter(outSize, nthr, ithr, start, end);

--- a/src/plugins/intel_cpu/src/nodes/gather_nd.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_nd.cpp
@@ -84,9 +84,9 @@ void GatherND::initSupportedPrimitiveDescriptors() {
 }
 
 void GatherND::prepareParams() {
-    auto& srcMemPtr = getParentEdgeAt(GATHERND_DATA)->getMemoryPtr();
-    auto& idxMemPtr = getParentEdgeAt(GATHERND_INDEXES)->getMemoryPtr();
-    auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(GATHERND_DATA)->getMemoryPtr();
+    auto idxMemPtr = getParentEdgeAt(GATHERND_INDEXES)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
     if (!srcMemPtr || !srcMemPtr->isAllocated())
         THROW_ERROR << " has not allocated input memory of 'data'.";
     if (!idxMemPtr || !idxMemPtr->isAllocated())
@@ -136,7 +136,7 @@ void GatherND::execute(dnnl::stream strm) {
                   getChildEdgeAt(0)->getMemoryPtr());
 }
 
-void GatherND::GatherNDExecutor::exec(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, MemoryPtr& dstMemPtr) {
+void GatherND::GatherNDExecutor::exec(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, const MemoryPtr& dstMemPtr) {
     if (dataLength > 1) {
         gatherBlocks(srcMemPtr, idxMemPtr, dstMemPtr);
         return;
@@ -149,7 +149,7 @@ void GatherND::GatherNDExecutor::exec(const MemoryPtr& srcMemPtr, const MemoryPt
               OV_CASE(sizeof(PrecisionTrait<Precision::I8>::value_type), PrecisionTrait<Precision::I8>::value_type));
 }
 
-void GatherND::GatherNDExecutor::gatherBlocks(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, MemoryPtr& dstMemPtr) {
+void GatherND::GatherNDExecutor::gatherBlocks(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, const MemoryPtr& dstMemPtr) {
     const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetPtr());
     const int32_t* indices = reinterpret_cast<const int32_t*>(idxMemPtr->GetPtr());
     uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());
@@ -186,7 +186,7 @@ void GatherND::GatherNDExecutor::gatherBlocks(const MemoryPtr& srcMemPtr, const 
 }
 
 template <typename dataType>
-void GatherND::GatherNDExecutor::gatherElementwise(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, MemoryPtr& dstMemPtr) {
+void GatherND::GatherNDExecutor::gatherElementwise(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, const MemoryPtr& dstMemPtr) {
     const dataType* srcData = reinterpret_cast<const dataType*>(srcMemPtr->GetPtr());
     const int32_t* indices = reinterpret_cast<const int32_t*>(idxMemPtr->GetPtr());
     dataType* dstData = reinterpret_cast<dataType*>(dstMemPtr->GetPtr());

--- a/src/plugins/intel_cpu/src/nodes/gather_nd.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_nd.cpp
@@ -150,9 +150,9 @@ void GatherND::GatherNDExecutor::exec(const MemoryPtr& srcMemPtr, const MemoryPt
 }
 
 void GatherND::GatherNDExecutor::gatherBlocks(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, const MemoryPtr& dstMemPtr) {
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetPtr());
-    const int32_t* indices = reinterpret_cast<const int32_t*>(idxMemPtr->GetPtr());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetData());
+    const int32_t* indices = reinterpret_cast<const int32_t*>(idxMemPtr->GetData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
 
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t start(0lu), end(0lu);
@@ -187,9 +187,9 @@ void GatherND::GatherNDExecutor::gatherBlocks(const MemoryPtr& srcMemPtr, const 
 
 template <typename dataType>
 void GatherND::GatherNDExecutor::gatherElementwise(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, const MemoryPtr& dstMemPtr) {
-    const dataType* srcData = reinterpret_cast<const dataType*>(srcMemPtr->GetPtr());
-    const int32_t* indices = reinterpret_cast<const int32_t*>(idxMemPtr->GetPtr());
-    dataType* dstData = reinterpret_cast<dataType*>(dstMemPtr->GetPtr());
+    const dataType* srcData = reinterpret_cast<const dataType*>(srcMemPtr->GetData());
+    const int32_t* indices = reinterpret_cast<const int32_t*>(idxMemPtr->GetData());
+    dataType* dstData = reinterpret_cast<dataType*>(dstMemPtr->GetData());
 
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t start(0lu), end(0lu);

--- a/src/plugins/intel_cpu/src/nodes/gather_nd.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_nd.cpp
@@ -97,8 +97,8 @@ void GatherND::prepareParams() {
         THROW_ERROR << " has unidentified preferable primitive descriptor.";
 
     attrs.srcDims = srcMemPtr->getStaticDims();
-    attrs.srcStrides = srcMemPtr->GetDescWithType<BlockedMemoryDesc>()->getStrides();
-    attrs.dstElementCount = dstMemPtr->GetShape().getElementsCount();
+    attrs.srcStrides = srcMemPtr->getDescWithType<BlockedMemoryDesc>()->getStrides();
+    attrs.dstElementCount = dstMemPtr->getShape().getElementsCount();
     attrs.sliceRank =  idxMemPtr->getStaticDims().back();
     execPtr = std::make_shared<GatherNDExecutor>(attrs);
 }
@@ -150,9 +150,9 @@ void GatherND::GatherNDExecutor::exec(const MemoryPtr& srcMemPtr, const MemoryPt
 }
 
 void GatherND::GatherNDExecutor::gatherBlocks(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, const MemoryPtr& dstMemPtr) {
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetData());
-    const int32_t* indices = reinterpret_cast<const int32_t*>(idxMemPtr->GetData());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->getData());
+    const int32_t* indices = reinterpret_cast<const int32_t*>(idxMemPtr->getData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->getData());
 
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t start(0lu), end(0lu);
@@ -187,9 +187,9 @@ void GatherND::GatherNDExecutor::gatherBlocks(const MemoryPtr& srcMemPtr, const 
 
 template <typename dataType>
 void GatherND::GatherNDExecutor::gatherElementwise(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, const MemoryPtr& dstMemPtr) {
-    const dataType* srcData = reinterpret_cast<const dataType*>(srcMemPtr->GetData());
-    const int32_t* indices = reinterpret_cast<const int32_t*>(idxMemPtr->GetData());
-    dataType* dstData = reinterpret_cast<dataType*>(dstMemPtr->GetData());
+    const dataType* srcData = reinterpret_cast<const dataType*>(srcMemPtr->getData());
+    const int32_t* indices = reinterpret_cast<const int32_t*>(idxMemPtr->getData());
+    dataType* dstData = reinterpret_cast<dataType*>(dstMemPtr->getData());
 
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t start(0lu), end(0lu);

--- a/src/plugins/intel_cpu/src/nodes/gather_nd.h
+++ b/src/plugins/intel_cpu/src/nodes/gather_nd.h
@@ -43,12 +43,12 @@ private:
     struct GatherNDExecutor {
         GatherNDExecutor(const GatherNDAttributes& attrs);
         ~GatherNDExecutor() = default;
-        void exec(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, MemoryPtr& dstMemPtr);
+        void exec(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, const MemoryPtr& dstMemPtr);
 
     private:
         template <typename dataType>
-        void gatherElementwise(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, MemoryPtr& dstMemPtr);
-        void gatherBlocks(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, MemoryPtr& dstMemPtr);
+        void gatherElementwise(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, const MemoryPtr& dstMemPtr);
+        void gatherBlocks(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, const MemoryPtr& dstMemPtr);
 
         size_t batchSize = 1lu;
         size_t cycles = 1lu;

--- a/src/plugins/intel_cpu/src/nodes/gather_tree.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_tree.cpp
@@ -141,11 +141,11 @@ GatherTree::GatherTreeExecutor::GatherTreeExecutor(const VectorDims& stepIdxDims
 template<typename DATA_T>
 void GatherTree::GatherTreeExecutor::exec(const MemoryPtr& stepIdxMemPtr, const MemoryPtr& parentIdxMemPtr,
     const MemoryPtr& maxSeqLenMemPtr, const MemoryPtr& endTokenMemPtr, const MemoryPtr& dstMemPtr) {
-    const auto *stepIdx = reinterpret_cast<DATA_T *>(stepIdxMemPtr->GetPtr());
-    const auto *parentIdx = reinterpret_cast<DATA_T *>(parentIdxMemPtr->GetPtr());
-    const auto *maxSeqLen = reinterpret_cast<DATA_T *>(maxSeqLenMemPtr->GetPtr());
-    const auto endToken = (reinterpret_cast<DATA_T *>(endTokenMemPtr->GetPtr()))[0];
-    auto *finalIdx = reinterpret_cast<DATA_T *>(dstMemPtr->GetPtr());
+    const auto *stepIdx = reinterpret_cast<DATA_T *>(stepIdxMemPtr->GetData());
+    const auto *parentIdx = reinterpret_cast<DATA_T *>(parentIdxMemPtr->GetData());
+    const auto *maxSeqLen = reinterpret_cast<DATA_T *>(maxSeqLenMemPtr->GetData());
+    const auto endToken = (reinterpret_cast<DATA_T *>(endTokenMemPtr->GetData()))[0];
+    auto *finalIdx = reinterpret_cast<DATA_T *>(dstMemPtr->GetData());
 
     bool incorrectResult = false;
     parallel_for2d(batchSize, beamWidth, [&](size_t batch, size_t beam) {

--- a/src/plugins/intel_cpu/src/nodes/gather_tree.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_tree.cpp
@@ -140,7 +140,7 @@ GatherTree::GatherTreeExecutor::GatherTreeExecutor(const VectorDims& stepIdxDims
 
 template<typename DATA_T>
 void GatherTree::GatherTreeExecutor::exec(const MemoryPtr& stepIdxMemPtr, const MemoryPtr& parentIdxMemPtr,
-    const MemoryPtr& maxSeqLenMemPtr, const MemoryPtr& endTokenMemPtr, MemoryPtr& dstMemPtr) {
+    const MemoryPtr& maxSeqLenMemPtr, const MemoryPtr& endTokenMemPtr, const MemoryPtr& dstMemPtr) {
     const auto *stepIdx = reinterpret_cast<DATA_T *>(stepIdxMemPtr->GetPtr());
     const auto *parentIdx = reinterpret_cast<DATA_T *>(parentIdxMemPtr->GetPtr());
     const auto *maxSeqLen = reinterpret_cast<DATA_T *>(maxSeqLenMemPtr->GetPtr());

--- a/src/plugins/intel_cpu/src/nodes/gather_tree.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_tree.cpp
@@ -141,11 +141,11 @@ GatherTree::GatherTreeExecutor::GatherTreeExecutor(const VectorDims& stepIdxDims
 template<typename DATA_T>
 void GatherTree::GatherTreeExecutor::exec(const MemoryPtr& stepIdxMemPtr, const MemoryPtr& parentIdxMemPtr,
     const MemoryPtr& maxSeqLenMemPtr, const MemoryPtr& endTokenMemPtr, const MemoryPtr& dstMemPtr) {
-    const auto *stepIdx = reinterpret_cast<DATA_T *>(stepIdxMemPtr->GetData());
-    const auto *parentIdx = reinterpret_cast<DATA_T *>(parentIdxMemPtr->GetData());
-    const auto *maxSeqLen = reinterpret_cast<DATA_T *>(maxSeqLenMemPtr->GetData());
-    const auto endToken = (reinterpret_cast<DATA_T *>(endTokenMemPtr->GetData()))[0];
-    auto *finalIdx = reinterpret_cast<DATA_T *>(dstMemPtr->GetData());
+    const auto *stepIdx = reinterpret_cast<DATA_T *>(stepIdxMemPtr->getData());
+    const auto *parentIdx = reinterpret_cast<DATA_T *>(parentIdxMemPtr->getData());
+    const auto *maxSeqLen = reinterpret_cast<DATA_T *>(maxSeqLenMemPtr->getData());
+    const auto endToken = (reinterpret_cast<DATA_T *>(endTokenMemPtr->getData()))[0];
+    auto *finalIdx = reinterpret_cast<DATA_T *>(dstMemPtr->getData());
 
     bool incorrectResult = false;
     parallel_for2d(batchSize, beamWidth, [&](size_t batch, size_t beam) {

--- a/src/plugins/intel_cpu/src/nodes/gather_tree.h
+++ b/src/plugins/intel_cpu/src/nodes/gather_tree.h
@@ -38,7 +38,7 @@ private:
                   const MemoryPtr& parentIdxMemPtr,
                   const MemoryPtr& maxSeqLenMemPtr,
                   const MemoryPtr& endTokenMemPtr,
-                  MemoryPtr& dstMemPtr);
+                  const MemoryPtr& dstMemPtr);
 
     private:
         const int32_t maxTime;

--- a/src/plugins/intel_cpu/src/nodes/generate_proposals.cpp
+++ b/src/plugins/intel_cpu/src/nodes/generate_proposals.cpp
@@ -362,10 +362,10 @@ void GenerateProposals::execute(dnnl::stream strm) {
         }
 
         // Prepare memory
-        const float *p_deltas_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->GetPtr());
-        const float *p_scores_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->GetPtr());
-        const float *p_anchors_item = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ANCHORS)->getMemoryPtr()->GetPtr());
-        const float *p_img_info_cpu = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->GetPtr());
+        const float *p_deltas_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->GetData());
+        const float *p_scores_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->GetData());
+        const float *p_anchors_item = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ANCHORS)->getMemoryPtr()->GetData());
+        const float *p_img_info_cpu = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->GetData());
 
         const int anchors_num = scoreDims[1];
 
@@ -453,9 +453,9 @@ void GenerateProposals::execute(dnnl::stream strm) {
         }
         // copy to out memory
         redefineOutputMemory({VectorDims{total_num_rois, 4}, VectorDims{total_num_rois}, VectorDims{batch_size}});
-        float *p_roi_item       = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetPtr());
-        float *p_roi_score_item = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->GetPtr());
-        uint8_t* p_roi_num_item = reinterpret_cast<uint8_t *>(getChildEdgesAtPort(OUTPUT_ROI_NUM)[0]->getMemoryPtr()->GetPtr());
+        float *p_roi_item       = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetData());
+        float *p_roi_score_item = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->GetData());
+        uint8_t* p_roi_num_item = reinterpret_cast<uint8_t *>(getChildEdgesAtPort(OUTPUT_ROI_NUM)[0]->getMemoryPtr()->GetData());
         memcpy(p_roi_item, &roi_item[0], roi_item.size() * sizeof(float));
         memcpy(p_roi_score_item, &score_item[0], score_item.size() * sizeof(float));
         memcpy(p_roi_num_item, &roi_num[0], getChildEdgesAtPort(OUTPUT_ROI_NUM)[0]->getMemoryPtr()->GetSize());

--- a/src/plugins/intel_cpu/src/nodes/generate_proposals.cpp
+++ b/src/plugins/intel_cpu/src/nodes/generate_proposals.cpp
@@ -362,10 +362,10 @@ void GenerateProposals::execute(dnnl::stream strm) {
         }
 
         // Prepare memory
-        const float *p_deltas_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->GetData());
-        const float *p_scores_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->GetData());
-        const float *p_anchors_item = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ANCHORS)->getMemoryPtr()->GetData());
-        const float *p_img_info_cpu = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->GetData());
+        const float *p_deltas_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_DELTAS)->getMemoryPtr()->getData());
+        const float *p_scores_item  = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_SCORES)->getMemoryPtr()->getData());
+        const float *p_anchors_item = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_ANCHORS)->getMemoryPtr()->getData());
+        const float *p_img_info_cpu = reinterpret_cast<const float *>(getParentEdgeAt(INPUT_IM_INFO)->getMemoryPtr()->getData());
 
         const int anchors_num = scoreDims[1];
 
@@ -453,12 +453,12 @@ void GenerateProposals::execute(dnnl::stream strm) {
         }
         // copy to out memory
         redefineOutputMemory({VectorDims{total_num_rois, 4}, VectorDims{total_num_rois}, VectorDims{batch_size}});
-        float *p_roi_item       = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->GetData());
-        float *p_roi_score_item = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->GetData());
-        uint8_t* p_roi_num_item = reinterpret_cast<uint8_t *>(getChildEdgesAtPort(OUTPUT_ROI_NUM)[0]->getMemoryPtr()->GetData());
+        float *p_roi_item       = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_ROIS)[0]->getMemoryPtr()->getData());
+        float *p_roi_score_item = reinterpret_cast<float *>(getChildEdgesAtPort(OUTPUT_SCORES)[0]->getMemoryPtr()->getData());
+        uint8_t* p_roi_num_item = reinterpret_cast<uint8_t *>(getChildEdgesAtPort(OUTPUT_ROI_NUM)[0]->getMemoryPtr()->getData());
         memcpy(p_roi_item, &roi_item[0], roi_item.size() * sizeof(float));
         memcpy(p_roi_score_item, &score_item[0], score_item.size() * sizeof(float));
-        memcpy(p_roi_num_item, &roi_num[0], getChildEdgesAtPort(OUTPUT_ROI_NUM)[0]->getMemoryPtr()->GetSize());
+        memcpy(p_roi_num_item, &roi_num[0], getChildEdgesAtPort(OUTPUT_ROI_NUM)[0]->getMemoryPtr()->getSize());
     } catch (const std::exception &e) {
         std::string errorMsg = e.what();
         IE_THROW() << errorMsg;

--- a/src/plugins/intel_cpu/src/nodes/grid_sample.cpp
+++ b/src/plugins/intel_cpu/src/nodes/grid_sample.cpp
@@ -179,13 +179,13 @@ void GridSample::createPrimitive() {
 }
 
 void GridSample::prepareParams() {
-    auto& dataMemPtr = getParentEdgeAt(IN_DATA)->getMemoryPtr();
+    auto dataMemPtr = getParentEdgeAt(IN_DATA)->getMemoryPtr();
     if (!dataMemPtr || !dataMemPtr->isAllocated())
         THROW_ERROR << " has not allocated input data memory.";
-    auto& gridMemPtr = getParentEdgeAt(IN_GRID)->getMemoryPtr();
+    auto gridMemPtr = getParentEdgeAt(IN_GRID)->getMemoryPtr();
     if (!gridMemPtr || !gridMemPtr->isAllocated())
         THROW_ERROR << " has not allocated input grid memory.";
-    auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         THROW_ERROR << " has not allocated output memory.";
     if (getSelectedPrimitiveDescriptor() == nullptr)

--- a/src/plugins/intel_cpu/src/nodes/grid_sample.cpp
+++ b/src/plugins/intel_cpu/src/nodes/grid_sample.cpp
@@ -262,9 +262,9 @@ void GridSample::prepareParams() {
 }
 
 void GridSample::execute(dnnl::stream strm) {
-    const void*    srcData = getParentEdgeAt(IN_DATA)->getMemoryPtr()->GetPtr();
-    const uint8_t* gridData = reinterpret_cast<uint8_t*>(getParentEdgeAt(IN_GRID)->getMemoryPtr()->GetPtr());
-    uint8_t*       dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const void*    srcData = getParentEdgeAt(IN_DATA)->getMemoryPtr()->GetData();
+    const uint8_t* gridData = reinterpret_cast<uint8_t*>(getParentEdgeAt(IN_GRID)->getMemoryPtr()->GetData());
+    uint8_t*       dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
 
     auto threadBody = [&](const int ithr, const int nthr) {
         const auto& p = execParamsPerThread[ithr];

--- a/src/plugins/intel_cpu/src/nodes/grid_sample.cpp
+++ b/src/plugins/intel_cpu/src/nodes/grid_sample.cpp
@@ -262,9 +262,9 @@ void GridSample::prepareParams() {
 }
 
 void GridSample::execute(dnnl::stream strm) {
-    const void*    srcData = getParentEdgeAt(IN_DATA)->getMemoryPtr()->GetData();
-    const uint8_t* gridData = reinterpret_cast<uint8_t*>(getParentEdgeAt(IN_GRID)->getMemoryPtr()->GetData());
-    uint8_t*       dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    const void*    srcData = getParentEdgeAt(IN_DATA)->getMemoryPtr()->getData();
+    const uint8_t* gridData = reinterpret_cast<uint8_t*>(getParentEdgeAt(IN_GRID)->getMemoryPtr()->getData());
+    uint8_t*       dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
     auto threadBody = [&](const int ithr, const int nthr) {
         const auto& p = execParamsPerThread[ithr];

--- a/src/plugins/intel_cpu/src/nodes/grn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/grn.cpp
@@ -94,8 +94,8 @@ void GRN::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void GRN::execute(dnnl::stream strm) {
-    const float* src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    float* dst_data = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetPtr());
+    const float* src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    float* dst_data = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
 
     parallel_for3d(N, H, W, [&](int b, int h, int w) {
         double variance = 0;

--- a/src/plugins/intel_cpu/src/nodes/grn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/grn.cpp
@@ -94,8 +94,8 @@ void GRN::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void GRN::execute(dnnl::stream strm) {
-    const float* src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    float* dst_data = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
+    const float* src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    float* dst_data = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
 
     parallel_for3d(N, H, W, [&](int b, int h, int w) {
         double variance = 0;

--- a/src/plugins/intel_cpu/src/nodes/if.cpp
+++ b/src/plugins/intel_cpu/src/nodes/if.cpp
@@ -29,7 +29,7 @@ void If::PortMapHelper::execute(dnnl::stream& strm) {
     // after subgraph inference we should redefine out memory of 'If'
     redefineTo();
 
-    cpu_memcpy(dstMemPtrs.front()->GetPtr(), srcMemPtr->GetPtr(), size);
+    cpu_memcpy(dstMemPtrs.front()->GetData(), srcMemPtr->GetData(), size);
 }
 
 void If::PortMapHelper::redefineTo() {
@@ -217,7 +217,7 @@ std::deque<MemoryPtr> If::getToMemories(const Node* node, const size_t port) con
 }
 
 void If::execute(dnnl::stream strm) {
-    const bool condition = static_cast<const bool>((reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr()))[0]);
+    const bool condition = static_cast<const bool>((reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->GetData()))[0]);
 
     auto& beforeMappers = condition ? beforeThenMappers : beforeElseMappers;
     auto& afterMappers = condition ? afterThenMappers : afterElseMappers;

--- a/src/plugins/intel_cpu/src/nodes/if.cpp
+++ b/src/plugins/intel_cpu/src/nodes/if.cpp
@@ -190,7 +190,7 @@ void If::prepareBeforeMappers(const bool isThen, const dnnl::engine& eng) {
     auto &inputMems = isThen ? inputMemThen : inputMemElse;
     auto &beforeMappers = isThen ? beforeThenMappers : beforeElseMappers;
     for (auto& map_rule : inputPortMap) {
-        auto &fromMem = getParentEdgesAtPort(map_rule.from)[0]->getMemoryPtr();
+        auto fromMem = getParentEdgesAtPort(map_rule.from)[0]->getMemoryPtr();
         auto &toMems = inputMems[map_rule.to];
 
         beforeMappers.emplace_back(std::make_shared<PortMapHelper>(fromMem, toMems, eng));

--- a/src/plugins/intel_cpu/src/nodes/if.cpp
+++ b/src/plugins/intel_cpu/src/nodes/if.cpp
@@ -21,7 +21,7 @@ If::PortMapHelper::PortMapHelper(const MemoryPtr &from, const std::deque<MemoryP
                                            const dnnl::engine& eng) : srcMemPtr(from), dstMemPtrs(to) {
     size = 0;
     if (srcMemPtr->getDesc().isDefined())
-        size = srcMemPtr->GetSize();
+        size = srcMemPtr->getSize();
 }
 
 void If::PortMapHelper::execute(dnnl::stream& strm) {
@@ -29,7 +29,7 @@ void If::PortMapHelper::execute(dnnl::stream& strm) {
     // after subgraph inference we should redefine out memory of 'If'
     redefineTo();
 
-    cpu_memcpy(dstMemPtrs.front()->GetData(), srcMemPtr->GetData(), size);
+    cpu_memcpy(dstMemPtrs.front()->getData(), srcMemPtr->getData(), size);
 }
 
 void If::PortMapHelper::redefineTo() {
@@ -41,7 +41,7 @@ void If::PortMapHelper::redefineTo() {
             dstMemPtrs[j]->redefineDesc(memDesc);
         }
 
-        size = srcMemPtr->GetSize();
+        size = srcMemPtr->getSize();
     }
 }
 
@@ -217,7 +217,7 @@ std::deque<MemoryPtr> If::getToMemories(const Node* node, const size_t port) con
 }
 
 void If::execute(dnnl::stream strm) {
-    const bool condition = static_cast<const bool>((reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->GetData()))[0]);
+    const bool condition = static_cast<const bool>((reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->getData()))[0]);
 
     auto& beforeMappers = condition ? beforeThenMappers : beforeElseMappers;
     auto& afterMappers = condition ? afterThenMappers : afterElseMappers;

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -273,13 +273,13 @@ void Input::cloneBlobIfRequired() {
         // but ngraph Constant uses actual bitWidth for data storage allocation
         // in that case we make a copy to avoid overflow
         if (constOp->get_byte_size() >= memDesc.getCurrentMemSize()) {
-            memory = MemoryPtr(new Memory(getEngine(), memDesc, constOp->get_data_ptr()));
+            memory = std::make_shared<Memory>(getEngine(), memDesc, constOp->get_data_ptr());
         } else {
-            memory = MemoryPtr(new Memory(getEngine(), memDesc));
+            memory = std::make_shared<Memory>(getEngine(), memDesc);
             memcpy(memory->GetData(), constOp->get_data_ptr(), constOp->get_byte_size());
         }
 
-        MemoryPtr ptr = MemoryPtr(new Memory(getEngine(), memDesc));
+        MemoryPtr ptr = std::make_shared<Memory>(getEngine(), memDesc);
         ptr->SetData(*memory.get(), needFlushDenormalsToZero);
 
         return ptr;

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -434,13 +434,13 @@ void Input::initSupportedPrimitiveDescriptors() {
 
 void Input::createPrimitive() {
     for (size_t i = 0; i < getChildEdges().size(); i++) {
-        auto &dstMemPtr = getChildEdgeAt(i)->getMemoryPtr();
+        auto dstMemPtr = getChildEdgeAt(i)->getMemoryPtr();
         if (!dstMemPtr || !dstMemPtr->isAllocated())
             IE_THROW() << "Destination memory didn't allocate for node " << getName()
                                << " to node " << getChildEdgeAt(i)->getChild()->getName() << ".";
     }
     for (size_t i = 0; i < getParentEdges().size(); i++) {
-        auto &srcMemPtr = getParentEdgeAt(i)->getMemoryPtr();
+        auto srcMemPtr = getParentEdgeAt(i)->getMemoryPtr();
         if (!srcMemPtr || !srcMemPtr->isAllocated())
             IE_THROW() << "Destination memory didn't allocate for node " << getName()
                                << " from node " << getParentEdgeAt(i)->getParent()->getName() << ".";

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -279,9 +279,7 @@ void Input::cloneBlobIfRequired() {
             memcpy(memory->getData(), constOp->get_data_ptr(), constOp->get_byte_size());
         }
 
-        auto threadSafeMngr =
-            std::make_shared<LockBasedMemoryMngr>(make_unique<DnnlMemoryMngr>(make_unique<MemoryMngrWithReuse>()));
-        MemoryPtr ptr = std::make_shared<Memory>(getEngine(), memDesc, threadSafeMngr);
+        MemoryPtr ptr = std::make_shared<StaticMemory>(getEngine(), memDesc);
         ptr->load(*memory.get(), needFlushDenormalsToZero);
 
         return ptr;

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -276,13 +276,13 @@ void Input::cloneBlobIfRequired() {
             memory = std::make_shared<Memory>(getEngine(), memDesc, constOp->get_data_ptr());
         } else {
             memory = std::make_shared<Memory>(getEngine(), memDesc);
-            memcpy(memory->GetData(), constOp->get_data_ptr(), constOp->get_byte_size());
+            memcpy(memory->getData(), constOp->get_data_ptr(), constOp->get_byte_size());
         }
 
         auto threadSafeMngr =
             std::make_shared<LockBasedMemoryMngr>(make_unique<DnnlMemoryMngr>(make_unique<MemoryMngrWithReuse>()));
         MemoryPtr ptr = std::make_shared<Memory>(getEngine(), memDesc, threadSafeMngr);
-        ptr->SetData(*memory.get(), needFlushDenormalsToZero);
+        ptr->load(*memory.get(), needFlushDenormalsToZero);
 
         return ptr;
     };

--- a/src/plugins/intel_cpu/src/nodes/interaction.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interaction.cpp
@@ -238,10 +238,10 @@ static inline void flat_triangle(const uint8_t* in, uint8_t* out, size_t size, s
 
 void Interaction::execRef(dnnl::stream strm) {
     using namespace dnnl;
-    uint8_t* outFeaturesPtr = reinterpret_cast<uint8_t*>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetPtr());
+    uint8_t* outFeaturesPtr = reinterpret_cast<uint8_t*>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
     std::vector<const uint8_t*> inputPtrs(inputSizes);
     for (uint32_t n = 0; n < inputSizes; n++) {
-        auto inPtr = reinterpret_cast<const uint8_t*>(getParentEdgeAt(n)->getMemoryPtr()->GetPtr());
+        auto inPtr = reinterpret_cast<const uint8_t*>(getParentEdgeAt(n)->getMemoryPtr()->GetData());
         inputPtrs[n] = inPtr;
     }
     std::unordered_map<int, memory> mem_ags{{DNNL_ARG_SRC, inputMemPtr->GetPrimitive()},
@@ -249,10 +249,10 @@ void Interaction::execRef(dnnl::stream strm) {
                                             {DNNL_ARG_DST, outputMemPtr->GetPrimitive()}};
     float* scales = fqScales.empty() ? nullptr : fqScales.data();
     for (int64_t start = 0; start < static_cast<int64_t>(batchSize); start++) {
-        cat(reinterpret_cast<uint8_t*>(inputMemPtr->GetPtr()), inputPtrs, featureSizes, start, dataPrecision.size());
+        cat(reinterpret_cast<uint8_t*>(inputMemPtr->GetData()), inputPtrs, featureSizes, start, dataPrecision.size());
         prim.execute(strm, mem_ags);
-        flat_triangle(reinterpret_cast<const uint8_t*>(outputMemPtr->GetPtr()),
-                      reinterpret_cast<uint8_t*>(flatMemPtr->GetPtr()),
+        flat_triangle(reinterpret_cast<const uint8_t*>(outputMemPtr->GetData()),
+                      reinterpret_cast<uint8_t*>(flatMemPtr->GetData()),
                       inputSizes,
                       dataPrecision.size());
         // in1 dense feature
@@ -266,7 +266,7 @@ void Interaction::execRef(dnnl::stream strm) {
         }
         if (moveInteractKernel) {
             jit_move_scale_call_args interArgs;
-            interArgs.p_in = flatMemPtr->GetPtr();
+            interArgs.p_in = flatMemPtr->GetData();
             interArgs.p_out = outFeaturesPtr + (start * outputFeaturesLen + featureSize) * outputDataType.size();
             interArgs.p_scales = scales;
             (*moveInteractKernel)(&interArgs);
@@ -306,8 +306,7 @@ void Interaction::prepareParams() {
     featureSizes.assign(inputSizes, featureSize);
     auto initMemoryPtr = [&](const InferenceEngine::Precision &prc, const intel_cpu::Shape& shape,
         MemoryPtr& ptr) {
-        ptr = std::make_shared<Memory>(getEngine());
-        ptr->Create(intel_cpu::DnnlBlockedMemoryDesc(prc, shape));
+        ptr = std::make_shared<Memory>(getEngine(), intel_cpu::DnnlBlockedMemoryDesc(prc, shape));
     };
     initMemoryPtr(dataPrecision, intel_cpu::Shape{inputSizes, featureSize}, inputMemPtr);
     initMemoryPtr(dataPrecision, intel_cpu::Shape{inputShapes.size(), inputShapes.size()}, outputMemPtr);

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -2182,7 +2182,7 @@ bool Interpolate::needShapeInfer() const {
         if (lastScales.empty()) {
             return true;
         }
-        const float *scales = reinterpret_cast<const float *>(getParentEdgesAtPort(get_scale_id())[0]->getMemory().GetPtr());
+        const float *scales = reinterpret_cast<const float *>(getParentEdgesAtPort(get_scale_id())[0]->getMemory().GetData());
         for (size_t i = 0; i < lastScales.size(); i++) {
             if (lastScales[i] != scales[i]) {
                 return true;
@@ -2192,7 +2192,7 @@ bool Interpolate::needShapeInfer() const {
         if (lastSizes.empty()) {
             return true;
         }
-        const int32_t *sizes = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(TARGET_SHAPE_ID)[0]->getMemory().GetPtr());
+        const int32_t *sizes = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(TARGET_SHAPE_ID)[0]->getMemory().GetData());
         for (size_t i = 0; i < lastSizes.size(); i++) {
             if (sizes[i] != lastSizes[i]) {
                 return true;
@@ -2208,10 +2208,10 @@ void Interpolate::executeDynamicImpl(dnnl::stream strm) {
     const size_t port = shapeCalcMode == InterpolateShapeCalcMode::sizes ? TARGET_SHAPE_ID : get_scale_id();
     const auto &memory = getParentEdgesAtPort(port)[0]->getMemory();
     if (shapeCalcMode == InterpolateShapeCalcMode::scales) {
-        const float *scales = reinterpret_cast<const float *>(memory.GetPtr());
+        const float *scales = reinterpret_cast<const float *>(memory.GetData());
         lastScales.assign(scales, scales + memory.getDesc().getShape().getElementsCount());
     } else {
-        const int32_t *sizes = reinterpret_cast<const int32_t *>(memory.GetPtr());
+        const int32_t *sizes = reinterpret_cast<const int32_t *>(memory.GetData());
         lastSizes.assign(sizes, sizes + memory.getDesc().getShape().getElementsCount());
     }
 }
@@ -2288,7 +2288,7 @@ void Interpolate::prepareParams() {
     if (shapeCalcMode == InterpolateShapeCalcMode::scales) {
         if (!isScaleConstant) {
             const auto& scalesMem = getParentEdgesAtPort(get_scale_id())[0]->getMemory();
-            const float* scalesData = reinterpret_cast<const float *>(scalesMem.GetPtr());
+            const float* scalesData = reinterpret_cast<const float *>(scalesMem.GetData());
             scales.assign(scalesData, scalesData + scalesMem.getStaticDims()[0]);
         }
     }
@@ -2447,7 +2447,7 @@ void Interpolate::execute(dnnl::stream strm) {
     auto srcMemPtr = getParentEdgeAt(DATA_ID)->getMemoryPtr();
 
     if (execPtr) {
-        uint8_t *dst_data = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());
+        uint8_t *dst_data = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
         const uint8_t *src_data_origin = reinterpret_cast<uint8_t*>(srcMemPtr->GetData());
         const uint8_t *src_data = nullptr;
         std::vector<uint8_t> srcPadded;

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -2238,26 +2238,26 @@ void Interpolate::prepareParams() {
         IE_THROW() << "Can't prepare params for Interpolate node with name: " << getName() << ", because input/output dims aren't defined";
     }
 
-    auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         IE_THROW() << errorPrefix << " did not allocate destination memory";
 
-    auto& srcMemPtr = getParentEdgeAt(DATA_ID)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(DATA_ID)->getMemoryPtr();
     if (!srcMemPtr || !srcMemPtr->isAllocated())
         IE_THROW() << errorPrefix << " did not allocate input memory";
 
     if (shapeCalcMode == InterpolateShapeCalcMode::sizes) {
-        auto& tsMemPtr = getParentEdgeAt(TARGET_SHAPE_ID)->getMemoryPtr();
+        auto tsMemPtr = getParentEdgeAt(TARGET_SHAPE_ID)->getMemoryPtr();
         if (!tsMemPtr || !tsMemPtr->isAllocated())
             IE_THROW() << errorPrefix << " did not allocate target shape memory";
     } else {
-        auto& scaleMemPtr = getParentEdgeAt(get_scale_id())->getMemoryPtr();
+        auto scaleMemPtr = getParentEdgeAt(get_scale_id())->getMemoryPtr();
         if (!scaleMemPtr || !scaleMemPtr->isAllocated())
             IE_THROW() << errorPrefix << " did not allocate scales memory";
     }
 
     if (isAxesSpecified) {
-        auto &axesMemPtr = getParentEdgeAt(get_axis_id())->getMemoryPtr();
+        auto axesMemPtr = getParentEdgeAt(get_axis_id())->getMemoryPtr();
         if (!axesMemPtr || !axesMemPtr->isAllocated())
             IE_THROW() << errorPrefix << " did not allocate axes memory";
     }
@@ -2353,8 +2353,8 @@ void Interpolate::prepareParams() {
 }
 
 void Interpolate::createPrimitive() {
-    auto& srcMemPtr = getParentEdgeAt(DATA_ID)->getMemoryPtr();
-    auto& dstMemPtr = getChildEdgesAtPort(0)[0]->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(DATA_ID)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgesAtPort(0)[0]->getMemoryPtr();
     if (!srcMemPtr || !srcMemPtr->isAllocated())
         IE_THROW() << errorPrefix << " did not allocate input memory";
     if (!dstMemPtr || !dstMemPtr->isAllocated())
@@ -2443,8 +2443,8 @@ std::vector<float> Interpolate::getScales(const VectorDims &srcDimPad, const Vec
 }
 
 void Interpolate::execute(dnnl::stream strm) {
-    auto &dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto &srcMemPtr = getParentEdgeAt(DATA_ID)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(DATA_ID)->getMemoryPtr();
 
     if (execPtr) {
         uint8_t *dst_data = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -2182,7 +2182,7 @@ bool Interpolate::needShapeInfer() const {
         if (lastScales.empty()) {
             return true;
         }
-        const float *scales = reinterpret_cast<const float *>(getParentEdgesAtPort(get_scale_id())[0]->getMemory().GetData());
+        const float *scales = reinterpret_cast<const float *>(getParentEdgesAtPort(get_scale_id())[0]->getMemory().getData());
         for (size_t i = 0; i < lastScales.size(); i++) {
             if (lastScales[i] != scales[i]) {
                 return true;
@@ -2192,7 +2192,7 @@ bool Interpolate::needShapeInfer() const {
         if (lastSizes.empty()) {
             return true;
         }
-        const int32_t *sizes = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(TARGET_SHAPE_ID)[0]->getMemory().GetData());
+        const int32_t *sizes = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(TARGET_SHAPE_ID)[0]->getMemory().getData());
         for (size_t i = 0; i < lastSizes.size(); i++) {
             if (sizes[i] != lastSizes[i]) {
                 return true;
@@ -2208,10 +2208,10 @@ void Interpolate::executeDynamicImpl(dnnl::stream strm) {
     const size_t port = shapeCalcMode == InterpolateShapeCalcMode::sizes ? TARGET_SHAPE_ID : get_scale_id();
     const auto &memory = getParentEdgesAtPort(port)[0]->getMemory();
     if (shapeCalcMode == InterpolateShapeCalcMode::scales) {
-        const float *scales = reinterpret_cast<const float *>(memory.GetData());
+        const float *scales = reinterpret_cast<const float *>(memory.getData());
         lastScales.assign(scales, scales + memory.getDesc().getShape().getElementsCount());
     } else {
-        const int32_t *sizes = reinterpret_cast<const int32_t *>(memory.GetData());
+        const int32_t *sizes = reinterpret_cast<const int32_t *>(memory.getData());
         lastSizes.assign(sizes, sizes + memory.getDesc().getShape().getElementsCount());
     }
 }
@@ -2288,7 +2288,7 @@ void Interpolate::prepareParams() {
     if (shapeCalcMode == InterpolateShapeCalcMode::scales) {
         if (!isScaleConstant) {
             const auto& scalesMem = getParentEdgesAtPort(get_scale_id())[0]->getMemory();
-            const float* scalesData = reinterpret_cast<const float *>(scalesMem.GetData());
+            const float* scalesData = reinterpret_cast<const float *>(scalesMem.getData());
             scales.assign(scalesData, scalesData + scalesMem.getStaticDims()[0]);
         }
     }
@@ -2447,8 +2447,8 @@ void Interpolate::execute(dnnl::stream strm) {
     auto srcMemPtr = getParentEdgeAt(DATA_ID)->getMemoryPtr();
 
     if (execPtr) {
-        uint8_t *dst_data = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
-        const uint8_t *src_data_origin = reinterpret_cast<uint8_t*>(srcMemPtr->GetData());
+        uint8_t *dst_data = reinterpret_cast<uint8_t*>(dstMemPtr->getData());
+        const uint8_t *src_data_origin = reinterpret_cast<uint8_t*>(srcMemPtr->getData());
         const uint8_t *src_data = nullptr;
         std::vector<uint8_t> srcPadded;
         if (hasPad) {

--- a/src/plugins/intel_cpu/src/nodes/log_softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/log_softmax.cpp
@@ -87,8 +87,8 @@ void LogSoftmax::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void LogSoftmax::execute(dnnl::stream strm) {
-    const float *srcData = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    float* dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetPtr());
+    const float *srcData = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    float* dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
 
     if (isLastDim) {
         parallel_for(axisStep, [&](size_t i) {

--- a/src/plugins/intel_cpu/src/nodes/log_softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/log_softmax.cpp
@@ -87,8 +87,8 @@ void LogSoftmax::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void LogSoftmax::execute(dnnl::stream strm) {
-    const float *srcData = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    float* dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
+    const float *srcData = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    float* dstData = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
 
     if (isLastDim) {
         parallel_for(axisStep, [&](size_t i) {

--- a/src/plugins/intel_cpu/src/nodes/lrn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/lrn.cpp
@@ -174,7 +174,7 @@ void Lrn::prepareParams() {
     if (selected_pd == nullptr)
         IE_THROW() << errorPrefix << "preferable primitive descriptor did not set";
 
-    auto inpDesc = getParentEdgeAt(0)->getMemory().GetDescWithType<DnnlMemoryDesc>();
+    auto inpDesc = getParentEdgeAt(0)->getMemory().getDescWithType<DnnlMemoryDesc>();
 
     dnnl::primitive_attr attr;
     attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
@@ -212,9 +212,9 @@ void Lrn::prepareParams() {
 
     auto scratchpadMem = getScratchPadMem(execPtr->getScratchPadDesc());
 
-    primArgs[DNNL_ARG_SCRATCHPAD] = scratchpadMem->GetPrimitive();
-    primArgs[DNNL_ARG_SRC] = srcMemPtr->GetPrimitive();
-    primArgs[DNNL_ARG_DST] = dstMemPtr->GetPrimitive();
+    primArgs[DNNL_ARG_SCRATCHPAD] = scratchpadMem->getPrimitive();
+    primArgs[DNNL_ARG_SRC] = srcMemPtr->getPrimitive();
+    primArgs[DNNL_ARG_DST] = dstMemPtr->getPrimitive();
 #ifdef CPU_DEBUG_CAPS
     if (result.second == CacheEntryBase::LookUpStatus::Miss) {
         auto pd = execPtr->getPrimitiveDesc();

--- a/src/plugins/intel_cpu/src/nodes/lrn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/lrn.cpp
@@ -163,8 +163,8 @@ std::shared_ptr<MemoryDesc> Lrn::getSrcMemDesc(const dnnl::primitive_desc &prim_
 }
 
 void Lrn::prepareParams() {
-    auto& srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
-    auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
     if (!srcMemPtr || !srcMemPtr->isAllocated())
         IE_THROW() << errorPrefix << " input memory did not allocate";
     if (!dstMemPtr || !dstMemPtr->isAllocated())

--- a/src/plugins/intel_cpu/src/nodes/mathematics.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mathematics.cpp
@@ -72,8 +72,8 @@ void Math::executeDynamicImpl(dnnl::stream strm) {
 
 void Math::execute(dnnl::stream strm) {
     size_t dataSize = getChildEdgesAtPort(0)[0]->getMemory().GetShape().getElementsCount();
-    const float *src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    float* dst_data = reinterpret_cast<float *>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const float *src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    float* dst_data = reinterpret_cast<float *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
 
     switch (getAlgorithm()) {
         case Algorithm::MathAbs:

--- a/src/plugins/intel_cpu/src/nodes/mathematics.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mathematics.cpp
@@ -71,9 +71,9 @@ void Math::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void Math::execute(dnnl::stream strm) {
-    size_t dataSize = getChildEdgesAtPort(0)[0]->getMemory().GetShape().getElementsCount();
-    const float *src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    float* dst_data = reinterpret_cast<float *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    size_t dataSize = getChildEdgesAtPort(0)[0]->getMemory().getShape().getElementsCount();
+    const float *src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    float* dst_data = reinterpret_cast<float *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
     switch (getAlgorithm()) {
         case Algorithm::MathAbs:

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -575,9 +575,9 @@ InferenceEngine::Precision MatMul::getRuntimePrecision() const {
 }
 
 void MatMul::prepareParams() {
-    auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto& src0MemPtr = getParentEdgeAt(0)->getMemoryPtr();
-    auto& src1MemPtr = getParentEdgeAt(1)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto src0MemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto src1MemPtr = getParentEdgeAt(1)->getMemoryPtr();
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         IE_THROW()  << errorPrefix << " did not allocate destination memory";
     if (!src0MemPtr || !src0MemPtr->isAllocated() || !src1MemPtr || !src1MemPtr->isAllocated())
@@ -615,7 +615,7 @@ void MatMul::prepareParams() {
 
     DnnlMemoryDescPtr dnnlBiasMemDesc = nullptr;
     if (withBiases) {
-        auto& biasMemory = getParentEdgeAt(2)->getMemoryPtr();
+        auto biasMemory = getParentEdgeAt(2)->getMemoryPtr();
         if (!biasMemory || !biasMemory->isAllocated())
             IE_THROW()  << errorPrefix << " did not allocate bias memory";
         dnnlBiasMemDesc = biasMemory->GetDescWithType<DnnlMemoryDesc>();

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -611,14 +611,14 @@ void MatMul::prepareParams() {
         src1TransposedDesc = inDataDesc[1];
     }
 
-    auto dstDnnlDesc = dstMemPtr->GetDescWithType<DnnlMemoryDesc>();
+    auto dstDnnlDesc = dstMemPtr->getDescWithType<DnnlMemoryDesc>();
 
     DnnlMemoryDescPtr dnnlBiasMemDesc = nullptr;
     if (withBiases) {
         auto biasMemory = getParentEdgeAt(2)->getMemoryPtr();
         if (!biasMemory || !biasMemory->isAllocated())
             IE_THROW()  << errorPrefix << " did not allocate bias memory";
-        dnnlBiasMemDesc = biasMemory->GetDescWithType<DnnlMemoryDesc>();
+        dnnlBiasMemDesc = biasMemory->getDescWithType<DnnlMemoryDesc>();
     }
 
     MatMulKey key = {src0TransposedDesc, src1TransposedDesc, dnnlBiasMemDesc,
@@ -669,12 +669,12 @@ void MatMul::prepareParams() {
 
     auto schratchpadMem = getScratchPadMem(execPtr->getScratchPadDesc());
 
-    primArgs[DNNL_ARG_SCRATCHPAD] = schratchpadMem->GetPrimitive();
-    primArgs[DNNL_ARG_SRC_0] = src0MemPtr->GetPrimitive();
-    primArgs[DNNL_ARG_WEIGHTS_0] = src1MemPtr->GetPrimitive();
-    primArgs[DNNL_ARG_DST] = dstMemPtr->GetPrimitive();
+    primArgs[DNNL_ARG_SCRATCHPAD] = schratchpadMem->getPrimitive();
+    primArgs[DNNL_ARG_SRC_0] = src0MemPtr->getPrimitive();
+    primArgs[DNNL_ARG_WEIGHTS_0] = src1MemPtr->getPrimitive();
+    primArgs[DNNL_ARG_DST] = dstMemPtr->getPrimitive();
     if (withBiases)
-        primArgs[DNNL_ARG_BIAS] = getParentEdgeAt(2)->getMemoryPtr()->GetPrimitive();
+        primArgs[DNNL_ARG_BIAS] = getParentEdgeAt(2)->getMemoryPtr()->getPrimitive();
 
     appendPostOpArgs(*attr, primArgs, postOpsArgs);
 #ifdef CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
@@ -302,8 +302,8 @@ void MatrixNms::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void MatrixNms::execute(dnnl::stream strm) {
-    const float* boxes = reinterpret_cast<const float*>(getParentEdgeAt(NMS_BOXES)->getMemoryPtr()->GetPtr());
-    const float* scores = reinterpret_cast<const float*>(getParentEdgeAt(NMS_SCORES)->getMemoryPtr()->GetPtr());
+    const float* boxes = reinterpret_cast<const float*>(getParentEdgeAt(NMS_BOXES)->getMemoryPtr()->GetData());
+    const float* scores = reinterpret_cast<const float*>(getParentEdgeAt(NMS_SCORES)->getMemoryPtr()->GetData());
 
     InferenceEngine::parallel_for2d(m_numBatches, m_numClasses, [&](size_t batchIdx, size_t classIdx) {
         if (classIdx == static_cast<size_t>(m_backgroundClass)) {
@@ -380,9 +380,9 @@ void MatrixNms::execute(dnnl::stream strm) {
         size_t totalBox = std::accumulate(m_numPerBatch.begin(), m_numPerBatch.end(), size_t(0));
         redefineOutputMemory({{totalBox, 6}, {totalBox, 1}, {m_numBatches}});
     }
-    float* selectedOutputs = reinterpret_cast<float*>(selectedOutputsMemPtr->GetPtr());
-    int* selectedIndices = reinterpret_cast<int*>(selectedIndicesMemPtr->GetPtr());
-    int* validOutputs = reinterpret_cast<int*>(validOutputsMemPtr->GetPtr());
+    float* selectedOutputs = reinterpret_cast<float*>(selectedOutputsMemPtr->GetData());
+    int* selectedIndices = reinterpret_cast<int*>(selectedIndicesMemPtr->GetData());
+    int* validOutputs = reinterpret_cast<int*>(validOutputsMemPtr->GetData());
     for (size_t i = 0; i < m_numPerBatch.size(); i++)
         validOutputs[i] = static_cast<int>(m_numPerBatch[i]);
 

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
@@ -302,8 +302,8 @@ void MatrixNms::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void MatrixNms::execute(dnnl::stream strm) {
-    const float* boxes = reinterpret_cast<const float*>(getParentEdgeAt(NMS_BOXES)->getMemoryPtr()->GetData());
-    const float* scores = reinterpret_cast<const float*>(getParentEdgeAt(NMS_SCORES)->getMemoryPtr()->GetData());
+    const float* boxes = reinterpret_cast<const float*>(getParentEdgeAt(NMS_BOXES)->getMemoryPtr()->getData());
+    const float* scores = reinterpret_cast<const float*>(getParentEdgeAt(NMS_SCORES)->getMemoryPtr()->getData());
 
     InferenceEngine::parallel_for2d(m_numBatches, m_numClasses, [&](size_t batchIdx, size_t classIdx) {
         if (classIdx == static_cast<size_t>(m_backgroundClass)) {
@@ -380,9 +380,9 @@ void MatrixNms::execute(dnnl::stream strm) {
         size_t totalBox = std::accumulate(m_numPerBatch.begin(), m_numPerBatch.end(), size_t(0));
         redefineOutputMemory({{totalBox, 6}, {totalBox, 1}, {m_numBatches}});
     }
-    float* selectedOutputs = reinterpret_cast<float*>(selectedOutputsMemPtr->GetData());
-    int* selectedIndices = reinterpret_cast<int*>(selectedIndicesMemPtr->GetData());
-    int* validOutputs = reinterpret_cast<int*>(validOutputsMemPtr->GetData());
+    float* selectedOutputs = reinterpret_cast<float*>(selectedOutputsMemPtr->getData());
+    int* selectedIndices = reinterpret_cast<int*>(selectedIndicesMemPtr->getData());
+    int* validOutputs = reinterpret_cast<int*>(validOutputsMemPtr->getData());
     for (size_t i = 0; i < m_numPerBatch.size(); i++)
         validOutputs[i] = static_cast<int>(m_numPerBatch[i]);
 

--- a/src/plugins/intel_cpu/src/nodes/memory.cpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.cpp
@@ -123,7 +123,7 @@ void MemoryInput::createPrimitive() {
 
     // default memory state is zero filled
     if (dataStore->getDesc().hasDefinedMaxSize())
-        dataStore->FillZero();
+        dataStore->nullify();
 }
 
 /**
@@ -134,11 +134,11 @@ void MemoryInput::createPrimitive() {
  */
 inline
 static void simple_copy(const IMemory& dst, const IMemory& src) {
-    auto srcPtr = static_cast<uint8_t*>(src.GetData());
-    auto dstPtr = static_cast<uint8_t*>(dst.GetData());
-    if (src.GetDataType() == dst.GetDataType()) {
-        auto srcSizeInByte = src.GetSize();
-        auto dstSizeInByte = dst.GetSize();
+    auto srcPtr = static_cast<uint8_t*>(src.getData());
+    auto dstPtr = static_cast<uint8_t*>(dst.getData());
+    if (src.getDataType() == dst.getDataType()) {
+        auto srcSizeInByte = src.getSize();
+        auto dstSizeInByte = dst.getSize();
 
         IE_ASSERT(srcSizeInByte == dstSizeInByte) << "MemoryNode objects are not compatible. Has different sizes.";
 
@@ -159,14 +159,14 @@ MemoryPtr MemoryInput::getStore() {
 
 void MemoryInput::storeState(const IMemory &new_state) {
     // TODO: Should be next one call:
-    //           dataStore.SetData(new_state, false);
+    //           dataStore.load(new_state, false);
     //       But because of performance reason we use simple manual copy
     simple_copy(*dataStore, new_state);
 }
 
 void MemoryInput::execute(dnnl::stream strm) {
     // TODO: Should be simple call of:
-    //           dst_mem.SetData(dataStore, false);
+    //           dst_mem.load(dataStore, false);
     //       But because of performance reason we use simple manual copy
     simple_copy(getChildEdgeAt(0)->getMemory(), *dataStore);
 }

--- a/src/plugins/intel_cpu/src/nodes/memory.hpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.hpp
@@ -101,7 +101,7 @@ public:
     void createPrimitive() override;
 
     void setInputNode(Node* node) override {}
-    void storeState(const Memory& mem);
+    void storeState(const IMemory& mem);
     MemoryPtr getStore();
  private:
     MemoryPtr dataStore;

--- a/src/plugins/intel_cpu/src/nodes/mha.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mha.cpp
@@ -1215,11 +1215,11 @@ void MHA::callBrgemm(brgemmCtx& ctx, std::unique_ptr<brgemm_kernel_t>& brgKernel
 
 template <typename in1_type>
 void MHA::mhaImpl() {
-    const uint8_t* pTranspose0In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    const uint8_t* pTranspose1In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(1)->getMemoryPtr()->GetPtr());
-    const float* pAddIn1 = reinterpret_cast<const float*>(getParentEdgeAt(2)->getMemoryPtr()->GetPtr());
-    const uint8_t* pTranspose2In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(3)->getMemoryPtr()->GetPtr());
-    uint8_t* pout = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const uint8_t* pTranspose0In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    const uint8_t* pTranspose1In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
+    const float* pAddIn1 = reinterpret_cast<const float*>(getParentEdgeAt(2)->getMemoryPtr()->GetData());
+    const uint8_t* pTranspose2In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(3)->getMemoryPtr()->GetData());
+    uint8_t* pout = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
 
     auto outPrcSize = outputPrecision.size();
 

--- a/src/plugins/intel_cpu/src/nodes/mha.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mha.cpp
@@ -902,11 +902,11 @@ void MHA::prepareParams() {
         return new_vec;
     };
 
-    const auto memDescTranspose0In0 = getParentEdgeAt(0)->getMemoryPtr()->GetDescWithType<BlockedMemoryDesc>();
-    const auto memDescTranspose1In0 = getParentEdgeAt(1)->getMemoryPtr()->GetDescWithType<BlockedMemoryDesc>();
-    const auto memDescAddIn1 = getParentEdgeAt(2)->getMemoryPtr()->GetDescWithType<BlockedMemoryDesc>();
-    const auto memDescTranspose2In0 = getParentEdgeAt(3)->getMemoryPtr()->GetDescWithType<BlockedMemoryDesc>();
-    const auto memDescOut = getChildEdgeAt(0)->getMemoryPtr()->GetDescWithType<BlockedMemoryDesc>();
+    const auto memDescTranspose0In0 = getParentEdgeAt(0)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>();
+    const auto memDescTranspose1In0 = getParentEdgeAt(1)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>();
+    const auto memDescAddIn1 = getParentEdgeAt(2)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>();
+    const auto memDescTranspose2In0 = getParentEdgeAt(3)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>();
+    const auto memDescOut = getChildEdgeAt(0)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>();
 
     dimsTranspose0In0 = memDescTranspose0In0->getBlockDims();
     dimsTranspose1In0 = memDescTranspose1In0->getBlockDims();
@@ -1215,11 +1215,11 @@ void MHA::callBrgemm(brgemmCtx& ctx, std::unique_ptr<brgemm_kernel_t>& brgKernel
 
 template <typename in1_type>
 void MHA::mhaImpl() {
-    const uint8_t* pTranspose0In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    const uint8_t* pTranspose1In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
-    const float* pAddIn1 = reinterpret_cast<const float*>(getParentEdgeAt(2)->getMemoryPtr()->GetData());
-    const uint8_t* pTranspose2In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(3)->getMemoryPtr()->GetData());
-    uint8_t* pout = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    const uint8_t* pTranspose0In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    const uint8_t* pTranspose1In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(1)->getMemoryPtr()->getData());
+    const float* pAddIn1 = reinterpret_cast<const float*>(getParentEdgeAt(2)->getMemoryPtr()->getData());
+    const uint8_t* pTranspose2In0 = reinterpret_cast<const uint8_t*>(getParentEdgeAt(3)->getMemoryPtr()->getData());
+    uint8_t* pout = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
     auto outPrcSize = outputPrecision.size();
 

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
@@ -203,8 +203,8 @@ void MultiClassNms::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void MultiClassNms::execute(dnnl::stream strm) {
-    const float* boxes = reinterpret_cast<const float*>(getParentEdgeAt(NMS_BOXES)->getMemoryPtr()->GetPtr());
-    const float* scores = reinterpret_cast<const float*>(getParentEdgeAt(NMS_SCORES)->getMemoryPtr()->GetPtr());
+    const float* boxes = reinterpret_cast<const float*>(getParentEdgeAt(NMS_BOXES)->getMemoryPtr()->GetData());
+    const float* scores = reinterpret_cast<const float*>(getParentEdgeAt(NMS_SCORES)->getMemoryPtr()->GetData());
 
     auto dims_boxes = getParentEdgeAt(NMS_BOXES)->getMemory().getStaticDims();
     auto dims_scores = getParentEdgeAt(NMS_SCORES)->getMemory().getStaticDims();
@@ -225,7 +225,7 @@ void MultiClassNms::execute(dnnl::stream strm) {
     int* roisnum = nullptr;
     VectorDims roisnumStrides;
     if (has_roinum) {
-        roisnum = reinterpret_cast<int*>(getParentEdgeAt(NMS_ROISNUM)->getMemoryPtr()->GetPtr());
+        roisnum = reinterpret_cast<int*>(getParentEdgeAt(NMS_ROISNUM)->getMemoryPtr()->GetData());
         roisnumStrides = getParentEdgeAt(NMS_ROISNUM)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
     }
 
@@ -328,9 +328,9 @@ void MultiClassNms::execute(dnnl::stream strm) {
         size_t totalBox = std::accumulate(m_selected_num.begin(), m_selected_num.end(), size_t(0));
         redefineOutputMemory({{totalBox, 6}, {totalBox, 1}, {m_numBatches}});
     }
-    int* selected_indices = reinterpret_cast<int*>(selectedIndicesMemPtr->GetPtr());
-    float* selected_outputs = reinterpret_cast<float*>(selectedOutputsMemPtr->GetPtr());
-    int* selected_num = reinterpret_cast<int*>(validOutputsMemPtr->GetPtr());
+    int* selected_indices = reinterpret_cast<int*>(selectedIndicesMemPtr->GetData());
+    float* selected_outputs = reinterpret_cast<float*>(selectedOutputsMemPtr->GetData());
+    int* selected_num = reinterpret_cast<int*>(validOutputsMemPtr->GetData());
 
     auto _flattened_index = [](int batch_idx, int box_idx, int num_box) {
         return batch_idx * num_box + box_idx;

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
@@ -203,8 +203,8 @@ void MultiClassNms::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void MultiClassNms::execute(dnnl::stream strm) {
-    const float* boxes = reinterpret_cast<const float*>(getParentEdgeAt(NMS_BOXES)->getMemoryPtr()->GetData());
-    const float* scores = reinterpret_cast<const float*>(getParentEdgeAt(NMS_SCORES)->getMemoryPtr()->GetData());
+    const float* boxes = reinterpret_cast<const float*>(getParentEdgeAt(NMS_BOXES)->getMemoryPtr()->getData());
+    const float* scores = reinterpret_cast<const float*>(getParentEdgeAt(NMS_SCORES)->getMemoryPtr()->getData());
 
     auto dims_boxes = getParentEdgeAt(NMS_BOXES)->getMemory().getStaticDims();
     auto dims_scores = getParentEdgeAt(NMS_SCORES)->getMemory().getStaticDims();
@@ -219,14 +219,14 @@ void MultiClassNms::execute(dnnl::stream strm) {
     auto selectedIndicesMemPtr = getChildEdgesAtPort(NMS_SELECTEDINDICES)[0]->getMemoryPtr();
     auto validOutputsMemPtr = getChildEdgesAtPort(NMS_SELECTEDNUM)[0]->getMemoryPtr();
 
-    auto boxesStrides = getParentEdgeAt(NMS_BOXES)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
-    auto scoresStrides = getParentEdgeAt(NMS_SCORES)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
+    auto boxesStrides = getParentEdgeAt(NMS_BOXES)->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
+    auto scoresStrides = getParentEdgeAt(NMS_SCORES)->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
 
     int* roisnum = nullptr;
     VectorDims roisnumStrides;
     if (has_roinum) {
-        roisnum = reinterpret_cast<int*>(getParentEdgeAt(NMS_ROISNUM)->getMemoryPtr()->GetData());
-        roisnumStrides = getParentEdgeAt(NMS_ROISNUM)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
+        roisnum = reinterpret_cast<int*>(getParentEdgeAt(NMS_ROISNUM)->getMemoryPtr()->getData());
+        roisnumStrides = getParentEdgeAt(NMS_ROISNUM)->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
     }
 
     if ((m_nmsEta >= 0) && (m_nmsEta < 1)) {
@@ -328,9 +328,9 @@ void MultiClassNms::execute(dnnl::stream strm) {
         size_t totalBox = std::accumulate(m_selected_num.begin(), m_selected_num.end(), size_t(0));
         redefineOutputMemory({{totalBox, 6}, {totalBox, 1}, {m_numBatches}});
     }
-    int* selected_indices = reinterpret_cast<int*>(selectedIndicesMemPtr->GetData());
-    float* selected_outputs = reinterpret_cast<float*>(selectedOutputsMemPtr->GetData());
-    int* selected_num = reinterpret_cast<int*>(validOutputsMemPtr->GetData());
+    int* selected_indices = reinterpret_cast<int*>(selectedIndicesMemPtr->getData());
+    float* selected_outputs = reinterpret_cast<float*>(selectedOutputsMemPtr->getData());
+    int* selected_num = reinterpret_cast<int*>(validOutputsMemPtr->getData());
 
     auto _flattened_index = [](int batch_idx, int box_idx, int num_box) {
         return batch_idx * num_box + box_idx;

--- a/src/plugins/intel_cpu/src/nodes/mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mvn.cpp
@@ -1464,8 +1464,8 @@ void MVN::execute(dnnl::stream strm) {
     auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
 
     if (execPtr) {
-        uint8_t *dst_data = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());
-        uint8_t *src_data = reinterpret_cast<uint8_t*>(srcMemPtr->GetPtr());
+        uint8_t *dst_data = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
+        uint8_t *src_data = reinterpret_cast<uint8_t*>(srcMemPtr->GetData());
         execPtr->exec(src_data, dst_data, postOpsDataPtrs.data());
     } else if (aclExecPtr) {
         aclExecPtr->exec({srcMemPtr}, {dstMemPtr}, postOpsDataPtrs.data());

--- a/src/plugins/intel_cpu/src/nodes/mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mvn.cpp
@@ -1464,8 +1464,8 @@ void MVN::execute(dnnl::stream strm) {
     auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
 
     if (execPtr) {
-        uint8_t *dst_data = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
-        uint8_t *src_data = reinterpret_cast<uint8_t*>(srcMemPtr->GetData());
+        uint8_t *dst_data = reinterpret_cast<uint8_t*>(dstMemPtr->getData());
+        uint8_t *src_data = reinterpret_cast<uint8_t*>(srcMemPtr->getData());
         execPtr->exec(src_data, dst_data, postOpsDataPtrs.data());
     } else if (aclExecPtr) {
         aclExecPtr->exec({srcMemPtr}, {dstMemPtr}, postOpsDataPtrs.data());

--- a/src/plugins/intel_cpu/src/nodes/mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mvn.cpp
@@ -1347,8 +1347,8 @@ void MVN::MVNRefExecutor::exec(const uint8_t *src_data, uint8_t *dst_data, const
 }
 
 void MVN::prepareParams() {
-    auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto& srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         IE_THROW() << "Destination memory didn't allocate.";
     if (!srcMemPtr || !srcMemPtr->isAllocated())
@@ -1460,8 +1460,8 @@ void MVN::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void MVN::execute(dnnl::stream strm) {
-    auto &dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto &srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
 
     if (execPtr) {
         uint8_t *dst_data = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());

--- a/src/plugins/intel_cpu/src/nodes/ngram.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ngram.cpp
@@ -115,7 +115,7 @@ void Ngram::prepareParams() {
 
 template <typename idces_type>
 std::vector<size_t> Ngram::computeBatchLenghts() {
-    auto* srcIndices = reinterpret_cast<const idces_type*>(getParentEdgeAt(1)->getMemoryPtr()->GetPtr());
+    auto* srcIndices = reinterpret_cast<const idces_type*>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
 
     std::vector<size_t> batchLenghts{0};
     batchLenghts.reserve(numIdces + 1);
@@ -130,8 +130,8 @@ std::vector<size_t> Ngram::computeBatchLenghts() {
 }
 
 void Ngram::execute(dnnl::stream strm) {
-    auto* srcData = reinterpret_cast<const float*>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    auto* dstData = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    auto* srcData = reinterpret_cast<const float*>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    auto* dstData = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
 
     std::vector<size_t> batchLenghts;
     if (idcesPrecision == InferenceEngine::Precision::I32) {

--- a/src/plugins/intel_cpu/src/nodes/ngram.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ngram.cpp
@@ -104,7 +104,7 @@ void Ngram::prepareParams() {
 
     idcesShapeSize = std::accumulate(srcIndicesDims.begin(), srcIndicesDims.end(), 1, std::multiplies<size_t>());
     numOutElems = std::accumulate(outDims.begin(), outDims.end(), 1, std::multiplies<size_t>());
-    idcesStride = getParentEdgeAt(1)->getMemoryPtr()->GetDescWithType<BlockedMemoryDesc>()->getStrides()[0];
+    idcesStride = getParentEdgeAt(1)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>()->getStrides()[0];
     numIdces = srcIndicesDims[0];
 
     windowStride = srcDataDims[1];
@@ -115,7 +115,7 @@ void Ngram::prepareParams() {
 
 template <typename idces_type>
 std::vector<size_t> Ngram::computeBatchLenghts() {
-    auto* srcIndices = reinterpret_cast<const idces_type*>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
+    auto* srcIndices = reinterpret_cast<const idces_type*>(getParentEdgeAt(1)->getMemoryPtr()->getData());
 
     std::vector<size_t> batchLenghts{0};
     batchLenghts.reserve(numIdces + 1);
@@ -130,8 +130,8 @@ std::vector<size_t> Ngram::computeBatchLenghts() {
 }
 
 void Ngram::execute(dnnl::stream strm) {
-    auto* srcData = reinterpret_cast<const float*>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    auto* dstData = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    auto* srcData = reinterpret_cast<const float*>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    auto* dstData = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
     std::vector<size_t> batchLenghts;
     if (idcesPrecision == InferenceEngine::Precision::I32) {

--- a/src/plugins/intel_cpu/src/nodes/non_max_suppression.cpp
+++ b/src/plugins/intel_cpu/src/nodes/non_max_suppression.cpp
@@ -723,20 +723,20 @@ void NonMaxSuppression::createJitKernel() {
 
 void NonMaxSuppression::executeDynamicImpl(dnnl::stream strm) {
     if (hasEmptyInputTensors() || (inputShapes.size() > NMS_MAXOUTPUTBOXESPERCLASS &&
-            reinterpret_cast<int *>(getParentEdgeAt(NMS_MAXOUTPUTBOXESPERCLASS)->getMemoryPtr()->GetPtr())[0] == 0)) {
+            reinterpret_cast<int *>(getParentEdgeAt(NMS_MAXOUTPUTBOXESPERCLASS)->getMemoryPtr()->GetData())[0] == 0)) {
         redefineOutputMemory({{0, 3}, {0, 3}, {1}});
-        *reinterpret_cast<int *>(getChildEdgesAtPort(NMS_VALIDOUTPUTS)[0]->getMemoryPtr()->GetPtr()) = 0;
+        *reinterpret_cast<int *>(getChildEdgesAtPort(NMS_VALIDOUTPUTS)[0]->getMemoryPtr()->GetData()) = 0;
         return;
     }
     execute(strm);
 }
 
 void NonMaxSuppression::execute(dnnl::stream strm) {
-    const float *boxes = reinterpret_cast<const float *>(getParentEdgeAt(NMS_BOXES)->getMemoryPtr()->GetPtr());
-    const float *scores = reinterpret_cast<const float *>(getParentEdgeAt(NMS_SCORES)->getMemoryPtr()->GetPtr());
+    const float *boxes = reinterpret_cast<const float *>(getParentEdgeAt(NMS_BOXES)->getMemoryPtr()->GetData());
+    const float *scores = reinterpret_cast<const float *>(getParentEdgeAt(NMS_SCORES)->getMemoryPtr()->GetData());
 
     if (inputShapes.size() > NMS_MAXOUTPUTBOXESPERCLASS) {
-        maxOutputBoxesPerClass = reinterpret_cast<int *>(getParentEdgeAt(NMS_MAXOUTPUTBOXESPERCLASS)->getMemoryPtr()->GetPtr())[0];
+        maxOutputBoxesPerClass = reinterpret_cast<int *>(getParentEdgeAt(NMS_MAXOUTPUTBOXESPERCLASS)->getMemoryPtr()->GetData())[0];
     }
 
     maxOutputBoxesPerClass = std::min(maxOutputBoxesPerClass, numBoxes);
@@ -746,13 +746,13 @@ void NonMaxSuppression::execute(dnnl::stream strm) {
     }
 
     if (inputShapes.size() > NMS_IOUTHRESHOLD)
-        iouThreshold = reinterpret_cast<float *>(getParentEdgeAt(NMS_IOUTHRESHOLD)->getMemoryPtr()->GetPtr())[0];
+        iouThreshold = reinterpret_cast<float *>(getParentEdgeAt(NMS_IOUTHRESHOLD)->getMemoryPtr()->GetData())[0];
 
     if (inputShapes.size() > NMS_SCORETHRESHOLD)
-        scoreThreshold = reinterpret_cast<float *>(getParentEdgeAt(NMS_SCORETHRESHOLD)->getMemoryPtr()->GetPtr())[0];
+        scoreThreshold = reinterpret_cast<float *>(getParentEdgeAt(NMS_SCORETHRESHOLD)->getMemoryPtr()->GetData())[0];
 
     if (inputShapes.size() > NMS_SOFTNMSSIGMA)
-        softNMSSigma = reinterpret_cast<float *>(getParentEdgeAt(NMS_SOFTNMSSIGMA)->getMemoryPtr()->GetPtr())[0];
+        softNMSSigma = reinterpret_cast<float *>(getParentEdgeAt(NMS_SOFTNMSSIGMA)->getMemoryPtr()->GetData())[0];
     scale = 0.0f;
     if (softNMSSigma > 0.0) {
         scale = -0.5f / softNMSSigma;
@@ -806,8 +806,8 @@ void NonMaxSuppression::execute(dnnl::stream strm) {
 
     int selectedIndicesStride = indicesMemPtr->GetDescWithType<BlockedMemoryDesc>()->getStrides()[0];
 
-    int *selectedIndicesPtr = reinterpret_cast<int *>(indicesMemPtr->GetPtr());
-    float *selectedScoresPtr = reinterpret_cast<float *>(scoresMemPtr->GetPtr());
+    int *selectedIndicesPtr = reinterpret_cast<int *>(indicesMemPtr->GetData());
+    float *selectedScoresPtr = reinterpret_cast<float *>(scoresMemPtr->GetData());
 
     size_t idx = 0lu;
     for (; idx < validOutputs; idx++) {
@@ -827,7 +827,7 @@ void NonMaxSuppression::execute(dnnl::stream strm) {
         std::fill(selectedScoresPtr, selectedScoresPtr + (maxNumberOfBoxes - idx) * selectedIndicesStride, -1.f);
     }
 
-    int *valid_outputs = reinterpret_cast<int *>(getChildEdgesAtPort(NMS_VALIDOUTPUTS)[0]->getMemoryPtr()->GetPtr());
+    int *valid_outputs = reinterpret_cast<int *>(getChildEdgesAtPort(NMS_VALIDOUTPUTS)[0]->getMemoryPtr()->GetData());
     *valid_outputs = static_cast<int>(validOutputs);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/non_max_suppression.cpp
+++ b/src/plugins/intel_cpu/src/nodes/non_max_suppression.cpp
@@ -723,20 +723,20 @@ void NonMaxSuppression::createJitKernel() {
 
 void NonMaxSuppression::executeDynamicImpl(dnnl::stream strm) {
     if (hasEmptyInputTensors() || (inputShapes.size() > NMS_MAXOUTPUTBOXESPERCLASS &&
-            reinterpret_cast<int *>(getParentEdgeAt(NMS_MAXOUTPUTBOXESPERCLASS)->getMemoryPtr()->GetData())[0] == 0)) {
+            reinterpret_cast<int *>(getParentEdgeAt(NMS_MAXOUTPUTBOXESPERCLASS)->getMemoryPtr()->getData())[0] == 0)) {
         redefineOutputMemory({{0, 3}, {0, 3}, {1}});
-        *reinterpret_cast<int *>(getChildEdgesAtPort(NMS_VALIDOUTPUTS)[0]->getMemoryPtr()->GetData()) = 0;
+        *reinterpret_cast<int *>(getChildEdgesAtPort(NMS_VALIDOUTPUTS)[0]->getMemoryPtr()->getData()) = 0;
         return;
     }
     execute(strm);
 }
 
 void NonMaxSuppression::execute(dnnl::stream strm) {
-    const float *boxes = reinterpret_cast<const float *>(getParentEdgeAt(NMS_BOXES)->getMemoryPtr()->GetData());
-    const float *scores = reinterpret_cast<const float *>(getParentEdgeAt(NMS_SCORES)->getMemoryPtr()->GetData());
+    const float *boxes = reinterpret_cast<const float *>(getParentEdgeAt(NMS_BOXES)->getMemoryPtr()->getData());
+    const float *scores = reinterpret_cast<const float *>(getParentEdgeAt(NMS_SCORES)->getMemoryPtr()->getData());
 
     if (inputShapes.size() > NMS_MAXOUTPUTBOXESPERCLASS) {
-        maxOutputBoxesPerClass = reinterpret_cast<int *>(getParentEdgeAt(NMS_MAXOUTPUTBOXESPERCLASS)->getMemoryPtr()->GetData())[0];
+        maxOutputBoxesPerClass = reinterpret_cast<int *>(getParentEdgeAt(NMS_MAXOUTPUTBOXESPERCLASS)->getMemoryPtr()->getData())[0];
     }
 
     maxOutputBoxesPerClass = std::min(maxOutputBoxesPerClass, numBoxes);
@@ -746,20 +746,20 @@ void NonMaxSuppression::execute(dnnl::stream strm) {
     }
 
     if (inputShapes.size() > NMS_IOUTHRESHOLD)
-        iouThreshold = reinterpret_cast<float *>(getParentEdgeAt(NMS_IOUTHRESHOLD)->getMemoryPtr()->GetData())[0];
+        iouThreshold = reinterpret_cast<float *>(getParentEdgeAt(NMS_IOUTHRESHOLD)->getMemoryPtr()->getData())[0];
 
     if (inputShapes.size() > NMS_SCORETHRESHOLD)
-        scoreThreshold = reinterpret_cast<float *>(getParentEdgeAt(NMS_SCORETHRESHOLD)->getMemoryPtr()->GetData())[0];
+        scoreThreshold = reinterpret_cast<float *>(getParentEdgeAt(NMS_SCORETHRESHOLD)->getMemoryPtr()->getData())[0];
 
     if (inputShapes.size() > NMS_SOFTNMSSIGMA)
-        softNMSSigma = reinterpret_cast<float *>(getParentEdgeAt(NMS_SOFTNMSSIGMA)->getMemoryPtr()->GetData())[0];
+        softNMSSigma = reinterpret_cast<float *>(getParentEdgeAt(NMS_SOFTNMSSIGMA)->getMemoryPtr()->getData())[0];
     scale = 0.0f;
     if (softNMSSigma > 0.0) {
         scale = -0.5f / softNMSSigma;
     }
 
-    auto boxesStrides = getParentEdgeAt(NMS_BOXES)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
-    auto scoresStrides = getParentEdgeAt(NMS_SCORES)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
+    auto boxesStrides = getParentEdgeAt(NMS_BOXES)->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
+    auto scoresStrides = getParentEdgeAt(NMS_SCORES)->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
 
     const auto maxNumberOfBoxes = maxOutputBoxesPerClass * numBatches * numClasses;
     std::vector<filteredBoxes> filtBoxes(maxNumberOfBoxes);
@@ -804,10 +804,10 @@ void NonMaxSuppression::execute(dnnl::stream strm) {
         redefineOutputMemory({newDims, newDims, {1}});
     }
 
-    int selectedIndicesStride = indicesMemPtr->GetDescWithType<BlockedMemoryDesc>()->getStrides()[0];
+    int selectedIndicesStride = indicesMemPtr->getDescWithType<BlockedMemoryDesc>()->getStrides()[0];
 
-    int *selectedIndicesPtr = reinterpret_cast<int *>(indicesMemPtr->GetData());
-    float *selectedScoresPtr = reinterpret_cast<float *>(scoresMemPtr->GetData());
+    int *selectedIndicesPtr = reinterpret_cast<int *>(indicesMemPtr->getData());
+    float *selectedScoresPtr = reinterpret_cast<float *>(scoresMemPtr->getData());
 
     size_t idx = 0lu;
     for (; idx < validOutputs; idx++) {
@@ -827,7 +827,7 @@ void NonMaxSuppression::execute(dnnl::stream strm) {
         std::fill(selectedScoresPtr, selectedScoresPtr + (maxNumberOfBoxes - idx) * selectedIndicesStride, -1.f);
     }
 
-    int *valid_outputs = reinterpret_cast<int *>(getChildEdgesAtPort(NMS_VALIDOUTPUTS)[0]->getMemoryPtr()->GetData());
+    int *valid_outputs = reinterpret_cast<int *>(getChildEdgesAtPort(NMS_VALIDOUTPUTS)[0]->getMemoryPtr()->getData());
     *valid_outputs = static_cast<int>(validOutputs);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/non_zero.cpp
+++ b/src/plugins/intel_cpu/src/nodes/non_zero.cpp
@@ -131,7 +131,7 @@ void NonZero::execute(dnnl::stream strm) {
 template <typename T>
 void NonZero::executeSpecified() {
     const T zero = 0;
-    const T *src = reinterpret_cast<T *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const T *src = reinterpret_cast<T *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
     auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
     Shape inShape = getParentEdgeAt(0)->getMemory().GetShape();
     size_t inRank = inShape.getRank();
@@ -148,7 +148,7 @@ void NonZero::executeSpecified() {
         VectorDims newDims{inRank, totalNonZeroCount};
         redefineOutputMemory({newDims});
     }
-    int* dst = reinterpret_cast<int*>(dstMemPtr->GetPtr());
+    int* dst = reinterpret_cast<int*>(dstMemPtr->GetData());
     if (totalNonZeroCount == 0)
         return;
 

--- a/src/plugins/intel_cpu/src/nodes/non_zero.cpp
+++ b/src/plugins/intel_cpu/src/nodes/non_zero.cpp
@@ -131,9 +131,9 @@ void NonZero::execute(dnnl::stream strm) {
 template <typename T>
 void NonZero::executeSpecified() {
     const T zero = 0;
-    const T *src = reinterpret_cast<T *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    const T *src = reinterpret_cast<T *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
     auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    Shape inShape = getParentEdgeAt(0)->getMemory().GetShape();
+    Shape inShape = getParentEdgeAt(0)->getMemory().getShape();
     size_t inRank = inShape.getRank();
     std::vector<size_t> nonZeroCounts = getNonZeroElementsCount(src, inShape);
     std::vector<size_t> destIndices(nonZeroCounts.size());
@@ -148,7 +148,7 @@ void NonZero::executeSpecified() {
         VectorDims newDims{inRank, totalNonZeroCount};
         redefineOutputMemory({newDims});
     }
-    int* dst = reinterpret_cast<int*>(dstMemPtr->GetData());
+    int* dst = reinterpret_cast<int*>(dstMemPtr->getData());
     if (totalNonZeroCount == 0)
         return;
 
@@ -365,7 +365,7 @@ void NonZero::executeSpecified() {
     }
     default: {
         size_t inSize = inShape.getElementsCount();
-        auto srcStrides = getParentEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
+        auto srcStrides = getParentEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
 
         parallel_nt(threadsCount, [&](int ithr, int nthr) {
             size_t& colIndex = destIndices[ithr];

--- a/src/plugins/intel_cpu/src/nodes/normalize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/normalize.cpp
@@ -937,8 +937,8 @@ void NormalizeL2::execute(dnnl::stream strm) {
     if (!execPtr)
         THROW_ERROR << "doesn't have a compiled executor.";
 
-    const uint8_t *src_ptr = reinterpret_cast<const uint8_t *>(getParentEdgeAt(DATA)->getMemoryPtr()->GetPtr());
-    uint8_t *dst_ptr = reinterpret_cast<uint8_t *>(getChildEdgeAt(DATA)->getMemoryPtr()->GetPtr());
+    const uint8_t *src_ptr = reinterpret_cast<const uint8_t *>(getParentEdgeAt(DATA)->getMemoryPtr()->GetData());
+    uint8_t *dst_ptr = reinterpret_cast<uint8_t *>(getChildEdgeAt(DATA)->getMemoryPtr()->GetData());
     execPtr->exec(src_ptr, dst_ptr, postOpsDataPtrs.data());
 }
 

--- a/src/plugins/intel_cpu/src/nodes/normalize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/normalize.cpp
@@ -874,8 +874,8 @@ void NormalizeL2::setPostOps(dnnl::primitive_attr& kernel_attrs, const VectorDim
 }
 
 void NormalizeL2::createPrimitive() {
-    auto& dstMemPtr = getChildEdgeAt(DATA)->getMemoryPtr();
-    auto& srcMemPtr = getParentEdgeAt(DATA)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(DATA)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(DATA)->getMemoryPtr();
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         THROW_ERROR << "can't get destination memory";
     if (!srcMemPtr || !srcMemPtr->isAllocated())

--- a/src/plugins/intel_cpu/src/nodes/normalize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/normalize.cpp
@@ -937,8 +937,8 @@ void NormalizeL2::execute(dnnl::stream strm) {
     if (!execPtr)
         THROW_ERROR << "doesn't have a compiled executor.";
 
-    const uint8_t *src_ptr = reinterpret_cast<const uint8_t *>(getParentEdgeAt(DATA)->getMemoryPtr()->GetData());
-    uint8_t *dst_ptr = reinterpret_cast<uint8_t *>(getChildEdgeAt(DATA)->getMemoryPtr()->GetData());
+    const uint8_t *src_ptr = reinterpret_cast<const uint8_t *>(getParentEdgeAt(DATA)->getMemoryPtr()->getData());
+    uint8_t *dst_ptr = reinterpret_cast<uint8_t *>(getChildEdgeAt(DATA)->getMemoryPtr()->getData());
     execPtr->exec(src_ptr, dst_ptr, postOpsDataPtrs.data());
 }
 

--- a/src/plugins/intel_cpu/src/nodes/one_hot.cpp
+++ b/src/plugins/intel_cpu/src/nodes/one_hot.cpp
@@ -33,7 +33,7 @@ public:
     Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
-        auto depth = reinterpret_cast<int32_t *>(data_dependency.at(1)->GetPtr())[0];
+        auto depth = reinterpret_cast<int32_t *>(data_dependency.at(1)->GetData())[0];
 
         auto result = input_shapes.front().get();
         result.insert(result.begin() + m_axis, depth);
@@ -132,7 +132,7 @@ OneHot::OneHot(const std::shared_ptr<ngraph::Node>& op, const GraphContext::CPtr
 }
 
 bool OneHot::needShapeInfer() const {
-    const auto depthNodePtr = reinterpret_cast<int32_t *>(getParentEdgesAtPort(1)[0]->getMemoryPtr()->GetPtr());
+    const auto depthNodePtr = reinterpret_cast<int32_t *>(getParentEdgesAtPort(1)[0]->getMemoryPtr()->GetData());
     if (depth != static_cast<size_t>(depthNodePtr[0])) {
         depth = depthNodePtr[0];
         return true;
@@ -162,11 +162,11 @@ void OneHot::initSupportedPrimitiveDescriptors() {
 
 template<typename out_type>
 void OneHot::one_hot(size_t prefix_size, size_t suffix_size) {
-    const auto *src_data = reinterpret_cast<const in_type *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    auto *dst_data = reinterpret_cast<out_type *>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const auto *src_data = reinterpret_cast<const in_type *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    auto *dst_data = reinterpret_cast<out_type *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
 
-    const out_type on_value = reinterpret_cast<const out_type *>(getParentEdgeAt(2)->getMemoryPtr()->GetPtr())[0];
-    const out_type off_value = reinterpret_cast<const out_type *>(getParentEdgeAt(3)->getMemoryPtr()->GetPtr())[0];
+    const out_type on_value = reinterpret_cast<const out_type *>(getParentEdgeAt(2)->getMemoryPtr()->GetData())[0];
+    const out_type off_value = reinterpret_cast<const out_type *>(getParentEdgeAt(3)->getMemoryPtr()->GetData())[0];
 
     // fill the output with off_value
     std::size_t dst_size = prefix_size * depth * suffix_size;

--- a/src/plugins/intel_cpu/src/nodes/one_hot.cpp
+++ b/src/plugins/intel_cpu/src/nodes/one_hot.cpp
@@ -33,7 +33,7 @@ public:
     Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
-        auto depth = reinterpret_cast<int32_t *>(data_dependency.at(1)->GetData())[0];
+        auto depth = reinterpret_cast<int32_t *>(data_dependency.at(1)->getData())[0];
 
         auto result = input_shapes.front().get();
         result.insert(result.begin() + m_axis, depth);
@@ -132,7 +132,7 @@ OneHot::OneHot(const std::shared_ptr<ngraph::Node>& op, const GraphContext::CPtr
 }
 
 bool OneHot::needShapeInfer() const {
-    const auto depthNodePtr = reinterpret_cast<int32_t *>(getParentEdgesAtPort(1)[0]->getMemoryPtr()->GetData());
+    const auto depthNodePtr = reinterpret_cast<int32_t *>(getParentEdgesAtPort(1)[0]->getMemoryPtr()->getData());
     if (depth != static_cast<size_t>(depthNodePtr[0])) {
         depth = depthNodePtr[0];
         return true;
@@ -162,11 +162,11 @@ void OneHot::initSupportedPrimitiveDescriptors() {
 
 template<typename out_type>
 void OneHot::one_hot(size_t prefix_size, size_t suffix_size) {
-    const auto *src_data = reinterpret_cast<const in_type *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    auto *dst_data = reinterpret_cast<out_type *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *src_data = reinterpret_cast<const in_type *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    auto *dst_data = reinterpret_cast<out_type *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
-    const out_type on_value = reinterpret_cast<const out_type *>(getParentEdgeAt(2)->getMemoryPtr()->GetData())[0];
-    const out_type off_value = reinterpret_cast<const out_type *>(getParentEdgeAt(3)->getMemoryPtr()->GetData())[0];
+    const out_type on_value = reinterpret_cast<const out_type *>(getParentEdgeAt(2)->getMemoryPtr()->getData())[0];
+    const out_type off_value = reinterpret_cast<const out_type *>(getParentEdgeAt(3)->getMemoryPtr()->getData())[0];
 
     // fill the output with off_value
     std::size_t dst_size = prefix_size * depth * suffix_size;
@@ -198,7 +198,7 @@ void OneHot::execute(dnnl::stream strm) {
     for (size_t i = 0; i < actual_axis; ++i)
         prefix_size *= input_dims[i];
 
-    std::size_t suffix_size = getParentEdgeAt(0)->getMemory().GetShape().getElementsCount() / prefix_size;
+    std::size_t suffix_size = getParentEdgeAt(0)->getMemory().getShape().getElementsCount() / prefix_size;
 
     OneHotContext ctx = {this, prefix_size, suffix_size};
     OV_SWITCH(intel_cpu, OneHotExecute, ctx, output_precision.size(),

--- a/src/plugins/intel_cpu/src/nodes/pad.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pad.cpp
@@ -239,7 +239,7 @@ void Pad::PadExecutor::paramsInitialization(const PadAttrs& attrs,
 
     auto fillingInParameters =
         [&](VectorIdxs& parameter, const size_t type, const size_t size, const int value) {
-            const int* ptr = reinterpret_cast<const int32_t*>(srcMemory[type]->GetPtr());
+            const int* ptr = reinterpret_cast<const int32_t*>(srcMemory[type]->GetData());
             parameter.resize(size);
             for (size_t i = 0; i < size; i++) {
                 parameter[i] = static_cast<int>(ptr[i]);
@@ -251,7 +251,7 @@ void Pad::PadExecutor::paramsInitialization(const PadAttrs& attrs,
     if (params.attrs.padsEnd.empty())
         fillingInParameters(params.attrs.padsEnd, PADS_END_ID, srcDims.size(), 0);
     if (!params.attrs.constPadValue)
-        params.attrs.padValue = reinterpret_cast<const float*>(srcMemory[PAD_VALUE_ID]->GetPtr())[0];
+        params.attrs.padValue = reinterpret_cast<const float*>(srcMemory[PAD_VALUE_ID]->GetData())[0];
     // pads are constant, so we can calculate new collapsing pads for first target dimensions and use it for the next
     // dimensions to avoid permanent identical pad calculations
     const size_t blockSize = srcMemPtr->getDesc().hasLayoutType(LayoutType::nCsp16c)
@@ -440,7 +440,7 @@ void Pad::PadExecutor::padConstant(const MemoryPtr& srcMemPtr, const MemoryPtr& 
 
 template <typename T>
 void Pad::PadExecutor::padConstantCommon(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr) {
-    T* dstData = reinterpret_cast<T*>(dstMemPtr->GetPtr());
+    T* dstData = reinterpret_cast<T*>(dstMemPtr->GetData());
     const T value = static_cast<T>(params.attrs.padValue);
     if (zeroInputDimsCase) {
         const auto workAmount = dstMemPtr->GetDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
@@ -451,7 +451,7 @@ void Pad::PadExecutor::padConstantCommon(const MemoryPtr& srcMemPtr, const Memor
         return;
     }
 
-    const T* srcData = reinterpret_cast<const T*>(srcMemPtr->GetPtr());
+    const T* srcData = reinterpret_cast<const T*>(srcMemPtr->GetData());
 
     parallel_nt(params.nThreads, [&](const int ithr, const int nthr) {
         size_t start = 0, end = 0;
@@ -489,8 +489,8 @@ void Pad::PadExecutor::padConstantCommon(const MemoryPtr& srcMemPtr, const Memor
 }
 
 void Pad::PadExecutor::padConstantZero(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr) {
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetPtr());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
 
     parallel_nt(params.nThreads, [&](const int ithr, const int nthr) {
         size_t start = 0, end = 0;
@@ -530,8 +530,8 @@ void Pad::PadExecutor::padConstantZero(const MemoryPtr& srcMemPtr, const MemoryP
 }
 
 void Pad::PadExecutor::padEdge(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr) {
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetPtr());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
 
     parallel_nt(params.nThreads, [&](const int ithr, const int nthr) {
         size_t start = 0, end = 0;
@@ -571,8 +571,8 @@ void Pad::PadExecutor::padEdge(const MemoryPtr& srcMemPtr, const MemoryPtr& dstM
 }
 
 void Pad::PadExecutor::padReflectOrSymmetric(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr, const bool isSymmetric) {
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetPtr());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
     const size_t shift = isSymmetric ? 1 : 0;
     const size_t endSrcShift = (params.srcDimsForReflectOrSymmetric[params.nDimsForWork] - params.srcODims[params.nDimsForWork]) * params.shift;
 

--- a/src/plugins/intel_cpu/src/nodes/pad.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pad.cpp
@@ -227,8 +227,8 @@ void Pad::PadExecutor::paramsInitialization(const PadAttrs& attrs,
         IE_THROW() << errorPrefix << "has not allocated source memory.";
     if (!srcMemPtr || !srcMemPtr->isAllocated())
         IE_THROW() << errorPrefix << "has not allocated destination memory.";
-    const auto srcBlockMemDesc = srcMemPtr->GetDescWithType<BlockedMemoryDesc>();
-    const auto dstBlockMemDesc = dstMemPtr->GetDescWithType<BlockedMemoryDesc>();
+    const auto srcBlockMemDesc = srcMemPtr->getDescWithType<BlockedMemoryDesc>();
+    const auto dstBlockMemDesc = dstMemPtr->getDescWithType<BlockedMemoryDesc>();
     const auto& srcDims = srcBlockMemDesc->getBlockDims();
     const auto& dstDims = dstBlockMemDesc->getBlockDims();
 
@@ -239,7 +239,7 @@ void Pad::PadExecutor::paramsInitialization(const PadAttrs& attrs,
 
     auto fillingInParameters =
         [&](VectorIdxs& parameter, const size_t type, const size_t size, const int value) {
-            const int* ptr = reinterpret_cast<const int32_t*>(srcMemory[type]->GetData());
+            const int* ptr = reinterpret_cast<const int32_t*>(srcMemory[type]->getData());
             parameter.resize(size);
             for (size_t i = 0; i < size; i++) {
                 parameter[i] = static_cast<int>(ptr[i]);
@@ -251,7 +251,7 @@ void Pad::PadExecutor::paramsInitialization(const PadAttrs& attrs,
     if (params.attrs.padsEnd.empty())
         fillingInParameters(params.attrs.padsEnd, PADS_END_ID, srcDims.size(), 0);
     if (!params.attrs.constPadValue)
-        params.attrs.padValue = reinterpret_cast<const float*>(srcMemory[PAD_VALUE_ID]->GetData())[0];
+        params.attrs.padValue = reinterpret_cast<const float*>(srcMemory[PAD_VALUE_ID]->getData())[0];
     // pads are constant, so we can calculate new collapsing pads for first target dimensions and use it for the next
     // dimensions to avoid permanent identical pad calculations
     const size_t blockSize = srcMemPtr->getDesc().hasLayoutType(LayoutType::nCsp16c)
@@ -440,10 +440,10 @@ void Pad::PadExecutor::padConstant(const MemoryPtr& srcMemPtr, const MemoryPtr& 
 
 template <typename T>
 void Pad::PadExecutor::padConstantCommon(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr) {
-    T* dstData = reinterpret_cast<T*>(dstMemPtr->GetData());
+    T* dstData = reinterpret_cast<T*>(dstMemPtr->getData());
     const T value = static_cast<T>(params.attrs.padValue);
     if (zeroInputDimsCase) {
-        const auto workAmount = dstMemPtr->GetDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
+        const auto workAmount = dstMemPtr->getDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
         parallel_for(workAmount, [&](size_t i) {
             dstData[i] = value;
         });
@@ -451,7 +451,7 @@ void Pad::PadExecutor::padConstantCommon(const MemoryPtr& srcMemPtr, const Memor
         return;
     }
 
-    const T* srcData = reinterpret_cast<const T*>(srcMemPtr->GetData());
+    const T* srcData = reinterpret_cast<const T*>(srcMemPtr->getData());
 
     parallel_nt(params.nThreads, [&](const int ithr, const int nthr) {
         size_t start = 0, end = 0;
@@ -489,8 +489,8 @@ void Pad::PadExecutor::padConstantCommon(const MemoryPtr& srcMemPtr, const Memor
 }
 
 void Pad::PadExecutor::padConstantZero(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr) {
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetData());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->getData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->getData());
 
     parallel_nt(params.nThreads, [&](const int ithr, const int nthr) {
         size_t start = 0, end = 0;
@@ -530,8 +530,8 @@ void Pad::PadExecutor::padConstantZero(const MemoryPtr& srcMemPtr, const MemoryP
 }
 
 void Pad::PadExecutor::padEdge(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr) {
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetData());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->getData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->getData());
 
     parallel_nt(params.nThreads, [&](const int ithr, const int nthr) {
         size_t start = 0, end = 0;
@@ -571,8 +571,8 @@ void Pad::PadExecutor::padEdge(const MemoryPtr& srcMemPtr, const MemoryPtr& dstM
 }
 
 void Pad::PadExecutor::padReflectOrSymmetric(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr, const bool isSymmetric) {
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetData());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->getData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->getData());
     const size_t shift = isSymmetric ? 1 : 0;
     const size_t endSrcShift = (params.srcDimsForReflectOrSymmetric[params.nDimsForWork] - params.srcODims[params.nDimsForWork]) * params.shift;
 

--- a/src/plugins/intel_cpu/src/nodes/pad.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pad.cpp
@@ -369,7 +369,7 @@ void Pad::PadExecutor::innerParamsInitialization() {
                             std::min(params.attrs.padsEnd[params.nDimsForWork], 0)) * params.shift;
 }
 
-void Pad::PadExecutor::exec(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr) {
+void Pad::PadExecutor::exec(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr) {
     if (zeroInputDimsCase) {
         padConstant(srcMemPtr, dstMemPtr);
     } else {
@@ -419,7 +419,7 @@ static inline void parallel_step(size_t nDims, const VectorDims& dims, std::vect
     }
 }
 
-void Pad::PadExecutor::padConstant(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr) {
+void Pad::PadExecutor::padConstant(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr) {
     if (params.attrs.padValue == 0 && !zeroInputDimsCase) {
         padConstantZero(srcMemPtr, dstMemPtr);
         return;
@@ -439,7 +439,7 @@ void Pad::PadExecutor::padConstant(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr) {
 }
 
 template <typename T>
-void Pad::PadExecutor::padConstantCommon(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr) {
+void Pad::PadExecutor::padConstantCommon(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr) {
     T* dstData = reinterpret_cast<T*>(dstMemPtr->GetPtr());
     const T value = static_cast<T>(params.attrs.padValue);
     if (zeroInputDimsCase) {
@@ -488,7 +488,7 @@ void Pad::PadExecutor::padConstantCommon(MemoryPtr& srcMemPtr, MemoryPtr& dstMem
     });
 }
 
-void Pad::PadExecutor::padConstantZero(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr) {
+void Pad::PadExecutor::padConstantZero(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr) {
     const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetPtr());
     uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());
 
@@ -529,7 +529,7 @@ void Pad::PadExecutor::padConstantZero(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPt
     });
 }
 
-void Pad::PadExecutor::padEdge(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr) {
+void Pad::PadExecutor::padEdge(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr) {
     const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetPtr());
     uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());
 
@@ -570,7 +570,7 @@ void Pad::PadExecutor::padEdge(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr) {
     });
 }
 
-void Pad::PadExecutor::padReflectOrSymmetric(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr, const bool isSymmetric) {
+void Pad::PadExecutor::padReflectOrSymmetric(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr, const bool isSymmetric) {
     const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetPtr());
     uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());
     const size_t shift = isSymmetric ? 1 : 0;

--- a/src/plugins/intel_cpu/src/nodes/pad.h
+++ b/src/plugins/intel_cpu/src/nodes/pad.h
@@ -57,15 +57,15 @@ private:
                     const std::vector<MemoryCPtr>& srcMemory,
                     const std::vector<MemoryCPtr>& dstMemory,
                     const std::string& errorPrefix);
-        void exec(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr);
+        void exec(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr);
         ~PadExecutor() = default;
 
     private:
-        void padConstant(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr);
-        template<typename T> void padConstantCommon(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr);
-        void padConstantZero(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr);
-        void padEdge(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr);
-        void padReflectOrSymmetric(MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr, const bool isSymmetric = false);
+        void padConstant(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr);
+        template<typename T> void padConstantCommon(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr);
+        void padConstantZero(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr);
+        void padEdge(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr);
+        void padReflectOrSymmetric(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr, const bool isSymmetric = false);
         void paramsInitialization(const PadAttrs& attrs,
                                   const std::vector<MemoryCPtr>& srcMemory,
                                   const std::vector<MemoryCPtr>& dstMemory);

--- a/src/plugins/intel_cpu/src/nodes/pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pooling.cpp
@@ -388,8 +388,8 @@ void Pooling::prepareParams() {
     }
 
     if (useACL) {
-        auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-        auto& srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+        auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+        auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
         if (!dstMemPtr || !dstMemPtr->isAllocated())
             IE_THROW() << "Destination memory didn't allocate.";
         if (!srcMemPtr || !srcMemPtr->isAllocated())

--- a/src/plugins/intel_cpu/src/nodes/pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pooling.cpp
@@ -410,8 +410,8 @@ void Pooling::prepareParams() {
                                                                                             *attr);
         selected_pd->setImplementationType(execPtr->getImplType());
     } else {
-        auto inDesc = getParentEdgesAtPort(0)[0]->getMemory().GetDescWithType<DnnlMemoryDesc>();
-        auto outDesc = getChildEdgesAtPort(0)[0]->getMemory().GetDescWithType<DnnlMemoryDesc>();
+        auto inDesc = getParentEdgesAtPort(0)[0]->getMemory().getDescWithType<DnnlMemoryDesc>();
+        auto outDesc = getChildEdgesAtPort(0)[0]->getMemory().getDescWithType<DnnlMemoryDesc>();
 
         if (isDynamicNode()) {
             if (poolingAttrs.auto_pad) {
@@ -468,9 +468,9 @@ void Pooling::prepareParams() {
         }
 
         auto scratchpadMem = getScratchPadMem(dnnlExecPtr->getScratchPadDesc());
-        primArgs[DNNL_ARG_SCRATCHPAD] = scratchpadMem->GetPrimitive();
-        primArgs[DNNL_ARG_SRC] = getParentEdgesAtPort(0)[0]->getMemoryPtr()->GetPrimitive();
-        primArgs[DNNL_ARG_DST] = getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetPrimitive();
+        primArgs[DNNL_ARG_SCRATCHPAD] = scratchpadMem->getPrimitive();
+        primArgs[DNNL_ARG_SRC] = getParentEdgesAtPort(0)[0]->getMemoryPtr()->getPrimitive();
+        primArgs[DNNL_ARG_DST] = getChildEdgesAtPort(0)[0]->getMemoryPtr()->getPrimitive();
 
         Node::appendPostOpArgs(*attr, primArgs, postOpsArgs);
 

--- a/src/plugins/intel_cpu/src/nodes/priorbox.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox.cpp
@@ -33,7 +33,7 @@ public:
     Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
-        const int* in_data = reinterpret_cast<const int*>(data_dependency.at(0)->GetPtr());
+        const int* in_data = reinterpret_cast<const int*>(data_dependency.at(0)->GetData());
         const int H = in_data[0];
         const int W = in_data[1];
         const auto output = static_cast<size_t>(4 * H * W * m_number_of_priors);
@@ -158,7 +158,7 @@ bool PriorBox::needShapeInfer() const {
     }
 
     const auto& outputShape = memory->GetShape().getStaticDims();
-    const int* in_data = reinterpret_cast<int*>(memory->GetPtr());
+    const int* in_data = reinterpret_cast<int*>(memory->GetData());
     const int h = in_data[0];
     const int w = in_data[1];
     const auto output = static_cast<size_t>(4 * h * w * number_of_priors);
@@ -189,18 +189,18 @@ void PriorBox::createPrimitive() {
 }
 
 void PriorBox::execute(dnnl::stream strm) {
-    const int* in_data = reinterpret_cast<int*>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const int* in_data = reinterpret_cast<int*>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
     const int H = in_data[0];
     const int W = in_data[1];
 
-    const int* in_image = reinterpret_cast<int*>(getParentEdgeAt(1)->getMemoryPtr()->GetPtr());
+    const int* in_image = reinterpret_cast<int*>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
     const int IH = in_image[0];
     const int IW = in_image[1];
 
     const int OH = 4 * H * W * number_of_priors;
     const int OW = 1;
 
-    float* dst_data = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    float* dst_data = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
 
     float step_ = step;
     auto min_size_ = min_size;

--- a/src/plugins/intel_cpu/src/nodes/priorbox.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox.cpp
@@ -152,7 +152,7 @@ PriorBox::PriorBox(const std::shared_ptr<ngraph::Node>& op, const GraphContext::
 }
 
 bool PriorBox::needShapeInfer() const {
-    auto& memory = getChildEdgeAt(0)->getMemoryPtr();
+    auto memory = getChildEdgeAt(0)->getMemoryPtr();
     if (memory->GetShape().isDynamic()) {
         return true;
     }

--- a/src/plugins/intel_cpu/src/nodes/priorbox.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox.cpp
@@ -33,7 +33,7 @@ public:
     Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
-        const int* in_data = reinterpret_cast<const int*>(data_dependency.at(0)->GetData());
+        const int* in_data = reinterpret_cast<const int*>(data_dependency.at(0)->getData());
         const int H = in_data[0];
         const int W = in_data[1];
         const auto output = static_cast<size_t>(4 * H * W * m_number_of_priors);
@@ -153,12 +153,12 @@ PriorBox::PriorBox(const std::shared_ptr<ngraph::Node>& op, const GraphContext::
 
 bool PriorBox::needShapeInfer() const {
     auto memory = getChildEdgeAt(0)->getMemoryPtr();
-    if (memory->GetShape().isDynamic()) {
+    if (memory->getShape().isDynamic()) {
         return true;
     }
 
-    const auto& outputShape = memory->GetShape().getStaticDims();
-    const int* in_data = reinterpret_cast<int*>(memory->GetData());
+    const auto& outputShape = memory->getShape().getStaticDims();
+    const int* in_data = reinterpret_cast<int*>(memory->getData());
     const int h = in_data[0];
     const int w = in_data[1];
     const auto output = static_cast<size_t>(4 * h * w * number_of_priors);
@@ -189,18 +189,18 @@ void PriorBox::createPrimitive() {
 }
 
 void PriorBox::execute(dnnl::stream strm) {
-    const int* in_data = reinterpret_cast<int*>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    const int* in_data = reinterpret_cast<int*>(getParentEdgeAt(0)->getMemoryPtr()->getData());
     const int H = in_data[0];
     const int W = in_data[1];
 
-    const int* in_image = reinterpret_cast<int*>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
+    const int* in_image = reinterpret_cast<int*>(getParentEdgeAt(1)->getMemoryPtr()->getData());
     const int IH = in_image[0];
     const int IW = in_image[1];
 
     const int OH = 4 * H * W * number_of_priors;
     const int OW = 1;
 
-    float* dst_data = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    float* dst_data = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
     float step_ = step;
     auto min_size_ = min_size;

--- a/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
@@ -32,7 +32,7 @@ public:
     Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
-        const int* in_data = reinterpret_cast<const int*>(data_dependency.at(0)->GetPtr());
+        const int* in_data = reinterpret_cast<const int*>(data_dependency.at(0)->GetData());
         const int H = in_data[0];
         const int W = in_data[1];
         const auto output = static_cast<size_t>(4 * H * W * m_number_of_priors);
@@ -112,7 +112,7 @@ bool PriorBoxClustered::needShapeInfer() const {
     }
 
     const auto& outputShape = memory->GetShape().getStaticDims();
-    const int* in_data = reinterpret_cast<int*>(memory->GetPtr());
+    const int* in_data = reinterpret_cast<int*>(memory->GetData());
     const int h = in_data[0];
     const int w = in_data[1];
     const auto output = static_cast<size_t>(4 * h * w * number_of_priors);
@@ -143,11 +143,11 @@ void PriorBoxClustered::createPrimitive() {
 }
 
 void PriorBoxClustered::execute(dnnl::stream strm) {
-    const int* in_data = reinterpret_cast<int*>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const int* in_data = reinterpret_cast<int*>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
     const int layer_height = in_data[0];
     const int layer_width = in_data[1];
 
-    const int* in_image = reinterpret_cast<int*>(getParentEdgeAt(1)->getMemoryPtr()->GetPtr());
+    const int* in_image = reinterpret_cast<int*>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
     int img_height = in_image[0];
     int img_width = in_image[1];
 
@@ -158,7 +158,7 @@ void PriorBoxClustered::execute(dnnl::stream strm) {
         step_h = static_cast<float>(img_height) / layer_height;
     }
 
-    float* dst_data = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    float* dst_data = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
     const auto& out_shape = getChildEdgeAt(0)->getMemory().GetShape().getStaticDims();
 
     size_t var_size = variances.size();

--- a/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
@@ -106,7 +106,7 @@ PriorBoxClustered::PriorBoxClustered(const std::shared_ptr<ngraph::Node>& op, co
 }
 
 bool PriorBoxClustered::needShapeInfer() const {
-    auto& memory = getChildEdgeAt(0)->getMemoryPtr();
+    auto memory = getChildEdgeAt(0)->getMemoryPtr();
     if (memory->GetShape().isDynamic()) {
         return true;
     }

--- a/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
@@ -32,7 +32,7 @@ public:
     Result infer(
         const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
         const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
-        const int* in_data = reinterpret_cast<const int*>(data_dependency.at(0)->GetData());
+        const int* in_data = reinterpret_cast<const int*>(data_dependency.at(0)->getData());
         const int H = in_data[0];
         const int W = in_data[1];
         const auto output = static_cast<size_t>(4 * H * W * m_number_of_priors);
@@ -107,12 +107,12 @@ PriorBoxClustered::PriorBoxClustered(const std::shared_ptr<ngraph::Node>& op, co
 
 bool PriorBoxClustered::needShapeInfer() const {
     auto memory = getChildEdgeAt(0)->getMemoryPtr();
-    if (memory->GetShape().isDynamic()) {
+    if (memory->getShape().isDynamic()) {
         return true;
     }
 
-    const auto& outputShape = memory->GetShape().getStaticDims();
-    const int* in_data = reinterpret_cast<int*>(memory->GetData());
+    const auto& outputShape = memory->getShape().getStaticDims();
+    const int* in_data = reinterpret_cast<int*>(memory->getData());
     const int h = in_data[0];
     const int w = in_data[1];
     const auto output = static_cast<size_t>(4 * h * w * number_of_priors);
@@ -143,11 +143,11 @@ void PriorBoxClustered::createPrimitive() {
 }
 
 void PriorBoxClustered::execute(dnnl::stream strm) {
-    const int* in_data = reinterpret_cast<int*>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    const int* in_data = reinterpret_cast<int*>(getParentEdgeAt(0)->getMemoryPtr()->getData());
     const int layer_height = in_data[0];
     const int layer_width = in_data[1];
 
-    const int* in_image = reinterpret_cast<int*>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
+    const int* in_image = reinterpret_cast<int*>(getParentEdgeAt(1)->getMemoryPtr()->getData());
     int img_height = in_image[0];
     int img_width = in_image[1];
 
@@ -158,8 +158,8 @@ void PriorBoxClustered::execute(dnnl::stream strm) {
         step_h = static_cast<float>(img_height) / layer_height;
     }
 
-    float* dst_data = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
-    const auto& out_shape = getChildEdgeAt(0)->getMemory().GetShape().getStaticDims();
+    float* dst_data = reinterpret_cast<float*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
+    const auto& out_shape = getChildEdgeAt(0)->getMemory().getShape().getStaticDims();
 
     size_t var_size = variances.size();
     parallel_for2d(layer_height, layer_width, [&](int64_t h, int64_t w) {

--- a/src/plugins/intel_cpu/src/nodes/proposal.cpp
+++ b/src/plugins/intel_cpu/src/nodes/proposal.cpp
@@ -164,13 +164,13 @@ void Proposal::executeDynamicImpl(dnnl::stream strm) {
 
 void Proposal::execute(dnnl::stream strm) {
     try {
-        const float* probabilitiesData = reinterpret_cast<const float *>(getParentEdgeAt(PROBABILITIES_IN_IDX)->getMemoryPtr()->GetPtr());
-        const float* anchorsData = reinterpret_cast<const float *>(getParentEdgeAt(ANCHORS_IN_IDX)->getMemoryPtr()->GetPtr());
-        const float* imgInfoData = reinterpret_cast<const float *>(getParentEdgeAt(IMG_INFO_IN_IDX)->getMemoryPtr()->GetPtr());
-        float* outRoiData = reinterpret_cast <float *>(getChildEdgesAtPort(ROI_OUT_IDX)[0]->getMemoryPtr()->GetPtr());
+        const float* probabilitiesData = reinterpret_cast<const float *>(getParentEdgeAt(PROBABILITIES_IN_IDX)->getMemoryPtr()->GetData());
+        const float* anchorsData = reinterpret_cast<const float *>(getParentEdgeAt(ANCHORS_IN_IDX)->getMemoryPtr()->GetData());
+        const float* imgInfoData = reinterpret_cast<const float *>(getParentEdgeAt(IMG_INFO_IN_IDX)->getMemoryPtr()->GetData());
+        float* outRoiData = reinterpret_cast <float *>(getChildEdgesAtPort(ROI_OUT_IDX)[0]->getMemoryPtr()->GetData());
         float* outProbData = nullptr;
         if (store_prob)
-            outProbData = reinterpret_cast <float *>(getChildEdgesAtPort(PROBABILITIES_OUT_IDX)[0]->getMemoryPtr()->GetPtr());
+            outProbData = reinterpret_cast <float *>(getChildEdgesAtPort(PROBABILITIES_OUT_IDX)[0]->getMemoryPtr()->GetData());
 
         auto inProbDims = getParentEdgeAt(0)->getMemory().getStaticDims();
         const size_t imgInfoSize = getParentEdgeAt(2)->getMemory().getStaticDims()[0];

--- a/src/plugins/intel_cpu/src/nodes/proposal.cpp
+++ b/src/plugins/intel_cpu/src/nodes/proposal.cpp
@@ -164,13 +164,13 @@ void Proposal::executeDynamicImpl(dnnl::stream strm) {
 
 void Proposal::execute(dnnl::stream strm) {
     try {
-        const float* probabilitiesData = reinterpret_cast<const float *>(getParentEdgeAt(PROBABILITIES_IN_IDX)->getMemoryPtr()->GetData());
-        const float* anchorsData = reinterpret_cast<const float *>(getParentEdgeAt(ANCHORS_IN_IDX)->getMemoryPtr()->GetData());
-        const float* imgInfoData = reinterpret_cast<const float *>(getParentEdgeAt(IMG_INFO_IN_IDX)->getMemoryPtr()->GetData());
-        float* outRoiData = reinterpret_cast <float *>(getChildEdgesAtPort(ROI_OUT_IDX)[0]->getMemoryPtr()->GetData());
+        const float* probabilitiesData = reinterpret_cast<const float *>(getParentEdgeAt(PROBABILITIES_IN_IDX)->getMemoryPtr()->getData());
+        const float* anchorsData = reinterpret_cast<const float *>(getParentEdgeAt(ANCHORS_IN_IDX)->getMemoryPtr()->getData());
+        const float* imgInfoData = reinterpret_cast<const float *>(getParentEdgeAt(IMG_INFO_IN_IDX)->getMemoryPtr()->getData());
+        float* outRoiData = reinterpret_cast <float *>(getChildEdgesAtPort(ROI_OUT_IDX)[0]->getMemoryPtr()->getData());
         float* outProbData = nullptr;
         if (store_prob)
-            outProbData = reinterpret_cast <float *>(getChildEdgesAtPort(PROBABILITIES_OUT_IDX)[0]->getMemoryPtr()->GetData());
+            outProbData = reinterpret_cast <float *>(getChildEdgesAtPort(PROBABILITIES_OUT_IDX)[0]->getMemoryPtr()->getData());
 
         auto inProbDims = getParentEdgeAt(0)->getMemory().getStaticDims();
         const size_t imgInfoSize = getParentEdgeAt(2)->getMemory().getStaticDims()[0];

--- a/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
@@ -482,9 +482,9 @@ void PSROIPooling::executeBilinearDeformable(const inputType *srcData, outputTyp
 
 template <typename inputType, typename outputType>
 void PSROIPooling::executeSpecified() {
-    const auto *srcData = reinterpret_cast<const inputType *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    const auto *bottomRoisBeginning = reinterpret_cast<const float *>(getParentEdgeAt(1)->getMemoryPtr()->GetPtr());
-    auto *dstData = reinterpret_cast<outputType *>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const auto *srcData = reinterpret_cast<const inputType *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *bottomRoisBeginning = reinterpret_cast<const float *>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
+    auto *dstData = reinterpret_cast<outputType *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
 
     auto srcDesc = getParentEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>();
     auto dstDesc = getChildEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>();
@@ -503,7 +503,7 @@ void PSROIPooling::executeSpecified() {
     int channelsEachClass = outputDim;
     if (!noTrans) {
         const auto mem = getParentEdgeAt(2)->getMemoryPtr();
-        bottomTrans = reinterpret_cast<const float *>(mem->GetPtr());
+        bottomTrans = reinterpret_cast<const float *>(mem->GetData());
         numClasses = static_cast<int>(mem->getStaticDims()[1]) / 2;
         channelsEachClass /= numClasses;
     }

--- a/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
@@ -482,12 +482,12 @@ void PSROIPooling::executeBilinearDeformable(const inputType *srcData, outputTyp
 
 template <typename inputType, typename outputType>
 void PSROIPooling::executeSpecified() {
-    const auto *srcData = reinterpret_cast<const inputType *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    const auto *bottomRoisBeginning = reinterpret_cast<const float *>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
-    auto *dstData = reinterpret_cast<outputType *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *srcData = reinterpret_cast<const inputType *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    const auto *bottomRoisBeginning = reinterpret_cast<const float *>(getParentEdgeAt(1)->getMemoryPtr()->getData());
+    auto *dstData = reinterpret_cast<outputType *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
-    auto srcDesc = getParentEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>();
-    auto dstDesc = getChildEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>();
+    auto srcDesc = getParentEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>();
+    auto dstDesc = getChildEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>();
 
     int realRois = 0;
     for (; realRois < nn; realRois++) {
@@ -503,7 +503,7 @@ void PSROIPooling::executeSpecified() {
     int channelsEachClass = outputDim;
     if (!noTrans) {
         const auto mem = getParentEdgeAt(2)->getMemoryPtr();
-        bottomTrans = reinterpret_cast<const float *>(mem->GetData());
+        bottomTrans = reinterpret_cast<const float *>(mem->getData());
         numClasses = static_cast<int>(mem->getStaticDims()[1]) / 2;
         channelsEachClass /= numClasses;
     }

--- a/src/plugins/intel_cpu/src/nodes/range.cpp
+++ b/src/plugins/intel_cpu/src/nodes/range.cpp
@@ -118,9 +118,9 @@ size_t Range::getWorkAmount(data_t *startPtr, data_t *stopPtr, data_t *stepPtr) 
         stopPtr = &limit;
     if (stepPtr == nullptr)
         stepPtr = &delta;
-    *startPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_START)->getMemoryPtr()->GetPtr())[0];
-    *stopPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_LIMIT)->getMemoryPtr()->GetPtr())[0];
-    *stepPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_DELTA)->getMemoryPtr()->GetPtr())[0];
+    *startPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_START)->getMemoryPtr()->GetData())[0];
+    *stopPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_LIMIT)->getMemoryPtr()->GetData())[0];
+    *stepPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_DELTA)->getMemoryPtr()->GetData())[0];
     const data_t span = *stopPtr - *startPtr;
     const data_t step = *stepPtr;
     if (std::is_same<data_t, int>::value) {
@@ -140,7 +140,7 @@ InferenceEngine::StatusCode Range::rangeKernel() {
         VectorDims newOutputShape {work_amount_dst};
         redefineOutputMemory({newOutputShape});
     }
-    data_t* dst_data = reinterpret_cast<data_t *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetPtr());
+    data_t* dst_data = reinterpret_cast<data_t *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t iwork = 0, end = 0;
         splitter(work_amount_dst, nthr, ithr, iwork, end);

--- a/src/plugins/intel_cpu/src/nodes/range.cpp
+++ b/src/plugins/intel_cpu/src/nodes/range.cpp
@@ -118,9 +118,9 @@ size_t Range::getWorkAmount(data_t *startPtr, data_t *stopPtr, data_t *stepPtr) 
         stopPtr = &limit;
     if (stepPtr == nullptr)
         stepPtr = &delta;
-    *startPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_START)->getMemoryPtr()->GetData())[0];
-    *stopPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_LIMIT)->getMemoryPtr()->GetData())[0];
-    *stepPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_DELTA)->getMemoryPtr()->GetData())[0];
+    *startPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_START)->getMemoryPtr()->getData())[0];
+    *stopPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_LIMIT)->getMemoryPtr()->getData())[0];
+    *stepPtr = reinterpret_cast<const data_t *>(getParentEdgeAt(RANGE_DELTA)->getMemoryPtr()->getData())[0];
     const data_t span = *stopPtr - *startPtr;
     const data_t step = *stepPtr;
     if (std::is_same<data_t, int>::value) {
@@ -140,7 +140,7 @@ InferenceEngine::StatusCode Range::rangeKernel() {
         VectorDims newOutputShape {work_amount_dst};
         redefineOutputMemory({newOutputShape});
     }
-    data_t* dst_data = reinterpret_cast<data_t *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
+    data_t* dst_data = reinterpret_cast<data_t *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t iwork = 0, end = 0;
         splitter(work_amount_dst, nthr, ithr, iwork, end);

--- a/src/plugins/intel_cpu/src/nodes/rdft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rdft.cpp
@@ -157,8 +157,8 @@ void RDFT::execute(dnnl::stream strm) {
     const auto& inputShape = inputMem.getStaticDims();
     const auto& outputShape = outputMem.getStaticDims();
 
-    auto inputPtr = reinterpret_cast<float*>(inputMem.GetPtr());
-    auto outputPtr = reinterpret_cast<float*>(outputMem.GetPtr());
+    auto inputPtr = reinterpret_cast<float*>(inputMem.GetData());
+    auto outputPtr = reinterpret_cast<float*>(outputMem.GetData());
 
     auto rank = inputShape.size() - inverse;
 
@@ -187,7 +187,7 @@ void RDFT::prepareParams() {
         if (axes.size() != newAxesSize) {
             axes.resize(newAxesSize);
         }
-        auto axesPtr = reinterpret_cast<const int*>(axesMem->GetPtr());
+        auto axesPtr = reinterpret_cast<const int*>(axesMem->GetData());
         auto inputRank = inputShapes[DATA_INDEX].getRank() - inverse;
         for (size_t i = 0; i < axes.size(); i++) {
             axes[i] = axesPtr[i] < 0 ? axesPtr[i] + inputRank : axesPtr[i];
@@ -213,7 +213,7 @@ void RDFT::prepareParams() {
             if (signalSizes.size() != newSize) {
                 signalSizes.resize(newSize);
             }
-            const auto& signalSizesPtr = reinterpret_cast<const int*>(signalSizesMem->GetPtr());
+            const auto& signalSizesPtr = reinterpret_cast<const int*>(signalSizesMem->GetData());
             for (size_t i = 0; i < newSize; i++) {
                 signalSizes[i] = signalSizesPtr[i];
             }
@@ -232,7 +232,7 @@ bool RDFT::axesChanged() const {
     if (axes.size() != axesMem->getStaticDims()[0]) {
         return true;
     }
-    auto axesPtr = reinterpret_cast<const int*>(axesMem->GetPtr());
+    auto axesPtr = reinterpret_cast<const int*>(axesMem->GetData());
     auto inputRank = inputShapes[DATA_INDEX].getRank() - inverse;
     for (size_t i = 0; i < axes.size(); i++) {
         auto newAxis = axesPtr[i] < 0 ? axesPtr[i] + inputRank : axesPtr[i];
@@ -267,7 +267,7 @@ bool RDFT::signalSizesChanged() const {
         if (signalSizes.size() != newSize || signalSizes.size() != axes.size()) {
             return true;
         }
-        const auto& signalSizesPtr = reinterpret_cast<const int*>(signalSizesMem->GetPtr());
+        const auto& signalSizesPtr = reinterpret_cast<const int*>(signalSizesMem->GetData());
         for (size_t i = 0; i < newSize; i++) {
             if (signalSizesPtr[i] != signalSizes[i]) {
                 return true;

--- a/src/plugins/intel_cpu/src/nodes/rdft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rdft.cpp
@@ -157,13 +157,13 @@ void RDFT::execute(dnnl::stream strm) {
     const auto& inputShape = inputMem.getStaticDims();
     const auto& outputShape = outputMem.getStaticDims();
 
-    auto inputPtr = reinterpret_cast<float*>(inputMem.GetData());
-    auto outputPtr = reinterpret_cast<float*>(outputMem.GetData());
+    auto inputPtr = reinterpret_cast<float*>(inputMem.getData());
+    auto outputPtr = reinterpret_cast<float*>(outputMem.getData());
 
     auto rank = inputShape.size() - inverse;
 
-    const auto& inputStrides = inputMem.GetDescWithType<BlockedMemoryDesc>()->getStrides();
-    const auto& outputStrides = outputMem.GetDescWithType<BlockedMemoryDesc>()->getStrides();
+    const auto& inputStrides = inputMem.getDescWithType<BlockedMemoryDesc>()->getStrides();
+    const auto& outputStrides = outputMem.getDescWithType<BlockedMemoryDesc>()->getStrides();
 
     executor->execute(inputPtr, outputPtr,
                       twiddles, rank,
@@ -187,7 +187,7 @@ void RDFT::prepareParams() {
         if (axes.size() != newAxesSize) {
             axes.resize(newAxesSize);
         }
-        auto axesPtr = reinterpret_cast<const int*>(axesMem->GetData());
+        auto axesPtr = reinterpret_cast<const int*>(axesMem->getData());
         auto inputRank = inputShapes[DATA_INDEX].getRank() - inverse;
         for (size_t i = 0; i < axes.size(); i++) {
             axes[i] = axesPtr[i] < 0 ? axesPtr[i] + inputRank : axesPtr[i];
@@ -213,7 +213,7 @@ void RDFT::prepareParams() {
             if (signalSizes.size() != newSize) {
                 signalSizes.resize(newSize);
             }
-            const auto& signalSizesPtr = reinterpret_cast<const int*>(signalSizesMem->GetData());
+            const auto& signalSizesPtr = reinterpret_cast<const int*>(signalSizesMem->getData());
             for (size_t i = 0; i < newSize; i++) {
                 signalSizes[i] = signalSizesPtr[i];
             }
@@ -232,7 +232,7 @@ bool RDFT::axesChanged() const {
     if (axes.size() != axesMem->getStaticDims()[0]) {
         return true;
     }
-    auto axesPtr = reinterpret_cast<const int*>(axesMem->GetData());
+    auto axesPtr = reinterpret_cast<const int*>(axesMem->getData());
     auto inputRank = inputShapes[DATA_INDEX].getRank() - inverse;
     for (size_t i = 0; i < axes.size(); i++) {
         auto newAxis = axesPtr[i] < 0 ? axesPtr[i] + inputRank : axesPtr[i];
@@ -267,7 +267,7 @@ bool RDFT::signalSizesChanged() const {
         if (signalSizes.size() != newSize || signalSizes.size() != axes.size()) {
             return true;
         }
-        const auto& signalSizesPtr = reinterpret_cast<const int*>(signalSizesMem->GetData());
+        const auto& signalSizesPtr = reinterpret_cast<const int*>(signalSizesMem->getData());
         for (size_t i = 0; i < newSize; i++) {
             if (signalSizesPtr[i] != signalSizes[i]) {
                 return true;

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -2086,8 +2086,8 @@ void Reduce::execute(dnnl::stream strm) {
     auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
     auto srcMemPtr = getParentEdgeAt(REDUCE_DATA)->getMemoryPtr();
 
-    const uint8_t *src_data = reinterpret_cast<const uint8_t *>(srcMemPtr->GetPtr());
-    uint8_t *dst_data = reinterpret_cast<uint8_t *>(dstMemPtr->GetPtr());
+    const uint8_t *src_data = reinterpret_cast<const uint8_t *>(srcMemPtr->GetData());
+    uint8_t *dst_data = reinterpret_cast<uint8_t *>(dstMemPtr->GetData());
 
     if (jit_mode) {
         if (is_hybrid_layout) {
@@ -2131,7 +2131,7 @@ void Reduce::reduce_type(const uint8_t *in_ptr, uint8_t *out_ptr, size_t dst_siz
     if (is_hybrid_layout) {
         uint8_t *proc_ptr = out_ptr;
         auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-        out_ptr = reinterpret_cast<uint8_t *>(dstMemPtr->GetPtr());
+        out_ptr = reinterpret_cast<uint8_t *>(dstMemPtr->GetData());
         if (layout == ReduceLayoutType::reduce_nspc) {
             nspc2ncsp(proc_ptr, out_ptr);
         } else {

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -1942,7 +1942,7 @@ void Reduce::prepareParams() {
         reduce_axes = raw_axes;
     }
 
-    auto &dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
     const SizeVector &dst_dims = dstMemPtr->getDesc().getShape().getDims();
     dst_size = dstMemPtr->GetSize();
     calc_process_dst_dims(reduce_axes, dst_dims);
@@ -1990,8 +1990,8 @@ void Reduce::createPrimitive() {
     if (!isExecutable()) {
         return;
     }
-    auto &dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto &srcMemPtr = getParentEdgeAt(REDUCE_DATA)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(REDUCE_DATA)->getMemoryPtr();
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         IE_THROW() << errorPrefix << " has not allocated destination memory.";
     if (!srcMemPtr || !srcMemPtr->isAllocated())
@@ -2083,8 +2083,8 @@ void Reduce::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void Reduce::execute(dnnl::stream strm) {
-    auto &dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto &srcMemPtr = getParentEdgeAt(REDUCE_DATA)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(REDUCE_DATA)->getMemoryPtr();
 
     const uint8_t *src_data = reinterpret_cast<const uint8_t *>(srcMemPtr->GetPtr());
     uint8_t *dst_data = reinterpret_cast<uint8_t *>(dstMemPtr->GetPtr());
@@ -2130,7 +2130,7 @@ void Reduce::reduce_type(const uint8_t *in_ptr, uint8_t *out_ptr, size_t dst_siz
 
     if (is_hybrid_layout) {
         uint8_t *proc_ptr = out_ptr;
-        auto &dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+        auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
         out_ptr = reinterpret_cast<uint8_t *>(dstMemPtr->GetPtr());
         if (layout == ReduceLayoutType::reduce_nspc) {
             nspc2ncsp(proc_ptr, out_ptr);

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -1944,7 +1944,7 @@ void Reduce::prepareParams() {
 
     auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
     const SizeVector &dst_dims = dstMemPtr->getDesc().getShape().getDims();
-    dst_size = dstMemPtr->GetSize();
+    dst_size = dstMemPtr->getSize();
     calc_process_dst_dims(reduce_axes, dst_dims);
     if (jit_mode) {
         set_reduce_dim_flags();
@@ -2086,8 +2086,8 @@ void Reduce::execute(dnnl::stream strm) {
     auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
     auto srcMemPtr = getParentEdgeAt(REDUCE_DATA)->getMemoryPtr();
 
-    const uint8_t *src_data = reinterpret_cast<const uint8_t *>(srcMemPtr->GetData());
-    uint8_t *dst_data = reinterpret_cast<uint8_t *>(dstMemPtr->GetData());
+    const uint8_t *src_data = reinterpret_cast<const uint8_t *>(srcMemPtr->getData());
+    uint8_t *dst_data = reinterpret_cast<uint8_t *>(dstMemPtr->getData());
 
     if (jit_mode) {
         if (is_hybrid_layout) {
@@ -2131,7 +2131,7 @@ void Reduce::reduce_type(const uint8_t *in_ptr, uint8_t *out_ptr, size_t dst_siz
     if (is_hybrid_layout) {
         uint8_t *proc_ptr = out_ptr;
         auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-        out_ptr = reinterpret_cast<uint8_t *>(dstMemPtr->GetData());
+        out_ptr = reinterpret_cast<uint8_t *>(dstMemPtr->getData());
         if (layout == ReduceLayoutType::reduce_nspc) {
             nspc2ncsp(proc_ptr, out_ptr);
         } else {
@@ -2976,7 +2976,7 @@ void Reduce::reduce_ref_process(const float *in_ptr, float *out_ptr, float init_
         reduced_dims_work_amount *= src_dims[i];
     reduced_dims_work_amount /= work_amount_dst;
 
-    SizeVector src_strides = getParentEdgeAt(REDUCE_DATA)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getStrides();
+    SizeVector src_strides = getParentEdgeAt(REDUCE_DATA)->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
     parallel_nt(0, [&](const int ithr, const int nthr) {
         int j;
         size_t i, start = 0, end = 0;

--- a/src/plugins/intel_cpu/src/nodes/reference.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reference.cpp
@@ -122,7 +122,7 @@ bool Reference::needShapeInfer() const {
 ov::TensorVector Reference::prepareInputs() const {
     ov::TensorVector inputs;
     for (size_t i = 0; i < inputShapes.size(); i++) {
-        void *srcDataPtr = getParentEdgesAtPort(i)[0]->getMemory().GetPtr();
+        void *srcDataPtr = getParentEdgesAtPort(i)[0]->getMemory().GetData();
         inputs.push_back(ov::Tensor(ngraphOp->get_input_element_type(i),
                                              getParentEdgesAtPort(i)[0]->getMemory().getStaticDims(), srcDataPtr));
     }
@@ -132,7 +132,7 @@ ov::TensorVector Reference::prepareInputs() const {
 ov::TensorVector Reference::prepareOutputs() const {
     ov::TensorVector outputs;
     for (size_t i = 0; i < outputShapes.size(); i++) {
-        void *dstDataPtr = getChildEdgesAtPort(i)[0]->getMemory().GetPtr();
+        void *dstDataPtr = getChildEdgesAtPort(i)[0]->getMemory().GetData();
         outputs.push_back(ov::Tensor(ngraphOp->get_output_element_type(i),
                                               getChildEdgesAtPort(i)[0]->getMemory().getStaticDims(), dstDataPtr));
     }

--- a/src/plugins/intel_cpu/src/nodes/reference.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reference.cpp
@@ -102,11 +102,11 @@ void Reference::executeDynamicImpl(dnnl::stream strm) {
         for (size_t i = 0; i < outputShapes.size(); ++i) {
             auto memory = getChildEdgesAtPort(i)[0]->getMemoryPtr();
             auto& tensor = outputs[i];
-            if (memory->GetSize() != tensor.get_byte_size()) {
+            if (memory->getSize() != tensor.get_byte_size()) {
                 IE_THROW(Unexpected) << "Output tensor data size mismatch occurred during the inference of a node with type " <<
                 getTypeStr() << " and name " << getName() << " on output port number " << i;
             }
-            cpu_memcpy(memory->GetData(), tensor.data(), tensor.get_byte_size());
+            cpu_memcpy(memory->getData(), tensor.data(), tensor.get_byte_size());
         }
     }
 }
@@ -122,7 +122,7 @@ bool Reference::needShapeInfer() const {
 ov::TensorVector Reference::prepareInputs() const {
     ov::TensorVector inputs;
     for (size_t i = 0; i < inputShapes.size(); i++) {
-        void *srcDataPtr = getParentEdgesAtPort(i)[0]->getMemory().GetData();
+        void *srcDataPtr = getParentEdgesAtPort(i)[0]->getMemory().getData();
         inputs.push_back(ov::Tensor(ngraphOp->get_input_element_type(i),
                                              getParentEdgesAtPort(i)[0]->getMemory().getStaticDims(), srcDataPtr));
     }
@@ -132,7 +132,7 @@ ov::TensorVector Reference::prepareInputs() const {
 ov::TensorVector Reference::prepareOutputs() const {
     ov::TensorVector outputs;
     for (size_t i = 0; i < outputShapes.size(); i++) {
-        void *dstDataPtr = getChildEdgesAtPort(i)[0]->getMemory().GetData();
+        void *dstDataPtr = getChildEdgesAtPort(i)[0]->getMemory().getData();
         outputs.push_back(ov::Tensor(ngraphOp->get_output_element_type(i),
                                               getChildEdgesAtPort(i)[0]->getMemory().getStaticDims(), dstDataPtr));
     }

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
@@ -410,8 +410,8 @@ void RegionYolo::execute(dnnl::stream strm) {
     size_t inputs_size = IH * IW * num_ * (classes + coords + 1);
     size_t total_size = 2 * IH * IW;
 
-    const auto *src_data = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    auto *dst_data = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const auto *src_data = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    auto *dst_data = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
 
     cpu_convert(src_data, dst_data, getParentEdgeAt(0)->getMemory().getDesc().getPrecision(),
                 getChildEdgeAt(0)->getMemory().getDesc().getPrecision(), output_size);

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
@@ -380,7 +380,7 @@ inline void RegionYolo::calculate_logistic(size_t start_index, int count, uint8_
 }
 
 void RegionYolo::execute(dnnl::stream strm) {
-    const auto &inShape = getParentEdgeAt(0)->getMemory().GetShape();
+    const auto &inShape = getParentEdgeAt(0)->getMemory().getShape();
     const auto &inDims = inShape.getStaticDims();
     size_t B =  (inShape.getRank() > 0) ? inDims[0] : 1;
     size_t IC = (inShape.getRank() > 1) ? inDims[1] : 1;
@@ -403,15 +403,15 @@ void RegionYolo::execute(dnnl::stream strm) {
         output_size = B * IH * IW * mask_size * (classes + coords + 1);
     }
 
-    if (output_size != getChildEdgeAt(0)->getMemoryPtr()->GetShape().getElementsCount())
+    if (output_size != getChildEdgeAt(0)->getMemoryPtr()->getShape().getElementsCount())
         IE_THROW() << "Incorrect layer configuration or output dimensions. " << output_size << " != "
-                   << getChildEdgeAt(0)->getMemoryPtr()->GetShape().getElementsCount();
+                   << getChildEdgeAt(0)->getMemoryPtr()->getShape().getElementsCount();
 
     size_t inputs_size = IH * IW * num_ * (classes + coords + 1);
     size_t total_size = 2 * IH * IW;
 
-    const auto *src_data = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    auto *dst_data = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *src_data = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    auto *dst_data = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
     cpu_convert(src_data, dst_data, getParentEdgeAt(0)->getMemory().getDesc().getPrecision(),
                 getChildEdgeAt(0)->getMemory().getDesc().getPrecision(), output_size);

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -225,7 +225,7 @@ void Reorder::createReorderPrimitive(const dnnl::memory::desc& srcDesc,
         auto newDesc = dnnl::memory::desc(DnnlExtensionUtils::convertToDnnlDims(newDims),
                                             src_blocked->GetDataType(),
                                             newFormat);
-        src_blocked->redefineDesc(DnnlExtensionUtils::makeDescriptor(newDesc), srcPtr, false);
+        src_blocked = std::make_shared<Memory>(getEngine(), DnnlExtensionUtils::makeDescriptor(newDesc), srcPtr, false);
 
         src_desc = src_blocked->GetPrimitive().get_desc();
     }

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -120,8 +120,8 @@ void Reorder::prepareParams() {
     if (isOptimized)
         return;
 
-    auto &srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
-    auto &dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         IE_THROW() << "Destination memory didn't allocate.";
     if (!srcMemPtr || !srcMemPtr->isAllocated())

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -176,8 +176,8 @@ void Reorder::prepareParams() {
         if (getSelectedPrimitiveDescriptor() == nullptr)
             IE_THROW() << "Preferable primitive descriptor is not set.";
 
-        createReorderPrimitive(srcMemPtr->GetDescWithType<DnnlMemoryDesc>()->getDnnlDesc(), srcMemPtr->GetData(),
-                               dstMemPtr->GetDescWithType<DnnlMemoryDesc>()->getDnnlDesc(), dstMemPtr->GetData());
+        createReorderPrimitive(srcMemPtr->getDescWithType<DnnlMemoryDesc>()->getDnnlDesc(), srcMemPtr->getData(),
+                               dstMemPtr->getDescWithType<DnnlMemoryDesc>()->getDnnlDesc(), dstMemPtr->getData());
     }
 }
 
@@ -194,7 +194,7 @@ void Reorder::createReorderPrimitive(const dnnl::memory::desc& srcDesc,
 
     dst_blocked = std::make_shared<Memory>(engine, DnnlExtensionUtils::makeDescriptor(dstDesc), dstPtr, false);
 
-    auto src_desc = src_blocked->GetPrimitive().get_desc();
+    auto src_desc = src_blocked->getPrimitive().get_desc();
     if (!src_permutation.empty()) {
         // reorder requires exact matching of logical dimensions between src & dst
         // sometime we have to permute source's logical dimensions to satisfy
@@ -204,7 +204,7 @@ void Reorder::createReorderPrimitive(const dnnl::memory::desc& srcDesc,
         src_desc = src_desc.permute_axes(src_permutation);
     }
 
-    auto dst_desc = dst_blocked->GetPrimitive().get_desc();
+    auto dst_desc = dst_blocked->getPrimitive().get_desc();
 
     // TODO: We should keep shape consistency for const and expected shape for node.
     //       If it requires reshape operation it should explicitly injected into graph.
@@ -218,16 +218,16 @@ void Reorder::createReorderPrimitive(const dnnl::memory::desc& srcDesc,
     // useful in situations when rank in IR does not much rank that is required by the oneDNN primitive,
     // but the input tensor can be reshaped (e.g. weights for grouped convolutions, biases etc.)
     if (src_blocked->getDesc().hasLayoutType(LayoutType::ncsp) &&
-        src_blocked->GetShape().getRank() != dst_blocked->GetShape().getRank()) {
+        src_blocked->getShape().getRank() != dst_blocked->getShape().getRank()) {
         const auto newDims = dst_blocked->getStaticDims();
         const auto newFormat = DnnlExtensionUtils::GetPlainFormatByRank(newDims.size());
 
         auto newDesc = dnnl::memory::desc(DnnlExtensionUtils::convertToDnnlDims(newDims),
-                                            src_blocked->GetDataType(),
+                                            src_blocked->getDataType(),
                                             newFormat);
         src_blocked = std::make_shared<Memory>(getEngine(), DnnlExtensionUtils::makeDescriptor(newDesc), srcPtr, false);
 
-        src_desc = src_blocked->GetPrimitive().get_desc();
+        src_desc = src_blocked->getPrimitive().get_desc();
     }
 
     auto result = getReorderPrim(context->getParamsCache(), getEngine(), src_desc, dst_desc);
@@ -239,8 +239,8 @@ void Reorder::createReorderPrimitive(const dnnl::memory::desc& srcDesc,
     selectedPD->setImplementationType(
         parse_impl_name(DnnlExtensionUtils::query_impl_info_str(prim.get_primitive_desc())));
 
-    auto src = getParentEdgesAtPort(0)[0]->getMemoryPtr()->GetPrimitive();
-    auto dst = getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetPrimitive();
+    auto src = getParentEdgesAtPort(0)[0]->getMemoryPtr()->getPrimitive();
+    auto dst = getChildEdgesAtPort(0)[0]->getMemoryPtr()->getPrimitive();
     primArgs = {{DNNL_ARG_SRC, src}, {DNNL_ARG_DST, dst}};
 
 #ifdef CPU_DEBUG_CAPS
@@ -265,8 +265,8 @@ void Reorder::optimizedNcsp2Nspc() {
     auto parentEdge = getParentEdgeAt(0);
     auto childEdge = getChildEdgeAt(0);
 
-    auto inDims = parentEdge->getMemory().GetShape().getStaticDims();
-    const auto dstStrides = childEdge->getMemoryPtr()->GetDescWithType<BlockedMemoryDesc>()->getStrides();
+    auto inDims = parentEdge->getMemory().getShape().getStaticDims();
+    const auto dstStrides = childEdge->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>()->getStrides();
     const size_t ndims = inDims.size();
     const size_t DIM0 = inDims[0];
     const size_t DIM1 = inDims[1];
@@ -274,8 +274,8 @@ void Reorder::optimizedNcsp2Nspc() {
     const size_t DIM3 = inDims[ndims - 2];
     const size_t DIM4 = inDims[ndims - 1];
 
-    auto src_data = reinterpret_cast<const uint8_t *>(parentEdge->getMemoryPtr()->GetData());
-    auto dst_data = reinterpret_cast<uint8_t *>(childEdge->getMemoryPtr()->GetData());
+    auto src_data = reinterpret_cast<const uint8_t *>(parentEdge->getMemoryPtr()->getData());
+    auto dst_data = reinterpret_cast<uint8_t *>(childEdge->getMemoryPtr()->getData());
 
     const size_t src_batch_stride = DIM1 * DIM2 * DIM3 * DIM4;
     const size_t dst_batch_stride = dstStrides[0];
@@ -299,7 +299,7 @@ void Reorder::optimizedNspc2Ncsp() {
     auto parentEdge = getParentEdgeAt(0);
     auto childEdge = getChildEdgeAt(0);
 
-    auto inDims = parentEdge->getMemory().GetShape().getStaticDims();
+    auto inDims = parentEdge->getMemory().getShape().getStaticDims();
     const size_t ndims = inDims.size();
     const size_t DIM0 = inDims[0];
     const size_t DIM1 = inDims[1];
@@ -307,10 +307,10 @@ void Reorder::optimizedNspc2Ncsp() {
     const size_t DIM3 = inDims[ndims - 2];
     const size_t DIM4 = inDims[ndims - 1];
 
-    auto src_data = reinterpret_cast<const float *>(parentEdge->getMemoryPtr()->GetData());
-    auto dst_data = reinterpret_cast<float *>(childEdge->getMemoryPtr()->GetData());
+    auto src_data = reinterpret_cast<const float *>(parentEdge->getMemoryPtr()->getData());
+    auto dst_data = reinterpret_cast<float *>(childEdge->getMemoryPtr()->getData());
 
-    const auto dstStrides = childEdge->getMemoryPtr()->GetDescWithType<BlockedMemoryDesc>()->getStrides();
+    const auto dstStrides = childEdge->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>()->getStrides();
     const size_t block_size = DIM2 * DIM3 * DIM4;
     const size_t src_batch_stride = block_size * DIM1;
     const size_t dst_batch_stride = dstStrides[0];
@@ -328,8 +328,8 @@ void Reorder::optimizedNspc2Ncsp() {
 void Reorder::execute(dnnl::stream strm) {
     if (isOptimized) {
         DEBUG_LOG("#", getExecIndex(), " Reorder ", getName(), "  is Optimized.",
-                   " input @", getParentEdgeAt(0)->getMemory().GetData(),
-                   " output @", getChildEdgeAt(0)->getMemory().GetData());
+                   " input @", getParentEdgeAt(0)->getMemory().getData(),
+                   " output @", getChildEdgeAt(0)->getMemory().getData());
         return;
     }
 
@@ -368,42 +368,42 @@ void Reorder::reorderData(const IMemory &input, const IMemory &output, MultiCach
     if (!input.getDesc().isDefined() || !output.getDesc().isDefined())
         IE_THROW() << "Can't reorder data with dynamic shapes";
 
-    if (input.GetShape().hasZeroDims() || output.GetShape().hasZeroDims()) {
+    if (input.getShape().hasZeroDims() || output.getShape().hasZeroDims()) {
         return;
     }
 
     if (input.getDesc().isCompatible(output.getDesc())) {
-        auto srcPtr = static_cast<uint8_t*>(input.GetData());
-        auto dstPtr = static_cast<uint8_t*>(output.GetData());
+        auto srcPtr = static_cast<uint8_t*>(input.getData());
+        auto dstPtr = static_cast<uint8_t*>(output.getData());
 
-        auto copySize = output.GetSize();
+        auto copySize = output.getSize();
         cpu_memcpy(dstPtr, srcPtr, copySize);
     } else {
         dnnl::reorder reorder;
         std::vector<uint8_t> tmpBuff;
 
-        auto srcMemory = input.GetPrimitive();
-        auto dstMemory = output.GetPrimitive();
+        auto srcMemory = input.getPrimitive();
+        auto dstMemory = output.getPrimitive();
         auto engine = dstMemory.get_engine();
         // try directly reorder
         reorder = getReorderPrim(cache, dstMemory.get_engine(), srcMemory.get_desc(), dstMemory.get_desc());
         if (!reorder) {
             // try precision conversion then do the reorder
-            if (output.GetDataType() != input.GetDataType() && Convert::isSupportedDesc(input.getDesc()) &&
+            if (output.getDataType() != input.getDataType() && Convert::isSupportedDesc(input.getDesc()) &&
                 Convert::isSupportedDesc(output.getDesc())) {
                 //we probably could not make the reorder because there is no one supporting this precision conversion
                 //lets try to convert data first using cpu_convert
-                auto data = static_cast<const uint8_t *>(input.GetData());
-                tmpBuff.resize(input.GetSize());
+                auto data = static_cast<const uint8_t *>(input.getData());
+                tmpBuff.resize(input.getSize());
 
-                const auto outPrc = DnnlExtensionUtils::DataTypeToIEPrecision(output.GetDataType());
-                cpu_convert(data, tmpBuff.data(), DnnlExtensionUtils::DataTypeToIEPrecision(input.GetDataType()),
-                            outPrc, input.GetSize() / input.getDesc().getPrecision().size());
+                const auto outPrc = DnnlExtensionUtils::DataTypeToIEPrecision(output.getDataType());
+                cpu_convert(data, tmpBuff.data(), DnnlExtensionUtils::DataTypeToIEPrecision(input.getDataType()),
+                            outPrc, input.getSize() / input.getDesc().getPrecision().size());
 
                 auto tmpDesc = input.getDesc().cloneWithNewPrecision(outPrc);
                 Memory tmpMem(engine, std::move(tmpDesc), tmpBuff.data());
 
-                srcMemory = tmpMem.GetPrimitive();
+                srcMemory = tmpMem.getPrimitive();
                 reorder = getReorderPrim(cache, dstMemory.get_engine(), srcMemory.get_desc(), dstMemory.get_desc());
             }
             if (!reorder) {

--- a/src/plugins/intel_cpu/src/nodes/reorder.h
+++ b/src/plugins/intel_cpu/src/nodes/reorder.h
@@ -61,7 +61,7 @@ public:
 
     static std::string getReorderArgs(const MemoryDesc &parentDesc, const MemoryDesc &childDesc);
 
-    static void reorderData(const Memory &input, const Memory &output, MultiCachePtr cache = nullptr);
+    static void reorderData(const IMemory &input, const IMemory &output, MultiCachePtr cache = nullptr);
 
 private:
     dnnl::reorder::primitive prim;

--- a/src/plugins/intel_cpu/src/nodes/reorg_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorg_yolo.cpp
@@ -59,8 +59,8 @@ void ReorgYolo::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void ReorgYolo::execute(dnnl::stream strm) {
-    const auto *src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    auto *dst_data = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetPtr());
+    const auto *src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    auto *dst_data = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
 
     const auto &inDims = getParentEdgeAt(0)->getMemory().getStaticDims();
     int IW = (inDims.size() > 3) ? inDims[3] : 1;

--- a/src/plugins/intel_cpu/src/nodes/reorg_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorg_yolo.cpp
@@ -59,8 +59,8 @@ void ReorgYolo::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void ReorgYolo::execute(dnnl::stream strm) {
-    const auto *src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    auto *dst_data = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetData());
+    const auto *src_data = reinterpret_cast<const float *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    auto *dst_data = reinterpret_cast<float *>(getChildEdgesAtPort(0)[0]->getMemoryPtr()->getData());
 
     const auto &inDims = getParentEdgeAt(0)->getMemory().getStaticDims();
     int IW = (inDims.size() > 3) ? inDims[3] : 1;

--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -46,7 +46,7 @@ public:
         const auto& inputShape = input_shapes[RESHAPE_SRC].get();
         const size_t inputShapeSize = inputShape.size();
         const auto memPtr = data_dependency.at(RESHAPE_PATTERN);
-        const auto data = memPtr->GetPtr();
+        const auto data = memPtr->GetData();
         const auto& dims = memPtr->getStaticDims();
         const auto outputPatternSize = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<Dim>());
         std::vector<int64_t> outPattern = ov::get_raw_data_as<int64_t>(
@@ -109,7 +109,7 @@ public:
         outputShape.reserve(inputShapeSize);
         if (itr != data_dependency.end()) {
             const auto memPtr = data_dependency.at(SQUEEZE_PATTERN);
-            const auto data = memPtr->GetPtr();
+            const auto data = memPtr->GetData();
             const auto& dims = memPtr->getStaticDims();
             const auto outputPatternSize = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<Dim>());
             std::vector<int64_t> outPattern = ov::get_raw_data_as<int64_t>(
@@ -164,7 +164,7 @@ public:
         const auto& inputShape = input_shapes[UNSQUEEZE_SRC].get();
         const size_t inputShapeSize = inputShape.size();
         const auto memPtr = data_dependency.at(UNSQUEEZE_PATTERN);
-        const auto data = memPtr->GetPtr();
+        const auto data = memPtr->GetData();
         const auto& dims = memPtr->getStaticDims();
         const auto outputPatternSize = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<Dim>());
         std::vector<int64_t> outPattern = ov::get_raw_data_as<int64_t>(
@@ -264,7 +264,7 @@ bool Reshape::needShapeInfer() const {
     if (lastSecondInputValues.empty()) {
         lastSecondInputValues.resize(mem.getStaticDims()[0], 0);
     }
-    const int32_t *sndInput = reinterpret_cast<const int32_t *>(mem.GetPtr());
+    const int32_t *sndInput = reinterpret_cast<const int32_t *>(mem.GetData());
     for (size_t i = 0; i < lastSecondInputValues.size(); i++) {
         if (lastSecondInputValues[i] != sndInput[i]) {
             for (size_t i = 0; i < lastSecondInputValues.size(); i++) {
@@ -325,8 +325,8 @@ void Reshape::execute(dnnl::stream strm) {
     auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
     auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
 
-    auto srcPtr = static_cast<uint8_t*>(srcMemPtr->GetPtr());
-    auto dstPtr = static_cast<uint8_t*>(dstMemPtr->GetPtr());
+    auto srcPtr = static_cast<uint8_t*>(srcMemPtr->GetData());
+    auto dstPtr = static_cast<uint8_t*>(dstMemPtr->GetData());
 
     if (dstPtr != srcPtr) {
         cpu_memcpy(dstPtr, srcPtr, dstMemPtr->GetSize());

--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -306,7 +306,7 @@ void Reshape::initSupportedPrimitiveDescriptors() {
     config.inConfs.resize(getParentEdges().size());
     auto& creatorsMap = BlockedDescCreator::getCommonCreators();
     for (size_t i = 0; i < getParentEdges().size(); i++) {
-        config.inConfs[i].inPlace(-1);
+        config.inConfs[i].inPlace(0 == i && canBeInPlace ? 0 : -1);
         config.inConfs[i].constant(false);
         config.inConfs[i].setMemDesc(creatorsMap.at(LayoutType::ncsp)->createSharedDesc((i > 0 ? secondInPrc : inPrec), getInputShapeAtPort(i)));
     }

--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -334,8 +334,14 @@ void Reshape::execute(dnnl::stream strm) {
 }
 
 bool Reshape::isExecutable() const {
-    bool inPlaceEnabled =
-        getSelectedPrimitiveDescriptor() && getSelectedPrimitiveDescriptor()->getConfig().outConfs[0].inPlace() >= 0;
+    bool inPlaceEnabled = false;
+    if (auto prim_desc = getSelectedPrimitiveDescriptor()) {
+        auto& config = prim_desc->getConfig();
+        if (config.inConfs[0].inPlace() >= 0 ||
+            config.outConfs[0].inPlace() >= 0) {
+            inPlaceEnabled = true;
+        }
+    }
     return !inPlaceEnabled;
 }
 

--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -322,8 +322,8 @@ void Reshape::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void Reshape::execute(dnnl::stream strm) {
-    auto& srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
-    auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
 
     auto srcPtr = static_cast<uint8_t*>(srcMemPtr->GetPtr());
     auto dstPtr = static_cast<uint8_t*>(dstMemPtr->GetPtr());

--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -46,7 +46,7 @@ public:
         const auto& inputShape = input_shapes[RESHAPE_SRC].get();
         const size_t inputShapeSize = inputShape.size();
         const auto memPtr = data_dependency.at(RESHAPE_PATTERN);
-        const auto data = memPtr->GetData();
+        const auto data = memPtr->getData();
         const auto& dims = memPtr->getStaticDims();
         const auto outputPatternSize = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<Dim>());
         std::vector<int64_t> outPattern = ov::get_raw_data_as<int64_t>(
@@ -109,7 +109,7 @@ public:
         outputShape.reserve(inputShapeSize);
         if (itr != data_dependency.end()) {
             const auto memPtr = data_dependency.at(SQUEEZE_PATTERN);
-            const auto data = memPtr->GetData();
+            const auto data = memPtr->getData();
             const auto& dims = memPtr->getStaticDims();
             const auto outputPatternSize = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<Dim>());
             std::vector<int64_t> outPattern = ov::get_raw_data_as<int64_t>(
@@ -164,7 +164,7 @@ public:
         const auto& inputShape = input_shapes[UNSQUEEZE_SRC].get();
         const size_t inputShapeSize = inputShape.size();
         const auto memPtr = data_dependency.at(UNSQUEEZE_PATTERN);
-        const auto data = memPtr->GetData();
+        const auto data = memPtr->getData();
         const auto& dims = memPtr->getStaticDims();
         const auto outputPatternSize = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<Dim>());
         std::vector<int64_t> outPattern = ov::get_raw_data_as<int64_t>(
@@ -264,7 +264,7 @@ bool Reshape::needShapeInfer() const {
     if (lastSecondInputValues.empty()) {
         lastSecondInputValues.resize(mem.getStaticDims()[0], 0);
     }
-    const int32_t *sndInput = reinterpret_cast<const int32_t *>(mem.GetData());
+    const int32_t *sndInput = reinterpret_cast<const int32_t *>(mem.getData());
     for (size_t i = 0; i < lastSecondInputValues.size(); i++) {
         if (lastSecondInputValues[i] != sndInput[i]) {
             for (size_t i = 0; i < lastSecondInputValues.size(); i++) {
@@ -325,11 +325,11 @@ void Reshape::execute(dnnl::stream strm) {
     auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
     auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
 
-    auto srcPtr = static_cast<uint8_t*>(srcMemPtr->GetData());
-    auto dstPtr = static_cast<uint8_t*>(dstMemPtr->GetData());
+    auto srcPtr = static_cast<uint8_t*>(srcMemPtr->getData());
+    auto dstPtr = static_cast<uint8_t*>(dstMemPtr->getData());
 
     if (dstPtr != srcPtr) {
-        cpu_memcpy(dstPtr, srcPtr, dstMemPtr->GetSize());
+        cpu_memcpy(dstPtr, srcPtr, dstMemPtr->getSize());
     }
 }
 

--- a/src/plugins/intel_cpu/src/nodes/reverse_sequence.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reverse_sequence.cpp
@@ -127,7 +127,7 @@ ReverseSequence::ReverseSequenceExecutor::ReverseSequenceExecutor(const VectorDi
 }
 
 template<typename T>
-void ReverseSequence::ReverseSequenceExecutor::exec(const MemoryPtr& dataMemPtr, const MemoryPtr& seqLengthsMemPtr, MemoryPtr& dstMemPtr) {
+void ReverseSequence::ReverseSequenceExecutor::exec(const MemoryPtr& dataMemPtr, const MemoryPtr& seqLengthsMemPtr, const MemoryPtr& dstMemPtr) {
     const VectorDims& srcDims = dataMemPtr->getStaticDims();
     const auto *srcData = reinterpret_cast<const float *>(dataMemPtr->GetPtr());
     auto *dstData = reinterpret_cast<float *>(dstMemPtr->GetPtr());

--- a/src/plugins/intel_cpu/src/nodes/reverse_sequence.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reverse_sequence.cpp
@@ -129,9 +129,9 @@ ReverseSequence::ReverseSequenceExecutor::ReverseSequenceExecutor(const VectorDi
 template<typename T>
 void ReverseSequence::ReverseSequenceExecutor::exec(const MemoryPtr& dataMemPtr, const MemoryPtr& seqLengthsMemPtr, const MemoryPtr& dstMemPtr) {
     const VectorDims& srcDims = dataMemPtr->getStaticDims();
-    const auto *srcData = reinterpret_cast<const float *>(dataMemPtr->GetPtr());
-    auto *dstData = reinterpret_cast<float *>(dstMemPtr->GetPtr());
-    auto *seqLengthsData = reinterpret_cast<T *>(seqLengthsMemPtr->GetPtr());
+    const auto *srcData = reinterpret_cast<const float *>(dataMemPtr->GetData());
+    auto *dstData = reinterpret_cast<float *>(dstMemPtr->GetData());
+    auto *seqLengthsData = reinterpret_cast<T *>(seqLengthsMemPtr->GetData());
 
     for (size_t i = 0; i < srcDims[batchAxis]; ++i) {
         if (static_cast<int32_t>(seqLengthsData[i]) > static_cast<int>(srcDims[seqAxis])) {

--- a/src/plugins/intel_cpu/src/nodes/reverse_sequence.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reverse_sequence.cpp
@@ -129,9 +129,9 @@ ReverseSequence::ReverseSequenceExecutor::ReverseSequenceExecutor(const VectorDi
 template<typename T>
 void ReverseSequence::ReverseSequenceExecutor::exec(const MemoryPtr& dataMemPtr, const MemoryPtr& seqLengthsMemPtr, const MemoryPtr& dstMemPtr) {
     const VectorDims& srcDims = dataMemPtr->getStaticDims();
-    const auto *srcData = reinterpret_cast<const float *>(dataMemPtr->GetData());
-    auto *dstData = reinterpret_cast<float *>(dstMemPtr->GetData());
-    auto *seqLengthsData = reinterpret_cast<T *>(seqLengthsMemPtr->GetData());
+    const auto *srcData = reinterpret_cast<const float *>(dataMemPtr->getData());
+    auto *dstData = reinterpret_cast<float *>(dstMemPtr->getData());
+    auto *seqLengthsData = reinterpret_cast<T *>(seqLengthsMemPtr->getData());
 
     for (size_t i = 0; i < srcDims[batchAxis]; ++i) {
         if (static_cast<int32_t>(seqLengthsData[i]) > static_cast<int>(srcDims[seqAxis])) {

--- a/src/plugins/intel_cpu/src/nodes/reverse_sequence.h
+++ b/src/plugins/intel_cpu/src/nodes/reverse_sequence.h
@@ -34,7 +34,7 @@ private:
         ~ReverseSequenceExecutor() = default;
 
         template<typename T>
-        void exec(const MemoryPtr& dataMemPtr, const MemoryPtr& seqLengthsMemPtr, MemoryPtr& dstMemPtr);
+        void exec(const MemoryPtr& dataMemPtr, const MemoryPtr& seqLengthsMemPtr, const MemoryPtr& dstMemPtr);
 
     private:
         const int batchAxis;

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -715,8 +715,8 @@ void RNN::fillWeights(const int *gate_map, const size_t wIdx, const size_t rIdx)
     auto ie_w_ptr = ie_w_vec.data();
     auto ie_r_ptr = ie_r_vec.data();
 
-    cpu_convert(wConstBlob->GetData(), ie_w_ptr, weightPrec, targetWeightPrec, ie_w_vec_size);
-    cpu_convert(rConstBlob->GetData(), ie_r_ptr, weightPrec, targetWeightPrec, ie_r_vec_size);
+    cpu_convert(wConstBlob->getData(), ie_w_ptr, weightPrec, targetWeightPrec, ie_w_vec_size);
+    cpu_convert(rConstBlob->getData(), ie_r_ptr, weightPrec, targetWeightPrec, ie_r_vec_size);
 
     const int step = SC * G;
 
@@ -760,12 +760,12 @@ void RNN::fillBiases(const int *gate_map) {
 
     auto *constInputNode = dynamic_cast<Input *>(getParentEdgesAtPort(bIdx)[0]->getParent().get());
     auto constBlob = constInputNode->getMemoryPtr();
-    auto const elementsCount = constBlob->GetSize() / constBlob->getDesc().getPrecision().size();
+    auto const elementsCount = constBlob->getSize() / constBlob->getDesc().getPrecision().size();
 
     std::vector<dataType> ie_b_vec(elementsCount);
-    cpu_convert(constBlob->GetData(),
+    cpu_convert(constBlob->getData(),
                 &ie_b_vec[0],
-                DnnlExtensionUtils::DataTypeToIEPrecision(constBlob->GetDataType()),
+                DnnlExtensionUtils::DataTypeToIEPrecision(constBlob->getDataType()),
                 Prec,
                 elementsCount);
 
@@ -1037,8 +1037,8 @@ void RNN::prepareParams() {
             THROW_ERROR << "has incorrect input size value in the first input.";
 
     auto dataMemPtr = getParentEdgesAtPort(0).front()->getMemoryPtr();
-    const size_t B = dataMemPtr->GetShape().getStaticDims()[0];
-    const size_t SL = is_cell ? 1lu : dataMemPtr->GetShape().getStaticDims()[1];
+    const size_t B = dataMemPtr->getShape().getStaticDims()[0];
+    const size_t SL = is_cell ? 1lu : dataMemPtr->getShape().getStaticDims()[1];
     const Shape shapeS_4D{L, D, B, SC};
 
     inDataDescs[0] = std::make_shared<DnnlBlockedMemoryDesc>(Shape{SL, B, DC}, inDataTypes[xIdx], memory::format_tag::tnc);
@@ -1104,23 +1104,23 @@ void RNN::prepareParams() {
     if (!primArgs.count(DNNL_ARG_WEIGHTS_LAYER) || !prevExecPtr ||
         !execPtr->getWeightDesc()->isCompatible(*(prevExecPtr->getWeightDesc()))) {
         prepareMemory(execPtr->getWeightDesc(), 0);
-        primArgs[DNNL_ARG_WEIGHTS_LAYER] = internalBlobMemory[0]->GetPrimitive();
+        primArgs[DNNL_ARG_WEIGHTS_LAYER] = internalBlobMemory[0]->getPrimitive();
     }
 
     if (!primArgs.count(DNNL_ARG_WEIGHTS_ITER) || !prevExecPtr ||
         !execPtr->getWeightIterDesc()->isCompatible(*(prevExecPtr->getWeightIterDesc()))) {
         prepareMemory(execPtr->getWeightIterDesc(), 1);
-        primArgs[DNNL_ARG_WEIGHTS_ITER] = internalBlobMemory[1]->GetPrimitive();
+        primArgs[DNNL_ARG_WEIGHTS_ITER] = internalBlobMemory[1]->getPrimitive();
     }
 
     if (!primArgs.count(DNNL_ARG_BIAS) || !prevExecPtr ||
         !execPtr->getBiasDesc()->isCompatible(*(prevExecPtr->getBiasDesc()))) {
         prepareMemory(execPtr->getBiasDesc(), 2);
-        primArgs[DNNL_ARG_BIAS] = internalBlobMemory[2]->GetPrimitive();
+        primArgs[DNNL_ARG_BIAS] = internalBlobMemory[2]->getPrimitive();
     }
 
     auto scratchpadMem = getScratchPadMem(execPtr->getScratchPadDesc());
-    primArgs[DNNL_ARG_SCRATCHPAD] = scratchpadMem->GetPrimitive();
+    primArgs[DNNL_ARG_SCRATCHPAD] = scratchpadMem->getPrimitive();
 }
 
 std::shared_ptr<MemoryDesc> RNN::getSrcMemDesc(const dnnl::primitive_desc& prim_desc, size_t idx) const {
@@ -1142,28 +1142,28 @@ void RNN::execute(dnnl::stream strm) {
 
     auto args = primArgs;
 
-    args[DNNL_ARG_SRC_LAYER] = src_data_mem->GetPrimitive();
-    args[DNNL_ARG_DST_LAYER] = dst_data_mem->GetPrimitive();
+    args[DNNL_ARG_SRC_LAYER] = src_data_mem->getPrimitive();
+    args[DNNL_ARG_DST_LAYER] = dst_data_mem->getPrimitive();
 
     int state_i_tags[] {DNNL_ARG_SRC_ITER, DNNL_ARG_SRC_ITER_C};
     int state_o_tags[] {DNNL_ARG_DST_ITER, DNNL_ARG_DST_ITER_C};
     for (size_t s = 0; s < S; s++) {
-        args[state_i_tags[s]] = getParentEdgeAt(s+1)->getMemoryPtr()->GetPrimitive();
+        args[state_i_tags[s]] = getParentEdgeAt(s+1)->getMemoryPtr()->getPrimitive();
     }
     if (is_augru) {
         const auto atten_port = is_cell ? 5 : 6;
-        args[DNNL_ARG_AUGRU_ATTENTION] = getParentEdgeAt(atten_port)->getMemoryPtr()->GetPrimitive();
+        args[DNNL_ARG_AUGRU_ATTENTION] = getParentEdgeAt(atten_port)->getMemoryPtr()->getPrimitive();
     }
 
     if (is_cell) {
         for (size_t s = 0; s < S; s++) {
-            args[state_o_tags[s]] = getChildEdgesAtPort(s)[0]->getMemoryPtr()->GetPrimitive();
+            args[state_o_tags[s]] = getChildEdgesAtPort(s)[0]->getMemoryPtr()->getPrimitive();
         }
     } else {
         size_t n_ports_with_init_states = outputShapes.size() - 1; // first is a sequence data
         for (size_t s = 0; s < std::min(S, n_ports_with_init_states); s++) {
             if (s < outputShapes.size()) {
-                args[state_o_tags[s]] = getChildEdgesAtPort(s+1)[0]->getMemoryPtr()->GetPrimitive();
+                args[state_o_tags[s]] = getChildEdgesAtPort(s+1)[0]->getMemoryPtr()->getPrimitive();
             }
         }
     }

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -715,8 +715,8 @@ void RNN::fillWeights(const int *gate_map, const size_t wIdx, const size_t rIdx)
     auto ie_w_ptr = ie_w_vec.data();
     auto ie_r_ptr = ie_r_vec.data();
 
-    cpu_convert(wConstBlob->GetPtr(), ie_w_ptr, weightPrec, targetWeightPrec, ie_w_vec_size);
-    cpu_convert(rConstBlob->GetPtr(), ie_r_ptr, weightPrec, targetWeightPrec, ie_r_vec_size);
+    cpu_convert(wConstBlob->GetData(), ie_w_ptr, weightPrec, targetWeightPrec, ie_w_vec_size);
+    cpu_convert(rConstBlob->GetData(), ie_r_ptr, weightPrec, targetWeightPrec, ie_r_vec_size);
 
     const int step = SC * G;
 
@@ -763,7 +763,7 @@ void RNN::fillBiases(const int *gate_map) {
     auto const elementsCount = constBlob->GetSize() / constBlob->getDesc().getPrecision().size();
 
     std::vector<dataType> ie_b_vec(elementsCount);
-    cpu_convert(constBlob->GetPtr(),
+    cpu_convert(constBlob->GetData(),
                 &ie_b_vec[0],
                 DnnlExtensionUtils::DataTypeToIEPrecision(constBlob->GetDataType()),
                 Prec,

--- a/src/plugins/intel_cpu/src/nodes/roi_align.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.cpp
@@ -847,8 +847,8 @@ struct ROIAlign::ROIAlignExecute {
     }
 };
 void ROIAlign::execute(dnnl::stream strm) {
-    auto inputPrec = getParentEdgeAt(0)->getMemory().GetDataType();
-    auto outputPrec = getChildEdgeAt(0)->getMemory().GetDataType();
+    auto inputPrec = getParentEdgeAt(0)->getMemory().getDataType();
+    auto outputPrec = getChildEdgeAt(0)->getMemory().getDataType();
     if (!((inputPrec == dnnl_bf16 && outputPrec == dnnl_bf16) ||
           (inputPrec == dnnl_f32 && outputPrec == dnnl_f32)))
         IE_THROW() <<"ROIAlign doesn't support demanded precisions";
@@ -868,15 +868,15 @@ void ROIAlign::executeSpecified() {
     auto &srcMemory1 = getParentEdgeAt(1)->getMemory();
     auto &dstMemory = getChildEdgeAt(0)->getMemory();
 
-    auto srcBlockDesc = srcMemory0.GetDescWithType<BlockedMemoryDesc>();
-    auto dstBlockDesc = dstMemory.GetDescWithType<BlockedMemoryDesc>();
+    auto srcBlockDesc = srcMemory0.getDescWithType<BlockedMemoryDesc>();
+    auto dstBlockDesc = dstMemory.getDescWithType<BlockedMemoryDesc>();
 
     auto isPlainFmt = srcBlockDesc->hasLayoutType(LayoutType::ncsp);
 
-    const auto *srcData = reinterpret_cast<const inputType *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    const auto *srcRoi = reinterpret_cast<const float *>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
-    const auto *srcRoiIdx = reinterpret_cast<const int *>(getParentEdgeAt(2)->getMemoryPtr()->GetData());
-    auto *dst = reinterpret_cast<outputType *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *srcData = reinterpret_cast<const inputType *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    const auto *srcRoi = reinterpret_cast<const float *>(getParentEdgeAt(1)->getMemoryPtr()->getData());
+    const auto *srcRoiIdx = reinterpret_cast<const int *>(getParentEdgeAt(2)->getMemoryPtr()->getData());
+    auto *dst = reinterpret_cast<outputType *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
     auto nominalRoiCount = static_cast<int>(srcMemory1.getStaticDims()[0]);
     int realRois = 0;

--- a/src/plugins/intel_cpu/src/nodes/roi_align.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.cpp
@@ -873,10 +873,10 @@ void ROIAlign::executeSpecified() {
 
     auto isPlainFmt = srcBlockDesc->hasLayoutType(LayoutType::ncsp);
 
-    const auto *srcData = reinterpret_cast<const inputType *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    const auto *srcRoi = reinterpret_cast<const float *>(getParentEdgeAt(1)->getMemoryPtr()->GetPtr());
-    const auto *srcRoiIdx = reinterpret_cast<const int *>(getParentEdgeAt(2)->getMemoryPtr()->GetPtr());
-    auto *dst = reinterpret_cast<outputType *>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const auto *srcData = reinterpret_cast<const inputType *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    const auto *srcRoi = reinterpret_cast<const float *>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
+    const auto *srcRoiIdx = reinterpret_cast<const int *>(getParentEdgeAt(2)->getMemoryPtr()->GetData());
+    auto *dst = reinterpret_cast<outputType *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
 
     auto nominalRoiCount = static_cast<int>(srcMemory1.getStaticDims()[0]);
     int realRois = 0;

--- a/src/plugins/intel_cpu/src/nodes/roi_align.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.cpp
@@ -811,8 +811,8 @@ void ROIAlign::initSupportedPrimitiveDescriptors() {
 }
 
 void ROIAlign::createPrimitive() {
-    auto& srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
-    auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
     if (!srcMemPtr || !srcMemPtr->isAllocated())
         IE_THROW() << errorPrefix << " did not allocate input memory";
     if (!dstMemPtr || !dstMemPtr->isAllocated())

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
@@ -554,12 +554,12 @@ public:
         if (!roi_pooling_kernel)
             IE_THROW() << "Could not execute. Kernel for RoiPooling node was not compiled.";
 
-        auto src_strides = srcData.GetDescWithType<BlockedMemoryDesc>()->getStrides();
-        auto src_roi_step = srcRoi.GetDescWithType<BlockedMemoryDesc>()->getStrides()[0];
-        auto dst_strides = dst.GetDescWithType<BlockedMemoryDesc>()->getStrides();
-        const auto* src_ptr = reinterpret_cast<const T*>(srcData.GetData());
-        const auto* roi_ptr = reinterpret_cast<const T*>(srcRoi.GetData());
-        auto* dst_ptr = reinterpret_cast<T*>(dst.GetData());
+        auto src_strides = srcData.getDescWithType<BlockedMemoryDesc>()->getStrides();
+        auto src_roi_step = srcRoi.getDescWithType<BlockedMemoryDesc>()->getStrides()[0];
+        auto dst_strides = dst.getDescWithType<BlockedMemoryDesc>()->getStrides();
+        const auto* src_ptr = reinterpret_cast<const T*>(srcData.getData());
+        const auto* roi_ptr = reinterpret_cast<const T*>(srcRoi.getData());
+        auto* dst_ptr = reinterpret_cast<T*>(dst.getData());
         executeOptimizedGeneric(src_ptr, roi_ptr, dst_ptr, src_strides, dst_strides, src_roi_step);
     }
 
@@ -674,12 +674,12 @@ public:
         const IMemory& srcData,
         const IMemory& srcRoi,
         const IMemory& dst) override {
-        auto src_strides = srcData.GetDescWithType<BlockedMemoryDesc>()->getStrides();
-        auto src_roi_step = srcRoi.GetDescWithType<BlockedMemoryDesc>()->getStrides()[0];
-        auto dst_strides = dst.GetDescWithType<BlockedMemoryDesc>()->getStrides();
-        const auto* src_ptr = reinterpret_cast<const T*>(srcData.GetData());
-        const auto* roi_ptr = reinterpret_cast<const T*>(srcRoi.GetData());
-        auto* dst_ptr = reinterpret_cast<T*>(dst.GetData());
+        auto src_strides = srcData.getDescWithType<BlockedMemoryDesc>()->getStrides();
+        auto src_roi_step = srcRoi.getDescWithType<BlockedMemoryDesc>()->getStrides()[0];
+        auto dst_strides = dst.getDescWithType<BlockedMemoryDesc>()->getStrides();
+        const auto* src_ptr = reinterpret_cast<const T*>(srcData.getData());
+        const auto* roi_ptr = reinterpret_cast<const T*>(srcRoi.getData());
+        auto* dst_ptr = reinterpret_cast<T*>(dst.getData());
         executeReference(src_ptr, roi_ptr, dst_ptr, src_strides, dst_strides, src_roi_step);
     }
 

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
@@ -548,18 +548,18 @@ public:
     }
 
     void exec(
-        const Memory& srcData,
-        const Memory& srcRoi,
-        const Memory& dst) override {
+        const IMemory& srcData,
+        const IMemory& srcRoi,
+        const IMemory& dst) override {
         if (!roi_pooling_kernel)
             IE_THROW() << "Could not execute. Kernel for RoiPooling node was not compiled.";
 
         auto src_strides = srcData.GetDescWithType<BlockedMemoryDesc>()->getStrides();
         auto src_roi_step = srcRoi.GetDescWithType<BlockedMemoryDesc>()->getStrides()[0];
         auto dst_strides = dst.GetDescWithType<BlockedMemoryDesc>()->getStrides();
-        const auto* src_ptr = reinterpret_cast<const T*>(srcData.GetPtr());
-        const auto* roi_ptr = reinterpret_cast<const T*>(srcRoi.GetPtr());
-        auto* dst_ptr = reinterpret_cast<T*>(dst.GetPtr());
+        const auto* src_ptr = reinterpret_cast<const T*>(srcData.GetData());
+        const auto* roi_ptr = reinterpret_cast<const T*>(srcRoi.GetData());
+        auto* dst_ptr = reinterpret_cast<T*>(dst.GetData());
         executeOptimizedGeneric(src_ptr, roi_ptr, dst_ptr, src_strides, dst_strides, src_roi_step);
     }
 
@@ -671,15 +671,15 @@ class ROIPooling::ROIPoolingRefExecutor : public ROIPooling::ROIPoolingExecutor 
 public:
     ROIPoolingRefExecutor(const jit_roi_pooling_params &_jpp) : jpp(_jpp) {}
     void exec(
-        const Memory& srcData,
-        const Memory& srcRoi,
-        const Memory& dst) override {
+        const IMemory& srcData,
+        const IMemory& srcRoi,
+        const IMemory& dst) override {
         auto src_strides = srcData.GetDescWithType<BlockedMemoryDesc>()->getStrides();
         auto src_roi_step = srcRoi.GetDescWithType<BlockedMemoryDesc>()->getStrides()[0];
         auto dst_strides = dst.GetDescWithType<BlockedMemoryDesc>()->getStrides();
-        const auto* src_ptr = reinterpret_cast<const T*>(srcData.GetPtr());
-        const auto* roi_ptr = reinterpret_cast<const T*>(srcRoi.GetPtr());
-        auto* dst_ptr = reinterpret_cast<T*>(dst.GetPtr());
+        const auto* src_ptr = reinterpret_cast<const T*>(srcData.GetData());
+        const auto* roi_ptr = reinterpret_cast<const T*>(srcRoi.GetData());
+        auto* dst_ptr = reinterpret_cast<T*>(dst.GetData());
         executeReference(src_ptr, roi_ptr, dst_ptr, src_strides, dst_strides, src_roi_step);
     }
 

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.h
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.h
@@ -93,9 +93,9 @@ private:
     public:
         ROIPoolingExecutor() = default;
         virtual void exec(
-            const ov::intel_cpu::Memory& srcData,
-            const ov::intel_cpu::Memory& srcRoi,
-            const ov::intel_cpu::Memory& dst) = 0;
+            const ov::intel_cpu::IMemory& srcData,
+            const ov::intel_cpu::IMemory& srcRoi,
+            const ov::intel_cpu::IMemory& dst) = 0;
         virtual ~ROIPoolingExecutor() = default;
 
         static std::shared_ptr<ROIPoolingExecutor> createROIPoolingNewExecutor(const jit_roi_pooling_params& jpp);

--- a/src/plugins/intel_cpu/src/nodes/roll.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roll.cpp
@@ -178,10 +178,10 @@ Roll::RollExecutor::RollExecutor(const VectorDims& dataDims, const VectorDims& s
 template<typename T>
 void Roll::RollExecutor::exec(const MemoryPtr& dataMemPtr, const MemoryPtr& shiftMemPtr, const MemoryPtr& axesMemPtr,
     const MemoryPtr& dstMemPtr) {
-    const auto *data = reinterpret_cast<const T *>(dataMemPtr->GetPtr());
-    const auto *shift = reinterpret_cast<const int32_t *>(shiftMemPtr->GetPtr());
-    const auto *axes = reinterpret_cast<const int32_t *>(axesMemPtr->GetPtr());
-    auto *dst = reinterpret_cast<T *>(dstMemPtr->GetPtr());
+    const auto *data = reinterpret_cast<const T *>(dataMemPtr->GetData());
+    const auto *shift = reinterpret_cast<const int32_t *>(shiftMemPtr->GetData());
+    const auto *axes = reinterpret_cast<const int32_t *>(axesMemPtr->GetData());
+    auto *dst = reinterpret_cast<T *>(dstMemPtr->GetData());
 
     std::vector<size_t> shiftsVector(numOfDims, 0ul);
     const VectorDims& dataDims = dataMemPtr->getStaticDims();

--- a/src/plugins/intel_cpu/src/nodes/roll.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roll.cpp
@@ -177,7 +177,7 @@ Roll::RollExecutor::RollExecutor(const VectorDims& dataDims, const VectorDims& s
 
 template<typename T>
 void Roll::RollExecutor::exec(const MemoryPtr& dataMemPtr, const MemoryPtr& shiftMemPtr, const MemoryPtr& axesMemPtr,
-    MemoryPtr& dstMemPtr) {
+    const MemoryPtr& dstMemPtr) {
     const auto *data = reinterpret_cast<const T *>(dataMemPtr->GetPtr());
     const auto *shift = reinterpret_cast<const int32_t *>(shiftMemPtr->GetPtr());
     const auto *axes = reinterpret_cast<const int32_t *>(axesMemPtr->GetPtr());

--- a/src/plugins/intel_cpu/src/nodes/roll.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roll.cpp
@@ -178,10 +178,10 @@ Roll::RollExecutor::RollExecutor(const VectorDims& dataDims, const VectorDims& s
 template<typename T>
 void Roll::RollExecutor::exec(const MemoryPtr& dataMemPtr, const MemoryPtr& shiftMemPtr, const MemoryPtr& axesMemPtr,
     const MemoryPtr& dstMemPtr) {
-    const auto *data = reinterpret_cast<const T *>(dataMemPtr->GetData());
-    const auto *shift = reinterpret_cast<const int32_t *>(shiftMemPtr->GetData());
-    const auto *axes = reinterpret_cast<const int32_t *>(axesMemPtr->GetData());
-    auto *dst = reinterpret_cast<T *>(dstMemPtr->GetData());
+    const auto *data = reinterpret_cast<const T *>(dataMemPtr->getData());
+    const auto *shift = reinterpret_cast<const int32_t *>(shiftMemPtr->getData());
+    const auto *axes = reinterpret_cast<const int32_t *>(axesMemPtr->getData());
+    auto *dst = reinterpret_cast<T *>(dstMemPtr->getData());
 
     std::vector<size_t> shiftsVector(numOfDims, 0ul);
     const VectorDims& dataDims = dataMemPtr->getStaticDims();
@@ -197,7 +197,7 @@ void Roll::RollExecutor::exec(const MemoryPtr& dataMemPtr, const MemoryPtr& shif
     const size_t rightBlockSize = blockSize - leftBlockSize;
     const size_t elementSize = sizeof(T);
 
-    const auto strides = dataMemPtr->GetDescWithType<BlockedMemoryDesc>()->getStrides();
+    const auto strides = dataMemPtr->getDescWithType<BlockedMemoryDesc>()->getStrides();
     const auto calculateShiftOffset = [](size_t dataOffset, size_t dimShift, size_t segmentSize, size_t dimSize){
         size_t pos = dataOffset / segmentSize % dimSize;
         size_t shift = (pos + dimShift) % dimSize - pos;

--- a/src/plugins/intel_cpu/src/nodes/roll.h
+++ b/src/plugins/intel_cpu/src/nodes/roll.h
@@ -34,7 +34,7 @@ private:
 
         template<typename T>
         void exec(const MemoryPtr& dataMemPtr, const MemoryPtr& shiftMemPtr, const MemoryPtr& axesMemPtr,
-                  MemoryPtr& dstMemPtr);
+                  const MemoryPtr& dstMemPtr);
 
     private:
         const size_t numOfDims;

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
@@ -259,10 +259,10 @@ void ScatterUpdate::execute(dnnl::stream strm) {
     auto indicesMemPtr = getParentEdgeAt(INDICES_ID)->getMemoryPtr();
     auto updateMemPtr = getParentEdgeAt(UPDATE_ID)->getMemoryPtr();
 
-    uint8_t *dstPtr = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());
-    uint8_t *srcPtr = reinterpret_cast<uint8_t*>(srcMemPtr->GetPtr());
-    uint8_t *indicesPtr = reinterpret_cast<uint8_t*>(indicesMemPtr->GetPtr());
-    uint8_t *updatePtr = reinterpret_cast<uint8_t*>(updateMemPtr->GetPtr());
+    uint8_t *dstPtr = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
+    uint8_t *srcPtr = reinterpret_cast<uint8_t*>(srcMemPtr->GetData());
+    uint8_t *indicesPtr = reinterpret_cast<uint8_t*>(indicesMemPtr->GetData());
+    uint8_t *updatePtr = reinterpret_cast<uint8_t*>(updateMemPtr->GetData());
 
     const auto& srcDataDim = getParentEdgeAt(DATA_ID)->getMemory().getStaticDims();
     const auto& indicesDim = getParentEdgeAt(INDICES_ID)->getMemory().getStaticDims();
@@ -270,7 +270,7 @@ void ScatterUpdate::execute(dnnl::stream strm) {
     int axis = 0;
     if (axisRelaxed) {
         auto axisMemPtr = getParentEdgeAt(AXIS_ID)->getMemoryPtr();
-        uint8_t *axisPtr = reinterpret_cast<uint8_t*>(axisMemPtr->GetPtr());
+        uint8_t *axisPtr = reinterpret_cast<uint8_t*>(axisMemPtr->GetData());
         if (axisSize == 4) {
             auto *axisPtr32 = reinterpret_cast<int32_t*>(axisPtr);
             axis = *axisPtr32;

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
@@ -254,10 +254,10 @@ static std::vector<size_t> getBlockND(const VectorDims& shape) {
 }
 
 void ScatterUpdate::execute(dnnl::stream strm) {
-    auto &srcMemPtr = getParentEdgeAt(DATA_ID)->getMemoryPtr();
-    auto &dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto &indicesMemPtr = getParentEdgeAt(INDICES_ID)->getMemoryPtr();
-    auto &updateMemPtr = getParentEdgeAt(UPDATE_ID)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(DATA_ID)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto indicesMemPtr = getParentEdgeAt(INDICES_ID)->getMemoryPtr();
+    auto updateMemPtr = getParentEdgeAt(UPDATE_ID)->getMemoryPtr();
 
     uint8_t *dstPtr = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());
     uint8_t *srcPtr = reinterpret_cast<uint8_t*>(srcMemPtr->GetPtr());
@@ -269,7 +269,7 @@ void ScatterUpdate::execute(dnnl::stream strm) {
     size_t srcRank = srcDataDim.size();
     int axis = 0;
     if (axisRelaxed) {
-        auto &axisMemPtr = getParentEdgeAt(AXIS_ID)->getMemoryPtr();
+        auto axisMemPtr = getParentEdgeAt(AXIS_ID)->getMemoryPtr();
         uint8_t *axisPtr = reinterpret_cast<uint8_t*>(axisMemPtr->GetPtr());
         if (axisSize == 4) {
             auto *axisPtr32 = reinterpret_cast<int32_t*>(axisPtr);

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
@@ -259,10 +259,10 @@ void ScatterUpdate::execute(dnnl::stream strm) {
     auto indicesMemPtr = getParentEdgeAt(INDICES_ID)->getMemoryPtr();
     auto updateMemPtr = getParentEdgeAt(UPDATE_ID)->getMemoryPtr();
 
-    uint8_t *dstPtr = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
-    uint8_t *srcPtr = reinterpret_cast<uint8_t*>(srcMemPtr->GetData());
-    uint8_t *indicesPtr = reinterpret_cast<uint8_t*>(indicesMemPtr->GetData());
-    uint8_t *updatePtr = reinterpret_cast<uint8_t*>(updateMemPtr->GetData());
+    uint8_t *dstPtr = reinterpret_cast<uint8_t*>(dstMemPtr->getData());
+    uint8_t *srcPtr = reinterpret_cast<uint8_t*>(srcMemPtr->getData());
+    uint8_t *indicesPtr = reinterpret_cast<uint8_t*>(indicesMemPtr->getData());
+    uint8_t *updatePtr = reinterpret_cast<uint8_t*>(updateMemPtr->getData());
 
     const auto& srcDataDim = getParentEdgeAt(DATA_ID)->getMemory().getStaticDims();
     const auto& indicesDim = getParentEdgeAt(INDICES_ID)->getMemory().getStaticDims();
@@ -270,7 +270,7 @@ void ScatterUpdate::execute(dnnl::stream strm) {
     int axis = 0;
     if (axisRelaxed) {
         auto axisMemPtr = getParentEdgeAt(AXIS_ID)->getMemoryPtr();
-        uint8_t *axisPtr = reinterpret_cast<uint8_t*>(axisMemPtr->GetData());
+        uint8_t *axisPtr = reinterpret_cast<uint8_t*>(axisMemPtr->getData());
         if (axisSize == 4) {
             auto *axisPtr32 = reinterpret_cast<int32_t*>(axisPtr);
             axis = *axisPtr32;

--- a/src/plugins/intel_cpu/src/nodes/shapeof.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.cpp
@@ -100,7 +100,7 @@ void ShapeOf::execute(dnnl::stream strm) {
     if (outPtr->getStaticDims().size() != 1 || dimsCount != outPtr->getStaticDims()[0])
         IE_THROW() << errorPrefix << "has inconsistent input shape and output size";
 
-    auto *dst = reinterpret_cast<int *>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    auto *dst = reinterpret_cast<int *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
 
     for (size_t i = 0; i < dimsCount; i++) {
         dst[i] = inDims[i];

--- a/src/plugins/intel_cpu/src/nodes/shapeof.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.cpp
@@ -100,7 +100,7 @@ void ShapeOf::execute(dnnl::stream strm) {
     if (outPtr->getStaticDims().size() != 1 || dimsCount != outPtr->getStaticDims()[0])
         IE_THROW() << errorPrefix << "has inconsistent input shape and output size";
 
-    auto *dst = reinterpret_cast<int *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    auto *dst = reinterpret_cast<int *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
 
     for (size_t i = 0; i < dimsCount; i++) {
         dst[i] = inDims[i];

--- a/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
@@ -125,8 +125,8 @@ void ShuffleChannels::initSupportedPrimitiveDescriptors() {
 }
 
 void ShuffleChannels::createPrimitive() {
-    auto &dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto &srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         THROW_SHCH_ERROR << "has not allocated destination memory";
     if (!srcMemPtr || !srcMemPtr->isAllocated())
@@ -149,7 +149,7 @@ void ShuffleChannels::createPrimitive() {
 }
 
 void ShuffleChannels::prepareParams() {
-    auto& srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
     auto builder = [](const ShuffleChannelsAttributes& key) -> std::shared_ptr<ShuffleChannelsExecutor> {
         return std::make_shared<ShuffleChannelsExecutor>(key);
     };

--- a/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
@@ -294,8 +294,8 @@ void ShuffleChannels::execute(dnnl::stream strm) {
 
     int MB = (attrs.axis != 0) ? getParentEdgeAt(0)->getMemoryPtr()->getStaticDims()[0] : -1;
 
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
     execPtr->exec(srcData, dstData, MB);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
@@ -154,7 +154,7 @@ void ShuffleChannels::prepareParams() {
         return std::make_shared<ShuffleChannelsExecutor>(key);
     };
     attrs.srcDims = srcMemPtr->getStaticDims();
-    attrs.srcBlockedDims = srcMemPtr->GetDescWithType<BlockedMemoryDesc>()->getBlockDims();
+    attrs.srcBlockedDims = srcMemPtr->getDescWithType<BlockedMemoryDesc>()->getBlockDims();
 
     auto cache = context->getParamsCache();
     auto result = cache->getOrCreate(attrs, builder);
@@ -294,8 +294,8 @@ void ShuffleChannels::execute(dnnl::stream strm) {
 
     int MB = (attrs.axis != 0) ? getParentEdgeAt(0)->getMemoryPtr()->getStaticDims()[0] : -1;
 
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemoryPtr()->getData());
     execPtr->exec(srcData, dstData, MB);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/softmax.cpp
@@ -163,7 +163,7 @@ void SoftMax::createDescriptor(const std::vector<MemoryDescPtr> &inputDesc,
 }
 
 void SoftMax::prepareParams() {
-    auto inpDesc = getParentEdgeAt(0)->getMemory().GetDescWithType<DnnlMemoryDesc>();
+    auto inpDesc = getParentEdgeAt(0)->getMemory().getDescWithType<DnnlMemoryDesc>();
     const NodeDesc* selected_pd = getSelectedPrimitiveDescriptor();
 
     if (selected_pd == nullptr)
@@ -217,9 +217,9 @@ void SoftMax::prepareParams() {
 
     auto scratchpadMem = getScratchPadMem(execPtr->getScratchPadDesc());
 
-    primArgs[DNNL_ARG_SCRATCHPAD] = scratchpadMem->GetPrimitive();
-    primArgs[DNNL_ARG_SRC] = getParentEdgesAtPort(0)[0]->getMemoryPtr()->GetPrimitive();
-    primArgs[DNNL_ARG_DST] = getChildEdgesAtPort(0)[0]->getMemoryPtr()->GetPrimitive();
+    primArgs[DNNL_ARG_SCRATCHPAD] = scratchpadMem->getPrimitive();
+    primArgs[DNNL_ARG_SRC] = getParentEdgesAtPort(0)[0]->getMemoryPtr()->getPrimitive();
+    primArgs[DNNL_ARG_DST] = getChildEdgesAtPort(0)[0]->getMemoryPtr()->getPrimitive();
 #ifdef CPU_DEBUG_CAPS
     if (result.second == CacheEntryBase::LookUpStatus::Miss) {
         auto pd = execPtr->getPrimitiveDesc();

--- a/src/plugins/intel_cpu/src/nodes/space_to_batch.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_batch.cpp
@@ -101,21 +101,21 @@ void SpaceToBatch::SpaceToBatchKernel() {
     const auto& srcMem = getParentEdgesAtPort(0)[0]->getMemoryPtr();
     const auto& dstMem = getChildEdgesAtPort(0)[0]->getMemoryPtr();
 
-    const auto *blockShapesPtr = reinterpret_cast<int *>(getParentEdgeAt(1)->getMemoryPtr()->GetPtr());
+    const auto *blockShapesPtr = reinterpret_cast<int *>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
     size_t dataRank = srcMem->GetShape().getRank();
     blockShapeIn.clear();
     for (size_t i = 0; i < dataRank; i++) {
         blockShapeIn.push_back(*(blockShapesPtr + i));
     }
 
-    const auto *padsBeginPtr = reinterpret_cast<int *>(getParentEdgeAt(2)->getMemoryPtr()->GetPtr());
+    const auto *padsBeginPtr = reinterpret_cast<int *>(getParentEdgeAt(2)->getMemoryPtr()->GetData());
     padsBeginIn.clear();
     for (size_t i = 0; i < dataRank; i++) {
         padsBeginIn.push_back(*(padsBeginPtr + i));
     }
 
-    const auto *srcData = reinterpret_cast<const T *>(srcMem->GetPtr());
-    auto *dstData = reinterpret_cast<T *>(dstMem->GetPtr());
+    const auto *srcData = reinterpret_cast<const T *>(srcMem->GetData());
+    auto *dstData = reinterpret_cast<T *>(dstMem->GetData());
 
     const int64_t srcLen = srcMem->GetSize() / sizeof(T);
     const int64_t dstLen = dstMem->GetSize() / sizeof(T);

--- a/src/plugins/intel_cpu/src/nodes/space_to_batch.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_batch.cpp
@@ -101,24 +101,24 @@ void SpaceToBatch::SpaceToBatchKernel() {
     const auto& srcMem = getParentEdgesAtPort(0)[0]->getMemoryPtr();
     const auto& dstMem = getChildEdgesAtPort(0)[0]->getMemoryPtr();
 
-    const auto *blockShapesPtr = reinterpret_cast<int *>(getParentEdgeAt(1)->getMemoryPtr()->GetData());
-    size_t dataRank = srcMem->GetShape().getRank();
+    const auto *blockShapesPtr = reinterpret_cast<int *>(getParentEdgeAt(1)->getMemoryPtr()->getData());
+    size_t dataRank = srcMem->getShape().getRank();
     blockShapeIn.clear();
     for (size_t i = 0; i < dataRank; i++) {
         blockShapeIn.push_back(*(blockShapesPtr + i));
     }
 
-    const auto *padsBeginPtr = reinterpret_cast<int *>(getParentEdgeAt(2)->getMemoryPtr()->GetData());
+    const auto *padsBeginPtr = reinterpret_cast<int *>(getParentEdgeAt(2)->getMemoryPtr()->getData());
     padsBeginIn.clear();
     for (size_t i = 0; i < dataRank; i++) {
         padsBeginIn.push_back(*(padsBeginPtr + i));
     }
 
-    const auto *srcData = reinterpret_cast<const T *>(srcMem->GetData());
-    auto *dstData = reinterpret_cast<T *>(dstMem->GetData());
+    const auto *srcData = reinterpret_cast<const T *>(srcMem->getData());
+    auto *dstData = reinterpret_cast<T *>(dstMem->getData());
 
-    const int64_t srcLen = srcMem->GetSize() / sizeof(T);
-    const int64_t dstLen = dstMem->GetSize() / sizeof(T);
+    const int64_t srcLen = srcMem->getSize() / sizeof(T);
+    const int64_t dstLen = dstMem->getSize() / sizeof(T);
 
     const auto &inDims = srcMem->getStaticDims();
     const auto &outDims = dstMem->getStaticDims();
@@ -140,10 +140,10 @@ void SpaceToBatch::SpaceToBatchKernel() {
         blockShape.erase(blockShape.begin() + 1);
     }
 
-    const auto outBlkDims = dstMem->GetDescWithType<BlockedMemoryDesc>()->getBlockDims();
+    const auto outBlkDims = dstMem->getDescWithType<BlockedMemoryDesc>()->getBlockDims();
     const int64_t blockSize = blocked ? outBlkDims.back() : 1lu;
     const int64_t blockCountInput = outBlkDims[1];
-    const int64_t blockCountOutput = srcMem->GetDescWithType<BlockedMemoryDesc>()->getBlockDims()[1];
+    const int64_t blockCountOutput = srcMem->getDescWithType<BlockedMemoryDesc>()->getBlockDims()[1];
     const int64_t blockRemainder = inShape5D[1] % blockSize;
     const int64_t lastBlock = blockRemainder == 0 ? blockSize : blockRemainder;
 
@@ -153,7 +153,7 @@ void SpaceToBatch::SpaceToBatchKernel() {
     const int64_t outSpatialStep = outShape5D[2] * outShape5D[3] * outShape5D[4];
     const int64_t outBatchStep = (blocked ? blockSize * blockCountOutput : outShape5D[1]) * outSpatialStep;
 
-    memset(dstData, 0, dstMem->GetSize());
+    memset(dstData, 0, dstMem->getSize());
 
     int64_t channels = (inShape5D[1] / blockSize);
     channels = channels == 0 ? 1 : channels;

--- a/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
@@ -313,8 +313,8 @@ void SpaceToDepth::execute(dnnl::stream strm) {
     if (!execPtr) {
         THROW_ERROR << "doesn't have a compiled executor.";
     }
-    const uint8_t* srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
-    uint8_t* dstData = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->GetPtr());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
+    uint8_t* dstData = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
     const int MB = getParentEdgeAt(0)->getMemoryPtr()->getStaticDims()[0];
     execPtr->exec(srcData, dstData, MB);
 }

--- a/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
@@ -164,8 +164,8 @@ void SpaceToDepth::initSupportedPrimitiveDescriptors() {
 }
 
 void SpaceToDepth::createPrimitive() {
-    auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto& srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(0)->getMemoryPtr();
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         THROW_ERROR << "has not allocated destination memory";
     if (!srcMemPtr || !srcMemPtr->isAllocated())

--- a/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
@@ -190,9 +190,9 @@ void SpaceToDepth::createPrimitive() {
 
 void SpaceToDepth::prepareParams() {
     attrs.srcBlockedDims =
-        getParentEdgeAt(0)->getMemoryPtr()->GetDescWithType<BlockedMemoryDesc>()->getBlockDims();
+        getParentEdgeAt(0)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>()->getBlockDims();
     attrs.destBlockedDims =
-        getChildEdgeAt(0)->getMemoryPtr()->GetDescWithType<BlockedMemoryDesc>()->getBlockDims();
+        getChildEdgeAt(0)->getMemoryPtr()->getDescWithType<BlockedMemoryDesc>()->getBlockDims();
     auto builder = [](const SpaceToDepthAttrs& key) -> std::shared_ptr<SpaceToDepthExecutor> {
         return std::make_shared<SpaceToDepthExecutor>(key);
     };
@@ -313,8 +313,8 @@ void SpaceToDepth::execute(dnnl::stream strm) {
     if (!execPtr) {
         THROW_ERROR << "doesn't have a compiled executor.";
     }
-    const uint8_t* srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
-    uint8_t* dstData = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->GetData());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t *>(getParentEdgeAt(0)->getMemoryPtr()->getData());
+    uint8_t* dstData = reinterpret_cast<uint8_t *>(getChildEdgeAt(0)->getMemoryPtr()->getData());
     const int MB = getParentEdgeAt(0)->getMemoryPtr()->getStaticDims()[0];
     execPtr->exec(srcData, dstData, MB);
 }

--- a/src/plugins/intel_cpu/src/nodes/split.cpp
+++ b/src/plugins/intel_cpu/src/nodes/split.cpp
@@ -543,10 +543,10 @@ void Split::resolveInPlaceEdges(Edge::LOOK look) {
                 //     getName() << " with type " << getTypeStr();
 
                 auto memMngr = std::make_shared<PartitionedMemoryMngr>(baseMemMngr, baseDim, offset, partDim);
-                childEdge->getMemoryPtr().reset(new Memory(getEngine()));
-                childEdge->getMemoryPtr()->Create(selected_pd->getConfig().outConfs[i].getMemDesc(), memMngr);
+                auto newMem = std::make_shared<Memory>(getEngine());
+                newMem->Create(selected_pd->getConfig().outConfs[i].getMemDesc(), memMngr);
 
-                childEdge->changeStatus(Edge::Status::Allocated);
+                childEdge->resetMemoryPtr(newMem);
             }
             offset += partDim;
         }

--- a/src/plugins/intel_cpu/src/nodes/split.cpp
+++ b/src/plugins/intel_cpu/src/nodes/split.cpp
@@ -531,12 +531,12 @@ void Split::resolveInPlaceEdges(Edge::LOOK look) {
         size_t numberOfOutputs = config.outConfs.size();
         size_t inplaceInpIndx = selected_pd->getConfig().outConfs[0].inPlace();
         auto baseDim = inputShapes.front().getDims()[axis];
-        IE_ASSERT(baseDim != Shape::UNDEFINED_DIM) << "Split node: " << getName() << " can not use inPlace memory with splitting on dynamic dimention";
+        IE_ASSERT(baseDim != Shape::UNDEFINED_DIM) << "Split node: " << getName() << " can not use inPlace memory with splitting on dynamic dimension";
         auto baseMemMngr = getParentEdgesAtPort(inplaceInpIndx).front()->getMemory().getMemoryMngr();
         ptrdiff_t offset = 0;
         for (size_t i = 0; i < numberOfOutputs; ++i) {
             auto partDim = outputShapes[i].getDims()[axis];
-            IE_ASSERT(partDim != Shape::UNDEFINED_DIM) << "Split node: " << getName() << " can not use inPlace memory with splitting on dynamic dimention";
+            IE_ASSERT(partDim != Shape::UNDEFINED_DIM) << "Split node: " << getName() << " can not use inPlace memory with splitting on dynamic dimension";
             const auto& childEdges = getChildEdgesAtPort(i);
             for (auto& childEdge : childEdges) {
                 // IE_ASSERT(parentEdge->getStatus() == Edge::Status::NotAllocated) << "Unexpected edge status in node: " <<

--- a/src/plugins/intel_cpu/src/nodes/split.cpp
+++ b/src/plugins/intel_cpu/src/nodes/split.cpp
@@ -543,9 +543,9 @@ void Split::resolveInPlaceEdges(Edge::LOOK look) {
                 //     getName() << " with type " << getTypeStr();
 
                 auto memMngr = std::make_shared<PartitionedMemoryMngr>(baseMemMngr, baseDim, offset, partDim);
-                auto newMem = std::make_shared<Memory>(getEngine(), std::unique_ptr<IMemoryMngr>(memMngr.get()), selected_pd->getConfig().outConfs[i].getMemDesc());
+                auto newMem = std::make_shared<Memory>(getEngine(), selected_pd->getConfig().outConfs[i].getMemDesc(), memMngr);
 
-                childEdge->resetMemoryPtr(newMem);
+                childEdge->reuse(newMem);
             }
             offset += partDim;
         }

--- a/src/plugins/intel_cpu/src/nodes/split.cpp
+++ b/src/plugins/intel_cpu/src/nodes/split.cpp
@@ -543,8 +543,15 @@ void Split::resolveInPlaceEdges(Edge::LOOK look) {
                 IE_ASSERT(childEdge->getStatus() == Edge::Status::NotAllocated) << " Unexpected edge status in node: " <<
                     getName() << " with type " << getTypeStr();
 
-                auto memMngr = std::make_shared<PartitionedMemoryMngr>(baseMemMngr, baseDim, offset, partDim);
-                auto newMem = std::make_shared<Memory>(getEngine(), selected_pd->getConfig().outConfs[i].getMemDesc(), memMngr);
+                auto memDesc = selected_pd->getConfig().outConfs[i].getMemDesc();
+                MemoryPtr newMem;
+                if (partDim != 0) {
+                    auto memMngr = std::make_shared<PartitionedMemoryMngr>(baseMemMngr, baseDim, offset, partDim);
+                    newMem = std::make_shared<Memory>(getEngine(), memDesc, memMngr);
+                } else {
+                    // empty tensor, no need to reference a part, default memory is enough
+                    newMem = std::make_shared<Memory>(getEngine(), memDesc);
+                }
 
                 childEdge->reuse(newMem);
             }

--- a/src/plugins/intel_cpu/src/nodes/split.h
+++ b/src/plugins/intel_cpu/src/nodes/split.h
@@ -23,7 +23,6 @@ public:
     void execute(dnnl::stream strm) override;
     bool created() const override;
 
-    bool isOptimized() const;
     void initOptimalPrimitiveDescriptor() override;
 
     bool isExecutable() const override;
@@ -32,6 +31,7 @@ public:
     bool needShapeInfer() const override;
     void prepareParams() override;
     void executeDynamicImpl(dnnl::stream strm) override { execute(strm); }
+    void resolveInPlaceEdges() override;
 
 private:
     struct SplitExecutor {

--- a/src/plugins/intel_cpu/src/nodes/split.h
+++ b/src/plugins/intel_cpu/src/nodes/split.h
@@ -31,7 +31,7 @@ public:
     bool needShapeInfer() const override;
     void prepareParams() override;
     void executeDynamicImpl(dnnl::stream strm) override { execute(strm); }
-    void resolveInPlaceEdges() override;
+    void resolveInPlaceEdges(Edge::LOOK look) override;
 
 private:
     struct SplitExecutor {

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
@@ -63,9 +63,9 @@ public:
             data_dependency.at(STRIDE_ID)->getDesc().getPrecision() != Precision::I32) {
             IE_THROW(Unexpected) << "The data type of begin/end/stride is NOT I32, which is unexpected!";
         }
-        auto beginPtr = reinterpret_cast<int32_t *>(data_dependency.at(BEGIN_ID)->GetPtr());
-        auto endPtr = reinterpret_cast<int32_t *>(data_dependency.at(END_ID)->GetPtr());
-        auto stridePtr = reinterpret_cast<int32_t *>(data_dependency.at(STRIDE_ID)->GetPtr());
+        auto beginPtr = reinterpret_cast<int32_t *>(data_dependency.at(BEGIN_ID)->GetData());
+        auto endPtr = reinterpret_cast<int32_t *>(data_dependency.at(END_ID)->GetData());
+        auto stridePtr = reinterpret_cast<int32_t *>(data_dependency.at(STRIDE_ID)->GetData());
 
         for (size_t i = 0, new_idx = 0; i < shapeIn.size(); ++i) {
             if (m_new_axis_mask_set.count(i)) {
@@ -505,7 +505,7 @@ void StridedSlice::StridedSliceCommonExecutor::paramsInitialization(const Stride
     const size_t nDims = std::max(inputRank, outputRank);
 
     auto fillingInParameters = [&](std::vector<int> &parameter, const size_t type, const size_t size, const int value) {
-        const int *ptr = reinterpret_cast<const int32_t *>(srcMemory[type]->GetPtr());
+        const int *ptr = reinterpret_cast<const int32_t *>(srcMemory[type]->GetData());
         parameter.assign(ptr, ptr + size);
 
         if (type != AXES_ID && params.attrs.ellipsisMaskCounter == 0 && size < nDims) {
@@ -840,8 +840,8 @@ void StridedSlice::StridedSliceCommonExecutor::indicesCalculationForOptimized() 
 }
 
 void StridedSlice::StridedSliceCommonExecutor::exec(const std::vector<MemoryCPtr>& srcMemory, const std::vector<MemoryCPtr>& dstMemory) {
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemory[0]->GetPtr());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemory[0]->GetPtr());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemory[0]->GetData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemory[0]->GetData());
     const uint8_t* srcShiftedData = srcData + srcShift;
     parallel_nt(nThreads, [&](const int ithr, const int nthr) {
         size_t start = 0, end = 0;

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
@@ -63,9 +63,9 @@ public:
             data_dependency.at(STRIDE_ID)->getDesc().getPrecision() != Precision::I32) {
             IE_THROW(Unexpected) << "The data type of begin/end/stride is NOT I32, which is unexpected!";
         }
-        auto beginPtr = reinterpret_cast<int32_t *>(data_dependency.at(BEGIN_ID)->GetData());
-        auto endPtr = reinterpret_cast<int32_t *>(data_dependency.at(END_ID)->GetData());
-        auto stridePtr = reinterpret_cast<int32_t *>(data_dependency.at(STRIDE_ID)->GetData());
+        auto beginPtr = reinterpret_cast<int32_t *>(data_dependency.at(BEGIN_ID)->getData());
+        auto endPtr = reinterpret_cast<int32_t *>(data_dependency.at(END_ID)->getData());
+        auto stridePtr = reinterpret_cast<int32_t *>(data_dependency.at(STRIDE_ID)->getData());
 
         for (size_t i = 0, new_idx = 0; i < shapeIn.size(); ++i) {
             if (m_new_axis_mask_set.count(i)) {
@@ -492,20 +492,20 @@ void StridedSlice::StridedSliceCommonExecutor::orderParametersByLayouts(const Bl
 void StridedSlice::StridedSliceCommonExecutor::paramsInitialization(const StridedSliceAttributes& attrs,
                                                                     const std::vector<MemoryCPtr>& srcMemory,
                                                                     const std::vector<MemoryCPtr>& dstMemory) {
-    const auto srcBlockedMemoryDesc = srcMemory[0]->GetDescWithType<BlockedMemoryDesc>();
-    const auto dstBlockedMemoryDesc = dstMemory[0]->GetDescWithType<BlockedMemoryDesc>();
+    const auto srcBlockedMemoryDesc = srcMemory[0]->getDescWithType<BlockedMemoryDesc>();
+    const auto dstBlockedMemoryDesc = dstMemory[0]->getDescWithType<BlockedMemoryDesc>();
 
     params.attrs = attrs;
     params.srcBlockedDims = srcBlockedMemoryDesc->getBlockDims();
     params.srcOrder = srcBlockedMemoryDesc->getOrder();
     params.dstBlockedDims = dstBlockedMemoryDesc->getBlockDims();
 
-    const size_t inputRank = srcMemory[0]->GetShape().getRank();
-    const size_t outputRank = dstMemory[0]->GetShape().getRank();
+    const size_t inputRank = srcMemory[0]->getShape().getRank();
+    const size_t outputRank = dstMemory[0]->getShape().getRank();
     const size_t nDims = std::max(inputRank, outputRank);
 
     auto fillingInParameters = [&](std::vector<int> &parameter, const size_t type, const size_t size, const int value) {
-        const int *ptr = reinterpret_cast<const int32_t *>(srcMemory[type]->GetData());
+        const int *ptr = reinterpret_cast<const int32_t *>(srcMemory[type]->getData());
         parameter.assign(ptr, ptr + size);
 
         if (type != AXES_ID && params.attrs.ellipsisMaskCounter == 0 && size < nDims) {
@@ -513,8 +513,8 @@ void StridedSlice::StridedSliceCommonExecutor::paramsInitialization(const Stride
         }
     };
 
-    params.attrs.beginDims = srcMemory[BEGIN_ID]->GetShape().getStaticDims();
-    params.attrs.endDims = srcMemory[END_ID]->GetShape().getStaticDims();
+    params.attrs.beginDims = srcMemory[BEGIN_ID]->getShape().getStaticDims();
+    params.attrs.endDims = srcMemory[END_ID]->getShape().getStaticDims();
     if (params.attrs.beginDims.size() != 1)
         IE_THROW() << errorPrefix << "should have begin vector with 1 dimension";
     if (params.attrs.endDims.size() != 1)
@@ -528,7 +528,7 @@ void StridedSlice::StridedSliceCommonExecutor::paramsInitialization(const Stride
         fillingInParameters(params.attrs.end, END_ID, params.attrs.endDims[0], 0);
 
     if (srcMemory.size() > STRIDE_ID) {
-        params.attrs.strideDims = srcMemory[STRIDE_ID]->GetShape().getStaticDims();
+        params.attrs.strideDims = srcMemory[STRIDE_ID]->getShape().getStaticDims();
         if (params.attrs.strideDims.size() > 1)
             IE_THROW() << errorPrefix << "should have stride vector with 1 dimension";
         if (params.attrs.beginDims[0] != params.attrs.strideDims[0])
@@ -539,7 +539,7 @@ void StridedSlice::StridedSliceCommonExecutor::paramsInitialization(const Stride
     }
 
     if (srcMemory.size() > AXES_ID) {
-        params.attrs.axesDims = srcMemory[AXES_ID]->GetShape().getStaticDims();
+        params.attrs.axesDims = srcMemory[AXES_ID]->getShape().getStaticDims();
         if (params.attrs.axesDims.size() != 1)
             IE_THROW() << errorPrefix << "should have axes vector with 1 dimension.";
         if (params.attrs.beginDims[0] != params.attrs.axesDims[0])
@@ -840,8 +840,8 @@ void StridedSlice::StridedSliceCommonExecutor::indicesCalculationForOptimized() 
 }
 
 void StridedSlice::StridedSliceCommonExecutor::exec(const std::vector<MemoryCPtr>& srcMemory, const std::vector<MemoryCPtr>& dstMemory) {
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemory[0]->GetData());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemory[0]->GetData());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemory[0]->getData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemory[0]->getData());
     const uint8_t* srcShiftedData = srcData + srcShift;
     parallel_nt(nThreads, [&](const int ithr, const int nthr) {
         size_t start = 0, end = 0;

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -244,7 +244,7 @@ InferenceEngine::Precision Snippet::getRuntimePrecision() const {
     for (size_t i = 0; i < getParentEdges().size(); i++) {
         auto parentEdge = getParentEdgeAt(i);
         if (parentEdge && parentEdge->getStatus() == Edge::Status::Validated && !parentEdge->getParent()->isConstant()) {
-            inputPrecisions.emplace_back(DnnlExtensionUtils::DataTypeToIEPrecision((parentEdge->getMemoryPtr()->GetDataType())));
+            inputPrecisions.emplace_back(DnnlExtensionUtils::DataTypeToIEPrecision((parentEdge->getMemoryPtr()->getDataType())));
         }
     }
 
@@ -320,7 +320,7 @@ bool Snippet::optimizeExecDomain(std::vector<VectorDims>& inputShapes, std::vect
 }
 ov::PartialShape Snippet::canonicalizeBody() {
     auto edgeToBlockedShape = [](const EdgePtr& edge) {
-        const auto blockedDesc = edge->getMemory().GetDescWithType<BlockedMemoryDesc>();
+        const auto blockedDesc = edge->getMemory().getDescWithType<BlockedMemoryDesc>();
         std::vector<Dimension> dims;
         // if blockDim == Shape::UNDEFINED_DIM, then it's a dynamic dimension, and we need to recreate a proper dynamic Dim
         for (const auto& d : blockedDesc->getBlockDims())
@@ -412,7 +412,7 @@ std::vector<VectorDims> Snippet::shapeInfer() {
         return success;
     };
     for (size_t i = 0; i < getParentEdges().size(); i++) {
-        VectorDims inDims {getParentEdgesAtPort(i)[0]->getMemory().GetShape().getDims()};
+        VectorDims inDims {getParentEdgesAtPort(i)[0]->getMemory().getShape().getDims()};
         if (masterShapeIsBlocked && !inputShapeIsBlocked[i])
             inDims.insert(inDims.end(), 1);
         // todo: this is a simple master_shape inference for shape-agnostic operations,
@@ -428,7 +428,7 @@ std::vector<VectorDims> Snippet::shapeInfer() {
         errorMessage << "Can't compute static master shape for Snippet node with name: " << getName();
         errorMessage << ". Input shapes = ( ";
         for (size_t i = 0; i < getParentEdges().size(); i++) {
-            errorMessage << i << " port = " << getParentEdgesAtPort(i)[0]->getMemory().GetShape().toString() << ", ";
+            errorMessage << i << " port = " << getParentEdgesAtPort(i)[0]->getMemory().getShape().toString() << ", ";
         }
         errorMessage << "). Master shape = ( " << Shape(masterShape).toString() << " )";
         IE_THROW() << errorMessage.str();
@@ -476,7 +476,7 @@ void Snippet::prepareParams() {
         for (size_t i = 0; i < numInputs; i++) {
             const auto memPtr = getParentEdgeAt(i)->getMemoryPtr();
             srcMemPtrs[i] = memPtr;
-            start_offset_in[i] =  memPtr->GetDescWithType<BlockedMemoryDesc>()->getOffsetPadding() * dataSize[i];
+            start_offset_in[i] =  memPtr->getDescWithType<BlockedMemoryDesc>()->getOffsetPadding() * dataSize[i];
         }
         const size_t numOutputs = outputShapes.size();
         start_offset_out.resize(numOutputs);
@@ -484,7 +484,7 @@ void Snippet::prepareParams() {
         for (size_t i = 0; i < numOutputs; i++) {
             const auto memPtr = getChildEdgeAt(i)->getMemoryPtr();
             dstMemPtrs[i] = memPtr;
-            start_offset_out[i] = memPtr->GetDescWithType<BlockedMemoryDesc>()->getOffsetPadding() * dataSize[i + numInputs];
+            start_offset_out[i] = memPtr->getDescWithType<BlockedMemoryDesc>()->getOffsetPadding() * dataSize[i + numInputs];
         }
     };
     // initialize start offsets to src and dst memory
@@ -584,10 +584,10 @@ void Snippet::generate(const jit_snippets_compile_args* jcp) {
 
 void Snippet::update_ptrs(jit_snippets_call_args& call_args) {
     for (size_t i = 0; i < srcMemPtrs.size(); i++)
-        call_args.src_ptrs[i] = reinterpret_cast<const uint8_t*>(srcMemPtrs[i]->GetData()) + start_offset_in[i];
+        call_args.src_ptrs[i] = reinterpret_cast<const uint8_t*>(srcMemPtrs[i]->getData()) + start_offset_in[i];
 
     for (size_t i = 0; i < dstMemPtrs.size(); i++)
-        call_args.dst_ptrs[i] = reinterpret_cast<uint8_t*>(dstMemPtrs[i]->GetData()) + start_offset_out[i];
+        call_args.dst_ptrs[i] = reinterpret_cast<uint8_t*>(dstMemPtrs[i]->getData()) + start_offset_out[i];
 
     if (buffer_scratchpad_size > 0) {
         call_args.buffer_scratchpad_ptr =

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -312,7 +312,8 @@ void DynamicBuffer::move_buffer(const MemoryPtr& new_buffer) {
     const auto src_offset_in_byte = stride > 0 ? 0 : (src_stride - valid_size);
     chunk_offset_in_byte = stride > 0 ? 0 : (dst_stride - valid_size);  // reset chunk_offset_in_byte
 
-    copy(reinterpret_cast<uint8_t*>(mem_holder_buffer->GetData()) + src_offset_in_byte, reinterpret_cast<uint8_t*>(new_buffer->GetData()) + chunk_offset_in_byte,
+    copy(reinterpret_cast<uint8_t*>(mem_holder_buffer->GetData()) + src_offset_in_byte,
+        reinterpret_cast<uint8_t*>(new_buffer->GetData()) + chunk_offset_in_byte,
         src_stride, dst_stride, count, valid_size);
 
     // assign mem_holder_buffer

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -634,7 +634,7 @@ void TensorIterator::executeDynamicImpl(dnnl::stream strm) {
 void TensorIterator::prepareInputPorts() {
     const auto &eng = getEngine();
     for (auto map_rule : inputPortMap) {
-        auto &from_mem = getParentEdgesAtPort(map_rule.from)[0]->getMemoryPtr();
+        auto from_mem = getParentEdgesAtPort(map_rule.from)[0]->getMemoryPtr();
         auto &to_mem = input_mems[map_rule.to].front();  // first memory is enough to access the shared underlying physical memory
 
         if (map_rule.axis == -1)
@@ -648,7 +648,7 @@ void TensorIterator::prepareInputPorts() {
 void TensorIterator::prepareOutputPorts() {
     const auto &eng = getEngine();
     for (auto map_rule : outputPortMap) {
-        auto &to_mem = getChildEdgesAtPort(map_rule.from)[0]->getMemoryPtr();
+        auto to_mem = getChildEdgesAtPort(map_rule.from)[0]->getMemoryPtr();
         auto &from_mem = output_mem[map_rule.to];
 
         if (map_rule.axis == -1)

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -89,8 +89,8 @@ public:
         auto axis = slice_rule.axis;
         auto stride = slice_rule.stride;
 
-        auto full_dims = full_blob->GetShape().getStaticDims();
-        auto part_dims = part_blob->GetShape().getStaticDims();
+        auto full_dims = full_blob->getShape().getStaticDims();
+        auto part_dims = part_blob->getShape().getStaticDims();
 
         auto abs_stride = std::abs(stride);
         auto sign_of_stride = stride < 0.0f ? -1 : 1;
@@ -101,11 +101,11 @@ public:
         IE_ASSERT(full_dims == part_dims) << "Shape mismatch for tensor iterator port";
 
         // make chunk view
-        auto chunk_desc = full_blob->GetDescWithType<DnnlMemoryDesc>()->getDnnlDesc();
+        auto chunk_desc = full_blob->getDescWithType<DnnlMemoryDesc>()->getDnnlDesc();
         chunk_desc.get()->dims[axis] = abs_stride;
         chunk_desc.get()->padded_dims[axis] = abs_stride;  // TODO: asamption that plain tensor
 
-        full_mem = full_blob->GetPrimitive();
+        full_mem = full_blob->getPrimitive();
         const auto full_mem_handler = full_mem.get_data_handle();
         dnnl::memory chunk_mem = {chunk_desc, eng, full_mem_handler};
 
@@ -117,9 +117,9 @@ public:
 
         if (sliced_src) {
             mem_holder_src = chunk_mem;
-            mem_holder_dst = to->GetPrimitive();
+            mem_holder_dst = to->getPrimitive();
         } else {
-            mem_holder_src = from->GetPrimitive();
+            mem_holder_src = from->getPrimitive();
             mem_holder_dst = chunk_mem;
         }
         reorder = getReorderPrim(cache, mem_holder_dst.get_engine(), mem_holder_src.get_desc(), mem_holder_dst.get_desc());
@@ -148,8 +148,8 @@ private:
 class BackEdgePortHelper : public PortMapHelper {
 public:
     BackEdgePortHelper(MultiCachePtr cache, const MemoryPtr &from, const MemoryPtr &to, const dnnl::engine& eng) {
-        mem_holder_src = from->GetPrimitive();
-        mem_holder_dst = to->GetPrimitive();
+        mem_holder_src = from->getPrimitive();
+        mem_holder_dst = to->getPrimitive();
         reorder = getReorderPrim(cache, mem_holder_dst.get_engine(), mem_holder_src.get_desc(), mem_holder_dst.get_desc());
     }
 
@@ -164,9 +164,9 @@ class IterCountPortHelper : public PortMapHelper {
 public:
     IterCountPortHelper(const MemoryPtr &to, const dnnl::engine& eng) {
         // Only scalar I32 tensor is supported
-        IE_ASSERT(to->GetDataType() == memory::data_type::s32);
-        IE_ASSERT(to->GetShape() == Shape(VectorDims{1}));
-        mem_holder_dst = to->GetPrimitive();
+        IE_ASSERT(to->getDataType() == memory::data_type::s32);
+        IE_ASSERT(to->getShape() == Shape(VectorDims{1}));
+        mem_holder_dst = to->getPrimitive();
     }
 
     void execute(dnnl::stream strm, int n_iter) override {
@@ -182,9 +182,9 @@ public:
 class asBoolCheck : public PortChecker {
 public:
     asBoolCheck(const MemoryPtr &mem) {
-        IE_ASSERT(mem->GetDataType() == memory::data_type::u8);
-        IE_ASSERT(mem->GetShape() == Shape(InferenceEngine::SizeVector{1}));
-        mem_holder = mem->GetPrimitive();
+        IE_ASSERT(mem->getDataType() == memory::data_type::u8);
+        IE_ASSERT(mem->getShape() == Shape(InferenceEngine::SizeVector{1}));
+        mem_holder = mem->getPrimitive();
     }
 
     int getStatus() override {
@@ -199,9 +199,9 @@ public:
 class asIntCheck : public PortChecker {
 public:
     asIntCheck(const MemoryPtr &mem) {
-        IE_ASSERT(mem->GetDataType() == memory::data_type::s32);
-        IE_ASSERT(mem->GetShape() == Shape(InferenceEngine::SizeVector{1}));
-        mem_holder = mem->GetPrimitive();
+        IE_ASSERT(mem->getDataType() == memory::data_type::s32);
+        IE_ASSERT(mem->getShape() == Shape(InferenceEngine::SizeVector{1}));
+        mem_holder = mem->getPrimitive();
     }
 
     int getStatus() override {
@@ -226,7 +226,7 @@ private:
 
 DynamicBuffer::DynamicBuffer(const MemoryPtr &from_, const std::vector<MemoryPtr> &to_,
                              const PortMap &map_rule_) : from(from_), to(to_), map_rule(map_rule_) {
-    elem_size = DnnlExtensionUtils::sizeOfDataType(from->GetDataType());
+    elem_size = DnnlExtensionUtils::sizeOfDataType(from->getDataType());
 }
 
 void DynamicBuffer::execute(const dnnl::engine& eng, const int iter) {
@@ -256,7 +256,7 @@ void DynamicBuffer::init(const dnnl::engine& eng) {
     const auto abs_stride = std::abs(stride);
 
     // We have no idea of "from" node memory dims until the sub_graph has been executed.
-    const auto& src_mem = from->GetPrimitive();
+    const auto& src_mem = from->getPrimitive();
     const auto& src_desc = src_mem.get_desc();
     const auto& dims = src_desc.get_dims();
     count = std::accumulate(dims.begin(), dims.begin() + map_rule.axis, size_t(1), std::multiplies<size_t>());
@@ -269,7 +269,7 @@ void DynamicBuffer::init(const dnnl::engine& eng) {
     }
 
     // reset chunk_offset_in_byte since the first execution
-    chunk_stride_in_byte = mem_holder_buffer->GetSize() / count;
+    chunk_stride_in_byte = mem_holder_buffer->getSize() / count;
     chunk_offset_in_byte = stride > 0 ? 0 : (chunk_stride_in_byte - chunk_unit_in_byte);
     num_execs = 0;
 }
@@ -312,13 +312,13 @@ void DynamicBuffer::move_buffer(const MemoryPtr& new_buffer) {
     const auto src_offset_in_byte = stride > 0 ? 0 : (src_stride - valid_size);
     chunk_offset_in_byte = stride > 0 ? 0 : (dst_stride - valid_size);  // reset chunk_offset_in_byte
 
-    copy(reinterpret_cast<uint8_t*>(mem_holder_buffer->GetData()) + src_offset_in_byte,
-        reinterpret_cast<uint8_t*>(new_buffer->GetData()) + chunk_offset_in_byte,
+    copy(reinterpret_cast<uint8_t*>(mem_holder_buffer->getData()) + src_offset_in_byte,
+        reinterpret_cast<uint8_t*>(new_buffer->getData()) + chunk_offset_in_byte,
         src_stride, dst_stride, count, valid_size);
 
     // assign mem_holder_buffer
     mem_holder_buffer = new_buffer;
-    chunk_stride_in_byte = mem_holder_buffer->GetSize() / count;
+    chunk_stride_in_byte = mem_holder_buffer->getSize() / count;
 
     // adjust for next execution
     if (stride > 0) {
@@ -332,7 +332,7 @@ void DynamicBuffer::move_data() {
     const auto src_stride = abs(map_rule.stride) * len;
     const auto dst_stride = chunk_stride_in_byte;
 
-    copy(reinterpret_cast<const uint8_t*>(from->GetData()), reinterpret_cast<uint8_t*>(mem_holder_buffer->GetData()) + chunk_offset_in_byte,
+    copy(reinterpret_cast<const uint8_t*>(from->getData()), reinterpret_cast<uint8_t*>(mem_holder_buffer->getData()) + chunk_offset_in_byte,
          src_stride, dst_stride, count, chunk_unit_in_byte);
 
     // adjust for next execution
@@ -350,7 +350,7 @@ void DynamicBuffer::transfer(const Node* node) {
         const auto stride = map_rule.stride;
         const auto abs_stride = std::abs(stride);
 
-        const auto& src_mem = from->GetPrimitive();
+        const auto& src_mem = from->getPrimitive();
         const auto& src_desc = src_mem.get_desc();
         auto dims = src_desc.get_dims();
         dims[axis] = abs_stride * num_execs;
@@ -363,10 +363,10 @@ void DynamicBuffer::transfer(const Node* node) {
         const auto dst_stride = to.front()->getStaticDims()[axis] * len;
         const auto valid_size = chunk_unit_in_byte * num_execs;
         const auto src_offset_in_byte = stride > 0 ? 0 : (src_stride - valid_size);
-        copy(reinterpret_cast<uint8_t*>(mem_holder_buffer->GetData()) + src_offset_in_byte, reinterpret_cast<uint8_t*>(to.front()->GetData()),
+        copy(reinterpret_cast<uint8_t*>(mem_holder_buffer->getData()) + src_offset_in_byte, reinterpret_cast<uint8_t*>(to.front()->getData()),
             src_stride, dst_stride, count, dst_stride);
     } else {
-        VectorDims newDims = to.front()->GetShape().getDims();
+        VectorDims newDims = to.front()->getShape().getDims();
         nullifyUndefinedDims(newDims);
 
         const auto desc = node->getBaseMemDescAtOutputPort(map_rule.from)->cloneWithNewDims(newDims);
@@ -521,8 +521,8 @@ void TensorIterator::createPrimitive() {
 
 bool TensorIterator::needPrepareParams() const {
     if (getAlgorithm() == Algorithm::TensorIteratorLoop) {
-        const auto tripCountPtr = reinterpret_cast<const uint32_t*>(getParentEdgesAtPort(loopTripCountIdx).front()->getMemoryPtr()->GetData());
-        const auto condPtr = reinterpret_cast<const uint8_t*>(getParentEdgesAtPort(loopExecutionConditionIdx).front()->getMemoryPtr()->GetData());
+        const auto tripCountPtr = reinterpret_cast<const uint32_t*>(getParentEdgesAtPort(loopTripCountIdx).front()->getMemoryPtr()->getData());
+        const auto condPtr = reinterpret_cast<const uint8_t*>(getParentEdgesAtPort(loopExecutionConditionIdx).front()->getMemoryPtr()->getData());
         if (tripCountPtr[0] != static_cast<size_t>(lastUsedTripCount) || static_cast<bool>(condPtr[0]) != lastUsedCond)
             return true;
     }
@@ -738,7 +738,7 @@ void TensorIterator::reshapeSubgraphInput() {
     for (auto map_rule : inputPortMap) {
         auto new_dims = sliced_input_dims(getParentEdgesAtPort(map_rule.from)[0]->getMemoryPtr(), map_rule.axis, map_rule.stride);
         auto &to_mems = input_mems[map_rule.to];
-        const auto& body_inshape = to_mems.front()->GetShape();
+        const auto& body_inshape = to_mems.front()->getShape();
         if (body_inshape.isDynamic() || body_inshape.getDims() != new_dims) {
             const auto desc = std::make_shared<CpuBlockedMemoryDesc>(to_mems.front()->getDesc().getPrecision(), Shape(new_dims));
             redefineToMemories(to_mems, desc);
@@ -754,7 +754,7 @@ void TensorIterator::reshapeAndFillOutput(dnnl::stream strm) {
             auto &from_mem = output_mem[map_rule.to];
 
             // if Loop or TI isn't executed we should fill dynamic dims by zero
-            auto newShape = from_mem->GetShape();
+            auto newShape = from_mem->getShape();
             auto newDims = newShape.getDims();
             nullifyUndefinedDims(newDims);
 
@@ -778,7 +778,7 @@ bool TensorIterator::checkForInputAndBodyShapesInequality() const {
     for (auto map_rule : inputPortMap) {
         auto original_dims = sliced_input_dims(getParentEdgesAtPort(map_rule.from)[0]->getMemoryPtr(), map_rule.axis, map_rule.stride);
         auto &to_mems = input_mems[map_rule.to];
-        const auto& body_inshape = to_mems.front()->GetShape();
+        const auto& body_inshape = to_mems.front()->getShape();
         if (body_inshape.isDynamic() || body_inshape.getDims() != original_dims) {
             return true;
         }

--- a/src/plugins/intel_cpu/src/nodes/tile.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tile.cpp
@@ -100,7 +100,7 @@ void Tile::prepareParams() {
     if (!constMap[TILE_REPEATS]) {
         const auto& repeatsMem = getParentEdgesAtPort(TILE_REPEATS)[0]->getMemory();
 
-        const int32_t* repeatsData = reinterpret_cast<const int32_t *>(repeatsMem.GetPtr());
+        const int32_t* repeatsData = reinterpret_cast<const int32_t *>(repeatsMem.GetData());
         originRepeats.assign(repeatsData, repeatsData + repeatsMem.getStaticDims()[0]);
 
         repeats.assign(std::max(originRepeats.size(), getInputShapeAtPort(TILE_INPUT).getRank()), 1lu);
@@ -124,7 +124,7 @@ bool Tile::needShapeInfer() const {
     if (!constMap[TILE_REPEATS]) {
         if (originRepeats.empty())
             return true;
-        const int32_t* repeatsData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(TILE_REPEATS)[0]->getMemory().GetPtr());
+        const int32_t* repeatsData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(TILE_REPEATS)[0]->getMemory().GetData());
         for (size_t i = 0lu; i < originRepeats.size(); i++) {
             if (originRepeats[i] != static_cast<size_t>(repeatsData[i]))
                 return true;
@@ -153,8 +153,8 @@ void Tile::plainExecute(dnnl::stream strm) {
 
     auto& srcMemory = getParentEdgeAt(TILE_INPUT)->getMemory();
 
-    const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(srcMemory.GetPtr());
-    uint8_t* dst_ptr = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemory().GetPtr());
+    const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(srcMemory.GetData());
+    uint8_t* dst_ptr = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemory().GetData());
 
     int m_inner_dim = 1;
     int m_outer_dim = 1;

--- a/src/plugins/intel_cpu/src/nodes/tile.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tile.cpp
@@ -100,7 +100,7 @@ void Tile::prepareParams() {
     if (!constMap[TILE_REPEATS]) {
         const auto& repeatsMem = getParentEdgesAtPort(TILE_REPEATS)[0]->getMemory();
 
-        const int32_t* repeatsData = reinterpret_cast<const int32_t *>(repeatsMem.GetData());
+        const int32_t* repeatsData = reinterpret_cast<const int32_t *>(repeatsMem.getData());
         originRepeats.assign(repeatsData, repeatsData + repeatsMem.getStaticDims()[0]);
 
         repeats.assign(std::max(originRepeats.size(), getInputShapeAtPort(TILE_INPUT).getRank()), 1lu);
@@ -110,8 +110,8 @@ void Tile::prepareParams() {
         }
     }
 
-    auto srcBlockedDims = getParentEdgeAt(TILE_INPUT)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getBlockDims();
-    auto dstBlockedDims = getChildEdgeAt(0)->getMemory().GetDescWithType<BlockedMemoryDesc>()->getBlockDims();
+    auto srcBlockedDims = getParentEdgeAt(TILE_INPUT)->getMemory().getDescWithType<BlockedMemoryDesc>()->getBlockDims();
+    auto dstBlockedDims = getChildEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>()->getBlockDims();
 
     optimizedCase = prepareOptimizedParams(this, srcBlockedDims, dstBlockedDims);
 }
@@ -124,7 +124,7 @@ bool Tile::needShapeInfer() const {
     if (!constMap[TILE_REPEATS]) {
         if (originRepeats.empty())
             return true;
-        const int32_t* repeatsData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(TILE_REPEATS)[0]->getMemory().GetData());
+        const int32_t* repeatsData = reinterpret_cast<const int32_t *>(getParentEdgesAtPort(TILE_REPEATS)[0]->getMemory().getData());
         for (size_t i = 0lu; i < originRepeats.size(); i++) {
             if (originRepeats[i] != static_cast<size_t>(repeatsData[i]))
                 return true;
@@ -153,8 +153,8 @@ void Tile::plainExecute(dnnl::stream strm) {
 
     auto& srcMemory = getParentEdgeAt(TILE_INPUT)->getMemory();
 
-    const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(srcMemory.GetData());
-    uint8_t* dst_ptr = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemory().GetData());
+    const uint8_t* src_ptr = reinterpret_cast<const uint8_t*>(srcMemory.getData());
+    uint8_t* dst_ptr = reinterpret_cast<uint8_t*>(getChildEdgeAt(0)->getMemory().getData());
 
     int m_inner_dim = 1;
     int m_outer_dim = 1;

--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -1981,8 +1981,8 @@ void TopK::preset_params() {
 }
 
 void TopK::prepareParams() {
-    auto &dstMemPtr = getChildEdgeAt(TOPK_DATA)->getMemoryPtr();
-    auto &srcMemPtr = getParentEdgeAt(TOPK_DATA)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(TOPK_DATA)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(TOPK_DATA)->getMemoryPtr();
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         IE_THROW() << errorPrefix << " has not allocated destination memory.";
     if (!srcMemPtr || !srcMemPtr->isAllocated())
@@ -2064,7 +2064,7 @@ void TopK::prepareParams() {
 }
 
 void TopK::createPrimitive() {
-    auto &srcMemPtr = getParentEdgeAt(TOPK_DATA)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(TOPK_DATA)->getMemoryPtr();
     if (srcMemPtr->getDesc().hasLayoutType(LayoutType::ncsp)) {
         layout = TopKLayoutType::topk_ncsp;
     } else if (srcMemPtr->getDesc().hasLayoutType(LayoutType::nspc)) {
@@ -2137,9 +2137,9 @@ void TopK::executeDynamicImpl(dnnl::stream strm) {
 }
 
 void TopK::execute(dnnl::stream strm) {
-    auto &srcMemPtr = getParentEdgeAt(TOPK_DATA)->getMemoryPtr();
-    auto &dstMemPtr = getChildEdgeAt(TOPK_DATA)->getMemoryPtr();
-    auto &dstIndexesMemPtr = getChildEdgeAt(TOPK_INDEX)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(TOPK_DATA)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(TOPK_DATA)->getMemoryPtr();
+    auto dstIndexesMemPtr = getChildEdgeAt(TOPK_INDEX)->getMemoryPtr();
 
     const uint8_t *src_data = reinterpret_cast<const uint8_t *>(srcMemPtr->GetPtr());
     uint8_t *dst_data = reinterpret_cast<uint8_t *>(dstMemPtr->GetPtr());

--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -1944,12 +1944,12 @@ void TopK::initSupportedPrimitiveDescriptors() {
 }
 
 bool TopK::needShapeInfer() const {
-    const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->GetPtr())[0];
+    const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->GetData())[0];
     return inputShapesModified() || src_k != top_k;
 }
 
 bool TopK::needPrepareParams() const {
-    const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->GetPtr())[0];
+    const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->GetData())[0];
     return inputShapesModified() || top_k != src_k;
 }
 
@@ -1994,14 +1994,14 @@ void TopK::prepareParams() {
     dst_dims = dstMemPtr->getDesc().getShape().getDims();
 
     if (isDynamicNode()) {
-        const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->GetPtr())[0];
+        const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->GetData())[0];
         if (static_cast<size_t>(src_k) > src_dims[axis])
             IE_THROW() << errorPrefix << " gets top_k out of range!";
         if (top_k != src_k) {
             top_k = src_k;
         }
     } else {
-        top_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->GetPtr())[0];
+        top_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->GetData())[0];
     }
 
     if (jit_mode) {
@@ -2141,9 +2141,9 @@ void TopK::execute(dnnl::stream strm) {
     auto dstMemPtr = getChildEdgeAt(TOPK_DATA)->getMemoryPtr();
     auto dstIndexesMemPtr = getChildEdgeAt(TOPK_INDEX)->getMemoryPtr();
 
-    const uint8_t *src_data = reinterpret_cast<const uint8_t *>(srcMemPtr->GetPtr());
-    uint8_t *dst_data = reinterpret_cast<uint8_t *>(dstMemPtr->GetPtr());
-    uint8_t *dst_idx = reinterpret_cast<uint8_t *>(dstIndexesMemPtr->GetPtr());
+    const uint8_t *src_data = reinterpret_cast<const uint8_t *>(srcMemPtr->GetData());
+    uint8_t *dst_data = reinterpret_cast<uint8_t *>(dstMemPtr->GetData());
+    uint8_t *dst_idx = reinterpret_cast<uint8_t *>(dstIndexesMemPtr->GetData());
 
     if (jit_mode) {
         topk_process(src_data, dst_data, dst_idx);

--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -1944,12 +1944,12 @@ void TopK::initSupportedPrimitiveDescriptors() {
 }
 
 bool TopK::needShapeInfer() const {
-    const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->GetData())[0];
+    const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->getData())[0];
     return inputShapesModified() || src_k != top_k;
 }
 
 bool TopK::needPrepareParams() const {
-    const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->GetData())[0];
+    const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->getData())[0];
     return inputShapesModified() || top_k != src_k;
 }
 
@@ -1994,14 +1994,14 @@ void TopK::prepareParams() {
     dst_dims = dstMemPtr->getDesc().getShape().getDims();
 
     if (isDynamicNode()) {
-        const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->GetData())[0];
+        const int src_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->getData())[0];
         if (static_cast<size_t>(src_k) > src_dims[axis])
             IE_THROW() << errorPrefix << " gets top_k out of range!";
         if (top_k != src_k) {
             top_k = src_k;
         }
     } else {
-        top_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->GetData())[0];
+        top_k = reinterpret_cast<int *>(getParentEdgeAt(TOPK_K)->getMemoryPtr()->getData())[0];
     }
 
     if (jit_mode) {
@@ -2010,7 +2010,7 @@ void TopK::prepareParams() {
             preset_params_done = true;
         }
 
-        auto layout_dims = dstMemPtr->GetDescWithType<BlockedMemoryDesc>()->getBlockDims();
+        auto layout_dims = dstMemPtr->getDescWithType<BlockedMemoryDesc>()->getBlockDims();
         calc_dims_size(layout_dims);
 
         axis_dim = src_dims[axis];
@@ -2108,7 +2108,7 @@ void TopK::createPrimitive() {
         jcp.bitonic_k_idx_cnt = 0;
 
         if (algorithm == TopKAlgorithm::topk_bitonic_sort) {
-            size_t src_count = srcMemPtr->GetDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
+            size_t src_count = srcMemPtr->getDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
             vec_process_ptr.resize(src_count * data_size);
             vec_process_idx_ptr.resize(src_count * sizeof(int32_t));
 
@@ -2141,9 +2141,9 @@ void TopK::execute(dnnl::stream strm) {
     auto dstMemPtr = getChildEdgeAt(TOPK_DATA)->getMemoryPtr();
     auto dstIndexesMemPtr = getChildEdgeAt(TOPK_INDEX)->getMemoryPtr();
 
-    const uint8_t *src_data = reinterpret_cast<const uint8_t *>(srcMemPtr->GetData());
-    uint8_t *dst_data = reinterpret_cast<uint8_t *>(dstMemPtr->GetData());
-    uint8_t *dst_idx = reinterpret_cast<uint8_t *>(dstIndexesMemPtr->GetData());
+    const uint8_t *src_data = reinterpret_cast<const uint8_t *>(srcMemPtr->getData());
+    uint8_t *dst_data = reinterpret_cast<uint8_t *>(dstMemPtr->getData());
+    uint8_t *dst_idx = reinterpret_cast<uint8_t *>(dstIndexesMemPtr->getData());
 
     if (jit_mode) {
         topk_process(src_data, dst_data, dst_idx);

--- a/src/plugins/intel_cpu/src/nodes/transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/transpose.cpp
@@ -216,7 +216,7 @@ void Transpose::prepareParams() {
     params.dst_block_dims = dstDesc->getBlockDims();
 
     if (!isInputOrderConst) {
-        auto orderPtr = reinterpret_cast<const int32_t*>(getParentEdgeAt(0)->getMemoryPtr()->GetPtr());
+        auto orderPtr = reinterpret_cast<const int32_t*>(getParentEdgeAt(0)->getMemoryPtr()->GetData());
         auto orderLen = getParentEdgeAt(0)->getMemoryPtr()->GetSize();
         params.order.assign(orderPtr, orderPtr + orderLen);
     }
@@ -275,8 +275,8 @@ void Transpose::createPrimitive() {
 
 template <typename T>
 static void transpose_to_0312(const int MB, const MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr) {
-    const auto src_data = reinterpret_cast<const T*>(srcMemPtr->GetPtr());
-    auto dst_data = reinterpret_cast<T*>(dstMemPtr->GetPtr());
+    const auto src_data = reinterpret_cast<const T*>(srcMemPtr->GetData());
+    auto dst_data = reinterpret_cast<T*>(dstMemPtr->GetData());
 
     const int DIM1 = srcMemPtr->getStaticDims()[1];
     const int DIM2 = srcMemPtr->getStaticDims()[2];
@@ -300,8 +300,8 @@ static void transpose_to_0312(const int MB, const MemoryPtr& srcMemPtr, MemoryPt
 
 template<typename T>
 static void transpose_to_04123(const int MB, const MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr) {
-    const auto src_data = reinterpret_cast<const T*>(srcMemPtr->GetPtr());
-    auto dst_data = reinterpret_cast<T*>(dstMemPtr->GetPtr());
+    const auto src_data = reinterpret_cast<const T*>(srcMemPtr->GetData());
+    auto dst_data = reinterpret_cast<T*>(dstMemPtr->GetData());
 
     const int DIM1 = srcMemPtr->getStaticDims()[1];
     const int DIM2 = srcMemPtr->getStaticDims()[2];
@@ -328,8 +328,8 @@ static void transpose_to_04123(const int MB, const MemoryPtr& srcMemPtr, MemoryP
 
 template<typename T>
 static void transpose_to_051234(const int MB, const MemoryPtr& srcMemPtr, MemoryPtr& dstMemPtr) {
-    const auto src_data = reinterpret_cast<const T*>(srcMemPtr->GetPtr());
-    auto dst_data = reinterpret_cast<T*>(dstMemPtr->GetPtr());
+    const auto src_data = reinterpret_cast<const T*>(srcMemPtr->GetData());
+    auto dst_data = reinterpret_cast<T*>(dstMemPtr->GetData());
 
     const int DIM1 = srcMemPtr->getStaticDims()[1];
     const int DIM2 = srcMemPtr->getStaticDims()[2];
@@ -401,8 +401,8 @@ void Transpose::TransposeJitExecutor::exec(Transpose* node, MemoryPtr& srcMemPtr
     if (!pKernel)
         IE_THROW() << "Could not execute. Kernel for Transpose node was not compiled.";
 
-    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetPtr());
-    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetPtr());
+    const uint8_t* srcData = reinterpret_cast<const uint8_t*>(srcMemPtr->GetData());
+    uint8_t* dstData = reinterpret_cast<uint8_t*>(dstMemPtr->GetData());
 
     pKernel->execute(srcData, dstData, MB);
 }

--- a/src/plugins/intel_cpu/src/nodes/transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/transpose.cpp
@@ -187,8 +187,8 @@ bool Transpose::needPrepareParams() const {
 void Transpose::prepareParams() {
     if (performAsReorder) {
         //  Transpose(order={0,3,1,2}) can be performed as Reorder(acdb=>abcd)
-        auto& srcMemPtr = getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr();
-        auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+        auto srcMemPtr = getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr();
+        auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
         auto dstDesc = dstMemPtr->GetDescWithType<DnnlMemoryDesc>()->getDnnlDesc();
         auto srcDesc = dnnl::memory::desc(dstDesc.get_dims(), dstDesc.get_data_type(), memory::format_tag::acdb);
         auto result = getReorderPrim(context->getParamsCache(), getEngine(), srcDesc, dstDesc);
@@ -237,8 +237,8 @@ void Transpose::prepareParams() {
 }
 
 void Transpose::createPrimitive() {
-    auto& dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-    auto& srcMemPtr = getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr();
+    auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+    auto srcMemPtr = getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr();
     if (!dstMemPtr || !dstMemPtr->isAllocated())
         IE_THROW() << "Destination memory was not allocated.";
     if (!srcMemPtr || !srcMemPtr->isAllocated())
@@ -378,8 +378,8 @@ void Transpose::execute(dnnl::stream strm) {
     if (prim) {
         prim.execute(strm, primArgs);
     } else if (execPtr) {
-        auto &dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
-        auto &srcMemPtr = getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr();
+        auto dstMemPtr = getChildEdgeAt(0)->getMemoryPtr();
+        auto srcMemPtr = getParentEdgeAt(INPUT_DATA_IDX)->getMemoryPtr();
 
         int MB = srcMemPtr->getStaticDims()[0];
 

--- a/src/plugins/intel_cpu/src/nodes/unique.cpp
+++ b/src/plugins/intel_cpu/src/nodes/unique.cpp
@@ -88,13 +88,13 @@ void Unique::createPrimitive() {
 }
 
 void Unique::prepareParams() {
-    auto& dataMemPtr = getParentEdgeAt(IN_DATA)->getMemoryPtr();
+    auto dataMemPtr = getParentEdgeAt(IN_DATA)->getMemoryPtr();
     if (!dataMemPtr || !dataMemPtr->isAllocated()) {
         THROW_ERROR << " has not allocated input data memory.";
     }
     for (int i = 0; i < 4; i++) {
         if (definedOutputs[i]) {
-            auto& dstMemPtr = getChildEdgeAt(i)->getMemoryPtr();
+            auto dstMemPtr = getChildEdgeAt(i)->getMemoryPtr();
             if (!dstMemPtr || !dstMemPtr->isAllocated()) {
                 THROW_ERROR << " has not allocated output memory at port " << i;
             }

--- a/src/plugins/intel_cpu/src/nodes/unique.cpp
+++ b/src/plugins/intel_cpu/src/nodes/unique.cpp
@@ -106,7 +106,7 @@ void Unique::prepareParams() {
 
     size_t srcLen = 1;
     if (flattened) {
-        srcLen = getParentEdgeAt(IN_DATA)->getMemoryPtr()->GetSize() / dataTypeSize;
+        srcLen = getParentEdgeAt(IN_DATA)->getMemoryPtr()->getSize() / dataTypeSize;
     } else {
         auto dstDataShape = getParentEdgeAt(IN_DATA)->getMemoryPtr()->getStaticDims();
         srcLen = dstDataShape[axis];
@@ -164,8 +164,8 @@ void Unique::executeDynamicImpl(dnnl::stream strm) {
 
 template <typename T>
 void Unique::flattenTensorExec() {
-    const T* srcDataPtr = reinterpret_cast<const T*>(getParentEdgeAt(IN_DATA)->getMemoryPtr()->GetData());
-    const size_t inputLen = getParentEdgeAt(IN_DATA)->getMemoryPtr()->GetSize() / sizeof(T);
+    const T* srcDataPtr = reinterpret_cast<const T*>(getParentEdgeAt(IN_DATA)->getMemoryPtr()->getData());
+    const size_t inputLen = getParentEdgeAt(IN_DATA)->getMemoryPtr()->getSize() / sizeof(T);
     std::vector<T> uniDataTmp(inputLen);
     auto uniDataTmpPtr = uniDataTmp.data();
     int *firstTmpPtr = nullptr, *inToOutTmpPtr = nullptr, *occurTmpPtr = nullptr;
@@ -263,18 +263,18 @@ void Unique::flattenTensorExec() {
 
     redefineOutputMemory({ {uniqueLen}, {uniqueLen}, {inputLen}, {uniqueLen}});
 
-    T* uniDataPtr = reinterpret_cast<T*>(getChildEdgesAtPort(UNIQUE_DATA)[0]->getMemoryPtr()->GetData());
+    T* uniDataPtr = reinterpret_cast<T*>(getChildEdgesAtPort(UNIQUE_DATA)[0]->getMemoryPtr()->getData());
     cpu_parallel_memcpy(uniDataPtr, uniDataTmpPtr, uniqueLen * sizeof(T));
     if (definedOutputs[FIRST_UNIQUE_IDX]) {
-        int *firstPtr = reinterpret_cast<int*>(getChildEdgesAtPort(FIRST_UNIQUE_IDX)[0]->getMemoryPtr()->GetData());
+        int *firstPtr = reinterpret_cast<int*>(getChildEdgesAtPort(FIRST_UNIQUE_IDX)[0]->getMemoryPtr()->getData());
         cpu_parallel_memcpy(firstPtr, firstUniTmp.data(), uniqueLen * sizeof(int));
     }
     if (definedOutputs[INPUT_TO_UNIQ_IDX]) {
-        auto inToOutPtr = reinterpret_cast<int*>(getChildEdgesAtPort(INPUT_TO_UNIQ_IDX)[0]->getMemoryPtr()->GetData());
+        auto inToOutPtr = reinterpret_cast<int*>(getChildEdgesAtPort(INPUT_TO_UNIQ_IDX)[0]->getMemoryPtr()->getData());
         cpu_parallel_memcpy(inToOutPtr, inToOutTmp.data(), inputLen * sizeof(int));
     }
     if (definedOutputs[OCCURRENCES_NUM]) {
-        auto occurPtr = reinterpret_cast<int*>(getChildEdgesAtPort(OCCURRENCES_NUM)[0]->getMemoryPtr()->GetData());
+        auto occurPtr = reinterpret_cast<int*>(getChildEdgesAtPort(OCCURRENCES_NUM)[0]->getMemoryPtr()->getData());
         cpu_parallel_memcpy(occurPtr, occurTmp.data(), uniqueLen * sizeof(int));
     }
 }
@@ -282,7 +282,7 @@ void Unique::flattenTensorExec() {
 template <typename T>
 void Unique::slicedTensorExec() {
     auto inDataMemPtr = getParentEdgeAt(IN_DATA)->getMemoryPtr();
-    auto srcDataPtr = reinterpret_cast<const T*>(inDataMemPtr->GetData());
+    auto srcDataPtr = reinterpret_cast<const T*>(inDataMemPtr->getData());
     int *firstTmpPtr = nullptr, *inToOutTmpPtr = nullptr, *occurTmpPtr = nullptr;
     if (definedOutputs[FIRST_UNIQUE_IDX]) {
         firstTmpPtr = firstUniTmp.data();

--- a/src/plugins/intel_cpu/src/nodes/unique.cpp
+++ b/src/plugins/intel_cpu/src/nodes/unique.cpp
@@ -164,7 +164,7 @@ void Unique::executeDynamicImpl(dnnl::stream strm) {
 
 template <typename T>
 void Unique::flattenTensorExec() {
-    const T* srcDataPtr = reinterpret_cast<const T*>(getParentEdgeAt(IN_DATA)->getMemoryPtr()->GetPtr());
+    const T* srcDataPtr = reinterpret_cast<const T*>(getParentEdgeAt(IN_DATA)->getMemoryPtr()->GetData());
     const size_t inputLen = getParentEdgeAt(IN_DATA)->getMemoryPtr()->GetSize() / sizeof(T);
     std::vector<T> uniDataTmp(inputLen);
     auto uniDataTmpPtr = uniDataTmp.data();
@@ -263,18 +263,18 @@ void Unique::flattenTensorExec() {
 
     redefineOutputMemory({ {uniqueLen}, {uniqueLen}, {inputLen}, {uniqueLen}});
 
-    T* uniDataPtr = reinterpret_cast<T*>(getChildEdgesAtPort(UNIQUE_DATA)[0]->getMemoryPtr()->GetPtr());
+    T* uniDataPtr = reinterpret_cast<T*>(getChildEdgesAtPort(UNIQUE_DATA)[0]->getMemoryPtr()->GetData());
     cpu_parallel_memcpy(uniDataPtr, uniDataTmpPtr, uniqueLen * sizeof(T));
     if (definedOutputs[FIRST_UNIQUE_IDX]) {
-        int *firstPtr = reinterpret_cast<int*>(getChildEdgesAtPort(FIRST_UNIQUE_IDX)[0]->getMemoryPtr()->GetPtr());
+        int *firstPtr = reinterpret_cast<int*>(getChildEdgesAtPort(FIRST_UNIQUE_IDX)[0]->getMemoryPtr()->GetData());
         cpu_parallel_memcpy(firstPtr, firstUniTmp.data(), uniqueLen * sizeof(int));
     }
     if (definedOutputs[INPUT_TO_UNIQ_IDX]) {
-        auto inToOutPtr = reinterpret_cast<int*>(getChildEdgesAtPort(INPUT_TO_UNIQ_IDX)[0]->getMemoryPtr()->GetPtr());
+        auto inToOutPtr = reinterpret_cast<int*>(getChildEdgesAtPort(INPUT_TO_UNIQ_IDX)[0]->getMemoryPtr()->GetData());
         cpu_parallel_memcpy(inToOutPtr, inToOutTmp.data(), inputLen * sizeof(int));
     }
     if (definedOutputs[OCCURRENCES_NUM]) {
-        auto occurPtr = reinterpret_cast<int*>(getChildEdgesAtPort(OCCURRENCES_NUM)[0]->getMemoryPtr()->GetPtr());
+        auto occurPtr = reinterpret_cast<int*>(getChildEdgesAtPort(OCCURRENCES_NUM)[0]->getMemoryPtr()->GetData());
         cpu_parallel_memcpy(occurPtr, occurTmp.data(), uniqueLen * sizeof(int));
     }
 }
@@ -282,7 +282,7 @@ void Unique::flattenTensorExec() {
 template <typename T>
 void Unique::slicedTensorExec() {
     auto inDataMemPtr = getParentEdgeAt(IN_DATA)->getMemoryPtr();
-    auto srcDataPtr = reinterpret_cast<const T*>(inDataMemPtr->GetPtr());
+    auto srcDataPtr = reinterpret_cast<const T*>(inDataMemPtr->GetData());
     int *firstTmpPtr = nullptr, *inToOutTmpPtr = nullptr, *occurTmpPtr = nullptr;
     if (definedOutputs[FIRST_UNIQUE_IDX]) {
         firstTmpPtr = firstUniTmp.data();

--- a/src/plugins/intel_cpu/src/nodes/unique.cpp
+++ b/src/plugins/intel_cpu/src/nodes/unique.cpp
@@ -367,16 +367,16 @@ void Unique::slicedTensorExec() {
 
     int *firstPtr = nullptr, *inToOutPtr = nullptr, *occurNPtr = nullptr;
     if (definedOutputs[FIRST_UNIQUE_IDX]) {
-        firstPtr = reinterpret_cast<int*>(getChildEdgesAtPort(FIRST_UNIQUE_IDX)[0]->getMemoryPtr()->GetPtr());
+        firstPtr = reinterpret_cast<int*>(getChildEdgesAtPort(FIRST_UNIQUE_IDX)[0]->getMemoryPtr()->getData());
     }
     if (definedOutputs[INPUT_TO_UNIQ_IDX]) {
-        inToOutPtr = reinterpret_cast<int*>(getChildEdgesAtPort(INPUT_TO_UNIQ_IDX)[0]->getMemoryPtr()->GetPtr());
+        inToOutPtr = reinterpret_cast<int*>(getChildEdgesAtPort(INPUT_TO_UNIQ_IDX)[0]->getMemoryPtr()->getData());
     }
     if (definedOutputs[OCCURRENCES_NUM]) {
-        occurNPtr = reinterpret_cast<int*>(getChildEdgesAtPort(OCCURRENCES_NUM)[0]->getMemoryPtr()->GetPtr());
+        occurNPtr = reinterpret_cast<int*>(getChildEdgesAtPort(OCCURRENCES_NUM)[0]->getMemoryPtr()->getData());
     }
 
-    T* dstDataPtr = reinterpret_cast<T*>(getChildEdgesAtPort(UNIQUE_DATA)[0]->getMemoryPtr()->GetPtr());
+    T* dstDataPtr = reinterpret_cast<T*>(getChildEdgesAtPort(UNIQUE_DATA)[0]->getMemoryPtr()->getData());
     const auto dstOuterStep = innerLen * uniqueLen;
     // Filling of the first output if needed.
     if (sorted || definedOutputs[UNIQUE_DATA]) {

--- a/src/plugins/intel_cpu/src/partitioned_mem_mgr.cpp
+++ b/src/plugins/intel_cpu/src/partitioned_mem_mgr.cpp
@@ -32,7 +32,7 @@ MemoryMngrPtr PartitionedMemoryMngr::sourceMemMngr() const {
 
 void* PartitionedMemoryMngr::getRawPtr() const noexcept {
     if (auto memMngr = sourceMemMngrNoThrow()) {
-        return static_cast<uint8_t*>(memMngr->getRawPtr()) + m_offset_blocks * m_size;
+        return static_cast<uint8_t*>(memMngr->getRawPtr()) + m_offset_blocks * m_size / m_size_blocks;
     }
     return nullptr;
 }
@@ -45,7 +45,7 @@ void PartitionedMemoryMngr::setExtBuff(void* ptr, size_t size) {
 bool PartitionedMemoryMngr::resize(size_t size) {
     auto memMngr = sourceMemMngr();
     m_size = size;
-    return memMngr->resize(size * m_part);
+    return memMngr->resize(m_size * m_total_blocks / m_size_blocks);
 }
 
 bool PartitionedMemoryMngr::hasExtBuffer() const noexcept {
@@ -61,7 +61,9 @@ void PartitionedMemoryMngr::registerMemory(Memory* memPtr) {
 }
 
 void PartitionedMemoryMngr::unregisterMemory(Memory* memPtr) {
-    auto memMngr = sourceMemMngr();
-    memMngr->unregisterMemory(memPtr);
+    if (!m_wEdge.expired()) {
+        auto memMngr = sourceMemMngr();
+        memMngr->unregisterMemory(memPtr);
+    }
 }
 

--- a/src/plugins/intel_cpu/src/partitioned_mem_mgr.cpp
+++ b/src/plugins/intel_cpu/src/partitioned_mem_mgr.cpp
@@ -6,64 +6,28 @@
 
 using namespace ov::intel_cpu;
 
-MemoryMngrPtr PartitionedMemoryMngr::sourceMemMngrNoThrow() const noexcept {
-    if (auto pEdge = m_wEdge.lock()) {
-        MemoryPtr pMem = nullptr;
-        try {
-            pMem = pEdge->getMemoryPtr();
-        }
-        catch(...) {
-            return nullptr;
-        }
-        if (pMem) {
-            if (auto memMngr = pMem->getMemoryMngr()) {
-                return memMngr;
-            }
-        }
-    }
-    return nullptr;
-}
-
-MemoryMngrPtr PartitionedMemoryMngr::sourceMemMngr() const {
-    auto memMngr = sourceMemMngrNoThrow();
-    IE_ASSERT(memMngr != nullptr) << "PartitionedMemoryMngr references nullptr";
-    return memMngr;
-}
-
 void* PartitionedMemoryMngr::getRawPtr() const noexcept {
-    if (auto memMngr = sourceMemMngrNoThrow()) {
-        return static_cast<uint8_t*>(memMngr->getRawPtr()) + m_offset_blocks * m_size / m_size_blocks;
-    }
-    return nullptr;
+    return static_cast<uint8_t*>(m_pMngr->getRawPtr()) + m_offset_blocks * m_size / m_size_blocks;
 }
 
 void PartitionedMemoryMngr::setExtBuff(void* ptr, size_t size) {
-    auto memMngr = sourceMemMngr();
-    memMngr->setExtBuff(ptr, size);
+    m_pMngr->setExtBuff(ptr, size);
 }
 
 bool PartitionedMemoryMngr::resize(size_t size) {
-    auto memMngr = sourceMemMngr();
     m_size = size;
-    return memMngr->resize(m_size * m_total_blocks / m_size_blocks);
+    return m_pMngr->resize(m_size * m_total_blocks / m_size_blocks);
 }
 
 bool PartitionedMemoryMngr::hasExtBuffer() const noexcept {
-    if (auto memMngr = sourceMemMngrNoThrow()) {
-        return memMngr->hasExtBuffer();
-    }
-    return false;
+    return m_pMngr->hasExtBuffer();
 }
 
 void PartitionedMemoryMngr::registerMemory(Memory* memPtr) {
-    auto memMngr = sourceMemMngr();
-    memMngr->registerMemory(memPtr);
+    m_pMngr->registerMemory(memPtr);
 }
 
 void PartitionedMemoryMngr::unregisterMemory(Memory* memPtr) {
-    if (!m_wEdge.expired()) {
-        auto memMngr = sourceMemMngr();
-        memMngr->unregisterMemory(memPtr);
-    }
+    m_pMngr->unregisterMemory(memPtr);
 }
 

--- a/src/plugins/intel_cpu/src/partitioned_mem_mgr.cpp
+++ b/src/plugins/intel_cpu/src/partitioned_mem_mgr.cpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "partitioned_mem_mgr.h"
+
+using namespace ov::intel_cpu;
+
+MemoryMngrPtr PartitionedMemoryMngr::sourceMemMngrNoThrow() const noexcept {
+    if (auto pEdge = m_wEdge.lock()) {
+        MemoryPtr pMem = nullptr;
+        try {
+            pMem = pEdge->getMemoryPtr();
+        }
+        catch(...) {
+            return nullptr;
+        }
+        if (pMem) {
+            if (auto memMngr = pMem->getMemoryMngr()) {
+                return memMngr;
+            }
+        }
+    }
+    return nullptr;
+}
+
+MemoryMngrPtr PartitionedMemoryMngr::sourceMemMngr() const {
+    auto memMngr = sourceMemMngrNoThrow();
+    IE_ASSERT(memMngr != nullptr) << "PartitionedMemoryMngr references nullptr";
+    return memMngr;
+}
+
+void* PartitionedMemoryMngr::getRawPtr() const noexcept {
+    if (auto memMngr = sourceMemMngrNoThrow()) {
+        return static_cast<uint8_t*>(memMngr->getRawPtr()) + m_offset_blocks * m_size;
+    }
+    return nullptr;
+}
+
+void PartitionedMemoryMngr::setExtBuff(void* ptr, size_t size) {
+    auto memMngr = sourceMemMngr();
+    memMngr->setExtBuff(ptr, size);
+}
+
+bool PartitionedMemoryMngr::resize(size_t size) {
+    auto memMngr = sourceMemMngr();
+    m_size = size;
+    return memMngr->resize(size * m_part);
+}
+
+bool PartitionedMemoryMngr::hasExtBuffer() const noexcept {
+    if (auto memMngr = sourceMemMngrNoThrow()) {
+        return memMngr->hasExtBuffer();
+    }
+    return false;
+}
+
+void PartitionedMemoryMngr::registerMemory(Memory* memPtr) {
+    auto memMngr = sourceMemMngr();
+    memMngr->registerMemory(memPtr);
+}
+
+void PartitionedMemoryMngr::unregisterMemory(Memory* memPtr) {
+    auto memMngr = sourceMemMngr();
+    memMngr->unregisterMemory(memPtr);
+}
+

--- a/src/plugins/intel_cpu/src/partitioned_mem_mgr.h
+++ b/src/plugins/intel_cpu/src/partitioned_mem_mgr.h
@@ -1,0 +1,36 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "edge.h"
+
+namespace ov {
+namespace intel_cpu {
+
+class PartitionedMemoryMngr : public IMemoryMngrObserver {
+public:
+    PartitionedMemoryMngr(EdgePtr pEdge, size_t part = 1, ptrdiff_t offset_blocks = 0)
+        : m_wEdge(pEdge), m_part(part), m_offset_blocks(offset_blocks) {}
+
+    void* getRawPtr() const noexcept override;
+    void setExtBuff(void* ptr, size_t size) override;
+    bool resize(size_t size) override;
+    bool hasExtBuffer() const noexcept override;
+    void registerMemory(Memory* memPtr) override;
+    void unregisterMemory(Memory* memPtr) override;
+
+private:
+    MemoryMngrPtr sourceMemMngr() const;
+    MemoryMngrPtr sourceMemMngrNoThrow() const noexcept;
+
+private:
+    EdgeWeakPtr m_wEdge;
+    size_t m_part = 1; // the size of the block as a fraction of the reference memory size
+    ptrdiff_t m_offset_blocks = 0; // offset from the reference memory beginning in blocks
+    size_t m_size = 0; // self size in bytes
+};
+
+}   // namespace intel_cpu
+}   // namespace ov

--- a/src/plugins/intel_cpu/src/partitioned_mem_mgr.h
+++ b/src/plugins/intel_cpu/src/partitioned_mem_mgr.h
@@ -4,15 +4,17 @@
 
 #pragma once
 
-#include "edge.h"
+#include "cpu_memory.h"
 
 namespace ov {
 namespace intel_cpu {
 
 class PartitionedMemoryMngr : public IMemoryMngrObserver {
 public:
-    PartitionedMemoryMngr(EdgePtr pEdge, size_t total_blocks = 1, ptrdiff_t offset_blocks = 0, size_t size_blocks = 1)
-        : m_wEdge(pEdge), m_total_blocks(total_blocks), m_offset_blocks(offset_blocks), m_size_blocks(size_blocks) {}
+    PartitionedMemoryMngr(MemoryMngrPtr pMngr, size_t total_blocks = 1, ptrdiff_t offset_blocks = 0, size_t size_blocks = 1)
+        : m_pMngr(pMngr), m_total_blocks(total_blocks), m_offset_blocks(offset_blocks), m_size_blocks(size_blocks) {
+        IE_ASSERT(m_pMngr) << "Memory manager is uninitialized";
+    }
 
     void* getRawPtr() const noexcept override;
     void setExtBuff(void* ptr, size_t size) override;
@@ -22,11 +24,7 @@ public:
     void unregisterMemory(Memory* memPtr) override;
 
 private:
-    MemoryMngrPtr sourceMemMngr() const;
-    MemoryMngrPtr sourceMemMngrNoThrow() const noexcept;
-
-private:
-    EdgeWeakPtr m_wEdge;
+    MemoryMngrPtr m_pMngr;
     size_t m_total_blocks = 1; // size of the parent memory in blocks
     ptrdiff_t m_offset_blocks = 0; // offset from the base pointer in blocks
     size_t m_size_blocks = 1; // size of the partition in blocks

--- a/src/plugins/intel_cpu/src/partitioned_mem_mgr.h
+++ b/src/plugins/intel_cpu/src/partitioned_mem_mgr.h
@@ -11,8 +11,8 @@ namespace intel_cpu {
 
 class PartitionedMemoryMngr : public IMemoryMngrObserver {
 public:
-    PartitionedMemoryMngr(EdgePtr pEdge, size_t part = 1, ptrdiff_t offset_blocks = 0)
-        : m_wEdge(pEdge), m_part(part), m_offset_blocks(offset_blocks) {}
+    PartitionedMemoryMngr(EdgePtr pEdge, size_t total_blocks = 1, ptrdiff_t offset_blocks = 0, size_t size_blocks = 1)
+        : m_wEdge(pEdge), m_total_blocks(total_blocks), m_offset_blocks(offset_blocks), m_size_blocks(size_blocks) {}
 
     void* getRawPtr() const noexcept override;
     void setExtBuff(void* ptr, size_t size) override;
@@ -27,8 +27,9 @@ private:
 
 private:
     EdgeWeakPtr m_wEdge;
-    size_t m_part = 1; // the size of the block as a fraction of the reference memory size
-    ptrdiff_t m_offset_blocks = 0; // offset from the reference memory beginning in blocks
+    size_t m_total_blocks = 1; // size of the parent memory in blocks
+    ptrdiff_t m_offset_blocks = 0; // offset from the base pointer in blocks
+    size_t m_size_blocks = 1; // size of the partition in blocks
     size_t m_size = 0; // self size in bytes
 };
 

--- a/src/plugins/intel_cpu/src/partitioned_mem_mgr.h
+++ b/src/plugins/intel_cpu/src/partitioned_mem_mgr.h
@@ -9,6 +9,11 @@
 namespace ov {
 namespace intel_cpu {
 
+/**
+ * This is a memory manager that represents a view on a partition inside a continuous memory block controlled by
+ * another memory manager.
+ * 
+ */
 class PartitionedMemoryMngr : public IMemoryMngrObserver {
 public:
     PartitionedMemoryMngr(MemoryMngrPtr pMngr, size_t total_blocks = 1, ptrdiff_t offset_blocks = 0, size_t size_blocks = 1)
@@ -25,10 +30,10 @@ public:
 
 private:
     MemoryMngrPtr m_pMngr;
-    size_t m_total_blocks = 1; // size of the parent memory in blocks
-    ptrdiff_t m_offset_blocks = 0; // offset from the base pointer in blocks
-    size_t m_size_blocks = 1; // size of the partition in blocks
-    size_t m_size = 0; // self size in bytes
+    size_t m_total_blocks = 1; // size of the parent memory in abstract blocks
+    ptrdiff_t m_offset_blocks = 0; // offset from the beginning of the external memory in abstract blocks
+    size_t m_size_blocks = 1; // size of the viewed partition in abstract blocks
+    size_t m_size = 0; // size of the viewed partition in bytes
 };
 
 }   // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/utils/blob_dump.cpp
+++ b/src/plugins/intel_cpu/src/utils/blob_dump.cpp
@@ -94,7 +94,7 @@ void BlobDumper::prepare_plain_data(const MemoryPtr &memory, std::vector<uint8_t
 
     // check if it already plain
     if (desc.hasLayoutType(LayoutType::ncsp)) {
-        cpu_memcpy(data.data(), reinterpret_cast<const uint8_t*>(memory->GetPtr()), size);
+        cpu_memcpy(data.data(), reinterpret_cast<const uint8_t*>(memory->GetData()), size);
         return;
     }
 

--- a/src/plugins/intel_cpu/src/utils/blob_dump.cpp
+++ b/src/plugins/intel_cpu/src/utils/blob_dump.cpp
@@ -94,12 +94,12 @@ void BlobDumper::prepare_plain_data(const MemoryPtr &memory, std::vector<uint8_t
 
     // check if it already plain
     if (desc.hasLayoutType(LayoutType::ncsp)) {
-        cpu_memcpy(data.data(), reinterpret_cast<const uint8_t*>(memory->GetData()), size);
+        cpu_memcpy(data.data(), reinterpret_cast<const uint8_t*>(memory->getData()), size);
         return;
     }
 
     // Copy to plain
-    const void *ptr = memory->GetData();
+    const void *ptr = memory->getData();
 
     switch (desc.getPrecision()) {
         case Precision::FP32:
@@ -161,9 +161,9 @@ void BlobDumper::dumpAsTxt(std::ostream &stream) const {
            << "shape: ";
     for (size_t d : dims) stream << d << " ";
     stream << "(" << data_size << ")" <<
-    " by address 0x" << std::hex << reinterpret_cast<const long long *>(memory->GetData()) << std::dec <<std::endl;
+    " by address 0x" << std::hex << reinterpret_cast<const long long *>(memory->getData()) << std::dec <<std::endl;
 
-    const void *ptr = memory->GetData();
+    const void *ptr = memory->getData();
 
     switch (desc.getPrecision()) {
         case Precision::FP32 : {

--- a/src/plugins/intel_cpu/src/utils/blob_dump.h
+++ b/src/plugins/intel_cpu/src/utils/blob_dump.h
@@ -29,8 +29,7 @@ public:
     BlobDumper() = default;
     BlobDumper(const DnnlBlockedMemoryDesc &desc) {
         dnnl::engine eng(dnnl::engine::kind::cpu, 0);
-        memory = std::make_shared<Memory>(eng);
-        memory->Create(desc);
+        memory = std::make_shared<Memory>(eng, desc);
     }
     BlobDumper(const BlobDumper&) = default;
     BlobDumper& operator = (BlobDumper&&) = default;
@@ -47,7 +46,7 @@ public:
     void dumpAsTxt(std::ostream &stream) const;
 
     void *getDataPtr() const {
-        return memory->GetPtr();
+        return memory->GetData();
     }
 };
 

--- a/src/plugins/intel_cpu/src/utils/blob_dump.h
+++ b/src/plugins/intel_cpu/src/utils/blob_dump.h
@@ -46,7 +46,7 @@ public:
     void dumpAsTxt(std::ostream &stream) const;
 
     void *getDataPtr() const {
-        return memory->GetData();
+        return memory->getData();
     }
 };
 

--- a/src/plugins/intel_cpu/src/utils/debug_capabilities.cpp
+++ b/src/plugins/intel_cpu/src/utils/debug_capabilities.cpp
@@ -199,7 +199,7 @@ std::ostream & operator<<(std::ostream & os, const Node &c_node) {
                     leftside << comma << desc->getPrecision().name()
                                 << "_" << desc->serializeFormat()
                                 << "_" << shape_str
-                                << "_" << ptr->GetData();
+                                << "_" << ptr->getData();
                     b_ouputed = true;
                 } else {
                     leftside << "(empty)";
@@ -292,7 +292,7 @@ std::ostream & operator<<(std::ostream & os, const Node &c_node) {
     if (node.getType() == intel_cpu::Type::Input && node.isConstant()) {
         if (auto input_node = reinterpret_cast<intel_cpu::node::Input *>(&node)) {
             auto pmem = input_node->getMemoryPtr();
-            void * data = pmem->GetData();
+            void * data = pmem->getData();
             auto shape = pmem->getDesc().getShape().getDims();
 
             if (shape_size(shape) <= 8) {

--- a/src/plugins/intel_cpu/src/utils/general_utils.h
+++ b/src/plugins/intel_cpu/src/utils/general_utils.h
@@ -44,6 +44,11 @@ constexpr inline bool implication(bool cause, bool cond) {
     return !cause || !!cond;
 }
 
+template <class T, class... Args>
+inline std::unique_ptr<T> make_unique(Args&&... args) {
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
 template<typename T>
 std::string vec2str(const std::vector<T> &vec) {
     if (!vec.empty()) {

--- a/src/plugins/intel_cpu/src/utils/general_utils.h
+++ b/src/plugins/intel_cpu/src/utils/general_utils.h
@@ -44,10 +44,14 @@ constexpr inline bool implication(bool cause, bool cond) {
     return !cause || !!cond;
 }
 
+#ifdef __cpp_lib_make_unique
+using std::make_unique;
+#else
 template <class T, class... Args>
 inline std::unique_ptr<T> make_unique(Args&&... args) {
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
+#endif
 
 template<typename T>
 std::string vec2str(const std::vector<T> &vec) {

--- a/src/plugins/intel_cpu/src/utils/node_dumper.cpp
+++ b/src/plugins/intel_cpu/src/utils/node_dumper.cpp
@@ -110,8 +110,7 @@ static void dumpInternalBlobs(const NodePtr& node, const DebugCapsConfig& config
         if (desc.getPrecision() == Precision::BIN)
             continue;
 
-        MemoryPtr memory = std::make_shared<Memory>(node->getEngine());
-        memory->Create(MemoryDescUtils::convertToDnnlBlockedMemoryDesc(desc), blb->buffer());
+        MemoryPtr memory = std::make_shared<Memory>(node->getEngine(), MemoryDescUtils::convertToDnnlBlockedMemoryDesc(desc), blb->buffer());
         BlobDumper dumper(memory);
         dump(dumper, dump_file, config);
     }

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_ngraph.cpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_ngraph.cpp
@@ -36,7 +36,7 @@ NgraphShapeInfer::infer(
             input_values[port] = std::make_shared<ngraph::runtime::HostTensor>(
                 InferenceEngine::details::convertPrecision(memPtr->getDesc().getPrecision()),
                 shape,
-                memPtr->GetPtr());
+                memPtr->GetData());
         }
     }
     // call shape inference API

--- a/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_ngraph.cpp
+++ b/src/plugins/intel_cpu/src/utils/shape_inference/shape_inference_ngraph.cpp
@@ -36,7 +36,7 @@ NgraphShapeInfer::infer(
             input_values[port] = std::make_shared<ngraph::runtime::HostTensor>(
                 InferenceEngine::details::convertPrecision(memPtr->getDesc().getPrecision()),
                 shape,
-                memPtr->GetData());
+                memPtr->getData());
         }
     }
     // call shape inference API

--- a/src/plugins/intel_cpu/src/weights_cache.hpp
+++ b/src/plugins/intel_cpu/src/weights_cache.hpp
@@ -63,7 +63,7 @@ class WeightsSharing {
         {}
 
         std::mutex guard;
-        std::weak_ptr<Memory> sharedMemory;
+        std::weak_ptr<IMemory> sharedMemory;
         std::atomic<bool> valid;
     };
 

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/concat.cpp
@@ -632,31 +632,84 @@ INSTANTIATE_TEST_SUITE_P(smoke_Concat_1D_dynamic, ConcatLayerCPUTest,
 INSTANTIATE_TEST_SUITE_P(concat_Concat4D_CPU_Block8inPlace, ConcatLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Values(0, 1),
-                                ::testing::Values(static_shapes_to_test_representation({{1, 8, 3, 5}, {1, 8, 3, 5}})),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(planar_4D, planarChannels_4D, blocked8_4D)),
+                                ::testing::Values(std::vector<InputShape>{
+                                                      {{}, {{1, 16, 5, 7}}},
+                                                      {{}, {{1, 16, 5, 7}}},
+                                                      {{}, {{1, 16, 5, 7}}},
+                                                  },
+                                                  std::vector<InputShape>{
+                                                      {{1, 16, -1, -1}, {{1, 16, 5, 7}, {1, 16, 16, 2}, {1, 16, 2, 8}}},
+                                                      {{1, 16, -1, -1}, {{1, 16, 5, 7}, {1, 16, 16, 2}, {1, 16, 2, 8}}},
+                                                      {{1, 16, -1, -1}, {{1, 16, 5, 7}, {1, 16, 16, 2}, {1, 16, 2, 8}}},
+                                                  }),
+                                ::testing::Values(ElementType::f32),
+                                ::testing::Values(planar_4D, blocked8_4D)),
                         ConcatLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Concat4D_CPU_Block16inPlace, ConcatLayerCPUTest,
+INSTANTIATE_TEST_SUITE_P(smoke_Concat4D_CPU_Block16inPlace_0, ConcatLayerCPUTest,
                         ::testing::Combine(
-                                ::testing::Values(0, 1),
-                                ::testing::Values(static_shapes_to_test_representation({{1, 32, 3, 5}, {1, 32, 3, 5}})),
-                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(0),
+                                ::testing::Values(std::vector<InputShape>{
+                                                      {{}, {{1, 32, 5, 7}}},
+                                                      {{}, {{1, 32, 5, 7}}},
+                                                      {{}, {{1, 32, 5, 7}}},
+                                                  },
+                                                  std::vector<InputShape>{
+                                                      {{1, 32, -1, -1}, {{1, 32, 5, 7}, {1, 32, 16, 2}, {1, 32, 2, 8}}},
+                                                      {{1, 32, -1, -1}, {{1, 32, 5, 7}, {1, 32, 16, 2}, {1, 32, 2, 8}}},
+                                                      {{1, 32, -1, -1}, {{1, 32, 5, 7}, {1, 32, 16, 2}, {1, 32, 2, 8}}},
+                                                  }),
+                                ::testing::Values(ElementType::f32),
+                                ::testing::Values(blocked16_4D)),
+                        ConcatLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Concat4D_CPU_Block16inPlace_1, ConcatLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(1),
+                                ::testing::Values(std::vector<InputShape>{
+                                                      {{}, {{1, 32, 5, 7}}},
+                                                      {{}, {{1, 16, 5, 7}}},
+                                                      {{}, {{1, 32, 5, 7}}},
+                                                  },
+                                                  std::vector<InputShape>{
+                                                      {{1, 32, -1, -1}, {{1, 32, 5, 7}, {1, 32, 16, 2}, {1, 32, 2, 8}}},
+                                                      {{1, 16, -1, -1}, {{1, 16, 5, 7}, {1, 16, 16, 2}, {1, 16, 2, 8}}},
+                                                      {{1, 32, -1, -1}, {{1, 32, 5, 7}, {1, 32, 16, 2}, {1, 32, 2, 8}}},
+                                                  }),
+                                ::testing::Values(ElementType::f32),
                                 ::testing::Values(blocked16_4D)),
                         ConcatLayerCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(concat_Concat5D_CPU_Block8inPlace, ConcatLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Values(0, 1),
-                                ::testing::Values(static_shapes_to_test_representation({{1, 16, 3, 5, 7}, {1, 16, 3, 5, 7}})),
+                                ::testing::Values(std::vector<InputShape>{
+                                                      {{}, {{1, 16, 3, 5, 7}}},
+                                                      {{}, {{1, 16, 3, 5, 7}}},
+                                                      {{}, {{1, 16, 3, 5, 7}}},
+                                                  },
+                                                  std::vector<InputShape>{
+                                                      {{1, 32, -1, -1, -1}, {{1, 32, 5, 7, 3}, {1, 32, 16, 2, 3}, {1, 32, 2, 8, 3}}},
+                                                      {{1, 32, -1, -1, -1}, {{1, 32, 5, 7, 3}, {1, 32, 16, 2, 3}, {1, 32, 2, 8, 3}}},
+                                                      {{1, 32, -1, -1, -1}, {{1, 32, 5, 7, 3}, {1, 32, 16, 2, 3}, {1, 32, 2, 8, 3}}},
+                                                  }),
                                 ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(planar_5D, planarChannels_5D, blocked8_5D)),
+                                ::testing::Values(planar_5D, blocked8_5D)),
                         ConcatLayerCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_Concat5D_CPU_Block16inPlace, ConcatLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Values(0, 1),
-                                ::testing::Values(static_shapes_to_test_representation({{1, 32, 3, 5, 7}, {1, 32, 3, 5, 7}})),
+                                ::testing::Values(std::vector<InputShape>{
+                                                      {{}, {{1, 32, 3, 5, 7}}},
+                                                      {{}, {{1, 32, 3, 5, 7}}},
+                                                      {{}, {{1, 32, 3, 5, 7}}},
+                                                  },
+                                                  std::vector<InputShape>{
+                                                      {{1, 32, -1, -1, -1}, {{1, 32, 5, 7, 3}, {1, 32, 16, 2, 3}, {1, 32, 2, 8, 3}}},
+                                                      {{1, 32, -1, -1, -1}, {{1, 32, 5, 7, 3}, {1, 32, 16, 2, 3}, {1, 32, 2, 8, 3}}},
+                                                      {{1, 32, -1, -1, -1}, {{1, 32, 5, 7, 3}, {1, 32, 16, 2, 3}, {1, 32, 2, 8, 3}}},
+                                                  }),
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::Values(blocked16_5D)),
                         ConcatLayerCPUTest::getTestCaseName);

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/gather.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/gather.cpp
@@ -146,7 +146,80 @@ protected:
     int64_t axis = 0;
 };
 
+typedef std::tuple<
+        InputShape,                        // Input shapes
+        std::vector<size_t>,               // Indices
+        int,                               // Axis
+        ElementType,                       // Network precision
+        CPUSpecificParams                 // CPU specific params
+> GatherInPlaceLayerTestCPUParams;
+
+class GatherInPlaceLayerTestCPU : public testing::WithParamInterface<GatherInPlaceLayerTestCPUParams>,
+                           virtual public ov::test::SubgraphBaseTest, public CPUTestsBase {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<GatherInPlaceLayerTestCPUParams> obj) {
+        InputShape inputShapes;
+        std::vector<size_t> indices;
+        int axis;
+        ElementType netPrecision;
+        CPUSpecificParams cpuParams;
+
+        std::tie(inputShapes, indices, axis, netPrecision, cpuParams) = obj.param;
+
+        std::ostringstream result;
+        result << "IS=(";
+
+        result << CommonTestUtils::partialShape2str({inputShapes.first}) << ")_TS=";
+
+        result << "{";
+        for (size_t i = 0lu; i < inputShapes.second.size(); i++) {
+            result << CommonTestUtils::vec2str(inputShapes.second[i]) << (i < inputShapes.second.size() - 1lu ? "_" : "");
+        }
+        result << "}_";
+        result << "axis=" << axis << "_";
+        result << "indices=" << CommonTestUtils::vec2str(indices) << "_";
+        result << "netPrc=" << netPrecision << "_";
+        result << CPUTestsBase::getTestCaseName(cpuParams);
+
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        InputShape inputShapes;
+        std::vector<size_t> indices;
+        int axis;
+        ElementType netPrecision;
+        CPUSpecificParams cpuParams;
+        constexpr ElementType intInputsPrecision = ElementType::i64;
+        constexpr int batchDims = 0;
+
+        std::tie(inputShapes, indices, axis, netPrecision, cpuParams) = this->GetParam();
+        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+        targetDevice = CommonTestUtils::DEVICE_CPU;
+        init_input_shapes({ inputShapes });
+
+        selectedType = makeSelectedTypeStr(selectedType, netPrecision);
+
+        ngraph::ParameterVector params {
+            std::make_shared<ov::op::v0::Parameter>(netPrecision, inputDynamicShapes[0])
+        };
+        params[0]->set_friendly_name("data");
+        auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
+        std::shared_ptr<ov::Node> gatherNode = std::make_shared<ov::op::v8::Gather>(paramOuts[0],
+            ov::op::v0::Constant::create(intInputsPrecision, ov::Shape({indices.size()}), indices),
+            ov::op::v0::Constant::create(intInputsPrecision, ov::Shape({1}), { axis }), batchDims);
+
+        function = makeNgraphFunction(netPrecision, params, gatherNode, "GatherCPU");
+    }
+};
+
 TEST_P(GatherLayerTestCPU, CompareWithRefs) {
+    run();
+    CheckPluginRelatedResults(compiledModel, "Gather");
+}
+
+TEST_P(GatherInPlaceLayerTestCPU, CompareWithRefs) {
     run();
     CheckPluginRelatedResults(compiledModel, "Gather");
 }
@@ -847,5 +920,36 @@ INSTANTIATE_TEST_SUITE_P(smoke_static_4D_ref8_Bmax, GatherLayerTestCPU,
                     ::testing::Values(cpuParamsRef),
                     ::testing::Values(additionalConfig[0])),
                 GatherLayerTestCPU::getTestCaseName);
+
+// InPlace
+
+const std::vector<ov::test::InputShape> shapesInPlace4D_0 = {
+    { {}, { {5, 4, 4, 19} } },   // Static shapes
+    { {5, 4, -1, -1}, { {5, 4, 4, 19}, {5, 4, 4, 25}, {5, 4, 2, 19} } },   // Static shapes
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_inplace_4D_0, GatherInPlaceLayerTestCPU,
+                ::testing::Combine(
+                    ::testing::ValuesIn(shapesInPlace4D_0),
+                    ::testing::Values(std::vector<size_t>{ 2 }),
+                    ::testing::Values(0),
+                    ::testing::Values(ElementType::f32),
+                    ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
+                GatherInPlaceLayerTestCPU::getTestCaseName);
+
+const std::vector<ov::test::InputShape> shapesInPlace4D_1 = {
+    { {}, { {1, 9, 4, 19} } },   // Static shapes
+    { {1, 9, -1, -1}, { {1, 9, 4, 19}, {1, 9, 4, 25}, {1, 9, 2, 19} } },   // Static shapes
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_inplace_4D_1, GatherInPlaceLayerTestCPU,
+                ::testing::Combine(
+                    ::testing::ValuesIn(shapesInPlace4D_1),
+                    ::testing::Values(std::vector<size_t>{ 4 }),
+                    ::testing::Values(1),
+                    ::testing::Values(ElementType::f32),
+                    ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
+                GatherInPlaceLayerTestCPU::getTestCaseName);
+
 } // namespace
 } // namespace CPULayerTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/split.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/split.cpp
@@ -92,12 +92,12 @@ protected:
 
 TEST_P(SplitLayerCPUTest, CompareWithRefs) {
     run();
-//     CheckPluginRelatedResults(executableNetwork, "Split");
+    CheckPluginRelatedResults(compiledModel, "Split");
 }
 
 namespace {
-const auto planar_4D_ref = CPUSpecificParams{{nchw}, {nchw}, {"ref"}, "ref"};
-const auto planar_5D_ref = CPUSpecificParams{{ncdhw}, {ncdhw}, {"ref"}, "ref"};
+const auto planar_4D_ref = CPUSpecificParams{{nchw}, {nchw}, {}, "ref"};
+const auto planar_5D_ref = CPUSpecificParams{{ncdhw}, {ncdhw}, {}, "ref"};
 
 const auto planar_4D = CPUSpecificParams{{nchw}, {nchw}, {}, "unknown"};
 const auto planar_5D = CPUSpecificParams{{ncdhw}, {ncdhw}, {}, "unknown"};
@@ -249,7 +249,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_planar, SplitLayerCPUTest,
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::ValuesIn(inputShapes4D_planar),
                                 ::testing::ValuesIn(outIndices3),
-                                ::testing::Values(planar_4D, planar_4D_ref, perChannels_4D)),
+                                ::testing::Values(planar_4D_ref, perChannels_4D)),
                         SplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes4D_block = {
@@ -336,7 +336,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Split5D_CPU_planar, SplitLayerCPUTest,
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::ValuesIn(inputShapes5D_planar),
                                 ::testing::ValuesIn(outIndices3),
-                                ::testing::Values(planar_5D, planar_5D_ref, perChannels_5D)),
+                                ::testing::Values(planar_5D_ref, perChannels_5D)),
                         SplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes5D_block = {
@@ -410,11 +410,11 @@ const std::vector<InputShape> inputShapes3D = {
 INSTANTIATE_TEST_SUITE_P(smoke_Split3D, SplitLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Values(7),
-                                ::testing::Values(0, 1, 2),
+                                ::testing::Values(1, 2),
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::ValuesIn(inputShapes3D),
                                 ::testing::Values(std::vector<size_t>({})),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"}, CPUSpecificParams{{}, {}, {"ref"}, "ref"})),
+                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
                                 SplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes2D = {
@@ -444,15 +444,24 @@ const std::vector<InputShape> inputShapes2D = {
 INSTANTIATE_TEST_SUITE_P(smoke_Split2D, SplitLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Values(2),
-                                ::testing::Values(0, 1),
+                                ::testing::Values(1),
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::ValuesIn(inputShapes2D),
                                 ::testing::Values(std::vector<size_t>({})),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"}, CPUSpecificParams{{}, {}, {"ref"}, "ref"})),
+                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
                         SplitLayerCPUTest::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_Split1D_static, SplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(5),
+                                ::testing::Values(0),
+                                ::testing::ValuesIn(netPrecisions),
+                                ::testing::Values(InputShape{ {}, {{10}} }),
+                                ::testing::Values(std::vector<size_t>({})),
+                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
+                            SplitLayerCPUTest::getTestCaseName);
+
 const std::vector<InputShape> inputShapes1D = {
-        { {}, {{10}} },
         {
             // dynamic
             {-1},
@@ -482,7 +491,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_Split1D, SplitLayerCPUTest,
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::ValuesIn(inputShapes1D),
                                 ::testing::Values(std::vector<size_t>({})),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"}, CPUSpecificParams{{}, {}, {"ref"}, "ref"})),
+                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
                             SplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes4D_dynBatch = {
@@ -504,48 +513,83 @@ INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_by_batch, SplitLayerCPUTest,
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::ValuesIn(inputShapes4D_dynBatch),
                                 ::testing::ValuesIn(outIndices3),
-                                ::testing::Values(planar_4D, planar_4D_ref, perChannels_4D)),
+                                ::testing::Values(planar_4D_ref, perChannels_4D)),
                         SplitLayerCPUTest::getTestCaseName);
 
 // ============================================== inPlace cases ============================================
-INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_Block8inPlace, SplitLayerCPUTest,
+const std::vector<InputShape> inputShapes4D_inPlace_0 = {
+        {{}, {{3, 24, 24, 9}}},
+        {{}, {{6, 24, 24}}},
+        {{}, {{9, 24}}},
+        {
+            // dynamic
+            {3, -1, -1, -1, -1},
+            // target
+            {
+                {3, 24, 6, 9, 4},
+                {3, 12, 12, 15, 5},
+            }
+        },
+        {
+            // dynamic
+            {6, -1, -1, -1},
+            // target
+            {
+                {6, 24, 6, 9},
+                {6, 12, 12, 15},
+            }
+        },
+        {
+            // dynamic
+            {9, -1, -1},
+            // target
+            {
+                {9, 24, 6},
+                {9, 12, 12},
+            }
+        }
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Split_CPU_planar_inPlace_0, SplitLayerCPUTest,
                     ::testing::Combine(
                             ::testing::Values(3),
-                            ::testing::Values(0, 1),
-                            ::testing::ValuesIn(netPrecisions),
-                            ::testing::Values(InputShape{ {}, {{3, 24, 24, 9}} }),
-                            ::testing::ValuesIn(outIndices3),
-                            ::testing::Values(planar_4D, planar_4D_ref, perChannels_4D, blocked8_4D)),
+                            ::testing::Values(0),
+                            ::testing::Values(ElementType::f32),
+                            ::testing::ValuesIn(inputShapes4D_inPlace_0),
+                            ::testing::Values(std::vector<size_t>{}),
+                            ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
                     SplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_Block16inPlace, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(4),
-                                ::testing::Values(0, 1),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InputShape{ {}, {{4, 64, 32, 12}} }),
-                                ::testing::ValuesIn(outIndices3),
-                                ::testing::Values(blocked16_4D)),
-                        SplitLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_Split4D_CPU_Block8inPlace_1, SplitLayerCPUTest,
+                    ::testing::Combine(
+                            ::testing::Values(4),
+                            ::testing::Values(1),
+                            ::testing::ValuesIn(netPrecisions),
+                            ::testing::Values(InputShape{ {}, {{1, 32, 5, 6}} },
+                                              InputShape{ {1, 32, -1, -1},
+                                                          {
+                                                              {1, 32, 5, 6},
+                                                              {1, 32, 5, 2},
+                                                              {1, 32, 5, 8}
+                                                           } }),
+                            ::testing::ValuesIn(outIndices4),
+                            ::testing::Values(planar_4D, blocked8_4D)),
+                    SplitLayerCPUTest::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Split5D_CPU_Block8inPlace, SplitLayerCPUTest,
+INSTANTIATE_TEST_SUITE_P(smoke_Split5D_CPU_Block16inPlace_1, SplitLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Values(3),
-                                ::testing::Values(0, 1),
+                                ::testing::Values(1),
                                 ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InputShape{ {}, {{3, 24, 24, 9, 15}} }),
+                                ::testing::Values(InputShape{ {}, {{1, 48, 5, 6, 3}} },
+                                              InputShape{ {1, 48, -1, -1, 3},
+                                                          {
+                                                              {1, 48, 5, 6, 3},
+                                                              {1, 48, 5, 2, 3},
+                                                              {1, 48, 5, 8, 3}
+                                                           } }),
                                 ::testing::ValuesIn(outIndices3),
-                                ::testing::Values(planar_5D, planar_5D_ref, perChannels_5D, blocked8_5D)),
-                        SplitLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_Split5D_CPU_Block16inPlace, SplitLayerCPUTest,
-                        ::testing::Combine(
-                                ::testing::Values(4),
-                                ::testing::Values(0, 1),
-                                ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(InputShape{ {}, {{4, 64, 32, 12, 20}} }),
-                                ::testing::ValuesIn(outIndices4),
-                                ::testing::Values(blocked16_5D)),
+                                ::testing::Values(planar_5D, blocked16_5D)),
                         SplitLayerCPUTest::getTestCaseName);
 
 } // namespace

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/variadic_split.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/variadic_split.cpp
@@ -611,6 +611,98 @@ INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_dynamic_lengths, VariadicSpli
                                 ::testing::Values(planar_4D_ref)),
                         VariadicSplitLayerCPUTest::getTestCaseName);
 
+// =========================================== in - place ============================================================//
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit_CPU_planar_inPlace_0, VariadicSplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(InputShape{ {}, {{5, 6, 5, 6, 7}} },
+                                                  InputShape{ {}, {{5, 6, 5, 6}} },
+                                                  InputShape{ {}, {{5, 6, 5}} },
+                                                  InputShape{ {5, -1, -1, -1, -1},
+                                                              {
+                                                                  {5, 6, 5, 6, 7},
+                                                                  {5, 2, 5, 2, 7},
+                                                                  {5, 8, 5, 8, 7}
+                                                              } },
+                                                  InputShape{ {5, -1, -1, -1},
+                                                              {
+                                                                  {5, 6, 5, 6},
+                                                                  {5, 2, 5, 2},
+                                                                  {5, 8, 5, 8}
+                                                              } },
+                                                  InputShape{ {5, -1, -1},
+                                                              {
+                                                                  {5, 6, 5},
+                                                                  {5, 2, 5},
+                                                                  {5, 8, 5}
+                                                              } }),
+                                ::testing::Values(0),
+                                ::testing::Values(LengthsPerInfer{{1, 2, -1}}),
+                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
+                                ::testing::Values(ElementType::f32),
+                               ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
+                        VariadicSplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit_CPU_planar_inPlace_1, VariadicSplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(InputShape{ {}, {{1, 6, 5, 6, 7}} },
+                                                  InputShape{ {}, {{1, 6, 5, 6}} },
+                                                  InputShape{ {}, {{1, 6, 5}} },
+                                                  InputShape{ {1, 6, -1, -1, -1},
+                                                              {
+                                                                  {1, 6, 5, 6, 7},
+                                                                  {1, 6, 5, 2, 7},
+                                                                  {1, 6, 5, 8, 7}
+                                                              } },
+                                                  InputShape{ {1, 6, -1, -1},
+                                                              {
+                                                                  {1, 6, 5, 6},
+                                                                  {1, 6, 5, 2},
+                                                                  {1, 6, 5, 8}
+                                                              } },
+                                                  InputShape{ {1, 6, -1},
+                                                              {
+                                                                  {1, 6, 5},
+                                                                  {1, 6, 3},
+                                                                  {1, 6, 7}
+                                                              } }),
+                                ::testing::Values(1),
+                                ::testing::Values(LengthsPerInfer{{1, 2, -1}}),
+                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
+                                ::testing::Values(ElementType::f32),
+                               ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"})),
+                        VariadicSplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_block8_inPlace, VariadicSplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(InputShape{ {}, {{1, 32, 5, 6}} },
+                                                  InputShape{ {1, 32, -1, -1},
+                                                              {
+                                                                  {1, 32, 5, 6},
+                                                                  {1, 32, 5, 2},
+                                                                  {1, 32, 5, 8}
+                                                              } }),
+                                ::testing::Values(1),
+                                ::testing::Values(LengthsPerInfer{{8, 16, -1}}),
+                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
+                                ::testing::Values(ElementType::f32),
+                               ::testing::Values(blocked8_4D)),
+                        VariadicSplitLayerCPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_block16_inPlace, VariadicSplitLayerCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(InputShape{ {}, {{1, 64, 5, 6}} },
+                                                  InputShape{ {1, 64, -1, -1},
+                                                              {
+                                                                  {1, 64, 5, 6},
+                                                                  {1, 64, 5, 2},
+                                                                  {1, 64, 5, 8}
+                                                              } }),
+                                ::testing::Values(1),
+                                ::testing::Values(LengthsPerInfer{{16, 32, -1}}),
+                                ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
+                                ::testing::Values(ElementType::f32),
+                               ::testing::Values(blocked16_4D)),
+                        VariadicSplitLayerCPUTest::getTestCaseName);
 } // namespace
 
 } // namespace CPULayerTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/single_layer_tests/variadic_split.cpp
+++ b/src/plugins/intel_cpu/tests/functional/single_layer_tests/variadic_split.cpp
@@ -127,8 +127,8 @@ TEST_P(VariadicSplitLayerCPUTest, CompareWithRefs) {
 }
 
 namespace {
-const auto planar_4D_ref = CPUSpecificParams{{nchw}, {nchw}, {"ref"}, "ref"};
-const auto planar_5D_ref = CPUSpecificParams{{ncdhw}, {ncdhw}, {"ref"}, "ref"};
+const auto planar_4D_ref = CPUSpecificParams{{nchw}, {nchw}, {}, "ref"};
+const auto planar_5D_ref = CPUSpecificParams{{ncdhw}, {ncdhw}, {}, "ref"};
 
 const auto planar_4D = CPUSpecificParams{{nchw}, {nchw}, {}, "unknown"};
 const auto planar_5D = CPUSpecificParams{{ncdhw}, {ncdhw}, {}, "unknown"};
@@ -239,7 +239,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit4D_CPU_planar_static, VariadicSplitL
                                 ::testing::Values(LengthsPerInfer{{1, 3, -1}}),
                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
                                 ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(planar_4D, planar_4D_ref, perChannels_4D)),
+                                ::testing::Values(planar_4D_ref, perChannels_4D)),
                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes4D_planar = {
@@ -326,7 +326,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit5D_CPU_planar_static, VariadicSplitL
                                 ::testing::Values(LengthsPerInfer{{2, 1, -1}}),
                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
                                 ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(planar_5D, planar_5D_ref, perChannels_5D)),
+                                ::testing::Values(planar_5D_ref, perChannels_5D)),
                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes5D_planar = {
@@ -409,11 +409,11 @@ INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit5D_CPU_Block16, VariadicSplitLayerCP
 INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit3D_static, VariadicSplitLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Values(InputShape{ {}, {{14, 7, 21}} }),
-                                ::testing::Values(0, 1, 2),
+                                ::testing::Values(1, 2),
                                 ::testing::Values(LengthsPerInfer{{2, 4, -1}}),
                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
                                 ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"}, CPUSpecificParams{{}, {}, {"ref"}, "ref"})),
+                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes3D = {
@@ -446,17 +446,17 @@ INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit3D, VariadicSplitLayerCPUTest,
                                 ::testing::Values(LengthsPerInfer{{2, 4, -1}}),
                                 ::testing::ValuesIn(lengthsTypes),
                                 ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {"ref"}, "ref"})),
+                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit2D_static, VariadicSplitLayerCPUTest,
                         ::testing::Combine(
                                 ::testing::Values(InputShape{ {}, {{6, 12}} }),
-                                ::testing::Values(0, 1),
+                                ::testing::Values(1),
                                 ::testing::Values(LengthsPerInfer{{2, -1}}),
                                 ::testing::Values(ngraph::helpers::InputLayerType::CONSTANT),
                                 ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "unknown"}, CPUSpecificParams{{}, {}, {"ref"}, "ref"})),
+                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes2D = {
@@ -489,7 +489,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit2D, VariadicSplitLayerCPUTest,
                                 ::testing::Values(LengthsPerInfer{{2, -1}}),
                                 ::testing::ValuesIn(lengthsTypes),
                                 ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {"ref"}, "ref"})),
+                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit1D_static, VariadicSplitLayerCPUTest,
@@ -532,7 +532,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit1D, VariadicSplitLayerCPUTest,
                                 ::testing::Values(LengthsPerInfer{{2, 1, 1, -1}}),
                                 ::testing::ValuesIn(lengthsTypes),
                                 ::testing::ValuesIn(netPrecisions),
-                                ::testing::Values(CPUSpecificParams{{}, {}, {"ref"}, "ref"})),
+                                ::testing::Values(CPUSpecificParams{{}, {}, {}, "ref"})),
                         VariadicSplitLayerCPUTest::getTestCaseName);
 
 const std::vector<InputShape> inputShapes4D_zero_dims = {

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_reshape_concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_reshape_concat.cpp
@@ -1,0 +1,147 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "ngraph_functions/builders.hpp"
+
+
+/*This test runs the following subgraph:
+
+    param1      param2      param3      param4
+       |          |          |           |
+       |          |          |           |
+    Softmax     Softmax    Softmax     Softmax
+       |          |          |           |
+       |          |          |           |
+    Reshape     Reshape    Reshape     Reshape
+       |          |          |           |
+       |          |          |           |
+       \          /          \          /
+        \        /            \        /
+         \      /              \      /
+          Concat                Concat
+               |                |
+               |                |
+              Reshape           Reshape
+                    |           |
+                    \          /
+                     \        /
+                      \      /
+                       Concat
+                          |
+                        Softmax
+                          
+                        Result
+  
+  The main purpose of this test is checking the code path when all the nodes except Softmax use "in-place" memory mode.
+  Softmax is used as a model of an arbitrary subgraph preceding the pattern.
+*/
+
+using namespace InferenceEngine;
+using namespace ov::test;
+
+namespace SubgraphTestsDefinitions {
+
+using VectorShapes = std::vector<InputShape>;
+
+class ConcatReshapeConcatSubgraphTest : public testing::WithParamInterface<VectorShapes>,
+                                        virtual public SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<VectorShapes> obj) {
+        VectorShapes& inputShapes = obj.param;
+
+        std::ostringstream result;
+        result << "IS=";
+        for (const auto& shape : inputShapes) {
+            result << CommonTestUtils::partialShape2str({shape.first}) << "_";
+        }
+        result << "TS=";
+        for (const auto& shape : inputShapes) {
+            result << "(";
+            if (!shape.second.empty()) {
+                for (const auto& itr : shape.second) {
+                    result << CommonTestUtils::vec2str(itr);
+                }
+            }
+            result << ")";
+        }
+        return result.str();
+    }
+
+    void SetUp() override {
+        constexpr size_t number_of_params = 4ul;
+        constexpr size_t softmax_axis = 1ul;
+        constexpr int concat_axis = 0;
+        targetDevice = CommonTestUtils::DEVICE_CPU;
+        auto netPrc = ov::element::f32;
+        auto& InputShapes = this->GetParam();
+        ASSERT_EQ(InputShapes.size(), number_of_params) << "Unexpected number of input shapes";
+        init_input_shapes(InputShapes);
+        auto input_params = ngraph::builder::makeDynamicParams(netPrc, inputDynamicShapes);
+
+        ov::NodeVector first_level_reshapes;
+
+        for (size_t i = 0; i < number_of_params; ++i) {
+            auto soft_max = std::make_shared<ngraph::opset1::Softmax>(input_params[i], softmax_axis);
+            auto reshape_param = ngraph::builder::makeConstant<int>(ov::element::i32, {1}, {0});
+            auto reshape = std::make_shared<ngraph::opset1::Unsqueeze>(soft_max, reshape_param);
+            first_level_reshapes.push_back(reshape);
+        }
+
+        auto concat1 = std::make_shared<ngraph::opset1::Concat>(ov::NodeVector{first_level_reshapes[0], first_level_reshapes[1]}, concat_axis);
+        auto concat2 = std::make_shared<ngraph::opset1::Concat>(ov::NodeVector{first_level_reshapes[2], first_level_reshapes[3]}, concat_axis);
+
+        ov::NodeVector second_level_reshapes;
+        ov::NodeVector first_level_concats = {concat1, concat2};
+
+        for (size_t i = 0; i < number_of_params / 2; ++i) {
+            auto reshape_param = ngraph::builder::makeConstant<int>(ov::element::i32, {1}, {0});
+            auto reshape = std::make_shared<ngraph::opset1::Unsqueeze>(first_level_concats[i], reshape_param);
+            second_level_reshapes.push_back(reshape);
+        }
+
+        auto concat3 = std::make_shared<ngraph::opset1::Concat>(second_level_reshapes, concat_axis);
+        auto soft_max = std::make_shared<ngraph::opset1::Softmax>(concat3, softmax_axis);
+
+        ngraph::ResultVector results;
+        for (int i = 0; i < soft_max->get_output_size(); i++)
+            results.push_back(std::make_shared<ngraph::opset1::Result>(soft_max->output(i)));
+
+        function = std::make_shared<ngraph::Function>(results, input_params, "ConcatReshapeConcatPattern");
+        ov::pass::Serialize serializer("ngraph.xml", "ngraph.bin");
+        serializer.run_on_model(function);
+    }
+};
+
+TEST_P(ConcatReshapeConcatSubgraphTest, CompareWithRefs) {
+    run();
+    ov::pass::Serialize serializer("exec_graph_dyn.xml", "exec_graph_dyn.bin");
+    serializer.run_on_model(std::const_pointer_cast<ov::Model>(compiledModel.get_runtime_model()));
+}
+
+namespace {
+
+const std::vector<std::vector<InputShape>> inputShapes = {
+    // {
+    //     // {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+    //     {{2, 64}, {{2, 64}}}, // input 0
+    //     {{2, 64}, {{2, 64}}}, // input 1
+    //     {{2, 64}, {{2, 64}}}, // input 2
+    //     {{2, 64}, {{2, 64}}}  // input 3
+    // },
+    {
+        // {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+        {{2, -1}, {{2, 64}}}, // input 0
+        {{2, -1}, {{2, 64}}}, // input 1
+        {{2, -1}, {{2, 64}}}, // input 2
+        {{2, -1}, {{2, 64}}}  // input 3
+    },
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Concat_Reshape_Concat, ConcatReshapeConcatSubgraphTest,
+                        ::testing::ValuesIn(inputShapes),
+                        ConcatReshapeConcatSubgraphTest::getTestCaseName);
+} // namespace
+} // namespace SubgraphTestsDefinitions

--- a/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_reshape_concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/subgraph_tests/src/concat_reshape_concat.cpp
@@ -106,7 +106,7 @@ public:
         auto soft_max = std::make_shared<ngraph::opset1::Softmax>(concat3, softmax_axis);
 
         ngraph::ResultVector results;
-        for (int i = 0; i < soft_max->get_output_size(); i++)
+        for (size_t i = 0; i < soft_max->get_output_size(); i++)
             results.push_back(std::make_shared<ngraph::opset1::Result>(soft_max->output(i)));
 
         function = std::make_shared<ngraph::Function>(results, input_params, "ConcatReshapeConcatPattern");

--- a/src/plugins/intel_cpu/tests/unit/dnnl_memory_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/dnnl_memory_test.cpp
@@ -58,7 +58,7 @@ TEST(MemoryTest, ConcurrentResizeGetPrimitive) {
         Memory cpu_mem1(eng);
         cpu_mem1.Create(desc);
         Memory cpu_mem2(eng);
-        cpu_mem2.Create(desc, cpu_mem1.getDnnlMemoryMngr()); // tie two memory objects (memory reuse)
+        cpu_mem2.Create(desc, cpu_mem1.getMemoryMngr()); // tie two memory objects (memory reuse)
         auto desc2 = std::make_shared<CpuBlockedMemoryDesc>(Precision::FP32, Shape{10, 20});
 
         std::atomic<bool> lock{true};

--- a/src/plugins/intel_cpu/tests/unit/dnnl_memory_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/dnnl_memory_test.cpp
@@ -26,8 +26,7 @@ TEST(MemoryTest, ConcurrentGetPrimitive) {
     dnnl::memory dnnl_mem1;
     dnnl::memory dnnl_mem2;
     auto desc = std::make_shared<CpuBlockedMemoryDesc>(Precision::FP32, Shape{10, 2});
-    Memory cpu_mem1(eng);
-    cpu_mem1.Create(desc);
+    Memory cpu_mem1(eng, desc);
 
     std::atomic<bool> lock{true};
 
@@ -55,10 +54,8 @@ TEST(MemoryTest, ConcurrentResizeGetPrimitive) {
     for (size_t i = 0; i < number_of_attempts; ++i) {
         dnnl::memory dnnl_mem;
         auto desc = std::make_shared<CpuBlockedMemoryDesc>(Precision::FP32, Shape{10, 2});
-        Memory cpu_mem1(eng);
-        cpu_mem1.Create(desc);
-        Memory cpu_mem2(eng);
-        cpu_mem2.Create(desc, cpu_mem1.getMemoryMngr()); // tie two memory objects (memory reuse)
+        Memory cpu_mem1(eng, desc);
+        Memory cpu_mem2(eng, desc, cpu_mem1.getMemoryMngr());
         auto desc2 = std::make_shared<CpuBlockedMemoryDesc>(Precision::FP32, Shape{10, 20});
 
         std::atomic<bool> lock{true};

--- a/src/plugins/intel_cpu/tests/unit/dnnl_memory_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/dnnl_memory_test.cpp
@@ -32,19 +32,19 @@ TEST(MemoryTest, ConcurrentGetPrimitive) {
 
     std::thread worker1([&](){
         while (lock.load()) {}
-        dnnl_mem1 = cpu_mem1.GetPrimitive();
+        dnnl_mem1 = cpu_mem1.getPrimitive();
     });
 
     std::thread worker2([&](){
         while (lock.load()) {}
-        dnnl_mem2 = cpu_mem1.GetPrimitive();
+        dnnl_mem2 = cpu_mem1.getPrimitive();
     });
 
     lock.store(false);
 
     worker1.join();
     worker2.join();
-    ASSERT_EQ(dnnl_mem1.get_data_handle(), cpu_mem1.GetData());
+    ASSERT_EQ(dnnl_mem1.get_data_handle(), cpu_mem1.getData());
     ASSERT_EQ(dnnl_mem1, dnnl_mem2);
 }
 
@@ -62,7 +62,7 @@ TEST(MemoryTest, ConcurrentResizeGetPrimitive) {
 
         std::thread worker1([&](){
             while (lock.load()) {}
-            dnnl_mem = cpu_mem1.GetPrimitive();
+            dnnl_mem = cpu_mem1.getPrimitive();
         });
 
         std::thread worker2([&](){
@@ -74,6 +74,6 @@ TEST(MemoryTest, ConcurrentResizeGetPrimitive) {
 
         worker1.join();
         worker2.join();
-        ASSERT_EQ(dnnl_mem.get_data_handle(), cpu_mem2.GetData());
+        ASSERT_EQ(dnnl_mem.get_data_handle(), cpu_mem2.getData());
     }
 }

--- a/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
@@ -22,8 +22,8 @@
 using namespace InferenceEngine;
 using namespace ov::intel_cpu;
 namespace ReorderCPUTest {
-inline void checkReorder(const ov::intel_cpu::Memory& inputMemory,
-                         const ov::intel_cpu::Memory& outputMemory,
+inline void checkReorder(const ov::intel_cpu::IMemory& inputMemory,
+                         const ov::intel_cpu::IMemory& outputMemory,
                          const InferenceEngine::Precision& prescision) {
     auto srcData = inputMemory.GetData();
     auto dstData = outputMemory.GetData();
@@ -68,7 +68,7 @@ inline std::string layoutName(const LayoutType& layout) {
     return "Unsupported layout type";
 }
 
-inline void fillData(const ov::intel_cpu::Memory& inputMemory, const InferenceEngine::Precision& prec) {
+inline void fillData(const ov::intel_cpu::IMemory& inputMemory, const InferenceEngine::Precision& prec) {
     ov::intel_cpu::DnnlMemoryDescPtr dnnlMdInput = inputMemory.GetDescWithType<DnnlMemoryDesc>();
     const dnnl::impl::memory_desc_wrapper mdInput{dnnlMdInput->getDnnlDesc().get()};
     auto elemNum = mdInput.nelems();

--- a/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
@@ -133,10 +133,8 @@ public:
         reorderNode->addEdge(parentEdge);
         reorderNode->addEdge(childEdge);
 
-        auto parentMemory = std::make_shared<ov::intel_cpu::Memory>(cpuEngine);
-        auto childMemory = std::make_shared<ov::intel_cpu::Memory>(cpuEngine);
-        parentMemory->Create(inputDesc, nullptr);
-        childMemory->Create(outputDesc, nullptr);
+        auto parentMemory = std::make_shared<ov::intel_cpu::Memory>(cpuEngine, inputDesc);
+        auto childMemory = std::make_shared<ov::intel_cpu::Memory>(cpuEngine, outputDesc);
 
         parentEdge->reuse(parentMemory);
         childEdge->reuse(childMemory);

--- a/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
@@ -25,10 +25,10 @@ namespace ReorderCPUTest {
 inline void checkReorder(const ov::intel_cpu::IMemory& inputMemory,
                          const ov::intel_cpu::IMemory& outputMemory,
                          const InferenceEngine::Precision& prescision) {
-    auto srcData = inputMemory.GetData();
-    auto dstData = outputMemory.GetData();
-    auto mdInput = inputMemory.GetDescWithType<DnnlMemoryDesc>()->getDnnlDesc();
-    auto mdOutput = outputMemory.GetDescWithType<DnnlMemoryDesc>()->getDnnlDesc();
+    auto srcData = inputMemory.getData();
+    auto dstData = outputMemory.getData();
+    auto mdInput = inputMemory.getDescWithType<DnnlMemoryDesc>()->getDnnlDesc();
+    auto mdOutput = outputMemory.getDescWithType<DnnlMemoryDesc>()->getDnnlDesc();
 
     const dnnl::impl::memory_desc_wrapper mdwInput(mdInput.get());
     const dnnl::impl::memory_desc_wrapper mdwOutput(mdOutput.get());
@@ -69,10 +69,10 @@ inline std::string layoutName(const LayoutType& layout) {
 }
 
 inline void fillData(const ov::intel_cpu::IMemory& inputMemory, const InferenceEngine::Precision& prec) {
-    ov::intel_cpu::DnnlMemoryDescPtr dnnlMdInput = inputMemory.GetDescWithType<DnnlMemoryDesc>();
+    ov::intel_cpu::DnnlMemoryDescPtr dnnlMdInput = inputMemory.getDescWithType<DnnlMemoryDesc>();
     const dnnl::impl::memory_desc_wrapper mdInput{dnnlMdInput->getDnnlDesc().get()};
     auto elemNum = mdInput.nelems();
-    auto inputReorderData = inputMemory.GetData();
+    auto inputReorderData = inputMemory.getData();
     switch (prec) {
     case InferenceEngine::Precision::FP32:
         for (int64_t i = 0; i < elemNum; ++i)
@@ -272,7 +272,7 @@ protected:
     // Fill dstData with zeros
     void generateInput() {
         fillData(parentEdge->getMemory(), prec);
-        memset(childEdge->getMemory().GetData(), 0, childEdge->getMemory().GetSize());
+        memset(childEdge->getMemory().getData(), 0, childEdge->getMemory().getSize());
     }
 
     size_t getNumElems(const std::vector<size_t>& dims) {


### PR DESCRIPTION
### Details:
Refactor plugin's memory usage so as to allow inplace memory use making a view on a part of the base tensor when certain conditions are fulfilled:
1. The portion of the base tensor to be mapped is known in advance
2. Only linear offset is allowed (strided read still must be performed via tensor descriptors)
3. Tensor reference chain can be determined on the compilation stage

### To Do list:

- [x] Does not work properly with memory reuse for static shapes
- [x] There should be issues with multi stream execution due to unsafe usage of memory manager in parallel threads
- [ ] Run in place direction resolution in the same pass of the in place conflicts detection in order to avoid possible extra reorders
- [ ] Remove linear offset from the memory descriptor
- [x] Consider removing `setDataPtr()` call from the `Memory` class
- [x] Add a mechanism of detection memory modifications to help reuse external memory on inputs
- [x] Extract memory initialization from `Edge::getMemoryPtr()` call
- [x] Add in-place dedicated tests for: Concat, Split, Variadic Split, Gather

### Tickets:
 - 109181
