### PR TITLE
[Snippets] Added support of MatMuls with transposed inputs

### DIFF
--- a/src/common/snippets/include/snippets/pass/common_optimizations.hpp
+++ b/src/common/snippets/include/snippets/pass/common_optimizations.hpp
@@ -5,7 +5,8 @@
 #pragma once
 
 #include "openvino/pass/graph_rewrite.hpp"
-#include "openvino/pass/pattern/matcher.hpp"
+
+#include "snippets/op/subgraph.hpp"
 
 namespace ov {
 namespace snippets {
@@ -15,6 +16,12 @@ class CommonOptimizations : public ov::pass::MatcherPass {
 public:
     OPENVINO_RTTI("CommonOptimizations", "0");
     CommonOptimizations();
+
+private:
+    // Move up Constants which aren't scalars from body to Subgraph and replace them with Parameters inside body
+    void ExtractConstants(const std::shared_ptr<op::Subgraph>& subgraph);
+    // Move up unsupported Transposes on Parameter outputs from body
+    void ExtractUnsupportedTransposes(const std::shared_ptr<op::Subgraph>& subgraph);
 };
 
 }  // namespace pass

--- a/src/common/snippets/include/snippets/pass/explicit_transpose_matmul_inputs.hpp
+++ b/src/common/snippets/include/snippets/pass/explicit_transpose_matmul_inputs.hpp
@@ -26,6 +26,9 @@ public:
     OPENVINO_RTTI("ExplicitTransposeMatMulInputs", "0");
     ExplicitTransposeMatMulInputs();
 
+    // Return `True` if all inputs (except 0-th input) have scalar shape. Otherwise returns `False`
+    static bool are_weights_scalar(const std::shared_ptr<ov::Node>& node);
+
 private:
     static void extract(const ov::Input<ov::Node>& input);
 };

