### PR TITLE
Add missing != operator, fixing compilation issue with Visual Studio 17.6 with /std:c++latest.

### DIFF
--- a/src/inference/include/ie/ie_precision.hpp
+++ b/src/inference/include/ie/ie_precision.hpp
@@ -165,6 +165,15 @@ public:
     }
 
     /**
+     * @brief Inequality operator with Precision object
+     * @param p A value of Precision to compare with
+     * @return `true` if values represent different precisions, `false` otherwise
+     */
+    bool operator!=(const Precision& p) const noexcept {
+        return !(*this == p);
+    }
+
+    /**
      * @brief Equality operator with ePrecision enum value
      * @param p A value of ePrecision to compare with
      * @return `true` if values represent the same precisions, `false` otherwise


### PR DESCRIPTION
This fixes a compilation problem that happens if compiling with Visual Studio 17.6 using the latest C++ language version.

To reproduce the problem, create e.g. a Windows console application and set the C++ language standard to latest (`/std:c++latest`). The following program then failed with error C2666:

```c++
#define NOMINMAX
#pragma warning(disable : 4996)

#include <Windows.h>

#include <iostream>
#include "openvino/openvino.hpp"
#include "ie/ie_precision.hpp"

using namespace InferenceEngine;
using namespace std;

int main()
{
    Precision p{};
    auto x = p == Precision::FP32;
    std::cout << "Hello World!\n";
}
```

### Tickets:
 - #17852
