### PR TITLE
Updated install docs for 2023.0

### DIFF
--- a/docs/install_guides/installing-openvino-apt.md
+++ b/docs/install_guides/installing-openvino-apt.md
@@ -4,7 +4,7 @@
 
 @sphinxdirective
 
-With the OpenVINO™ 2022.3 release, you can install OpenVINO Runtime on Linux using the APT repository. 
+With the OpenVINO™ 2023.0 release, you can install OpenVINO Runtime on Linux using the APT repository. 
 OpenVINO™ Development Tools can be installed via PyPI only.
 See `Installing Additional Components <step-3-optional-install-additional-components>`__ for more information. 
 
@@ -40,7 +40,7 @@ Prerequisites
 .. tab:: Software Requirements
 
   * `CMake 3.13 or higher, 64-bit <https://cmake.org/download/>`__
-  * GCC 7.5.0 (for Ubuntu 18.04) or GCC 9.3.0 (for Ubuntu 20.04)
+  * GCC 7.5.0 (for Ubuntu 18.04), GCC 9.3.0 (for Ubuntu 20.04) or GCC 11.3.0 (for Ubuntu 22.04)
   * `Python 3.7 - 3.11, 64-bit <https://www.python.org/downloads/>`__
 
 
@@ -78,11 +78,11 @@ Step 1: Set Up the OpenVINO Toolkit APT Repository
 
 2. Add the repository via the following command:
 
-   .. tab:: Ubuntu 18
+   .. tab:: Ubuntu 22
 
       .. code-block:: sh
 
-         echo "deb https://apt.repos.intel.com/openvino/2023 ubuntu18 main" | sudo tee /etc/apt/sources.list.d/intel-openvino-2023.list
+         echo "deb https://apt.repos.intel.com/openvino/2023 ubuntu22 main" | sudo tee /etc/apt/sources.list.d/intel-openvino-2023.list
 
    .. tab:: Ubuntu 20
 
@@ -90,11 +90,11 @@ Step 1: Set Up the OpenVINO Toolkit APT Repository
 
          echo "deb https://apt.repos.intel.com/openvino/2023 ubuntu20 main" | sudo tee /etc/apt/sources.list.d/intel-openvino-2023.list
 
-   .. tab:: Ubuntu 22
+   .. tab:: Ubuntu 18
 
       .. code-block:: sh
 
-         echo "deb https://apt.repos.intel.com/openvino/2023 ubuntu22 main" | sudo tee /etc/apt/sources.list.d/intel-openvino-2023.list
+         echo "deb https://apt.repos.intel.com/openvino/2023 ubuntu18 main" | sudo tee /etc/apt/sources.list.d/intel-openvino-2023.list
 
 
 3. Update the list of packages via the update command:

--- a/docs/install_guides/installing-openvino-brew.md
+++ b/docs/install_guides/installing-openvino-brew.md
@@ -3,13 +3,9 @@
 @sphinxdirective
 
 .. note::
-   
-   Only CPU is supported for inference if you install OpenVINO via Homebrew.
 
    Installing OpenVINO Runtime from Homebrew is recommended for C++ developers. 
    If you work with Python, consider :doc:`installing OpenVINO from PyPI <openvino_docs_install_guides_installing_openvino_pip>`
-
-   The current Homebrew package provides inference support for CPU only.
 
 You can use `Homebrew <https://brew.sh/>`__ to install OpenVINO Runtime on macOS and Linux. 
 OpenVINO™ Development Tools can be installed via PyPI only. 
@@ -42,7 +38,7 @@ See `Installing Additional Components <#optional-installing-additional-component
    
      * `Homebrew <https://brew.sh/>`_
      * `CMake 3.13 or higher, 64-bit <https://cmake.org/download/>`__
-     * GCC 7.5.0 (for Ubuntu 18.04) or GCC 9.3.0 (for Ubuntu 20.04)
+     * GCC 7.5.0 (for Ubuntu 18.04), GCC 9.3.0 (for Ubuntu 20.04) or GCC 11.3.0 (for Ubuntu 22.04)
      * `Python 3.7 - 3.10, 64-bit <https://www.python.org/downloads/>`__
 
 

--- a/docs/install_guides/installing-openvino-conda.md
+++ b/docs/install_guides/installing-openvino-conda.md
@@ -7,8 +7,6 @@
    Installing OpenVINO Runtime from Conda Forge is recommended for C++ developers, as it provides only the C++ Runtime API.
    If you work with Python, consider :doc:`installing OpenVINO from PyPI <openvino_docs_install_guides_installing_openvino_pip>`
 
-   The current Anaconda package does not provide support for GPU inference.
-
 .. tab:: System Requirements
 
    | Full requirement listing is available in:
@@ -50,7 +48,7 @@ Installing OpenVINO Runtime with Anaconda Package Manager
 
    .. code-block:: sh
 
