### PR TITLE
[Snippets] Added tailing processing support for splitted Loops

### DIFF
--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -32,6 +32,9 @@ public:
         // True if after each Loop iteration the corresponding data pointer should be incremented.
         // Otherwise, the data pointer shift is skipped
         bool is_incremented = true;
+        int64_t ptr_increment = 0;
+        int64_t finalization_offset = 0;
+        int64_t data_size = 0;
     };
 
     class LoopInfo {
@@ -40,7 +43,8 @@ public:
         LoopInfo(size_t work_amount, size_t increment, size_t dim_idx,
                  const std::vector<LoopPort>& entries,
                  const std::vector<LoopPort>& exits)
-            : work_amount(work_amount), increment(increment), dim_idx(dim_idx), entry_points(entries), exit_points(exits) {}
+            : work_amount(work_amount), increment(increment), dim_idx(dim_idx),
+              entry_points(entries), exit_points(exits) {}
         LoopInfo(size_t work_amount, size_t increment, size_t dim_idx,
                  const std::vector<ExpressionPort>& entries,
                  const std::vector<ExpressionPort>& exits);
@@ -104,16 +108,19 @@ public:
     void expression_replacement(constExprIt new_expr_begin, constExprIt new_expr_end, const ExpressionPtr& decomposed_expr,
                                 size_t loop_id, const std::vector<ExpressionPort>& new_entries, const std::vector<ExpressionPort>& exits);
 
+    // Note: these methods find iterators of first entry loop point and last exit point (bounds of Loop)
+    //       If there are already inserted LoopBegin and LoopEnd in Linear IR, the methods can find them as well if `loop_ops_inserted` = true
     void get_loop_bounds(const LinearIR& linear_ir,
                          size_t loop_id,
                          LinearIR::constExprIt& loop_begin_pos,
-                         LinearIR::constExprIt& loop_end_pos) const;
+                         LinearIR::constExprIt& loop_end_pos,
+                         bool loop_ops_inserted = false) const;
     static void get_loop_bounds(const LinearIR& linear_ir,
                                 const std::vector<LoopPort>& entries,
                                 const std::vector<LoopPort>& exits,
                                 LinearIR::constExprIt& loop_begin_pos,
                                 LinearIR::constExprIt& loop_end_pos,
-                                size_t loop_id);
+                                size_t loop_id, bool loop_ops_inserted = false);
 
 private:
     static void get_io_loop_ports(LinearIR::constExprIt loop_begin_pos,

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -44,7 +44,7 @@ public:
                  const std::vector<LoopPort>& entries,
                  const std::vector<LoopPort>& exits)
             : work_amount(work_amount), increment(increment), dim_idx(dim_idx),
-              entry_points(entries), exit_points(exits) {}
+              entry_points(entries), exit_points(exits), outer_splited_loop(false) {}
         LoopInfo(size_t work_amount, size_t increment, size_t dim_idx,
                  const std::vector<ExpressionPort>& entries,
                  const std::vector<ExpressionPort>& exits);
@@ -58,6 +58,8 @@ public:
         // Note: Scalars aren't entry expressions but can be before first entry expr in Linear IR
         std::vector<LoopPort> entry_points = {};
         std::vector<LoopPort> exit_points = {};
+        // True if this Loop is outer Loop for nested Loops that splits the same dimension
+        bool outer_splited_loop = false;
     };
     using LoopInfoPtr = std::shared_ptr<LoopInfo>;
 

--- a/src/common/snippets/include/snippets/lowered/loop_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_manager.hpp
@@ -75,13 +75,12 @@ public:
     void mark_loop(LinearIR::constExprIt loop_begin_pos,
                    LinearIR::constExprIt loop_end_pos,
                    size_t loop_depth, size_t vector_size);
