### PR TITLE
[DOCS] Updating model conversion diagram - for 23.0

### DIFF
--- a/docs/_static/images/model_conversion_diagram.svg
+++ b/docs/_static/images/model_conversion_diagram.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9eaab59dc35a5e40bef352cf140f1a6e37b9f9bb10ae64b1eafc1b9060c361ca
-size 168807
+oid sha256:bc27fc105f73d9fb6e1a5436843c090c0748486632084aa27611222b2738a108
+size 187128


### PR DESCRIPTION
Porting: https://github.com/openvinotoolkit/openvino/pull/17871

Removing info about soon to be deprecated Kaldi, MxNet and Caffee frameworks.