-      conda install -c conda-forge openvino=2022.3.0
+      conda install -c conda-forge openvino=2023.0.0
 
    Congratulations! You have finished installing OpenVINO Runtime.
 
@@ -63,7 +61,7 @@ with the proper OpenVINO version number:
 
 .. code-block:: sh
    
-   conda remove openvino=2022.3.0
+   conda remove openvino=2023.0.0
 
 
 What's Next?

--- a/docs/install_guides/installing-openvino-from-archive-linux.md
+++ b/docs/install_guides/installing-openvino-from-archive-linux.md
@@ -45,7 +45,7 @@ See the `Release Notes <https://software.intel.com/en-us/articles/OpenVINO-RelNo
 
     * GCC 8.4.1
 
-  .. tab:: CENTOS 7
+  .. tab:: CentOS 7
 
     * GCC 8.3.1
     Use the following instructions to install it:
@@ -54,7 +54,7 @@ See the `Release Notes <https://software.intel.com/en-us/articles/OpenVINO-RelNo
     .. code-block:: sh
 
       sudo yum update -y && sudo yum install -y centos-release-scl epel-release
-      sudo yum install -y devtoolset-8 git patchelf
+      sudo yum install -y devtoolset-8
 
     Enable devtoolset-8 and check current gcc version
 
@@ -88,45 +88,53 @@ Step 1: Download and Install the OpenVINO Core Components
    
       cd <user_home>/Downloads
     
-4. Download the `OpenVINO Runtime archive file for your system <https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.3/linux/>`_, extract the files, rename the extracted folder and move it to the desired path:
+4. Download the `OpenVINO Runtime archive file for your system <https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0/linux/>`_, extract the files, rename the extracted folder and move it to the desired path:
+
+   .. tab:: Ubuntu 22.04
+
+      .. code-block:: sh
+   
+         curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0/linux/l_openvino_toolkit_ubuntu22_2023.0.0.9052.9752fafe8eb_x86_64.tgz --output openvino_2023.0.0.tgz
+         tar -xf openvino_2023.0.0.tgz
+         sudo mv l_openvino_toolkit_ubuntu22_2023.0.0.9052.9752fafe8eb_x86_64 /opt/intel/openvino_2023.0.0
 
    .. tab:: Ubuntu 20.04
 
       .. code-block:: sh
    
-         curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.3/linux/l_openvino_toolkit_ubuntu20_2022.3.0.9052.9752fafe8eb_x86_64.tgz --output openvino_2022.3.0.tgz
-         tar -xf openvino_2022.3.0.tgz
-         sudo mv l_openvino_toolkit_ubuntu20_2022.3.0.9052.9752fafe8eb_x86_64 /opt/intel/openvino_2022.3.0
-  
+         curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0/linux/l_openvino_toolkit_ubuntu20_2023.0.0.9052.9752fafe8eb_x86_64.tgz --output openvino_2023.0.0.tgz
+         tar -xf openvino_2023.0.0.tgz
+         sudo mv l_openvino_toolkit_ubuntu20_2023.0.0.9052.9752fafe8eb_x86_64 /opt/intel/openvino_2023.0.0
+
    .. tab:: Ubuntu 18.04
 
       .. code-block:: sh
    
-         curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.3/linux/l_openvino_toolkit_ubuntu18_2022.3.0.9052.9752fafe8eb_x86_64.tgz --output openvino_2022.3.0.tgz
-         tar -xf openvino_2022.3.0.tgz
-         sudo mv l_openvino_toolkit_ubuntu18_2022.3.0.9052.9752fafe8eb_x86_64 /opt/intel/openvino_2022.3.0
+         curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0/linux/l_openvino_toolkit_ubuntu18_2023.0.0.9052.9752fafe8eb_x86_64.tgz --output openvino_2023.0.0.tgz
+         tar -xf openvino_2023.0.0.tgz
+         sudo mv l_openvino_toolkit_ubuntu18_2023.0.0.9052.9752fafe8eb_x86_64 /opt/intel/openvino_2023.0.0
 
    .. tab:: RHEL 8
 
       .. code-block:: sh
    
-         curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.3/linux/l_openvino_toolkit_rhel8_2022.3.0.9052.9752fafe8eb_x86_64.tgz --output openvino_2022.3.0.tgz
-         tar -xf openvino_2022.3.0.tgz
-         sudo mv l_openvino_toolkit_rhel8_2022.3.0.9052.9752fafe8eb_x86_64 /opt/intel/openvino_2022.3.0
+         curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0/linux/l_openvino_toolkit_rhel8_2023.0.0.9052.9752fafe8eb_x86_64.tgz --output openvino_2023.0.0.tgz
+         tar -xf openvino_2023.0.0.tgz
+         sudo mv l_openvino_toolkit_rhel8_2023.0.0.9052.9752fafe8eb_x86_64 /opt/intel/openvino_2023.0.0
 
    .. tab:: CentOS 7
 
       .. code-block:: sh
    