--- a/src/common/snippets/include/snippets/pass/explicit_transpose_matmul_inputs.hpp
+++ b/src/common/snippets/include/snippets/pass/explicit_transpose_matmul_inputs.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "openvino/pass/graph_rewrite.hpp"
-#include "openvino/pass/pattern/matcher.hpp"
 
 namespace ov {
 namespace snippets {
@@ -13,18 +12,22 @@ namespace pass {
 
 /**
  * @interface ExplicitTransposeMatMulInputs
- * @brief At the moment Snippets supports Transpose only with order {0, 2, 3, 1},
- *        so if there is pattern in graph:
- *         in0     Transpose{0, 2, 1, 3}
- *           \    /
- *           MatMul[false, true]
- *        We can set false in MatMul parameter `transposed_b` and
- *        change Transpose order to {0, 2, 3, 1} which is supported by Snippets
+ * @brief The pass extracts explicit Transpose node from MatMul with transposed_<a|b> and moves it to Parameter.
+ *        If there is another Transpose, the pass fuses extracted Transpose and existing Transpose.
+ *        For example, At the moment Snippets supports Transpose only with order {0, 2, 3, 1}, so if there is pattern in graph:
+ *                  in0     Transpose{0, 2, 1, 3}
+ *                    \    /
+ *                    MatMul[false, true]
+ *        We can set `false` in MatMul parameter `transposed_b` and change Transpose order to {0, 2, 3, 1} which is supported by Snippets
  * @ingroup snippets
  */
 class ExplicitTransposeMatMulInputs: public ov::pass::MatcherPass {
 public:
+    OPENVINO_RTTI("ExplicitTransposeMatMulInputs", "0");
     ExplicitTransposeMatMulInputs();
+
+private:
+    static void extract(const ov::Input<ov::Node>& input);
 };
 
 }  // namespace pass

--- a/src/common/snippets/src/pass/common_optimizations.cpp
+++ b/src/common/snippets/src/pass/common_optimizations.cpp
@@ -58,8 +58,8 @@ void CommonOptimizations::ExtractUnsupportedTransposes(const std::shared_ptr<op:
     const auto parameters = body->get_parameters();
     // [107806]: If count of Parameters isn't equal to Subgraph inputs,
     //           we cannot guarantee correct extraction since we don't have correct connections between body I/O and Subgraph I/O.
-    if (parameters.size() != subgraph->input_values().size())
-        return;
+    OPENVINO_ASSERT(parameters.size() == subgraph->input_values().size(),
+                    "Failed to extract unsupported transposes: the count of Parameters isn't equal to Subgraph inputs");
 
     bool updated = false;
     for (size_t i = 0; i < parameters.size(); ++i) {

--- a/src/common/snippets/src/pass/explicit_transpose_matmul_inputs.cpp
+++ b/src/common/snippets/src/pass/explicit_transpose_matmul_inputs.cpp
@@ -2,79 +2,98 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "snippets/pass/explicit_transpose_matmul_inputs.hpp"
+
+#include "snippets/op/subgraph.hpp"
 #include "snippets/itt.hpp"
 
-#include "snippets/pass/explicit_transpose_matmul_inputs.hpp"
-#include "snippets/pass/transpose_decomposition.hpp"
-#include "snippets/op/subgraph.hpp"
-
-#include "openvino/core/rt_info.hpp"
+#include "openvino/pass/pattern/matcher.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/core/rt_info.hpp"
+
+
+void ov::snippets::pass::ExplicitTransposeMatMulInputs::extract(const ov::Input<ov::Node>& input) {
+    auto parent = input.get_source_output().get_node_shared_ptr();
+    auto transpose = ngraph::as_type_ptr<ov::op::v1::Transpose>(parent);
+    while (!transpose && !ov::is_type<ov::op::v0::Parameter>(parent)) {
+        // We can set supported order and transposed_<a|b>=false only if ops have scalar shapes to avoid shape mismatching
+        const auto parent_count = parent->inputs().size();
+        bool are_weights_scalar = true;
+        for (size_t j = 1; j < parent_count; ++j) {
+            are_weights_scalar = are_weights_scalar && ngraph::shape_size(parent->get_input_shape(j)) == 1;
+        }
+        if (!are_weights_scalar)
+            break;
+
+        parent = parent->get_input_node_shared_ptr(0);
+        transpose = ngraph::as_type_ptr<ov::op::v1::Transpose>(parent);
+    }
+
+    // If there isn't another Transpose, need to create new Transpose
+    if (transpose) {
+        const auto transpose_pattern = ngraph::as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+        OPENVINO_ASSERT(transpose_pattern,
+                        "ExplicitTransposeMatMulInputs expects existing Transpose with Constant order");
+
+        auto transposed_order = transpose_pattern->cast_vector<int32_t>();
+        OPENVINO_ASSERT(transposed_order.size() > 2, "Incorrect Transpose order for ExplicitTransposeMatMulInputs");
+        std::swap(*transposed_order.rbegin(), *(transposed_order.rbegin() + 1));
+
+        auto new_transpose_order = std::make_shared<ov::op::v0::Constant>(transpose_pattern->get_element_type(),
+                                                                          ngraph::Shape{transposed_order.size()},
+                                                                          transposed_order);
+        new_transpose_order->set_friendly_name(transpose_pattern->get_friendly_name());
+        ov::copy_runtime_info(transpose_pattern, new_transpose_order);
+        transpose->set_argument(1, new_transpose_order);
+        return;
+    }
+
+    // Create new Transpose before Parameter
+    OPENVINO_ASSERT(ov::is_type<opset1::Parameter>(parent),
+                    "ExplicitTransposeMatMulInputs expects Parameter in cases when there isn't existing Transpose on input");
+    const auto& consumers = parent->get_output_target_inputs(0);
+    OPENVINO_ASSERT(consumers.size() == 1,
+                    "ExplicitTransposeMatMulInputs expects Parameter with one consumer in cases when there isn't existing Transpose on input");
+    // Extract Transpose from MatMul
+    const auto rank = input.get_shape().size();
+    std::vector<size_t> transpose_order(rank, 0);
+    std::iota(transpose_order.begin(), transpose_order.end(), 0);
+    std::swap(transpose_order[rank - 1], transpose_order[rank - 2]);
+
+    const auto constant_order = std::make_shared<opset1::Constant>(ov::element::i32, ov::Shape{rank}, transpose_order);
+    const auto new_transpose = std::make_shared<opset1::Transpose>(parent, constant_order); // parent is Parameter
+    const auto consumer_input = *(consumers.begin());
+    consumer_input.replace_source_output(new_transpose);
+}
 
 ov::snippets::pass::ExplicitTransposeMatMulInputs::ExplicitTransposeMatMulInputs() {
     MATCHER_SCOPE(ExplicitTransposeMatMulInputs);
 
-    auto m_matmul0 = std::make_shared<ov::opset1::MatMul>(
+    auto m_matmul0 = std::make_shared<ov::op::v0::MatMul>(
             ov::pass::pattern::any_input(ov::pass::pattern::has_static_shape()),
             ov::pass::pattern::any_input(ov::pass::pattern::has_static_shape()));
 
     register_matcher(std::make_shared<ov::pass::pattern::Matcher>(m_matmul0, matcher_name),
         [=](ov::pass::pattern::Matcher &m) {
-        OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::op::ExplicitTransposeMatMulInputs")
-        auto root = m.get_match_root();
-        bool rewritten = false;
+            OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::op::ExplicitTransposeMatMulInputs")
+            auto root = m.get_match_root();
+            bool rewritten = false;
 
-        auto matmul0 = ov::as_type_ptr<ov::opset1::MatMul>(root);
-        if (!matmul0)
-            return false;
+            auto matmul = ngraph::as_type_ptr<ov::op::v0::MatMul>(root);
+            if (!matmul)
+                return false;
 
-        for (size_t i = 0; i < matmul0->get_input_size(); i++) {
-            if (i == 0 && !matmul0->get_transpose_a())
-                continue;
-            if (i == 1 && !matmul0->get_transpose_b())
-                continue;
-
-            auto parent1 = matmul0->get_input_node_shared_ptr(i);
-            auto transpose1 = ov::as_type_ptr<ov::opset1::Transpose>(parent1);
-            while (!transpose1 && !ov::is_type<ov::opset1::Parameter>(parent1)) {
-                // We can set supported order and transposed_b(false) only if ops have scalar shapes to avoid shape mismatching
-                const auto parent_count = parent1->inputs().size();
-                bool are_weights_scalar = true;
-                for (size_t j = 1; j < parent_count; ++j) {
-                    are_weights_scalar = are_weights_scalar && ov::shape_size(parent1->get_input_shape(j)) == 1;
-                }
-                if (!are_weights_scalar)
-                    break;
-
-                parent1 = parent1->get_input_node_shared_ptr(0);
-                transpose1 = ov::as_type_ptr<ov::opset1::Transpose>(parent1);
+            if (matmul->get_transpose_a()) {
+                extract(matmul->input(0));
+                matmul->set_transpose_a(false);
+                rewritten |= true;
             }
-            if (!transpose1)
-                continue;
-
-            const auto transpose_pattern = ov::as_type_ptr<ov::opset1::Constant>(transpose1->get_input_node_shared_ptr(1));
-            if (!transpose_pattern)
-                continue;
-
-            auto transposed_order = transpose_pattern->cast_vector<int32_t>();
-            std::swap(*transposed_order.rbegin(), *(transposed_order.rbegin() + 1));
-            if (pass::TransposeDecomposition::supported_cases.count(transposed_order) == 0)
-                continue;
-
-            auto new_transpose_order = std::make_shared<ov::opset1::Constant>(transpose_pattern->get_element_type(),
-                                                                                  ov::Shape{4},
-                                                                                  transposed_order);
-            new_transpose_order->set_friendly_name(transpose_pattern->get_friendly_name());
-            ov::copy_runtime_info(transpose_pattern, new_transpose_order);
-            transpose1->set_argument(1, new_transpose_order);
-            if (i == 0) {
-                matmul0->set_transpose_a(false);
-            } else {
-                matmul0->set_transpose_b(false);
+            if (matmul->get_transpose_b()) {
+                extract(matmul->input(1));
+                matmul->set_transpose_b(false);
+                rewritten |= true;
             }
-            rewritten |= true;
-        }
 
-        return rewritten;
-    });
+            return rewritten;
+        });
 }

--- a/src/common/snippets/tests/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/tests/src/pass/mha_tokenization.cpp
@@ -18,6 +18,7 @@ void TokenizeMHASnippetsTests::run() {
     manager.register_pass<ov::snippets::pass::EnumerateNodes>();
     manager.register_pass<ov::snippets::pass::TokenizeMHASnippets>();
     manager.register_pass<ov::snippets::pass::CommonOptimizations>();
+    disable_rt_info_check();
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA) {

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
@@ -227,6 +227,21 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAFQ, MHAFQ,
                                  ::testing::Values(CPUTestUtils::cpuEmptyPluginConfig)),
                          MHA::getTestCaseName);
 
+const std::vector<std::vector<ov::PartialShape>> inputShapesTransposedB = {
+        {{1, 12, 12, 64}, {1, 12, 48, 64}, {1, 12, 48, 64}}
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHATransposedB, MHATransposedB,
+                         ::testing::Combine(
+                                 ::testing::ValuesIn(inputShapesTransposedB),
+                                 ::testing::Values(std::vector<element::Type>{}),
+                                 ::testing::Values(ov::element::f32),
+                                 ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
+                                 ::testing::Values(2),
+                                 ::testing::Values(1),
+                                 ::testing::Values(CommonTestUtils::DEVICE_CPU),
+                                 ::testing::Values(std::map<std::string, std::string>{})),
+                         MHA::getTestCaseName);
 
 } // namespace
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/include/snippets/mha.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/mha.hpp
@@ -71,7 +71,9 @@ class MHAMulAdd : public MHA {
     void init_subgraph() override;
 };
 
-
+class MHATransposedB : public MHA {
+    void init_subgraph() override;
+};
 } // namespace snippets
 } // namespace test
 } // namespace ov

