### PR TITLE
Use 2023.0.0 debian packages on CI

### DIFF
--- a/.ci/azure/linux_debian.yml
+++ b/.ci/azure/linux_debian.yml
@@ -233,8 +233,8 @@ jobs:
       sudo apt-get install --no-install-recommends gnupg wget -y
       wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
       sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-      echo "deb https://apt.repos.intel.com/openvino/2022 focal main" | sudo tee /etc/apt/sources.list.d/intel-openvino-2022.list
-      sudo apt-get update -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/intel-openvino-2022.list
+      echo "deb https://apt.repos.intel.com/openvino/2023 ubuntu20 main" | sudo tee /etc/apt/sources.list.d/intel-openvino-2023.list
+      sudo apt-get update -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/intel-openvino-2023.list
       sudo apt-get install openvino -y || exit 1
       # install our local one and make sure the conflicts are resolved
       sudo apt-get install --no-install-recommends dpkg-dev -y

--- a/cmake/packaging/debian.cmake
+++ b/cmake/packaging/debian.cmake
@@ -85,7 +85,7 @@ macro(ov_cpack_settings)
         # - 2022.1.1, 2022.2 do not have debian packages enabled, distributed only as archives
         # - 2022.3 is the first release where Debian updated packages are introduced, others 2022.3.X are LTS
         2022.3.0 2022.3.1 2022.3.2 2022.3.3 2022.3.4 2022.3.5
-        2023.0
+        2023.0.0
         )
 
     #

--- a/cmake/packaging/rpm.cmake
+++ b/cmake/packaging/rpm.cmake
@@ -71,7 +71,7 @@ macro(ov_cpack_settings)
         # - 2022.1.1, 2022.2 do not have rpm packages enabled, distributed only as archives
         # - 2022.3 is the first release where RPM updated packages are introduced, others 2022.3.X are LTS
         2022.3.0 2022.3.1 2022.3.2 2022.3.3 2022.3.4 2022.3.5
-        2023.0
+        2023.0.0
         )
 
     find_host_program(rpmlint_PROGRAM NAMES rpmlint DOC "Path to rpmlint")


### PR DESCRIPTION
### Details:
 - They are used to test that previous version of release is deleted during installation of current one