-         curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.3/linux/l_openvino_toolkit_centos7_2022.3.0.9052.9752fafe8eb_x86_64.tgz --output openvino_2022.3.0.tgz
-         tar -xf openvino_2022.3.0.tgz
-         sudo mv l_openvino_toolkit_centos7_2022.3.0.9052.9752fafe8eb_x86_64 /opt/intel/openvino_2022.3.0
+         curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0/linux/l_openvino_toolkit_centos7_2023.0.0.9052.9752fafe8eb_x86_64.tgz --output openvino_2023.0.0.tgz
+         tar -xf openvino_2023.0.0.tgz
+         sudo mv l_openvino_toolkit_centos7_2023.0.0.9052.9752fafe8eb_x86_64 /opt/intel/openvino_2023.0.0
 
 5. Install required system dependencies on Linux. To do this, OpenVINO provides a script in the extracted installation directory. Run the following command:
    
    .. code-block:: sh
    
-      cd /opt/intel/openvino_2022.3.0
+      cd /opt/intel/openvino_2023.0.0
       sudo -E ./install_dependencies/install_openvino_dependencies.sh 
 
 6. For simplicity, it is useful to create a symbolic link as below:
@@ -134,16 +142,16 @@ Step 1: Download and Install the OpenVINO Core Components
    .. code-block:: sh
    
       cd /opt/intel
-      sudo ln -s openvino_2022.3.0 openvino_2022
+      sudo ln -s openvino_2023.0.0 openvino_2023
   
    .. note::
-      If you have already installed a previous release of OpenVINO 2022, a symbolic link to the ``openvino_2022`` folder may already exist. 
-      Unlink the previous link with ``sudo unlink openvino_2022``, and then re-run the command above.
+      If you have already installed a previous release of OpenVINO 2023, a symbolic link to the ``openvino_2023`` folder may already exist. 
+      Unlink the previous link with ``sudo unlink openvino_2023``, and then re-run the command above.
 
 
-Congratulations, you have finished the installation! The ``/opt/intel/openvino_2022`` folder now contains 
-the core components for OpenVINO. If you used a different path in Step 2, for example, ``/home/<USER>/Intel/``, 
-OpenVINO is now in ``/home/<USER>/Intel/openvino_2022``. The path to the ``openvino_2022`` directory is 
+Congratulations, you have finished the installation! The ``/opt/intel/openvino_2023`` folder now contains 
+the core components for OpenVINO. If you used a different path in Step 2, for example, ``/home/<USER>/intel/``, 
+OpenVINO is now in ``/home/<USER>/intel/openvino_2023``. The path to the ``openvino_2023`` directory is 
 also referred as ``<INSTALL_DIR>`` throughout the OpenVINO documentation.
 
 
@@ -152,11 +160,11 @@ Step 2: Configure the Environment
 
 You must update several environment variables before you can compile and run OpenVINO applications. 
 Open a terminal window and run the ``setupvars.sh`` script as shown below to temporarily set your environment variables. 
-If your <INSTALL_DIR> is not ``/opt/intel/openvino_2022``, use the correct one instead.
+If your <INSTALL_DIR> is not ``/opt/intel/openvino_2023``, use the correct one instead.
 
 .. code-block:: sh
 
-   source /opt/intel/openvino_2022/setupvars.sh
+   source /opt/intel/openvino_2023/setupvars.sh
 
 
 If you have more than one OpenVINO version installed on your system, you can easily switch versions by sourcing the `setupvars.sh` of your choice.
@@ -165,7 +173,7 @@ If you have more than one OpenVINO version installed on your system, you can eas
    
    The above command must be re-run every time you start a new terminal session. 
    To set up Linux to automatically run the command every time a new terminal is opened, 
-   open ``~/.bashrc`` in your favorite editor and add ``source /opt/intel/openvino_2022/setupvars.sh`` after the last line. 
+   open ``~/.bashrc`` in your favorite editor and add ``source /opt/intel/openvino_2023/setupvars.sh`` after the last line. 
    Next time when you open a terminal, you will see ``[setupvars.sh] OpenVINO™ environment initialized``. 
    Changing ``.bashrc`` is not recommended when you have multiple OpenVINO versions on your machine and want to switch among them.
 

--- a/docs/install_guides/installing-openvino-from-archive-macos.md
+++ b/docs/install_guides/installing-openvino-from-archive-macos.md
@@ -2,7 +2,7 @@
 
 @sphinxdirective
 
-With the OpenVINO™ 2022.3 release, you can download and use archive files to install OpenVINO Runtime. The archive files contain pre-built binaries and library files needed for OpenVINO Runtime, as well as code samples.
+With the OpenVINO™ 2023.0 release, you can download and use archive files to install OpenVINO Runtime. The archive files contain pre-built binaries and library files needed for OpenVINO Runtime, as well as code samples.
 
 Installing OpenVINO Runtime from archive files is recommended for C++ developers. If you are working with Python, the PyPI package has everything needed for Python development and deployment on CPU and GPUs. Visit the :doc:`Install OpenVINO from PyPI <openvino_docs_install_guides_installing_openvino_pip>` page for instructions on how to install OpenVINO Runtime for Python using PyPI.
 