--- a/src/tests/functional/plugin/shared/include/snippets/mha.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/mha.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "shared_test_classes/base/snippets_test_utils.hpp"
+#include "ngraph_helpers/snippets_ngraph_functions/include/snippets_helpers.hpp"
 
 namespace ov {
 namespace test {
@@ -30,7 +31,7 @@ protected:
     void SetUp() override;
 
     void generate_inputs(const std::vector<ngraph::Shape>& targetInputStaticShapes) override;
-    virtual void init_subgraph();
+    virtual std::shared_ptr<SnippetsFunctionBase> get_subgraph();
 
     bool m_with_mul = false;
     std::vector<ov::element::Type> m_input_types;
@@ -39,41 +40,42 @@ protected:
 class MHASelect : public MHA {
 protected:
     void generate_inputs(const std::vector<ngraph::Shape>& targetInputStaticShapes) override;
-    void init_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
 };
 
 class MHAWOTransposeOnInputs : public MHA {
 protected:
-    void init_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
 };
 
 class MHAWOTranspose : public MHA {
 protected:
-    void init_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
+};
+
+class MHAMulAdd : public MHA {
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
+};
+
+class MHATransposedB : public MHA {
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
 };
 
 class MHAINT8MatMul : public MHA {
 protected:
-    void init_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
 };
 
 class MHAFQAfterMatMul : public MHA {
 protected:
-    void init_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
 };
 
 class MHAFQ : public MHA {
 protected:
-    void init_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
 };
 
-class MHAMulAdd : public MHA {
-    void init_subgraph() override;
-};
-
-class MHATransposedB : public MHA {
-    void init_subgraph() override;
-};
 } // namespace snippets
 } // namespace test
 } // namespace ov

