### PR TITLE
[conformance] Add rel pass rate to highlight table

### DIFF
--- a/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/template/highlight_tables_template.html
+++ b/src/tests/ie_test_utils/functional_test_utils/layer_tests_summary/template/highlight_tables_template.html
@@ -1,123 +1,192 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
         integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-    <title>{% block title %}highlight_table{% endblock %}</title>
+    <link rel="stylesheet" href="template/style.css" />
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+        integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+        crossorigin="anonymous"></script>
+    <script src="template/filters.js"></script>
+    <script src="template/chosen.jquery.min.js" type="text/javascript"></script>
+    <title>Report</title>
 </head>
-<body>
-    {% block content%}
-        <h1 class="ml-3 mt-3">Highlights</h1>
-        <ul class="list-group list-group-flush">
-            {% for test_mode in expected_test_mode %}
-                <li class="list-group-item">
-                    {% if expected_test_mode|length > 1 %}
-                        <h3><span class="mr-3">&#9679</span>{{ test_mode }}</h3>
-                    {% endif %} 
-                    <table class="table table-hover">
-                        <thead>
-                            <tr>
-                                <th class="table-dark">Plugins</th>
-                                {% for device in devices %}
-                                    <th class="table-dark">{{ device }}</th>
-                                {% endfor %}
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td class="table-primary">Total ops pass:</td>
-                                {% for device in devices %}
-                                    <td>
-                                        {% if device in ops_info[test_mode] %}
-                                            <!-- 10(+3)/(205)(-10) -->
-                                            {{ ops_info[test_mode][device]['totalPass'] }}
-                                            {% if ops_info[test_mode][device]['diffTotalPass'] > 0 %}
-                                                (<span class="text-success font-weight-bold">+{{ ops_info[test_mode][device]['diffTotalPass'] }}</span>)
-                                            {% elif ops_info[test_mode][device]['diffTotalPass'] < 0 %}
-                                                (<span class="text-danger font-weight-bold">{{ ops_info[test_mode][device]['diffTotalPass'] }}</span>)
-                                            {% endif %}
-                                            /{{ ops_info[test_mode][device]['totalAmount'] }}
-                                            {% if ops_info[test_mode][device]['diffTotalAmount'] > 0 %}
-                                                (<span class="text-success font-weight-bold">+{{ ops_info[test_mode][device]['diffTotalAmount'] }}</span>)
-                                            {% elif ops_info[test_mode][device]['diffTotalAmount'] < 0 %}
-                                                (<span class="text-danger font-weight-bold">{{ ops_info[test_mode][device]['diffTotalAmount'] }}</span>)
-                                            {% endif %}
-                                        {% else %}
-                                            NOT RUN
-                                        {% endif %}
-                                    </td>
-                                {% endfor %}
-                            </tr>
-                            <tr>
-                                <td class="table-primary">Passrate:</td>
-                                {% for device in devices %}
-                                    <td>
-                                        {% if device in general_pass_rate[test_mode] %}
-                                            {{ general_pass_rate[test_mode][device]['current'] }}
-                                            {% if general_pass_rate[test_mode][device]['prev'] > 0 %}
-                                                (<span class="text-success font-weight-bold">+{{ general_pass_rate[test_mode][device]['prev'] }}</span>)
-                                            {% elif general_pass_rate[test_mode][device]['prev'] < 0 %}
-                                                (<span class="text-danger font-weight-bold">{{ general_pass_rate[test_mode][device]['prev'] }}</span>)
-                                            {% endif %}
-                                            %
-                                        {% else %}
-                                            NOT RUN
-                                        {% endif %}
-                                    </td>
-                                {% endfor %}
-                            </tr>
 
