### PR TITLE
[GPU] Better device input memory reuse

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_blob.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_blob.hpp
@@ -54,7 +54,14 @@ public:
 
     bool is_allocated() const noexcept;
     bool is_locked() const noexcept;
-    cldnn::memory::ptr get_memory() { return m_memory_object; }
+    cldnn::memory::ptr get_memory() {
+        auto engine = m_memory_object->get_engine();
+        return engine->reinterpret_buffer(*m_memory_object, m_layout);
+    }
+    cldnn::memory::ptr get_original_memory() {
+        return m_memory_object;
+    }
+    void setShape(const InferenceEngine::SizeVector& dims);
 
 protected:
     std::shared_ptr<InferenceEngine::IAllocator> m_allocator;
@@ -80,6 +87,7 @@ protected:
     void lock() const;
     void unlock() const;
 
+    bool is_shared() const;
     bool supports_caching() const;
 };
 
@@ -115,6 +123,7 @@ public:
     InferenceEngine::LockedMemory<const void> rmap() const noexcept override { return _impl.rmap(); }
     InferenceEngine::LockedMemory<void> wmap()noexcept override { return _impl.wmap(); }
     RemoteBlobImpl* getImpl() { return &_impl; }
+    void setShape(const InferenceEngine::SizeVector& dims) override { _impl.setShape(dims); }
 
 protected:
     const std::shared_ptr<InferenceEngine::IAllocator> &getAllocator() const noexcept override { return _impl.getAllocator(); }

--- a/src/plugins/intel_gpu/src/plugin/infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/infer_request.cpp
@@ -227,27 +227,12 @@ void InferRequest::set_input(const std::string& name, const Blob::Ptr& data) {
     auto remote_ptr = data->as<gpu::ClBlob>();
     bool is_remote = remote_ptr != nullptr;
 
-    auto node = findInputByNodeName(name);
-    bool isDynamic = node && node->get_output_partial_shape(0).is_dynamic();
-
     if (is_remote) {
         _deviceInputs[name] = data;
         _inputs[name] = data;
     } else {
-        if (data->buffer() == nullptr)
-            IE_THROW(NotAllocated) << str_input_not_allocated << " Input name: \'" << name << "\'";
+        OPENVINO_ASSERT(data->buffer().as<void*>() != nullptr, str_input_not_allocated, " Input name: \'", name, "\'");
         _inputs[name] = data;
-        if (isDynamic) {
-            // We must create new input data if it has never been allocated or previously allocated
-            // device blob is smaller than currently assigned user blob
-            bool needs_realloc = _deviceInputs.find(name) == _deviceInputs.end() || _deviceInputs.at(name)->byteSize() < data->byteSize();
-            if (needs_realloc) {
-                _deviceInputs[name] = create_device_blob(data->getTensorDesc());
-            } else {
-                if (_deviceInputs.at(name)->getTensorDesc() != data->getTensorDesc())
-                    _deviceInputs[name] = reinterpret_device_blob(_deviceInputs[name], data->getTensorDesc());
-            }
-        }
     }
 }
 
