### PR TITLE
[GNA] Fixed gna_unit tests for debug build

### DIFF
--- a/src/plugins/intel_gna/src/log/dump.cpp
+++ b/src/plugins/intel_gna/src/log/dump.cpp
@@ -163,6 +163,9 @@ void WriteInputAndOutputTextGNAImpl(const Gna2Model& gnaModel,
                                     const std::string refFolderName) {
     for (uint32_t i = 0; i < gnaModel.NumberOfOperations; i++) {
         const auto& operation = gnaModel.Operations[i];
+        if(operation.Type == Gna2OperationTypeNone) {
+            continue;
+        }
         std::stringstream out_file_name;
         const auto& outputTensor = *operation.Operands[OutOpIdx];
         const auto& intputTensor = *operation.Operands[InOpIdx];


### PR DESCRIPTION
### Details:
 - Fixed unit tests crashing with debug build, because gnaModel can contain only one Gna2OperationTypeNone operation

### Tickets:
 - *n/a*
