### PR TITLE
[PyOV] Restrict `numpy` for unsupported Python versions

### DIFF
--- a/src/bindings/python/requirements.txt
+++ b/src/bindings/python/requirements.txt
@@ -1,2 +1,3 @@
-numpy>=1.16.6
+numpy>=1.16.6,<1.25; python_version<'3.9'
+numpy>=1.16.6; python_version>='3.9'
 singledispatchmethod; python_version<'3.8'

--- a/src/bindings/python/requirements.txt
+++ b/src/bindings/python/requirements.txt
@@ -1,3 +1,2 @@
-numpy>=1.16.6,<1.25; python_version<'3.9'
-numpy>=1.16.6; python_version>='3.9'
+numpy>=1.16.6
 singledispatchmethod; python_version<'3.8'

--- a/tools/mo/requirements.txt
+++ b/tools/mo/requirements.txt
@@ -1,5 +1,6 @@
 -c ../constraints.txt
-numpy>=1.16.6
+numpy>=1.16.6,<1.25; python_version<'3.9'
+numpy>=1.16.6; python_version>='3.9'
 importlib-metadata; python_version < "3.8" and sys_platform == "win32"
 networkx
 defusedxml


### PR DESCRIPTION
### Details:
 - pip resolver is sporadically choosing `numpy==1.25.0rc1` for unsupported Python versions, causing random CI fails
 - the PR is currently a draft because of a **discussion in the ticket** - I recommend waiting to see if there are more reproductions before merging, but it's a subject to change and discuss

### Tickets:
 - 112557