@@ -922,8 +907,9 @@ void InferRequest::prepare_input(const cldnn::primitive_id& inputName, Blob::Ptr
         bool has_device_blob = _deviceInputs.find(inputName) != _deviceInputs.end();
         bool should_allocate_device_blob = !has_device_blob;
         if (has_device_blob) {
-            auto device_blob = _deviceInputs.at(inputName);
-            if (device_blob->byteSize() < inputBlob->byteSize()) {
+            auto device_blob = _deviceInputs.at(inputName)->as<gpu::ClBlob>();
+            auto blob = getBlobImpl(device_blob);
+            if (blob->get_original_memory()->size() < inputBlob->byteSize()) {
                 should_allocate_device_blob = true;
             }
         }

--- a/src/plugins/intel_gpu/src/plugin/remote_blob.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_blob.cpp
@@ -108,6 +108,19 @@ AnyMap RemoteBlobImpl::getParams() const {
     }
 }
 
+void RemoteBlobImpl::setShape(const SizeVector& dims) {
+    if (ov::shape_size(dims) > m_memory_object->count()) {
+        OPENVINO_ASSERT(!is_shared(), "Cannot call setShape for Blobs created on top of preallocated memory if shape was increased.");
+        if (!deallocate()) {
+            IE_THROW() << "Cannot deallocate blob while an attempt to enlarge blob area in setShape.";
+        }
+
+        m_layout.set_partial_shape(ov::PartialShape{dims});
+
+        allocate();
+    }
+}
+
 bool RemoteBlobImpl::deallocate() noexcept {
     m_memory_object.reset();
     return m_memory_object == nullptr;
@@ -132,7 +145,6 @@ void RemoteBlobImpl::allocate() {
         if (m_memory_object)
             return;
     }
-
 
     auto& engine = context->get_engine();
 
@@ -197,11 +209,10 @@ std::shared_ptr<InferenceEngine::RemoteContext> RemoteBlobImpl::getContext() con
 }
 
 void RemoteBlobImpl::reinterpret(const cldnn::layout& new_layout) {
-    OPENVINO_ASSERT(m_layout.bytes_count() >= new_layout.bytes_count(),
-                    "[GPU] Can't reinterpret blob to the size bigger than allocated memory buffer");
+    OPENVINO_ASSERT(m_memory_object->size() >= new_layout.bytes_count(),
+                    "[GPU] Can't reinterpret blob to the size bigger than allocated memory buffer",
+                    " (", m_memory_object->size(), " vs ",  new_layout.bytes_count(), ")");
     m_layout = new_layout;
-    auto engine = m_memory_object->get_engine();
-    m_memory_object = engine->reinterpret_buffer(*m_memory_object, new_layout);
 }
 
 void RemoteBlobImpl::lock() const {
@@ -273,12 +284,16 @@ LockedMemory<void> RemoteBlobImpl::wmap() noexcept {
     }
 }
 
-bool RemoteBlobImpl::supports_caching() const {
+bool RemoteBlobImpl::is_shared() const {
     return m_mem_type == BlobType::BT_BUF_SHARED ||
            m_mem_type == BlobType::BT_USM_SHARED ||
            m_mem_type == BlobType::BT_IMG_SHARED ||
            m_mem_type == BlobType::BT_SURF_SHARED ||
            m_mem_type == BlobType::BT_DX_BUF_SHARED;
+}
+
+bool RemoteBlobImpl::supports_caching() const {
+    return is_shared();
 }
 
 }  // namespace intel_gpu

--- a/src/plugins/intel_gpu/tests/functional/remote_blob_tests/gpu_remote_tensor_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_blob_tests/gpu_remote_tensor_tests.cpp
@@ -2040,3 +2040,17 @@ TEST(OVRemoteContextGPU, smoke_RemoteContextSingleDevice) {
         check_contexts_are_same(default_ctx, core.get_default_context(CommonTestUtils::DEVICE_GPU));
     }
 }
+
+TEST(OVRemoteContextGPU, smoke_RemoteTensorSetShape) {
+#if defined(ANDROID)
+    GTEST_SKIP();
+#endif
+    auto core = ov::Core();
+    auto context = core.get_default_context(CommonTestUtils::DEVICE_GPU);
+
+    auto remote_tensor = context.create_tensor(ov::element::f32, ov::Shape{1, 2, 3, 4});
+
+    ASSERT_NO_THROW(remote_tensor.set_shape({2, 3, 4, 5}));
+    ASSERT_NO_THROW(remote_tensor.set_shape({1, 3, 4, 5}));
+    ASSERT_NO_THROW(remote_tensor.set_shape({3, 3, 4, 5}));
+}


### PR DESCRIPTION
### Details:
 - Currently we do redundant device input realloc in dynamic case even if actual memory buffer is big enough. This patch fixes it, so memory handle in remote blob is not changed and stores actual memory layout and size, and `m_layout` stores currently requested layout, so get_memory() now does reinterpret internally, but doesn't update original memory handle.
 - Also removed device blobs check from set_input() as similar logic is implemented in prepare_inputs() 