@@ -53,53 +53,53 @@ Step 1: Install OpenVINO Core Components
       cd <user_home>/Downloads
 
 
-4. Download the `OpenVINO Runtime archive file for macOS <https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.3/macos/>`__, extract the files, rename the extracted folder and move it to the desired path:
+4. Download the `OpenVINO Runtime archive file for macOS <https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0/macos/>`__, extract the files, rename the extracted folder and move it to the desired path:
 
    .. tab:: x86, 64-bit
 
       .. code-block:: sh
 
-         curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.3/macos/m_openvino_toolkit_macos_10_15_2022.3.0.9052.9752fafe8eb_x86_64.tgz --output openvino_2022.3.0.tgz
-         tar -xf openvino_2022.3.0.tgz
-         sudo mv m_openvino_toolkit_macos_10_15_2022.3.0.9052.9752fafe8eb_x86_64 /opt/intel/openvino_2022.3.0
+         curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0/macos/m_openvino_toolkit_macos_10_15_2023.0.0.9052.9752fafe8eb_x86_64.tgz --output openvino_2023.0.0.tgz
+         tar -xf openvino_2023.0.0.tgz
+         sudo mv m_openvino_toolkit_macos_10_15_2023.0.0.9052.9752fafe8eb_x86_64 /opt/intel/openvino_2023.0.0
 
    .. tab:: ARM, 64-bit
 
       .. code-block:: sh
 
-         curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.3/macos/m_openvino_toolkit_macos_11_0_2022.3.0.9052.9752fafe8eb_arm64.tgz --output openvino_2022.3.0.tgz
-         tar -xf openvino_2022.3.0.tgz
-         sudo mv m_openvino_toolkit_macos_11_0_2022.3.0.9052.9752fafe8eb_arm64 /opt/intel/openvino_2022.3.0
+         curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0/macos/m_openvino_toolkit_macos_11_0_2023.0.0.9052.9752fafe8eb_arm64.tgz --output openvino_2023.0.0.tgz
+         tar -xf openvino_2023.0.0.tgz
+         sudo mv m_openvino_toolkit_macos_11_0_2023.0.0.9052.9752fafe8eb_arm64 /opt/intel/openvino_2023.0.0
 
 
 5. For simplicity, it is useful to create a symbolic link as below:
 
    .. code-block:: sh
 
-      sudo ln -s openvino_2022.3.0 openvino_2022
+      sudo ln -s openvino_2023.0.0 openvino_2023
 
    .. note::
 
-      If you have already installed a previous release of OpenVINO 2022, a symbolic link to the ``openvino_2022`` folder may already exist. Unlink the previous link with ``sudo unlink openvino_2022``, and then re-run the command above.
+      If you have already installed a previous release of OpenVINO 2023, a symbolic link to the ``openvino_2023`` folder may already exist. Unlink the previous link with ``sudo unlink openvino_2023``, and then re-run the command above.
 
 
-Congratulations, you finished the installation! The ``/opt/intel/openvino_2022`` folder now contains the core components for OpenVINO. If you used a different path in Step 2, you will find the ``openvino_2022`` folder there. The path to the ``openvino_2022`` directory is also referred as ``<INSTALL_DIR>`` throughout the OpenVINO documentation.
+Congratulations, you finished the installation! The ``/opt/intel/openvino_2023`` folder now contains the core components for OpenVINO. If you used a different path in Step 2, you will find the ``openvino_2023`` folder there. The path to the ``openvino_2023`` directory is also referred as ``<INSTALL_DIR>`` throughout the OpenVINO documentation.
 
 Step 2: Configure the Environment
 +++++++++++++++++++++++++++++++++
 
-You must update several environment variables before you can compile and run OpenVINO applications. Open a terminal window and run the ``setupvars.sh`` script as shown below to temporarily set your environment variables. If your ``<INSTALL_DIR>`` is not ``/opt/intel/openvino_2022``, use the correct one instead.
+You must update several environment variables before you can compile and run OpenVINO applications. Open a terminal window and run the ``setupvars.sh`` script as shown below to temporarily set your environment variables. If your ``<INSTALL_DIR>`` is not ``/opt/intel/openvino_2023``, use the correct one instead.
 
 .. code-block:: sh
 
-   source /opt/intel/openvino_2022/setupvars.sh
+   source /opt/intel/openvino_2023/setupvars.sh
 
 
 If you have more than one OpenVINO™ version on your machine, you can easily switch its version by sourcing the ``setupvars.sh`` of your choice.
 
 .. note::
 
