### PR TITLE
Revert "Stale PRs/Issues action limit extention (#17491)"

### DIFF
--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -22,6 +22,4 @@ jobs:
           days-before-issue-stale: 274
           days-before-close: 7
           ascending: true
-          operations-per-run: 5000
-          repo-token: ${{ secrets.STALE_ISSUES_TOKEN }}
           exempt-pr-labels: 'no_stale'


### PR DESCRIPTION
This reverts commit c351335661b5fd4bbfe229fe548a439db237814a.

The number of PRs to scan has reduced and we don't need so many operations per run (and personal token for higher API request limits) anymore