-                        </tbody>
-                    </table>
-                </li>
+<body>
+    <div class="main">
+        <h2>Operations coverage summary: Tag: {{report_tag}} | Version: {{report_version}} | Time: {{ timestamp }}</h2>
+        <div class="legend">
+            <div>
+                <span class="table-primary border"></span><span>Collected statistic info</span>
+            </div>
+            <div>
+                <span class="table-secondary border">N/A</span><span>No Tests</span>
+            </div>
+            <div>
+                <span><b>Passrates are based on relative weights each subgraphs! You can check absolute value in `General passrate` row!</b></span>
+            </div>
+            <div>
+                <span><b>Status:</b></span>
+                <span class="green">P:85</span><span>Passed</span>
+                <span class="red">F:0</span><span>Failed</span>
+                <span class="grey">S:2</span><span>Skipped</span>
+                <span class="dark">C:0</span><span>Crashed</span>
+                <span class="grey-red">H:0</span><span>Hanged</span>
+            </div>
+            <div>
+                <span><b>Plugin operation implementation status:</b></span>
+                <div class="checkmark"></div><div>Implemented</div>
+                <div class="check"></div><div>Not implemented</div>
+            </div>
+        </div>
+    </div>
+    <!-- Filters block -->
+    <div class="filters">
+        <form id="filters">
+            <div class="form-group">
+                <label for="operationName"><b>Operation Name</b></label>
+                <input id="operationName" type="text" class="form-control" />
+            </div>
+            <div class="form-group">
+                <label for="opsetNumber"><b>Opset Number</b></label>
+                <select id="opsetNumber" class="form-control"></select>
+            </div>
+            <div class="form-group">
+                <label for="devices"><b>Devices</b></label>
+                <select id="devices" class="form-control"></select>
+            </div>
+            <div class="form-group">
+                <label for="implementation"><b>Plugin Implementation</b></label>
+                <select id="implementation" class="form-control">
+                    <option value="0">All</option>
+                    <option value="i">Implemented</option>
+                    <option value="ni">Not implemented</option>
+                    <option value="ns">No status</option>
+                </select>
+            </div>
+            <div class="form-group col-5" style="padding-left:0">
+                <label for="status"><b>Status</b></label>
+                <select id="status" class="form-control" multiple>
+                    <option value="100p">100% Passed</option>
+                    <option value="100f">100% Failed</option>
+                    <option value="p">Passed</option>
+                    <option value="f">Failed</option>
+                    <option value="s">Skipped</option>
+                    <option value="c">Crashed</option>
+                    <option value="h">Hanged</option>
+                    <option value="ex">Existing tests</option>
+                    <option value="na">No tests</option>
+                    <option value="ns">No status</option>
+                </select>
+            </div>
+            <button type="submit" class="btn btn-primary">Apply filters</button>
+            <button type="button" class="btn btn-secondary" id="reset">Reset filters</button>
+        </form>
+    </div>
+
+    {{api_info}}
+
+    <!-- Results -->
+    <table class="table table-hover table-bordered" id="report">
+        <thead>
+            <tr>
+                <th class="table-dark">Plugins</th>
+                <th class="table-dark">SW Plugins</th>
+                {% for device in devices %}
+                    <th class="table-dark" style="text-align: center;">{{ device }}</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody id="statistic">
+            <td class="table-primary" rowspan="{{ sw_plugins|length + 1 }}">General passrate (=passed_tests/all_tests):</td>
+            {% for sw_plugin in sw_plugins %}
+                <tr>
+                    <td>{{sw_plugin}}</td>
+                    {% for device in devices %}
+                        {% if device in general_pass_rate[sw_plugin] %}
+                            <td style="text-align: center;">
+                                {{ general_pass_rate["ov_plugin"][sw_plugin][device]['passrate'] }}%
+                            </td>
+                        {% else %}
+                            <td style="text-align: center;">NOT RUN</td>
+                        {% endif %}
+                    {% endfor %}
+                </tr>
             {% endfor %}