-   The above command must be re-run every time you start a new terminal session. To set up macOS to automatically run the command every time a new terminal is opened, open ``~/.zshrc`` in your favorite editor and add ``source /opt/intel/openvino_2022/setupvars.sh`` after the last line. Next time when you open a terminal, you will see ``[setupvars.sh] OpenVINO™ environment initialized``. Changing ``~/.zshrc`` is not recommended when you have multiple OpenVINO versions on your machine and want to switch among them.
+   The above command must be re-run every time you start a new terminal session. To set up macOS to automatically run the command every time a new terminal is opened, open ``~/.zshrc`` in your favorite editor and add ``source /opt/intel/openvino_2023/setupvars.sh`` after the last line. Next time when you open a terminal, you will see ``[setupvars.sh] OpenVINO™ environment initialized``. Changing ``~/.zshrc`` is not recommended when you have multiple OpenVINO versions on your machine and want to switch among them.
 
 The environment variables are set. Continue to the next section if you want to download any additional components.
 

--- a/docs/install_guides/installing-openvino-from-archive-windows.md
+++ b/docs/install_guides/installing-openvino-from-archive-windows.md
@@ -2,7 +2,7 @@
 
 @sphinxdirective
  
-With the OpenVINO™ 2022.3 release, you can download and use archive files to install OpenVINO Runtime. The archive files contain pre-built binaries and library files needed for OpenVINO Runtime, as well as code samples.
+With the OpenVINO™ 2023.0 release, you can download and use archive files to install OpenVINO Runtime. The archive files contain pre-built binaries and library files needed for OpenVINO Runtime, as well as code samples.
 
 Installing OpenVINO Runtime from archive files is recommended for C++ developers. If you are working with Python, the PyPI package has everything needed for Python development and deployment on CPU and GPUs. See the :doc:`Install OpenVINO from PyPI <openvino_docs_install_guides_installing_openvino_pip>` page for instructions on how to install OpenVINO Runtime for Python using PyPI.
 
@@ -77,12 +77,12 @@ Step 1: Download and Install OpenVINO Core Components
    .. code-block:: sh
 
       cd <user_home>/Downloads
-      curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.3/windows/w_openvino_toolkit_windows_2022.3.0.9052.9752fafe8eb_x86_64.zip --output openvino_2022.   3.0.zip
+      curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0/windows/w_openvino_toolkit_windows_2023.0.0.9052.9752fafe8eb_x86_64.zip --output openvino_2023.0.0.zip
 
 
    .. note::
 
-      A ``.sha256`` file is provided together with the archive file to validate your download process. To do that, download the ``.sha256`` file from the same repository and run ``CertUtil -hashfile openvino_2022.3.0.zip SHA256``. Compare the returned value in the output with what's in the ``.sha256`` file: if the values are the same, you have downloaded the correct file successfully; if not, create a Support ticket `here <https://www.intel.com/content/www/us/en/support/contact-intel.html>`__.
+      A ``.sha256`` file is provided together with the archive file to validate your download process. To do that, download the ``.sha256`` file from the same repository and run ``CertUtil -hashfile openvino_2023.0.0.zip SHA256``. Compare the returned value in the output with what's in the ``.sha256`` file: if the values are the same, you have downloaded the correct file successfully; if not, create a Support ticket `here <https://www.intel.com/content/www/us/en/support/contact-intel.html>`__.
 
 
 3. Use your favorite tool to extract the archive file, rename the extracted folder, and move it to the ``C:\Program Files (x86)\Intel`` directory.
@@ -91,9 +91,9 @@ Step 1: Download and Install OpenVINO Core Components
 
    .. code-block:: sh
 
-      tar -xf openvino_2022.3.0.zip
-      ren w_openvino_toolkit_windows_2022.3.0.9052.9752fafe8eb_x86_64 openvino_2022.3.0
-      move openvino_2022.3.0 "C:\Program Files (x86)\Intel"
+      tar -xf openvino_2023.0.0.zip
+      ren w_openvino_toolkit_windows_2023.0.0.9052.9752fafe8eb_x86_64 openvino_2023.0.0
+      move openvino_2023.0.0 "C:\Program Files (x86)\Intel"
 
 
 4. For simplicity, it is useful to create a symbolic link. Open a command prompt window as administrator (see Step 1 for how to do this) and run the following commands:
@@ -101,26 +101,26 @@ Step 1: Download and Install OpenVINO Core Components
    .. code-block:: sh
 
       cd C:\Program Files (x86)\Intel
-      mklink /D openvino_2022 openvino_2022.3.0
+      mklink /D openvino_2023 openvino_2023.0.0
 
 
    .. note::
 
