### PR TITLE
Use OpenCL from CCI

### DIFF
--- a/.ci/azure/linux_arm64.yml
+++ b/.ci/azure/linux_arm64.yml
@@ -141,17 +141,12 @@ jobs:
       sudo mv arm64-sources.list /etc/apt/sources.list.d/
       sudo -E dpkg --add-architecture arm64
       sudo -E apt-get update -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/arm64-sources.list
-      sudo -E apt-get install -y --no-install-recommends \
-          libpython3-dev:arm64 \
-          ocl-icd-opencl-dev:arm64 \
-          opencl-headers:arm64
+      sudo -E apt-get install -y --no-install-recommends libpython3-dev:arm64
     displayName: 'Install arm64 libraries'
 
   - script: |
       git submodule update --init -- $(OPENVINO_REPO_DIR)/src/plugins
       git submodule update --init -- $(OPENVINO_REPO_DIR)/thirdparty/gtest
-      git submodule update --init -- $(OPENVINO_REPO_DIR)/thirdparty/ocl/cl_headers
-      git submodule update --init -- $(OPENVINO_REPO_DIR)/thirdparty/ocl/clhpp_headers
       git submodule update --init -- $(OPENVINO_REPO_DIR)/thirdparty/open_model_zoo
     displayName: 'Init submodules for non Conan dependencies'
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -5,9 +5,9 @@ pugixml/[>=1.10]
 protobuf/[>=3.20.3]
 ittapi/[>=3.23.0]
 zlib/[>=1.2.8]
-opencl-icd-loader/[>=2022.09.30]
-# opencl-clhpp-headers/[>=2022.09.30]
-opencl-headers/[>=2022.09.30]
+opencl-icd-loader/2022.09.30
+opencl-clhpp-headers/2022.09.30
+opencl-headers/2022.09.30
 xbyak/[>=6.62]
 snappy/[>=1.1.7]
 gflags/2.2.2


### PR DESCRIPTION
### Details:
 - See https://github.com/conan-io/conan-center-index/pull/17416
 - Now, we can use OpenCL from CCI in post-commit jobs, which tests Conan integration