-            {% if api_info.keys()|length > 0 %}
-                <li class="list-group-item">
-                    <h3><span class="mr-3">&#9679</span> API </h3>
-                    <table class="table table-hover">
-                        <thead>
-                            <tr>
-                                <th class="table-dark">Plugins</th>
-                                <th class="table-dark">SW Plugins</th>
-                                {% for device in devices %}
-                                    <th class="table-dark">{{ device }}</th>
-                                {% endfor %}
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for test_type in api_info %}
-                                <td class="table-primary" rowspan="{{ api_info[test_type].keys()|length + 1 }}">{{ test_type }}</td>
-                            
-                                {% for sw_plugin in sw_plugins %}
-                                    <tr>
-                                        <td>{{sw_plugin}}</td>
-                                        {% for device in devices %}
-                                            {% if device in api_info[test_type][sw_plugin] %}
-                                                <td>
-                                                    {{ api_info[test_type][sw_plugin][device]['passrate'] }}
-                                                    {% if api_info[test_type][sw_plugin][device]['diff'] > 0 %}
-                                                        (<span class="text-success font-weight-bold">+{{ api_info[test_type][sw_plugin][device]['diff'] }}</span>)
-                                                    {% elif api_info[test_type][sw_plugin][device]['diff'] < 0 %}
-                                                        (<span class="text-danger font-weight-bold">{{ api_info[test_type][sw_plugin][device]['diff'] }}</span>)
-                                                    {% endif %}
-                                                    %
-                                                </td>
-                                            {% else %}
-                                                <td>NOT RUN</td>
-                                            {% endif %}
-                                        {% endfor %}
-                                    </tr>
-                                {% endfor %}    
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </li>
-            {% endif %}
-        </ul>
-    {% endblock %}
+
+            <td class="table-primary" rowspan="{{ sw_plugins|length + 1 }}">AVG passrate (=sum_pass_rates/covered_ops_num):</td>
+            {% for sw_plugin in sw_plugins %}
+                <tr>
+                    <td>{{sw_plugin}}</td>
+                    {% for device in devices %}
+                        {% if device in general_pass_rate[sw_plugin] %}
+                            <td style="text-align: center;">
+                                {{ general_pass_rate["ov_plugin"][sw_plugin][device]['real_passrate'] }}%
+                            </td>
+                        {% else %}
+                            <td style="text-align: center;">NOT RUN</td>
+                        {% endif %}
+                    {% endfor %}
+                </tr>
+            {% endfor %}
+        </tbody>
+        <tbody id="data">
+            {% for test_type in api_info %}
+                <td class="table-primary" rowspan="{{ api_info[test_type].keys()|length + 1 }}">{{ test_type }}</td>
+            
+                {% for sw_plugin in sw_plugins %}
+                    <tr>
+                        <td>{{sw_plugin}}</td>
+                        {% for device in devices %}
+                            {% if device in api_info[test_type][sw_plugin] %}
+                                <td style="text-align: center;">
+                                    <span>Rel:</span>
+                                    {{ api_info[test_type][sw_plugin][device]['rel_passrate'] }}
+                                    {% if api_info[test_type][sw_plugin][device]['diff'] > 0 %}
+                                        (<span class="text-success font-weight-bold" title="Passrate have increased since last run">+{{ api_info[test_type][sw_plugin][device]['diff'] }}</span>)
+                                    {% elif api_info[test_type][sw_plugin][device]['diff'] < 0 %}
+                                        (<span class="text-danger font-weight-bold" title="Passrate have decreased since last run">{{ api_info[test_type][sw_plugin][device]['diff'] }}</span>)
+                                    {% endif %}
+                                    %
+                                    <span>Total:</span>
+                                    {{ api_info[test_type][sw_plugin][device]['passrate'] }}
+                                    {% if api_info[test_type][sw_plugin][device]['diff'] > 0 %}
+                                        (<span class="text-success font-weight-bold" title="Passrate have increased since last run">+{{ api_info[test_type][sw_plugin][device]['diff'] }}</span>)
+                                    {% elif api_info[test_type][sw_plugin][device]['diff'] < 0 %}
+                                        (<span class="text-danger font-weight-bold" title="Passrate have decreased since last run">{{ api_info[test_type][sw_plugin][device]['diff'] }}</span>)
+                                    {% endif %}
+                                    %
+
+                                    <div class="flex">
+                                        <div>
+                                                <span class="green" title="Passed">P:{{ api_info[test_type][sw_plugin][device]['passrate'] }}</span>
+                                                <span class="red" title="Failed">F:{{ api_info[test_type][sw_plugin][device]['passrate'] }}</span>
+                                                <span class="grey" title="Skipped">S:{{ api_info[test_type][sw_plugin][device]['passrate'] }}</span>
+                                                <span class="dark" title="Crashed">C:{{ api_info[test_type][sw_plugin][device]['passrate'] }}</span>
+                                                <span class="grey-red" title="Hanged">H:{{ api_info[test_type][sw_plugin][device]['passrate'] }}</span>
+                                        </div>
+                                    </div>
+
+
+                                </td>
+                            {% else %}
+                                <td style="text-align: center;">NOT RUN</td>
+                            {% endif %}
+                        {% endfor %}
+                    </tr>
+                {% endfor %}    
+            {% endfor %}
+        </tbody>
+    </table>
+    <div id="message" style="display:none">
+        There is no data related to selected filters. Please set new filters.
+    </div>
 </body>
+
 </html>


### PR DESCRIPTION
### Details:
It was add some details about run to the top and information about relative passrate. 
Example below was run on cmd(some data was only for devices CPU, GPU, NVIDIA, commit hash is also random):
python highlight_tables.py --current_xmls ..\summary2 --prev_xml  ..\summary1  --expected_devices VPUX DGPU NVIDIA GNA TEMPLATE GPU CPU_ARM CPU  --expected_test_mode static dynamic apiConformanceTests  --current_commit 82ec92dd9860208eb7a9088ddc70af18600e6e2e --prev_commit 82ec92dd9860208eb7a9088ddc70af18600e6e2e

<img width="1268" alt="Screenshot 2023-05-29 161825" src="https://github.com/openvinotoolkit/openvino/assets/68700881/ca95a7f6-467e-481c-aa80-102db7679e9a">


### Tickets:
 - *CVS-109776*