-      If you have already installed a previous release of OpenVINO 2022, a symbolic link to the ``openvino_2022`` folder may already exist. If you want to override it, navigate to the ``C:\Program Files (x86)\Intel`` folder and delete the existing linked folder before running the ``mklink`` command.
+      If you have already installed a previous release of OpenVINO 2022, a symbolic link to the ``openvino_2023`` folder may already exist. If you want to override it, navigate to the ``C:\Program Files (x86)\Intel`` folder and delete the existing linked folder before running the ``mklink`` command.
 
 
-Congratulations, you finished the installation! The ``C:\Program Files (x86)\Intel\openvino_2022`` folder now contains the core components for OpenVINO. If you used a different path in Step 1, you will find the ``openvino_2022`` folder there. The path to the ``openvino_2022`` directory is also referred as ``<INSTALL_DIR>`` throughout the OpenVINO documentation.
+Congratulations, you finished the installation! The ``C:\Program Files (x86)\Intel\openvino_2023`` folder now contains the core components for OpenVINO. If you used a different path in Step 1, you will find the ``openvino_2023`` folder there. The path to the ``openvino_2023`` directory is also referred as ``<INSTALL_DIR>`` throughout the OpenVINO documentation.
 
 .. _set-the-environment-variables-windows:
 
 Step 2: Configure the Environment
 +++++++++++++++++++++++++++++++++
 
-You must update several environment variables before you can compile and run OpenVINO™ applications. Open the Command Prompt, and run the ``setupvars.bat`` batch file to temporarily set your environment variables. If your ``<INSTALL_DIR>`` is not ``C:\Program Files (x86)\Intel\openvino_2022``, use the correct directory instead.
+You must update several environment variables before you can compile and run OpenVINO™ applications. Open the Command Prompt, and run the ``setupvars.bat`` batch file to temporarily set your environment variables. If your ``<INSTALL_DIR>`` is not ``C:\Program Files (x86)\Intel\openvino_2023``, use the correct directory instead.
 
 .. code-block: sh
 
-   "C:\Program Files (x86)\Intel\openvino_2022\setupvars.bat"
+   "C:\Program Files (x86)\Intel\openvino_2023\setupvars.bat"
 
 
 .. important::

--- a/docs/install_guides/installing-openvino-pip.md
+++ b/docs/install_guides/installing-openvino-pip.md
@@ -83,7 +83,7 @@ Use the following command:
 
 .. code-block:: sh
 
-   pip install openvino
+   python -m pip install openvino
 
 
 Step 5. Verify that the Package Is Installed
@@ -93,10 +93,9 @@ Run the command below:
 
 .. code-block:: sh
 
-   python -c "from openvino.runtime import Core"
+   python -c "from openvino.runtime import Core; print(Core().available_devices)"
 
-
-If installation was successful, you will not see any error messages (no console output). Congratulations! You have finished installing OpenVINO Runtime.
+If installation was successful, you will see the list of available devices. Congratulations! You have finished installing OpenVINO Runtime.
 
 
 What's Next?

--- a/docs/install_guides/installing-openvino-raspbian.md
+++ b/docs/install_guides/installing-openvino-raspbian.md
@@ -6,7 +6,7 @@
 
    * These steps apply to Raspbian OS (the official OS for Raspberry Pi boards).
    * These steps have been validated with Raspberry Pi 3.
-   * There is also an open-source version of OpenVINO™ that can be compiled for arch64 (see `build instructions <https://github.com/openvinotoolkit/openvino/blob/master/docs/dev/build_raspbian.md>`_).
+   * There is also an open-source version of OpenVINO™ that can be compiled for aarch64 (see `build instructions <https://github.com/openvinotoolkit/openvino/blob/master/docs/dev/build_raspbian.md>`_).
 
 Development and Target Systems
 ###############################
@@ -38,37 +38,37 @@ Step 1: Download and Install OpenVINO Runtime
 
       The ``/opt/intel`` path is the recommended folder path for administrators or root users. If you prefer to install OpenVINO in regular userspace, the recommended path is ``/home/<USER>/intel``. You may use a different path if desired.
 
-#. Go to your ``~/Downloads`` directory and download OpenVINO Runtime archive file for Debian from `OpenVINO package repository <https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.3/linux/>`_.
-
-   .. tab:: ARM 32-bit
-
-      .. code-block:: sh
-
-         cd ~/Downloads/
-         sudo wget https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.3/linux/l_openvino_toolkit_debian9_2022.3.0.9052.9752fafe8eb_armhf.tgz -O openvino_2022.3.0.tgz
+#. Go to your ``~/Downloads`` directory and download OpenVINO Runtime archive file for Debian from `OpenVINO package repository <https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0/linux/>`_.
 
    .. tab:: ARM 64-bit
 
       .. code-block:: sh
 
          cd ~/Downloads/
-         sudo wget https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.3/linux/l_openvino_toolkit_debian9_2022.3.0.9052.9752fafe8eb_arm64.tgz -O openvino_2022.3.0.tgz
+         sudo wget https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0/linux/l_openvino_toolkit_debian9_2023.0.0.9052.9752fafe8eb_arm64.tgz -O openvino_2023.0.0.tgz
+
+   .. tab:: ARM 32-bit
+
+      .. code-block:: sh
+
+         cd ~/Downloads/
+         sudo wget https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.0/linux/l_openvino_toolkit_debian9_2023.0.0.9052.9752fafe8eb_armhf.tgz -O openvino_2023.0.0.tgz
 
 #. Extract the archive file and move it to the installation folder:
 