--- a/src/tests/functional/plugin/shared/src/snippets/mha.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/mha.cpp
@@ -134,6 +134,11 @@ void MHAMulAdd::init_subgraph() {
     function = f.getOriginal();
 }
 
+void MHATransposedB::init_subgraph() {
+    auto f = ov::test::snippets::MHATransposedInputFunction(inputDynamicShapes, true);
+    function = f.getOriginal();
+}
+
 TEST_P(MHA, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
@@ -158,6 +163,11 @@ TEST_P(MHAWOTranspose, CompareWithRefImpl) {
 }
 
 TEST_P(MHAMulAdd, CompareWithRefImpl) {
+    run();
+    validateNumSubgraphs();
+}
+
+TEST_P(MHATransposedB, CompareWithRefImpl) {
     run();
     validateNumSubgraphs();
 }

--- a/src/tests/functional/plugin/shared/src/snippets/mha.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/mha.cpp
@@ -51,7 +51,8 @@ void MHA::SetUp() {
     std::tie(inputShapes, m_input_types, prc, m_with_mul, ref_num_nodes, ref_num_subgraphs, targetDevice, additionalConfig) = this->GetParam();
     init_input_shapes(static_partial_shapes_to_test_representation(inputShapes));
 
-    init_subgraph();
+    const auto subgraph_model = get_subgraph();
+    function = subgraph_model->getOriginal();
 
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
     if (!configuration.count(InferenceEngine::PluginConfigInternalParams::KEY_SNIPPETS_MODE)) {
@@ -76,9 +77,8 @@ void MHA::generate_inputs(const std::vector<ngraph::Shape>& targetInputStaticSha
     }
 }
 
-void MHA::init_subgraph() {
-    auto f = ov::test::snippets::MHAFunction(inputDynamicShapes, m_input_types, m_with_mul);
-    function = f.getOriginal();
+std::shared_ptr<SnippetsFunctionBase> MHA::get_subgraph() {
+    return std::make_shared<ov::test::snippets::MHAFunction>(inputDynamicShapes, m_input_types, m_with_mul);
 }
 
 void MHASelect::generate_inputs(const std::vector<ngraph::Shape>& targetInputStaticShapes) {
@@ -99,44 +99,36 @@ void MHASelect::generate_inputs(const std::vector<ngraph::Shape>& targetInputSta
     }
 }
 
-void MHASelect::init_subgraph() {
-    auto f = ov::test::snippets::MHASelectFunction(inputDynamicShapes, m_input_types);
-    function = f.getOriginal();
+std::shared_ptr<SnippetsFunctionBase> MHASelect::get_subgraph() {
+    return std::make_shared<ov::test::snippets::MHASelectFunction>(inputDynamicShapes, m_input_types);
 }
 
-void MHAWOTransposeOnInputs::init_subgraph() {
-    auto f = ov::test::snippets::MHAWOTransposeOnInputsFunction(inputDynamicShapes);
-    function = f.getOriginal();
+std::shared_ptr<SnippetsFunctionBase> MHAWOTransposeOnInputs::get_subgraph() {
+    return std::make_shared<ov::test::snippets::MHAWOTransposeOnInputsFunction>(inputDynamicShapes);
 }
 
-void MHAWOTranspose::init_subgraph() {
-    auto f = ov::test::snippets::MHAWOTransposeFunction(inputDynamicShapes, m_input_types);
-    function = f.getOriginal();
+std::shared_ptr<SnippetsFunctionBase> MHAWOTranspose::get_subgraph() {
+    return std::make_shared<ov::test::snippets::MHAWOTransposeFunction>(inputDynamicShapes, m_input_types);
 }
 
-void MHAINT8MatMul::init_subgraph() {
-    auto f = ov::test::snippets::MHAINT8MatMulFunction(inputDynamicShapes);
-    function = f.getOriginal();
+std::shared_ptr<SnippetsFunctionBase> MHAINT8MatMul::get_subgraph() {
+    return std::make_shared<ov::test::snippets::MHAINT8MatMulFunction>(inputDynamicShapes);
 }
 
-void MHAFQAfterMatMul::init_subgraph() {
-    auto f = ov::test::snippets::MHAFQAfterMatMulFunction(inputDynamicShapes);
-    function = f.getOriginal();
+std::shared_ptr<SnippetsFunctionBase> MHAFQAfterMatMul::get_subgraph() {
+    return std::make_shared<ov::test::snippets::MHAFQAfterMatMulFunction>(inputDynamicShapes);
 }
 
-void MHAFQ::init_subgraph() {
-    auto f = ov::test::snippets::MHAFQFunction(inputDynamicShapes);
-    function = f.getOriginal();
+std::shared_ptr<SnippetsFunctionBase> MHAFQ::get_subgraph() {
+    return std::make_shared<ov::test::snippets::MHAFQFunction>(inputDynamicShapes);
 }
 
-void MHAMulAdd::init_subgraph() {
-    auto f = ov::test::snippets::MHAMulAddFunction(inputDynamicShapes);
-    function = f.getOriginal();
+std::shared_ptr<SnippetsFunctionBase> MHAMulAdd::get_subgraph() {
+    return std::make_shared<ov::test::snippets::MHAMulAddFunction>(inputDynamicShapes);
 }
 
-void MHATransposedB::init_subgraph() {
-    auto f = ov::test::snippets::MHATransposedInputFunction(inputDynamicShapes, true);
-    function = f.getOriginal();
+std::shared_ptr<SnippetsFunctionBase> MHATransposedB::get_subgraph() {
+    return std::make_shared<ov::test::snippets::MHATransposedInputFunction>(inputDynamicShapes, true);
 }
 
 TEST_P(MHA, CompareWithRefImpl) {
@@ -158,31 +150,37 @@ TEST_P(MHAWOTransposeOnInputs, CompareWithRefImpl) {
 }
 
 TEST_P(MHAWOTranspose, CompareWithRefImpl) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     validateNumSubgraphs();
 }
 
 TEST_P(MHAMulAdd, CompareWithRefImpl) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     validateNumSubgraphs();
 }
 
 TEST_P(MHATransposedB, CompareWithRefImpl) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     validateNumSubgraphs();
 }
 
 TEST_P(MHAINT8MatMul, CompareWithRefImpl) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     validateNumSubgraphs();
 }
 
 TEST_P(MHAFQAfterMatMul, CompareWithRefImpl) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     validateNumSubgraphs();
 }
 
 TEST_P(MHAFQ, CompareWithRefImpl) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     validateNumSubgraphs();
 }

--- a/src/tests/ngraph_helpers/snippets_ngraph_functions/include/subgraph_mha.hpp
+++ b/src/tests/ngraph_helpers/snippets_ngraph_functions/include/subgraph_mha.hpp
@@ -289,6 +289,31 @@ protected:
     std::shared_ptr<ov::Model> initOriginal() const override;
 };
 
+/* Graph:
+ *       Transpose/Parameter
+ *    \     /
+ *    MatMul0 [transposed_b = true/false]
+ *       |
+ *    Softmax
+ *        \      /
+ *         MatMul1
+ *           |
+ */
+class MHATransposedInputFunction : public SnippetsFunctionBase {
+public:
+    explicit MHATransposedInputFunction(const std::vector<PartialShape>& inputShapes, bool transposed_b = false,
+                                        std::vector<int64_t> order = {})
+        : SnippetsFunctionBase(inputShapes), m_transposed_b(transposed_b), m_order(order) {
+        NGRAPH_CHECK(input_shapes.size() == 3, "Got invalid number of input shapes");
+    }
+protected:
+    std::shared_ptr<ov::Model> initOriginal() const override;
+    std::shared_ptr<ov::Model> initReference() const override;
+
+    bool m_transposed_b = false;
+    std::vector<int64_t> m_order = {};
+};
+
 }  // namespace snippets
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - *Updated pass `ExplicitTransposeMatMulInputs`. Now the pass can extract `Transpose` from transposed inputs from MatMul if there isn't another `Transpose` even*
 - *Added function that extracts unsupported `Transpose` from body*
 - *Failed onnx tests are fixed by https://github.com/openvinotoolkit/openvino/pull/17774*

### Tickets:
 - *111980*