-    void mark_loop(LinearIR::constExprIt loop_begin_pos,
-                   LinearIR::constExprIt loop_end_pos,
-                   size_t work_amount,
-                   size_t work_amount_increment,
-                   size_t dim_idx,
-                   const std::vector<ExpressionPort>& entries,
-                   const std::vector<ExpressionPort>& exits);
+    // Return Loop ID
+    size_t mark_loop(LinearIR::constExprIt loop_begin_pos,
+                    LinearIR::constExprIt loop_end_pos,
+                    size_t work_amount, size_t work_amount_increment, size_t dim_idx,
+                    const std::vector<ExpressionPort>& entries,
+                    const std::vector<ExpressionPort>& exits);
 
     void fuse_loops(const LinearIR& linear_ir, size_t loop_id_upper, size_t loop_id_lower, bool fuse_into_upper = true);
     void fuse_loops(LinearIR::constExprIt loop_begin_target, LinearIR::constExprIt loop_end_target,

--- a/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
@@ -15,7 +15,7 @@ namespace pass {
 
 /**
  * @interface InitLoops
- * @brief The pass explicitly insert LoadBegin and LoadEnd in Linear IR using LoopManager::LoopInfo from Loop markup algorithm
+ * @brief The pass initialize scheduling information in LoopInfo
  * @ingroup snippets
  */
 class InitLoops : public Pass {
@@ -25,15 +25,14 @@ public:
     bool run(LinearIR& linear_ir) override;
 
 private:
-    static void insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, size_t loop_id, bool has_outer_loop);
-
-    static std::vector<int64_t> init_ptr_increments(std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
-                                                    std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs,
-                                                    const LinearIR::LoopManagerPtr& loop_manager,
-                                                    size_t loop_id, size_t work_amount, size_t dim_idx);
-    static std::vector<int64_t> init_finalization_offsets(const std::vector<int64_t>& ptr_increments, size_t work_amount);
-    static std::vector<int64_t> init_element_type_sizes(const std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
-                                                        const std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs);
+    static void init_ptr_increments(std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
+                                    std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs,
+                                    const LinearIR::LoopManagerPtr& loop_manager, size_t work_amount, size_t loop_id, size_t dim_idx);
+    static void init_finalization_offsets(std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
+                                          std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs,
+                                          size_t work_amount);
+    static void init_element_type_sizes(std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
+                                        std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
@@ -27,7 +27,7 @@ public:
 private:
     static void init_ptr_increments(std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
                                     std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs,
-                                    const LinearIR::LoopManagerPtr& loop_manager, size_t work_amount, size_t loop_id, size_t dim_idx);
+                                    size_t work_amount, size_t dim_idx);
     static void init_finalization_offsets(std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
                                           std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs,
                                           size_t work_amount);

--- a/src/common/snippets/include/snippets/lowered/pass/insert_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_loops.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "pass.hpp"
+
+#include "snippets/lowered/loop_manager.hpp"
+
+namespace ov {
+namespace snippets {
+namespace lowered {
+namespace pass {
+
+/**
+ * @interface InsertLoops
+ * @brief The pass explicitly insert LoadBegin and LoadEnd in Linear IR using LoopManager::LoopInfo from Loop markup algorithm
+ * @ingroup snippets
+ */
+class InsertLoops : public Pass {
+public:
+    OPENVINO_RTTI("InsertLoops", "Pass")
+    InsertLoops();
+    bool run(LinearIR& linear_ir) override;
+private:
+    static void insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, size_t loop_id, bool has_outer_loop);
+    static void filter_ports(std::vector<LinearIR::LoopManager::LoopPort>& loop_entries, std::vector<LinearIR::LoopManager::LoopPort>& loop_exits);
+};
+
+} // namespace pass
+} // namespace lowered
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/include/snippets/lowered/pass/insert_tail_loop.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_tail_loop.hpp
@@ -6,6 +6,8 @@
 
 #include "pass.hpp"
 
+#include "snippets/op/loop.hpp"
+
 namespace ov {
 namespace snippets {
 namespace lowered {
@@ -18,13 +20,24 @@ namespace pass {
  * @ingroup snippets
  */
 class InsertTailLoop : public Pass {
-    static void tail_transformations(LinearIR& linear_ir,
-                                     LinearIR::container::const_iterator tail_begin,
-                                     LinearIR::container::const_iterator tail_end,
-                                     size_t tail_size);
 public:
     OPENVINO_RTTI("InsertTailLoop", "Pass")
     bool run(LinearIR& linear_ir) override;
+
+private:
+    static std::shared_ptr<op::LoopEnd> create_tail_loop(LinearIR& linear_ir,
+                                                         LinearIR::constExprIt vector_begin,
+                                                         LinearIR::constExprIt vector_end,
+                                                         LinearIR::constExprIt& tail_begin,
+                                                         LinearIR::constExprIt& tail_end,
+                                                         const std::shared_ptr<op::LoopEnd>& vector_loop_end,
+                                                         bool need_vector_loop,
+                                                         size_t tail_size, const std::vector<int64_t>& tail_finalization_offsets);
+    static void tail_transformations(LinearIR& linear_ir,
+                                     LinearIR::constExprIt tail_begin,
+                                     LinearIR::constExprIt tail_end,
+                                     size_t tail_size);
+    static bool optimize_single_evaluation(const std::shared_ptr<op::LoopEnd>& loop);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/op/brgemm.hpp
+++ b/src/common/snippets/include/snippets/op/brgemm.hpp
@@ -22,6 +22,9 @@ public:
     Brgemm(const Output<Node>& A, const Output<Node>& B,
            const size_t offset_a = 0lu, const size_t offset_b = 0lu, const size_t offset_c = 0lu,
            std::vector<size_t> layout_a = {}, std::vector<size_t> layout_b = {}, std::vector<size_t> layout_c = {});
+    Brgemm(const Output<Node>& A, const Output<Node>& B,
+           const PortDescriptor& desc_a, const PortDescriptor& desc_b, const PortDescriptor& desc_c,
+           std::vector<size_t> layout_a = {}, std::vector<size_t> layout_b = {}, std::vector<size_t> layout_c = {});
     Brgemm() = default;
 
     size_t get_offset_a() const { return get_input_offset(0); }

--- a/src/common/snippets/include/snippets/op/loop.hpp
+++ b/src/common/snippets/include/snippets/op/loop.hpp
@@ -62,6 +62,7 @@ private:
  * @param ptr_increments specifies i/o pointer increment performed on every iteration. This is an alternative to
  * apply_increments, which enables more flexibility.
  * @param finalization_offsets pointer increments that are be applied to i/o pointers before exiting the loop
+ * @param id the identifier of Loop in Loop system in LoopManager
  * @ingroup snippets
  */
 class LoopEnd : public LoopBase {
@@ -69,10 +70,10 @@ public:
     OPENVINO_OP("LoopEnd", "SnippetsOpset", LoopBase);
     LoopEnd(const Output<Node>& loop_begin, size_t work_amount, size_t work_amount_increment,
               std::vector<bool> apply_increment, std::vector<int64_t> finalization_offsets,
-              std::vector<int64_t> element_type_sizes, size_t input_num, size_t output_num);
+              std::vector<int64_t> element_type_sizes, size_t input_num, size_t output_num, size_t id);
     LoopEnd(const Output<Node>& loop_begin, size_t work_amount, size_t work_amount_increment,
             std::vector<int64_t> ptr_increments, std::vector<int64_t> finalization_offsets,
-            std::vector<int64_t> element_type_sizes, size_t input_num, size_t output_num);
+            std::vector<int64_t> element_type_sizes, size_t input_num, size_t output_num, size_t id);
     LoopEnd() = default;
     std::shared_ptr<LoopBegin> get_loop_begin();
     void validate_and_infer_types() override;
@@ -97,17 +98,19 @@ public:
     size_t get_work_amount() const;
     size_t get_increment() const;
     bool get_evaluate_once() const;
+    size_t get_id() const;
     bool visit_attributes(AttributeVisitor& visitor) override;
 
 private:
-    std::vector<int64_t> ptr_increments = {};
-    std::vector<int64_t> finalization_offsets = {};
-    std::vector<int64_t> element_type_sizes = {};
-    size_t work_amount = 0;
-    size_t work_amount_increment = 0;
-    size_t input_num = 0;
-    size_t output_num = 0;
-    bool evaluate_once = false; // true if the Loop is executed only once, used to skip setting and testing the loop counter
+    std::vector<int64_t> m_ptr_increments = {};
+    std::vector<int64_t> m_finalization_offsets = {};
+    std::vector<int64_t> m_element_type_sizes = {};
+    size_t m_work_amount = 0;
+    size_t m_work_amount_increment = 0;
+    size_t m_input_num = 0;
+    size_t m_output_num = 0;
+    size_t m_id = 0;  // the corresponding Loop identificator in LoopManager
+    bool m_evaluate_once = false; // true if the Loop is executed only once, used to skip setting and testing the loop counter
 };
 
 } // namespace op

--- a/src/common/snippets/include/snippets/op/memory_access.hpp
+++ b/src/common/snippets/include/snippets/op/memory_access.hpp
@@ -44,6 +44,7 @@ public:
 
         friend class MemoryAccess;
     };
+    using PortMap = std::map<size_t, PortDescriptor>;
 
     void set_input_count(size_t count, size_t idx = 0);
     void set_output_count(size_t count, size_t idx = 0);
@@ -55,8 +56,8 @@ public:
     size_t get_input_offset(size_t idx = 0) const;
     size_t get_output_offset(size_t idx = 0) const;
 
-    std::map<size_t, PortDescriptor> get_memory_access_input_ports() const { return m_input_ports; }
-    std::map<size_t, PortDescriptor> get_memory_access_output_ports() const { return m_output_ports; }
+    PortMap get_memory_access_input_ports() const { return m_input_ports; }
+    PortMap get_memory_access_output_ports() const { return m_output_ports; }
 
     bool is_memory_access_input_port(size_t idx) const;
     bool is_memory_access_output_port(size_t idx) const;
@@ -69,6 +70,7 @@ public:
 protected:
     explicit MemoryAccess(const OutputVector& arguments, size_t input_count = 0, size_t output_count = 0);
     explicit MemoryAccess(const OutputVector& arguments, const std::set<size_t>& input_ports, const std::set<size_t>& output_ports);
+    explicit MemoryAccess(const OutputVector& arguments, const PortMap& input_ports, const PortMap& output_ports);
     MemoryAccess() = default;
 
     // This method can be called only in ctors
@@ -80,8 +82,8 @@ protected:
     const PortDescriptor& get_output_port_descriptor(const size_t i) const;
 
     // [port_num, port_desc]
-    std::map<size_t, PortDescriptor> m_input_ports;
-    std::map<size_t, PortDescriptor> m_output_ports;
+    PortMap m_input_ports;
+    PortMap m_output_ports;
 };
 
 } // namespace op

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -211,18 +211,17 @@ void LinearIR::LoopManager::mark_loop(LinearIR::constExprIt loop_begin_pos,
     }
 }
 
-void LinearIR::LoopManager::mark_loop(LinearIR::constExprIt loop_begin_pos,
-                                      LinearIR::constExprIt loop_end_pos,
-                                      size_t work_amount,
-                                      size_t work_amount_increment,
-                                      size_t dim_idx,
-                                      const std::vector<ExpressionPort>& entries,
-                                      const std::vector<ExpressionPort>& exits) {
+size_t LinearIR::LoopManager::mark_loop(LinearIR::constExprIt loop_begin_pos,
+                                        LinearIR::constExprIt loop_end_pos,
+                                        size_t work_amount, size_t work_amount_increment, size_t dim_idx,
+                                        const std::vector<ExpressionPort>& entries,
+                                        const std::vector<ExpressionPort>& exits) {
     const auto loop_info = std::make_shared<LoopManager::LoopInfo>(work_amount, work_amount_increment, dim_idx, entries, exits);
     const auto loop_id = this->add_loop_info(loop_info);
     for (auto expr_it = loop_begin_pos; expr_it != loop_end_pos; ++expr_it) {
         insert_loop_id(*expr_it, loop_id);
     }
+    return loop_id;
 }
 void LinearIR::LoopManager::fuse_loops(const LinearIR& linear_ir, size_t loop_id_upper, size_t loop_id_lower, bool fuse_into_upper) {
     LinearIR::constExprIt loop_begin_target, loop_end_target;

--- a/src/common/snippets/src/lowered/pass/cleanup_loop_offsets.cpp
+++ b/src/common/snippets/src/lowered/pass/cleanup_loop_offsets.cpp
@@ -40,13 +40,24 @@ bool CleanupLoopOffsets::run(LinearIR& linear_ir) {
                     for (size_t i = 0; i < fin_offsets.size(); i++)
                         per_port_connector_offset[loop_inputs[i]] = i;
 
+                    const auto outer_increment = static_cast<int64_t>(outer_loop_end->get_increment());
                     auto outer_ptr_increments = outer_loop_end->get_ptr_increments();
                     const auto& outer_loop_inputs = next_expr_it->get()->get_input_port_connectors();
                     for (size_t i = 0; i < outer_ptr_increments.size(); i++) {
                         const auto& managed_connector = outer_loop_inputs[i];
                         const auto& found = per_port_connector_offset.find(managed_connector);
                         if (found != per_port_connector_offset.end()) {
-                            outer_ptr_increments[i] += fin_offsets[found->second];
+                            if (fin_offsets[found->second] % outer_increment != 0)
+                                continue;
+                            // Since data ptr is incremented on [ptr_increment x increment],
+                            // we should guarantee proportionality of ptr shifts
+                            // For example,
+                            // Inner Loop: WA = 32, Inc = 1, ptr_increment[0] = 20, final_offset[0] = -640
+                            // Outer Loop: WA = 70, Inc = 32, ptr_increment[0] = 20, final_offset[0] = -1400
+                            // To save data ptr shift proportionality, we have to calculate so:
+                            //    outer_ptr_increment[0] = 20 + (-640 / 32) = 20 + (-20) = 0
+                            const auto shift = fin_offsets[found->second] / outer_increment;
+                            outer_ptr_increments[i] += shift;
                             fin_offsets[found->second] = 0;
                             is_modified = true;
                         }

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -108,6 +108,9 @@ bool FuseLoops::fuse_upper_into_current(LinearIR& linear_ir, const LinearIR::Loo
     loop_manager->fuse_loops(target_loop_begin_pos, target_loop_end_pos, target_loop_id, current_loop_id, false);
     // Update work_amount for Loop (increment is constant because increments must be the identical for fusion):
     loop_current->work_amount = std::max(loop_current->work_amount, loop_target->work_amount);
+    // If one of the Loops is outer for nested loops that splits the same dimension,
+    // after fusion new common Loop save this status
+    loop_current->outer_splited_loop = loop_current->outer_splited_loop || loop_target->outer_splited_loop;
 
     const auto insertion_place = current_loop_begin_pos;
     const auto is_move_needed = target_loop_end_pos != current_loop_begin_pos;
@@ -150,6 +153,9 @@ bool FuseLoops::fuse_lower_into_current(LinearIR& linear_ir, const LinearIR::Loo
     loop_manager->fuse_loops(target_loop_begin_pos, target_loop_end_pos, current_loop_id, target_loop_id);
     // Update work_amount for Loop (increment is constant because increments must be the identical for fusion):
     loop_current->work_amount = std::max(loop_current->work_amount, loop_target->work_amount);
+    // If one of the Loops is outer for nested loops that splits the same dimension,
+    // after fusion new common Loop save this status
+    loop_current->outer_splited_loop = loop_current->outer_splited_loop || loop_target->outer_splited_loop;
 
     const auto insertion_place = current_loop_end_pos;
     const auto is_move_needed = insertion_place != target_loop_begin_pos;

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -6,7 +6,6 @@
 
 #include "snippets/lowered/linear_ir.hpp"
 #include "snippets/lowered/loop_manager.hpp"
-#include "snippets/snippets_isa.hpp"
 #include "snippets/itt.hpp"
 
 namespace ov {
@@ -17,62 +16,11 @@ namespace pass {
 using LoopPort = LinearIR::LoopManager::LoopPort;
 
 namespace {
-void filter_ports(std::vector<LoopPort>& loop_entries, std::vector<LoopPort>& loop_exits) {
-    std::vector<LoopPort> new_loop_entries;
-    std::vector<LoopPort> new_loop_exits;
-    new_loop_entries.reserve(loop_entries.size());
-    new_loop_exits.reserve(loop_exits.size());
-
-    for (const auto& loop_entry_point : loop_entries) {
-        const auto& expr = loop_entry_point.expr_port->get_expr();
-        const auto ma = ov::as_type_ptr<op::MemoryAccess>(expr->get_node());
-        if (ma && ma->is_memory_access_input_port(loop_entry_point.expr_port->get_index())) {
-            new_loop_entries.push_back(loop_entry_point);
-        }
-    }
-
-    for (const auto& loop_exit_point : loop_exits) {
-        const auto& expr = loop_exit_point.expr_port->get_expr();
-        const auto ma = ov::as_type_ptr<op::MemoryAccess>(expr->get_node());
-        if (ma && ma->is_memory_access_output_port(loop_exit_point.expr_port->get_index())) {
-            new_loop_exits.push_back(loop_exit_point);
-        }
-    }
-
-    loop_entries = new_loop_entries;
-    loop_exits = new_loop_exits;
-}
-
-int64_t get_dim_stride(const LinearIR::LoopManagerPtr& loop_manager, const std::vector<size_t>& loop_ids,
-                       size_t loop_id, size_t dim, size_t dim_idx,
+int64_t get_dim_stride(const LinearIR::LoopManagerPtr& loop_manager, size_t dim,
                        const std::vector<size_t>& layout, const std::vector<size_t>& shape) {
-    // Example, shape = [3, 384, 64], loop_ids = [2, 1, 0], layout = [0, 1, 2]
-    // Loop Info:                            | Pointer increments:
-    // - 2: work_amount = 12, dim_idx = 1    | 1 x 64 x 32 - (1 * shape[layout[2]] * 32) where 32 is work_amount of inner splitted Loop
-    // - 1: work_amount = 32, dim_idx = 1    | 1 x 64 - (1 * shape[layout[2]])
-    // - 0: work_amount = 64, dim_idx = 0    | 1
-    // Note that dim_idx enumerates dimensions from the end: 64, 384, 3
-    // Firstly, we find all Loop IDs with the same dimension index.
-    // The Loop Info's with the same dimension index mean that these Loops split this dimension together.
-    // It's possible in Brgemm Blocking by M, for example
-    std::vector<size_t> splitted_loops;
-    // Inner -> Outer
-    for (auto it = loop_ids.rbegin(); it != loop_ids.rend(); ++it) {
-        const auto id = *it;
-        if (loop_manager->get_loop_info(id)->dim_idx == dim_idx) {
-            splitted_loops.push_back(id);
-        }
-    }
-
     int64_t stride = 1;
     for (int i = static_cast<int>(layout.size()) - 1; i >= 0; i--) {
         if (layout[i] == dim) {
-            // We added work amount of inner splitted Loops
-            for (auto id : splitted_loops) {
-                if (id == loop_id)
-                    break;
-                stride *= loop_manager->get_loop_info(id)->work_amount;
-            }
             break;
         }
         stride *= static_cast<int64_t>(shape[layout[i]]);
@@ -82,27 +30,21 @@ int64_t get_dim_stride(const LinearIR::LoopManagerPtr& loop_manager, const std::
 }  // namespace
 
 InitLoops::InitLoops() : Pass() {}
-std::vector<int64_t> InitLoops::init_ptr_increments(std::vector<LoopPort>& loop_inputs,
-                                                    std::vector<LoopPort>& loop_outputs,
-                                                    const LinearIR::LoopManagerPtr& loop_manager,
-                                                    size_t loop_id, size_t work_amount, size_t dim_idx) {
-    std::vector<int64_t> ptr_increments;
-    ptr_increments.reserve(loop_inputs.size() + loop_outputs.size());
 
+void InitLoops::init_ptr_increments(std::vector<LoopPort>& loop_inputs, std::vector<LoopPort>& loop_outputs,
+                                    const LinearIR::LoopManagerPtr& loop_manager, size_t work_amount, size_t loop_id, size_t dim_idx) {
     for (auto& loop_input : loop_inputs) {
         const auto& port = loop_input.expr_port;
-        // For strides we have to use layout from source since source writes data by special rules
         const auto source = *port->get_connected_ports().begin();
         const auto loop_ids = port->get_expr()->get_loop_ids();
         const auto& layout = port->get_descriptor_ptr()->get_layout();
         const auto& shape = port->get_descriptor_ptr()->get_shape();
         const auto& dim = *(layout.rbegin() + dim_idx);
-        int64_t ptr_increment = 0;
+        loop_input.ptr_increment = 0;
         // If relevant dim is not broadcasted, then ptr_increment is the dim stride in the new layout
         if (loop_input.is_incremented && !(shape[dim] == 1 && work_amount != 1)) {
-            ptr_increment = get_dim_stride(loop_manager, loop_ids, loop_id, dim, dim_idx, source.get_descriptor_ptr()->get_layout(), shape);
+            loop_input.ptr_increment = get_dim_stride(loop_manager, dim, source.get_descriptor_ptr()->get_layout(), shape);
         }
-        ptr_increments.push_back(ptr_increment);
     }
 
     for (auto& loop_output : loop_outputs) {
@@ -111,76 +53,35 @@ std::vector<int64_t> InitLoops::init_ptr_increments(std::vector<LoopPort>& loop_
         const auto& layout = port->get_descriptor_ptr()->get_layout();
         const auto& shape = port->get_descriptor_ptr()->get_shape();
         const auto& dim = *(layout.rbegin() + dim_idx);
-        int64_t ptr_increment = 0;
+        loop_output.ptr_increment = 0;
         // If relevant dim is not broadcasted, then ptr_increment is the dim stride in the new layout
         if (loop_output.is_incremented && !(shape[dim] == 1 && work_amount != 1)) {
-            ptr_increment = get_dim_stride(loop_manager, loop_ids, loop_id, dim, dim_idx, layout, shape);
+            loop_output.ptr_increment = get_dim_stride(loop_manager, dim, layout, shape);
         }
-        ptr_increments.push_back(ptr_increment);
     }
-    return ptr_increments;
 }
 
-std::vector<int64_t> InitLoops::init_finalization_offsets(const std::vector<int64_t>& ptr_increments, size_t work_amount) {
-    std::vector<int64_t> finalization_offsets;
-    finalization_offsets.resize(ptr_increments.size());
-    for (size_t i = 0; i < ptr_increments.size(); ++i) {
-        finalization_offsets[i] = -1 * ptr_increments[i] * work_amount;
+void InitLoops::init_finalization_offsets(std::vector<LinearIR::LoopManager::LoopPort>& loop_inputs,
+                                          std::vector<LinearIR::LoopManager::LoopPort>& loop_outputs,
+                                          size_t work_amount) {
+    for (auto& loop_input : loop_inputs) {
+        loop_input.finalization_offset = -1 * loop_input.ptr_increment * work_amount;
     }
-    return finalization_offsets;
+    for (auto& loop_output : loop_outputs) {
+        loop_output.finalization_offset = -1 * loop_output.ptr_increment * work_amount;
+    }
 }
 
-std::vector<int64_t> InitLoops::init_element_type_sizes(const std::vector<LoopPort>& loop_inputs,
-                                                        const std::vector<LoopPort>& loop_outputs) {
-    std::vector<int64_t> element_types;
-    element_types.reserve(loop_inputs.size() + loop_outputs.size());
-    for (const auto& in : loop_inputs) {
-        const auto& port = in.expr_port;
-        element_types.push_back(port->get_expr()->get_node()->get_input_element_type(port->get_index()).size());
+void InitLoops::init_element_type_sizes(std::vector<LoopPort>& loop_inputs,
+                                        std::vector<LoopPort>& loop_outputs) {
+    for (auto& loop_input : loop_inputs) {
+        const auto& port = loop_input.expr_port;
+        loop_input.data_size = static_cast<int64_t>(port->get_expr()->get_node()->get_input_element_type(port->get_index()).size());
     }
-    for (const auto& out : loop_outputs) {
-        const auto& port = out.expr_port;
-        element_types.push_back(port->get_expr()->get_node()->get_output_element_type(port->get_index()).size());
+    for (auto& loop_output : loop_outputs) {
+        const auto& port = loop_output.expr_port;
+        loop_output.data_size = static_cast<int64_t>(port->get_expr()->get_node()->get_output_element_type(port->get_index()).size());
     }
-    return element_types;
-}
-
-void InitLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, size_t loop_id, bool has_outer_loop) {
-    const auto loop_info = loop_manager->get_loop_info(loop_id);
-    auto loop_entries = loop_info->entry_points;
-    auto loop_exits = loop_info->exit_points;
-    const auto work_amount = loop_info->work_amount;
-    const auto work_amount_increment = loop_info->increment;
-    const auto dim_idx = loop_info->dim_idx;
-
-    LinearIR::constExprIt loop_begin_pos, loop_end_pos;
-    loop_manager->get_loop_bounds(linear_ir, loop_id, loop_begin_pos, loop_end_pos);
-
-    // Remove non MemoryAccess ports since Loop can have only GPR inputs
-    filter_ports(loop_entries, loop_exits);
-
-    const auto ptr_increments = init_ptr_increments(loop_entries, loop_exits, loop_manager, loop_id, work_amount, dim_idx);
-    const auto finalization_offsets = init_finalization_offsets(ptr_increments, work_amount);
-    const auto io_data_sizes = init_element_type_sizes(loop_entries, loop_exits);
-
-    const auto& loop_begin = std::make_shared<op::LoopBegin>();
-    const auto& loop_begin_expr = linear_ir.create_expression(loop_begin, std::vector<PortConnectorPtr>{});
-    linear_ir.insert(loop_begin_pos, loop_begin_expr);
-
-    const auto& loop_end = std::make_shared<op::LoopEnd>(
-            loop_begin->output(0), work_amount, work_amount_increment, ptr_increments, finalization_offsets,
-            io_data_sizes, loop_entries.size(), loop_exits.size());
-    loop_end->has_outer_loop = has_outer_loop;
-
-    std::vector<PortConnectorPtr> loop_end_inputs;
-    for (const auto& expr_point : loop_entries)
-        loop_end_inputs.push_back(expr_point.expr_port->get_port_connector_ptr());
-    for (const auto& expr_port : loop_exits)
-        loop_end_inputs.push_back(expr_port.expr_port->get_port_connector_ptr());
-    loop_end_inputs.push_back(loop_begin_expr->get_output_port_connector(0));
-
-    const auto& loop_end_expr = linear_ir.create_expression(loop_end, loop_end_inputs);
-    linear_ir.insert(loop_end_pos, loop_end_expr);
 }
 
 bool InitLoops::run(LinearIR& linear_ir) {
@@ -189,28 +90,17 @@ bool InitLoops::run(LinearIR& linear_ir) {
         return false;
 
     const auto& loop_manager = linear_ir.get_loop_manager();
+    const auto& loops = loop_manager->get_map();
+    for (const auto& loop : loops) {
+        const auto loop_id = loop.first;
+        const auto loop_info = loop.second;
 
-    std::set<size_t> inserted_loops;
-    for (auto expr_it = linear_ir.begin(); expr_it != linear_ir.end(); expr_it++) {
-        const auto expr = *expr_it;
-        const auto& node = expr->get_node();
-        if (ov::is_type<op::LoopBase>(node) ||
-            ov::is_type<op::Buffer>(node) ||     // Need to cover Buffer
-            ov::is_type<ov::op::v0::Parameter>(node) ||
-            ov::is_type<ov::op::v0::Result>(node))
-            continue;
+        const auto work_amount = loop_info->work_amount;
+        const auto dim_idx = loop_info->dim_idx;
 
-        // Outer Loop ----> Inner Loop
-        const auto expr_loops = expr->get_loop_ids();
-        const auto loop_depth = expr_loops.size();
-        for (size_t i = 0; i < loop_depth; ++i) {
-            const auto loop_id = expr_loops[i];
-            if (inserted_loops.count(loop_id) == 0) {
-                const bool has_outer_loop = i > 0 && inserted_loops.find(expr_loops[i - 1]) != inserted_loops.end();
-                insertion(linear_ir, loop_manager, loop_id, has_outer_loop);
-                inserted_loops.insert(loop_id);  // save Loop ID
-            }
-        }
+        init_ptr_increments(loop_info->entry_points, loop_info->exit_points, loop_manager, work_amount, loop_id, dim_idx);
+        init_finalization_offsets(loop_info->entry_points, loop_info->exit_points, work_amount);
+        init_element_type_sizes(loop_info->entry_points, loop_info->exit_points);
     }
 
     return true;

--- a/src/common/snippets/src/lowered/pass/insert_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_loops.cpp
@@ -1,0 +1,144 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "snippets/lowered/pass/insert_loops.hpp"
+
+#include "snippets/lowered/linear_ir.hpp"
+#include "snippets/lowered/loop_manager.hpp"
+#include "snippets/snippets_isa.hpp"
+#include "snippets/itt.hpp"
+
+namespace ov {
+namespace snippets {
+namespace lowered {
+namespace pass {
+
+using LoopPort = LinearIR::LoopManager::LoopPort;
+
+namespace {
+std::vector<size_t> get_outer_loop_ids(const ExpressionPtr& expr, size_t loop_id) {
+    const auto loop_ids = expr->get_loop_ids();
+    const auto it = std::find(loop_ids.cbegin(), loop_ids.cend(), loop_id);
+    OPENVINO_ASSERT(it != loop_ids.cend(), "Loop ID hasn't been found");
+    return std::vector<size_t>(loop_ids.cbegin(), it);
+}
+}  // namespace
+
+InsertLoops::InsertLoops() : Pass() {}
+
+void InsertLoops::filter_ports(std::vector<LoopPort>& loop_entries, std::vector<LoopPort>& loop_exits) {
+    std::vector<LoopPort> new_loop_entries;
+    std::vector<LoopPort> new_loop_exits;
+    new_loop_entries.reserve(loop_entries.size());
+    new_loop_exits.reserve(loop_exits.size());
+
+    for (const auto& loop_entry_point : loop_entries) {
+        const auto& expr = loop_entry_point.expr_port->get_expr();
+        const auto ma = ov::as_type_ptr<op::MemoryAccess>(expr->get_node());
+        if (ma && ma->is_memory_access_input_port(loop_entry_point.expr_port->get_index())) {
+            new_loop_entries.push_back(loop_entry_point);
+        }
+    }
+
+    for (const auto& loop_exit_point : loop_exits) {
+        const auto& expr = loop_exit_point.expr_port->get_expr();
+        const auto ma = ov::as_type_ptr<op::MemoryAccess>(expr->get_node());
+        if (ma && ma->is_memory_access_output_port(loop_exit_point.expr_port->get_index())) {
+            new_loop_exits.push_back(loop_exit_point);
+        }
+    }
+
+    loop_entries = new_loop_entries;
+    loop_exits = new_loop_exits;
+}
+
+void InsertLoops::insertion(LinearIR& linear_ir, const LinearIR::LoopManagerPtr& loop_manager, size_t loop_id, bool has_outer_loop) {
+    const auto loop_info = loop_manager->get_loop_info(loop_id);
+    auto loop_entries = loop_info->entry_points;
+    auto loop_exits = loop_info->exit_points;
+    const auto work_amount = loop_info->work_amount;
+    const auto work_amount_increment = loop_info->increment;
+
+    LinearIR::constExprIt loop_begin_pos, loop_end_pos;
+    loop_manager->get_loop_bounds(linear_ir, loop_id, loop_begin_pos, loop_end_pos);
+
+    // Remove non MemoryAccess ports since Loop can have only GPR inputs
+    filter_ports(loop_entries, loop_exits);
+
+    const auto in_out_num = loop_entries.size() + loop_exits.size();
+    std::vector<int64_t> ptr_increments, finalization_offsets, io_data_sizes;
+    std::vector<PortConnectorPtr> loop_end_inputs;
+    ptr_increments.reserve(in_out_num);
+    finalization_offsets.reserve(in_out_num);
+    io_data_sizes.reserve(in_out_num);
+    loop_end_inputs.reserve(in_out_num);
+
+    auto init_params = [&ptr_increments, &finalization_offsets, &io_data_sizes, &loop_end_inputs](const std::vector<LoopPort>& ports) {
+        for (const auto& port : ports) {
+            ptr_increments.push_back(port.ptr_increment);
+            finalization_offsets.push_back(port.finalization_offset);
+            io_data_sizes.push_back(port.data_size);
+            loop_end_inputs.push_back(port.expr_port->get_port_connector_ptr());
+        }
+    };
+    init_params(loop_entries);
+    init_params(loop_exits);
+
+    const auto& loop_begin = std::make_shared<op::LoopBegin>();
+    const auto& loop_begin_expr = linear_ir.create_expression(loop_begin, std::vector<PortConnectorPtr>{});
+    linear_ir.insert(loop_begin_pos, loop_begin_expr);
+
+    const auto& loop_end = std::make_shared<op::LoopEnd>(
+            loop_begin->output(0), work_amount, work_amount_increment, ptr_increments, finalization_offsets,
+            io_data_sizes, loop_entries.size(), loop_exits.size(), loop_id);
+    loop_end->has_outer_loop = has_outer_loop;
+
+    // Add LoopBegin port connector
+    loop_end_inputs.push_back(loop_begin_expr->get_output_port_connector(0));
+
+    const auto& loop_end_expr = linear_ir.create_expression(loop_end, loop_end_inputs);
+    const auto& it = linear_ir.insert(loop_end_pos, loop_end_expr);
+
+    const auto outer_loop_ids = get_outer_loop_ids(*std::prev(it), loop_id);
+    loop_begin_expr->set_loop_ids(outer_loop_ids);
+    loop_end_expr->set_loop_ids(outer_loop_ids);
+}
+
+bool InsertLoops::run(LinearIR& linear_ir) {
+    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::InsertLoops")
+    if (linear_ir.empty())
+        return false;
+
+    const auto& loop_manager = linear_ir.get_loop_manager();
+
+    std::set<size_t> inserted_loops;
+    for (auto expr_it = linear_ir.begin(); expr_it != linear_ir.end(); expr_it++) {
+        const auto expr = *expr_it;
+        const auto& node = expr->get_node();
+        if (ov::is_type<op::LoopBase>(node) ||
+            ov::is_type<op::Buffer>(node) ||     // Need to cover Buffer
+            ov::is_type<ov::op::v0::Parameter>(node) ||
+            ov::is_type<ov::op::v0::Result>(node))
+            continue;
+
+        // Outer Loop ----> Inner Loop
+        const auto expr_loops = expr->get_loop_ids();
+        const auto loop_depth = expr_loops.size();
+        for (size_t i = 0; i < loop_depth; ++i) {
+            const auto loop_id = expr_loops[i];
+            if (inserted_loops.count(loop_id) == 0) {
+                const bool has_outer_loop = i > 0 && inserted_loops.find(expr_loops[i - 1]) != inserted_loops.end();
+                insertion(linear_ir, loop_manager, loop_id, has_outer_loop);
+                inserted_loops.insert(loop_id);  // save Loop ID
+            }
+        }
+    }
+
+    return true;
+}
+
+} // namespace pass
+} // namespace lowered
+} // namespace snippets
+} // namespace ov

--- a/src/common/snippets/src/lowered/pass/insert_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_loops.cpp
@@ -117,7 +117,6 @@ bool InsertLoops::run(LinearIR& linear_ir) {
         const auto expr = *expr_it;
         const auto& node = expr->get_node();
         if (ov::is_type<op::LoopBase>(node) ||
-            ov::is_type<op::Buffer>(node) ||     // Need to cover Buffer
             ov::is_type<ov::op::v0::Parameter>(node) ||
             ov::is_type<ov::op::v0::Result>(node))
             continue;

--- a/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_tail_loop.cpp
@@ -5,6 +5,8 @@
 #include "snippets/lowered/pass/insert_tail_loop.hpp"
 
 #include "snippets/lowered/linear_ir.hpp"
+#include "snippets/lowered/loop_manager.hpp"
+#include "snippets/lowered/pass/init_loops.hpp"
 #include "snippets/snippets_isa.hpp"
 #include "snippets/itt.hpp"
 
@@ -13,9 +15,74 @@ namespace snippets {
 namespace lowered {
 namespace pass {
 
+std::shared_ptr<op::LoopEnd> InsertTailLoop::create_tail_loop(LinearIR& linear_ir,
+                                                              LinearIR::constExprIt vector_begin,
+                                                              LinearIR::constExprIt vector_end,
+                                                              LinearIR::constExprIt& tail_begin,
+                                                              LinearIR::constExprIt& tail_end,
+                                                              const std::shared_ptr<op::LoopEnd>& vector_loop_end,
+                                                              bool need_vector_loop,
+                                                              size_t tail_size,
+                                                              const std::vector<int64_t>& tail_finalization_offsets) {
+    // tail is required => transform the body into a tail representation
+    // tail loop is fake loop because for tail we should calculate only
+    // finalization offsets which are supported by LoopEnd.
+    if (need_vector_loop) {
+        auto vector_loop_deep_copy = LinearIR::deep_copy_range(vector_begin, vector_end);
+        auto is_par_or_res = [](const ExpressionPtr& expr) {
+            return is_type<ov::op::v0::Parameter>(expr->get_node()) ||
+                   is_type<ov::op::v0::Result>(expr->get_node());
+        };
+        // Note: It's illegal to insert Parameter or Result to the IR, but they can appear inside vector loop
+        //  So we have to remo them before injecting tail loop into linear_ir
+        auto to_erase = std::remove_if(vector_loop_deep_copy.begin(), vector_loop_deep_copy.end(), is_par_or_res);
+        vector_loop_deep_copy.erase(to_erase, vector_loop_deep_copy.end());
+        tail_begin = linear_ir.insert(vector_end, vector_loop_deep_copy.begin(), vector_loop_deep_copy.end());
+        tail_end = vector_end;
+    } else {
+        tail_begin = vector_begin;
+        tail_end = vector_end;
+    }
+
+    const auto& loop_manager = linear_ir.get_loop_manager();
+    const auto current_dim_idx = loop_manager->get_loop_info(vector_loop_end->get_id())->dim_idx;
+    for (auto it = std::next(tail_begin); it != std::prev(tail_end); ++it) {
+        const auto& expr = *it;
+        const auto inner_loop_end = ov::as_type_ptr<op::LoopEnd>(expr->get_node());
+        if (!inner_loop_end)
+            continue;
+        const auto loop_info = loop_manager->get_loop_info(inner_loop_end->get_id());
+        if (loop_info->dim_idx != current_dim_idx)
+            continue;
+        const auto inner_loop_begin = inner_loop_end->get_loop_begin();
+        const auto inner_tail_work_amount = static_cast<int64_t>(inner_loop_end->get_work_amount());
+        const auto inner_tail_increment = inner_loop_end->get_increment();
+        auto inner_finalization_offsets = inner_loop_end->get_finalization_offsets();
+        for (auto& offset : inner_finalization_offsets) {
+            offset = offset / inner_tail_work_amount * static_cast<int64_t>(tail_size);
+        }
+        inner_loop_end->set_work_amount(tail_size);
+        inner_loop_end->set_increment(std::min(inner_tail_increment, tail_size));
+        inner_loop_end->set_finalization_offsets(inner_finalization_offsets);
+        const auto inner_loop_begin_it = std::find(tail_begin, it, linear_ir.get_expr_by_node(inner_loop_begin));
+        const auto inner_loop_end_it = std::next(tail_end);
+        OPENVINO_ASSERT(inner_loop_begin_it != it, "LoopBegin has not been found!");
+        tail_transformations(linear_ir, inner_loop_begin_it, inner_loop_end_it, tail_size);
+    }
+
+    tail_transformations(linear_ir, tail_begin, tail_end, tail_size);
+    std::shared_ptr<op::LoopEnd> tail_loop_end = ov::as_type_ptr<op::LoopBegin>((*tail_begin)->get_node())->get_loop_end();
+    tail_loop_end->set_increment(tail_size);
+    // ptr increments were set to the old increment, need to update them in accordance with the new one
+    tail_loop_end->set_work_amount(tail_size);
+    tail_loop_end->set_finalization_offsets(tail_finalization_offsets);
+    tail_loop_end->has_outer_loop = vector_loop_end->has_outer_loop;
+    return tail_loop_end;
+}
+
 void InsertTailLoop::tail_transformations(LinearIR& linear_ir,
-                                          LinearIR::container::const_iterator tail_begin,
-                                          LinearIR::container::const_iterator tail_end,
+                                          LinearIR::constExprIt tail_begin,
+                                          LinearIR::constExprIt tail_end,
                                           const size_t tail_size) {
     const auto& config = linear_ir.get_config();
     auto insertFill = [tail_size](const ov::Input<ov::Node>& input) -> std::shared_ptr<ov::Node> {
@@ -30,7 +97,14 @@ void InsertTailLoop::tail_transformations(LinearIR& linear_ir,
         return fill;
     };
 
-    for (auto expr_it = tail_begin; expr_it != tail_end; expr_it++) {
+    for (auto expr_it = std::next(tail_begin); expr_it != tail_end; expr_it++) {
+        // Skip inner Loops
+        const auto loop_begin = ov::as_type_ptr<op::LoopBegin>(expr_it->get()->get_node());
+        if (loop_begin) {
+            expr_it = std::find(expr_it, tail_end, linear_ir.get_expr_by_node(loop_begin->get_loop_end()));
+            OPENVINO_ASSERT(expr_it != tail_end, "LoopEnd has not been found");
+            continue;
+        }
         // We should fill vector regs by float_min and zero to have
         // correct math calculations for ReduceMax and ReduceSum in scalar case.
         // Note: We find Maximum and Add ops because HorizonMax and HorizonSum are outside Loop,
@@ -69,9 +143,7 @@ void InsertTailLoop::tail_transformations(LinearIR& linear_ir,
     }
 }
 
-bool InsertTailLoop::run(LinearIR& linear_ir) {
-    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::insertTailLoop")
-    bool modified = false;
+bool InsertTailLoop::optimize_single_evaluation(const std::shared_ptr<op::LoopEnd>& loop) {
     // *1* solo vector/tail loop + empty outer loop
     //      => skip increments (both counter & ptr) : set evaluate_once flag
     // *2* solo vector/tail loop + non-empty outer loop
@@ -79,126 +151,65 @@ bool InsertTailLoop::run(LinearIR& linear_ir) {
     //         and perform pointer increments through finalization offsets
     // *3* vector loop(s) + one tail loop
     //      => vector as usual, tail depends on outer loop, see *1* and *2*
-    auto optimize_single_evaluation = [](const std::shared_ptr<op::LoopEnd>& loop, bool force_ptr_increment = false) {
-        if (loop->get_work_amount() < 2 * loop->get_increment()) {
-            loop->set_evaluate_once(true);
-            if (force_ptr_increment || loop->has_outer_loop) {
-                std::vector<int64_t> new_finalization_offsets(loop->get_finalization_offsets());
-                const auto& ptr_increments = loop->get_ptr_increments();
-                const auto work_amount_incr = static_cast<int64_t>(loop->get_increment());
-                for (size_t i = 0; i < new_finalization_offsets.size(); i++) {
-                    new_finalization_offsets[i] += ptr_increments[i] * work_amount_incr;
-                }
-                loop->set_finalization_offsets(new_finalization_offsets);
-            }
-            return true;
-        } else {
-            return false;
-        }
-    };
-    auto is_loop_with_buffers = [&linear_ir](const std::shared_ptr<op::LoopEnd>& loop_end) {
-        auto is_buffer_input = [](const PortConnectorPtr& input) {
-            const auto& parent_expr = input->get_source().get_expr();
-            return ov::is_type<op::Buffer>(parent_expr->get_node());
-        };
-        auto is_buffer_output = [](const PortConnectorPtr& output) {
-            const auto child_exprs_inputs = output->get_consumers();
-            return std::any_of(child_exprs_inputs.begin(), child_exprs_inputs.end(),
-                               [](const ExpressionPort& lp) {return ov::is_type<op::Buffer>(lp.get_expr()->get_node());});
-        };
+    if (loop->get_work_amount() >= 2 * loop->get_increment())
+        return false;
 
-        const auto& loop_end_expr = linear_ir.get_expr_by_node(loop_end);
-        const auto inputs = loop_end_expr->get_input_port_connectors();
-        const auto in_num = loop_end->get_input_num();
-        const auto out_num = loop_end->get_output_num();
-        OPENVINO_ASSERT(inputs.size() == (in_num + out_num + 1),
-                        std::string("The LoopEnd expression must have the count of inputs is") +
-                        std::string("equal to count of input and outputs of Loop plus one for work amount"));
-        const std::vector<PortConnectorPtr> loop_ins(inputs.begin(), inputs.begin() + in_num);
-        const std::vector<PortConnectorPtr> loop_outs(inputs.begin() + in_num, inputs.begin() + in_num + out_num);
-        return std::any_of(loop_ins.begin(), loop_ins.end(), is_buffer_input) ||
-               std::any_of(loop_outs.begin(), loop_outs.end(), is_buffer_output);
-    };
-    for (auto expr_it = linear_ir.begin(); expr_it != linear_ir.end();) {
-        const auto& loop_begin = ov::as_type_ptr<ov::snippets::op::LoopBegin>((*expr_it)->get_node());
-        if (!loop_begin) {
-            expr_it++;
+    std::vector<int64_t> new_finalization_offsets(loop->get_finalization_offsets());
+    const auto& ptr_increments = loop->get_ptr_increments();
+    const auto work_amount_incr = static_cast<int64_t>(loop->get_increment());
+    for (size_t i = 0; i < new_finalization_offsets.size(); i++) {
+        new_finalization_offsets[i] += ptr_increments[i] * work_amount_incr;
+    }
+    loop->set_finalization_offsets(new_finalization_offsets);
+    loop->set_evaluate_once(true);
+    return true;
+}
+
+bool InsertTailLoop::run(LinearIR& linear_ir) {
+    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::insertTailLoop")
+    const auto& loop_manager = linear_ir.get_loop_manager();
+    bool modified = false;
+
+    for (auto expr_it = linear_ir.cbegin(); expr_it != linear_ir.cend(); ++expr_it) {
+        const auto& expr = *expr_it;
+        const auto node = expr->get_node();
+        const auto loop_end = ov::as_type_ptr<op::LoopEnd>(node);
+        if (!loop_end)
             continue;
+
+        const auto work_amount = loop_end->get_work_amount();
+        const auto increment = loop_end->get_increment();
+        const auto loop_info = loop_manager->get_loop_info(loop_end->get_id());
+        const auto tail_size = work_amount % increment;
+        const auto need_tail = tail_size != 0;
+        const auto need_vector_loop = work_amount >= increment;
+        // Note, that finalization_offsets could be modified inside optimize_single_evaluation,
+        // so need to save them here to cover (evaluate_once vector with non-zero finalization_offsets + tail)
+        const auto tail_finalization_offsets = need_tail ? loop_end->get_finalization_offsets() : std::vector<int64_t>{};
+        // vector loops are required => Just copy the body, original loop is already a vector one
+        if (need_vector_loop) {
+            // Note that finalization offsets should be applied after the last iteration.
+            // So if there is a tail, then we should apply offsets after it, but not now.
+            if (need_tail)
+                loop_end->set_finalization_offsets(std::vector<int64_t>(tail_finalization_offsets.size(), 0));
+
+            optimize_single_evaluation(loop_end);
         }
 
-        // ignore outer loops and possible manual scalar loops
-        const auto& loop_end = loop_begin->get_loop_end();
-        if (loop_end->get_increment() != 1) {
-            auto loop_begin_expr_it = expr_it;
-            const auto vector_loop_end = loop_end;
-            while ((*expr_it)->get_node() != vector_loop_end)
-                expr_it++;
-            // Note that exp_it points to the element AFTER loop_end
-            expr_it++;
-            const bool is_there_buffer = is_loop_with_buffers(vector_loop_end);
-            const auto work_amount = vector_loop_end->get_work_amount();
-            const auto increment = vector_loop_end->get_increment();
-            const auto tail_size = work_amount % increment;
-            const auto need_tail = tail_size != 0;
-            const auto need_vector_loop = work_amount >= increment;
-            // Note, that finalization_offsets could be modified inside optimize_single_evaluation,
-            // so need to save them here to cover (evaluate_once vector with non-zero finalization_offsets + tail)
-            std::vector<int64_t> tail_finalization_offsets = need_tail ? vector_loop_end->get_finalization_offsets()
-                                                                       : std::vector<int64_t> {};
-            // vector loops are required => Just copy the body, original loop is already a vector one
-            if (need_vector_loop) {
-                // Note that finalization offsets should be applied after the last iteration.
-                // So if there is a tail, then we should apply offsets after it, but not now.
-                if (need_tail)
-                    vector_loop_end->set_finalization_offsets(
-                            std::vector<int64_t>(tail_finalization_offsets.size(), 0));
-
-                // force ptr increments if there is tail
-                optimize_single_evaluation(vector_loop_end, need_tail || is_there_buffer);
-            }
-
-            // tail is required => transform the body into a tail representation
-            // tail loop is fake loop because for tail we should calculate only
-            // finalization offsets which are supported by LoopEnd.
-            if (need_tail) {
-                LinearIR::constExprIt tail_begin;
-                LinearIR::constExprIt tail_end;
-                if (need_vector_loop) {
-                    auto vector_loop_deep_copy = LinearIR::deep_copy_range(loop_begin_expr_it, expr_it);
-                    auto is_par_or_res = [](const ExpressionPtr& expr) {
-                        return is_type<ov::op::v0::Parameter>(expr->get_node()) ||
-                               is_type<ov::op::v0::Result>(expr->get_node());
-                    };
-                    // Note: It's illegal to insert Parameter or Result to the IR, but they can appear inside vector loop
-                    //  So we have to remo them before injecting tail loop into linear_ir
-                    auto to_erase = std::remove_if(vector_loop_deep_copy.begin(), vector_loop_deep_copy.end(), is_par_or_res);
-                    vector_loop_deep_copy.erase(to_erase, vector_loop_deep_copy.end());
-                    tail_begin = linear_ir.insert(expr_it, vector_loop_deep_copy.begin(), vector_loop_deep_copy.end());
-                    tail_end = expr_it;
-                } else {
-                    tail_begin = loop_begin_expr_it;
-                    tail_end = expr_it;
-                }
-
-                tail_transformations(linear_ir, tail_begin, tail_end, tail_size);
-                std::shared_ptr<op::LoopEnd> tail_loop_end =
-                        ov::as_type_ptr<op::LoopBegin>((*tail_begin)->get_node())->get_loop_end();
-                tail_loop_end->set_finalization_offsets(tail_finalization_offsets);
-                tail_loop_end->set_increment(tail_size);
-                // ptr increments were set to the old increment, need to update them in accordance with the new one
-                tail_loop_end->set_work_amount(tail_size);
-                tail_loop_end->has_outer_loop = vector_loop_end->has_outer_loop;
-
-                // Note: despite the fact that the tail loop is always executed once, we still need
-                // to keep finalization_offsets to reset Buffer
-                optimize_single_evaluation(tail_loop_end, is_there_buffer);
-            }
-            modified = true;
-        } else {
-            // if there is a loop, then exprt_it already points to the next statement (after loop end)
-            // so we need to increment iterator only if there was no loop
-            expr_it++;
+        // tail is required => transform the body into a tail representation
+        // tail loop is fake loop because for tail we should calculate only
+        // finalization offsets which are supported by LoopEnd.
+        if (need_tail) {
+            const auto loop_begin = loop_end->get_loop_begin();
+            const auto begin_it = std::find(linear_ir.begin(), linear_ir.end(), linear_ir.get_expr_by_node(loop_begin));
+            LinearIR::constExprIt tail_begin, tail_end;
+            const auto tail_loop_end = create_tail_loop(linear_ir, begin_it, std::next(expr_it), tail_begin, tail_end,
+                                                        loop_end, need_vector_loop, tail_size, tail_finalization_offsets);
+            optimize_single_evaluation(tail_loop_end);
+            // Skip new tail loop. Note: tail_end refs to the next expression after LoopEnd of tail
+            expr_it = std::prev(tail_end);
         }
+        modified = true;
     }
     return modified;
 }

--- a/src/common/snippets/src/lowered/pass/load_movebroadcast_to_broadcastload.cpp
+++ b/src/common/snippets/src/lowered/pass/load_movebroadcast_to_broadcastload.cpp
@@ -5,6 +5,7 @@
 #include "snippets/lowered/pass/load_movebroadcast_to_broadcastload.hpp"
 
 #include "snippets/lowered/linear_ir.hpp"
+#include "snippets/lowered/loop_manager.hpp"
 #include "snippets/snippets_isa.hpp"
 #include "snippets/itt.hpp"
 
@@ -13,9 +14,9 @@ namespace snippets {
 namespace lowered {
 namespace pass {
 
-
 bool LoadMoveBroadcastToBroadcastLoad::run(LinearIR& linear_ir) {
     OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::LoadMoveBroadcastToBroadcastLoad")
+    const auto& loop_manager = linear_ir.get_loop_manager();
     bool modified = false;
 
     for (auto expr_it = linear_ir.begin(); expr_it != linear_ir.end(); expr_it++) {
@@ -47,6 +48,11 @@ bool LoadMoveBroadcastToBroadcastLoad::run(LinearIR& linear_ir) {
             const auto move_consumers = expr->get_output_port_connector(0)->get_consumers();
             PortDescriptorUtils::set_port_descriptor_ptr(broadcastload->output(0), expr->get_output_port(0).get_descriptor_ptr()->clone());
             const auto broadcastload_expr = linear_ir.create_expression(broadcastload, { parent_expr->get_input_port_connector(0) });
+            // Copy Loop identifies
+            broadcastload_expr->set_loop_ids(parent_expr->get_loop_ids());
+            // Update the corresponding Loops with
+            loop_manager->update_loops_port(parent_expr->get_loop_ids(), parent_expr->get_input_port(0), {broadcastload_expr->get_input_port(0)}, true);
+
             const auto mv_expr_it = expr_it;
             const auto insertion_pos = std::next(expr_it);
             expr_it = linear_ir.insert(insertion_pos, broadcastload_expr);

--- a/src/common/snippets/src/lowered/pass/move_result_out_of_loop.cpp
+++ b/src/common/snippets/src/lowered/pass/move_result_out_of_loop.cpp
@@ -46,6 +46,8 @@ bool MoveResultOutOfLoop::run(LinearIR& linear_ir) {
                 linear_ir.move(result_it, insertion_pos);
                 modified = true;
             }
+            // The Result is executed out of Loop
+            expr->set_loop_ids({});
             continue;
         }
 
@@ -57,6 +59,8 @@ bool MoveResultOutOfLoop::run(LinearIR& linear_ir) {
             linear_ir.move(forward_it, loop_end_pos);
             modified = true;
         }
+        // The Result is executed out of Loop
+        expr->set_loop_ids({});
     }
 
     return modified;

--- a/src/common/snippets/src/lowered/pass/move_scalar_to_consumer.cpp
+++ b/src/common/snippets/src/lowered/pass/move_scalar_to_consumer.cpp
@@ -39,6 +39,7 @@ bool MoveScalarToConsumer::run(LinearIR& linear_ir) {
                 linear_ir.move(forward_it, consumer_it);
                 modified = true;
             }
+            expr->set_loop_ids(consumer_expr->get_loop_ids());
         }
     }
     return modified;

--- a/src/common/snippets/src/lowered/pass/validate_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_loops.cpp
@@ -57,8 +57,10 @@ bool ValidateLoops::run(LinearIR& linear_ir) {
                 if (std::find(dim_indexes.cbegin(), dim_indexes.cend(), dim_idx) != dim_indexes.cend()) {
                     OPENVINO_ASSERT(*dim_indexes.rbegin() == dim_idx,
                                     "Incorrect Loop ID configuration: the Loops with splitted dimension should be successively nested");
-                    OPENVINO_ASSERT(i == 0 || loop_manager->get_loop_info(loop_ids[i - 1])->increment == loop_manager->get_loop_info(id)->work_amount,
+                    OPENVINO_ASSERT(loop_manager->get_loop_info(loop_ids[i - 1])->increment == loop_manager->get_loop_info(id)->work_amount,
                                     "Incorrect Loop ID configuration: the Loops with splitted dimension should be successively nested");
+                    OPENVINO_ASSERT(loop_manager->get_loop_info(loop_ids[i - 1])->outer_splited_loop,
+                                    "Incorrect Loop ID configuration: the outer Loop with splitted dimension should have `outer_splited_loop=True`");
                 }
                 OPENVINO_ASSERT(i == 0 || loop_manager->get_loop_info(loop_ids[i - 1])->dim_idx >= dim_idx,
                                 "Incorrect Loop ID configuration: dim_idx should be sorted in accordance with loop nesting");

--- a/src/common/snippets/src/lowered/pass/validate_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_loops.cpp
@@ -54,16 +54,15 @@ bool ValidateLoops::run(LinearIR& linear_ir) {
             for (size_t i = 0; i < loop_ids.size(); ++i) {
                 const auto id = loop_ids[i];
                 const auto dim_idx = loop_manager->get_loop_info(id)->dim_idx;
-                if (std::find(dim_indexes.cbegin(), dim_indexes.cend(), dim_idx) == dim_indexes.cend()) {
-                    dim_indexes.push_back(dim_idx);
-                } else {
+                if (std::find(dim_indexes.cbegin(), dim_indexes.cend(), dim_idx) != dim_indexes.cend()) {
                     OPENVINO_ASSERT(*dim_indexes.rbegin() == dim_idx,
                                     "Incorrect Loop ID configuration: the Loops with splitted dimension should be successively nested");
+                    OPENVINO_ASSERT(i == 0 || loop_manager->get_loop_info(loop_ids[i - 1])->increment == loop_manager->get_loop_info(id)->work_amount,
+                                    "Incorrect Loop ID configuration: the Loops with splitted dimension should be successively nested");
                 }
-                if (i > 0) {
-                    OPENVINO_ASSERT(loop_manager->get_loop_info(loop_ids[i - 1])->dim_idx >= dim_idx,
-                                    "Incorrect Loop ID configuration: dim_idx should be sorted in accordance with loop nesting");
-                }
+                OPENVINO_ASSERT(i == 0 || loop_manager->get_loop_info(loop_ids[i - 1])->dim_idx >= dim_idx,
+                                "Incorrect Loop ID configuration: dim_idx should be sorted in accordance with loop nesting");
+                dim_indexes.push_back(dim_idx);
             }
             validated_nested_loops.insert(loop_ids);
         }

--- a/src/common/snippets/src/op/brgemm.cpp
+++ b/src/common/snippets/src/op/brgemm.cpp
@@ -24,6 +24,14 @@ Brgemm::Brgemm(const Output<Node>& A, const Output<Node>& B,
     custom_constructor_validate_and_infer_types(std::move(layout_a), std::move(layout_b), std::move(layout_c));
 }
 
+Brgemm::Brgemm(const Output<Node>& A, const Output<Node>& B,
+               const PortDescriptor& desc_a, const PortDescriptor& desc_b, const PortDescriptor& desc_c,
+               std::vector<size_t> layout_a, std::vector<size_t> layout_b, std::vector<size_t> layout_c)
+    : MemoryAccess({A, B}, PortMap{{0, desc_a}, {1, desc_b}}, PortMap{{0, desc_c}}) {
+    set_output_size(1);
+    custom_constructor_validate_and_infer_types(std::move(layout_a), std::move(layout_b), std::move(layout_c));
+}
+
 void Brgemm::custom_constructor_validate_and_infer_types(std::vector<size_t> layout_a, std::vector<size_t> layout_b, std::vector<size_t> layout_c) {
     INTERNAL_OP_SCOPE(BrgemmCPU_constructor_validate_and_infer_types);
     validate_inputs();
@@ -56,7 +64,7 @@ std::shared_ptr<Node> Brgemm::clone_with_new_inputs(const OutputVector& new_args
     INTERNAL_OP_SCOPE(Brgemm_clone_with_new_inputs);
     check_new_args_count(this, new_args);
     return std::make_shared<Brgemm>(new_args.at(0), new_args.at(1),
-                                    get_offset_a(), get_offset_b(), get_offset_c(),
+                                    get_input_port_descriptor(0), get_input_port_descriptor(1), get_output_port_descriptor(0),
                                     lowered::PortDescriptorUtils::get_port_descriptor_ptr(input(0))->get_layout(),
                                     lowered::PortDescriptorUtils::get_port_descriptor_ptr(input(1))->get_layout(),
                                     lowered::PortDescriptorUtils::get_port_descriptor_ptr(output(0))->get_layout());

--- a/src/common/snippets/src/op/memory_access.cpp
+++ b/src/common/snippets/src/op/memory_access.cpp
@@ -24,6 +24,9 @@ MemoryAccess::MemoryAccess(const OutputVector& arguments, const std::set<size_t>
     ctor_initialize(input_ports, output_ports);
 }
 
+MemoryAccess::MemoryAccess(const OutputVector& arguments, const PortMap& input_ports, const PortMap& output_ports)
+    : Op(arguments), m_input_ports(input_ports), m_output_ports(output_ports) {}
+
 void MemoryAccess::ctor_initialize(const std::set<size_t>& input_ports, const std::set<size_t>& output_ports) {
     for (auto port : input_ports) {
         m_input_ports[port] = {0, 0, port};

--- a/src/common/snippets/tests/src/pass/lowered/loop.cpp
+++ b/src/common/snippets/tests/src/pass/lowered/loop.cpp
@@ -1,0 +1,161 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "subgraph_simple.hpp"
+
+#include "snippets/lowered/linear_ir.hpp"
+#include "snippets/lowered/pass/init_loops.hpp"
+#include "snippets/lowered/pass/insert_load_store.hpp"
+#include "snippets/lowered/pass/cleanup_loop_offsets.hpp"
+#include "snippets/lowered/pass/validate_loops.hpp"
+#include "snippets/lowered/pass/insert_loops.hpp"
+#include "snippets/lowered/pass/insert_tail_loop.hpp"
+
+#include "snippets/op/loop.hpp"
+
+
+using Snippets_TailProcessingTransformation = ::testing::Test;
+// [Inserted Loop number, [ptr_increments, final_offsets]
+using ref_map = std::map<size_t, std::pair<std::vector<int64_t>, std::vector<int64_t>>>;
+using namespace ov::snippets::lowered;
+
+constexpr static size_t vector_size = 16;
+
+static void init_linear_ir(const std::vector<ov::PartialShape>& in_shapes, LinearIR& linear_ir, size_t block_size) {
+    auto body = ov::test::snippets::AddFunction(in_shapes).getOriginal();
+    linear_ir = LinearIR(body);
+    auto expr_it = std::find_if(linear_ir.cbegin(), linear_ir.cend(),
+                                [](const ExpressionPtr& expr) { return ov::is_type<ov::op::v1::Add>(expr->get_node()); });
+    ASSERT_TRUE(expr_it != linear_ir.cend());
+    const auto add = *expr_it;
+    const auto loop_entry_points = std::vector<ExpressionPort>{add->get_input_port(0), add->get_input_port(1)};
+    const auto loop_exit_points = std::vector<ExpressionPort>{add->get_output_port(0)};
+    const auto loop_manager = linear_ir.get_loop_manager();
+    const auto in_shape0 = in_shapes[0].get_shape();
+    const auto in_shape1 = in_shapes[1].get_shape();
+    const auto inner_wa = std::max(*in_shape0.rbegin(), *in_shape1.rbegin());
+    const auto inner_inc = vector_size;
+    const auto blocked_wa = block_size;
+    const auto blocked_inc = 1;
+    const auto outer_wa = std::max(*(in_shape0.rbegin() + 1), *(in_shape1.rbegin() + 1));
+    const auto outer_inc = blocked_wa;
+    loop_manager->mark_loop(expr_it, std::next(expr_it), inner_wa, inner_inc, 0, loop_entry_points, loop_exit_points);
+    loop_manager->mark_loop(expr_it, std::next(expr_it), blocked_wa, blocked_inc, 1, loop_entry_points, loop_exit_points);
+    loop_manager->mark_loop(expr_it, std::next(expr_it), outer_wa, outer_inc, 1, loop_entry_points, loop_exit_points);
+}
+
+static void init_pipeline(pass::PassPipeline& pass_pipeline) {
+    pass_pipeline.register_pass<pass::InsertLoadStore>(vector_size);
+    pass_pipeline.register_pass<pass::ValidateLoops>();
+    pass_pipeline.register_pass<pass::InitLoops>();
+    pass_pipeline.register_pass<pass::InsertLoops>();
+}
+
+static void validate(const LinearIR& linear_ir, const ref_map& reference) {
+    size_t loop_num = 0;
+    for (const auto& expr : linear_ir) {
+        const auto& node = expr->get_node();
+        const auto loop_end = ov::as_type_ptr<ov::snippets::op::LoopEnd>(node);
+        if (!loop_end)
+            continue;
+        ASSERT_GT(reference.count(loop_num), 0);
+        ASSERT_TRUE(loop_end->get_ptr_increments() == reference.at(loop_num).first);
+        ASSERT_TRUE(loop_end->get_finalization_offsets() == reference.at(loop_num).second);
+        loop_num++;
+    }
+}
+
+TEST(Snippets_TailProcessingTransformation, BlockedWOTail_OriginalPtrShifts) {
+    LinearIR linear_ir;
+    ov::Shape inputShape0 = {1, 2, 16, 20};
+    ov::Shape inputShape1 = {1, 2, 16, 20};
+    init_linear_ir({inputShape0, inputShape1}, linear_ir, 4);
+
+    pass::PassPipeline pass_pipeline;
+    init_pipeline(pass_pipeline);
+    pass_pipeline.run(linear_ir);
+
+    // [Inserted Loop number, [ptr_increments, final_offsets]
+    std::map<size_t, std::pair<std::vector<int64_t>, std::vector<int64_t>>> reference;
+    reference[0] = { std::vector<int64_t>(3, 1), std::vector<int64_t>(3, -20)};
+    reference[1] = { std::vector<int64_t>(3, 20), std::vector<int64_t>(3, -80)};
+    reference[2] = { std::vector<int64_t>(3, 20), std::vector<int64_t>(3, -320)};
+
+    validate(linear_ir, reference);
+}
+
+TEST(Snippets_TailProcessingTransformation, BlockedWOTail_CleanUpPtrShifts) {
+    LinearIR linear_ir;
+    ov::Shape inputShape0 = {1, 2, 16, 20};
+    ov::Shape inputShape1 = {1, 2, 16, 20};
+    init_linear_ir({inputShape0, inputShape1}, linear_ir, 4);
+
+    pass::PassPipeline pass_pipeline;
+    init_pipeline(pass_pipeline);
+    pass_pipeline.register_pass<pass::CleanupLoopOffsets>();
+    pass_pipeline.run(linear_ir);
+
+    // [Inserted Loop number, [ptr_increments, final_offsets]
+    std::map<size_t, std::pair<std::vector<int64_t>, std::vector<int64_t>>> reference;
+    reference[0] = { std::vector<int64_t>(3, 1), std::vector<int64_t>(3, 0)};
+    reference[1] = { std::vector<int64_t>(3, 0), std::vector<int64_t>(3, 0)};
+    reference[2] = { std::vector<int64_t>(3, 0), std::vector<int64_t>(3, 0)};
+
+    validate(linear_ir, reference);
+}
+
+TEST(Snippets_TailProcessingTransformation, BlockedTail_OriginalPtrShifts) {
+    LinearIR linear_ir;
+    ov::Shape inputShape0 = {1, 2, 18, 20};
+    ov::Shape inputShape1 = {1, 2, 18, 20};
+    init_linear_ir({inputShape0, inputShape1}, linear_ir, 4);
+
+    pass::PassPipeline pass_pipeline;
+    init_pipeline(pass_pipeline);
+    pass_pipeline.register_pass<pass::InsertTailLoop>();
+    pass_pipeline.run(linear_ir);
+
+    // [Inserted Loop number, [ptr_increments, final_offsets]
+    std::map<size_t, std::pair<std::vector<int64_t>, std::vector<int64_t>>> reference;
+    reference[0] = { std::vector<int64_t>(3, 1), std::vector<int64_t>(3, 16)};  // Vector Inner
+    reference[1] = { std::vector<int64_t>(3, 1), std::vector<int64_t>(3, -16)};  // Blocked Inner
+    reference[2] = { std::vector<int64_t>(3, 20), std::vector<int64_t>(3, -80)};  // Vector Blocked
+    reference[3] = { std::vector<int64_t>(3, 20), std::vector<int64_t>(3, 0)}; // Vector Outer
+
+    reference[4] = { std::vector<int64_t>(3, 1), std::vector<int64_t>(3, 16)};  // Vector Inner
+    reference[5] = { std::vector<int64_t>(3, 1), std::vector<int64_t>(3, -16)};  // Blocked Inner
+    reference[6] = { std::vector<int64_t>(3, 20), std::vector<int64_t>(3, -40)};  // Tail Blocked
+    reference[7] = { std::vector<int64_t>(3, 20), std::vector<int64_t>(3, -320)};  // Tail Blocked
+
+    validate(linear_ir, reference);
+}
+
+TEST(Snippets_TailProcessingTransformation, BlockedTail_CleanUpPtrShifts) {
+    LinearIR linear_ir;
+    ov::Shape inputShape0 = {1, 2, 18, 20};
+    ov::Shape inputShape1 = {1, 2, 18, 20};
+    init_linear_ir({inputShape0, inputShape1}, linear_ir, 4);
+
+    pass::PassPipeline pass_pipeline;
+    init_pipeline(pass_pipeline);
+    pass_pipeline.register_pass<pass::CleanupLoopOffsets>();
+    pass_pipeline.register_pass<pass::InsertTailLoop>();
+    pass_pipeline.run(linear_ir);
+
+    // [Inserted Loop number, [ptr_increments, final_offsets]
+    std::map<size_t, std::pair<std::vector<int64_t>, std::vector<int64_t>>> reference;
+    reference[0] = { std::vector<int64_t>(3, 1), std::vector<int64_t>(3, 16)};  // Vector Inner
+    reference[1] = { std::vector<int64_t>(3, 1), std::vector<int64_t>(3, 4)};  // Blocked Inner
+    reference[2] = { std::vector<int64_t>(3, 0), std::vector<int64_t>(3, 0)};  // Vector Blocked
+    reference[3] = { std::vector<int64_t>(3, 0), std::vector<int64_t>(3, 0)}; // Vector Outer
+
+    reference[4] = { std::vector<int64_t>(3, 1), std::vector<int64_t>(3, 16)};  // Vector Inner
+    reference[5] = { std::vector<int64_t>(3, 1), std::vector<int64_t>(3, 4)};  // Blocked Inner
+    reference[6] = { std::vector<int64_t>(3, 0), std::vector<int64_t>(3, 0)};  // Tail Blocked
+    reference[7] = { std::vector<int64_t>(3, 0), std::vector<int64_t>(3, 0)};  // Tail Blocked
+
+    validate(linear_ir, reference);
+}

--- a/src/common/snippets/tests/src/pass/lowered/loop.cpp
+++ b/src/common/snippets/tests/src/pass/lowered/loop.cpp
@@ -45,6 +45,7 @@ static void init_linear_ir(const std::vector<ov::PartialShape>& in_shapes, Linea
     loop_manager->mark_loop(expr_it, std::next(expr_it), inner_wa, inner_inc, 0, loop_entry_points, loop_exit_points);
     loop_manager->mark_loop(expr_it, std::next(expr_it), blocked_wa, blocked_inc, 1, loop_entry_points, loop_exit_points);
     loop_manager->mark_loop(expr_it, std::next(expr_it), outer_wa, outer_inc, 1, loop_entry_points, loop_exit_points);
+    loop_manager->get_loop_info(2)->outer_splited_loop = true;
 }
 
 static void init_pipeline(pass::PassPipeline& pass_pipeline) {

--- a/src/common/snippets/tests/src/pass/lowered/loop.cpp
+++ b/src/common/snippets/tests/src/pass/lowered/loop.cpp
@@ -44,8 +44,8 @@ static void init_linear_ir(const std::vector<ov::PartialShape>& in_shapes, Linea
     const auto outer_inc = blocked_wa;
     loop_manager->mark_loop(expr_it, std::next(expr_it), inner_wa, inner_inc, 0, loop_entry_points, loop_exit_points);
     loop_manager->mark_loop(expr_it, std::next(expr_it), blocked_wa, blocked_inc, 1, loop_entry_points, loop_exit_points);
-    loop_manager->mark_loop(expr_it, std::next(expr_it), outer_wa, outer_inc, 1, loop_entry_points, loop_exit_points);
-    loop_manager->get_loop_info(2)->outer_splited_loop = true;
+    const auto loop_id = loop_manager->mark_loop(expr_it, std::next(expr_it), outer_wa, outer_inc, 1, loop_entry_points, loop_exit_points);
+    loop_manager->get_loop_info(loop_id)->outer_splited_loop = true;
 }
 
 static void init_pipeline(pass::PassPipeline& pass_pipeline) {

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_copy_b.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_copy_b.hpp
@@ -28,6 +28,9 @@ public:
     BrgemmCopyB(const Output<Node>& x, const element::Type src_type, const Type type = Type::OnlyRepacking,
                 const size_t offset_in = 0lu, const size_t offset_out0 = 0lu, const size_t offset_out1 = 0lu,
                 std::vector<size_t> layout_input = {});
+    BrgemmCopyB(const Output<Node>& x, const element::Type src_type, const Type type = Type::OnlyRepacking,
+                const PortDescriptor& desc_in0 = {}, const PortDescriptor& desc_out0 = {}, const PortDescriptor& desc_out1 = {},
+                std::vector<size_t> layout_input = {});
     BrgemmCopyB() = default;
 
     size_t get_offset_in() const { return get_input_offset(0); }

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.hpp
@@ -35,6 +35,12 @@ public:
     BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Output<Node>& scratch, const Type type,
               const size_t offset_a = 0, const size_t offset_b = 0, const size_t offset_scratch = 0, const size_t offset_c = 0,
               std::vector<size_t> layout_a = {}, std::vector<size_t> layout_b = {}, std::vector<size_t> layout_c = {});
+    BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Type type,
+              const PortDescriptor& desc_a, const PortDescriptor& desc_b, const PortDescriptor& desc_c,
+              std::vector<size_t> layout_a = {}, std::vector<size_t> layout_b = {}, std::vector<size_t> layout_c = {});
+    BrgemmCPU(const Output<Node>& A, const Output<Node>& B, const Output<Node>& scratch, const Type type,
+              const PortDescriptor& desc_a, const PortDescriptor& desc_b, const PortDescriptor& desc_scratch, const PortDescriptor& desc_c,
+              std::vector<size_t> layout_a = {}, std::vector<size_t> layout_b = {}, std::vector<size_t> layout_c = {});
     BrgemmCPU() = default;
 
     void validate_and_infer_types() override;

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/add.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/add.cpp
@@ -30,11 +30,13 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_Eltwise, Add,
 std::vector<std::vector<ov::Shape>> inShapesStatic{
         {{1, 128, 1, 1}, {1, 128, 1, 1}},
         {{1, 128, 1, 9}, {1, 128, 1, 9}},
+        {{1, 128, 1, 16}, {1, 128, 1, 16}},
         {{1, 128, 1, 17}, {1, 128, 1, 17}},
         {{1, 128, 1, 29}, {1, 128, 1, 29}},
         {{1, 128, 1, 33}, {1, 128, 1, 33}},
         {{1, 128, 9, 30}, {1, 128, 1, 30}},
         {{1, 128, 9, 1}, {1, 128, 1, 30}},
+        {{1, 128, 9, 16}, {1, 128, 9, 1}},
 };
 INSTANTIATE_TEST_SUITE_P(smoke_Snippets_Eltwise, AddPair,
                          ::testing::Combine(


### PR DESCRIPTION
### Details:
 - *Added `ptr_increments` and etc. storage in `LoopInfo`* 
 - *Split `InitLoops` into 2 passes: `InitLoops` (inits `ptr_increments` and etc. storage in `LoopInfo`) and `InsertLoops` (explicitly insert in Linear IR)*
 - *Added `loop_ids` support for `Loops`, `Buffers` and passes that are called after `InitLoops` to have correct `LoopManager` during the whole pipeline*
 - *Updated `InsertTailLoop` logic: added tailing processing support for splitted Loops*
 - *Fixed `clone_with_new_inputs` for `Brgemm` ops - before `count` weren't copied*

### TODO:
- [x] *Added test*