-   .. tab:: ARM 32-bit
-
-      .. code-block:: sh
-
-         sudo tar -xf openvino_2022.3.0.tgz
-         sudo mv l_openvino_toolkit_debian9_2022.3.0.9052.9752fafe8eb_armhf /opt/intel/openvino_2022.3.0
-
    .. tab:: ARM 64-bit
 
       .. code-block:: sh
 
-         sudo tar -xf openvino_2022.3.0.tgz
-         sudo mv l_openvino_toolkit_debian9_2022.3.0.9052.9752fafe8eb_arm64 /opt/intel/openvino_2022.3.0
+         sudo tar -xf openvino_2023.0.0.tgz
+         sudo mv l_openvino_toolkit_debian9_2023.0.0.9052.9752fafe8eb_arm64 /opt/intel/openvino_2023.0.0
+
+   .. tab:: ARM 32-bit
+
+      .. code-block:: sh
+
+         sudo tar -xf openvino_2023.0.0.tgz
+         sudo mv l_openvino_toolkit_debian9_2023.0.0.9052.9752fafe8eb_armhf /opt/intel/openvino_2023.0.0
 
 #. Install required system dependencies on Linux. To do this, OpenVINO provides a script in the extracted installation directory. Run the following command:
 
@@ -80,14 +80,14 @@ Step 1: Download and Install OpenVINO Runtime
 
    .. code-block:: sh
 
-      sudo ln -s openvino_2022.3.0 openvino_2022
+      sudo ln -s openvino_2023.0.0 openvino_2023
 
    .. note::
 
-      If you have already installed a previous release of OpenVINO 2022, a symbolic link to the ``openvino_2022`` folder may already exist. Unlink the previous link with ``sudo unlink openvino_2022``, and then re-run the command above.
+      If you have already installed a previous release of OpenVINO 2023, a symbolic link to the ``openvino_2023`` folder may already exist. Unlink the previous link with ``sudo unlink openvino_2023``, and then re-run the command above.
 
 
-Congratulations, you finished the installation! The ``/opt/intel/openvino_2022`` folder now contains the core components for OpenVINO. If you used a different path in Step 2, for example, ``/home/<USER>/intel/``, OpenVINO is then installed in ``/home/<USER>/intel/openvino_2022``. The path to the ``openvino_2022`` directory is also referred as ``<INSTALL_DIR>`` throughout the OpenVINO documentation.
+Congratulations, you finished the installation! The ``/opt/intel/openvino_2023`` folder now contains the core components for OpenVINO. If you used a different path in Step 2, for example, ``/home/<USER>/intel/``, OpenVINO is then installed in ``/home/<USER>/intel/openvino_2023``. The path to the ``openvino_2023`` directory is also referred as ``<INSTALL_DIR>`` throughout the OpenVINO documentation.
 
 .. _install-external-dependencies:
 
@@ -108,18 +108,18 @@ CMake is installed. Continue to the next section to set the environment variable
 Step 3: Set the Environment Variables
 #####################################
 
-You must update several environment variables before you can compile and run OpenVINO applications. Open a terminal window and run the ``setupvars.sh`` script as shown below to temporarily set your environment variables. If your <INSTALL_DIR> is not ``/opt/intel/openvino_2022``, use the correct one instead.
+You must update several environment variables before you can compile and run OpenVINO applications. Open a terminal window and run the ``setupvars.sh`` script as shown below to temporarily set your environment variables. If your <INSTALL_DIR> is not ``/opt/intel/openvino_2023``, use the correct one instead.
 
 .. code-block:: sh
 
-   source /opt/intel/openvino_2022/setupvars.sh
+   source /opt/intel/openvino_2023/setupvars.sh
 
 
 If you have more than one OpenVINO version on your machine, you can easily switch its version by sourcing the ``setupvars.sh`` of your choice.
 
 .. note::
 
-   The above command must be re-run every time you start a new terminal session. To set up Linux to automatically run the command every time a new terminal is opened, open ``~/.bashrc`` in your favorite editor and add ``source /opt/intel/openvino_2022/setupvars.sh`` after the last line. Next time when you open a terminal, you will see ``[setupvars.sh] OpenVINO™ environment initialized``. Changing ``.bashrc`` is not recommended when you have multiple OpenVINO versions on your machine and want to switch among them.
+   The above command must be re-run every time you start a new terminal session. To set up Linux to automatically run the command every time a new terminal is opened, open ``~/.bashrc`` in your favorite editor and add ``source /opt/intel/openvino_2023/setupvars.sh`` after the last line. Next time when you open a terminal, you will see ``[setupvars.sh] OpenVINO™ environment initialized``. Changing ``.bashrc`` is not recommended when you have multiple OpenVINO versions on your machine and want to switch among them.
 
 The environment variables are set. Continue to the next section if you want to download any additional components.
 

--- a/docs/install_guides/installing-openvino-yum.md
+++ b/docs/install_guides/installing-openvino-yum.md
@@ -4,7 +4,7 @@
 
 @sphinxdirective
 
-With the OpenVINO™ 2022.3 release, you can install OpenVINO Runtime on Linux using the YUM repository. 
+With the OpenVINO™ 2023.0 release, you can install OpenVINO Runtime on Linux using the YUM repository. 
 OpenVINO™ Development Tools can be installed via PyPI only. See 
 `Installing Additional Components <#step-3-optional-install-additional-components>`__ for more information.
 

--- a/docs/install_guides/pypi-openvino-dev.md
+++ b/docs/install_guides/pypi-openvino-dev.md
@@ -102,9 +102,9 @@ For example, to install and configure the components for working with TensorFlow
 
 - To verify that OpenVINO Runtime from the **runtime package** is available, run the command below:
    ```sh
-   python -c "from openvino.runtime import Core"
+   python -c "from openvino.runtime import Core; print(Core().available_devices)"
    ```
-   If installation was successful, you will not see any error messages (no console output).
+   If installation was successful, you will see a list of available devices.
 
 <a id="whats-in-the-package"></a>
 
@@ -181,7 +181,7 @@ sudo apt-get install libpython3.7
 - [OpenVINO™ Notebooks](https://github.com/openvinotoolkit/openvino_notebooks)
 - [OpenVINO Installation Selector Tool](https://www.intel.com/content/www/us/en/developer/tools/openvino-toolkit/download.html)
 
-Copyright © 2018-2022 Intel Corporation
+Copyright © 2018-2023 Intel Corporation
 > **LEGAL NOTICE**: Your use of this software and any required dependent software (the
 “Software Package”) is subject to the terms and conditions of the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.html) for the Software Package, which may also include notices, disclaimers, or
 license terms for third party or open source software included in or with the Software Package, and your use indicates your acceptance of all such terms. Please refer to the “third-party-programs.txt” or other similarly-named text file included with the Software Package for additional details.

--- a/docs/install_guides/pypi-openvino-rt.md
+++ b/docs/install_guides/pypi-openvino-rt.md
@@ -62,10 +62,10 @@ Run the command below: <br>
 
 Run the command below:
 ```sh
-python -c "from openvino.runtime import Core"
+python -c "from openvino.runtime import Core; print(Core().available_devices)"
 ```
-   
-If installation was successful, you will not see any error messages (no console output).
+
+If installation was successful, you will see the list of available devices.
 
 ## Troubleshooting
 
@@ -100,7 +100,7 @@ sudo apt-get install libpython3.7
 - [OpenVINO™ Notebooks](https://github.com/openvinotoolkit/openvino_notebooks)
 - [OpenVINO Installation Selector Tool](https://www.intel.com/content/www/us/en/developer/tools/openvino-toolkit/download.html)
 
-Copyright © 2018-2022 Intel Corporation
+Copyright © 2018-2023 Intel Corporation
 > **LEGAL NOTICE**: Your use of this software and any required dependent software (the
 “Software Package”) is subject to the terms and conditions of the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.html) for the Software Package, which may also include notices, disclaimers, or
 license terms for third party or open source software included in or with the Software Package, and your use indicates your acceptance of all such terms. Please refer to the “third-party-programs.txt” or other similarly-named text file included with the Software Package for additional details.

--- a/docs/install_guides/troubleshooting-steps.md
+++ b/docs/install_guides/troubleshooting-steps.md
@@ -71,9 +71,9 @@ Verify that OpenVINO is correctly installed
 
   .. code-block:: sh
 
-     python -c "from openvino.runtime import Core"
+     python -c "from openvino.runtime import Core; print(Core().available_devices)"
    
-  If OpenVINO was successfully installed, nothing will happen. If not, an error will be displayed.
+  If OpenVINO was successfully installed, you will see a list of available devices.
 
 * If you installed OpenVINO Runtime using the archive file, you can search "openvino" in Apps & Features on a Windows system, or check your installation directory on Linux to see if OpenVINO is there.
 

--- a/docs/install_guides/uninstalling-openvino.md
+++ b/docs/install_guides/uninstalling-openvino.md
@@ -33,7 +33,7 @@ If you have installed OpenVINO Runtime from archive files, you can uninstall it 
 
   .. code-block:: sh
 
-    rm /opt/intel/openvino_2022
+    rm /opt/intel/openvino_2023
 
   To delete the files:
 


### PR DESCRIPTION
### Details:
 - Updated versions in all places (exact archives names will be later)
 - Added more descriptive example to check that OpenVINO installed via pypi correctly (printing of available devices)
 - Sorted some tabs (Ubuntu 22.04 comes earlier than Ubuntu 18.04 as more modern platform), arm64 is more important than armhf.
